### PR TITLE
[5.8] [Proposal] Add where empty clauses

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1034,6 +1034,57 @@ class Builder
     }
 
     /**
+     * Add a "where nullif" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $boolean
+     * @param  bool    $not
+     * @return $this
+     */
+    public function whereEmpty($column, $boolean = 'and', $not = false)
+    {
+        $type = $not ? 'NotEmpty' : 'Empty';
+
+        $this->wheres[] = compact('type', 'column', 'boolean');
+
+        return $this;
+    }
+
+    /**
+     * Add an "or where nullif" clause to the query.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereEmpty($column)
+    {
+        return $this->whereEmpty($column, 'or');
+    }
+
+    /**
+     * Add a "where not nullif" clause to the query.
+     *
+     * @param  string  $column
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function whereNotEmpty($column, $boolean = 'and')
+    {
+        return $this->whereEmpty($column, $boolean, true);
+    }
+
+    /**
+     * Add a "or where not nullif" clause to the query.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Query\Builder|static
+     */
+    public function orWhereNotEmpty($column)
+    {
+        return $this->whereNotEmpty($column, 'or');
+    }
+
+    /**
      * Add a where between statement to the query.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -364,6 +364,32 @@ class Grammar extends BaseGrammar
     }
 
     /**
+     * Compile a where nullif clause.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array                              $where
+     *
+     * @return string
+     */
+    protected function whereEmpty(Builder $query, $where)
+    {
+        return 'nullif ('.$this->wrap($where['column']).', '.$this->quoteString('').') is null';
+    }
+
+    /**
+     * Compile a where nullif clause.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array                              $where
+     *
+     * @return string
+     */
+    protected function whereNotEmpty(Builder $query, $where)
+    {
+        return 'nullif ('.$this->wrap($where['column']).', '.$this->quoteString('').') is not null';
+    }
+
+    /**
      * Compile a "between" where clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -366,9 +366,8 @@ class Grammar extends BaseGrammar
     /**
      * Compile a where nullif clause.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array                              $where
-     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereEmpty(Builder $query, $where)
@@ -379,9 +378,8 @@ class Grammar extends BaseGrammar
     /**
      * Compile a where nullif clause.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param array                              $where
-     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return string
      */
     protected function whereNotEmpty(Builder $query, $where)

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -971,6 +971,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testBasicWhereEmpties()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereEmpty('id');
+        $this->assertEquals('select * from "users" where nullif ("id", \'\') is null', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereEmpty('id');
+        $this->assertEquals('select * from "users" where "id" = ? or nullif ("id", \'\') is null', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
+    public function testBasicWhereNotEmpties()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotEmpty('id');
+        $this->assertEquals('select * from "users" where nullif ("id", \'\') is not null', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotEmpty('id');
+        $this->assertEquals('select * from "users" where "id" > ? or nullif ("id", \'\') is not null', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testGroupBys()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This PR is a proposal to add where empty clauses.
Instead of using a combination of `where` and `orWhereNull` to handle empty columns like this:

```php
DB::table('users')
    ->where('title', '=', '')
    ->orWhereNull('title');
```

Or even using a where closure with another clause:
```php
DB::table('users')
    ->where('id', '>', 1)
    ->where(function(Builder $query) {
        $query->where('title', '=', '');
        $query->orWhereNull('title');
    });
```

We can just handle it by using this way:
```php
DB::table('users')->whereEmpty('title');
```