### PR TITLE
[5.8] Remove unused Migrator $notes dynamic property

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -94,8 +94,6 @@ class Migrator
      */
     public function run($paths = [], array $options = [])
     {
-        $this->notes = [];
-
         // Once we grab all of the migration files for the path, we will compare them
         // against the migrations that have already been run for this package then
         // run each of the outstanding migrations against a database connection.
@@ -213,8 +211,6 @@ class Migrator
      */
     public function rollback($paths = [], array $options = [])
     {
-        $this->notes = [];
-
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.
@@ -294,8 +290,6 @@ class Migrator
      */
     public function reset($paths = [], $pretend = false)
     {
-        $this->notes = [];
-
         // Next, we will reverse the migration list so we can run them back in the
         // correct order for resetting this database. This will allow us to get
         // the database back into its "empty" state ready for the migrations.


### PR DESCRIPTION
Migrator class has dynamic `$this->notes` property, which not using.
It looks like legacy code because there is `note` method, but it uses `$this->output` to write notes.

```php
protected function note($message)
{
    if ($this->output) {
        $this->output->writeln($message);
    }
}
```