### PR TITLE
[5.9] Add singletonIf method to Container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -359,6 +359,20 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Register a shared binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function singletonIf($abstract, $concrete = null)
+    {
+        if (! $this->bound($abstract)) {
+            $this->singleton($abstract, $concrete);
+        }
+    }
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string    $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -73,6 +73,15 @@ interface Container extends ContainerInterface
     public function singleton($abstract, $concrete = null);
 
     /**
+     * Register a shared binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function singletonIf($abstract, $concrete = null);
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string    $abstract

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -65,6 +65,36 @@ class ContainerTest extends TestCase
         $this->assertEquals('Dayle', $container->make('name'));
     }
 
+    public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
+    {
+        $container = new Container;
+        $class = new stdClass;
+        $container->singleton('class', function () use ($class) {
+            return $class;
+        });
+        $otherClass = new stdClass;
+        $container->singletonIf('class', function () use ($otherClass) {
+            return $otherClass;
+        });
+
+        $this->assertSame($class, $container->make('class'));
+    }
+
+    public function testSingletonIfDoesRegisterIfBindingNotRegisteredYet()
+    {
+        $container = new Container;
+        $class = new stdClass;
+        $container->singleton('class', function () use ($class) {
+            return $class;
+        });
+        $otherClass = new stdClass;
+        $container->singletonIf('otherClass', function () use ($otherClass) {
+            return $otherClass;
+        });
+
+        $this->assertSame($otherClass, $container->make('otherClass'));
+    }
+
     public function testSharedClosureResolution()
     {
         $container = new Container;


### PR DESCRIPTION
This PR adds `singletonIf` method similar to `bindIf`.

I'm trying to overwrite singleton binded in deferred service provider of 3rd party package inside of my package, but no luck, because my package loading earlier.

Without this PR in 3rd party package it could be solved this way:

```php
if (!$this->app->bound(ConfigRetrieverInterface::class)) {
    $this->app->singleton(ConfigRetrieverInterface::class, function () {
        return new ConfigRetriever();
    });
}
```

With this PR:
```php
$this->app->singletonIf(ConfigRetrieverInterface::class, function () {
    return new ConfigRetriever();
});
```