### PR TITLE
[5.5] Added return type to avoid errors in tests

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -311,6 +311,6 @@ class MailFake implements Mailer
      */
     public function failures()
     {
-        //
+        return [];
     }
 }


### PR DESCRIPTION
We got this error in our unittests on php 7.2:

```
1) ..redacted..Test::test_notify
count(): Parameter must be an array or an object that implements Countable
```

This fix solves that issue