### PR TITLE
[5.8] Allow TestResponse dump method chaining

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1042,7 +1042,7 @@ class TestResponse
     /**
      * Dump the content from the response.
      *
-     * @return void
+     * @return $this
      */
     public function dump()
     {
@@ -1055,16 +1055,20 @@ class TestResponse
         }
 
         dump($content);
+
+        return $this;
     }
 
     /**
      * Dump the headers from the response.
      *
-     * @return void
+     * @return $this
      */
     public function dumpHeaders()
     {
         dump($this->headers->all());
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
https://github.com/laravel/framework/pull/28960 merged today no longer exits PHPUnit when calling `dump()` nor `dumpHeaders()`. However method chaining for the typical HTTP feature test won't work.

This change allows the test to continue as normal, showing PHPUnit's test case Pass/Fail along with the `TestResponse` dump.

### Example dump() chaining

```php
$this->getJson(route('posts.show', $post))
    ->dump() // now returns null
    ->assertStatus(Response::HTTP_UNAUTHORIZED)
    ->assertJson([
        'error' => 'token_not_provided',
    ]);
```

### Before

```
  Feature
    Tests\Feature\PostsTest
        testShowDeniesAuthorizationToGuest        {#8568
  +"status": "success"
}
ERROR
     
Error: Call to a member function assertStatus() on null
```

### After

```
  Feature
    Tests\Feature\PostsTest
        testShowDeniesAuthorizationToGuest       {#8568
  +"status": "success"
}
FAIL
    
Response status code [200] does not match expected 401 status code.
Failed asserting that false is true.
```