### PR TITLE
[5.8] Fix Database Query Builder dynamicWhere method $parameters type

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1609,7 +1609,7 @@ class Builder
      * Handles dynamic "where" clauses to the query.
      *
      * @param  string  $method
-     * @param  string  $parameters
+     * @param  array  $parameters
      * @return $this
      */
     public function dynamicWhere($method, $parameters)


### PR DESCRIPTION
`dynamicWhere` method accepts arrays only, because under the hood it calls `addDynamic` method where `$parameters` used as array:
```php
$this->where(Str::snake($segment), '=', $parameters[$index], $bool);
```

It's a possible place where `array` typehints should be added to methods. But I'm not sure if it wouldn't break some magical stuff.