### PR TITLE
[5.8] Don't check for status code in assertJsonMissingValidationErrors()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -697,7 +697,7 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
-        if (empty($this->getContent()) && $this->getStatusCode() == 204) {
+        if ($this->getContent() === '') {
             PHPUnit::assertTrue(true);
 
             return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -581,18 +581,23 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
     {
-        $emptyTestResponse204 = TestResponse::fromBaseResponse(
+        $emptyResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('')
         );
-        $emptyTestResponse204->setStatusCode(204);
-        $emptyTestResponse204->assertJsonMissingValidationErrors();
 
+        $emptyResponse->assertJsonMissingValidationErrors();
+    }
+
+    public function testAssertJsonMissingValidationErrorsOnInvalidJson()
+    {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
 
-        $emptyTestResponseNot204 = TestResponse::fromBaseResponse(
-            (new Response)->setContent('')
+        $emptyResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent('~invalid json')
         );
-        $emptyTestResponseNot204->assertJsonMissingValidationErrors();
+
+        $emptyResponse->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -593,11 +593,11 @@ class FoundationTestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Invalid JSON was returned from the route.');
 
-        $emptyResponse = TestResponse::fromBaseResponse(
+        $invalidJsonResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('~invalid json')
         );
 
-        $emptyResponse->assertJsonMissingValidationErrors();
+        $invalidJsonResponse->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()


### PR DESCRIPTION
https://github.com/laravel/framework/pull/28595 fixes a problem where returning an empty response causes the `assertJsonMissingValidationErrors` assertion to fail because an empty response is not valid json.

This PR removes the status code 204 check. With this PR you can write tests using `assertJsonMissingValidationErrors` without explicitly returning a response. For example:

Controller:
```php
public function post(Request $request)
{
    $data = $request->validate([
        // a bunch of validation rules
    ]);

    SomeModel::create($data);
}
```

Test:
```php
function it_stores_the_model()
{
    $this->postJson('/model/store', [
            // a bunch of values
        ])
        ->assertJsonMissingValidationErrors()
        ->assertStatus(200);
}
```

Using a combination of these two assertions is useful because if the validation fails, the test will output exactly what went wrong. It also checks if your code explodes and causes a 500 error.

Often when writing api endpoints, you don't return a response. It is either not necessary, or because the consumer should just do another index call. However, currently the test above fails because we are not explicitly returning a 204 status code.