### PR TITLE
Collection: Add support for multidimensional arrays in `only` method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1341,6 +1341,16 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $keys = is_array($keys) ? $keys : func_get_args();
 
+        $isMultidimensionalArray = $this->every(function ($item) {
+            return is_array($item);
+        });
+
+        if ($isMultidimensionalArray) {
+            return new static(array_map(function ($items) use ($keys) {
+                return Arr::only($items, $keys);
+            }, $this->items));
+        }
+
         return new static(Arr::only($this->items, $keys));
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2359,6 +2359,50 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(collect(['first', 'email']))->all());
     }
 
+    public function testOnlyOnMultidimensionalArrays()
+    {
+        $people = new Collection([
+            [
+                'first' => 'John',
+                'last' => 'Doe',
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'first' => 'Jane',
+                'last' => 'Doe',
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'first' => 'John',
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'first' => 'Jane',
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ], $people->only(['first', 'name', 'email'])->all());
+
+        $this->assertEquals([
+            [
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ], $people->only(['missing-key', 'name', 'email'])->all());
+
+        $this->assertEquals($people->all(), $people->only(null)->all());
+    }
+
     public function testGettingAvgItemsFromCollection()
     {
         $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);


### PR DESCRIPTION
This PR adds support for handling multidimensional arrays in `only` method.

Multidimensional arrays can not use higher order functions.
Selecting keys like this now is only possible "manually" with e.g. `map` or `transform`.

```php
$people = collect([
    [
        'first' => 'John',
        'last' => 'Doe',
        'name' => 'John Doe',
        'email' => 'john.doe@gmail.com',
    ],
    [
        'first' => 'Jane',
        'last' => 'Doe',
        'name' => 'Jane Doe',
        'email' => 'jane.doe@gmail.com',
    ],
]);
```

## Before this PR
#### Using `only` before this PR
```php
$people->only(['first', 'name', 'email'])->all();
//=> []
```

#### Using higher order function `map`
```php
$people->map->only(['first', 'name', 'email']);
//=> PHP Error: 
//=> Call to a member function only() on array in
//=> src/Illuminate/Support/HigherOrderCollectionProxy.php on line 60
```

#### How to select keys before this PR
```php
$people->map(function ($person) {
    return [
        'first' => $person['first'],
        'name' => $person['name'],
        'email' => $person['email'],
    ];
});
//=> [
//=>     [
//=>         'first' => 'John',
//=>         'name' => 'John Doe',
//=>         'email' => 'john.doe@gmail.com',
//=>     ],
//=>     [
//=>         'first' => 'Jane',
//=>         'name' => 'Jane Doe',
//=>         'email' => 'jane.doe@gmail.com',
//=>     ],
//=> ]
```

## After this PR
#### Using `only` after this PR
```php
$people->only(['first', 'name', 'email'])->all();
//=> [
//=>     [
//=>         'first' => 'John',
//=>         'name' => 'John Doe',
//=>         'email' => 'john.doe@gmail.com',
//=>     ],
//=>     [
//=>         'first' => 'Jane',
//=>         'name' => 'Jane Doe',
//=>         'email' => 'jane.doe@gmail.com',
//=>     ],
//=> ]
```