### PR TITLE
[5.8] Fix return type of Session Store save method

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -36,7 +36,7 @@ interface Session
     /**
      * Save the session data to storage.
      *
-     * @return bool
+     * @return void
      */
     public function save();
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -119,7 +119,7 @@ class Store implements Session
     /**
      * Save the session data to storage.
      *
-     * @return bool
+     * @return void
      */
     public function save()
     {


### PR DESCRIPTION
`\Illuminate\Contracts\Session\Session` contract defines that `save` method should return `bool`, but in fact we have only single implementation and it returns `void`.

I don't know should it be targeted to 5.9 or 5.8.