### PR TITLE
fix phpunit7.5.12 Declaration of Illuminate\Foundation\Testing\Assert::assertArraySubset

### DIFF
--- a/src/Illuminate/Foundation/Testing/Assert.php
+++ b/src/Illuminate/Foundation/Testing/Assert.php
@@ -25,7 +25,7 @@ abstract class Assert extends PHPUnit
      *
      * @link https://github.com/sebastianbergmann/phpunit/issues/3494
      */
-    public static function assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void
+    public static function assertArraySubset($subset, $array, $checkForObjectIdentity = false, $message = ''): void
     {
         if (! (is_array($subset) || $subset instanceof ArrayAccess)) {
             throw InvalidArgumentHelper::factory(1, 'array or ArrayAccess');


### PR DESCRIPTION
This problem exists in php 7.1

fix phpunit7.5.12  Declaration of Illuminate\Foundation\Testing\Assert::assertArraySubset($subset, $array, bool $checkForObjectIdentity = false, string $message = ''): void should be compatible with PHPUnit\Framework\Assert::assertArra ySubset($subset, $array, $strict = false, $message = '')
