### PR TITLE
[5.8] Fix database rules with WHERE clauses

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -166,7 +166,7 @@ trait DatabaseRule
     protected function formatWheres()
     {
         return collect($this->wheres)->map(function ($where) {
-            return $where['column'].','.$where['value'];
+            return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
         })->implode(',');
     }
 }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -37,11 +37,11 @@ class ValidationExistsRuleTest extends TestCase
     {
         $rule = new Exists('table');
         $rule->where('foo', 'bar');
-        $this->assertEquals('exists:table,NULL,foo,bar', (string) $rule);
+        $this->assertEquals('exists:table,NULL,foo,"bar"', (string) $rule);
 
         $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('exists:table,column,foo,bar', (string) $rule);
+        $this->assertEquals('exists:table,column,foo,"bar"', (string) $rule);
     }
 
     public function testItChoosesValidRecordsUsingWhereInRule()

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -12,36 +12,40 @@ class ValidationUniqueRuleTest extends TestCase
     {
         $rule = new Unique('table');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,NULL,NULL,id,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,NULL,NULL,id,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"Taylor, Otwell",id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell"\'..-"', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,bar', (string) $rule);
-        $this->assertEquals('Taylor, Otwell"\'..-"', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,bar')[2]));
-        $this->assertEquals('id_column', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,bar')[3]));
+        $this->assertEquals('unique:table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"', (string) $rule);
+        $this->assertEquals('Taylor, Otwell"\'..-"', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[2]));
+        $this->assertEquals('id_column', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[3]));
 
         $rule = new Unique('table', 'column');
         $rule->ignore(null, 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,NULL,id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
 
         $model = new EloquentModelStub(['id_column' => 1]);
 
         $rule = new Unique('table', 'column');
         $rule->ignore($model);
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"1",id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore($model, 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"1",id_column,foo,bar', (string) $rule);
+        $this->assertEquals('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
+
+        $rule = new Unique('table');
+        $rule->where('foo', '"bar"');
+        $this->assertEquals('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
     }
 }
 


### PR DESCRIPTION
`exists` and `unique` rules fail if a `WHERE` clause has an empty string value:

```php
Validator::make(
    ['id' => 1],
    ['id' => Rule::exists('users')->where('name', '')]
)->passes();
```

This throws an exception:

> Undefined offset: 1

The error is caused by `rtrim(..., , ',')` in `Exists::__toString()`:

```php
dump((string) Rule::exists('users')->where('name', ''));

// expected: exists:users,NULL,name,
// actual:   exists:users,NULL,name
```

The underlying issue is that `ValidationRuleParser::parseParameters()` parses parameters as CSV, but only receives plain text. This also affects values that can be interpreted as CSV:

```php
Rule::exists('users')->where('name', '"foo"') // where "name" = 'foo'
```

We can fix it by converting all values to CSV as we do with `in` and `notin` rules (#21012).

Fixes #28697.

---

Theoretically, this can be a breaking change if someone works around the issue by providing CSV values:

```php
 Rule::exists('users')->where('name', '""')
```

Do we consider cases like this?