### PR TITLE
[5.8] @error directive with custom bag name

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\View\Compilers\Concerns;
 
+use Illuminate\Support\Arr;
+
 trait CompilesErrors
 {
     /**
@@ -13,8 +15,8 @@ trait CompilesErrors
     protected function compileError($expression)
     {
         $expression = explode(',', $this->stripParentheses($expression));
-        $bag = Arr::get($expression, 0, 'default');
-        $attribute = trim(Arr::get($expression, 1, $expression));
+        $attribute = trim(Arr::get($expression, 0));
+        $bag = trim(Arr::get($expression, 1, '\'default\''));
 
         return '<?php if ($errors->getBag('.$bag.')->has('.$attribute.')) :
 if (isset($message)) { $messageCache = $message; }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -12,11 +12,13 @@ trait CompilesErrors
      */
     protected function compileError($expression)
     {
-        $expression = $this->stripParentheses($expression);
+        $expression = explode(',', $this->stripParentheses($expression));
+        $bag = Arr::get($expression, 0, 'default');
+        $attribute = trim(Arr::get($expression, 1, $expression));
 
-        return '<?php if ($errors->has('.$expression.')) :
+        return '<?php if ($errors->getBag('.$bag.')->has('.$attribute.')) :
 if (isset($message)) { $messageCache = $message; }
-$message = $errors->first('.$expression.'); ?>';
+$message = $errors->getBag('.$bag.')->first('.$attribute.'); ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -21,7 +21,7 @@ endif; ?>';
 
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
-    
+
     public function testErrorsWithCustomBagAreCompiled()
     {
         $string = '
@@ -36,7 +36,7 @@ $message = $errors->getBag(\'login\')->first(\'email\'); ?>
 <?php unset($message);
 if (isset($messageCache)) { $message = $messageCache; }
 endif; ?>';
-        
+
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -11,14 +11,32 @@ class BladeErrorTest extends AbstractBladeTestCase
     <span>{{ $message }}</span>
 @enderror';
         $expected = '
-<?php if ($errors->has(\'email\')) :
+<?php if ($errors->getBag(\'default\')->has(\'email\')) :
 if (isset($message)) { $messageCache = $message; }
-$message = $errors->first(\'email\'); ?>
+$message = $errors->getBag(\'default\')->first(\'email\'); ?>
     <span><?php echo e($message); ?></span>
 <?php unset($message);
 if (isset($messageCache)) { $message = $messageCache; }
 endif; ?>';
 
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+    
+    public function testErrorsWithCustomBagAreCompiled()
+    {
+        $string = '
+@error(\'email\', \'login\')
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php if ($errors->getBag(\'login\')->has(\'email\')) :
+if (isset($message)) { $messageCache = $message; }
+$message = $errors->getBag(\'login\')->first(\'email\'); ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($messageCache)) { $message = $messageCache; }
+endif; ?>';
+        
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
I want to use `@error('name')` directive with custom ErrorBag
so I **proposed** defining ErrorBag name by passing 2 parameters to `@error` directive
`@error($attribute, $errorBagName)`
example: 
```
@error('email`, 'login')
    {{ $message }}
@enderror
```