### PR TITLE
[5.8] Prevent event cache from firing multiple times the same event(s)

### DIFF
--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -48,9 +48,9 @@ class EventCacheCommand extends Command
         $events = [];
 
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge($provider->discoverEvents(), $provider->listens());
+            $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
 
-            $events = array_merge_recursive($events, $providerEvents);
+            $events[get_class($provider)] = $providerEvents;
         }
 
         return $events;

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -29,10 +29,7 @@ class EventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $events = array_merge_recursive(
-            $this->discoveredEvents(),
-            $this->listens()
-        );
+        $events = $this->getEvents();
 
         foreach ($events as $event => $listeners) {
             foreach (array_unique($listeners) as $listener) {
@@ -60,12 +57,27 @@ class EventServiceProvider extends ServiceProvider
      *
      * @return array
      */
-    protected function discoveredEvents()
+    public function getEvents()
     {
         if ($this->app->eventsAreCached()) {
-            return require $this->app->getCachedEventsPath();
-        }
+            $cache = require $this->app->getCachedEventsPath();
 
+            return $cache[get_class($this)] ?? [];
+        } else {
+            return array_merge_recursive(
+                $this->discoveredEvents(),
+                $this->listens()
+            );
+        }
+    }
+
+    /**
+     * Get the discovered events for the application.
+     *
+     * @return array
+     */
+    protected function discoveredEvents()
+    {
         return $this->shouldDiscoverEvents()
                     ? $this->discoverEvents()
                     : [];


### PR DESCRIPTION
This is a proposed solution for solving #28872 .

Changes explanations:

## EventCacheCommand 
- The `discoverEvents` are cached only when `shouldDiscoverEvents` is true on the related providers, otherwise only the `listens` are cached.
- I've changed the structure of `events.php` so the the events/Listeners are grouped by EventServiceProvider.
```
[
  [Arrayof EventServiceProviders] => [Arrayof Events] => [Arrayof Listeners] 
]
```

instead of the old structure : 
```
[
   [Arrayof Events] => [Arrayof Listeners] 
]
```
- I've changed `array_merge` to `array_merge_recursive` because it still is technically possible that a basic `listen` event is also inside a discovered event.

## EventServiceProvider

- The `boot` methods now calls a `getEvents` to get the events of both discover and listen
- If the events are cached, the `getEvents` will return ONLY the events located under the name of the current EventServiceProvider in the `events.php` cache.
Indeed, the $this->listens() are already cached and they are all located inside the cache file, so there is no need to merge the cache file with listens;
There is also no need to check for `shouldDiscoverEvents` because it was already done inside the `event:cache` command.



I hope this helps, cheers !