### PR TITLE
[5.8] Convert percentage sign in filename fallback

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -141,7 +141,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
         $filename = $name ?? basename($path);
 
         $disposition = $response->headers->makeDisposition(
-            $disposition, $filename, Str::ascii($filename)
+            $disposition, $filename, $this->fallbackName($filename)
         );
 
         $response->headers->replace($headers + [
@@ -170,6 +170,17 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     public function download($path, $name = null, array $headers = [])
     {
         return $this->response($path, $name, $headers, 'attachment');
+    }
+    
+    /**
+     * Convert the string to ASCII characters that are equivalent to the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function fallbackName($name)
+    {
+        return str_replace('%', '', Str::ascii($name));
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -171,7 +171,7 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
     {
         return $this->response($path, $name, $headers, 'attachment');
     }
-    
+
     /**
      * Convert the string to ASCII characters that are equivalent to the given name.
      *

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -69,7 +69,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertEquals('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
     }
-    
+
     public function testDownloadPercentInFilename()
     {
         $this->filesystem->write('Hello%World.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -69,6 +69,15 @@ class FilesystemAdapterTest extends TestCase
         $this->assertInstanceOf(StreamedResponse::class, $response);
         $this->assertEquals('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
     }
+    
+    public function testDownloadPercentInFilename()
+    {
+        $this->filesystem->write('Hello%World.txt', 'Hello World');
+        $files = new FilesystemAdapter($this->filesystem);
+        $response = $files->download('Hello%World.txt', 'Hello%World.txt');
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertEquals('attachment; filename=HelloWorld.txt; filename*=utf-8\'\'Hello%25World.txt', $response->headers->get('content-disposition'));
+    }
 
     public function testExists()
     {


### PR DESCRIPTION
This is a follow-up to #28551, and similar to #6097 and how it's done in the current ResponseFactory:
https://github.com/laravel/framework/blob/7ac7818dbcfd69417c2f6fe61ef7176cf375863a/src/Illuminate/Routing/ResponseFactory.php#L159-L179

The fallback can't include a percentage sign, so this check is added.