### PR TITLE
[5.8] Pass columns param to getCountForPagination()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -747,7 +747,7 @@ class Builder
 
         $perPage = $perPage ?: $this->model->getPerPage();
 
-        $results = ($total = $this->toBase()->getCountForPagination())
+        $results = ($total = $this->toBase()->getCountForPagination($columns))
                                     ? $this->forPage($page, $perPage)->get($columns)
                                     : $this->model->newCollection();
 


### PR DESCRIPTION
In the `Illuminate/Database/Eloquent/Builder.php` paginate() function pass the `$columns` parram to `getCountForPagination()`

Ref #28842 

![image](https://user-images.githubusercontent.com/15308102/59496790-c87ed400-8ec4-11e9-9ef5-2aed1008f2ef.png)