### PR TITLE
[5.8] fix MorphTo Relation ignores parent $timestamp when touching 

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -294,6 +294,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $class = $class ?: static::class;
 
+        if (! get_class_vars($class)['timestamps']) {
+            return true;
+        }
+
         foreach (static::$ignoreOnTouch as $ignoredClass) {
             if ($class === $ignoredClass || is_subclass_of($class, $ignoredClass)) {
                 return true;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -294,7 +294,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $class = $class ?: static::class;
 
-        if (! get_class_vars($class)['timestamps']) {
+        if (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) {
             return true;
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1903,6 +1903,13 @@ class DatabaseEloquentModelTest extends TestCase
             Model::isIgnoringTouch(Model::class)
         );
     }
+
+    public function testNotTouchingModelWithoutTimestamps()
+    {
+        $this->assertTrue(
+            Model::isIgnoringTouch(EloquentModelWithoutTimestamps::class)
+        );
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1904,9 +1904,9 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
-    public function testTouchingModelWithUpdatedAtNull()
+    public function testNotTouchingModelWithUpdatedAtNull()
     {
-        $this->assertFalse(
+        $this->assertTrue(
             Model::isIgnoringTouch(EloquentModelWithUpdatedAtNull::class)
         );
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1896,6 +1896,13 @@ class DatabaseEloquentModelTest extends TestCase
             return new BaseBuilder($connection, $grammar, $processor);
         });
     }
+
+    public function testTouchingModelWithTimestamps()
+    {
+        $this->assertFalse(
+            Model::isIgnoringTouch(Model::class)
+        );
+    }
 }
 
 class EloquentTestObserverStub
@@ -2302,4 +2309,10 @@ class EloquentModelEventObjectStub extends Model
     protected $dispatchesEvents = [
         'saving' => EloquentModelSavingEventStub::class,
     ];
+}
+
+class EloquentModelWithoutTimestamps extends Model
+{
+    protected $table = 'stub';
+    public $timestamps = false;
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2336,4 +2336,3 @@ class EloquentModelWithUpdatedAtNull extends Model
     protected $table = 'stub';
     const UPDATED_AT = null;
 }
-

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1904,6 +1904,13 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+    public function testTouchingModelWithUpdatedAtNull()
+    {
+        $this->assertFalse(
+            Model::isIgnoringTouch(EloquentModelWithUpdatedAtNull::class)
+        );
+    }
+
     public function testNotTouchingModelWithoutTimestamps()
     {
         $this->assertTrue(
@@ -2323,3 +2330,10 @@ class EloquentModelWithoutTimestamps extends Model
     protected $table = 'stub';
     public $timestamps = false;
 }
+
+class EloquentModelWithUpdatedAtNull extends Model
+{
+    protected $table = 'stub';
+    const UPDATED_AT = null;
+}
+


### PR DESCRIPTION
Fixed bug with touching model which has $timestamps set to false resulting in Illuminate\Database\QueryException: SQLSTATE[HY000]: General error: 1 no such column: updated_at

for source issue and more details see #28638