### PR TITLE
[5.8] Casting of null values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -469,11 +469,13 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        list($type, $argument) = array_pad(explode(':', $this->getCasts()[$key], 2), 2, '');
+
+        if (is_null($value) && $argument !== 'always') {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($type) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -482,7 +484,7 @@ trait HasAttributes
             case 'double':
                 return $this->fromFloat($value);
             case 'decimal':
-                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
+                return $this->asDecimal($value, $argument);
             case 'string':
                 return (string) $value;
             case 'bool':

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -469,7 +469,7 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        list($type, $argument) = array_pad(explode(':', $this->getCasts()[$key], 2), 2, '');
+        [$type, $argument] = array_pad(explode(':', $this->getCasts()[$key], 2), 2, '');
 
         if (is_null($value) && $argument !== 'always') {
             return $value;

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -25,6 +25,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
             $table->json('array_as_json_field')->nullable();
             $table->json('object_as_json_field')->nullable();
             $table->json('collection_as_json_field')->nullable();
+            $table->json('collection_always_as_json_field')->nullable();
         });
     }
 
@@ -74,6 +75,17 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
         $this->assertInstanceOf(Collection::class, $user->collection_as_json_field);
         $this->assertEquals('value1', $user->collection_as_json_field->get('key1'));
     }
+
+    public function test_null_collections_are_castable()
+    {
+        /** @var JsonCast $user */
+        $user = JsonCast::create([
+            'collection_always_as_json_field' => null,
+        ]);
+
+        $this->assertInstanceOf(Collection::class, $user->collection_always_as_json_field);
+        $this->assertCount(0, $user->collection_always_as_json_field);
+    }
 }
 
 /**
@@ -82,6 +94,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
  * @property $array_as_json_field
  * @property $object_as_json_field
  * @property $collection_as_json_field
+ * @property $collection_always_as_json_field
  */
 class JsonCast extends Model
 {
@@ -95,5 +108,6 @@ class JsonCast extends Model
         'array_as_json_field' => 'array',
         'object_as_json_field' => 'object',
         'collection_as_json_field' => 'collection',
+        'collection_always_as_json_field' => 'collection:always',
     ];
 }


### PR DESCRIPTION
### Problem

Currently if I cast a Model attribute as a 'collection' it is possible to get back either a `Collection` object or `null`. This makes it a little more difficult to work with because now you need to constantly check if you have an object before you can call methods on it.

```php
class Show extends Model
{
    protected $casts = [
        'tags' => 'collection',
    ];
}
```

| id | name | tags |
|---|---|---|
| 1 | Donnie Darko | ['suspense', 'thriller', 'teen'] |
| 2 | The Fifth Element | null |
| 3 | Avatar the Last Airbender | ['animation', 'fantasy'] |

If the database contains a valid JSON object, I will get back a `Collection`.  If the database contains `null`, I will get back `null`.

```php
$show1 = (Show::find(1))->tags;
$show2 = (Show::find(2))->tags;
```

`$show1` will return a `Collection` to me with the elements 'suspense', 'thriller', and 'teen'.

`$show2` will return null to me.

Because of this different return type I can't go straight to a `Collection` method without possibly getting an error.

```php
$show2 = (Show::find(2))->tags->contains('suspense');  //results in error
```

This happens because of the greediness of this line:

https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L472

### Solution

I am proposing an argument that can be passed to our castings, similar to how an argument is passed to the 'decimal' cast.

```php
class Show extends Model
{
    protected $casts = [
        'tags' => 'collection:always',
    ];
}
```

By using `collection:always` instead of `collection`, we will **always** receive a `Collection` object from the casting.  If the field is null, we will get an empty `Collection`.