### PR TITLE
[5.9] Allow multiple throttles by naming

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -39,13 +39,14 @@ class ThrottleRequests
      * @param  \Closure  $next
      * @param  int|string  $maxAttempts
      * @param  float|int  $decayMinutes
+     * @param  string  $prefix
      * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
      */
-    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        $key = $this->resolveRequestSignature($request);
+        $key = $prefix.$this->resolveRequestSignature($request);
 
         $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -47,13 +47,14 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      * @param  \Closure  $next
      * @param  int|string  $maxAttempts
      * @param  float|int  $decayMinutes
+     * @param  string  $prefix
      * @return mixed
      *
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
-    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        $key = $this->resolveRequestSignature($request);
+        $key = $prefix.$this->resolveRequestSignature($request);
 
         $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
 


### PR DESCRIPTION
Related issues and PRs: #28323 #16786 #28339 

Currently the key used to limit requests are generated by either user id or user ip, the request route is not considered. Therefor we have the following limitations:

1. We cannot apply throttle on a single route twice. For example, it is impossible to let users download at most 10 times a minute, but not more than 100 times an hour.
```php
Route::post('/download', 'Ctrl@create')->middleware('throttle:10,1', 'throttle:100,60');
```
What currently happens is that we now count 2 hits on each request and after 5 request in a minute, he will be blocked for a minute.

2. We cannot use independent throttles on different routes:
```php
// User can email 5 times an hour
Route::post('/email', 'Ctrl@email')->middleware('throttle:5,60');
// User can search 100 times an hour
Route::get('/search', 'Ctrl@search')->middleware('throttle:100,60);
```
What currently happens is that if a user searches 5 times in a 5 minute period, he/she is not able to email in the next hour.

This PR suggests that we name our throttles so that we can use them independently like the followings:
```php
// User can send 1000 requests of any kind in an hour.
Route::prefix('pane')->middleware('auth', 'throttle:1000,60')->group(function() {
    // User can download 10 times a minute, but not more than 100 times an hour.
    Route::post('/download', 'Ctrl@create')->middleware('throttle:10,1,minute_download', 'throttle:100,60,hour_download');
    // User can email 5 times an hour
    Route::post('/email', 'Ctrl@email')->middleware('throttle:5,60,email');
    // User can search 100 times an hour
    Route::get('/search', 'Ctrl@search')->middleware('throttle:100,60,search');
});
```

PS: Beside adding an optional parameter to `ThrottleRequests::handle` function, the behavior is backward compatible. So probably this is OK for 5.8 as well.