### PR TITLE
[5.8] SERVER_PORT env in ServeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -109,7 +109,7 @@ class ServeCommand extends Command
         return [
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', '127.0.0.1'],
 
-            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', 8000],
+            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', env('SERVER_PORT', 8000)],
 
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
         ];


### PR DESCRIPTION
I work at a relatively large corporate firm and we heavily use Laravel/Lumen to make microservices. I often run 4 or 5 of these projects simultaneously using the command `php artisan serve`. It would be really handy if I could specify a default port for each of the projects by adding a new environment variable into the .env.

In this pull request I've made a very small change by adding the env() function to the ServeCommand so if the environment variable SERVER_PORT is set it will use that port otherwise it will default to the standard port 8000 if this is not set.