### PR TITLE
[5.8] Fix PostgresGrammar DocBlocks parameters types

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -200,7 +200,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the SQL needed to drop all tables.
      *
-     * @param  string  $tables
+     * @param  array  $tables
      * @return string
      */
     public function compileDropAllTables($tables)
@@ -211,7 +211,7 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the SQL needed to drop all views.
      *
-     * @param  string  $views
+     * @param  array  $views
      * @return string
      */
     public function compileDropAllViews($views)


### PR DESCRIPTION
`compileDropAllTables` & `compileDropAllViews` methods must receive parameters of `array` type because it's used in `implode` method.

These methods are candidates to add `array` typehints.