### PR TITLE
Implementing MustVerifyEmail contract on User model

### DIFF
--- a/src/Illuminate/Foundation/Auth/User.php
+++ b/src/Illuminate/Foundation/Auth/User.php
@@ -10,11 +10,13 @@ use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
+use Illuminate\Contracts\Auth\MustVerifyEmail as MustVerifyEmailContract;
 
 class User extends Model implements
     AuthenticatableContract,
     AuthorizableContract,
-    CanResetPasswordContract
+    CanResetPasswordContract,
+    MustVerifyEmailContract
 {
     use Authenticatable, Authorizable, CanResetPassword, MustVerifyEmail;
 }

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -22,6 +22,19 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
 
         $listener->handle(new Registered($user));
     }
+    
+    /**
+     * @return void
+     */
+    public function testUserIsInstanceOfMustVerifyEmail()
+    {
+        $user = $this->getMockBuilder(User::class)->getMock();
+        $user->expects($this->once())->method('sendEmailVerificationNotification');
+
+        $listener = new SendEmailVerificationNotification;
+        
+        $listener->handle(new Registered($user));
+    }
 
     /**
      * @return void

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Auth;
 
 use PHPUnit\Framework\TestCase;
-use Illuminate\Foundation\Auth\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -18,19 +17,6 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
         $user = $this->getMockBuilder(MustVerifyEmail::class)->getMock();
         $user->method('hasVerifiedEmail')->willReturn(false);
         $user->expects($this->once())->method('sendEmailVerificationNotification');
-
-        $listener = new SendEmailVerificationNotification;
-
-        $listener->handle(new Registered($user));
-    }
-
-    /**
-     * @return void
-     */
-    public function testUserIsNotInstanceOfMustVerifyEmail()
-    {
-        $user = $this->getMockBuilder(User::class)->getMock();
-        $user->expects($this->never())->method('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification;
 

--- a/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
+++ b/tests/Auth/AuthListenersSendEmailVerificationNotificationHandleFunctionTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Auth;
 
 use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Auth\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -32,7 +33,7 @@ class AuthListenersSendEmailVerificationNotificationHandleFunctionTest extends T
         $user->expects($this->once())->method('sendEmailVerificationNotification');
 
         $listener = new SendEmailVerificationNotification;
-        
+
         $listener->handle(new Registered($user));
     }
 


### PR DESCRIPTION
Laravel, by default registers the `Registered` event automatically to the listener `Illuminate\Auth\Listeners\SendEmailVerificationNotification`.

The `handle` method code looks like 
```
public function handle(Registered $event)
    {
        if ($event->user instanceof MustVerifyEmail && !$event->user->hasVerifiedEmail()) {
            $event->user->sendEmailVerificationNotification();
        }
    }
```

This handle does nothing if a developer doesn't implement the `Illuminate\Contracts\Auth\MustVerifyEmail` on the `App\User` class.

The base class `Illuminate\Foundation\Auth\User` implements these methods in a trait. So, if we could add `Illuminate\Contracts\Auth\MustVerifyEmail` to the base class `Illuminate\Foundation\Auth\User` interface list, `SendEmailVerificationNotification` would work fine. 

Or else, there is no point in automatically assigning the `SendEmailVerificationNotification` class listening to the `Registered` event.