### PR TITLE
Update relationship when __set attribute existing in relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,6 +250,13 @@ trait HasAttributes
                 $relation = $value;
             }
 
+            // If the value is is set, we'll still go ahead and set it in this list
+            // of attributes. Values that does not Arrayable or null represents the relationships
+            // are updated.
+            elseif (isset($value)) {
+                $relation = $value;
+            }
+
             // If the relationships snake-casing is enabled, we will snake case this
             // key so that the relation attribute is snake cased in this returned
             // array to the developers, making this consistent with attributes.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1532,6 +1532,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function __set($key, $value)
     {
+        if ($this->relationLoaded($key)) {
+            $this->setRelation($key, $value);
+
+            return;
+        }
+
         $this->setAttribute($key, $value);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1757,6 +1757,35 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(isset($model->some_relation));
     }
 
+    public function testRelationsToArrayShowIssetValues()
+    {
+        $model = new EloquentModelStub();
+
+        $relationKey = 'foo';
+        $relationValue = 'bar';
+
+        $model->setRelation($relationKey, $relationValue);
+
+        $relationsToArray = $model->relationsToArray();
+
+        $this->assertArrayHasKey($relationKey, $relationsToArray);
+        $this->assertEquals($relationsToArray[$relationKey], $relationValue);
+    }
+
+    public function testChangeRelationWhenSetAttributeIsARelationAlreadyLoaded()
+    {
+        $model = new EloquentModelStub();
+        $relationKey = 'foo';
+        $relationValue = 'bar';
+        $model->setRelation($relationKey, $relationValue);
+
+        $newRelationValue = 'some_new_bar_value';
+        $model->$relationKey = $newRelationValue;
+
+        $this->assertEquals($model->$relationKey, $newRelationValue);
+        $this->assertEquals($model->getRelation($relationKey), $newRelationValue);
+    }
+
     public function testNonExistingAttributeWithInternalMethodNameDoesntCallMethod()
     {
         $model = m::mock(EloquentModelStub::class.'[delete,getRelationValue]');


### PR DESCRIPTION
Recently I needed change a relationship value in a collection model when mapping the collection. For example:

```php
Tools::with('tags')->map(function (Tool $tool) {
    $tool->tags = $tool->tags->map->value;

    return $value;
});
```

When I did this, doesn't worked. After a while analyzing the problem I understood, when I do `$tool->tags = 'someValue'` I create or update value in attributes, but `tags` is a relationship, so when I call some method like `toArray`, this method join the attributes and relationship, so relationship values override attributes value.

After a while I got a solution, I can do something like this:

```php
Tools::with('tags')->map(function (Tool $tool) {
    $tool->tags->transform(function ($tag) { return $tag->value; });

    return $value;
});
```

But I consider this solutions not a good solution, because transform the relationship is different of create and override.

Thinking about this problem I developed this solution. When set some attribute,  checks the attribute is a relationship loaded, if is, override the relationship, if not, create or update the attribute (the old way).