### PR TITLE
[5.8] Fixes PHPDocs in MiddlewareNameResolver::resolve

### DIFF
--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -9,7 +9,7 @@ class MiddlewareNameResolver
     /**
      * Resolve the middleware name to a class name(s) preserving passed parameters.
      *
-     * @param  string  $name
+     * @param  \Closure|string  $name
      * @param  array  $map
      * @param  array  $middlewareGroups
      * @return \Closure|string|array


### PR DESCRIPTION
This pull request addresses a wrong PHPDoc in `MiddlewareNameResolver::resolve`.