### PR TITLE
[5.8] Add support for containsAll in Str:contains

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -104,7 +104,7 @@ class Str
      */
     public static function contains($haystack, $needles, $containsAll = false)
     {
-        if (!$containsAll) {
+        if (! $containsAll) {
             foreach ((array) $needles as $needle) {
                 if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                     return true;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -99,14 +99,23 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $containsAll
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $containsAll = false)
     {
-        foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
-                return true;
+        if (!$containsAll) {
+            foreach ((array)$needles as $needle) {
+                if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+                    return true;
+                }
             }
+
+            return false;
+        }
+
+        if (count((array)$needles) == count(array_intersect(explode(' ', strtolower($haystack)), (array)$needles))) {
+            return true;
         }
 
         return false;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -105,7 +105,7 @@ class Str
     public static function contains($haystack, $needles, $containsAll = false)
     {
         if (!$containsAll) {
-            foreach ((array)$needles as $needle) {
+            foreach ((array) $needles as $needle) {
                 if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                     return true;
                 }
@@ -114,7 +114,7 @@ class Str
             return false;
         }
 
-        if (count((array)$needles) == count(array_intersect(explode(' ', strtolower($haystack)), (array)$needles))) {
+        if (count((array) $needles) == count(array_intersect(explode(' ', strtolower($haystack)), (array) $needles))) {
             return true;
         }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -127,6 +127,11 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
+        $this->assertTrue(Str::contains('taylor otwell', ['taylor', 'otwell'], true));
+        $this->assertTrue(Str::contains('taylor otwell', 'taylor', true));
+        $this->assertFalse(Str::contains('taylor otwell', 'xxx', true));
+        $this->assertTrue(Str::contains('taylor otwell', ['taylor'], true));
+        $this->assertFalse(Str::contains('taylor otwell', ['taylor', 'xxx'], true));
     }
 
     public function testParseCallback()


### PR DESCRIPTION
Hi everyone,

Every now and then I run into a dilemma where I want to check if an array of values is contained within a string.

This adds the functionality to check for all array values inside a string.

Check out the tests to see all the supported scenarios.

I hope you guys find this useful, too 🙂
