### PR TITLE
[5.8] Fix test of Collection::sortKeysDesc()

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1082,7 +1082,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
 
-        $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeys()->all());
+        $this->assertSame(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeysDesc()->all());
     }
 
     public function testReverse()


### PR DESCRIPTION
Fixes problem with `\Illuminate\Tests\Support\SupportCollectionTest::testSortKeysDesc()` calling `Collection::sortKeys()`, instead of `Collection::sortKeysDesc()`.

This test was previously green due to the use of `assertEquals()` which allows arrays to have a different key order.

