### PR TITLE
[5.9] Add Str::extractPattern

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -149,6 +149,38 @@ class Str
     }
 
     /**
+     * Extract a pattern from the given string.
+     *
+     * @param  string $haystack
+     * @param  string $pattern
+     * @param  string|int|array $index Index(es) to return
+     * @param  string|array|null $default Default value or keyed values to return if missing a match.
+     * @return mixed
+     */
+    public static function extractPattern(string $haystack, string $pattern, $index, $default = null)
+    {
+        $matches = [];
+
+        preg_match($pattern, $haystack, $matches, PREG_UNMATCHED_AS_NULL);
+
+        if (! is_array($index)) {
+            return $matches[$index] ?? $default;
+        }
+
+        $values = [];
+
+        foreach ($index as $key) {
+            if (is_array($default)) {
+                $values[$key] = $matches[$key] ?? $default[$key] ?? null;
+            } else {
+                $values[$key] = $matches[$key] ?? $default;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
      * Cap a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -159,6 +159,23 @@ class SupportStrTest extends TestCase
         $this->assertEquals('/test/string', Str::start('//test/string', '/'));
     }
 
+    public function testExtractPattern()
+    {
+        $this->assertEquals('10011', Str::extractPattern('10011 Foo', '/^(?<number>\d+)\s+(?<word>[\w]+)$/', 'number'));
+
+        $parts = Str::extractPattern('10011 Foo', '/^(?<number>\d+)\s+(?<word>[\w]+)$/', ['number', 'word']);
+        $this->assertEquals('10011', $parts['number']);
+        $this->assertEquals('Foo', $parts['word']);
+
+        $this->assertEquals('bar', Str::extractPattern('10011 Foo', '/^(?<number>\d+)\s+(?<word>[\w]+)$/', 'missing', 'bar'));
+
+        $parts = Str::extractPattern('10011 Foo', '/^(?<number>\d+)\s+(?<word>[\w]+)$/', ['missing', 'indexes'], ['missing' => 'bar', 'indexes' => 'baz']);
+        $this->assertEquals('bar', $parts['missing']);
+        $this->assertEquals('baz', $parts['indexes']);
+
+        $this->assertEquals('bar', Str::extractPattern('No match.', '/^(?<number>\d+)\s+(?<word>[\w]+)$/', 'missing', 'bar'));
+    }
+
     public function testFinish()
     {
         $this->assertEquals('abbc', Str::finish('ab', 'bc'));


### PR DESCRIPTION
Adds a method to simplify extracting patterns from strings using a regex. For most usages, this will condense a repetitive, multiple line pattern into a single line that doesn't leave a leftover variable in scope.

Before for a relatively simple case:

```
$matches = [];

preg_match($pattern, $subject, $matches, PREG_UNMATCHED_AS_NULL);

$value = $matches['key'] ?? 'default';
```

After:

```
$value = Str::extractPattern($subject, $pattern, 'key', 'default');
```

NOTE: This PR uses PREG_UNMATCHED_AS_NULL, which only became available as of PHP 7.2, but Laravel currently targets PHP 7.1 as its minimum version.

Passing tests are included (for PHP 7.2+) and the PR is a single commit for easy cherry-picking later on if need be. For my part, I find myself copying this function from one project to another, so its utility isn't limited to a one-off as far as I can tell.