### PR TITLE
[5.8] Add option to create policy in art make:model command

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -45,6 +45,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->input->setOption('migration', true);
             $this->input->setOption('controller', true);
             $this->input->setOption('resource', true);
+            $this->input->setOption('policy', true);
         }
 
         if ($this->option('factory')) {
@@ -57,6 +58,10 @@ class ModelMakeCommand extends GeneratorCommand
 
         if ($this->option('controller') || $this->option('resource')) {
             $this->createController();
+        }
+
+        if ($this->option('policy')) {
+            $this->createPolicy();
         }
     }
 
@@ -112,6 +117,21 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Create a policy for the model.
+     *
+     * @return void
+     */
+    protected function createPolicy()
+    {
+        $policy = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:policy', [
+            'name' => "{$policy}Policy",
+            '--model' => $this->qualifyClass($this->getNameInput()),
+        ]);
+    }
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string
@@ -142,6 +162,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
 
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
+
+            ['policy', 'pc', InputOption::VALUE_NONE, 'Create a new policy for the model'],
 
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
 


### PR DESCRIPTION
I regularly use policies so I figured this would be helpful - I'm not sure about the shorthand that I chose for this option as `p` is occupied by the pivot option.

```php
...
['policy', 'pc', InputOption::VALUE_NONE, 'Create a new policy for the model'],
['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
...
```