### PR TITLE
[5.8] Error handling for maintenance mode commands

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\InteractsWithTime;
 
@@ -32,12 +33,17 @@ class DownCommand extends Command
      */
     public function handle()
     {
-        file_put_contents(
-            storage_path('framework/down'),
-            json_encode($this->getDownFilePayload(), JSON_PRETTY_PRINT)
-        );
+        try {
+            file_put_contents(storage_path('framework/down'),
+                              json_encode($this->getDownFilePayload(),
+                              JSON_PRETTY_PRINT));
+            $this->comment('Application is now in maintenance mode.');
+        } catch (Exception $e) {
+            $this->error('Application is failed to enter maintenance mode.');
+            $this->error($e->getMessage());
 
-        $this->comment('Application is now in maintenance mode.');
+            return false;
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Exception;
 use Illuminate\Console\Command;
 
 class UpCommand extends Command
@@ -27,8 +28,19 @@ class UpCommand extends Command
      */
     public function handle()
     {
-        @unlink(storage_path('framework/down'));
+        try {
+            if (! file_exists(storage_path('framework/down'))) {
+                $this->comment('Application is already up.');
 
-        $this->info('Application is now live.');
+                return true;
+            }
+            unlink(storage_path('framework/down'));
+            $this->info('Application is now live.');
+        } catch (Exception $e) {
+            $this->error('Application is failed to up.');
+            $this->error($e->getMessage());
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Artisan command for controlling maintenance mode has not handled errors.

When execute commands by non-granted user,
`artisan down` throw Exception error messages, and also
`artisan up` shows `Application is now live.` but still maintenance mode.

This PR implements error handlings for that.

Command behavior is belows:
- `artisan down`
  - success: Display `Application is now in maintenance mode.` with `exit_status = 0`
  - failed: Display `Application is failed to enter maintenance mode.` with `exit_status = 1`

- `artisan up`
  - success to up: Display `Application is now live.` with `exit_status = 0`
  - already up: Display `Application is already up.` with `exit_status = 0`
  - failed: Display `Application is failed to up.` with `exit_status = 1`