### PR TITLE
[5.8] Allow console environment argument to be separated with a space

### DIFF
--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Foundation;
 
 use Closure;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class EnvironmentDetector
@@ -48,7 +47,7 @@ class EnvironmentDetector
         // and if it was that automatically overrides as the environment. Otherwise, we
         // will check the environment as a "web" request like a typical HTTP request.
         if (! is_null($value = $this->getEnvironmentArgument($args))) {
-            return head(array_slice(explode('=', $value), 1));
+            return $value;
         }
 
         return $this->detectWebEnvironment($callback);
@@ -62,8 +61,14 @@ class EnvironmentDetector
      */
     protected function getEnvironmentArgument(array $args)
     {
-        return Arr::first($args, function ($value) {
-            return Str::startsWith($value, '--env');
-        });
+        foreach ($args as $i => $value) {
+            if ($value === '--env') {
+                return $args[$i + 1] ?? null;
+            }
+
+            if (Str::startsWith($value, '--env')) {
+                return head(array_slice(explode('=', $value), 1));
+            }
+        }
     }
 }

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -32,4 +32,24 @@ class FoundationEnvironmentDetectorTest extends TestCase
         }, ['--env=local']);
         $this->assertEquals('local', $result);
     }
+
+    public function testConsoleEnvironmentDetectionSeparatedWithSpace()
+    {
+        $env = new EnvironmentDetector;
+
+        $result = $env->detect(function () {
+            return 'foobar';
+        }, ['--env', 'local']);
+        $this->assertEquals('local', $result);
+    }
+
+    public function testConsoleEnvironmentDetectionWithNoValue()
+    {
+        $env = new EnvironmentDetector;
+
+        $result = $env->detect(function () {
+            return 'foobar';
+        }, ['--env']);
+        $this->assertEquals('foobar', $result);
+    }
 }


### PR DESCRIPTION
Following explanations are from @matt-allan in the issue #28831:

The Symfony console component that is used by the Artisan console allows separating option names and values with either a space or an equals (=) sign. For example:

```
$ php artisan serve --port=9090 
Laravel development server started: <http://127.0.0.1:9090>
$ php artisan serve --port 9090 
Laravel development server started: <http://127.0.0.1:9090>
```

However, the `--env` option is only parsed correctly if you use an equals sign. If you use a space `app()->environment()` will return false.

This inconsistency is pretty confusing and difficult to debug. If you dump `$this->option('env')` in a command it will return the expected value but `app()->environment()` will return false.

Fixes #28831