### PR TITLE
[5.8] Add assert method for empty response 

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -173,6 +173,21 @@ class TestResponse
     }
 
     /**
+     * Assert that the response is empty.
+     *
+     * @return $this
+     */
+    public function assertEmpty()
+    {
+        PHPUnit::assertTrue(
+            $this->isEmpty(),
+            'Response status code ['.$this->getStatusCode().'] is not a empty response status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Asserts that the response contains the given header and equals the optional value.
      *
      * @param  string  $headerName

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -131,6 +131,21 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeTextInOrder(['foobar', 'qux', 'baz']);
     }
 
+    public function testAssertEmpty()
+    {
+        $statusCode = 200;
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a empty response status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+
+        $response->assertEmpty();
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
This PR adds one more method to response testing:

```
assertEmpty()
```

This assert check if response status is 204 or 304, it's a call for the method `isEmpty`. I think this way is more verbose and straightforward.

This PR is the same of #28875  with resolving conflicts. 