### PR TITLE
[5.8] Sql Server issue with dropAllTables when foreign key constraints exist

### DIFF
--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -268,6 +268,18 @@ class Builder
     }
 
     /**
+     * Drop all foreign keys from the database.
+     *
+     * @return void
+     *
+     * @throws \LogicException
+     */
+    public function dropAllForeignKeys()
+    {
+        throw new LogicException('This database driver does not support dropping all foreign keys.');
+    }
+
+    /**
      * Execute the blueprint to build / modify the table.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -268,18 +268,6 @@ class Builder
     }
 
     /**
-     * Drop all foreign keys from the database.
-     *
-     * @return void
-     *
-     * @throws \LogicException
-     */
-    public function dropAllForeignKeys()
-    {
-        throw new LogicException('This database driver does not support dropping all foreign keys.');
-    }
-
-    /**
      * Execute the blueprint to build / modify the table.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -317,7 +317,7 @@ class SqlServerGrammar extends Grammar
      *
      * @return string
      */
-    public function dropAllForeignKeys()
+    public function compileDropAllForeignKeys()
     {
         return "DECLARE @sql NVARCHAR(MAX) = N'';
             SELECT @sql += 'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(parent_object_id))

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -313,7 +313,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile the command to drop all foreign keys
+     * Compile the command to drop all foreign keys.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -313,6 +313,22 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the command to drop all foreign keys
+     *
+     * @return string
+     */
+    public function dropAllForeignKeys()
+    {
+        return "DECLARE @sql NVARCHAR(MAX) = N'';
+            SELECT @sql += 'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(parent_object_id))
+                + '.' + QUOTENAME(OBJECT_NAME(parent_object_id)) + 
+                ' DROP CONSTRAINT ' + QUOTENAME(name) + ';'
+            FROM sys.foreign_keys;
+            
+            EXEC sp_executesql @sql;";
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -11,7 +11,7 @@ class SqlServerBuilder extends Builder
      */
     public function dropAllTables()
     {
-        $this->connection->statement($this->grammar->dropAllForeignKeys());
+        $this->connection->statement($this->grammar->compileDropAllForeignKeys());
         $this->connection->statement($this->grammar->compileDropAllTables());
     }
 }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -11,10 +11,7 @@ class SqlServerBuilder extends Builder
      */
     public function dropAllTables()
     {
-        $this->disableForeignKeyConstraints();
-
+        $this->connection->statement($this->grammar->dropAllForeignKeys());
         $this->connection->statement($this->grammar->compileDropAllTables());
-
-        $this->enableForeignKeyConstraints();
     }
 }

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -12,6 +12,7 @@ class SqlServerBuilder extends Builder
     public function dropAllTables()
     {
         $this->connection->statement($this->grammar->compileDropAllForeignKeys());
+
         $this->connection->statement($this->grammar->compileDropAllTables());
     }
 }


### PR DESCRIPTION
### Issue
There is an issue with migrations while using a sqlsrv connection. The issue occurs in the SqlServerBuilder->dropAllTables() method when there are foreign key constraints in the database and the database will throw a foreign key constraint exception while running commands like php artisan migrate:fresh. The SqlServerGrammer class returns the following command for this method: EXEC sp_msforeachtable "ALTER TABLE ? NOCHECK CONSTRAINT all"; The problem is that this sql server command only disables the constraints on INSERT and DELETE and does not work for TRUNCATE or DROP TABLE. 

### Solution
The only solution I have found to dropping tables with foreign key constraints in SQL Server is to first drop the foreign keys on every table.

### Reproduction
An example of this issue can be found in the following project when configured with a sqlsrv connection. https://github.com/walliby/sql-server-drop-table-issue. Running phpunit, on the ExampleTest which uses RefreshDatabase will throw a db foreign key constraint error every other time you run the test. The reason the test fails every other time is because it will throw the error on the users table but still drop the role_user table which has the foreign keys. The second time, it will succeed, as the role_user table was deleted by the previous run.