### PR TITLE
[5.8] Make the parameters columns always used

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2591,9 +2591,7 @@ class Builder
     {
         $original = $this->columns;
 
-        if (is_null($original)) {
-            $this->columns = $columns;
-        }
+        $this->columns = $columns;
 
         $result = $callback();
 


### PR DESCRIPTION
When I call
`$builder = $builder->select($columns)`
then some special scenarios, I need to specify the columns again via
`$builder->get($columns2)`
but it doesn't work

Before, the get method has some hidden rules, namely: you must have not used select

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
