### PR TITLE
[5.8] Don't add page query string param for the first page of pagination to avoid SEO duplicate content issues

### DIFF
--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v5.8.24...5.8)
 
+### Added
+- Added `json` option to `route:list` command ([#28894](https://github.com/laravel/framework/pull/28894))
+
+### TODO
+- allow view assertions to see all data ([#28893](https://github.com/laravel/framework/pull/28893))
+- Let mix helper use assets url ([#28905](https://github.com/laravel/framework/pull/28905))
+- Prevent event cache from firing multiple times the same event(s) ([#28904](https://github.com/laravel/framework/pull/28904))
+- Fix assertJsonMissingValidationErrors() on empty response ([#28595](https://github.com/laravel/framework/pull/28595))
+- Don't check for status code in assertJsonMissingValidationErrors() ([#28913](https://github.com/laravel/framework/pull/28913))
+
 
 ## [v5.8.24 (2019-06-19)](https://github.com/laravel/framework/compare/v5.8.23...v5.8.24)
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -31,7 +31,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * The connection name for the model.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 
@@ -1222,7 +1222,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the current connection name for the model.
      *
-     * @return string
+     * @return string|null
      */
     public function getConnectionName()
     {
@@ -1232,7 +1232,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Set the connection associated with the model.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return $this
      */
     public function setConnection($name)
@@ -1441,7 +1441,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     /**
      * Get the queueable connection for the entity.
      *
-     * @return mixed
+     * @return string|null
      */
     public function getQueueableConnection()
     {

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -7,7 +7,7 @@ abstract class Migration
     /**
      * The name of the database connection to use.
      *
-     * @var string
+     * @var string|null
      */
     protected $connection;
 
@@ -21,7 +21,7 @@ abstract class Migration
     /**
      * Get the migration connection name.
      *
-     * @return string
+     * @return string|null
      */
     public function getConnection()
     {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -697,7 +697,7 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
-        if (empty($this->getContent()) && $this->getStatusCode() == 204) {
+        if ($this->getContent() === '') {
             PHPUnit::assertTrue(true);
 
             return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -668,6 +668,12 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
+        if (empty($this->getContent())) {
+            PHPUnit::assertTrue(true);
+
+            return $this;
+        }
+
         $json = $this->json();
 
         if (! array_key_exists('errors', $json)) {

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -668,7 +668,7 @@ class TestResponse
      */
     public function assertJsonMissingValidationErrors($keys = null)
     {
-        if (empty($this->getContent())) {
+        if (empty($this->getContent()) && $this->getStatusCode() == 204) {
             PHPUnit::assertTrue(true);
 
             return $this;

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -166,14 +166,20 @@ abstract class AbstractPaginator implements Htmlable
         // If we have any extra query string key / value pairs that need to be added
         // onto the URL, we will put them in query string form and then attach it
         // to the URL. This allows for extra information like sortings storage.
-        $parameters = [$this->pageName => $page];
+        $parameters = $page > 1
+            ? [$this->pageName => $page]
+            : [];
 
         if (count($this->query) > 0) {
             $parameters = array_merge($this->query, $parameters);
         }
 
+        $separator = !empty($parameters)
+            ? (Str::contains($this->path, '?') ? '&' : '?')
+            : '';
+
         return $this->path
-                        .(Str::contains($this->path, '?') ? '&' : '?')
+                        .$separator
                         .Arr::query($parameters)
                         .$this->buildFragment();
     }

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -174,7 +174,7 @@ abstract class AbstractPaginator implements Htmlable
             $parameters = array_merge($this->query, $parameters);
         }
 
-        $separator = !empty($parameters)
+        $separator = ! empty($parameters)
             ? (Str::contains($this->path, '?') ? '&' : '?')
             : '';
 

--- a/src/Illuminate/Support/Facades/Schema.php
+++ b/src/Illuminate/Support/Facades/Schema.php
@@ -23,7 +23,7 @@ class Schema extends Facade
     /**
      * Get a schema builder instance for a connection.
      *
-     * @param  string  $name
+     * @param  string|null  $name
      * @return \Illuminate\Database\Schema\Builder
      */
     public static function connection($name)

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -581,18 +581,23 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
     {
-        $emptyTestResponse204 = TestResponse::fromBaseResponse(
+        $emptyResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('')
         );
-        $emptyTestResponse204->setStatusCode(204);
-        $emptyTestResponse204->assertJsonMissingValidationErrors();
 
+        $emptyResponse->assertJsonMissingValidationErrors();
+    }
+
+    public function testAssertJsonMissingValidationErrorsOnInvalidJson()
+    {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Invalid JSON was returned from the route.');
 
-        $emptyTestResponseNot204 = TestResponse::fromBaseResponse(
-            (new Response)->setContent('')
+        $emptyResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent('~invalid json')
         );
-        $emptyTestResponseNot204->assertJsonMissingValidationErrors();
+
+        $emptyResponse->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -448,11 +448,18 @@ class FoundationTestResponseTest extends TestCase
 
     public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
     {
-        $testResponse = TestResponse::fromBaseResponse(
+        $emptyTestResponse204 = TestResponse::fromBaseResponse(
             (new Response)->setContent('')
         );
+        $emptyTestResponse204->setStatusCode(204);
+        $emptyTestResponse204->assertJsonMissingValidationErrors();
 
-        $testResponse->assertJsonMissingValidationErrors();
+        $this->expectException(AssertionFailedError::class);
+
+        $emptyTestResponseNot204 = TestResponse::fromBaseResponse(
+            (new Response)->setContent('')
+        );
+        $emptyTestResponseNot204->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -446,6 +446,15 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonMissingValidationErrors();
     }
 
+    public function testAssertJsonMissingValidationErrorsOnAnEmptyResponse()
+    {
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent('')
+        );
+
+        $testResponse->assertJsonMissingValidationErrors();
+    }
+
     public function testMacroable()
     {
         TestResponse::macro('foo', function () {

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -593,11 +593,11 @@ class FoundationTestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Invalid JSON was returned from the route.');
 
-        $emptyResponse = TestResponse::fromBaseResponse(
+        $invalidJsonResponse = TestResponse::fromBaseResponse(
             (new Response)->setContent('~invalid json')
         );
 
-        $emptyResponse->assertJsonMissingValidationErrors();
+        $invalidJsonResponse->assertJsonMissingValidationErrors();
     }
 
     public function testMacroable()

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -448,8 +448,11 @@ class ResourceTest extends TestCase
     {
         Route::get('/', function () {
             $paginator = new LengthAwarePaginator(
-                collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
-                10, 15, 1
+                collect([
+                    new Post(['id' => 5, 'title' => 'Test Title']),
+                    new Post(['id' => 6, 'title' => 'Test Title 2']),
+                ]),
+                10, 1, 1
             );
 
             return new PostCollectionResource($paginator);
@@ -467,20 +470,24 @@ class ResourceTest extends TestCase
                     'id' => 5,
                     'title' => 'Test Title',
                 ],
+                [
+                    'id' => 6,
+                    'title' => 'Test Title 2',
+                ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/?page=10',
                 'prev' => null,
-                'next' => null,
+                'next' => '/?page=2',
             ],
             'meta' => [
                 'current_page' => 1,
                 'from' => 1,
-                'last_page' => 1,
+                'last_page' => 10,
                 'path' => '/',
-                'per_page' => 15,
-                'to' => 1,
+                'per_page' => 1,
+                'to' => 2,
                 'total' => 10,
             ],
         ]);
@@ -510,8 +517,8 @@ class ResourceTest extends TestCase
                 ],
             ],
             'links' => [
-                'first' => '/?page=1',
-                'last' => '/?page=1',
+                'first' => '/',
+                'last' => '/',
                 'prev' => null,
                 'next' => null,
             ],

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -56,6 +56,15 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEmpty($paginator->items());
     }
 
+    public function testLengthAwarePaginatorDoesNotAddPageOne()
+    {
+        $this->p->setPath('http://website.com');
+        $this->p->setPageName('foo');
+
+        $this->assertEquals('http://website.com',
+                            $this->p->url(1));
+    }
+
     public function testLengthAwarePaginatorCanGenerateUrls()
     {
         $this->p->setPath('http://website.com');
@@ -64,10 +73,13 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com?foo=3',
+                            $this->p->url($this->p->currentPage() + 1));
+
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertEquals('http://website.com',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -88,10 +100,13 @@ class LengthAwarePaginatorTest extends TestCase
         $this->assertEquals('http://website.com/test?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test?foo=3',
+                            $this->p->url($this->p->currentPage() + 1));
+
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertEquals('http://website.com/test',
                             $this->p->url($this->p->currentPage() - 2));
     }
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -19,9 +19,9 @@ class PaginatorTest extends TestCase
         $pageInfo = [
             'per_page' => 2,
             'current_page' => 2,
-            'first_page_url' => '/?page=1',
+            'first_page_url' => '/',
             'next_page_url' => '/?page=3',
-            'prev_page_url' => '/?page=1',
+            'prev_page_url' => '/',
             'from' => 3,
             'to' => 4,
             'data' => ['item3', 'item4'],
@@ -36,7 +36,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=3', $p->nextPageUrl());
     }
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
@@ -44,7 +44,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertEquals('http://website.com/test?page=3', $p->nextPageUrl());
     }
 
     public function testItRetrievesThePaginatorOptions()

--- a/tests/Pagination/UrlWindowTest.php
+++ b/tests/Pagination/UrlWindowTest.php
@@ -19,7 +19,7 @@ class UrlWindowTest extends TestCase
     {
         $p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2);
         $window = new UrlWindow($p);
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => null], $window->get());
     }
 
     public function testPresenterCanGetAUrlRangeForAWindowOfLinks()
@@ -35,7 +35,7 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
 
         /*
          * Test Being Near The End Of The List
@@ -47,7 +47,7 @@ class UrlWindowTest extends TestCase
             $last[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => null, 'last' => $last], $window->get());
     }
 
     public function testCustomUrlRangeForAWindowOfLinks()
@@ -66,6 +66,6 @@ class UrlWindowTest extends TestCase
             $slider[$i] = '/?page='.$i;
         }
 
-        $this->assertEquals(['first' => [1 => '/?page=1', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
+        $this->assertEquals(['first' => [1 => '/', 2 => '/?page=2'], 'slider' => $slider, 'last' => [12 => '/?page=12', 13 => '/?page=13']], $window->get());
     }
 }


### PR DESCRIPTION
Paginator will currently return the page query string parameter for the first page of pagination (?page=1), when on proceeding pages.

This introduces a potential SEO duplicate content issue, as the page now has 2 URLs, which a site owner would need to address via canonical links.

This PR changes the url() method of AbstractPaginator to only return the paging query string param for pages > 1.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
