### PR TITLE
[5.9] Let release method have return value

### DIFF
--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -46,11 +46,11 @@ class RedisLock extends Lock
     /**
      * Release the lock.
      *
-     * @return void
+     * @return int
      */
     public function release()
     {
-        $this->redis->eval(LuaScripts::releaseLock(), 1, $this->name, $this->owner);
+        return $this->redis->eval(LuaScripts::releaseLock(), 1, $this->name, $this->owner);
     }
 
     /**


### PR DESCRIPTION
The releaseLock function is used in release function.  ReleaseLock function has return value 0 or 1, but release function doesn't has return value.

I think sometimes we may use return value determine the lock succeed or fail to be release. Then we may do something according the successful or fail status.

Below is source code of the releaseLock:
```php
<?php
namespace Illuminate\Cache;
class LuaScripts
{
    /**
     * Get the Lua script to atomically release a lock.
     *
     * KEYS[1] - The name of the lock
     * ARGV[1] - The owner key of the lock instance trying to release it
     *
     * @return string
     */
    public static function releaseLock()
    {
        return <<<'LUA'
if redis.call("get",KEYS[1]) == ARGV[1] then
    return redis.call("del",KEYS[1])
else
    return 0
end
LUA;
    }
}
```