### PR TITLE
[5.8] Add json field handling in getAttribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -314,8 +314,7 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            $this->hasGetMutator($key)) {
+        if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key) || Str::contains($key, '->')) {
             return $this->getAttributeValue($key);
         }
 
@@ -356,8 +355,7 @@ trait HasAttributes
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
+        if (in_array($key, $this->getDates()) && ! is_null($value)) {
             return $this->asDateTime($value);
         }
 
@@ -374,6 +372,12 @@ trait HasAttributes
     {
         if (isset($this->attributes[$key])) {
             return $this->attributes[$key];
+        }
+
+        if (Str::contains($key, '->')) {
+            [$key, $path] = explode('->', $key, 2);
+
+            return Arr::get($this->getArrayAttributeByKey($key), str_replace('->', '.', $key));
         }
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -377,7 +377,7 @@ trait HasAttributes
         if (Str::contains($key, '->')) {
             [$key, $path] = explode('->', $key, 2);
 
-            return Arr::get($this->getArrayAttributeByKey($key), str_replace('->', '.', $key));
+            return Arr::get($this->getArrayAttributeByKey($key), str_replace('->', '.', $path));
         }
     }
 


### PR DESCRIPTION
Hi,

This PR allow us to query a key in a json attribute with `->` syntax:

```php
$user = User::create([
	'email' => 'oss@mathieutu.dev',
	'details' => [
		'firstName' => 'Mathieu',
		'website' => 'mathieutu.dev',
		// ...
	],
]);

$user->getAttribute('details->firstName') // Mathieu
```

It handles dates, casting, etc, like a standard attributes.

It brings consistency with the already allowed `$user->setAttribute('details->firstName')`.

As previously, I'd be glad to add tests to this PR if you tell me that you're interested in merging it.

Thanks,

Matt'