### PR TITLE
[5.8] Add null type to Eloquent Model $connection DocBlock

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -31,7 +31,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The connection name for the model.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 
@@ -1222,7 +1222,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the current connection name for the model.
      *
-     * @return string
+     * @return string|null
      */
     public function getConnectionName()
     {
@@ -1232,7 +1232,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Set the connection associated with the model.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return $this
      */
     public function setConnection($name)
@@ -1441,7 +1441,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the queueable connection for the entity.
      *
-     * @return mixed
+     * @return string|null
      */
     public function getQueueableConnection()
     {


### PR DESCRIPTION
This PR fixes DocBlocks of `$connection` property and all related methods which interacts with it.

- `getConnectionName` could return `null` because by default `$connection` property has `null` value.
- `setConnection` method accepts `getConnectionName` as parameter on new instance creation and $connection might be `null` in that case; that means it might get `null` value too.
- `getQueueableConnection` method has `string|null` return value in `Illuminate\Contracts\Queue\QueueableEntity` contract and returns `getConnectionName` in default implementation.

It was found while adding configurable database connection to package models:
https://github.com/cybercog/laravel-love/pull/68