### PR TITLE
[5.8] Add hints to Artisan Facade methods

### DIFF
--- a/src/Illuminate/Support/Facades/Artisan.php
+++ b/src/Illuminate/Support/Facades/Artisan.php
@@ -5,11 +5,12 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 
 /**
- * @method static int handle(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output = null)
- * @method static int call(string $command, array $parameters = [], $outputBuffer = null)
- * @method static int queue(string $command, array $parameters = [])
+ * @method static int handle(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface|null $output = null)
+ * @method static int call(string $command, array $parameters = [], \Symfony\Component\Console\Output\OutputInterface|null $outputBuffer = null)
+ * @method static \Illuminate\Foundation\Bus\PendingDispatch queue(string $command, array $parameters = [])
  * @method static array all()
  * @method static string output()
+ * @method static void terminate(\Symfony\Component\Console\Input\InputInterface $input, int $status)
  *
  * @see \Illuminate\Contracts\Console\Kernel
  */


### PR DESCRIPTION
Continue of #28788 

This PR adds missing `terminate` method and fixes signature of 3 methods in Artisan Facade:
- handle (add missing `null` type for `$output` param)
- call (add missing typehints for `$outputBuffer` param)
- queue (fixed return type)