### PR TITLE
Adds mergeFiles method to Request

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -310,6 +310,20 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     }
 
     /**
+     * Merge new files into the current request's files array.
+     *
+     * @param array $files
+     * @return $this
+     */
+    public function mergeFiles(array $files)
+    {
+        $this->files->add($files);
+        $this->convertedFiles = null;
+
+        return $this;
+    }
+
+    /**
      * Replace the input for the current request.
      *
      * @param  array  $input

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -549,6 +549,17 @@ class HttpRequestTest extends TestCase
         $this->assertEquals('Dayle', $request->input('buddy'));
     }
 
+    public function testMergeFilesMethod()
+    {
+        $file = $this->getMockBuilder(UploadedFile::class)->setConstructorArgs([__FILE__, 'photo.jpg'])->getMock();
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+        $merge = ['photo' => $file];
+        $request->mergeFiles($merge);
+        $this->assertTrue($request->hasFile('photo'));
+        $this->assertEquals('Taylor', $request->input('name'));
+        $this->assertEquals($file, $request->file('photo'));
+    }
+
     public function testReplaceMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);


### PR DESCRIPTION
Request has a method to merge new inputs into the current request, but is unable to add files through this way.

This Pull request adds a new `mergeFiles` method, who enable the user to add new instances of `\Symfony\Component\HttpFoundation\File\UploadedFile` to the request via the `mergeFiles` method.

There is one downside with this solution, I'm exposing Symfony as a requirement directly on an Illuminate method. It would be nice to let the user add files without needing to create a `UploadedFile` instance.

Why this add value?

I have a form where the user can upload an optional image. If the user uploads anything, I want to create a default image. But, I want that generated image to be processed as it was uploaded by the user. Being able to add files to the request simplify this process a lot.

Without the `mergeFiles` method, the only way I was able to find to add new files to the Request was by adding the files an then creating a new Request

```php
$file = new \Symfony\Component\HttpFoundation\File\UploadedFile($image_path, 'jpeg');
$request->files->add(['photo' => $file]);
$request = CreateJobRequest::createFrom($request);
```

now I can simply do:
```
$file = new \Symfony\Component\HttpFoundation\File\UploadedFile($image_path, 'jpeg');
$request->mergeFiles(['photo' => $file]);
```