### PR TITLE
[5.9] Make storage link relative by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "symfony/routing": "^4.3",
         "symfony/var-dumper": "^4.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1",
-        "vlucas/phpdotenv": "^3.3"
+        "vlucas/phpdotenv": "^3.3",
+        "webmozart/path-util": "^2.3"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
         "symfony/routing": "^4.3",
         "symfony/var-dumper": "^4.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1",
-        "vlucas/phpdotenv": "^3.3",
-        "webmozart/path-util": "^2.3"
+        "vlucas/phpdotenv": "^3.3"
     },
     "replace": {
         "illuminate/auth": "self.version",

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -632,10 +632,10 @@ class Filesystem
 
         if (strlen($tail)) {
             $levelsUp = substr_count($tail, '/') + 1;
+
             return str_repeat('../', $levelsUp).$path;
         }
 
         return $path;
     }
-
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -4,6 +4,7 @@ namespace Illuminate\Filesystem;
 
 use ErrorException;
 use FilesystemIterator;
+use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -606,4 +607,35 @@ class Filesystem
     {
         return $this->deleteDirectory($directory, true);
     }
+
+    /**
+     * Compute the relative path to a target from a given base path.
+     *
+     * @param  string  $target
+     * @param  string  $basePath
+     * @return string
+     */
+    public function relativePath($target, $basePath)
+    {
+        throw_unless($basePath[0] == '/' && $target[0] == '/',
+            InvalidArgumentException::class, 'Both target and base path must be absolute');
+
+        // Find length of common prefix
+        $i = 0;
+        $limit = min(strlen($target), strlen($basePath));
+        while ($i < $limit && $basePath[$i] === $target[$i]) {
+            $i++;
+        }
+
+        $path = ltrim(substr($target, $i), '/');
+        $tail = substr($basePath, $i);
+
+        if (strlen($tail)) {
+            $levelsUp = substr_count($tail, '/') + 1;
+            return str_repeat('../', $levelsUp) . $path;
+        }
+
+        return $path;
+    }
+
 }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -632,7 +632,7 @@ class Filesystem
 
         if (strlen($tail)) {
             $levelsUp = substr_count($tail, '/') + 1;
-            return str_repeat('../', $levelsUp) . $path;
+            return str_repeat('../', $levelsUp).$path;
         }
 
         return $path;

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -11,7 +11,9 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:link';
+    protected $signature = 'storage:link
+                    {--absolute : Use an absolute pathname in the link (default is relative)}
+                    {--force : Overwrite existing link}';
 
     /**
      * The console command description.
@@ -27,12 +29,23 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
-        if (file_exists(public_path('storage'))) {
-            return $this->error('The "public/storage" directory already exists.');
+        $publicPath = public_path('storage');
+
+        // For broken symlinks, `file_exists()` returns `false`, but `is_link()` returns `true`
+        if (is_link($publicPath) || file_exists($publicPath)) {
+            if (! $this->option('force')) {
+                return $this->error('The "public/storage" directory already exists.');
+            }
+
+            if (!unlink($publicPath)) {
+                return $this->error('Failed to remove existing "public/storage" directory.');
+            }
+
+            $this->warn('Removed existing "public/storage" directory.');
         }
 
         $this->laravel->make('files')->link(
-            storage_path('app/public'), public_path('storage')
+            storage_path('app/public'), $publicPath
         );
 
         $this->info('The [public/storage] directory has been linked.');

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Webmozart\PathUtil\Path;
 use Illuminate\Console\Command;
 
 class StorageLinkCommand extends Command
@@ -31,6 +30,7 @@ class StorageLinkCommand extends Command
     public function handle()
     {
         $publicPath = public_path('storage');
+        $targetPath = storage_path('app/public');
 
         // For broken symlinks, `file_exists()` returns `false`, but `is_link()` returns `true`
         if (is_link($publicPath) || file_exists($publicPath)) {
@@ -45,13 +45,13 @@ class StorageLinkCommand extends Command
             $this->warn('Removed existing "public/storage" directory.');
         }
 
-        $targetPath = storage_path('app/public');
+        $files = $this->laravel->make('files');
 
         if (! $this->option('absolute')) {
-            $targetPath = Path::makeRelative($targetPath, dirname($publicPath));
+            $targetPath = $files->relativePath($targetPath, public_path());
         }
 
-        $this->laravel->make('files')->link($targetPath, $publicPath);
+        $files->link($targetPath, $publicPath);
 
         $this->info('The [public/storage] directory has been linked.');
     }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Webmozart\PathUtil\Path;
 
 class StorageLinkCommand extends Command
 {
@@ -44,9 +45,13 @@ class StorageLinkCommand extends Command
             $this->warn('Removed existing "public/storage" directory.');
         }
 
-        $this->laravel->make('files')->link(
-            storage_path('app/public'), $publicPath
-        );
+        $targetPath = storage_path('app/public');
+
+        if (! $this->option('absolute')) {
+            $targetPath = Path::makeRelative($targetPath, dirname($publicPath));
+        }
+
+        $this->laravel->make('files')->link($targetPath, $publicPath);
 
         $this->info('The [public/storage] directory has been linked.');
     }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Console\Command;
 use Webmozart\PathUtil\Path;
+use Illuminate\Console\Command;
 
 class StorageLinkCommand extends Command
 {
@@ -38,7 +38,7 @@ class StorageLinkCommand extends Command
                 return $this->error('The "public/storage" directory already exists.');
             }
 
-            if (!unlink($publicPath)) {
+            if (! unlink($publicPath)) {
                 return $this->error('Failed to remove existing "public/storage" directory.');
             }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -513,6 +513,23 @@ class FilesystemTest extends TestCase
         $this->assertContainsOnlyInstancesOf(SplFileInfo::class, $files->allFiles($this->tempDir));
     }
 
+    public function testRelativePath()
+    {
+        $files = new Filesystem;
+
+        $this->assertEquals('storage',
+            $files->relativePath('/srv/site.net/storage', '/srv/site.net'));
+        $this->assertEquals('../storage/app/public',
+            $files->relativePath('/srv/site.net/storage/app/public', '/srv/site.net/public'));
+        $this->assertEquals('../storage/app/alternative/location/foo',
+            $files->relativePath('/srv/site.net/storage/app/alternative/location/foo', '/srv/site.net/public'));
+        $this->assertEquals('../../../foo/bar/xyz',
+            $files->relativePath('/foo/bar/xyz', '/srv/site.net/public'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $files->relativePath('not/absolute', '/srv/site.net/public');
+    }
+
     public function testCreateFtpDriver()
     {
         $filesystem = new FilesystemManager(new Application);


### PR DESCRIPTION
This pull request
- uses a relative path for the `public/storage` symlink by default, enabling usage regardless of mount points (host machine / guest VM),
- adds an `--absolute` option for cases where an absolute path is desired, and
- adds a `--force` option to overwrite existing `public/storage` entries, enabling the command to be an idempotent operation.

The change has been [proposed before](https://github.com/laravel/ideas/issues/899), and attempted at [least](https://github.com/laravel/framework/pull/26535) [twice](https://github.com/laravel/framework/pull/15584), but both previous pull requests failed to take configurable storage path into account.

This pull requests uses `webmozart/path-util` to determine the relative path.