### PR TITLE
[5.8] Fix typehint for EloquentCollection::find, as it may return null.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -17,7 +17,7 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @param  mixed  $key
      * @param  mixed  $default
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return \Illuminate\Database\Eloquent\Model|static|null
      */
     public function find($key, $default = null)
     {


### PR DESCRIPTION
The current return typehint for the `find` method on the Eloquent collection class is `@return \Illuminate\Database\Eloquent\Model|static`. This is incorrect, as `null` is returned if `$key` is not found in the collection.