### PR TITLE
[5.8] Use ClusterInterface instead of PredisCluster

### DIFF
--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -4,7 +4,7 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Predis\Command\ServerFlushDatabase;
-use Predis\Connection\Aggregate\PredisCluster;
+use Predis\Connection\Aggregate\ClusterInterface;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 
 /**
@@ -53,7 +53,7 @@ class PredisConnection extends Connection implements ConnectionContract
      */
     public function flushdb()
     {
-        if (! $this->client->getConnection() instanceof PredisCluster) {
+        if (! $this->client->getConnection() instanceof ClusterInterface) {
             return $this->command('flushdb');
         }
 


### PR DESCRIPTION
### The issue

There is an issue when running the `artisan cache:clear` command with a redis cluster using the Predis library:

```bash
php artisan cache:clear

Predis\NotSupportedException  : Cannot use 'FLUSHDB' with redis-cluster.
```

### The reason why

There is logic to check whether the connection is using a cluster or single node, which determines how the flush command should be executed. However the condition for this check isn't working correctly.

The current logic checks to see if the connection is an instance of `Predis\Connection\Aggregate\PredisCluster`, however when I was debugging the error I noticed the instance I got was of `Predis\Connection\Aggregate\RedisCluster`.

### The proposed solution

Both of these classes implement the `Predis\Connection\Aggregate\ClusterInterface` interface, so by checking if the connection is an instance of this interface instead, the error no longer occurs.

### Supporting info
My Redis config in `config/database.php` is:
```php
'redis' => [
    'client' => 'predis',

    'options' => [
        'cluster' => 'redis',
    ],

    'clusters' => [
        'default' => [
            'parameters' => [
                'host' => '127.0.0.1',
                'password' => null,
                'port' => 6379,
            ],
        ],
    ],

],
```