### PR TITLE
[5.9] Default path in Applications contract

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -17,9 +17,10 @@ interface Application extends Container
     /**
      * Get the base path of the Laravel installation.
      *
+     * @param  string  $path
      * @return string
      */
-    public function basePath();
+    public function basePath($path = '');
 
     /**
      * Get the path to the bootstrap directory.


### PR DESCRIPTION
~Use the Application methods define in the contract when possible and~ change `basePath` in the contract to reflect the usage in Foundation Application.

---

It's strange to depend sometimes on container's paths (like `app('path.storage')`) and sometimes on Application methods. Could we simplify the Application contract in the next release to remove `xxxPath` methods and use the paths bind in the container everywhere ?

I myself implement a custom Application using the Contract and it would be cool to be able to run and develop extensions using the Contract only.
