### PR TITLE
[5.9] Allow single scope to be specified as string on builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -875,14 +875,14 @@ class Builder
     /**
      * Call the given local model scopes.
      *
-     * @param  array  $scopes
+     * @param  array|string  $scopes
      * @return static|mixed
      */
-    public function scopes(array $scopes)
+    public function scopes($scopes)
     {
         $builder = $this;
 
-        foreach ($scopes as $scope => $parameters) {
+        foreach (Arr::wrap($scopes) as $scope => $parameters) {
             // If the scope key is an integer, then the scope was passed as the value and
             // the parameter list is empty, so we will format the scope name and these
             // parameters here. Then, we'll be ready to call the scope on the model.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1814,8 +1814,16 @@ class DatabaseEloquentModelTest extends TestCase
         ];
 
         $this->assertInstanceOf(Builder::class, $model->scopes($scopes));
-
         $this->assertSame($scopes, $model->scopesCalled);
+    }
+
+    public function testScopesMethodWithString()
+    {
+        $model = new EloquentModelStub;
+        $this->addMockConnection($model);
+
+        $this->assertInstanceOf(Builder::class, $model->scopes('published'));
+        $this->assertSame(['published'], $model->scopesCalled);
     }
 
     public function testIsWithNull()


### PR DESCRIPTION
Resubmission of #28892 to avoid breaking change on 5.8

```php
// Old
$query->scopes(['published']);

// New
$query->scopes('published');
```