### PR TITLE
[5.8] add ability to paginate all results

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -33,7 +33,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  mixed  $items
      * @param  int  $total
-     * @param  int  $perPage
+     * @param  int|string  $perPage
      * @param  int|null  $currentPage
      * @param  array  $options (path, query, fragment, pageName)
      * @return void
@@ -44,6 +44,10 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
 
         foreach ($options as $key => $value) {
             $this->{$key} = $value;
+        }
+
+        if (!is_int($perPage)) {
+            $perPage = $total;
         }
 
         $this->total = $total;

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -46,7 +46,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             $this->{$key} = $value;
         }
 
-        if (!is_int($perPage)) {
+        if (! is_int($perPage)) {
             $perPage = $total;
         }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -108,4 +108,16 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertSame($this->options, $this->p->getOptions());
     }
+
+    public function testItCanRetrieveAllResults()
+    {
+        $paginator = new LengthAwarePaginator(['item1', 'item2', 'item3', 'item4'], 4, 'all', 1);
+
+        $this->assertEquals(1, $paginator->lastPage());
+        $this->assertEquals(1, $paginator->currentPage());
+        $this->assertEquals(4, $paginator->total());
+        $this->assertEquals(4, $paginator->perPage());
+        $this->assertFalse($paginator->hasPages());
+        $this->assertFalse($paginator->hasMorePages());
+    }
 }


### PR DESCRIPTION
### Scenario

Assume we have a `Post` model, with a corresponding resource route and resource controller. For the `index` route, it is not uncommon to display a list of paginated results. It is also not uncommon to use a query parameter to set the number of results per page, with a sensible default.

```php
public function index(Request $request)
{
    $posts = Post::paginate($request->query('perPage', 25));

    return view('posts/index', compact('posts'));
}
```

### Problem

This works fine for any valid integer value, but if we want to show **all** results, we need to either use more verbose code in our controller or fake it with a very large number.

```php
public function index(Request $request)
{
    if ($request->query('perPage') === 'all') {
        $posts = Post:all();
    } else {
        $posts = Post::paginate($request->query('perPage', 25));
    }
}
```

```php
public function index(Request $request)
{
    $posts = $request->query('perPage') === 'all' ? Post:all() : Post::paginate($request->query('perPage', 25);
}
```

```php
public function index(Request $request)
{
    $posts = Post::paginate(999999999);
}
```

### Solution

If a non integer value is passed for the perPage parameter, we will set the `perPage` value to the `total`, so all results are returned.

```php
public function index(Request $request)
{
    $posts = Post::paginate('all');
}
```

This allows us to keep our controller simple and fluent.