### PR TITLE
Revert "[5.8] Add 'index' => 'viewAny' to resourceAbilityMap"

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -105,7 +105,6 @@ trait AuthorizesRequests
     protected function resourceAbilityMap()
     {
         return [
-            'index' => 'viewAny',
             'show' => 'view',
             'create' => 'create',
             'store' => 'create',


### PR DESCRIPTION
Reverts laravel/framework#28820

Breaking change. See https://github.com/laravel/framework/issues/28862

Although do we just "press forward" since reverting might also be a BC now if anyone depending on new behaviour? I'll leave it for Taylor to decide.