### PR TITLE
[5.8] Write manifest with exclusive lock

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -191,7 +191,8 @@ class ProviderRepository
         }
 
         $this->files->put(
-            $this->manifestPath, '<?php return '.var_export($manifest, true).';'
+            $this->manifestPath, '<?php return '.var_export($manifest, true).';',
+            true
         );
 
         return array_merge(['when' => []], $manifest);

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -81,7 +81,7 @@ class FoundationProviderRepositoryTest extends TestCase
     public function testWriteManifestStoresToProperLocation()
     {
         $repo = new ProviderRepository(m::mock(ApplicationContract::class), $files = m::mock(Filesystem::class), __DIR__.'/services.php');
-        $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';');
+        $files->shouldReceive('put')->once()->with(__DIR__.'/services.php', '<?php return '.var_export(['foo'], true).';', true);
 
         $result = $repo->writeManifest(['foo']);
 


### PR DESCRIPTION
On very busy sites, multiple processes could attempt to write to the file, causing race conditions in writing to it with invalid syntax. Lock the file exclusively to avoid parse errors.