### PR TITLE
[5.8] Added "$extendedResourceAbilities" and "$extendedResourceMethodsWithoutModels for resource authorization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasExtendedResourceAuthorization.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasExtendedResourceAuthorization.php
@@ -1,0 +1,22 @@
+<?php
+
+    namespace Illuminate\Database\Eloquent\Concerns;
+
+
+    trait HasExtendedResourceAuthorization
+    {
+        /**
+         * The extended resource abilities which should be authorized when using authorizeResource
+         *
+         * @var array
+         */
+        public static $extendedResourceAbilities = [];
+
+        /**
+         * The extended resource methods without models which should be authorized when using authorizeResource
+         *
+         * @var array
+         */
+        public static $extendedResourceMethodsWithoutModel = [];
+
+    }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -26,6 +26,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
+        Concerns\HasExtendedResourceAuthorization,
         ForwardsCalls;
 
     /**


### PR DESCRIPTION
### Details
Added "$extendedResourceAbilities" and "$extendedResourceMethodsWithoutModels" arguments to "authorizeResource()" method in "AuthorizeRequests" trait.

Added "HasExtendedResourceAuthorization" trait to base Model class which also defines above 2 arguments as public static properties with defaults [].

---
### Benefits:
1. This provides an easy way to add custom methods for route authorization when using authorizeResource() method:
  
       public function __construct(){
           $extendedResourceAbilities = ['method_name'=>'ability_name'];
           $extendedResourceMethodsWithoutModel = ['method_name'];

           $this->authorizeResource(User::class, 'user', [], null, $extendedResourceAbilities, $extendedResourceMethodsWithoutModel);
       }


      ##### Or through model

       public static $extendedResourceAbilities = ['method_name'=>'ability_name'];
       public static $extendedResourceMethodsWithoutModel = ['method_name'];

2. This also eliminates the need to override resourceAbilityMap() and resourceMethodsWithoutModels() methods per controller basis.

3. Both of the arguments can be defined as public static properties.

---
 ### Drawbacks
 None. Passing these 2 arguments from "authorizeResource()" method takes precedence.

---
 ### Reason for draft
 First timer and not confident enough.
 
---
 ### Target Version
It is target for 5.8 and earlier because it's a minor feature.
It will not break anything as it just takes those properties/arguments and merges them respectively according to precedence and it must be fully backward compatible.

---
 ### Closings
 Looking forward for comments and suggestions.
 Thanks in advance for your consideration and input on this feature.