### PR TITLE
[5.8] Suggest resolution when no relationship value is returned

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -413,6 +413,12 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
+            if (is_null($relation)) {
+                throw new LogicException(sprintf(
+                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
+                ));
+            }
+
             throw new LogicException(sprintf(
                 '%s::%s must return a relationship instance.', static::class, $method
             ));


### PR DESCRIPTION
By far one of the most common issues I've seen people new to Laravel ask for help with is when they forget the `return` keyword when defining relationships, to the point where there are nearly 3000 results on Google when you search for the exception.

I guess it comes from the fact builder methods don't have to return a value, and they're often talked about alongside relationships.

All this PR does is put a bit more information and a suggestion in the exception's text to point them in the right direction.