### PR TITLE
[5.8]  Helper limit must not return more characters than specified

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -241,6 +241,8 @@ class Str
             return $value;
         }
 
+        $limit = $limit - mb_strwidth($end, 'UTF-8');
+
         return rtrim(mb_strimwidth($value, 0, $limit, '', 'UTF-8')).$end;
     }
 


### PR DESCRIPTION
## The problem
If we specify a string with 10 characters, but we want a maximum of 5 characters, we get 8 characters back from the helper function.
`Str::limit('1234567890', 5);`
This returns:
`12345...`

## Solution
This solution takes into account the maximum number of characters
`Str::limit('1234567890', 5);`
Must return the following:
`12...`

