### PR TITLE
[5.8] Add Event Facade methods hints

### DIFF
--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -6,15 +6,19 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Testing\Fakes\EventFake;
 
 /**
- * @method static void listen(string|array $events, $listener)
+ * @method static void listen(string|array $events, mixed $listener)
  * @method static bool hasListeners(string $eventName)
- * @method static void subscribe(object|string $subscriber)
- * @method static array|null until(string|object $event, $payload = [])
- * @method static array|null dispatch(string|object $event, $payload = [], bool $halt = false)
  * @method static void push(string $event, array $payload = [])
  * @method static void flush(string $event)
+ * @method static void subscribe(object|string $subscriber)
+ * @method static array|null until(string|object $event, mixed $payload = [])
+ * @method static array|null dispatch(string|object $event, mixed $payload = [], bool $halt = false)
+ * @method static array getListeners(string $eventName)
+ * @method static \Closure makeListener(\Closure|string $listener, bool $wildcard = false)
+ * @method static \Closure createClassListener(string $listener, bool $wildcard = false)
  * @method static void forget(string $event)
  * @method static void forgetPushed()
+ * @method static \Illuminate\Events\Dispatcher setQueueResolver(callable $resolver)
  *
  * @see \Illuminate\Events\Dispatcher
  */


### PR DESCRIPTION
Continue of #28788

This PR adds bunch of missing methods to Event Facade and changes order of methods accordingly to their appearance in `\Illuminate\Events\Dispatcher` class.