### PR TITLE
[5.8] Arr::get also accepts int for $key

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -275,7 +275,7 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string  $key
+     * @param  string|int  $key
      * @param  mixed   $default
      * @return mixed
      */


### PR DESCRIPTION
This is also evident when `static::exists` is called which has this signature
```
     * @param  string|int  $key
```
![image](https://user-images.githubusercontent.com/87493/59722618-66a3ce80-9224-11e9-8bdd-cde738e072cd.png)
