### PR TITLE
[5.8] Fixes method description in docblock for first method in Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -804,7 +804,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Get the first item from the collection.
+     * Get the first item from the collection passing the given truth test.
      *
      * @param  callable|null  $callback
      * @param  mixed  $default


### PR DESCRIPTION
The description in the docblock for the ``first`` method in ``Illuminate\Support\Collection`` is incorrect and a bit misleading IMO. It got me puzzled for some time.
