### PR TITLE
[5.8] Revert "Let users fill out if they use ATTR_EMULATE_PREPARES=true"

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,7 +7,6 @@ about: 'Report a general framework issue. Please ensure your Laravel version is 
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:
-- Are you using `PDO::ATTR_EMULATE_PREPARES => true`: y/n
 
 ### Description:
 


### PR DESCRIPTION
Reverts laravel/framework#29048

It's best that these sorts of things are covered in the docs. If we start to cover every single nuance in the issue template, things will get out of control fast and the issue template will fill up. Most of the issues posted on this tracker don't have anything to do with this specific thing.