### PR TITLE
[5.8] Warning on failure of APP_KEY generate command

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -77,6 +77,12 @@ class KeyGenerateCommand extends Command
             return false;
         }
 
+        if (! preg_match($this->keyReplacementPattern(), file_get_contents($this->laravel->environmentFilePath()))) {
+            $this->warn('Failed to set application key! Make sure your .env file has APP_KEY variable.');
+
+            return false;
+        }
+
         $this->writeNewEnvironmentFileWith($key);
 
         return true;


### PR DESCRIPTION

Currently executing `key:generate` command while APP_KEY is missing from .env file will shows that "key set successfully" which is in fact didn't. 

This change will show a message so the user know that APP_KEY variable is needed in .env file before running the command.

 