### PR TITLE
[5.8] Revert "Let mix helper use assets url"

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -63,6 +63,6 @@ class Mix
             }
         }
 
-        return new HtmlString(app('config')->get('app.asset_url').$manifestDirectory.$manifest[$path]);
+        return new HtmlString($manifestDirectory.$manifest[$path]);
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Str;
 use Illuminate\Foundation\Mix;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
-use Illuminate\Contracts\Config\Repository;
 
 class FoundationHelpersTest extends TestCase
 {
@@ -68,10 +67,6 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixDoesNotIncludeHost()
     {
-        $app = new Application;
-        $app['config'] = m::mock(Repository::class);
-        $app['config']->shouldReceive('get')->with('app.asset_url');
-
         $manifest = $this->makeManifest();
 
         $result = mix('/unversioned.css');
@@ -83,10 +78,6 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixCachesManifestForSubsequentCalls()
     {
-        $app = new Application;
-        $app['config'] = m::mock(Repository::class);
-        $app['config']->shouldReceive('get')->with('app.asset_url');
-
         $manifest = $this->makeManifest();
         mix('unversioned.css');
         unlink($manifest);
@@ -98,10 +89,6 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixAssetMissingStartingSlashHaveItAdded()
     {
-        $app = new Application;
-        $app['config'] = m::mock(Repository::class);
-        $app['config']->shouldReceive('get')->with('app.asset_url');
-
         $manifest = $this->makeManifest();
 
         $result = mix('unversioned.css');
@@ -121,10 +108,6 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixWithManifestDirectory()
     {
-        $app = new Application;
-        $app['config'] = m::mock(Repository::class);
-        $app['config']->shouldReceive('get')->with('app.asset_url');
-
         mkdir($directory = __DIR__.'/mix');
         $manifest = $this->makeManifest('mix');
 


### PR DESCRIPTION
Reverts laravel/framework#28905. This is a major breaking change, as outlined by the comments on the original issue. It should instead me merged into master.