### PR TITLE
[5.8] Pass down the serverVersion database connection option to Doctrine DBAL connection

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -897,11 +897,15 @@ class Connection implements ConnectionInterface
         if (is_null($this->doctrineConnection)) {
             $driver = $this->getDoctrineDriver();
 
-            $this->doctrineConnection = new DoctrineConnection([
+            $this->doctrineConnection = new DoctrineConnection(array_filter([
                 'pdo' => $this->getPdo(),
                 'dbname' => $this->getConfig('database'),
                 'driver' => $driver->getName(),
-            ], $driver);
+                // One can manually pass the serverVersion config to the database connection
+                // options. This is used by Doctrine instead of going through the regular
+                // regular platform version detection. This config was not being used.
+                'serverVersion' => $this->getConfig('serverVersion'),
+            ]), $driver);
         }
 
         return $this->doctrineConnection;


### PR DESCRIPTION
I got into this issue while I was trying to run the migrations against Azure's MySQL
database. Azure's setup uses a [gateway](https://docs.microsoft.com/en-us/azure/mysql/concepts-supported-versions) to proxy connections to the correct server,
which tricks PDO, because the gateway version is different than the actual server
that the migration runs. The server runs 5.7, while the gateway server runs a 5.6.

By using this [option](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.9/reference/configuration.html#automatic-platform-version-detection), we can manually pass the server version (5.7) and the correct
data types will be mapped. In my case, JSON columns were throwing an exception, even
though they are supported in the actual server.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
