### PR TITLE
[5.8] Add missing null type to $connection in Database Migration class DocBlock

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -7,7 +7,7 @@ abstract class Migration
     /**
      * The name of the database connection to use.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 
@@ -21,7 +21,7 @@ abstract class Migration
     /**
      * Get the migration connection name.
      *
-     * @return string
+     * @return string|null
      */
     public function getConnection()
     {


### PR DESCRIPTION
This PR is similar to #28915 & #28916

By default in migrations `$connection` property has `null` value, but it's missing this type in DocBlock.
`getConnection()` method returns `null` value by default.