### PR TITLE
[5.9] 'make:' command custom class extends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - printf "\n" | pecl install -f redis
+  - printf "\n" | pecl install -f redis-4.3.0
   - travis_retry composer self-update
   - mysql -e 'CREATE DATABASE forge;'
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -359,6 +359,20 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Register a shared binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function singletonIf($abstract, $concrete = null)
+    {
+        if (! $this->bound($abstract)) {
+            $this->singleton($abstract, $concrete);
+        }
+    }
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string    $abstract

--- a/src/Illuminate/Contracts/Container/Container.php
+++ b/src/Illuminate/Contracts/Container/Container.php
@@ -73,6 +73,15 @@ interface Container extends ContainerInterface
     public function singleton($abstract, $concrete = null);
 
     /**
+     * Register a shared binding if it hasn't already been registered.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|string|null  $concrete
+     * @return void
+     */
+    public function singletonIf($abstract, $concrete = null);
+
+    /**
      * "Extend" an abstract type in the container.
      *
      * @param  string    $abstract

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -28,6 +28,11 @@ class RequestMakeCommand extends GeneratorCommand
     protected $type = 'Request';
 
     /**
+     * @var string
+     */
+    protected $defaultParent = \Illuminate\Foundation\Http\FormRequest::class;
+
+    /**
      * Get the stub file for the generator.
      *
      * @return string

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Foundation\Http\FormRequest;
+use NamespacedDummyParent;
 
-class DummyClass extends FormRequest
+class DummyClass extends DummyParent
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -64,10 +64,14 @@ class MailgunTransport extends Transport
 
         $message->setBcc([]);
 
-        $this->client->request(
+        $response = $this->client->request(
             'POST',
             "https://{$this->endpoint}/v3/{$this->domain}/messages.mime",
             $this->payload($message, $to)
+        );
+
+        $message->getHeaders()->addTextHeader(
+            'X-Mailgun-Message-ID', $this->getMessageId($response)
         );
 
         $this->sendPerformed($message);
@@ -126,6 +130,19 @@ class MailgunTransport extends Transport
     {
         return array_merge(
             (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()
+        );
+    }
+
+    /**
+     * Get the message ID from the response.
+     *
+     * @param  \Psr\Http\Message\ResponseInterface  $response
+     * @return string
+     */
+    protected function getMessageId($response)
+    {
+        return object_get(
+            json_decode($response->getBody()->getContents()), 'id'
         );
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -65,6 +65,36 @@ class ContainerTest extends TestCase
         $this->assertEquals('Dayle', $container->make('name'));
     }
 
+    public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
+    {
+        $container = new Container;
+        $class = new stdClass;
+        $container->singleton('class', function () use ($class) {
+            return $class;
+        });
+        $otherClass = new stdClass;
+        $container->singletonIf('class', function () use ($otherClass) {
+            return $otherClass;
+        });
+
+        $this->assertSame($class, $container->make('class'));
+    }
+
+    public function testSingletonIfDoesRegisterIfBindingNotRegisteredYet()
+    {
+        $container = new Container;
+        $class = new stdClass;
+        $container->singleton('class', function () use ($class) {
+            return $class;
+        });
+        $otherClass = new stdClass;
+        $container->singletonIf('otherClass', function () use ($otherClass) {
+            return $otherClass;
+        });
+
+        $this->assertSame($otherClass, $container->make('otherClass'));
+    }
+
     public function testSharedClosureResolution()
     {
         $container = new Container;


### PR DESCRIPTION
### Inspiration
Inspiration was drawn from [Tweet A by Taylor](https://twitter.com/taylorotwell/status/1144430661572407296),
[Tweet B in thread by Taylor](https://twitter.com/taylorotwell/status/1144441642390380544)
and [Reply in thread by Victor Bolshov](https://twitter.com/crocodile2u/status/1144514813072199680)

## Benefit
The benefit of this PR is allowing the user to define their own baseclasses for any make command instead of having to overwrite the default imported Illuminate/Laravel ones for every created file, which gets cumbersome in large projects

This PR currently allows to define your own Request baseclass in a new console.php config file as this is a class I personally have extended in company projects, and is one of the few make commands that only has a single stub where this functionality makes sense.

## Drawbacks
As mentioned in [tweet B](https://twitter.com/taylorotwell/status/1144441642390380544)  there are multiple stubs for some commands making this a complex change needing extension of various MakeCommand classes to handle switching stubs.

I'm willing to invest the time to extend this PR to all other make: commands where either there are multiple stubs depending on command input switches, or where it makes less sense to extend a base class.

## Alternative
An alternative approach could be a new command input to pass the parent class but that would defeat the purpose of having it set as a default (it could still be added to use as an override for very large projects) and it would conflict in the case of make:controller since it already has a --parent input.

### Reason for draft
However I first put this PR in draft mode to allow for input if this would be a desirable way of handling base classes (as opposed to the magic detection proposed in Taylor's tweet) and if I should continue this PR to a full implementation.

### Targeted version
It is targeted at 5.9 because, while technically it can work in 5.8 without breaking backwards compatibility, it needs a new config file (the existing config files didn't seem appropriate for this behavior)
and I don't know if adding a new config file can be done in a minor version update like that (since that would go in laravel/laravel).

### Closings 
If this all seems too much for a core update than that's fine with me, though to me it feels like putting this functionality in a 3rd party package is not ideal either, as to my knowledge it's not directly possible to override an existing make: command.

retry of #29012 because I failed to remove the merge commit and didn't start from the correct branch

Thanks in advance for your consideration and input on this feature