### PR TITLE
[5.8] Fixed cache repository getMultiple implementation

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -134,17 +134,13 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function getMultiple($keys, $default = null)
     {
-        if (is_null($default)) {
-            return $this->many($keys);
-        }
+        $defaults = [];
 
         foreach ($keys as $key) {
-            if (! isset($default[$key])) {
-                $default[$key] = null;
-            }
+            $defaults[$key] = $default;
         }
 
-        return $this->many($default);
+        return $this->many($defaults);
     }
 
     /**

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -276,11 +276,11 @@ class CacheRepositoryTest extends TestCase
     public function testGettingMultipleValuesFromCache()
     {
         $keys = ['key1', 'key2', 'key3'];
-        $default = ['key2' => 5];
+        $default = 5;
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('many')->once()->with(['key2', 'key1', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
-        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => null], $repo->getMultiple($keys, $default));
+        $repo->getStore()->shouldReceive('many')->once()->with(['key1', 'key2', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
+        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => 5], $repo->getMultiple($keys, $default));
     }
 
     public function testRemovingMultipleKeys()


### PR DESCRIPTION
The `$default` param of `Psr\SimpleCache\CacheInterface::getMultiple` is meant to be **the** default value, and not an array of defaults, or something of a similar form

---

For example, Symfony call `getMultiple` using `new stdClass` as the defaultm which crashes, because Laravel is trying to iterate over the parameter, instead of using it as the default.

```
Error Cannot use object of type stdClass as array 
    .../vendor/laravel/framework/src/Illuminate/Cache/Repository.php:131 Illuminate\Cache\Repository::getMultiple
    .../vendor/symfony/cache/Adapter/SimpleCacheAdapter.php:45 Symfony\Component\Cache\Adapter\SimpleCacheAdapter::doFetch
    .../vendor/symfony/cache/Adapter/AbstractAdapter.php:164 Symfony\Component\Cache\Adapter\AbstractAdapter::getItem
    .../vendor/php-http/cache-plugin/src/CachePlugin.php:143 Http\Client\Common\Plugin\CachePlugin::doHandleRequest
```