### PR TITLE
[5.9] Move ramsey/uuid to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "opis/closure": "^3.1",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
-        "ramsey/uuid": "^3.7",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/console": "^4.3",
         "symfony/debug": "^4.3",
@@ -87,6 +86,7 @@
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",
+        "ramsey/uuid": "^3.7",
         "symfony/css-selector": "^4.3",
         "symfony/dom-crawler": "^4.3",
         "true/punycode": "^2.1"
@@ -131,6 +131,7 @@
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
+        "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.3).",
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.3).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",


### PR DESCRIPTION
I don't think we need to force this dependency on people, since it won't always be used by people. Why not instead move it to the require section of the laravel/laravel example app, so people still get it by default, but can opt-out easily?