### PR TITLE
[5.8] Fix for Redis Sentinel configuration

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -170,7 +170,7 @@ class RedisManager implements Factory
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
         return array_filter($parsed, function ($key) {
-            return ! in_array((string)$key, ['driver', 'username']);
+            return ! in_array((string) $key, ['driver', 'username']);
         }, ARRAY_FILTER_USE_KEY);
     }
 

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -170,7 +170,7 @@ class RedisManager implements Factory
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
         return array_filter($parsed, function ($key) {
-            return ! in_array($key, ['driver', 'username']);
+            return ! in_array((string)$key, ['driver', 'username']);
         }, ARRAY_FILTER_USE_KEY);
     }
 


### PR DESCRIPTION
Since Laravel 5.8.19 our Redis cluster configuration failed to load.

Since 5.8.19 the function parseConnectionConfiguration is used. But because of the array key 0 the array_filter will return false and filter our the first server connection.

Redis input:
`Array
(
    [0] => tcp://10.10.68.31:26379
    [1] => tcp://10.10.68.32:26379
    [2] => tcp://10.10.68.16:26379
)`

After the function:

`Array
(
    [1] => tcp://10.10.68.32:26379
    [2] => tcp://10.10.68.16:26379
)`

If we pass the key as a string, the function returns all servers back to the Redis resolve.
Because the function removes key 0, the default connection is loaded en crashes on no connection.

`Connection refused [tcp://127.0.0.1:6379]`