### PR TITLE
[5.8] Replace contents of service manifest atomically

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -190,7 +190,7 @@ class ProviderRepository
             throw new Exception('The bootstrap/cache directory must be present and writable.');
         }
 
-        $this->files->put(
+        $this->files->replace(
             $this->manifestPath, '<?php return '.var_export($manifest, true).';'
         );
 


### PR DESCRIPTION
It is possible for concurrent requests to try and write the services manifest (`bootstrap/cache/services.php`) at the same time. This can occur whenever the file is not present (e.g. after `php artisan clear-compiled`) or when the set of providers changes (after code changes).

Each request will first read the manifest file or detect its absence, take some time to generate the contents of a new manifest, and lastly try to write the manifest. This write action will be done without obtaining a file lock first.

https://github.com/laravel/framework/blob/15b4e49b54752faf5b0e4ca90f6c39a2aa4d87e8/src/Illuminate/Foundation/ProviderRepository.php#L193-L195

We have encountered broken service manifest files in our installations multiple times in the last few days. Once it breaks, both HTTP requests and Artisan requests will fail. Manual deletion of the file is needed.

Example of broken file:

```php
<?php return array (
  'providers' =>
  array (
    0 => 'Laravel\\Tinker\\TinkerServiceProvider',
    1 => 'Carbon\\Laravel\\ServiceProvider',
    2 => 'Company\\Providers\\RouteServiceProvider',
  ),
  'eager' =>
  array (
    0 => 'Carbon\\Laravel\\ServiceProvider',
    1 => 'Company\\Providers\\RouteServiceProvider',
  ),
  'deferred' =>
  array (
    'command.tinker' => 'Laravel\\Tinker\\TinkerServiceProvider',
  ),
  'when' =>
  array (
    'Laravel\\Tinker\\TinkerServiceProvider' =>
    array (
    ),
  ),
);seServiceProvider',
    9 => 'Company\\Providers\\SessionServiceProvider',
    10 => 'Company\\Providers\\ViewServiceProvider',
    11 => 'Company\\Providers\\AppServiceProvider',
    12 => 'Company\\Providers\\AuthServiceProvider',
    13 => 'Company\\Providers\\ViewServiceProvider',
    14 => 'Company\\Providers\\RouteServiceProvider',
  ),
  'eager' =>
  array (
    0 => 'Illuminate\\Filesystem\\FilesystemServiceProvider',
    1 => 'Carbon\\Laravel\\ServiceProvider',
    2 => 'Company\\Providers\\DatabaseServiceProvider',
    3 => 'Company\\Providers\\SessionServiceProvider',
    4 => 'Company\\Providers\\ViewServiceProvider',
    5 => 'Company\\Providers\\AppServiceProvider',
    6 => 'Company\\Providers\\AuthServiceProvider',
    7 => 'Company\\Providers\\ViewServiceProvider',
    8 => 'Company\\Providers\\RouteServiceProvider',
  ),
```

This pull request will alter the behavior of writing the manifest file so it uses atomic actions. Concurrent writing will no longer occur.

Please note that this bug has been around since version [5.2.0](https://github.com/laravel/framework/blob/v5.2.0/src/Illuminate/Foundation/ProviderRepository.php#L186-L188)