### PR TITLE
[5.8] remove failing assertions for Str::containsAll() tests

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -132,9 +132,7 @@ class SupportStrTest extends TestCase
     public function testStrContainsAll()
     {
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
-        $this->assertTrue(Str::containsAll('taylor otwell', 'taylor'));
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
-        $this->assertFalse(Str::containsAll('taylor otwell', 'xxx'));
         $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
     }
 


### PR DESCRIPTION
Hi there,

I just noticed that the tests weren't fully updated after this commit https://github.com/laravel/framework/pull/28806/commits/91d5cfde39d78d8c26e40429ae38754a4c688155 

That commit forces `$needles` to be an array, so we can now safely remove the assertions that would have kept the functionality of `Str::contains()` inside the new method. 

Thanks so much 🙂