### PR TITLE
[5.9] Drop Carbon v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",
-        "nesbot/carbon": "^1.26.3 || ^2.0",
+        "nesbot/carbon": "^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.1",
         "illuminate/contracts": "5.9.*",
-        "nesbot/carbon": "^1.26.3 || ^2.0"
+        "nesbot/carbon": "^2.0"
     },
     "conflict": {
         "tightenco/collect": "<5.5.33"

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -56,10 +56,6 @@ class DateFacadeTest extends TestCase
 
     public function testCarbonImmutable()
     {
-        if (! class_exists(CarbonImmutable::class)) {
-            $this->markTestSkipped('Test for Carbon 2 only');
-        }
-
         DateFactory::use(CarbonImmutable::class);
         $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
         DateFactory::use(Carbon::class);

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Support;
 use DateTime;
 use DateTimeInterface;
 use BadMethodCallException;
-use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 use Carbon\Carbon as BaseCarbon;
@@ -87,11 +86,7 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonCanSerializeToJson()
     {
-        $this->assertSame(class_exists(CarbonImmutable::class) ? '2017-06-27T13:14:15.000000Z' : [
-            'date' => '2017-06-27 13:14:15.000000',
-            'timezone_type' => 3,
-            'timezone' => 'UTC',
-        ], $this->now->jsonSerialize());
+        $this->assertSame('2017-06-27T13:14:15.000000Z', $this->now->jsonSerialize());
     }
 
     public function testSetStateReturnsCorrectType()


### PR DESCRIPTION
Carbon v1 is now warning to drop support and upgrade to v2 instead so it's best that we drop support for it in newer versions. See https://github.com/briannesbitt/Carbon/issues/1685
