### PR TITLE
[5.8] By default attribute can access directly and they are public.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1615,6 +1615,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
+        if (Str::startsWith($method, "get") || Str::startsWith($method, "set")) {
+            $attribute = substr($method, 3);
+            $attribute = Str::snake($attribute);
+            if (Str::startsWith($method, "get")) {
+                if (array_key_exists($attribute, $this->attributes)) {
+                    return $this->{$attribute};
+                }
+            } else {
+                $this->{$attribute} = $parameters[0];
+                return true;
+            }
+        }
+
         return $this->forwardCallTo($this->newQuery(), $method, $parameters);
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1615,10 +1615,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
-        if (Str::startsWith($method, "get") || Str::startsWith($method, "set")) {
+        if (Str::startsWith($method, 'get') || Str::startsWith($method, 'set')) {
             $attribute = substr($method, 3);
             $attribute = Str::snake($attribute);
-            if (Str::startsWith($method, "get")) {
+            if (Str::startsWith($method, 'get')) {
                 if (array_key_exists($attribute, $this->attributes)) {
                     return $this->{$attribute};
                 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1624,6 +1624,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 }
             } else {
                 $this->{$attribute} = $parameters[0];
+
                 return true;
             }
         }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -68,6 +68,15 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
+    public function testAttributeManipulationWithGetterAndSetter()
+    {
+        $model = new EloquentModelStub;
+        $model->setNameTest('foo');
+        $this->assertEquals('foo', $model->name_test);
+        $this->assertEquals('foo', $model->getNameTest());
+        $this->assertTrue(isset($model->name_test));
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
This PR introduces a way to increase encapsulation. By default, an attribute can access directly, and they are public.
With this change, we can use getter and setter for using attributes that can improve encapsulation.
for example, we can use like this
```
        $model->setName('foo');
        $this->assertEquals('foo', $model->getName());
```