### PR TITLE
[5.9] Change replaceClass return

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -159,7 +159,9 @@ abstract class GeneratorCommand extends Command
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+        $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+
+        return $stub;
     }
 
     /**
@@ -196,13 +198,15 @@ abstract class GeneratorCommand extends Command
      *
      * @param  string  $stub
      * @param  string  $name
-     * @return string
+     * @return $this
      */
-    protected function replaceClass($stub, $name)
+    protected function replaceClass(&$stub, $name)
     {
         $class = str_replace($this->getNamespace($name).'\\', '', $name);
 
-        return str_replace('DummyClass', $class, $stub);
+        $stub = str_replace('DummyClass', $class, $stub);
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -34,13 +34,15 @@ class ConsoleMakeCommand extends GeneratorCommand
      *
      * @param  string  $stub
      * @param  string  $name
-     * @return string
+     * @return $this
      */
-    protected function replaceClass($stub, $name)
+    protected function replaceClass(&$stub, $name)
     {
-        $stub = parent::replaceClass($stub, $name);
+        parent::replaceClass($stub, $name);
 
-        return str_replace('dummy:command', $this->option('command'), $stub);
+        str_replace('dummy:command', $this->option('command'), $stub);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
> More details see [PR #28712](https://github.com/laravel/framework/pull/28712)

PR Intention:

In file `src/Illuminate/Console/GeneratorCommand.php`,

```php
    protected function replaceClass($stub, $name)
    {
        $class = str_replace($this->getNamespace($name).'\\', '', $name);

        return str_replace('DummyClass', $class, $stub);
    }

    protected function replaceNamespace(&$stub, $name)
    {
        $stub = str_replace(
            ['DummyNamespace', 'DummyRootNamespace', 'NamespacedDummyUserModel'],
            [$this->getNamespace($name), $this->rootNamespace(), $this->userProviderModel()],
            $stub
        );

        return $this;
    }
```

we have to replace the content in order:
```php
// in method buildClass
$this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
```
----
Think about this, if we want to replace more rules in furture

```php
$this->replaceRule1()->replaceRule2()->replaceRule3();
```

So, it's better to call `replace` methods without specific order.



<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
