### PR TITLE
[5.8] Fix Illuminate\Contracts null arguments in DocBlocks

### DIFF
--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -10,8 +10,8 @@ interface Factory
      * @param  string  $name
      * @param  string  $value
      * @param  int     $minutes
-     * @param  string  $path
-     * @param  string  $domain
+     * @param  string|null  $path
+     * @param  string|null  $domain
      * @param  bool|null    $secure
      * @param  bool    $httpOnly
      * @param  bool         $raw
@@ -25,8 +25,8 @@ interface Factory
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  string  $path
-     * @param  string  $domain
+     * @param  string|null  $path
+     * @param  string|null  $domain
      * @param  bool|null    $secure
      * @param  bool    $httpOnly
      * @param  bool         $raw
@@ -39,8 +39,8 @@ interface Factory
      * Expire the given cookie.
      *
      * @param  string  $name
-     * @param  string  $path
-     * @param  string  $domain
+     * @param  string|null  $path
+     * @param  string|null  $domain
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
     public function forget($name, $path = null, $domain = null);

--- a/src/Illuminate/Contracts/Filesystem/Factory.php
+++ b/src/Illuminate/Contracts/Filesystem/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a filesystem implementation.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public function disk($name = null);

--- a/src/Illuminate/Contracts/Mail/MailQueue.php
+++ b/src/Illuminate/Contracts/Mail/MailQueue.php
@@ -8,7 +8,7 @@ interface MailQueue
      * Queue a new e-mail message for sending.
      *
      * @param  string|array|\Illuminate\Contracts\Mail\Mailable  $view
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     public function queue($view, $queue = null);
@@ -18,7 +18,7 @@ interface MailQueue
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|array|\Illuminate\Contracts\Mail\Mailable  $view
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     public function later($delay, $view, $queue = null);

--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -34,7 +34,7 @@ interface Mailer
      *
      * @param  string|array|\Illuminate\Contracts\Mail\Mailable  $view
      * @param  array  $data
-     * @param  \Closure|string  $callback
+     * @param  \Closure|string|null  $callback
      * @return void
      */
     public function send($view, array $data = [], $callback = null);

--- a/src/Illuminate/Contracts/Queue/Factory.php
+++ b/src/Illuminate/Contracts/Queue/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Resolve a queue connection instance.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Contracts\Queue\Queue
      */
     public function connection($name = null);

--- a/src/Illuminate/Contracts/Queue/Queue.php
+++ b/src/Illuminate/Contracts/Queue/Queue.php
@@ -7,7 +7,7 @@ interface Queue
     /**
      * Get the size of the queue.
      *
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return int
      */
     public function size($queue = null);
@@ -17,7 +17,7 @@ interface Queue
      *
      * @param  string|object  $job
      * @param  mixed   $data
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     public function push($job, $data = '', $queue = null);
@@ -36,7 +36,7 @@ interface Queue
      * Push a raw payload onto the queue.
      *
      * @param  string  $payload
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @param  array   $options
      * @return mixed
      */
@@ -48,7 +48,7 @@ interface Queue
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
      * @param  mixed   $data
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null);
@@ -69,7 +69,7 @@ interface Queue
      *
      * @param  array   $jobs
      * @param  mixed   $data
-     * @param  string  $queue
+     * @param  string|null  $queue
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null);

--- a/src/Illuminate/Contracts/Redis/Factory.php
+++ b/src/Illuminate/Contracts/Redis/Factory.php
@@ -7,7 +7,7 @@ interface Factory
     /**
      * Get a Redis connection by name.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection($name = null);

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -24,7 +24,7 @@ interface UrlGenerator
      *
      * @param  string  $path
      * @param  mixed  $extra
-     * @param  bool  $secure
+     * @param  bool|null  $secure
      * @return string
      */
     public function to($path, $extra = [], $secure = null);
@@ -42,7 +42,7 @@ interface UrlGenerator
      * Generate the URL to an application asset.
      *
      * @param  string  $path
-     * @param  bool    $secure
+     * @param  bool|null  $secure
      * @return string
      */
     public function asset($path, $secure = null);

--- a/src/Illuminate/Contracts/Support/MessageBag.php
+++ b/src/Illuminate/Contracts/Support/MessageBag.php
@@ -39,8 +39,8 @@ interface MessageBag extends Arrayable
     /**
      * Get the first message from the bag for a given key.
      *
-     * @param  string  $key
-     * @param  string  $format
+     * @param  string|null  $key
+     * @param  string|null  $format
      * @return string
      */
     public function first($key = null, $format = null);
@@ -49,7 +49,7 @@ interface MessageBag extends Arrayable
      * Get all of the messages from the bag for a given key.
      *
      * @param  string  $key
-     * @param  string  $format
+     * @param  string|null  $format
      * @return array
      */
     public function get($key, $format = null);
@@ -57,7 +57,7 @@ interface MessageBag extends Arrayable
     /**
      * Get all of the messages for every key in the bag.
      *
-     * @param  string  $format
+     * @param  string|null  $format
      * @return array
      */
     public function all($format = null);

--- a/src/Illuminate/Contracts/Translation/Loader.php
+++ b/src/Illuminate/Contracts/Translation/Loader.php
@@ -9,7 +9,7 @@ interface Loader
      *
      * @param  string  $locale
      * @param  string  $group
-     * @param  string  $namespace
+     * @param  string|null  $namespace
      * @return array
      */
     public function load($locale, $group, $namespace = null);

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -9,7 +9,7 @@ interface Translator
      *
      * @param  string  $key
      * @param  array   $replace
-     * @param  string  $locale
+     * @param  string|null  $locale
      * @return mixed
      */
     public function trans($key, array $replace = [], $locale = null);
@@ -20,7 +20,7 @@ interface Translator
      * @param  string  $key
      * @param  int|array|\Countable  $number
      * @param  array   $replace
-     * @param  string  $locale
+     * @param  string|null  $locale
      * @return string
      */
     public function transChoice($key, $number, array $replace = [], $locale = null);

--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -20,7 +20,7 @@ interface Factory
      *
      * @param  string  $rule
      * @param  \Closure|string  $extension
-     * @param  string  $message
+     * @param  string|null  $message
      * @return void
      */
     public function extend($rule, $extension, $message = null);
@@ -30,7 +30,7 @@ interface Factory
      *
      * @param  string   $rule
      * @param  \Closure|string  $extension
-     * @param  string  $message
+     * @param  string|null  $message
      * @return void
      */
     public function extendImplicit($rule, $extension, $message = null);


### PR DESCRIPTION
In continue to #28720 I've searched through all the Illuminate\Contracts namespace and fixed DocBlocks for null argument types issues.