### PR TITLE
[5.9] Add path() method to pagination objects

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -93,7 +93,7 @@ interface Paginator
     public function hasMorePages();
 
     /**
-     * Get the base path
+     * Get the base path.
      *
      * @return string|null
      */

--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -93,6 +93,13 @@ interface Paginator
     public function hasMorePages();
 
     /**
+     * Get the base path
+     *
+     * @return string|null
+     */
+    public function path();
+
+    /**
      * Determine if the list of items is empty or not.
      *
      * @return bool

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -172,8 +172,8 @@ abstract class AbstractPaginator implements Htmlable
             $parameters = array_merge($this->query, $parameters);
         }
 
-        return $this->path
-                        .(Str::contains($this->path, '?') ? '&' : '?')
+        return $this->path()
+                        .(Str::contains($this->path(), '?') ? '&' : '?')
                         .Arr::query($parameters)
                         .$this->buildFragment();
     }
@@ -385,6 +385,16 @@ abstract class AbstractPaginator implements Htmlable
         $this->path = $path;
 
         return $this;
+    }
+
+    /**
+     * Get the base path.
+     *
+     * @return string|null
+     */
+    public function path()
+    {
+        return $this->path;
     }
 
     /**

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -170,7 +170,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'last_page' => $this->lastPage(),
             'last_page_url' => $this->url($this->lastPage()),
             'next_page_url' => $this->nextPageUrl(),
-            'path' => $this->path,
+            'path' => $this->path(),
             'per_page' => $this->perPage(),
             'prev_page_url' => $this->previousPageUrl(),
             'to' => $this->lastItem(),

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -149,7 +149,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
             'next_page_url' => $this->nextPageUrl(),
-            'path' => $this->path,
+            'path' => $this->path(),
             'per_page' => $this->perPage(),
             'prev_page_url' => $this->previousPageUrl(),
             'to' => $this->lastItem(),

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -61,6 +61,9 @@ class LengthAwarePaginatorTest extends TestCase
         $this->p->setPath('http://website.com');
         $this->p->setPageName('foo');
 
+        $this->assertEquals('http://website.com',
+                            $this->p->path());
+
         $this->assertEquals('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -54,4 +54,12 @@ class PaginatorTest extends TestCase
 
         $this->assertSame($p->getOptions(), $options);
     }
+
+    public function testPaginatorReturnsPath()
+    {
+        $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
+                                    ['path' => 'http://website.com/test']);
+
+        $this->assertSame($p->path(), 'http://website.com/test');
+    }
 }


### PR DESCRIPTION
this **PR** Adds **path()** method to differrent pagination objects .

use case example:

```php
//inside controller
return new UserCollection($lengthAwarePaginatorObject);

class UserCollection extends ResourceCollection
{
    public function toArray($request)
    {
        return [
         //when trying to access $this->path will throw protected prop exception
            'legacy_respond_path' => $this->path(), 
            //....,
            //....,
            //....,
        ];
    }
}
```
