### PR TITLE
[5.9] Allow .env file to be specified with --env-file parameter on CLI

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -14,7 +14,7 @@ class LoadEnvironmentVariables
     /**
      * The console input object.
      *
-     * @var  \Symfony\Component\Console\Input\ArgvInput
+     * @var \Symfony\Component\Console\Input\ArgvInput
      */
     private $input;
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -14,7 +14,7 @@ class LoadEnvironmentVariables
     /**
      * The console input object.
      *
-     * @var ArgvInput
+     * @var  \Symfony\Component\Console\Input\ArgvInput
      */
     private $input;
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -26,7 +26,7 @@ class LoadEnvironmentVariables
     /**
      * Bootstrap the given application.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function bootstrap(Application $app)
@@ -47,7 +47,7 @@ class LoadEnvironmentVariables
     /**
      * Detect if a custom environment file matching the APP_ENV exists.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     protected function checkForSpecificEnvironmentFile($app)

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -5,8 +5,8 @@ namespace Illuminate\Tests\Foundation;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Symfony\Component\Console\Input\ArgvInput;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 
 class LoadEnvironmentVariablesTest extends TestCase
 {

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Symfony\Component\Console\Input\ArgvInput;
 
 class LoadEnvironmentVariablesTest extends TestCase
 {
@@ -34,7 +35,7 @@ class LoadEnvironmentVariablesTest extends TestCase
     {
         $this->expectOutputString('');
 
-        (new LoadEnvironmentVariables)->bootstrap($this->getAppMock('.env'));
+        (new LoadEnvironmentVariables(new ArgvInput))->bootstrap($this->getAppMock('.env'));
 
         $this->assertSame('BAR', env('FOO'));
         $this->assertSame('BAR', getenv('FOO'));
@@ -46,6 +47,32 @@ class LoadEnvironmentVariablesTest extends TestCase
     {
         $this->expectOutputString('');
 
-        (new LoadEnvironmentVariables)->bootstrap($this->getAppMock('BAD_FILE'));
+        (new LoadEnvironmentVariables(new ArgvInput))->bootstrap($this->getAppMock('BAD_FILE'));
+    }
+
+    public function testCanLoadSpecifiedEnvFile()
+    {
+        $filename = '.alternative_env';
+        $argInput = m::mock(ArgvInput::class);
+
+        $argInput->shouldReceive('hasParameterOption')
+            ->once()->with('--env-file')->andReturn(true);
+        $argInput->shouldReceive('getParameterOption')
+            ->once()->with('--env-file')->andReturn($filename);
+
+        $app = m::mock(Application::class);
+
+        $app->shouldReceive('configurationIsCached')
+            ->once()->with()->andReturn(false);
+        $app->shouldReceive('runningInConsole')
+            ->once()->with()->andReturn(true);
+        $app->shouldReceive('environmentPath')
+            ->twice()->with()->andReturn(__DIR__.'/../fixtures');
+        $app->shouldReceive('loadEnvironmentFrom')
+            ->once()->with($filename);
+        $app->shouldReceive('environmentFile')
+            ->once()->with()->andReturn($filename);
+
+        (new LoadEnvironmentVariables($argInput))->bootstrap($app);
     }
 }


### PR DESCRIPTION
This is a proposed solution to #28854. It provides the `--env-file` CLI parameter which will allow the  enviroment file to be set without affecting the app environment config value.

When loading the environment file, the `--env-file` parameter has higher precedence than `--env` so the config value may still be set if specifying a custom file (i.e. you can use both parameters if necessary).

Existing behaviour of the `--env` parameter should be unaffected.