### PR TITLE
Persist indenting after newlines in replaced content blade templates

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -341,7 +341,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function compileStatements($value)
     {
         return preg_replace_callback(
-            '/\B@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?3) )* \))?/x', function ($match) {
+            '/\B([\h]*)@(@?\w+(?:::\w+)?)([ \t]*)(\( ( (?>[^()]+) | (?4) )* \))?/x', function ($match) {
                 return $this->compileStatement($match);
             }, $value
         );
@@ -355,15 +355,15 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function compileStatement($match)
     {
-        if (Str::contains($match[1], '@')) {
-            $match[0] = isset($match[3]) ? $match[1].$match[3] : $match[1];
-        } elseif (isset($this->customDirectives[$match[1]])) {
-            $match[0] = $this->callCustomDirective($match[1], Arr::get($match, 3));
-        } elseif (method_exists($this, $method = 'compile'.ucfirst($match[1]))) {
-            $match[0] = $this->$method(Arr::get($match, 3));
+        if (Str::contains($match[2], '@')) {
+            $match[0] = isset($match[4]) ? $match[1].$match[2].$match[4] : $match[1].$match[2];
+        } elseif (isset($this->customDirectives[$match[2]])) {
+            $match[0] = $match[1].$this->callCustomDirective($match[2], Arr::get($match, 4));
+        } elseif (method_exists($this, $method = 'compile'.ucfirst($match[2]))) {
+            $match[0] = $match[1].$this->$method(Arr::get($match, 4), $match[1]);
         }
 
-        return isset($match[3]) ? $match[0] : $match[0].$match[2];
+        return isset($match[4]) ? $match[0] : $match[0].$match[3];
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -18,52 +18,56 @@ trait CompilesIncludes
     /**
      * Compile the include statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param string $expression
+     * @param string $indenting
      * @return string
      */
-    protected function compileInclude($expression)
+    protected function compileInclude($expression, $indenting = '')
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
+        return "<?php echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']) + ['indenting' => '" . $indenting . "'])->render(); ?>";
     }
 
     /**
      * Compile the include-if statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param string $expression
+     * @param string $indenting
      * @return string
      */
-    protected function compileIncludeIf($expression)
+    protected function compileIncludeIf($expression, $indenting = '')
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
+        return "<?php if (\$__env->exists({$expression})) echo \$__env->make({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']) + ['indenting' => '" . $indenting . "'])->render(); ?>";
     }
 
     /**
      * Compile the include-when statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param string $expression
+     * @param string $indenting
      * @return string
      */
-    protected function compileIncludeWhen($expression)
+    protected function compileIncludeWhen($expression, $indenting = '')
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->renderWhen($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
+        return "<?php echo \$__env->renderWhen($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']) + ['indenting' => '" . $indenting . "']); ?>";
     }
 
     /**
      * Compile the include-first statements into valid PHP.
      *
-     * @param  string  $expression
+     * @param string $expression
+     * @param string $indenting
      * @return string
      */
-    protected function compileIncludeFirst($expression)
+    protected function compileIncludeFirst($expression, $indenting = '')
     {
         $expression = $this->stripParentheses($expression);
 
-        return "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
+        return "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']) + ['indenting' => '" . $indenting . "'])->render(); ?>";
     }
 }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -139,7 +139,17 @@ class View implements ArrayAccess, ViewContract
      */
     protected function getContents()
     {
-        return $this->engine->get($this->path, $this->gatherData());
+        $content = $this->engine->get($this->path, $this->gatherData());
+
+        if(isset($this->data['indenting'])){
+            $content = preg_replace('/(\r\n|\r|\n)/', '$1'.$this->data['indenting'], $content);
+        }
+
+        if (!in_array(substr($content,-1), ["\n", "\r", "\r\n"])){
+            $content .= PHP_EOL;
+        }
+
+        return $content;
     }
 
     /**

--- a/tests/View/Blade/BladeIncludeFirstTest.php
+++ b/tests/View/Blade/BladeIncludeFirstTest.php
@@ -6,7 +6,7 @@ class BladeIncludeFirstTest extends AbstractBladeTestCase
 {
     public function testIncludeFirstsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
+        $this->assertEquals('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
+        $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
     }
 }

--- a/tests/View/Blade/BladeIncludeIfTest.php
+++ b/tests/View/Blade/BladeIncludeIfTest.php
@@ -6,7 +6,7 @@ class BladeIncludeIfTest extends AbstractBladeTestCase
 {
     public function testIncludeIfsAreCompiled()
     {
-        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
-        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
+        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
+        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeIncludeTest.php
+++ b/tests/View/Blade/BladeIncludeTest.php
@@ -6,7 +6,7 @@ class BladeIncludeTest extends AbstractBladeTestCase
 {
     public function testIncludesAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
-        $this->assertEquals('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
+        $this->assertEquals('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
+        $this->assertEquals('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeIncludeWhenTest.php
+++ b/tests/View/Blade/BladeIncludeWhenTest.php
@@ -6,7 +6,7 @@ class BladeIncludeWhenTest extends AbstractBladeTestCase
 {
     public function testIncludeWhensAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
+        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\']); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
+        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\']); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
     }
 }

--- a/tests/View/Blade/BladeVerbatimTest.php
+++ b/tests/View/Blade/BladeVerbatimTest.php
@@ -70,7 +70,7 @@ class BladeVerbatimTest extends AbstractBladeTestCase
     <?php echo e($third); ?>
 
 <?php endif; ?>
-<?php echo $__env->make("users", \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>
+<?php echo $__env->make("users", \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']) + [\'indenting\' => \'\'])->render(); ?>
 
     {{ $fourth }} @include("test")
  

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -346,7 +346,7 @@ class ViewFactoryTest extends TestCase
         $factory->endSlot();
         echo 'component';
         $contents = $factory->renderComponent();
-        $this->assertEquals('title<hr> component Taylor laravel.com', $contents);
+        $this->assertEquals('title<hr> component Taylor laravel.com'.PHP_EOL, $contents);
     }
 
     public function testTranslation()

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -69,7 +69,7 @@ class ViewTest extends TestCase
             return '';
         }));
 
-        $this->assertEquals('contents', $view->render(function () {
+        $this->assertEquals('contents'.PHP_EOL, $view->render(function () {
             //
         }));
     }
@@ -99,8 +99,8 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender')->twice();
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->twice();
 
-        $this->assertEquals('contents', $view->render());
-        $this->assertEquals('contents', (string) $view);
+        $this->assertEquals('contents'.PHP_EOL, $view->render());
+        $this->assertEquals('contents'.PHP_EOL, (string) $view);
     }
 
     public function testViewNestBindsASubView()
@@ -192,7 +192,7 @@ class ViewTest extends TestCase
 
         $view->renderable = m::mock(Renderable::class);
         $view->renderable->shouldReceive('render')->once()->andReturn('text');
-        $this->assertEquals('contents', $view->render());
+        $this->assertEquals('contents'.PHP_EOL, $view->render());
     }
 
     public function testViewRenderSections()


### PR DESCRIPTION
Fix for issue #28767

Content of included.blade.php:
```
Line 1
Line 2
```

Conent of including file:
```
<html>
     @include('included')
</html>
````

Results currently in the following HTML:
```
<html>
     Line 1
Line2 </html>
```

This fix generates the following HTML:
```
<html>
     Line 1
     Line2
</html>
```