### PR TITLE
[5.8] Remove unused argument from DateFactory useDefault docblock

### DIFF
--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -134,7 +134,6 @@ class DateFactory
     /**
      * Use the default date class when generating dates.
      *
-     * @param  callable  $callable
      * @return void
      */
     public static function useDefault()


### PR DESCRIPTION
Method `useDefault` was introduced in commit: https://github.com/laravel/framework/commit/5264832eb3ec4607d055a017e3762493b2d16856#diff-ce42eb98bed63cd105c92c7e3e712b4b

It has unused argument $callable in DocBlock. It seems like copy-paste by mistake from `useCallable` method.