### PR TITLE
[5.9] Avoid deprecated whoops code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
         "doctrine/dbal": "^2.6",
-        "filp/whoops": "^2.1.4",
+        "filp/whoops": "^2.4",
         "guzzlehttp/guzzle": "^6.3",
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
@@ -118,7 +118,7 @@
         "ext-posix": "Required to use all features of the queue worker.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (^3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
-        "filp/whoops": "Required for friendly error pages in development (^2.1.4).",
+        "filp/whoops": "Required for friendly error pages in development (^2.4).",
         "fzaninotto/faker": "Required to use the eloquent factory builder (^1.4).",
         "guzzlehttp/guzzle": "Required to use the Mailgun mail driver and the ping methods on schedules (^6.0).",
         "laravel/tinker": "Required to use the tinker console command (^1.0).",

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -335,7 +335,7 @@ class Handler implements ExceptionHandlerContract
     protected function renderExceptionWithWhoops(Exception $e)
     {
         return tap(new Whoops, function ($whoops) {
-            $whoops->pushHandler($this->whoopsHandler());
+            $whoops->appendHandler($this->whoopsHandler());
 
             $whoops->writeToOutput(false);
 


### PR DESCRIPTION
`pushHandler` is deprecated from v2.4.0 onwards.