### PR TITLE
[5.9] Fix possible issue with implementing Translator contract

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -39,4 +39,14 @@ interface Translator
      * @return void
      */
     public function setLocale($locale);
+
+    /**
+     * Get the translation for a given key from the JSON translation files.
+     *
+     * @param  string  $key
+     * @param  array  $replace
+     * @param  string  $locale
+     * @return string|array
+     */
+    public function getFromJson($key, array $replace = [], $locale = null);
 }


### PR DESCRIPTION
In the case of implementing Translator contract in own Translator class and without realization of getFromJson method there will be an exception in LengthAwarePaginator because it tries to call the getFromJson method.