### PR TITLE
[5.9] Use Env::get() helper instead of $_ENV

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation;
 use Closure;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -549,8 +550,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        if (isset($_ENV['APP_RUNNING_IN_CONSOLE'])) {
-            return $_ENV['APP_RUNNING_IN_CONSOLE'] === 'true';
+        if (Env::get('APP_RUNNING_IN_CONSOLE') !== null) {
+            return Env::get('APP_RUNNING_IN_CONSOLE') === true;
         }
 
         return php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg';
@@ -893,7 +894,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return $_ENV['APP_SERVICES_CACHE'] ?? $this->bootstrapPath().'/cache/services.php';
+        return Env::get('APP_SERVICES_CACHE', $this->bootstrapPath().'/cache/services.php');
     }
 
     /**
@@ -903,7 +904,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedPackagesPath()
     {
-        return $_ENV['APP_PACKAGES_CACHE'] ?? $this->bootstrapPath().'/cache/packages.php';
+        return Env::get('APP_PACKAGES_CACHE', $this->bootstrapPath().'/cache/packages.php');
     }
 
     /**
@@ -923,7 +924,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedConfigPath()
     {
-        return $_ENV['APP_CONFIG_CACHE'] ?? $this->bootstrapPath().'/cache/config.php';
+        return Env::get('APP_CONFIG_CACHE', $this->bootstrapPath().'/cache/config.php');
     }
 
     /**
@@ -943,7 +944,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return $_ENV['APP_ROUTES_CACHE'] ?? $this->bootstrapPath().'/cache/routes.php';
+        return Env::get('APP_ROUTES_CACHE', $this->bootstrapPath().'/cache/routes.php');
     }
 
     /**
@@ -963,7 +964,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedEventsPath()
     {
-        return $_ENV['APP_EVENTS_CACHE'] ?? $this->bootstrapPath().'/cache/events.php';
+        return Env::get('APP_EVENTS_CACHE', $this->bootstrapPath().'/cache/events.php');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -7,6 +7,7 @@ use Exception;
 use Throwable;
 use ReflectionClass;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Symfony\Component\Finder\Finder;
@@ -112,7 +113,7 @@ class Kernel implements KernelContract
      */
     protected function scheduleCache()
     {
-        return $_ENV['SCHEDULE_CACHE_DRIVER'] ?? null;
+        return Env::get('SCHEDULE_CACHE_DRIVER');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Env;
 use Illuminate\Console\Command;
 use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Input\InputOption;
@@ -112,7 +113,7 @@ class ServeCommand extends Command
         return [
             ['host', null, InputOption::VALUE_OPTIONAL, 'The host address to serve the application on', '127.0.0.1'],
 
-            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', $_ENV['SERVER_PORT'] ?? null],
+            ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
 
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
         ];


### PR DESCRIPTION
In the next release of Laravel, the base repo [has switched](https://github.com/laravel/laravel/blob/ebc6f6e2c794b07c6d432483fd654aebf2ffe222/phpunit.xml#L26-L31) values set in `phpunit.xml` to `<server` values from the previously used `<env` values.

My brain tells me "this is how you set environment variables now in Laravel". So if I want to override the `APP_CONFIG_CACHE` value, I'd set the following...

```diff
<php>
    <server name="APP_ENV" value="testing"/>
    <server name="BCRYPT_ROUNDS" value="4"/>
    <server name="CACHE_DRIVER" value="array"/>
    <server name="MAIL_DRIVER" value="array"/>
    <server name="QUEUE_CONNECTION" value="sync"/>
    <server name="SESSION_DRIVER" value="array"/>
+   <server name="APP_CONFIG_CACHE" value="path/to/cache.php"/>
</php>
```

But this won't work because the `Application` is looking in `$_ENV` which is not being populated with this value. I would need to set the following instead...

```diff
<php>
    <server name="APP_ENV" value="testing"/>
    <server name="BCRYPT_ROUNDS" value="4"/>
    <server name="CACHE_DRIVER" value="array"/>
    <server name="MAIL_DRIVER" value="array"/>
    <server name="QUEUE_CONNECTION" value="sync"/>
    <server name="SESSION_DRIVER" value="array"/>
+   <env name="APP_CONFIG_CACHE" value="path/to/cache.php"/>
</php>
```

Using the helper instead of the global `$_ENV` means that both of these approaches works.

See also: https://github.com/laravel/laravel/pull/5050#discussion_r298912081