### PR TITLE
[5.8] Remove Base64 from Route Cache

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -104,6 +104,10 @@ class RouteCacheCommand extends Command
     {
         $stub = $this->files->get(__DIR__.'/stubs/routes.stub');
 
-        return str_replace('{{routes}}', base64_encode(serialize($routes)), $stub);
+        return str_replace(
+            '{{routes}}',
+            str_replace(['\\', '\'', ], ['\\\\','\\\''], serialize($routes)),
+            $stub
+        );
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/routes.stub
+++ b/src/Illuminate/Foundation/Console/stubs/routes.stub
@@ -12,5 +12,5 @@
 */
 
 app('router')->setRoutes(
-    unserialize(base64_decode('{{routes}}'))
+    unserialize('{{routes}}')
 );


### PR DESCRIPTION
As we could see, Laravel's route cache stores the serialized object in base64 encoded format. So it needs to decode every time it runs. 

I think we can get rid of the decode step by storing the serialized object directly without any additional encoding. Escaping the data should be enough to prevent syntax error.

The benefit of this is we can minimalize the process of loading routes, while the loading routes is done for every request, so I think it is a significant impact on the performance.