### PR TITLE
[5.8] update toResponse return type

### DIFF
--- a/src/Illuminate/Contracts/Support/Responsable.php
+++ b/src/Illuminate/Contracts/Support/Responsable.php
@@ -8,7 +8,7 @@ interface Responsable
      * Create an HTTP response that represents the object.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function toResponse($request);
 }


### PR DESCRIPTION
The current docblock specifies an `\Illuminate\Http\Response` return type, however a bunch of Laravel core response types and helper methods do not extend this class, i.e.

- `\Illuminate\Http\JsonResponse`
- `\Illuminate\Http\RedirectResponse` 
- `\Symfony\Component\HttpFoundation\BinaryFileResponse` via `response()->download()`
- `\Symfony\Component\HttpFoundation\StreamedResponse` via `response()->streamDownload()`
- etc

```php
public function toResponse($request)
{
    return response()->download(...);
}
```

The \Illuminate\Http\Response also extends this Symfony class, so this should cover everything.

P.S. sorry about the docblock PR - I come in peace ✌️