### PR TITLE
[5.8] Query Builder Paginate gives Syntax error if you pass columns into paginate()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2138,7 +2138,7 @@ class Builder
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = $this->getCountForPagination($columns);
+        $total = $this->getCountForPagination();
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 


### PR DESCRIPTION
- Laravel Version: 5.8.22
- PHP Version: 7.2.17
- Database Driver & Version: MySql 8.0

### Description:
Database Query Builder Paginate gives SQLSTATE[42000]: Syntax error if you pass columns into paginate()

### Steps To Reproduce:

```
$results = DB::table('users')->paginate(20, ['id', 'name']);
```

> Illuminate \ Database \ QueryException (42000)
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ' `name`) as aggregate from `users`' at line 1 (SQL: select count(`id`, `name`) as aggregate from `users`)



I think that's why you didn't pass `$columns` in `Illuminate/Database/Eloquent/Builder::paginate()`

![image](https://user-images.githubusercontent.com/10154558/59760721-6b13ca00-92ac-11e9-8f64-6b8d6143484f.png)
