### PR TITLE
[5.8] Add `@componentFirst` Directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -45,4 +45,15 @@ trait CompilesComponents
     {
         return '<?php $__env->endSlot(); ?>';
     }
+
+    /**
+     * Compile the component-first statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileComponentFirst($expression)
+    {
+        return "<?php \$__env->startComponentFirst{$expression}; ?>";
+    }
 }

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Concerns;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 
 trait ManagesComponents
@@ -50,6 +51,22 @@ trait ManagesComponents
 
             $this->slots[$this->currentComponent()] = [];
         }
+    }
+
+    /**
+     * Get the first view that actually exists from the given list, and start a component.
+     *
+     * @param  array  $names
+     * @param  array  $data
+     * @return void
+     */
+    public function startComponentFirst(array $names, array $data = [])
+    {
+        $name = Arr::first($names, function ($item) {
+            return $this->exists($item);
+        });
+
+        $this->startComponent($name, $data);
     }
 
     /**

--- a/tests/View/Blade/BladeComponentFirstTest.php
+++ b/tests/View/Blade/BladeComponentFirstTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeComponentFirstTest extends AbstractBladeTestCase
+{
+    public function testComponentFirstsAreCompiled()
+    {
+        $this->assertEquals('<?php $__env->startComponentFirst(["one", "two"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"])'));
+        $this->assertEquals('<?php $__env->startComponentFirst(["one", "two"], ["foo" => "bar"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"], ["foo" => "bar"])'));
+    }
+}


### PR DESCRIPTION
The `@component` and `@include` Blade directives perform the same function with 2 distinctions.

+ `@component`s allow you to pass in data via `@slot`s.
+ `@component`s only access variables passed to them, while `@include`s access all variables currently defined.

Even though these directives are so similar, `@include` gets some additional variations that are very useful.

+ `@includeWhen`
+ `@includeIf`
+ `@includeFirst`

Ideally, both the components and includes would maintain parity between these variations. This PR starts towards that goal by adding a `@componentFirst` directive.

```blade
<div>
    @componentFirst(['missing/file', 'found/file'])
        @slot('title', 'Test Component')
    @endcomponent
</div>
```