### PR TITLE
[5.8] fix tests for Str::containsAll

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -132,9 +132,9 @@ class SupportStrTest extends TestCase
     public function testStrContainsAll()
     {
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
-        $this->assertTrue(Str::containsAll('taylor otwell', 'taylor'));
         $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
-        $this->assertFalse(Str::containsAll('taylor otwell', 'xxx'));
+        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
+        $this->assertFalse(Str::containsAll('taylor otwell', ['xxx']));
         $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
     }
 


### PR DESCRIPTION
Since you changed the params to accept only `arrays` the `tests` stopped working !