### PR TITLE
[5.8] Fix columns parameter on paginate method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2138,7 +2138,7 @@ class Builder
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $total = $this->getCountForPagination($columns);
+        $total = $this->getCountForPagination();
 
         $results = $total ? $this->forPage($page, $perPage)->get($columns) : collect();
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2826,7 +2826,7 @@ SQL;
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
-        $builder->shouldReceive('getCountForPagination')->once()->with($columns)->andReturn(2);
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn($results);
 
@@ -2853,7 +2853,7 @@ SQL;
 
         $results = collect([['test' => 'foo'], ['test' => 'bar']]);
 
-        $builder->shouldReceive('getCountForPagination')->once()->with($columns)->andReturn(2);
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
         $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
         $builder->shouldReceive('get')->once()->andReturn($results);
 
@@ -2884,7 +2884,7 @@ SQL;
 
         $results = [];
 
-        $builder->shouldReceive('getCountForPagination')->once()->with($columns)->andReturn(0);
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(0);
         $builder->shouldNotReceive('forPage');
         $builder->shouldNotReceive('get');
 
@@ -2899,6 +2899,33 @@ SQL;
         $result = $builder->paginate();
 
         $this->assertEquals(new LengthAwarePaginator($results, 0, $perPage, $page, [
+            'path' => $path,
+            'pageName' => $pageName,
+        ]), $result);
+    }
+
+    public function testPaginateWithSpecificColumns()
+    {
+        $perPage = 16;
+        $columns = ['id', 'name'];
+        $pageName = 'page-name';
+        $page = 1;
+        $builder = $this->getMockQueryBuilder();
+        $path = 'http://foo.bar?page=3';
+
+        $results = collect([['id' => 3, 'name' => 'Taylor'], ['id' => 5, 'name' => 'Mohamed']]);
+
+        $builder->shouldReceive('getCountForPagination')->once()->andReturn(2);
+        $builder->shouldReceive('forPage')->once()->with($page, $perPage)->andReturnSelf();
+        $builder->shouldReceive('get')->once()->andReturn($results);
+
+        Paginator::currentPathResolver(function () use ($path) {
+            return $path;
+        });
+
+        $result = $builder->paginate($perPage, $columns, $pageName, $page);
+
+        $this->assertEquals(new LengthAwarePaginator($results, 2, $perPage, $page, [
             'path' => $path,
             'pageName' => $pageName,
         ]), $result);

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
@@ -18,12 +19,14 @@ class QueryBuilderTest extends DatabaseTestCase
         parent::setUp();
 
         Schema::create('posts', function (Blueprint $table) {
+            $table->string('title');
+            $table->text('content');
             $table->timestamp('created_at');
         });
 
         DB::table('posts')->insert([
-            ['created_at' => new Carbon('2017-11-12 13:14:15')],
-            ['created_at' => new Carbon('2018-01-02 03:04:05')],
+            ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2017-11-12 13:14:15')],
+            ['title' => 'Bar Post', 'content' => 'Lorem Ipsum.', 'created_at' => new Carbon('2018-01-02 03:04:05')],
         ]);
     }
 
@@ -58,5 +61,16 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $this->assertSame(1, DB::table('posts')->whereTime('created_at', '03:04:05')->count());
         $this->assertSame(1, DB::table('posts')->whereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
+    }
+
+    public function testPaginateWithSpecificColumns()
+    {
+        $result = DB::table('posts')->paginate(5, ['title', 'content']);
+
+        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
+        $this->assertEquals($result->items(), [
+            (object) ['title' => 'Foo Post', 'content' => 'Lorem Ipsum.'],
+            (object) ['title' => 'Bar Post', 'content' => 'Lorem Ipsum.'],
+        ]);
     }
 }


### PR DESCRIPTION
This is currently broken and will throw a SQL exception:

```php
DB::table('posts')->paginate(5, ['title', 'content']);
```

At the moment when you attempt to pass specific columns on the paginate method on the base query builder it will fail when you provide more than one column. SQL queries can only handle a count for a specific column and not multiple ones. That's why it's unwanted to pass along the columns parameter from the paginate method to the getCountForPagination method. Since we just want to do a count of the current result set a simple count with the '*' sign is enough. At the moment the Eloquent builder already handles pagination in this way.

It's noted by @staudenmeir that the only difference is when you provide a specific column to the getCountForPagination method is that it'll only count non-NULLs. However, it's not feasible to allow this to be done in combination with the paginate method because the columns param on the paginate method soley exists to filter which columns will be retrieved in the paginated result set (which is currently broken thus). See https://github.com/laravel/framework/issues/28844#issuecomment-502917795

I've added an extra integration test which reproduces the problem at hand. I've updated the tests in the DatabaseQueryBuilderTest class to reflect the changes made to getCountForPagination call.

This has been a long outstanding issue so hopefully this will prevent more issues from popping up.

Fixes https://github.com/laravel/framework/issues/28890
