### PR TITLE
Create tests for assertNotFound

### DIFF
--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -131,6 +131,21 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
     }
 
+    public function testAssertNotFound()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a not found status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertNotFound();
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
Looking in response tests I could see that are missing some tests for some asserts methods, so I decide create some PRs adding this tests but on separate PRs, this way if needs we can discuss each separated test

This PR adds tests for `assertNotFound` method.