### PR TITLE
[5.9] Add ability to get normalized response from gate: Gate::access(...)

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -20,4 +20,14 @@ class AuthorizationException extends Exception
 
         $this->code = $code;
     }
+
+    /**
+     * Create a deny response object from this exception.
+     *
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function toResponse()
+    {
+        return Response::deny($this->message, $this->code);
+    }
 }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -8,11 +8,12 @@ trait HandlesAuthorization
      * Create a new access response.
      *
      * @param  string|null  $message
+     * @param  mixed        $code
      * @return \Illuminate\Auth\Access\Response
      */
-    protected function allow($message = null)
+    protected function allow($message = null, $code = null)
     {
-        return new Response($message);
+        return Response::allow($message, $code);
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/Access/Gate.php
+++ b/src/Illuminate/Contracts/Auth/Access/Gate.php
@@ -104,11 +104,22 @@ interface Gate
     public function authorize($ability, $arguments = []);
 
     /**
+     * Get the access response for the given ability.
+     *
+     * @param  string  $ability
+     * @param  array|mixed  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function access($ability, $arguments = []);
+
+    /**
      * Get the raw result from the authorization callback.
      *
      * @param  string  $ability
      * @param  array|mixed  $arguments
      * @return mixed
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function raw($ability, $arguments = []);
 

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -4,18 +4,65 @@ namespace Illuminate\Tests\Auth;
 
 use PHPUnit\Framework\TestCase;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class AuthAccessResponseTest extends TestCase
 {
-    /**
-     * @return void
-     */
-    public function testStringMethodWillReturnString()
+    public function test_allow_method()
     {
-        $response = new Response('some data');
+        $response = Response::allow('some message', 'some_code');
+
+        $this->assertTrue($response->allowed());
+        $this->assertFalse($response->denied());
+        $this->assertEquals('some message', $response->message());
+        $this->assertEquals('some_code', $response->code());
+    }
+
+    public function test_deny_method()
+    {
+        $response = Response::deny('some message', 'some_code');
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertEquals('some message', $response->message());
+        $this->assertEquals('some_code', $response->code());
+    }
+
+    public function test_authorize_method_throws_authorization_exception_when_response_denied()
+    {
+        $this->expectException(AuthorizationException::class);
+        $this->expectExceptionMessage('Some message.');
+        $this->expectExceptionCode('some_code');
+
+        $response = Response::deny('Some message.', 'some_code');
+
+        $response->authorize();
+    }
+
+    public function test_throw_if_needed_doesnt_throw_authorization_exception_when_response_allowed()
+    {
+        $response = Response::allow('Some message.', 'some_code');
+
+        $this->assertEquals($response, $response->authorize());
+    }
+
+    public function test_casting_to_string_returns_message()
+    {
+        $response = new Response('some data', true);
         $this->assertSame('some data', (string) $response);
 
-        $response = new Response;
+        $response = new Response(null, false);
         $this->assertSame('', (string) $response);
+    }
+
+    public function test_response_to_array_method()
+    {
+        $response = new Response('Not allowed.', false, 'some_code');
+
+        $this->assertEquals([
+            'allowed' => false,
+            'message' => 'Not allowed.',
+            'code' => 'some_code',
+        ], $response->toArray());
     }
 }


### PR DESCRIPTION
Following on from the recent addition of specifying a reason `code` when denying policies this PR adds a method onto the `Gate` which allows you to get the `Response` object for a given ability check.

### Why is this useful?

A good use case for this is anytime you want to check if an ability is not granted and understand *why*, without it throwing an exception.

### How is this solved at the moment in userland?

This can be solved by using `authorize` and catching the `AuthorizationException` but this quickly becomes unmaintainable if you need to check lots of permissions (see serialization frontend example).

```php
// Image if you had to check lots of user permissions
// and pass the deny messages and reasons onto the view... could get messy.
try {
    Gate::authorize('delete', $user);
    $allowed = true;
} catch (AuthorizationException $e) {
    $allowed = false;
    $denyCode = $e->getCode();
}
```

### What this PR does

Instead of the above, with this PR you can now do:

```php
$response = Gate::response('delete', $user);
$response->allowed(); // bool
$response->denied(); // bool
$response->message(); // Message from the policy, both allow and deny could send a message.
$response->code(); // The code from the policy, both allow and deny could send a code/reason of some kind.
```

This allows for more complex serialization of your permissions for example if you wanted to pass them onto your frontend for use in Javascript:

```php
return view('users.index', [
    'permissions' => $users->mapWithKeys(function($user) {
        return [
            "{$user->getKey()}.edit" => Gate::response('edit', $user),
            "{$user->getKey()}.delete" => Gate::response('delete', $user),
        ];
    }),
]);
```

```html
// In your view:
<script>
const permissions = '{{ $permissions->toJson() }}';
</script>
```

The above will serialize by default like:

```json
{
    "3.edit": {
        "allowed": true,
        "message": null,
        "code": null
    },
    "3.delete": {
        "allowed": false,
        "message": "You are not allowed to delete this user because they are an admin.",
        "code": "user_admin"
    }
}
```

I believe this PR is the final key needed to have a comprehensive workflow related to handling permissions. @JosephSilber mentioned on twitter he would also like to see this kind of normalization for an access response.