### PR TITLE
[5.9] Modify the acquire method of the RedisLock class

### DIFF
--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -34,13 +34,11 @@ class RedisLock extends Lock
      */
     public function acquire()
     {
-        $result = $this->redis->setnx($this->name, $this->owner);
-
-        if ($result === 1 && $this->seconds > 0) {
-            $this->redis->expire($this->name, $this->seconds);
+        if ($this->seconds > 0) {
+            return (bool) $this->redis->set($this->name, $this->owner, 'ex', $this->seconds, 'nx');
         }
 
-        return $result === 1;
+        return (bool) $this->redis->setnx($this->name, $this->owner);
     }
 
     /**


### PR DESCRIPTION
Raw acquire method will do two redis commands to set the expiration time.I think it is not a good ideal, because the second command probably fail. I modify the function that combine two command in one command. It guarantee the acquire method atomic.