### PR TITLE
[5.5] Wrap Union statement with parentheses in PostgresGrammar

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -144,7 +144,6 @@ class PostgresGrammar extends Grammar
         return $conjunction.'('.$union['query']->toSql().')';
     }
 
-
     /**
      * Compile the columns for the update statement.
      *

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -132,6 +132,20 @@ class PostgresGrammar extends Grammar
     }
 
     /**
+     * Compile a single union statement.
+     *
+     * @param  array  $union
+     * @return string
+     */
+    protected function compileUnion(array $union)
+    {
+        $conjunction = $union['all'] ? ' union all ' : ' union ';
+
+        return $conjunction.'('.$union['query']->toSql().')';
+    }
+
+
+    /**
      * Compile the columns for the update statement.
      *
      * @param  array   $values

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -572,7 +572,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getPostgresBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('select * from `users` where `id` = ? union (select * from `users` where `id` = ?)', $builder->toSql());
+        $this->assertEquals('select * from "users" where "id" = ? union (select * from "users" where "id" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getMysqlBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -569,6 +569,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1);
+        $builder->union($this->getPostgresBuilder()->select('*')->from('users')->where('id', '=', 2));
+        $this->assertEquals('select * from `users` where `id` = ? union (select * from `users` where `id` = ?)', $builder->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
+
         $builder = $this->getMysqlBuilder();
         $expectedSql = '(select `a` from `t1` where `a` = ? and `b` = ?) union (select `a` from `t2` where `a` = ? and `b` = ?) order by `a` asc limit 10';
         $union = $this->getMysqlBuilder()->select('a')->from('t2')->where('a', 11)->where('b', 2);


### PR DESCRIPTION
With the latest 5.5 version there is a problem: if you try to make a complex union query -- it is most likely to fail because union statement is not wrapped with parentheses. Since query is not segmented correctly, you cannot use limit and order by.

Example:
```php
$query = Model::query();
$query->unionAll(
    Model::query()
       ->join('table as t2', 'models.id', '=', 't2.parent_id')
       ->orderByRaw('t2.season, t2.episode ASC')
)
```
Without parentheses query will end up in an error:

> Undefined table: 7 ERROR:  missing FROM-clause entry for table "catalog_titles"

Also if you want to _limit_ your union results -- it is also not possible. Limit statement outside parentheses is treated as part of main query.
This issue was fixed for MySQL and was not fixed for Postgres and has many complaints throughout github.