### PR TITLE
[5.8] Set a message for SuspiciousOperationException

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -205,7 +205,7 @@ class Handler implements ExceptionHandlerContract
         } elseif ($e instanceof TokenMismatchException) {
             $e = new HttpException(419, $e->getMessage(), $e);
         } elseif ($e instanceof SuspiciousOperationException) {
-            $e = new NotFoundHttpException('Bad hostname provided', $e);
+            $e = new NotFoundHttpException('Bad hostname provided.', $e);
         }
 
         return $e;

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -205,7 +205,7 @@ class Handler implements ExceptionHandlerContract
         } elseif ($e instanceof TokenMismatchException) {
             $e = new HttpException(419, $e->getMessage(), $e);
         } elseif ($e instanceof SuspiciousOperationException) {
-            $e = new NotFoundHttpException(null, $e);
+            $e = new NotFoundHttpException('Bad hostname provided', $e);
         }
 
         return $e;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -200,7 +200,7 @@ class FoundationExceptionsHandlerTest extends TestCase
         $response = $this->handler->render($this->request, new SuspiciousOperationException('Invalid method override "__CONSTRUCT"'));
 
         $this->assertEquals(404, $response->getStatusCode());
-        $this->assertStringContainsString('"message": ""', $response->getContent());
+        $this->assertStringContainsString('"message": "Bad hostname provided"', $response->getContent());
 
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);


### PR DESCRIPTION
Having now had the time to look at the Symfony code, this exception arises when the host name is invalid or not trusted. Thus, we should set a friendly message to that effect.