### PR TITLE
[5.8] Sequential array support for App::call() + tests

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -3,23 +3,25 @@
 namespace Illuminate\Container;
 
 use Closure;
-use ReflectionMethod;
-use ReflectionFunction;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use ReflectionFunction;
+use ReflectionMethod;
 
 class BoundMethod
 {
     /**
      * Call the given Closure / class@method and inject its dependencies.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  callable|string  $callback
-     * @param  array  $parameters
-     * @param  string|null  $defaultMethod
-     * @return mixed
+     * @param \Illuminate\Container\Container $container
+     * @param callable|string                 $callback
+     * @param array                           $parameters
+     * @param string|null                     $defaultMethod
      *
      * @throws \ReflectionException
      * @throws \InvalidArgumentException
+     *
+     * @return mixed
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
@@ -37,13 +39,14 @@ class BoundMethod
     /**
      * Call a string reference to a class using Class@method syntax.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  string  $target
-     * @param  array  $parameters
-     * @param  string|null  $defaultMethod
-     * @return mixed
+     * @param \Illuminate\Container\Container $container
+     * @param string                          $target
+     * @param array                           $parameters
+     * @param string|null                     $defaultMethod
      *
      * @throws \InvalidArgumentException
+     *
+     * @return mixed
      */
     protected static function callClass($container, $target, array $parameters = [], $defaultMethod = null)
     {
@@ -67,14 +70,15 @@ class BoundMethod
     /**
      * Call a method that has been bound to the container.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  callable  $callback
-     * @param  mixed  $default
+     * @param \Illuminate\Container\Container $container
+     * @param callable                        $callback
+     * @param mixed                           $default
+     *
      * @return mixed
      */
     protected static function callBoundMethod($container, $callback, $default)
     {
-        if (! is_array($callback)) {
+        if (!is_array($callback)) {
             return $default instanceof Closure ? $default() : $default;
         }
 
@@ -93,7 +97,8 @@ class BoundMethod
     /**
      * Normalize the given callback into a Class@method string.
      *
-     * @param  callable  $callback
+     * @param callable $callback
+     *
      * @return string
      */
     protected static function normalizeMethod($callback)
@@ -104,17 +109,52 @@ class BoundMethod
     }
 
     /**
+     * Adds missing dependencies to the user-provided input.
+     *
+     * @param       $container
+     * @param       $callback
+     * @param array $inputData
+     *
+     * @return array
+     */
+    protected static function addMissingDependencies($container, $callback, array $inputData)
+    {
+        $parameters = static::getCallReflector($callback)->getParameters();
+
+        if (count($parameters) <= count($inputData)) {
+            return $inputData;
+        }
+
+        foreach ($parameters as $i => $parameter) {
+            // Injects missing type hinted parameters within the array
+            $class = $parameter->getClass()->name ?? false;
+            if ($class && !($inputData[$i] ?? false) instanceof $class) {
+                array_splice($inputData, $i, 0, [$container->make($class)]);
+            } elseif (!array_key_exists($i, $inputData) && $parameter->isDefaultValueAvailable()) {
+                $inputData[] = $parameter->getDefaultValue();
+            }
+        }
+
+        return $inputData;
+    }
+
+    /**
      * Get all dependencies for a given method.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  callable|string  $callback
-     * @param  array  $parameters
-     * @return array
+     * @param \Illuminate\Container\Container $container
+     * @param callable|string                 $callback
+     * @param array                           $parameters
      *
      * @throws \ReflectionException
+     *
+     * @return array
      */
     protected static function getMethodDependencies($container, $callback, array $parameters = [])
     {
+        if ($parameters !== [] && !Arr::isAssoc($parameters)) {
+            return static::addMissingDependencies($container, $callback, $parameters);
+        }
+
         $dependencies = [];
 
         foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
@@ -127,10 +167,11 @@ class BoundMethod
     /**
      * Get the proper reflection instance for the given callback.
      *
-     * @param  callable|string $callback
-     * @return \ReflectionFunctionAbstract
+     * @param callable|string $callback
      *
      * @throws \ReflectionException
+     *
+     * @return \ReflectionFunctionAbstract
      */
     protected static function getCallReflector($callback)
     {
@@ -146,10 +187,11 @@ class BoundMethod
     /**
      * Get the dependency for the given call parameter.
      *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  \ReflectionParameter  $parameter
-     * @param  array  $parameters
-     * @param  array  $dependencies
+     * @param \Illuminate\Container\Container $container
+     * @param \ReflectionParameter            $parameter
+     * @param array                           $parameters
+     * @param array                           $dependencies
+     *
      * @return void
      */
     protected static function addDependencyForCallParameter($container, $parameter,
@@ -173,7 +215,8 @@ class BoundMethod
     /**
      * Determine if the given string is in Class@method syntax.
      *
-     * @param  mixed  $callback
+     * @param mixed $callback
+     *
      * @return bool
      */
     protected static function isCallableWithAtSign($callback)

--- a/tests/Container/BoundMethodTest.php
+++ b/tests/Container/BoundMethodTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use Illuminate\Container\BoundMethod;
+use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+
+class BoundMethodTest extends TestCase
+{
+    public function testBoundMethodAccessor()
+    {
+        $defaulty = function ($a, $b = 'default b', $c = 'default c') {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b']);
+        $this->assertSame(['a', 'b', 'default c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', 'b', null]);
+        $this->assertSame(['a', 'b', null], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a', null]);
+        $this->assertSame(['a', null, 'default c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $defaulty, ['a']);
+        $this->assertSame(['a', 'default b', 'default c'], $args);
+    }
+
+    public function testExtraNumberOfInputArePassedIntoMethod()
+    {
+        $callable = function ($a, $b) {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callable, ['a', 'b', 'c', 'd']);
+        $this->assertEquals(['a', 'b', 'c', 'd'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callable, ['a', 'b', 'c', null]);
+        $this->assertEquals(['a', 'b', 'c', null], $args);
+    }
+
+    public function testCallingWithNoArgs()
+    {
+        $callee = function () {
+        };
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a', 'b', 'c']);
+        $this->assertSame(['a', 'b', 'c'], $args);
+        $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['key_a' => 'value_a', 'key_b' => 'value_b']);
+        $this->assertSame(['key_a' => 'value_a', 'key_b' => 'value_b'], $args);
+    }
+
+    public function testCanInjectAtEnd()
+    {
+        $callee = function ($a, $b = 'default b', ContainerBoundMethodStub $c = null) {
+            return [$a, $b, $c];
+        };
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a']);
+
+        $this->assertEquals('a', $a);
+        $this->assertEquals('default b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+        $this->assertCount(3, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a', 'b']);
+
+        $this->assertEquals('a', $a);
+        $this->assertEquals('b', $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $c);
+
+        $this->assertCount(3, $args);
+    }
+
+    public function testCanInjectAtMiddle()
+    {
+        $callee = function ($a, ContainerBoundMethodStub $b, $c = 'default c') {
+        };
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a' => 'passed a', 'junk' => 'junk']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertArrayNotHasKey(3, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['c' => 'value c', 'junk' => 'junk', 'a' => 'passed a']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertArrayNotHasKey(3, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', 'value c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertCount(3, $args);
+
+        $obj = new ContainerBoundMethodStub();
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj]);
+
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('default c', $c);
+        $this->assertCount(3, $args);
+        $this->assertArrayNotHasKey(3, $args);
+
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj, 'passed c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertEquals('passed c', $c);
+        $this->assertArrayNotHasKey(3, $args);
+        $stub2 = new ContainerBoundMethodStub2();
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertArrayNotHasKey(3, $args);
+    }
+
+    public function testCanInjectTwoAtMiddle()
+    {
+        $callee = function ($a, ContainerBoundMethodStub $b, ContainerBoundMethodStub2 $c, $d = 'default d') {
+        };
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['a' => 'passed a', 'junk' => 'junk']);
+
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub2::class, $c);
+        $this->assertEquals('default d', $d);
+        $this->assertArrayNotHasKey(4, $args);
+
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['c' => 'value c', 'junk' => 'junk', 'a' => 'passed a']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertEquals('value c', $c);
+        $this->assertEquals('default d', $d);
+        $this->assertArrayNotHasKey(4, $args);
+
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', 'value c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub2::class, $c);
+        $this->assertEquals('value c', $d);
+        $this->assertArrayNotHasKey(4, $args);
+
+        $obj = new ContainerBoundMethodStub();
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj]);
+
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub2::class, $c);
+        $this->assertEquals('default d', $d);
+        $this->assertCount(4, $args);
+        $this->assertArrayNotHasKey(4, $args);
+
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $obj, 'passed c']);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($obj, $b);
+        $this->assertInstanceOf(ContainerBoundMethodStub2::class, $c);
+        $this->assertEquals('passed c', $d);
+        $this->assertArrayNotHasKey(4, $args);
+
+        $stub2 = new ContainerBoundMethodStub2();
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertInstanceOf(ContainerBoundMethodStub::class, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertCount(4, $args);
+
+        $stub = new ContainerBoundMethodStub();
+        $stub2 = new ContainerBoundMethodStub2();
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub, $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($stub, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertEquals('default d', $d);
+        $this->assertCount(4, $args);
+    }
+
+    public function testCanWorkWithTypeHintedInterFaces()
+    {
+        $callee = function ($a, ContainerBoundMethodStub $b, ContainerCallAbstractStub $c, $d = 'default d') {
+        };
+
+        $stub = new ContainerBoundMethodStub();
+        $stub2 = new ContainerBoundMethodStub();
+        [$a, $b, $c, $d] = $args = BoundMethodAccessor::getMethodDependencies(new Container(), $callee, ['passed a', $stub, $stub2]);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($stub, $b);
+        $this->assertSame($stub2, $c);
+        $this->assertEquals('default d', $d);
+        $this->assertCount(4, $args);
+
+        $app = new Container();
+        $app->bind(ContainerCallAbstractStub::class, ContainerBoundMethodStub::class);
+        $stub = new ContainerBoundMethodStub();
+        $stub2 = new ContainerBoundMethodStub();
+        $args = ['passed a', $stub, $stub2];
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($app, $callee, $args);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($stub, $b);
+        $this->assertTrue(get_class($c) === ContainerBoundMethodStub::class);
+        $this->assertEquals('default d', $d);
+        $this->assertCount(4, $args);
+
+        $app = new Container();
+        $app->bind(ContainerCallAbstractStub::class, ContainerBoundMethodStub::class);
+        $stub = new ContainerBoundMethodStub();
+        [$a, $b, $c] = $args = BoundMethodAccessor::getMethodDependencies($app, $callee, ['passed a', $stub]);
+        $this->assertEquals('passed a', $a);
+        $this->assertSame($stub, $b);
+        $this->assertTrue(get_class($c) === ContainerBoundMethodStub::class);
+        $this->assertEquals('default d', $d);
+        $this->assertCount(4, $args);
+    }
+}
+
+class BoundMethodAccessor extends BoundMethod
+{
+    public static function getMethodDependencies($container, $callback, array $inputData = [])
+    {
+        return parent::getMethodDependencies($container, $callback, $inputData);
+    }
+
+    public static function isCallableWithAtSign($callback)
+    {
+        return parent::isCallableWithAtSign($callback);
+    }
+}
+
+interface ContainerCallAbstractStub
+{
+    //
+}
+
+class ContainerBoundMethodStub implements ContainerCallAbstractStub
+{
+}
+
+class ContainerBoundMethodStub2
+{
+}
+
+class BoundMethodAccessorStub
+{
+    public function injectedAtMiddle($a, ContainerBoundMethodStub $b, $c = 'default c')
+    {
+    }
+
+    public function injectedAtMiddleTwo($a, ContainerBoundMethodStub $b, $c = 'default c')
+    {
+    }
+}

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Tests\Container;
 
 use Closure;
-use stdClass;
-use ReflectionException;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
+use PHPUnit\Framework\TestCase;
+use ReflectionException;
+use stdClass;
 
 class ContainerCallTest extends TestCase
 {
@@ -15,50 +15,65 @@ class ContainerCallTest extends TestCase
         $this->expectException(ReflectionException::class);
         $this->expectExceptionMessage('Function ContainerTestCallStub() does not exist');
 
-        $container = new Container;
+        $container = new Container();
         $container->call('ContainerTestCallStub');
     }
 
     public function testCallWithAtSignBasedClassReferences()
     {
-        $container = new Container;
+        $container = new Container();
         $result = $container->call(ContainerTestCallStub::class.'@work', ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $result);
 
-        $container = new Container;
+        $container = new Container();
         $result = $container->call(ContainerTestCallStub::class.'@inject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
-        $container = new Container;
+        $container = new Container();
         $result = $container->call(ContainerTestCallStub::class.'@inject', ['default' => 'foo']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('foo', $result[1]);
 
-        $container = new Container;
+        $container = new Container();
         $result = $container->call(ContainerTestCallStub::class, ['foo', 'bar'], 'work');
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
     public function testCallWithCallableArray()
     {
-        $container = new Container;
-        $stub = new ContainerTestCallStub;
+        $container = new Container();
+        $stub = new ContainerTestCallStub();
         $result = $container->call([$stub, 'work'], ['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $result);
+
+        $container = new Container();
+        $stub = new ContainerTestCallStub();
+        $result = $container->call([$stub, 'work'], ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['bar', 'foo'], $result);
     }
 
     public function testCallWithStaticMethodNameString()
     {
-        $container = new Container;
+        $container = new Container();
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
+
+        $container = new Container();
+        $result = $container->call([new ContainerTestCallStub(), 'inject'], ['baz']);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+        $this->assertEquals('baz', $result[1]);
+        $container = new Container();
+        $object = new ContainerCallConcreteStub();
+        $result = $container->call([new ContainerTestCallStub(), 'inject'], [$object, 'foo']);
+        $this->assertSame($object, $result[0]);
+        $this->assertEquals('foo', $result[1]);
     }
 
     public function testCallWithGlobalMethodName()
     {
-        $container = new Container;
+        $container = new Container();
         $result = $container->call('Illuminate\Tests\Container\containerTestInject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
@@ -66,61 +81,90 @@ class ContainerCallTest extends TestCase
 
     public function testCallWithBoundMethod()
     {
-        $container = new Container;
+        $container = new Container();
         $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call(ContainerTestCallStub::class.'@unresolvable');
         $this->assertEquals(['foo', 'bar'], $result);
 
-        $container = new Container;
+        $container = new Container();
         $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
-        $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
+        $result = $container->call([new ContainerTestCallStub(), 'unresolvable']);
         $this->assertEquals(['foo', 'bar'], $result);
 
-        $container = new Container;
-        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
+        $container = new Container();
+        $result = $container->call([new ContainerTestCallStub(), 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('bar', $result[1]);
 
-        $container = new Container;
-        $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
+        $container = new Container();
+        $result = $container->call([new ContainerTestCallStub(), 'inject'], ['_stub' => 'foo']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
     {
-        $container = new Container;
+        $container = new Container();
         $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call(ContainerTestCallStub::class.'@unresolvable');
         $this->assertEquals(['foo', 'bar'], $result);
 
-        $container = new Container;
+        $container = new Container();
         $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
-        $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
+        $result = $container->call([new ContainerTestCallStub(), 'unresolvable']);
         $this->assertEquals(['foo', 'bar'], $result);
     }
 
     public function testClosureCallWithInjectedDependency()
     {
-        $container = new Container;
-        $container->call(function (ContainerCallConcreteStub $stub) {
+        $container = new Container();
+        $result = $container->call(function (ContainerCallConcreteStub $stub) {
+            return $stub;
         }, ['foo' => 'bar']);
 
-        $container->call(function (ContainerCallConcreteStub $stub) {
-        }, ['foo' => 'bar', 'stub' => new ContainerCallConcreteStub]);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+        $result = $container->call(function (ContainerCallConcreteStub $stub) {
+            return $stub;
+        }, ['foo' => 'bar', 'stub' => new ContainerCallConcreteStub()]);
+
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+        $obj = new ContainerCallConcreteStub();
+        $result = $container->call(function (ContainerCallConcreteStub $stub) {
+            return $stub;
+        }, [$obj]);
+        $this->assertSame($obj, $result);
+
+        $obj = new ContainerCallConcreteStub();
+        $result = $container->call(function (ContainerCallConcreteStub $stub, $baz = 'taylor') {
+            return [$stub, $baz];
+        }, ['foo' => 'bar', 'stub' => $obj]);
+        $this->assertSame($obj, $result[0]);
+        $this->assertEquals('taylor', $result[1]);
+        $obj = new ContainerCallConcreteStub();
+        $result = $container->call(function ($foo, ContainerCallConcreteStub $stub) {
+            return [$foo, $stub];
+        }, ['foo', $obj]);
+        $this->assertEquals('foo', $result[0]);
+        $this->assertSame($obj, $result[1]);
+
+        $result = $container->call(function ($foo = 'default foo', ContainerCallConcreteStub $stub = null) {
+            return [$foo, $stub];
+        }, []);
+        $this->assertEquals('default foo', $result[0]);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[1]);
     }
 
     public function testCallWithDependencies()
     {
-        $container = new Container;
+        $container = new Container();
         $result = $container->call(function (stdClass $foo, $bar = []) {
             return func_get_args();
         });
@@ -135,7 +179,7 @@ class ContainerCallTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
 
-        $stub = new ContainerCallConcreteStub;
+        $stub = new ContainerCallConcreteStub();
         $result = $container->call(function (stdClass $foo, ContainerCallConcreteStub $bar) {
             return func_get_args();
         }, [ContainerCallConcreteStub::class => $stub]);
@@ -155,6 +199,70 @@ class ContainerCallTest extends TestCase
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals('taylor', $result[1]);
+    }
+
+    public function testTypeErrorHappensWhenWrongDataIsPassed()
+    {
+        $callable = function (ContainerCallConcreteStub $stub) {
+        };
+        $this->expectException(\TypeError::class);
+        (new Container())->call($callable, ['foo']);
+    }
+
+    public function testWithDefaultParametersIndexedArraySyntax()
+    {
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['foo', 'bar', 'baz']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty');
+        $this->assertEquals(['default a', 'default b', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['foo', null]);
+        $this->assertEquals(['foo', null, 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', [null, null, null]);
+        $this->assertEquals([null, null, null], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2']);
+        $this->assertEquals(['foo', 'bar', 'baz', 'foo2', 'bar2', 'baz2'], $result);
+    }
+
+    public function testWithDefaultParametersAssociativeSyntax()
+    {
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['c' => 'baz', 'b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaulty', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyBandC', ['a' => 'foo']);
+        $this->assertEquals(['foo', 'default b', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['a' => 'foo', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@defaultyOnlyC', ['b' => 'bar', 'a' => 'foo']);
+        $this->assertEquals(['foo', 'bar', 'default c'], $result);
+        $container = new Container();
+        $result = $container->call(ContainerTestDefaultyParams::class.'@noDefault', ['a' => 'foo', 'c' => 'baz', 'b' => 'bar']);
+        $this->assertEquals(['foo', 'bar', 'baz'], $result);
     }
 }
 
@@ -189,6 +297,29 @@ function containerTestInject(ContainerCallConcreteStub $stub, $default = 'taylor
 class ContainerStaticMethodStub
 {
     public static function inject(ContainerCallConcreteStub $stub, $default = 'taylor')
+    {
+        return func_get_args();
+    }
+}
+
+class ContainerTestDefaultyParams
+{
+    public function defaulty($a = 'default a', $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+
+    public function defaultyBandC($a, $b = 'default b', $c = 'default c')
+    {
+        return func_get_args();
+    }
+
+    public function defaultyOnlyC($a, $b, $c = 'default c')
+    {
+        return func_get_args();
+    }
+
+    public function noDefault($a, $b, $c)
     {
         return func_get_args();
     }


### PR DESCRIPTION
- Addresses:
https://github.com/laravel/framework/issues/26851

- Re-submission: 
https://github.com/laravel/framework/pull/27751

#27751 was rejected because that was a "code bloat", but in this PR the same goal is achieved with a much simpler logic, (no nested conditions) and almost half the code.

- Tests:
The tests were reviewed and now are more covering more cases. (compared to https://github.com/laravel/framework/pull/27751)

- Why it does not break ?
This PR adds a protected method which steps in only when the user input is a none empty sequential array, to avoid intercepting the flow of previous functionality.

End users can use `app()->call()` just like native `call_user_func_array` and pass the arguments as sequential array. (I think there are also cases for laravel to use it internal e.g. in facade class)