### PR TITLE
[5.8] Validate the characters passed to $name on MigrationMakeCommand

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
-use InvalidArgumentException;
 
 class MigrateMakeCommand extends BaseCommand
 {

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Console\Migrations;
 use Illuminate\Support\Str;
 use Illuminate\Support\Composer;
 use Illuminate\Database\Migrations\MigrationCreator;
+use InvalidArgumentException;
 
 class MigrateMakeCommand extends BaseCommand
 {
@@ -69,10 +70,10 @@ class MigrateMakeCommand extends BaseCommand
         $name = Str::snake(trim($this->input->getArgument('name')));
 
         // Later on we're going to convert $name into a classname for the
-        // migration.  As such, we need to confirm that there are no characters
+        // migration. As such, we need to confirm that there are no characters
         // that are not allowed in a classname
         if (! (bool) preg_match("%^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$%", $name)) {
-            throw new \InvalidArgumentException("Invalid characters present in proposed classname {$name}");
+            throw new InvalidArgumentException("Invalid characters present in proposed classname {$name}");
         }
 
         $table = $this->input->getOption('table');

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -71,7 +71,7 @@ class MigrateMakeCommand extends BaseCommand
         // Later on we're going to convert $name into a classname for the
         // migration.  As such, we need to confirm that there are no characters
         // that are not allowed in a classname
-        if (!(bool)preg_match("%^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$%", $name)) {
+        if (! (bool) preg_match("%^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$%", $name)) {
             throw new \InvalidArgumentException("Invalid characters present in proposed classname {$name}");
         }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -68,6 +68,13 @@ class MigrateMakeCommand extends BaseCommand
         // to be freshly created so we can create the appropriate migrations.
         $name = Str::snake(trim($this->input->getArgument('name')));
 
+        // Later on we're going to convert $name into a classname for the
+        // migration.  As such, we need to confirm that there are no characters
+        // that are not allowed in a classname
+        if (!(bool)preg_match("%^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$%", $name)) {
+            throw new \InvalidArgumentException("Invalid characters present in proposed classname {$name}");
+        }
+
         $table = $this->input->getOption('table');
 
         $create = $this->input->getOption('create') ?: false;

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -18,6 +18,20 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         m::close();
     }
 
+    public function testBasicCreateWithInvalidCharsThrowsException()
+    {
+        $command = new MigrateMakeCommand(
+            $creator = m::mock(MigrationCreator::class),
+            $composer = m::mock(Composer::class)
+        );
+        $app = new Application;
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->runCommand($command, ['name' => 'invalid,classname!']);
+    }
+
     public function testBasicCreateDumpsAutoload()
     {
         $command = new MigrateMakeCommand(

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Database;
 
 use Mockery as m;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Composer;
 use Illuminate\Foundation\Application;
@@ -27,7 +28,7 @@ class DatabaseMigrationMakeCommandTest extends TestCase
         $app = new Application;
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->runCommand($command, ['name' => 'invalid,classname!']);
     }


### PR DESCRIPTION
Reference: #28938 

The name passed to the `make:migration` command forms the base of the classname of the generated migration file. Currently this `name` param isn't validated, meaning classes can be created with invalid class names.

This PR adds a simple check to confirm there are no unsupported characters (using the RegEx defined in the PHP docs at https://www.php.net/manual/en/language.oop5.basic.php), and throws an InvalidArgumentException should such characters be found.
