### PR TITLE
[5.8] Added a Blade directory `@includeAll` for dynamic including of views

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -29,6 +29,19 @@ trait CompilesIncludes
     }
 
     /**
+     * Compile the include statements into valid PHP for all views from the specified folder.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeAll($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->renderAll($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
+    }
+
+    /**
      * Compile the include-if statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -203,7 +203,7 @@ class Factory implements FactoryContract
         $data = array_merge($mergeData, $this->parseData($data));
 
         foreach ($items as $item) {
-            if (!$item->isDir()) {
+            if (! $item->isDir()) {
                 $filename = Arr::first(explode('.', $item->getFilename()));
                 $view = $path.'.'.$filename;
 

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View;
 
+use FilesystemIterator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -180,6 +181,37 @@ class Factory implements FactoryContract
         }
 
         return $this->make($view, $this->parseData($data), $mergeData)->render();
+    }
+
+    /**
+     * Get the rendered content of the view based on a given condition from all files
+     * in the specified folder.
+     *
+     * @param string $path
+     * @param array $data
+     * @param array $mergeData
+     *
+     * @return string
+     */
+    public function renderAll($path, $data = [], $mergeData = [])
+    {
+        $result = '';
+
+        $dir = resource_path('views/'.str_replace('.', '/', $this->normalizeName($path)));
+        $items = new FilesystemIterator($dir);
+
+        $data = array_merge($mergeData, $this->parseData($data));
+
+        foreach ($items as $item) {
+            if (!$item->isDir()) {
+                $filename = Arr::first(explode('.', $item->getFilename()));
+                $view = $path.'.'.$filename;
+
+                $result .= $this->make($view, $data, $mergeData)->render();
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/View/Blade/BladeIncludeAllTest.php
+++ b/tests/View/Blade/BladeIncludeAllTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIncludeAllTest extends AbstractBladeTestCase
+{
+    public function testIncludeAllAreCompiled()
+    {
+        $this->assertEquals('<?php echo $__env->renderAll(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeAll(\'foo\')'));
+        $this->assertEquals('<?php echo $__env->renderAll(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeAll(name(foo))'));
+    }
+}


### PR DESCRIPTION
The function allows you to automatically include all template files from the specified folder.

For example:
```
// resources:
resource
|-views
| - index.blade.php
| - foo
| | - bar
| - | - q1.blade.php
| - | - q2.blade.php
| - | - q3.blade.php
```

```
// resources/views/index.blade.php
@includeAll('foo.bar')
```

Where does it apply?

In several projects, we often change SEO scripts, so it is not a good idea to prescribe each file manually.
This directive allows you to specify a folder from which all views files will be automatically downloaded.

![2019-06-07_16-04-25](https://user-images.githubusercontent.com/10347617/59106029-036d8e80-893e-11e9-858e-782d2cecd5a6.png)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
