### PR TITLE
[5.8] Add missing throws in MigrationCreator getStub method

### DIFF
--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -88,6 +88,8 @@ class MigrationCreator
      * @param  string  $table
      * @param  bool    $create
      * @return string
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     protected function getStub($table, $create)
     {


### PR DESCRIPTION
Declare that `\Illuminate\Contracts\Filesystem\FileNotFoundException` exception could be thrown, as stated in Filesystem `get` method.