### PR TITLE
[5.8] Let users fill out if they use ATTR_EMULATE_PREPARES=true

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,6 +7,7 @@ about: 'Report a general framework issue. Please ensure your Laravel version is 
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:
+- Are you using `PDO::ATTR_EMULATE_PREPARES => true`: y/n
 
 ### Description:
 


### PR DESCRIPTION
Laravel will miss-behave in multiple ways with MySQL and PgSQL as documented in various issues and even PRs, because people try to get a fix in but _the_ recommendation right now is to *not* use it.

I figured it might save everyones time if ppl fill this out upfront because it's often takes some forth and back until users mention this.

See:
- https://github.com/laravel/framework/issues/29023
- https://github.com/laravel/framework/issues/23850
- https://github.com/laravel/framework/issues/25818
- https://github.com/laravel/framework/issues/27951
- https://github.com/laravel/framework/pull/28149

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
