### PR TITLE
[5.5] Normalize to lowercase the dictionary key in the eloquent relations mapping multiple records while eager loading records

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -236,7 +236,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
+            if (isset($dictionary[$key = $this->normalizeDictionaryKey($model->{$this->parentKey})])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );
@@ -260,7 +260,8 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->{$this->accessor}->{$this->foreignPivotKey}][] = $result;
+            $normalizedKey = $this->normalizeDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+            $dictionary[$normalizedKey][] = $result;
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -129,7 +129,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $this->normalizeDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );
@@ -165,7 +165,7 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$result->{$foreign} => $result];
+            return [$this->normalizeDictionaryKey($result->{$foreign}) => $result];
         })->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -303,6 +303,16 @@ abstract class Relation
     }
 
     /**
+     * Normalize the dictionary key.
+     * @param  mixed  $key - int | string
+     * @return mixed - int | string
+     */
+    protected function normalizeDictionaryKey($key)
+    {
+        return is_string($key) ? strtolower($key) : $key;
+    }
+
+    /**
      * Set or get the morph map for polymorphic relations.
      *
      * @param  array|null  $map


### PR DESCRIPTION
The dictionary keys are case sensitive and therefore if the foreign keys are strings and differ in both tables, then the records are not mapped properly and loaded.