### PR TITLE
[5.8] Use cache for maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -973,7 +973,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return $this['cache.store']->has('framework_down');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class DownCommand extends Command
 {
@@ -29,14 +30,13 @@ class DownCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param CacheContract $cache
      * @return int
      */
-    public function handle()
+    public function handle(CacheContract $cache)
     {
         try {
-            file_put_contents(storage_path('framework/down'),
-                              json_encode($this->getDownFilePayload(),
-                              JSON_PRETTY_PRINT));
+            $cache->forever('framework_down', $this->getDownFilePayload());
 
             $this->comment('Application is now in maintenance mode.');
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Console;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class UpCommand extends Command
 {
@@ -24,18 +25,19 @@ class UpCommand extends Command
     /**
      * Execute the console command.
      *
+     * @param CacheContract $cache
      * @return int
      */
-    public function handle()
+    public function handle(CacheContract $cache)
     {
         try {
-            if (! file_exists(storage_path('framework/down'))) {
+            if (! $cache->has('framework_down')) {
                 $this->comment('Application is already up.');
 
                 return true;
             }
 
-            unlink(storage_path('framework/down'));
+            $cache->forget('framework_down');
 
             $this->info('Application is now live.');
         } catch (Exception $e) {

--- a/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
+++ b/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php
@@ -46,7 +46,7 @@ class CheckForMaintenanceMode
     public function handle($request, Closure $next)
     {
         if ($this->app->isDownForMaintenance()) {
-            $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
+            $data = $this->app['cache.store']->get('framework_down');
 
             if (isset($data['allowed']) && IpUtils::checkIp($request->ip(), (array) $data['allowed'])) {
                 return $next($request);


### PR DESCRIPTION
In Docker Swarm we need to put all application replicas in maintenance mode. Cache is a good option for storing application state as it is shared by all replicas.
