### PR TITLE
[5.8] Replace self:: with static::

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -367,7 +367,7 @@ abstract class Relation
      */
     public static function getMorphedModel($alias)
     {
-        return self::$morphMap[$alias] ?? null;
+        return static::$morphMap[$alias] ?? null;
     }
 
     /**


### PR DESCRIPTION
`static::$morphMap` is used everywhere else.

This would only be a breaking change if someone was overriding `$morphMap` and expecting it *not* to be used.