### PR TITLE
[5.8] Added toDelimitedJson in Collection to help exporting data better to AWS S3 for Athena/Redshift

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1946,6 +1946,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Convert each item into separate JSONs using a separator.
+     *
+     * @param string $separator
+     * @return string
+     */
+    public function toDelimitedJson($separator = "\n")
+    {
+        return $this->reduce(function ($string, $value) use ($separator) {
+            $jsonValue = (new static($value))->toJson();
+
+            return $string.$jsonValue.$separator;
+        }, '');
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2418,7 +2418,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             $c->toDelimitedJson(':'),
-            "{\"foo\":\"bar\"}:{\"foo\":\"bar\"}:{\"foo\":\"bar\"}:"
+            '{"foo":"bar"}:{"foo":"bar"}:{"foo":"bar"}:'
         );
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2403,6 +2403,25 @@ class SupportCollectionTest extends TestCase
         ], $c->jsonSerialize());
     }
 
+    public function testDelimitedJson()
+    {
+        $c = new Collection([
+            ['foo' => 'bar'],
+            ['foo' => 'bar'],
+            ['foo' => 'bar'],
+        ]);
+
+        $this->assertEquals(
+            $c->toDelimitedJson(),
+            "{\"foo\":\"bar\"}\n{\"foo\":\"bar\"}\n{\"foo\":\"bar\"}\n"
+        );
+
+        $this->assertEquals(
+            $c->toDelimitedJson(':'),
+            "{\"foo\":\"bar\"}:{\"foo\":\"bar\"}:{\"foo\":\"bar\"}:"
+        );
+    }
+
     public function testCombineWithArray()
     {
         $expected = [


### PR DESCRIPTION
**Summary:**
This takes a collection and exports it by default in `one-per-line` JSON. This is the difference between `toJson()` and `toDelimitedJson()`:

```php
$collection = collect([
  ['field' => 'value'],
  ['field' => 'value'],
]);

// This outputs [{"field":"value"},{"field":"value"}]
$collection->toJson();

// This outputs {"field":"value"}\n{"field":"value"}\n
$collection->toDelimitedJson();

// This outputs {"field":"value"}:{"field":"value"}:
$collection->toDelimitedJson(':');
```

**You may ask: why?**
This is a good function that will help you prepare any data into a friendy JSON-format ready to be exported to S3 and later be pulled in Athena/Redshift. If using `->toJson()` to export your data into batches and put them into a JSON file in S3, it cannot be read properly by Athena in case you want to query big data. When pulling files from the bucket, the one-per-line JSON is readable.

You can have, for example, tons of stats regarding your app, you process them and format your stats into a readable format and store them in the database and you want to export the base recoreds into S3 or anywhere in batches to later use Big Data to process them for further reference and/or insights to avoid keeping stale data into the database.

Here is an example in which you can export the data in an Athena-friendly verison.

```php
// You prepare your data to involve less requests in case you want to show it to your users.
Stats::chunk(500, function ($chunk) {
    FormattedStat::create([
        'unique_hits_by_ip' => $chunk->groupBy('ip')->count(),
        // ...
    ]);
});

// Export to S3 & destroy stale records in the DB.
Stats::chunk(500, function ($chunk) {
    $content = $chunk->toDelimitedJson();
    Storage::cloud()->put('exported.json', $content); // cloud filesystem driver is set to s3
    Stats::destroy($chunk->pluck('id'));
});
```