### PR TITLE
Add Hash Facade methods hints

### DIFF
--- a/src/Illuminate/Support/Facades/Hash.php
+++ b/src/Illuminate/Support/Facades/Hash.php
@@ -3,10 +3,14 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static \Illuminate\Hashing\BcryptHasher createBcryptDriver()
+ * @method static \Illuminate\Hashing\ArgonHasher createArgonDriver()
+ * @method static \Illuminate\Hashing\Argon2IdHasher createArgon2idDriver()
  * @method static array info(string $hashedValue)
  * @method static string make(string $value, array $options = [])
  * @method static bool check(string $value, string $hashedValue, array $options = [])
  * @method static bool needsRehash(string $hashedValue, array $options = [])
+ * @method static string getDefaultDriver()
  *
  * @see \Illuminate\Hashing\HashManager
  */


### PR DESCRIPTION
Continue of #28788

This PR adds missing methods from `\Illuminate\Hashing\HashManager`.