### PR TITLE
[5.8] Show members causing failure in array validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -661,7 +661,7 @@ class Validator implements ValidatorContract
 
         $result = [];
         $failed = array_only(array_dot($invalid), array_keys($this->failed()));
-        foreach($failed as $key => $failure){
+        foreach ($failed as $key => $failure){
             array_set($result, $key, $failure);
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -655,9 +655,17 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        return array_intersect_key(
+        $invalid = array_intersect_key(
             $this->data, $this->attributesThatHaveMessages()
         );
+
+        $result = [];
+        $failed = array_only(array_dot($invalid), array_keys($this->failed()));
+        foreach($failed as $key => $failure){
+            array_set($result, $key, $failure);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -661,7 +661,7 @@ class Validator implements ValidatorContract
 
         $result = [];
         $failed = array_only(array_dot($invalid), array_keys($this->failed()));
-        foreach ($failed as $key => $failure){
+        foreach ($failed as $key => $failure) {
             array_set($result, $key, $failure);
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4096,6 +4096,37 @@ class ValidationValidatorTest extends TestCase
         ]);
     }
 
+    public function testNestedInvalidMethod()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [
+            "testvalid" => "filled",
+            "testinvalid" => "",
+            "records" =>
+            [
+                "ABC123",
+                "ABC122",
+                "ABB132",
+                "ADCD23"
+            ]
+        ],[
+            "testvalid" => "filled",
+            "testinvalid" => "filled",
+            "records.*" => [
+                "required",
+                "regex:/[A-F]{3}[0-9]{3}/"
+            ]
+        ]);
+
+        $this->assertEquals($v->invalid(), [
+            'testinvalid' => '',
+            'records' => [
+                3 => "ADCD23"
+            ]
+        ]);
+    }
+
     public function testValidMethod()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4101,28 +4101,28 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
 
         $v = new Validator($trans, [
-            "testvalid" => "filled",
-            "testinvalid" => "",
-            "records" =>
+            'testvalid' => 'filled',
+            'testinvalid' => '',
+            'records' =>
             [
-                "ABC123",
-                "ABC122",
-                "ABB132",
-                "ADCD23"
+                'ABC123',
+                'ABC122',
+                'ABB132',
+                'ADCD23'
             ]
         ],[
-            "testvalid" => "filled",
-            "testinvalid" => "filled",
-            "records.*" => [
-                "required",
-                "regex:/[A-F]{3}[0-9]{3}/"
+            'testvalid' => 'filled',
+            'testinvalid' => 'filled',
+            'records.*' => [
+                'required',
+                'regex:/[A-F]{3}[0-9]{3}/'
             ]
         ]);
 
         $this->assertEquals($v->invalid(), [
             'testinvalid' => '',
             'records' => [
-                3 => "ADCD23"
+                3 => 'ADCD23'
             ]
         ]);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4103,27 +4103,26 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, [
             'testvalid' => 'filled',
             'testinvalid' => '',
-            'records' =>
-            [
+            'records' => [
                 'ABC123',
                 'ABC122',
                 'ABB132',
-                'ADCD23'
-            ]
-        ],[
+                'ADCD23',
+            ],
+        ], [
             'testvalid' => 'filled',
             'testinvalid' => 'filled',
             'records.*' => [
                 'required',
-                'regex:/[A-F]{3}[0-9]{3}/'
-            ]
+                'regex:/[A-F]{3}[0-9]{3}/',
+            ],
         ]);
 
         $this->assertEquals($v->invalid(), [
             'testinvalid' => '',
             'records' => [
-                3 => 'ADCD23'
-            ]
+                3 => 'ADCD23',
+            ],
         ]);
     }
 


### PR DESCRIPTION
When a nested validation occurs, the whole array is returned inside the `invalid()` items. This allows the system to return only the items which caused the validation to fail. 

Related to #28599.