### PR TITLE
[5.8] adds Str::containsAll() method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -113,6 +113,24 @@ class Str
     }
 
     /**
+     * Determine if a given string contains all array values.
+     *
+     * @param  string  $haystack
+     * @param  string|array  $needles
+     * @return bool
+     */
+    public static function containsAll($haystack, $needles)
+    {
+        foreach ((array) $needles as $needle) {
+            if (! static::contains($haystack, $needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -116,12 +116,12 @@ class Str
      * Determine if a given string contains all array values.
      *
      * @param  string  $haystack
-     * @param  string|array  $needles
+     * @param  array  $needles
      * @return bool
      */
-    public static function containsAll($haystack, $needles)
+    public static function containsAll($haystack, array $needles)
     {
-        foreach ((array) $needles as $needle) {
+        foreach ($needles as $needle) {
             if (! static::contains($haystack, $needle)) {
                 return false;
             }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -129,6 +129,15 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', ''));
     }
 
+    public function testStrContainsAll()
+    {
+        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
+        $this->assertTrue(Str::containsAll('taylor otwell', 'taylor'));
+        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
+        $this->assertFalse(Str::containsAll('taylor otwell', 'xxx'));
+        $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
+    }
+
     public function testParseCallback()
     {
         $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method', 'foo'));


### PR DESCRIPTION
Hi everyone,

As discussed here https://github.com/laravel/framework/pull/28688 and https://github.com/laravel/framework/pull/28695 - in order to avoid a breaking change, I abstracted it into a new method called `containsAll()` and I am using `contains()` to check whether the value is contained inside the string.

Every now and then I run into a dilemma where I want to check if an array of values is contained within a string.

This adds the functionality to check for all array values inside a string.

Check out the tests to see all the supported scenarios.

I hope you guys find this useful, too 🙂

Chris