### PR TITLE
[5.9] Convert Arrayable Eloquent attributes to Array

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -197,9 +197,8 @@ trait HasAttributes
             }
 
             if ($attributes[$key] instanceof Arrayable) {
-                $attributes[$key] = $attributes[$key]->toArray(); 
+                $attributes[$key] = $attributes[$key]->toArray();
             }
-
         }
 
         return $attributes;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -110,7 +110,7 @@ trait HasAttributes
         foreach ($this->getArrayableAppends() as $key) {
             $attributes[$key] = $this->mutateAttributeForArray($key, null);
         }
-        
+
         foreach ($attributes as $key => $value) {
             if ($value instanceof Arrayable) {
                 $attributes[$key] = $value->toArray();

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -111,12 +111,6 @@ trait HasAttributes
             $attributes[$key] = $this->mutateAttributeForArray($key, null);
         }
 
-        foreach ($attributes as $key => $value) {
-            if ($value instanceof Arrayable) {
-                $attributes[$key] = $value->toArray();
-            }
-        }
-
         return $attributes;
     }
 
@@ -201,6 +195,11 @@ trait HasAttributes
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
+
+            if ($attributes[$key] instanceof Arrayable) {
+                $attributes[$key] = $attributes[$key]->toArray(); 
+            }
+
         }
 
         return $attributes;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -110,6 +110,12 @@ trait HasAttributes
         foreach ($this->getArrayableAppends() as $key) {
             $attributes[$key] = $this->mutateAttributeForArray($key, null);
         }
+        
+        foreach ($attributes as $key => $value) {
+            if ($value instanceof Arrayable) {
+                $attributes[$key] = $value->toArray();
+            }
+        }
 
         return $attributes;
     }


### PR DESCRIPTION
Hi, 
If you cast a json field to a collection, or have mutators/getters which return Arrayable object in a Eloquent model, the `toArray()` method will not convert them to array recursively as it is supposed to do (it has this behavior in collections, and for model's relations).

This PR fix that.

I'll add some tests later, if you agree with this PR.

I'm wondering about the targeted version. I would initially target 5.8, as it's a fix, but It could be considerate as a BC, because it changes the behavior of this toArray() method concerning nested Arrayable objects.

So maybe 6.0? I let you take the decision 😉.

Thanks, 
Matt.

