### PR TITLE
[5.8] Added a Blade directory `@includeAll` for dynamic including of views

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -29,6 +29,19 @@ trait CompilesIncludes
     }
 
     /**
+     * Compile the include statements into valid PHP for all views from the specified folder.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeAll($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->renderAll($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
+    }
+
+    /**
      * Compile the include-if statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -199,14 +199,14 @@ class Factory implements FactoryContract
         $path = Str::finish($path, '/');
         $mask = $data['mask'] ?? '*';
 
-        $resource = resource_path('views/' . str_replace('.', '/', $this->normalizeName($path)));
+        $resource = resource_path('views/'.str_replace('.', '/', $this->normalizeName($path)));
         $resource = Str::finish($resource, '/');
 
         $data = array_merge($mergeData, Arr::except($this->parseData($data), ['mask']));
 
-        foreach (glob($resource . $mask) as $view) {
+        foreach (glob($resource.$mask) as $view) {
             $filename = Arr::first(explode('.', pathinfo($view, PATHINFO_FILENAME)));
-            $view = $path . $filename;
+            $view = $path.$filename;
 
             $result .= $this->make($view, $data, $mergeData)->render();
         }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -183,6 +183,38 @@ class Factory implements FactoryContract
     }
 
     /**
+     * Get the rendered content of the view based on a given condition from all files
+     * in the specified folder.
+     *
+     * @param string $path
+     * @param array $data
+     * @param array $mergeData
+     *
+     * @return string
+     */
+    public function renderAll($path, $data = [], $mergeData = [])
+    {
+        $result = '';
+
+        $path = Str::finish($path, '/');
+        $mask = $data['mask'] ?? '*';
+
+        $resource = resource_path('views/' . str_replace('.', '/', $this->normalizeName($path)));
+        $resource = Str::finish($resource, '/');
+
+        $data = array_merge($mergeData, Arr::except($this->parseData($data), ['mask']));
+
+        foreach (glob($resource . $mask) as $view) {
+            $filename = Arr::first(explode('.', pathinfo($view, PATHINFO_FILENAME)));
+            $view = $path . $filename;
+
+            $result .= $this->make($view, $data, $mergeData)->render();
+        }
+
+        return $result;
+    }
+
+    /**
      * Get the rendered contents of a partial from a loop.
      *
      * @param  string  $view

--- a/tests/View/Blade/BladeIncludeAllTest.php
+++ b/tests/View/Blade/BladeIncludeAllTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIncludeAllTest extends AbstractBladeTestCase
+{
+    public function testIncludeAllAreCompiled()
+    {
+        $this->assertEquals('<?php echo $__env->renderAll(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeAll(\'foo\')'));
+        $this->assertEquals('<?php echo $__env->renderAll(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeAll(name(foo))'));
+    }
+}


### PR DESCRIPTION
The function allows you to automatically include all template files from the specified folder.

For example:
```
// resources:
resource
|-views
| - index.blade.php
| - foo
| | - bar
| - | - q1.blade.php
| - | - q2.blade.php
| - | - q3.blade.php
| | - baz
| - | - k3.blade.php
```

```
// resources/views/index.blade.php
// include all files from `resources/views/foo/bar` folder
@includeAll('foo.bar')
```

You can also use a mask:
```
// resources:
resource
|-views
| - index.blade.php
| - foo
| | - q1.blade.php
| | - q2.blade.php
| | - k1.blade.php
| | - k2.blade.php
```

```
// resources/views/index.blade.php
// include `q*` files from `resources/views/foo` folder
//     resources/views/foo/q1.blade.php
//     resources/views/foo/q2.blade.php

@includeAll('foo', ['mask' => 'q*'])

// resources/views/index.blade.php
// include `k*` files from `resources/views/foo` folder
//     resources/views/foo/k1.blade.php
//     resources/views/foo/k2.blade.php

@includeAll('foo', ['mask' => 'k*'])
```

Where does it apply?

In several projects, we often change SEO scripts, so it is not a good idea to prescribe each file manually.
This directive allows you to specify a folder from which all views files will be automatically downloaded.

![2019-06-07_16-04-25](https://user-images.githubusercontent.com/10347617/59106029-036d8e80-893e-11e9-858e-782d2cecd5a6.png)