### PR TITLE
[5.8] Update Collection toArray to work with collections of stdClass

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1910,7 +1910,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function toArray()
     {
         return array_map(function ($value) {
-            
             if ($value instanceof \stdClass){
                 return (array) $value;
             }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1910,11 +1910,13 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function toArray()
     {
         return array_map(function ($value) {
-            if ($value instanceof \stdClass) {
+            if ($value instanceof Arrayable){
+                return $value->toArray();
+            } elseif ($value instanceof \stdClass) {
                 return (array) $value;
             }
             
-            return $value instanceof Arrayable ? $value->toArray() : $value;
+            return $value;
         }, $this->items);
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1913,6 +1913,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             if ($value instanceof \stdClass) {
                 return (array) $value;
             }
+            
             return $value instanceof Arrayable ? $value->toArray() : $value;
         }, $this->items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1910,6 +1910,11 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function toArray()
     {
         return array_map(function ($value) {
+            
+            if ($value instanceof \stdClass){
+                return (array) $value;
+            }
+            
             return $value instanceof Arrayable ? $value->toArray() : $value;
         }, $this->items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1913,7 +1913,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             if ($value instanceof \stdClass){
                 return (array) $value;
             }
-            
             return $value instanceof Arrayable ? $value->toArray() : $value;
         }, $this->items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1910,7 +1910,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function toArray()
     {
         return array_map(function ($value) {
-            if ($value instanceof \stdClass){
+            if ($value instanceof \stdClass) {
                 return (array) $value;
             }
             return $value instanceof Arrayable ? $value->toArray() : $value;


### PR DESCRIPTION
Saves having to always do the following if you have a collection of `stdClass`, like from the result of a custom select from the query builder:
```
                ........
                ->map(function (\stdClass $value) {
                    return (array)$value;
                })
                ->toArray()
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
