### PR TITLE
[5.8] Check presence of force flag in command signature

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -22,7 +22,7 @@ trait ConfirmableTrait
         $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;
 
         if ($shouldConfirm) {
-            if ($this->option('force')) {
+            if ($this->hasOption('force') && $this->option('force')) {
                 return true;
             }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When using the ConfirmableTrait, you get an exception in production if you don't have `force` in the command signature:

    Symfony\Component\Console\Exception\InvalidArgumentException: The "force" option does not exist.

This was a non-obvious error, and caught me by surprise during a deployment -- you'd only get it when your app was in production mode.

This PR makes `force` an optional feature when using ConfirmableTrait.