### PR TITLE
[5.9] ServiceProvider::mergeConfigFrom check if cached

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -67,9 +67,11 @@ abstract class ServiceProvider
      */
     protected function mergeConfigFrom($path, $key)
     {
-        $config = $this->app['config']->get($key, []);
+        if (! $this->app->configurationIsCached()) {
+            $config = $this->app['config']->get($key, []);
 
-        $this->app['config']->set($key, array_merge(require $path, $config));
+            $this->app['config']->set($key, array_merge(require $path, $config));
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #28997

`mergeConfigFrom` should follow the same pattern as `loadRoutesFrom` in that it checks the config cache prior to loading.

Merging configs on each request partially defeats the purpose of config caching.
