### PR TITLE
[5.8] update Gate `resource` method

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -150,10 +150,11 @@ class Gate implements GateContract
     public function resource($name, $class, array $abilities = null)
     {
         $abilities = $abilities ?: [
-            'view'   => 'view',
-            'create' => 'create',
-            'update' => 'update',
-            'delete' => 'delete',
+            'viewAny' => 'viewAny',
+            'view'    => 'view',
+            'create'  => 'create',
+            'update'  => 'update',
+            'delete'  => 'delete',
         ];
 
         foreach ($abilities as $ability => $method) {


### PR DESCRIPTION
this goes along with PR #28654 

this ability is for the `index` resource method.

named `viewAny` for consistency with Laravel Nova.

