### PR TITLE
[5.8] Fix strict comparison in redis configuration Parsing

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -170,7 +170,7 @@ class RedisManager implements Factory
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
         return array_filter($parsed, function ($key) {
-            return ! in_array($key, ['driver', 'username']);
+            return ! in_array($key, ['driver', 'username'], true);
         }, ARRAY_FILTER_USE_KEY);
     }
 


### PR DESCRIPTION
Proper fix for issue https://github.com/laravel/framework/pull/28829.

Problem: 
- Input of the function:
`[0 => 'url1', 1 => 'url2', 2 => 'url3']`

- Expected output:
`[0 => 'url1', 1 => 'url2', 2 => 'url3']`

- Actual output:
`[1 => 'url2', 2 => 'url3']`

This is about strict comparison in `in_array` method:
```php
>>> in_array(0, ['foo'])
=> true
>>> in_array(0, ['foo'], true)
=> false
```

Thanks. 
Matt'

PS: [Again](https://github.com/laravel/framework/issues/28721#issuecomment-498865044), this would not happen with tests. 

I have no time to add proper tests on all of this RedisManager, but I think this is something we should have. **Can be a good first PR for someone who want to contribute.**
