### PR TITLE
[5.5] Fixed cache repository setMultiple with an iterator

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -229,7 +229,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function setMultiple($values, $ttl = null)
     {
-        $this->putMany($values, $ttl);
+        $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl);
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Cache;
 use DateTime;
 use DateInterval;
 use Mockery as m;
+use ArrayIterator;
 use DateTimeImmutable;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
@@ -113,12 +114,20 @@ class CacheRepositoryTest extends TestCase
         $repo->put(['foo' => 'bar', 'bar' => 'baz'], 1);
     }
 
-    public function testSettingMultipleItemsInCache()
+    public function testSettingMultipleItemsInCacheArray()
     {
         // Alias of PuttingMultiple
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
         $repo->setMultiple(['foo' => 'bar', 'bar' => 'baz'], 1);
+    }
+
+    public function testSettingMultipleItemsInCacheIterator()
+    {
+        // Alias of PuttingMultiple
+        $repo = $this->getRepository();
+        $repo->getStore()->shouldReceive('putMany')->once()->with(['foo' => 'bar', 'bar' => 'baz'], 1);
+        $repo->setMultiple(new ArrayIterator(['foo' => 'bar', 'bar' => 'baz']), 1);
     }
 
     public function testPutWithDatetimeInPastOrZeroSecondsDoesntSaveItem()


### PR DESCRIPTION
The `Psr\SimpleCache\CacheInterface` interface we implement says that an arbitrary iterable can be passed to `setMultiple`, thus we need to convert it to an array before we pass it to `putMany`.

---

Without this fix, the following error will occur it something iterable that's not an array is used:

```
TypeError: Argument 1 passed to Illuminate\Cache\Repository::putMany() must be of the type array, object given, called in /data/src/Illuminate/Cache/Repository.php on line 232

/data/src/Illuminate/Cache/Repository.php:216
/data/src/Illuminate/Cache/Repository.php:232
```