### PR TITLE
[5.9] Use seconds instead minutes in Cookie

### DIFF
--- a/src/Illuminate/Contracts/Cookie/Factory.php
+++ b/src/Illuminate/Contracts/Cookie/Factory.php
@@ -9,7 +9,7 @@ interface Factory
      *
      * @param  string  $name
      * @param  string  $value
-     * @param  int     $minutes
+     * @param  int     $seconds
      * @param  string|null  $path
      * @param  string|null  $domain
      * @param  bool|null    $secure
@@ -18,7 +18,7 @@ interface Factory
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null);
+    public function make($name, $value, $seconds = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null);
 
     /**
      * Create a cookie that lasts "forever" (five years).

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -52,7 +52,7 @@ class CookieJar implements JarContract
      *
      * @param  string       $name
      * @param  string       $value
-     * @param  int          $minutes
+     * @param  int          $seconds
      * @param  string|null  $path
      * @param  string|null  $domain
      * @param  bool|null    $secure
@@ -61,11 +61,11 @@ class CookieJar implements JarContract
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function make($name, $value, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
+    public function make($name, $value, $seconds = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
         [$path, $domain, $secure, $sameSite] = $this->getPathAndDomain($path, $domain, $secure, $sameSite);
 
-        $time = ($minutes == 0) ? 0 : $this->availableAt($minutes * 60);
+        $time = ($seconds === 0) ? 0 : $this->availableAt($seconds);
 
         return new Cookie($name, $value, $time, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
@@ -85,7 +85,7 @@ class CookieJar implements JarContract
      */
     public function forever($name, $value, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
-        return $this->make($name, $value, 2628000, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+        return $this->make($name, $value, 157680000, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
 
     /**
@@ -98,7 +98,7 @@ class CookieJar implements JarContract
      */
     public function forget($name, $path = null, $domain = null)
     {
-        return $this->make($name, null, -2628000, $path, $domain);
+        return $this->make($name, null, -157680000, $path, $domain);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -303,7 +303,7 @@ if (! function_exists('cookie')) {
      *
      * @param  string|null  $name
      * @param  string|null  $value
-     * @param  int  $minutes
+     * @param  int  $seconds
      * @param  string|null  $path
      * @param  string|null  $domain
      * @param  bool  $secure
@@ -312,7 +312,7 @@ if (! function_exists('cookie')) {
      * @param  string|null  $sameSite
      * @return \Illuminate\Cookie\CookieJar|\Symfony\Component\HttpFoundation\Cookie
      */
-    function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
+    function cookie($name = null, $value = null, $seconds = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
         $cookie = app(CookieFactory::class);
 
@@ -320,7 +320,7 @@ if (! function_exists('cookie')) {
             return $cookie;
         }
 
-        return $cookie->make($name, $value, $minutes, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
+        return $cookie->make($name, $value, $seconds, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
     }
 }
 

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -85,7 +85,7 @@ class CookieSessionHandler implements SessionHandlerInterface
         $this->cookie->queue($sessionId, json_encode([
             'data' => $data,
             'expires' => $this->availableAt($this->minutes * 60),
-        ]), $this->minutes);
+        ]), $this->minutes * 60);
 
         return true;
     }


### PR DESCRIPTION
Using seconds instead minutes in Cookie for more flexibility (such in Cache).