### PR TITLE
[5.8] Make sure changing a database field to binary does not include collation

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -121,7 +121,7 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
-        if ($fluent['type'] === 'json') {
+        if ($fluent['type'] === 'json' || $fluent['type'] === 'binary') {
             $options['customSchemaOptions'] = [
                 'collation' => '',
             ];

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -121,7 +121,7 @@ class ChangeColumn
             $options['length'] = static::calculateDoctrineTextLength($fluent['type']);
         }
 
-        if ($fluent['type'] === 'json' || $fluent['type'] === 'binary') {
+        if (in_array($fluent['type'], ['json', 'binary'])) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
             ];


### PR DESCRIPTION
This PR will fix an issue very close to https://github.com/laravel/framework/issues/25735#issuecomment-423773584. It will fix pretty much the same error but then when changing a text field in to a binary.