### PR TITLE
[5.8] Add Crypt Facade methods hints

### DIFF
--- a/src/Illuminate/Contracts/Encryption/Encrypter.php
+++ b/src/Illuminate/Contracts/Encryption/Encrypter.php
@@ -9,7 +9,7 @@ interface Encrypter
      *
      * @param  mixed  $value
      * @param  bool  $serialize
-     * @return mixed
+     * @return string
      *
      * @throws \Illuminate\Contracts\Encryption\EncryptException
      */
@@ -18,7 +18,7 @@ interface Encrypter
     /**
      * Decrypt the given value.
      *
-     * @param  mixed  $payload
+     * @param  string  $payload
      * @param  bool  $unserialize
      * @return mixed
      *

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -125,7 +125,7 @@ class Encrypter implements EncrypterContract
     /**
      * Decrypt the given value.
      *
-     * @param  mixed  $payload
+     * @param  string  $payload
      * @param  bool  $unserialize
      * @return mixed
      *

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static string encrypt($value, bool $serialize = true)
+ * @method static bool supported(string $key, string $cipher)
+ * @method static string generateKey(string $cipher)
+ * @method static string encrypt(mixed $value, bool $serialize = true)
  * @method static string encryptString(string $value)
- * @method static string decrypt($payload, bool $unserialize = true)
+ * @method static mixed decrypt(mixed $payload, bool $unserialize = true)
  * @method static string decryptString(string $payload)
+ * @method static string getKey()
  *
  * @see \Illuminate\Encryption\Encrypter
  */

--- a/src/Illuminate/Support/Facades/Crypt.php
+++ b/src/Illuminate/Support/Facades/Crypt.php
@@ -7,7 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static string generateKey(string $cipher)
  * @method static string encrypt(mixed $value, bool $serialize = true)
  * @method static string encryptString(string $value)
- * @method static mixed decrypt(mixed $payload, bool $unserialize = true)
+ * @method static mixed decrypt(string $payload, bool $unserialize = true)
  * @method static string decryptString(string $payload)
  * @method static string getKey()
  *


### PR DESCRIPTION
Continue of #28788

This PR adds bunch of missing methods to Crypt Facade and adds missing return type of `decrypt` method.
