### PR TITLE
[5.8] Fix MailFake raw method DocBlock return type

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -267,7 +267,7 @@ class MailFake implements Mailer, MailQueue
      *
      * @param  string  $text
      * @param  \Closure|string  $callback
-     * @return int
+     * @return void
      */
     public function raw($text, $callback)
     {


### PR DESCRIPTION
`MailFake` class `raw` method should return `void` to match `Illuminate\Contracts\Mail\Mailer` contract.