### PR TITLE
[5.8] Fix exception type in Database Connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -700,13 +700,13 @@ class Connection implements ConnectionInterface
     /**
      * Handle a query exception.
      *
-     * @param  \Exception  $e
+     * @param  \Illuminate\Database\QueryException  $e
      * @param  string  $query
      * @param  array  $bindings
      * @param  \Closure  $callback
      * @return mixed
      *
-     * @throws \Exception
+     * @throws \Illuminate\Database\QueryException
      */
     protected function handleQueryException($e, $query, $bindings, Closure $callback)
     {

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -708,7 +708,7 @@ class Connection implements ConnectionInterface
      *
      * @throws \Illuminate\Database\QueryException
      */
-    protected function handleQueryException($e, $query, $bindings, Closure $callback)
+    protected function handleQueryException(QueryException $e, $query, $bindings, Closure $callback)
     {
         if ($this->transactions >= 1) {
             throw $e;


### PR DESCRIPTION
Database Connection `handleQueryException` method executes only in case when `QueryException` is caught in `run` method.

`QueryException` typehint could be safely added because this method calls `tryAgainIfCausedByLostConnection` method, which already has such typehint.