### PR TITLE
[5.9] Show members causing failure in array validation

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -655,9 +655,17 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        return array_intersect_key(
+        $invalid = array_intersect_key(
             $this->data, $this->attributesThatHaveMessages()
         );
+
+        $result = [];
+        $failed = Arr::only(Arr::dot($invalid), array_keys($this->failed()));
+        foreach ($failed as $key => $failure) {
+            Arr::set($result, $key, $failure);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4134,6 +4134,34 @@ class ValidationValidatorTest extends TestCase
         ]);
     }
 
+    public function testNestedInvalidMethod()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [
+            'testvalid' => 'filled',
+            'testinvalid' => '',
+            'records' => [
+                'ABC123',
+                'ABC122',
+                'ABB132',
+                'ADCD23',
+            ],
+        ], [
+            'testvalid' => 'filled',
+            'testinvalid' => 'filled',
+            'records.*' => [
+                'required',
+                'regex:/[A-F]{3}[0-9]{3}/',
+            ],
+        ]);
+        $this->assertEquals($v->invalid(), [
+            'testinvalid' => '',
+            'records' => [
+                3 => 'ADCD23',
+            ],
+        ]);
+    }
+
     public function testMultipleFileUploads()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
When a nested validation occurs, the whole array is returned inside the invalid() items. This allows the system to return only the items which caused the validation to fail.

Related to #28599 and #28777.
