### PR TITLE
[5.8] Fixed email validator for empty domain part

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-openssl": "*",
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
-        "egulias/email-validator": "^2.0",
+        "egulias/email-validator": "^2.1.9",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
-        "egulias/email-validator": "^2.0",
+        "egulias/email-validator": "^2.1.9",
         "illuminate/container": "5.8.*",
         "illuminate/contracts": "5.8.*",
         "illuminate/support": "5.8.*",

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2098,6 +2098,18 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEmailWithEmptyDomainPart()
+    {
+        $validator = new Validator($this->getIlluminateArrayTranslator(), ['email' => 'foo@'], ['email' => 'email']);
+        $this->assertFalse($validator->passes());
+
+        $validator = new Validator($this->getIlluminateArrayTranslator(), ['email' => 'foo@ '], ['email' => 'email']);
+        $this->assertFalse($validator->passes());
+
+        $validator = new Validator($this->getIlluminateArrayTranslator(), ['email' => 'foo@'], ['email' => 'email']);
+        $this->assertFalse($validator->passes());
+    }
+
     /**
      * @dataProvider validUrls
      */


### PR DESCRIPTION
The [email validator](https://github.com/egulias/EmailValidator) introduced in 5.8 allowed spaces in the domain part as mentioned in #28233 .
This got fixed in the [current release](https://github.com/egulias/EmailValidator/releases/tag/2.1.9) so I set the minimum required version for this dependency to this release.