### PR TITLE
[5.5] Fix mapping eagerly loaded multiple related records in eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -236,7 +236,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
+            if (isset($dictionary[$key = $this->normalizeDictionaryKey($model->{$this->parentKey})])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );
@@ -260,7 +260,8 @@ class BelongsToMany extends Relation
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->{$this->accessor}->{$this->foreignPivotKey}][] = $result;
+            $normalizedKey = $this->normalizeDictionaryKey($result->{$this->accessor}->{$this->foreignPivotKey});
+            $dictionary[$normalizedKey][] = $result;
         }
 
         return $dictionary;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -129,7 +129,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $this->normalizeDictionaryKey($model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );
@@ -165,7 +165,7 @@ abstract class HasOneOrMany extends Relation
         $foreign = $this->getForeignKeyName();
 
         return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$result->{$foreign} => $result];
+            return [$this->normalizeDictionaryKey($result->{$foreign}) => $result];
         })->all();
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -303,6 +303,16 @@ abstract class Relation
     }
 
     /**
+     * Normalize the dictionary key.
+     * @param  mixed  $key - int | string
+     * @return mixed - int | string
+     */
+    protected function normalizeDictionaryKey($key)
+    {
+        return is_string($key) ? strtolower($key) : $key;
+    }
+
+    /**
      * Set or get the morph map for polymorphic relations.
      *
      * @param  array|null  $map

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -304,8 +304,8 @@ abstract class Relation
 
     /**
      * Normalize the dictionary key.
-     * @param  mixed  $key - int | string
-     * @return mixed - int | string
+     * @param  string|mixed  $key
+     * @return string|mixed
      */
     protected function normalizeDictionaryKey($key)
     {

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -118,28 +118,28 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         Schema::dropIfExists('labels');
         Schema::dropIfExists('items_labels');
 
-        \DB::statement("CREATE TABLE items (
+        \DB::statement('CREATE TABLE items (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             uuid TEXT unique NOT NULL COLLATE NOCASE,
             title TEXT,
             created_at DATETIME,
             updated_at DATETIME
-        )");
+        )');
 
-        \DB::statement("CREATE TABLE labels (
+        \DB::statement('CREATE TABLE labels (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT,
             created_at DATETIME,
             updated_at DATETIME
-        )");
+        )');
 
-        \DB::statement("CREATE TABLE items_labels (
+        \DB::statement('CREATE TABLE items_labels (
             item_uuid TEXT NOT NULL COLLATE NOCASE,
             label_id INTEGER NOT NULL,
-            flag TEXT DEFAULT '',
+            flag TEXT DEFAULT \'\',
             created_at DATETIME,
             updated_at DATETIME
-        )");
+        )');
 
         Carbon::setTestNow(
             Carbon::createFromFormat('Y-m-d H:i:s', '2019-05-31 10:10:10')

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -157,7 +157,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             $label3->id => ['flag' => 'exclude'],
         ]);
 
-        // Tags with flag = exclude should be excluded
+        // Labels with flag = exclude should be excluded
         $this->assertCount(2, $item->labels);
         $this->assertInstanceOf(Collection::class, $item->labels);
         $this->assertEquals($label->name, $item->labels[0]->name);
@@ -190,7 +190,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         // Testing on the pivot model
         $this->assertInstanceOf(Pivot::class, $item->labels[0]->pivot);
-        // assert that the keys are kept as they are in the DB (ABC vs abc)
+        // Assert that the keys are kept as they are in the DB (ABC vs abc)
         $this->assertNotEquals($item->uuid, $item->labels[0]->pivot->item_uuid);
         $this->assertEquals(strtolower($item->uuid), strtolower($item->labels[0]->pivot->item_uuid));
         $this->assertEquals('item_uuid', $item->labels[0]->pivot->getForeignKey());
@@ -203,6 +203,18 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             ],
             $item->labels[0]->pivot->toArray()
         );
+
+        // reverse test
+        $label = Label::with('items')->find(1);
+
+        $this->assertCount(1, $label->items);
+        $this->assertInstanceOf(Collection::class, $label->items);
+        $this->assertEquals($item->uuid, $label->items[0]->uuid);
+        // Testing on the pivot model
+        $this->assertInstanceOf(Pivot::class, $label->items[0]->pivot);
+        // Assert that the keys are kept as they are in the DB (ABC vs abc)
+        $this->assertNotEquals($item->uuid, $label->items[0]->pivot->item_uuid);
+        $this->assertEquals(strtolower($item->uuid), strtolower($label->items[0]->pivot->item_uuid));
     }
 
     /**
@@ -790,7 +802,7 @@ class Label extends Model
 
     public function items()
     {
-        return $this->belongsToMany(Item::class, 'items_labels', 'label_id', 'item_uuid');
+        return $this->belongsToMany(Item::class, 'items_labels', 'label_id', 'item_uuid', 'id', 'uuid');
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -111,7 +111,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $connection = Schema::getConnection();
 
         if ($connection->getDriverName() != 'sqlite') {
-            $this->markTestSkipped("DB needs to be configured with sqlite");
+            $this->markTestSkipped('DB needs to be configured with sqlite');
         }
 
         Schema::dropIfExists('items');


### PR DESCRIPTION
The pull request does not include any breaking changes. It does not introduce any new features but simply converts the dictionary key to lowercase (if the foreign key values are varchars instead of integers).
In cases when the relationships define foreign keys as strings and the values of the foreign keys differ in terms of uppercase/lowercase then the eagerly loaded multiple records would fail to be mapped/attached to the parent record.
The dictionary technique of mapping the related data is transitional and therefore its mapping keys do not affect anyhow the DB records at the end.

**Consider the following example:**

**Items table**
| uuid      | name    |
|--------|-------- |
| ABC      | First      |
| bbb      | Second |
| ccc       | Third     |

**Labels table**
| id   | name   |
|----|--------|
| 1    | label 1  |
| 2   | label 2  |
| 3   | label 3  |

**items_labels table**
| item_uuid | label_id |
|-----------|--------|
| ABC          | 1           |
| abc           | 2           |
| bbb          | 3           |


`Item::with('labels')->find('ABC');`

MySQL collation by default is case-insensitive and the SQL statements would return both label 1 and label 2 but prior to the fix only label 1 would be mapped and attached (via the dictionary technique) to the item record.
After the fix I am proposing, both label 1 and label 2 would be attached to the item record.

For case sensitive DB collations (like SQLite by default or MySQL `_cs` collations) the fix would not matter but would not break anything either.

@taylorotwell, I included an integration test and had to define the SQLite table columns via raw statements. I could not find a better way to define the collation of the columns via the schema builder.
