### PR TITLE
Add keyByValue() method to Illuminate\Support\Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -952,7 +952,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Key an associative array by a it's values.
+     * Key an associative array by it's values.
      *
      * @return static
      */

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -952,6 +952,18 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Key an associative array by a it's values.
+     *
+     * @return static
+     */
+    public function keyByValue()
+    {
+        return $this->keyBy(function ($value) {
+            return $value;
+        });
+    }
+
+    /**
      * Determine if an item exists in the collection by key.
      *
      * @param  mixed  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1927,7 +1927,17 @@ class SupportCollectionTest extends TestCase
         });
         $this->assertEquals([
             '[0,"Taylor","Otwell"]' => ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
-            '[1,"Lucas","Michot"]' => ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
+            '[1,"Lucas","Michot"]'  => ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
+        ], $result->all());
+    }
+
+    public function testKeyByValue()
+    {
+        $data = new Collection(['Otwell', 'Michot']);
+        $result = $data->keyByValue();
+        $this->assertEquals([
+            'Otwell' => 'Otwell',
+            'Michot' => 'Michot',
         ], $result->all());
     }
 


### PR DESCRIPTION
- Allows the collection to be expressively keyed by its values without having to call keyBy() and pass in an anonymous function

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
