### PR TITLE
[5.8] Update generatedAs() signature

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Fluent;
+use Illuminate\Database\Query\Expression;
 
 /**
  * @method ColumnDefinition after(string $column) Place the column "after" another column (MySQL)

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Schema;
 
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Fluent;
 
 /**
@@ -14,7 +15,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition comment(string $comment) Add a comment to the column (MySQL)
  * @method ColumnDefinition default(mixed $value) Specify a "default" value for the column
  * @method ColumnDefinition first() Place the column "first" in the table (MySQL)
- * @method ColumnDefinition generatedAs(string $expression) Create a SQL compliant identity column (PostgreSQL)
+ * @method ColumnDefinition generatedAs(string|Expression $expression = null) Create a SQL compliant identity column (PostgreSQL)
  * @method ColumnDefinition index(string $indexName = null) Add an index
  * @method ColumnDefinition nullable(bool $value = true) Allow NULL values to be inserted into the column
  * @method ColumnDefinition primary() Add a primary index


### PR DESCRIPTION
> generatedAs() **optionally** accepts a **string** or an **Expression** containing sequence options

According to #26096.