### PR TITLE
[5.8] compile `@endcomponentFirst`

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -56,4 +56,14 @@ trait CompilesComponents
     {
         return "<?php \$__env->startComponentFirst{$expression}; ?>";
     }
+
+    /**
+     * Compile the end-component-first statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndComponentFirst()
+    {
+        return $this->compileEndComponent();
+    }
 }


### PR DESCRIPTION
while the `@endcomponent` directive is perfectly valid to end a `@componentFirst`, the IDEs struggle to match the 2 up resulting in a syntax error, which I'm sure people will be upset about.

I would prefer the plugin handle this if it can, but I'm not sure if it can, or where to change that, so I'm PR'ing here for now.