### PR TITLE
[5.8] Use const HTTP_TOO_MANY_REQUESTS for readability

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Support\Facades\Lang;
@@ -53,7 +54,7 @@ trait ThrottlesLogins
 
         throw ValidationException::withMessages([
             $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
-        ])->status(429);
+        ])->status(Response::HTTP_TOO_MANY_REQUESTS);
     }
 
     /**


### PR DESCRIPTION
Use constant Response::HTTP_TOO_MANY_REQUESTS instead of hardcoded value 429

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
