### PR TITLE
[5.8] add strict param to Str::contains method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -99,35 +99,22 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $strict
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $strict = false)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if (! $strict && $needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
-        }
 
-        return false;
-    }
-
-    /**
-     * Determine if a given string contains all array values.
-     *
-     * @param  string  $haystack
-     * @param  array  $needles
-     * @return bool
-     */
-    public static function containsAll($haystack, array $needles)
-    {
-        foreach ($needles as $needle) {
-            if (! static::contains($haystack, $needle)) {
+            if ($strict && ! static::contains($haystack, $needle)) {
                 return false;
             }
         }
 
-        return true;
+        return $strict;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -127,15 +127,11 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
-    }
-
-    public function testStrContainsAll()
-    {
-        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor', 'otwell']));
-        $this->assertTrue(Str::containsAll('taylor otwell', 'taylor'));
-        $this->assertTrue(Str::containsAll('taylor otwell', ['taylor']));
-        $this->assertFalse(Str::containsAll('taylor otwell', 'xxx'));
-        $this->assertFalse(Str::containsAll('taylor otwell', ['taylor', 'xxx']));
+        $this->assertTrue(Str::contains('taylor otwell', ['taylor', 'otwell'], true));
+        $this->assertTrue(Str::contains('taylor otwell', 'taylor', true));
+        $this->assertTrue(Str::contains('taylor otwell', ['taylor'], true));
+        $this->assertFalse(Str::contains('taylor otwell', 'xxx', true));
+        $this->assertFalse(Str::contains('taylor otwell', ['taylor', 'xxx'], true));
     }
 
     public function testParseCallback()


### PR DESCRIPTION
Migrate `containsAll()` to `contains()` by just adding `$strict` param