### PR TITLE
[5.8] Make TestResponse tappable

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Tappable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Foundation\Testing\Assert as PHPUnit;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -18,7 +19,7 @@ use Illuminate\Foundation\Testing\Constraints\SeeInOrder;
  */
 class TestResponse
 {
-    use Macroable {
+    use Tappable, Macroable {
         __call as macroCall;
     }
 

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -703,6 +703,17 @@ class FoundationTestResponseTest extends TestCase
         );
     }
 
+    public function testItCanBeTapped()
+    {
+        $response = TestResponse::fromBaseResponse(
+            (new Response)->setContent('')->setStatusCode(418)
+        );
+
+        $response->tap(function ($response) {
+            $this->assertInstanceOf(TestResponse::class, $response);
+        })->assertStatus(418);
+    }
+
     private function makeMockResponse($content)
     {
         $baseResponse = tap(new Response, function ($response) use ($content) {


### PR DESCRIPTION
This PR adds the new [tappable trait](https://github.com/laravel/framework/pull/28507) to the `TestResponse`. This way you can do stuff like this:

```php
$this->getJson('/api/users/index')
    ->assertStatus(200)
    ->tap(function (TestResponse $response) {
        $this->assertMatchesJsonSnapshot($response);
    });
```

Instead of having to do:
```php
$response = $this->getJson('/api/users/index')
    ->assertStatus(200);

$this->assertMatchesJsonSnapshot($response);
```