### PR TITLE
[5.8] Storing Mailgun Message-ID in the headers after sending

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -64,10 +64,14 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->request(
+        $response = $this->client->request(
             'POST',
             "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
             $this->payload($message, $to)
+        );
+
+        $message->getHeaders()->addTextHeader(
+            'X-Mailgun-Message-ID', $this->getMessageId($response)
         );
 
         $this->sendPerformed($message);
@@ -126,6 +130,19 @@ class MailgunTransport extends Transport
     {
         return array_merge(
             (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
+        );
+    }
+
+    /**
+     * Get the message ID from the response.
+     *
+     * @param  \Psr\Http\Message\ResponseInterface  $response
+     * @return string
+     */
+    protected function getMessageId($response)
+    {
+        return object_get(
+            json_decode($response->getBody()->getContents()), 'id'
         );
     }
 


### PR DESCRIPTION
This stores the message ID from Mailgun into the `X-Mailgun-Message-ID` header so that sendPerformed() can reference it. The same behaviour already exists for SparkPost (https://github.com/laravel/framework/pull/18594) and SES (https://github.com/laravel/framework/pull/16366).

My personal use case is that it allows me to track individual emails (for open, click and spam complaint events) when I receive webhooks from Mailgun / SparkPost / SES.