### PR TITLE
[5.5] Update return docblock of Mailable::render() to string

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -167,7 +167,7 @@ class Mailable implements MailableContract, Renderable
     /**
      * Render the mailable into a view.
      *
-     * @return \Illuminate\View\View
+     * @return string
      */
     public function render()
     {


### PR DESCRIPTION
The mailer render() method that this wraps returns a string, which was corrected in https://github.com/laravel/framework/pull/22639