### PR TITLE
[5.8] Add on as an alias of disk in Storage

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -81,6 +81,17 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
+     * Get a filesystem instance.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    public function on($name = null)
+    {
+        return $this->disk($name);
+    }
+
+    /**
      * Get a default cloud filesystem instance.
      *
      * @return \Illuminate\Contracts\Filesystem\Filesystem


### PR DESCRIPTION
Gives the consistency to DB::on - A thought!

The Storage with disk is quite different than a normal guessable word like on like we have in DB::on used in multiple databases. Why not Storage::on 

The changes enable:

```
Storage::on($name);

// Just like
Storage::disk($name);

// In consistent with

DB::on($connection);

```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
