### PR TITLE
[5.8] Add unguarded flag to make:model

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -122,6 +122,10 @@ class ModelMakeCommand extends GeneratorCommand
             return __DIR__.'/stubs/pivot.model.stub';
         }
 
+        if ($this->option('unguarded')) {
+            return __DIR__.'/stubs/unguarded.model.stub';
+        }
+
         return __DIR__.'/stubs/model.stub';
     }
 
@@ -144,6 +148,8 @@ class ModelMakeCommand extends GeneratorCommand
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
 
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
+
+            ['unguarded', 'u', InputOption::VALUE_NONE, 'Indicates if the generated model should be unguarded for mass assignment'],
 
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
         ];

--- a/src/Illuminate/Foundation/Console/stubs/unguarded.model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unguarded.model.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DummyClass extends Model
+{
+    protected $guarded = [];
+
+    //
+}


### PR DESCRIPTION
This PR adds the ability to add a flag (`--unguarded` or `-u`) to the `make:model` command to specify that a model should be generated as unguarded for mass-assignment.

The stub adds:

```php
protected $guarded = [];
```
## Why?

There are times where when I make a model the only reason I'm opening the model for awhile is to unguard it. I know there are some other options (e.g. calling unguard() from a service provider, but I prefer to have the property defined on the model as opposed to silently disabling in a provider or globally).