### PR TITLE
[5.9] Add support for callbacks in Command::anticipate()

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -357,11 +357,11 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array|callable  $choices
      * @param  string|null  $default
      * @return mixed
      */
-    public function anticipate($question, array $choices, $default = null)
+    public function anticipate($question, $choices, $default = null)
     {
         return $this->askWithCompletion($question, $choices, $default);
     }
@@ -370,15 +370,15 @@ class Command extends SymfonyCommand
      * Prompt the user for input with auto completion.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array|callable $choices
      * @param  string|null  $default
      * @return mixed
      */
-    public function askWithCompletion($question, array $choices, $default = null)
+    public function askWithCompletion($question, $choices, $default = null)
     {
         $question = new Question($question, $default);
 
-        $question->setAutocompleterValues($choices);
+        is_callable($choices) ? $question->setAutocompleterCallback($choices) : $question->setAutocompleterValues($choices);
 
         return $this->output->askQuestion($question);
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -378,7 +378,9 @@ class Command extends SymfonyCommand
     {
         $question = new Question($question, $default);
 
-        is_callable($choices) ? $question->setAutocompleterCallback($choices) : $question->setAutocompleterValues($choices);
+        is_callable($choices)
+            ? $question->setAutocompleterCallback($choices)
+            : $question->setAutocompleterValues($choices);
 
         return $this->output->askQuestion($question);
     }


### PR DESCRIPTION
- Allows the Illuminate\Console\Command::anticipate() method to accept a
callback as it's second parameter instead of an array
- The callback should accept a user input string and return an array of choices
- The callback will be run every time the user's input changes
- This would be useful when the choices array needs to be dynamically
generated based on the user's input, for example by querying some API
- This utilises the new Command::setAutocompleterCallback() method made
available in Symfony Console 4.3
- Although this PR does not cause a breaking change to the Laravel API, it
cannot be back-ported to releases prior to 5.9 as it depends on Symfony
Console 4.3

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
