### PR TITLE
[5.8] Remove restore method from SoftDeletes annotation

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -6,7 +6,6 @@ namespace Illuminate\Database\Eloquent;
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
- * @method bool restore()
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
Method already exists in trait, there is no need to duplicate it in annotation.

It was introduced in recent commit: https://github.com/laravel/framework/commit/7b91285cf7c100b07bf3e277bc0acb3e0598b7aa#diff-b565fe8ac473cfd17864956b2f146308