### PR TITLE
[5.8] Reworked env to allow getenv/putenv to be disabled

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -3,13 +3,10 @@
 namespace Illuminate\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
-use Dotenv\Environment\DotenvFactory;
+use Illuminate\Support\Env;
 use Dotenv\Exception\InvalidFileException;
-use Dotenv\Environment\Adapter\PutenvAdapter;
 use Symfony\Component\Console\Input\ArgvInput;
-use Dotenv\Environment\Adapter\EnvConstAdapter;
 use Illuminate\Contracts\Foundation\Application;
-use Dotenv\Environment\Adapter\ServerConstAdapter;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class LoadEnvironmentVariables
@@ -89,7 +86,7 @@ class LoadEnvironmentVariables
         return Dotenv::create(
             $app->environmentPath(),
             $app->environmentFile(),
-            new DotenvFactory([new EnvConstAdapter, new ServerConstAdapter, new PutenvAdapter])
+            Env::getFactory()
         );
     }
 

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -69,7 +69,7 @@ class Env
                 static::$putenv ? [new PutenvAdapter] : []
             );
 
-            static::$factory = (new DotenvFactory($adapters))
+            static::$factory = new DotenvFactory($adapters);
         }
 
         return static::$factory;

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Illuminate\Support;
 
 use PhpOption\Option;

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -1,0 +1,128 @@
+<?php
+
+
+namespace Illuminate\Support;
+
+use PhpOption\Option;
+use Dotenv\Environment\DotenvFactory;
+use Dotenv\Environment\Adapter\PutenvAdapter;
+use Dotenv\Environment\Adapter\EnvConstAdapter;
+use Dotenv\Environment\Adapter\ServerConstAdapter;
+
+class Env
+{
+    /**
+     * If the putenv adapter is enabled.
+     *
+     * @var bool
+     */
+    protected static $putenv = true;
+
+    /**
+     * The environment factory instance.
+     *
+     * @var \Dotenv\Environment\FactoryInterface|null
+     */
+    protected static $factory;
+
+    /**
+     * The environment variables instance.
+     *
+     * @var \Dotenv\Environment\VariablesInterface|null
+     */
+    protected static $variables;
+
+    /**
+     * Enable the putenv adapter.
+     *
+     * @var bool
+     */
+    public static function enablePutenv()
+    {
+        static::$putenv = true;
+        static::$factory = null;
+        static::$variables = null;
+    }
+
+    /**
+     * Disable the putenv adapter.
+     *
+     * @var bool
+     */
+    public static function disablePutenv()
+    {
+        static::$putenv = false;
+        static::$factory = null;
+        static::$variables = null;
+    }
+
+    /**
+     * Get the environment factory instance.
+     *
+     * @return \Dotenv\Environment\FactoryInterface
+     */
+    public static function getFactory()
+    {
+        if (static::$factory === null) {
+            $adapters = array_merge(
+                [new EnvConstAdapter, new ServerConstAdapter],
+                static::$putenv ? [new PutenvAdapter] : []
+            );
+
+            static::$factory = (new DotenvFactory($adapters))
+        }
+
+        return static::$factory;
+    }
+
+    /**
+     * Get the environment variables instance.
+     *
+     * @return \Dotenv\Environment\VariablesInterface
+     */
+    public static function getVariables()
+    {
+        if (static::$variables === null) {
+            static::$variables = static::getFactory()->createImmutable();
+        }
+
+        return static::$variables;
+    }
+
+    /**
+     * Gets the value of an environment variable.
+     *
+     * @param  string  $key
+     * @param  mixed   $default
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        return Option::fromValue(static::getVariables()->get($key))
+            ->map(function ($value) {
+                switch (strtolower($value)) {
+                    case 'true':
+                    case '(true)':
+                        return true;
+                    case 'false':
+                    case '(false)':
+                        return false;
+                    case 'empty':
+                    case '(empty)':
+                        return '';
+                    case 'null':
+                    case '(null)':
+                        return;
+                }
+
+                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
+                    return $matches[2];
+                }
+
+                return $value;
+            })
+            ->getOrCall(function () use ($default) {
+                return value($default);
+            });
+    }
+}

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -43,7 +43,7 @@
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^4.2).",
         "symfony/var-dumper": "Required to use the dd function (^4.2).",
-        "vlucas/phpdotenv": "Required to use the env helper (^3.3)."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^3.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,16 +1,12 @@
 <?php
 
-use PhpOption\Option;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Illuminate\Support\Optional;
 use Illuminate\Support\Collection;
-use Dotenv\Environment\DotenvFactory;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\HigherOrderTapProxy;
-use Dotenv\Environment\Adapter\PutenvAdapter;
-use Dotenv\Environment\Adapter\EnvConstAdapter;
-use Dotenv\Environment\Adapter\ServerConstAdapter;
 
 if (! function_exists('append_config')) {
     /**
@@ -640,38 +636,7 @@ if (! function_exists('env')) {
      */
     function env($key, $default = null)
     {
-        static $variables;
-
-        if ($variables === null) {
-            $variables = (new DotenvFactory([new EnvConstAdapter, new PutenvAdapter, new ServerConstAdapter]))->createImmutable();
-        }
-
-        return Option::fromValue($variables->get($key))
-            ->map(function ($value) {
-                switch (strtolower($value)) {
-                    case 'true':
-                    case '(true)':
-                        return true;
-                    case 'false':
-                    case '(false)':
-                        return false;
-                    case 'empty':
-                    case '(empty)':
-                        return '';
-                    case 'null':
-                    case '(null)':
-                        return;
-                }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
-            })
-            ->getOrCall(function () use ($default) {
-                return value($default);
-            });
+        return Env::get($key, $default);
     }
 }
 


### PR DESCRIPTION
It is currently not easily possible to disable `putenv` and `getenv`. It is now super easy to disable this by adding `Illuminate\Support\Env::disablePutenv();` to your `bootstrap/app.php` file.

This is particularly important for Lumen apps, where config caching is not available. This PR can be regarded as a security fix affecting Lumen apps running on server shared with any other sites.

---

I really do think that in Laravel 5.9 we should toggle the default from putenv being enabled to being disabled, in the interest of security. Now that it can easily be turned on in the boostrap file, we no longer have the developer experience issues we had before.