### PR TITLE
Fix possible issue with implementing Translator contract

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,7 +39,7 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
-    
+
     /**
      * Get the translation for a given key from the JSON translation files.
      *

--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,4 +39,14 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
+    
+    /**
+     * Get the translation for a given key from the JSON translation files.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string  $locale
+     * @return string|array
+     */
+    public function getFromJson($key, array $replace = [], $locale = null);
 }


### PR DESCRIPTION
In the case of implementing Translator contract in own Translator class and without realization of getFromJson method there will be an exception in LengthAwarePaginator because it tries to call the getFromJson method.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
