### PR TITLE
[5.9] Allow passing a code when using $this->deny() when creating AuthorizationException

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -6,5 +6,18 @@ use Exception;
 
 class AuthorizationException extends Exception
 {
-    //
+    /**
+     * Create a new authorization exception instance.
+     *
+     * @param  string|null  $message
+     * @param  mixed|null  $code
+     * @param  \Exception|null  $previous
+     * @return void
+     */
+    public function __construct($message = '', $code = null, Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+
+        $this->code = $code;
+    }
 }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -19,12 +19,13 @@ trait HandlesAuthorization
      * Throws an unauthorized exception.
      *
      * @param  string  $message
+     * @param  mixed|null  $code
      * @return void
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    protected function deny($message = 'This action is unauthorized.')
+    protected function deny($message = 'This action is unauthorized.', $code = null)
     {
-        throw new AuthorizationException($message);
+        throw new AuthorizationException($message, $code);
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -573,12 +573,26 @@ class AuthAccessGateTest extends TestCase
     {
         $this->expectException(AuthorizationException::class);
         $this->expectExceptionMessage('You are not an admin.');
+        $this->expectExceptionCode(null);
 
         $gate = $this->getBasicGate();
 
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
 
         $gate->authorize('create', new AccessGateTestDummy);
+    }
+
+    public function test_authorize_throws_unauthorized_exception_with_custom_status_code()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Not allowed to view as it is not published.');
+        $this->expectExceptionCode('unpublished');
+
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithDenyExceptionCode::class);
+
+        $gate->authorize('view', new AccessGateTestDummy);
     }
 
     public function test_authorize_returns_allowed_response()
@@ -1005,5 +1019,15 @@ class AccessGateTestBeforeCallback
     public static function allowEverythingStatically($user = null)
     {
         return true;
+    }
+}
+
+class AccessGateTestPolicyWithDenyExceptionCode
+{
+    use HandlesAuthorization;
+
+    public function view()
+    {
+        return $this->deny('Not allowed to view as it is not published.', 'unpublished');
     }
 }


### PR DESCRIPTION
This is in response to this [tweet by Freek](https://twitter.com/freekmurze/status/1144256094128267264) about providing a way to pass the reason why a policy has denied access to something. We currently have the ability to set a descriptive message but not a "status" code/enum of some kind.

As we're simply throwing an exception and exceptions support status codes, we can use same functionality by allowing a second parameter to be passed to the deny method to set the status code:

```php
use App\Post;

class PostPolicy
{
    use HandlesAuthorization;

    public function view(?$user, Post $post)
    {
        if (is_null($post->published_at)) {
            return $this->deny('Not allowed to view as it is not published.', 'unpublished');
       }

      return true;
    }
}
````

If you catch the `AuthorizationException` you'll now have access to the actual status code on the exception object itself:

```php
Artisan::command('test', function () {
    try {
        Gate::authorize('view', $post);
    } catch (AuthorizationException $e) {
        dd($e->getCode()); // unpublished
    }
});
```

This could allow you to output a different error message under certain scenarioes or generate other useful metrics as the status codes are less volatile than error messages.