### PR TITLE
[5.8] Fix DocBlock missing null $table argument type in MigrationCreator

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -39,7 +39,7 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $path
-     * @param  string  $table
+     * @param  string|null  $table
      * @param  bool    $create
      * @return string
      *
@@ -85,7 +85,7 @@ class MigrationCreator
     /**
      * Get the migration stub file.
      *
-     * @param  string  $table
+     * @param  string|null  $table
      * @param  bool    $create
      * @return string
      */
@@ -108,7 +108,7 @@ class MigrationCreator
      *
      * @param  string  $name
      * @param  string  $stub
-     * @param  string  $table
+     * @param  string|null  $table
      * @return string
      */
     protected function populateStub($name, $stub, $table)
@@ -151,7 +151,7 @@ class MigrationCreator
     /**
      * Fire the registered post create hooks.
      *
-     * @param  string  $table
+     * @param  string|null  $table
      * @return void
      */
     protected function firePostCreateHooks($table)


### PR DESCRIPTION
`null` type is missing in DocBlocks where `$table` argument is passing.