### PR TITLE
[5.8] Notification fake accepts custom channels

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -193,9 +193,10 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
      *
      * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
      * @param  mixed  $notification
+     * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification)
+    public function sendNow($notifiables, $notification, array $channels = null)
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             $notifiables = [$notifiables];
@@ -208,7 +209,7 @@ class NotificationFake implements NotificationFactory, NotificationDispatcher
 
             $this->notifications[get_class($notifiable)][$notifiable->getKey()][get_class($notification)][] = [
                 'notification' => $notification,
-                'channels' => $notification->via($notifiable),
+                'channels' => $channels ?: $notification->via($notifiable),
                 'notifiable' => $notifiable,
                 'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {


### PR DESCRIPTION
When dispatching notifications *now* you have the option to pass in the channels you want to deliver that notification - overriding the channels returned from the notification's `via` method.

Unfortunately the `NotificationFake` doesn't support this use case - and it records the notifications having been sent over their default channels instead. This means that you cannot test that the notification was sent over the given channel instead.

This change is simply reflecting the implementation in `NotificationSender` into the fake.

```php
Notification::fake();

$user->notify(new MessageReceived($message), [NexmoVoiceChannel::class]);

Notification::assertSentTo($user, MessageReceived::class, function ($notification, $channels) {
    return $channels[0] === NexmoVoiceChannel::class;
]);
```

For some additional context, my use-case is that the notification is usually delivered by email/text however a user might want to receive it via a phone call instead. An alternative approach might be to pass that in through the notification's constructor instead but that felt a little odd. 