### PR TITLE
[5.8] Add setDriver()

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -203,6 +203,17 @@ class RedisManager implements Factory
     {
         $this->events = false;
     }
+    
+    /**
+     * Change the default driver.
+     *
+     * @param  string  $driver
+     * @return void
+     */
+    public function setDriver($driver)
+    {
+        $this->driver = $driver;
+    }
 
     /**
      * Pass methods onto the default Redis connection.

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -203,7 +203,7 @@ class RedisManager implements Factory
     {
         $this->events = false;
     }
-    
+
     /**
      * Change the default driver.
      *


### PR DESCRIPTION
I'd like to change the Redis driver at runtime (in tests, to verify that a part of my package works both with predis and phpredis). I'm unable to do that because `RedisManager` seems to be a singleton whose `driver` property can't be changed.

```php
>>> use Illuminate\Support\Facades\Redis;
>>> config('database.redis.client');
=> "phpredis"
>>> Redis::resolve('default');
=> Illuminate\Redis\Connections\PhpRedisConnection {#3062}
>>> config(['database.redis.client' => 'predis']);
=> null
>>> config('database.redis.client');
=> "predis"
>>> Redis::resolve('default');
=> Illuminate\Redis\Connections\PhpRedisConnection {#3058}
```

Changing the `driver` property on `RedisManager` should allow to switch the connection driver. All methods for resolving connections use the `connector()` method which returns a connector instance based on the value of the `driver` property:

https://github.com/laravel/framework/blob/74b4267278c0b80c1aec36b21dab16ba69689d20/src/Illuminate/Redis/RedisManager.php#L147-L160

I see that changing the Redis **driver** at runtime doesn't have much use in application code, unlike the database, because you can have multiple connections. However, it's impossible to test predis and phpredis support without this feature. If you don't want a setter, changing the visibility of the `driver` property to a public would work as well.