### PR TITLE
[5.8] allow view assertions to see all data

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -766,13 +766,13 @@ class TestResponse
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->original->getData());
+            PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
         } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->getData()[$key]));
+            PHPUnit::assertTrue($value($this->original->gatherData()[$key]));
         } elseif ($value instanceof Model) {
-            PHPUnit::assertTrue($value->is($this->original->getData()[$key]));
+            PHPUnit::assertTrue($value->is($this->original->gatherData()[$key]));
         } else {
-            PHPUnit::assertEquals($value, $this->original->getData()[$key]);
+            PHPUnit::assertEquals($value, $this->original->gatherData()[$key]);
         }
 
         return $this;
@@ -807,7 +807,7 @@ class TestResponse
     {
         $this->ensureResponseHasView();
 
-        return $this->original->getData()[$key];
+        return $this->original->gatherData()[$key];
     }
 
     /**
@@ -820,7 +820,7 @@ class TestResponse
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertArrayNotHasKey($key, $this->original->getData());
+        PHPUnit::assertArrayNotHasKey($key, $this->original->gatherData());
 
         return $this;
     }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -147,7 +147,7 @@ class View implements ArrayAccess, ViewContract
      *
      * @return array
      */
-    protected function gatherData()
+    public function gatherData()
     {
         $data = array_merge($this->factory->getShared(), $this->data);
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -31,7 +31,7 @@ class FoundationTestResponseTest extends TestCase
     {
         $response = $this->makeMockResponse([
             'render' => 'hello world',
-            'getData' => ['foo' => 'bar'],
+            'gatherData' => ['foo' => 'bar'],
         ]);
 
         $response->assertViewHas('foo');
@@ -48,7 +48,7 @@ class FoundationTestResponseTest extends TestCase
 
         $response = $this->makeMockResponse([
             'render' => 'hello world',
-            'getData' => ['foo' => $model],
+            'gatherData' => ['foo' => $model],
         ]);
 
         $response->original->foo = $model;


### PR DESCRIPTION
### Problem

The `assertViewHas()` assertion in the HTTP testing will currently only look at data bound directly to the view, and not data that has been 'shared' with the view.  This makes it a little clunkier to check for shared data.

```php
$response = $this->get('/');

$response->assertOk();

$response->assertViewHas('someKey');  // fails with shared data

$this->assertArrayHasKey('someKey', $response->original->gatherData());
```

### Solution

The view assertions now use the `gatherData()` method, instead of the `getData()` method, which provides us both the directly bound data, and the globally shared data.

### Concerns

- Is this BC kosher? Not sure if this would be considered a 'bug fix' or a 'change of behavior', and I guess depends on the intent of the assertion.
- Or does this belong in a separate assertion? `assertViewHasShared()` or something similar?