### PR TITLE
[5.8] Add missing null type to Schema facade connection method DocBlock

### DIFF
--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -23,7 +23,7 @@ class Schema extends Facade
     /**
      * Get a schema builder instance for a connection.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Database\Schema\Builder
      */
     public static function connection($name)


### PR DESCRIPTION
This PR adds missing `null` type to `$name` property of `Schema::connection` method.

This method uses `connection` method of `Illuminate\Database\DatabaseManager` which already has `$name` property with `string|null` type.

With `null` value default database connection will be used.

It was found while adding configurable database connection to package database migrations:
https://github.com/cybercog/laravel-love/pull/68