### PR TITLE
[5.8] Set connection name on cursor() results

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -643,7 +643,7 @@ class Builder
     public function cursor()
     {
         foreach ($this->applyScopes()->query->cursor() as $record) {
-            yield $this->model->newFromBuilder($record);
+            yield $this->newModelInstance()->newFromBuilder($record);
         }
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -184,6 +184,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::where('id', 1)->cursor();
         foreach ($models as $model) {
             $this->assertEquals(1, $model->id);
+            $this->assertEquals('default', $model->getConnectionName());
         }
 
         $records = DB::table('users')->where('id', 1)->cursor();


### PR DESCRIPTION
When a model uses the default connection, `cursor()` doesn't set the connection name.

```php
User::first()->getConnectionName(); // 'mysql'
User::cursor()->current()->getConnectionName(); // null
```

Fixes #28794.