### PR TITLE
[5.8] Prevent TestRespone dump methods from ending execution of the script

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1054,7 +1054,7 @@ class TestResponse
             $content = $json;
         }
 
-        dd($content);
+        dump($content);
     }
 
     /**
@@ -1064,7 +1064,7 @@ class TestResponse
      */
     public function dumpHeaders()
     {
-        dd($this->headers->all());
+        dump($this->headers->all());
     }
 
     /**


### PR DESCRIPTION
Greetings!

This is something that has been bothering me for quite some time so I propose a change. `TestResponse::dump()` and `TestResponse::dumpHeaders()` methods actually use `dd()` helper (instead of `dump()`) thus killing the execution of the script.

Not only is this counter-intuitive, but also should be classified as a bug because it goes against the examples [official documentation provides](https://laravel.com/docs/5.8/http-tests#debugging-responses):

```php
    public function testBasicTest()
    {
        $response = $this->get('/');

        $response->dumpHeaders();

        $response->dump();
    }
```

The way it's currently implemented this example from the docs won't even work properly, because only headers will be dumped and then the execution of the script will be halted. Making `TestResponse` dump methods to actually dump things like `dump()` does would drastically improve tests' debugging experience out of the box (for now I've been registering `realDump` macro for `TestResponse` in my projects which is inconvenient).

For those, who want previous behavior we can also discuss introducing `dd()` and `ddHeaders()` methods to `TestResponse` class.