### PR TITLE
[5.8] Fix Builder::dump() and dd() with global scopes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -71,7 +71,7 @@ class Builder
      * @var array
      */
     protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql',
+        'insert', 'insertGetId', 'getBindings', 'toSql', 'dump', 'dd',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
     ];
 


### PR DESCRIPTION
`Eloquent\Builder::dump()` and `dd()` don't include global scopes, we need to call `toBase()` first.

There aren't any tests for these methods.