### PR TITLE
[5.9] Add optional id attribute for csrf_field helper and @csrf Blade directive

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -335,6 +335,7 @@ if (! function_exists('csrf_field')) {
     function csrf_field($id = null)
     {
         $id_attribute = $id ? 'id="'.$id.'"' : '';
+
         return new HtmlString('<input type="hidden" name="_token" value="'.csrf_token().'" '.$id_attribute.'>');
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -328,11 +328,14 @@ if (! function_exists('csrf_field')) {
     /**
      * Generate a CSRF token form field.
      *
+     * @param  string  $id
+     *
      * @return \Illuminate\Support\HtmlString
      */
-    function csrf_field()
+    function csrf_field($id = null)
     {
-        return new HtmlString('<input type="hidden" name="_token" value="'.csrf_token().'">');
+        $id_attribute = $id ? 'id="'.$id.'"' : '';
+        return new HtmlString('<input type="hidden" name="_token" value="'.csrf_token().'" '.$id_attribute.'>');
     }
 }
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesHelpers.php
@@ -7,11 +7,12 @@ trait CompilesHelpers
     /**
      * Compile the CSRF statements into valid PHP.
      *
+     * @param  string  $arguments
      * @return string
      */
-    protected function compileCsrf()
+    protected function compileCsrf($arguments)
     {
-        return '<?php echo csrf_field(); ?>';
+        return "<?php echo csrf_field{$arguments}; ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -6,7 +6,8 @@ class BladeHelpersTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
-        $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
+        $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString("@csrf()"));
+        $this->assertEquals('<?php echo csrf_field(\'csrf-token\'); ?>', $this->compiler->compileString("@csrf('csrf-token')"));
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
         $this->assertEquals('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -6,7 +6,7 @@ class BladeHelpersTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
-        $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString("@csrf()"));
+        $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf()'));
         $this->assertEquals('<?php echo csrf_field(\'csrf-token\'); ?>', $this->compiler->compileString("@csrf('csrf-token')"));
         $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
         $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));


### PR DESCRIPTION
This is exactly the same PR as #28753, but on `master` instead of `5.8`, following contributors content.

Copying here the description from #28753.

---

Hi!

This PR adds an optional `$id` parameter to `@csrf` and `csrf_field()`. So this: 
```
@csrf('csrf')
```
now generates:
```html
<input type="hidden" name="_token" value="[a random string]" id="csrf">
```

## Example of use case

When JavaScript enhances a server-side rendered page and take control over a form, I find `@csrf` to be less useful because of the missing `id`. The `id` attribute helps to grab the token in a more easy and performant way. Without it, I end up writing the whole `<input>` string.

Example form:
```html
<form id="contact">
  <!-- lot of fields and buttons, pew pew -->
  <input type="hidden" name="_token" id="csrf" value="…">
</form>
```

Five ways to grab the token using JavaScript:
```js
// HTMLFormElement.elements[id]
document.forms['contact'].elements['csrf'].value

// HTMLFormElement.elements[name]
document.forms['contact'].elements._token.value

// HTMLElement.id
document.getElementById('csrf').value

// When HTMLElement has an id, it becomes a window property
window.csrf.value

// For potential jQuery-enthusiasts
$('#csrf').val()
```
## Benefits of the `id`

- Short syntax in the Blade view and in the JavaScript.
- No need to know the `<form>` `id` (in the example: `contact`) to grab the token value.

## Does it break something?

No. This is a backward compatible enhancement.

A test has been added.