### PR TITLE
[5.8] Add `findBy` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1367,7 +1367,7 @@ class Builder
         }
 
         if (Str::startsWith($method, 'find')) {
-            return $this->findBy(strtolower(substr($method, 4)), ...$parameters);
+            return $this->findBy(Str::snake(substr($method, 4)), ...$parameters);
         }
 
         $this->forwardCallTo($this->query, $method, $parameters);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -390,6 +390,19 @@ class Builder
     }
 
     /**
+     * Find a model by a specified key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @param  array  $columns
+     * @return mixed
+     */
+    public function findBy($key, $value, $columns = ['*'])
+    {
+        return $this->where($key, $value)->first($columns);
+    }
+
+    /**
      * Get the first record matching the attributes or instantiate it.
      *
      * @param  array  $attributes
@@ -1351,6 +1364,10 @@ class Builder
 
         if (in_array($method, $this->passthru)) {
             return $this->toBase()->{$method}(...$parameters);
+        }
+
+        if (Str::startsWith($method, 'find')) {
+            return $this->findBy(strtolower(substr($method, 4)), ...$parameters);
         }
 
         $this->forwardCallTo($this->query, $method, $parameters);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -159,6 +159,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals('baz', $result);
     }
 
+    public function testFindByMethod()
+    {
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
+
+        $result = $builder->findBy('foo', 'bar', ['column']);
+        $this->assertEquals('baz', $result);
+    }
+
     public function testFirstMethod()
     {
         $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);


### PR DESCRIPTION
Added a `findBy` method that you can use it when you want to find with a different key than `getKey()`
```
//before
User::where('name', 'John Doe')->first();
User::where('email', 'johndoe@email.com')->first();

//after
User::findName('John Doe');
User::findEmail('johndoe@email.com');
```