### PR TITLE
[5.8] Add whereHasMorph()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -16,7 +16,7 @@ trait QueriesRelationships
     /**
      * Add a relationship count / exists condition to the query.
      *
-     * @param  string  $relation
+     * @param  string|\Illuminate\Database\Eloquent\Relations\Relation  $relation
      * @param  string  $operator
      * @param  int     $count
      * @param  string  $boolean
@@ -25,14 +25,16 @@ trait QueriesRelationships
      */
     public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
     {
-        if (strpos($relation, '.') !== false) {
-            return $this->hasNested($relation, $operator, $count, $boolean, $callback);
+        if (is_string($relation)) {
+            if (strpos($relation, '.') !== false) {
+                return $this->hasNested($relation, $operator, $count, $boolean, $callback);
+            }
+
+            $relation = $this->getRelationWithoutConstraints($relation);
         }
 
-        $relation = $this->getRelationWithoutConstraints($relation);
-
         if ($relation instanceof MorphTo) {
-            throw new RuntimeException('has() and whereHas() do not support MorphTo relationships.');
+            throw new RuntimeException('Please use whereHasMorph() for MorphTo relationships.');
         }
 
         // If we only need to check for the existence of the relation, then we can optimize
@@ -180,6 +182,161 @@ trait QueriesRelationships
     public function orWhereDoesntHave($relation, Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query.
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  string  $operator
+     * @param  int  $count
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    {
+        $relation = $this->getRelationWithoutConstraints($relation);
+
+        $types = (array) $types;
+
+        if ($types === ['*']) {
+            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType());
+        }
+
+        return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
+            foreach ($types as $type) {
+                $query->orWhere(function ($query) use ($relation, $callback, $operator, $count, $type) {
+                    $belongsTo = $this->getBelongsToRelation($relation, $type);
+
+                    $belongsTo->getQuery()->mergeConstraintsFrom($relation->getQuery());
+
+                    if ($callback) {
+                        $callback = function ($query) use ($callback, $type) {
+                            return $callback($query, $type);
+                        };
+                    }
+
+                    $query->where($relation->getMorphType(), '=', $type)
+                        ->whereHas($belongsTo, $callback, $operator, $count);
+                });
+            }
+        }, null, null, $boolean);
+    }
+
+    /**
+     * Get the BelongsTo relationship for a single polymorphic type.
+     *
+     * @param  \Illuminate\Database\Eloquent\Relations\MorphTo  $relation
+     * @param  string  $type
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    protected function getBelongsToRelation(MorphTo $relation, $type)
+    {
+        return Relation::noConstraints(function () use ($relation, $type) {
+            return $this->model->belongsTo(
+                Relation::getMorphedModel($type) ?? $type,
+                $relation->getForeignKeyName(),
+                $relation->getOwnerKeyName()
+            );
+        });
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orHasMorph($relation, $types, $operator = '>=', $count = 1)
+    {
+        return $this->hasMorph($relation, $types, $operator, $count, 'or');
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query.
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  string  $boolean
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
+    {
+        return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with an "or".
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orDoesntHaveMorph($relation, $types)
+    {
+        return $this->doesntHaveMorph($relation, $types, 'or');
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses.
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  \Closure  $callback
+     * @param  string  $operator
+     * @param  int  $count
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    {
+        return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses.
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  \Closure|null  $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    {
+        return $this->doesntHaveMorph($relation, $types, 'and', $callback);
+    }
+
+    /**
+     * Add a polymorphic relationship count / exists condition to the query with where clauses and an "or".
+     *
+     * @param  string  $relation
+     * @param  string|array  $types
+     * @param  \Closure  $callback
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
+    public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    {
+        return $this->doesntHaveMorph($relation, $types, 'or', $callback);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -202,7 +202,11 @@ trait QueriesRelationships
         $types = (array) $types;
 
         if ($types === ['*']) {
-            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType());
+            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->all();
+
+            foreach ($types as &$type) {
+                $type = Relation::getMorphedModel($type) ?? $type;
+            }
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -210,8 +210,6 @@ trait QueriesRelationships
                 $query->orWhere(function ($query) use ($relation, $callback, $operator, $count, $type) {
                     $belongsTo = $this->getBelongsToRelation($relation, $type);
 
-                    $belongsTo->getQuery()->mergeConstraintsFrom($relation->getQuery());
-
                     if ($callback) {
                         $callback = function ($query) use ($callback, $type) {
                             return $callback($query, $type);
@@ -234,13 +232,17 @@ trait QueriesRelationships
      */
     protected function getBelongsToRelation(MorphTo $relation, $type)
     {
-        return Relation::noConstraints(function () use ($relation, $type) {
+        $belongsTo = Relation::noConstraints(function () use ($relation, $type) {
             return $this->model->belongsTo(
                 Relation::getMorphedModel($type) ?? $type,
                 $relation->getForeignKeyName(),
                 $relation->getOwnerKeyName()
             );
         });
+
+        $belongsTo->getQuery()->mergeConstraintsFrom($relation->getQuery());
+
+        return $belongsTo;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -216,7 +216,7 @@ trait QueriesRelationships
                         };
                     }
 
-                    $query->where($relation->getMorphType(), '=', $type)
+                    $query->where($relation->getMorphType(), '=', (new $type)->getMorphClass())
                         ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }
@@ -234,7 +234,7 @@ trait QueriesRelationships
     {
         $belongsTo = Relation::noConstraints(function () use ($relation, $type) {
             return $this->model->belongsTo(
-                Relation::getMorphedModel($type) ?? $type,
+                $type,
                 $relation->getForeignKeyName(),
                 $relation->getOwnerKeyName()
             );

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -74,23 +74,6 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
 
-    public function testWhereHasMorphWithMorphMap()
-    {
-        Relation::morphMap(['posts' => Post::class]);
-
-        Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
-
-        try {
-            $comments = Comment::whereHasMorph('commentable', ['posts', Video::class], function (Builder $query) {
-                $query->where('title', 'foo');
-            })->get();
-
-            $this->assertEquals([1, 4], $comments->pluck('id')->all());
-        } finally {
-            Relation::morphMap([], false);
-        }
-    }
-
     public function testWhereHasMorphWithRelationConstraint()
     {
         $comments = Comment::whereHasMorph('commentableWithConstraint', Video::class, function (Builder $query) {

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentWhereHasMorphTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentWhereHasMorphTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+            $table->softDeletes();
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('title');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->morphs('commentable');
+            $table->softDeletes();
+        });
+
+        $models = [];
+
+        $models[] = Post::create(['title' => 'foo']);
+        $models[] = Post::create(['title' => 'bar']);
+        $models[] = Post::create(['title' => 'baz']);
+        end($models)->delete();
+
+        $models[] = Video::create(['title' => 'foo']);
+        $models[] = Video::create(['title' => 'bar']);
+        $models[] = Video::create(['title' => 'baz']);
+
+        foreach ($models as $model) {
+            (new Comment)->commentable()->associate($model)->save();
+        }
+    }
+
+    public function testWhereHasMorph()
+    {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+            $query->where('title', 'foo');
+        })->get();
+
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
+    }
+
+    public function testWhereHasMorphWithWildcard()
+    {
+        // Test newModelQuery() without global scopes.
+        Comment::where('commentable_type', Video::class)->delete();
+
+        $comments = Comment::withTrashed()
+            ->whereHasMorph('commentable', '*', function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
+    }
+
+    public function testWhereHasMorphWithMorphMap()
+    {
+        Relation::morphMap(['posts' => Post::class]);
+
+        Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
+
+        try {
+            $comments = Comment::whereHasMorph('commentable', ['posts', Video::class], function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+            $this->assertEquals([1, 4], $comments->pluck('id')->all());
+        } finally {
+            Relation::morphMap([], false);
+        }
+    }
+
+    public function testWhereHasMorphWithRelationConstraint()
+    {
+        $comments = Comment::whereHasMorph('commentableWithConstraint', Video::class, function (Builder $query) {
+            $query->where('title', 'like', 'ba%');
+        })->get();
+
+        $this->assertEquals([5], $comments->pluck('id')->all());
+    }
+
+    public function testWhereHasMorphWitDifferentConstraints()
+    {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query, $type) {
+            if ($type === Post::class) {
+                $query->where('title', 'foo');
+            }
+
+            if ($type === Video::class) {
+                $query->where('title', 'bar');
+            }
+        })->get();
+
+        $this->assertEquals([1, 5], $comments->pluck('id')->all());
+    }
+
+    public function testWhereHasMorphWithOwnerKey()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('slug')->nullable();
+        });
+
+        Schema::table('comments', function (Blueprint $table) {
+            $table->string('commentable_id')->change();
+        });
+
+        Post::where('id', 1)->update(['slug' => 'foo']);
+
+        Comment::where('id', 1)->update(['commentable_id' => 'foo']);
+
+        $comments = Comment::whereHasMorph('commentableWithOwnerKey', Post::class, function (Builder $query) {
+            $query->where('title', 'foo');
+        })->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
+
+    public function testHasMorph()
+    {
+        $comments = Comment::hasMorph('commentable', Post::class)->get();
+
+        $this->assertEquals([1, 2], $comments->pluck('id')->all());
+    }
+
+    public function testOrHasMorph()
+    {
+        $comments = Comment::where('id', 1)->orHasMorph('commentable', Video::class)->get();
+
+        $this->assertEquals([1, 4, 5, 6], $comments->pluck('id')->all());
+    }
+
+    public function testDoesntHaveMorph()
+    {
+        $comments = Comment::doesntHaveMorph('commentable', Post::class)->get();
+
+        $this->assertEquals([3], $comments->pluck('id')->all());
+    }
+
+    public function testOrDoesntHaveMorph()
+    {
+        $comments = Comment::where('id', 1)->orDoesntHaveMorph('commentable', Post::class)->get();
+
+        $this->assertEquals([1, 3], $comments->pluck('id')->all());
+    }
+
+    public function testOrWhereHasMorph()
+    {
+        $comments = Comment::where('id', 1)
+            ->orWhereHasMorph('commentable', Video::class, function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
+    }
+
+    public function testWhereDoesntHaveMorph()
+    {
+        $comments = Comment::whereDoesntHaveMorph('commentable', Post::class, function (Builder $query) {
+            $query->where('title', 'foo');
+        })->get();
+
+        $this->assertEquals([2, 3], $comments->pluck('id')->all());
+    }
+
+    public function testOrWhereDoesntHaveMorph()
+    {
+        $comments = Comment::where('id', 1)
+            ->orWhereDoesntHaveMorph('commentable', Post::class, function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+        $this->assertEquals([1, 2, 3], $comments->pluck('id')->all());
+    }
+}
+
+class Comment extends Model
+{
+    use SoftDeletes;
+
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+
+    public function commentableWithConstraint()
+    {
+        return $this->morphTo('commentable')->where('title', 'bar');
+    }
+
+    public function commentableWithOwnerKey()
+    {
+        return $this->morphTo('commentable', null, null, 'slug');
+    }
+}
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = ['id'];
+}

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -61,6 +61,23 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         $this->assertEquals([1, 4], $comments->pluck('id')->all());
     }
 
+    public function testWhereHasMorphWithMorphMap()
+    {
+        Relation::morphMap(['posts' => Post::class]);
+
+        Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
+
+        try {
+            $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+            $this->assertEquals([1, 4], $comments->pluck('id')->all());
+        } finally {
+            Relation::morphMap([], false);
+        }
+    }
+
     public function testWhereHasMorphWithWildcard()
     {
         // Test newModelQuery() without global scopes.
@@ -72,6 +89,23 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
             })->get();
 
         $this->assertEquals([1, 4], $comments->pluck('id')->all());
+    }
+
+    public function testWhereHasMorphWithWildcardAndMorphMap()
+    {
+        Relation::morphMap(['posts' => Post::class]);
+
+        Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
+
+        try {
+            $comments = Comment::whereHasMorph('commentable', '*', function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+            $this->assertEquals([4, 1], $comments->pluck('id')->all());
+        } finally {
+            Relation::morphMap([], false);
+        }
     }
 
     public function testWhereHasMorphWithRelationConstraint()

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -192,6 +192,15 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
         $this->assertEquals([1, 2, 3], $comments->pluck('id')->all());
     }
+
+    public function testModelScopesAreAccessible()
+    {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+            $query->someSharedModelScope();
+        })->get();
+
+        $this->assertEquals([1, 4], $comments->pluck('id')->all());
+    }
 }
 
 class Comment extends Model
@@ -225,6 +234,11 @@ class Post extends Model
     public $timestamps = false;
 
     protected $guarded = ['id'];
+
+    public function scopeSomeSharedModelScope($query)
+    {
+        $query->where('title', '=', 'foo');
+    }
 }
 
 class Video extends Model
@@ -232,4 +246,9 @@ class Video extends Model
     public $timestamps = false;
 
     protected $guarded = ['id'];
+
+    public function scopeSomeSharedModelScope($query)
+    {
+        $query->where('title', '=', 'foo');
+    }
 }


### PR DESCRIPTION
Due to the nature of polymorphism, `whereHas()` doesn't work with `MorphTo` relationships (#5429, #18523).

As a solution, @timacdonald and I are proposing `whereHasMorph()` and the corresponding methods:

```php
Comment::whereHasMorph('commentable', [Post::class, Video::class], function ($query) {
    $query->where('title', 'foo');
})->get();
```
```sql
select * from "comments"
where (
  (
    "commentable_type" = 'App\Post' and exists (
      select * from "posts" where "comments"."commentable_id" = "posts"."id" and "title" = 'foo'
    )
  ) or (
    "commentable_type" = 'App\Video' and exists (
      select * from "videos" where "comments"."commentable_id" = "videos"."id" and "title" = 'foo'
    )
  )
)
```

By creating a temporary `BelongsTo` relationship for each type and allowing relationship instances as the first argument of `has()`, we can reuse most of the existing code.

~~If the user has registered custom aliases in the `morphMap`, they need to provide them instead of class names:~~

To simplify queries with different constraints, we pass the type as the second parameter:

```php
Comment::whereHasMorph('commentable', [Post::class, Video::class], function ($query, $type) {
    if ($type === Post::class) {
        // $query->
    }

    if ($type === Video::class) {
        // $query->
    }
});
```

You can also provide a wildcard and let Laravel get the possible types from the database:

```php
Comment::whereHasMorph('commentable', '*', function ($query) {
    $query->where('title', 'foo');
})->get();
```

The downside here is the additional query that should be mentioned in the docs.

Theoretically, you could use `*` as an alias, but we think it's a better choice than something like `null `.