### PR TITLE
[5.8] Fixed cache repository getMultiple

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -138,6 +138,10 @@ class Repository implements CacheContract, ArrayAccess
             return $this->many($keys);
         }
 
+        if (! is_array($default)) {
+            $default = get_object_vars($default);
+        }
+
         foreach ($keys as $key) {
             if (! isset($default[$key])) {
                 $default[$key] = null;

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cache;
 
+use stdClass;
 use DateTime;
 use DateInterval;
 use Mockery as m;
@@ -265,10 +266,21 @@ class CacheRepositoryTest extends TestCase
         $repo->clear();
     }
 
-    public function testGettingMultipleValuesFromCache()
+    public function testGettingMultipleValuesFromCacheWithArrayDefaults()
     {
         $keys = ['key1', 'key2', 'key3'];
         $default = ['key2' => 5];
+
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('many')->once()->with(['key2', 'key1', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
+        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => null], $repo->getMultiple($keys, $default));
+    }
+
+    public function testGettingMultipleValuesFromCacheWithStdClassDefaults()
+    {
+        $keys = ['key1', 'key2', 'key3'];
+        $default = new stdClass();
+        $default->key2 = 5;
 
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('many')->once()->with(['key2', 'key1', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Cache;
 
-use stdClass;
 use DateTime;
+use stdClass;
 use DateInterval;
 use Mockery as m;
 use DateTimeImmutable;


### PR DESCRIPTION
TLDR: Some implementations use a `stdClass` as the `$default` param, and we are expected to support both in order to fulfil the PSR specification `Psr\SimpleCache\CacheInterface` we implement.

---

In particular, without this fix, I am getting the following error:

```
Error Cannot use object of type stdClass as array 
    .../vendor/laravel/framework/src/Illuminate/Cache/Repository.php:131 Illuminate\Cache\Repository::getMultiple
    .../vendor/symfony/cache/Adapter/SimpleCacheAdapter.php:45 Symfony\Component\Cache\Adapter\SimpleCacheAdapter::doFetch
    .../vendor/symfony/cache/Adapter/AbstractAdapter.php:164 Symfony\Component\Cache\Adapter\AbstractAdapter::getItem
    .../vendor/php-http/cache-plugin/src/CachePlugin.php:143 Http\Client\Common\Plugin\CachePlugin::doHandleRequest
```

* Line 131 of `Repository.php` (`v5.5.40` of laravel/framework) is the line that tries to do an `isset` test on `$default` which won't work unless we have an array (or a class that is array accessable).
* Line 45 of `SimpleCacheAdapter.php` (`v3.4.29`) is the line that calls `getMultiple` with a `stdClass` as the `$default` parameter.

With this fix in place, the `stdClass` is converted to an `array` before the `isset` is run on it. Moreover, when the code then goes to call `many` later, it is passing a genuine `array`, as is required.