### PR TITLE
Remove base64 from route cache 

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,7 +7,6 @@ about: 'Report a general framework issue. Please ensure your Laravel version is 
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:
-- Are you using `PDO::ATTR_EMULATE_PREPARES => true`: y/n
 
 ### Description:
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -134,17 +134,13 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function getMultiple($keys, $default = null)
     {
-        if (is_null($default)) {
-            return $this->many($keys);
-        }
+        $defaults = [];
 
         foreach ($keys as $key) {
-            if (! isset($default[$key])) {
-                $default[$key] = null;
-            }
+            $defaults[$key] = $default;
         }
 
-        return $this->many($default);
+        return $this->many($defaults);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -104,6 +104,10 @@ class RouteCacheCommand extends Command
     {
         $stub = $this->files->get(__DIR__.'/stubs/routes.stub');
 
-        return str_replace('{{routes}}', base64_encode(serialize($routes)), $stub);
+        return str_replace(
+            '{{routes}}',
+            str_replace(['\\', '\'', ], ['\\\\','\\\''], serialize($routes)),
+            $stub
+        );
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/routes.stub
+++ b/src/Illuminate/Foundation/Console/stubs/routes.stub
@@ -12,5 +12,5 @@
 */
 
 app('router')->setRoutes(
-    unserialize(base64_decode('{{routes}}'))
+    unserialize('{{routes}}')
 );

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -276,11 +276,11 @@ class CacheRepositoryTest extends TestCase
     public function testGettingMultipleValuesFromCache()
     {
         $keys = ['key1', 'key2', 'key3'];
-        $default = ['key2' => 5];
+        $default = 5;
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('many')->once()->with(['key2', 'key1', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
-        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => null], $repo->getMultiple($keys, $default));
+        $repo->getStore()->shouldReceive('many')->once()->with(['key1', 'key2', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
+        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => 5], $repo->getMultiple($keys, $default));
     }
 
     public function testRemovingMultipleKeys()


### PR DESCRIPTION
CC: @36864

I am sorry for the `"significant impact on the performance"` sentence which I said on the PR https://github.com/laravel/framework/pull/29081, it seems the benchmark result is not like what I said before. The actual impact is not very significant. But it is still faster.

You could see the code that I wrote to do benchmark here: https://github.com/ammarfaizi2/laravel_benchmark_route_cache

So here are the results:
## Without route cache
```
root@esteh:~/test# php artisan route:clear
Route cache cleared!
root@esteh:~/test# php benchmark.php
Test 0: 0.35951805114746
Test 1: 0.17243003845215
Test 2: 0.15333890914917
Test 3: 0.15670490264893
Test 4: 0.15610313415527
Test 5: 0.16067695617676
Test 6: 0.15519094467163
Test 7: 0.15584301948547
Test 8: 0.15520596504211
Test 9: 0.15413594245911
```

## With current Laravel route cache (base64 encoded)
```
root@esteh:~/test# php artisan route:cache
Route cache cleared!
Routes cached successfully!
root@esteh:~/test# php benchmark.php
Test 0: 0.27187609672546
Test 1: 0.16425585746765
Test 2: 0.16555285453796
Test 3: 0.15509080886841
Test 4: 0.13947486877441
Test 5: 0.14857387542725
Test 6: 0.14321708679199
Test 7: 0.14907097816467
Test 8: 0.14355897903442
Test 9: 0.14916396141052
```

## With route cache (without any encoding)
```
root@esteh:~/test# php artisan route:cache2
Route cache cleared!
Routes cached successfully!
root@esteh:~/test# php benchmark.php
Test 0: 0.20811605453491
Test 1: 0.13638710975647
Test 2: 0.13595986366272
Test 3: 0.13499903678894
Test 4: 0.13642120361328
Test 5: 0.13596487045288
Test 6: 0.13824105262756
Test 7: 0.13454413414001
Test 8: 0.13550209999084
Test 9: 0.13746905326843
```

The another benefit of this is on the cache file size.
## Current Laravel route cache (base64 encoded).
```
root@esteh:~/test# php artisan route:cache
Route cache cleared!
Routes cached successfully!
root@esteh:~/test# ll bootstrap/cache -h
total 9.9M
drwxr-xr-x 2 root root 4.0K Jul  5 16:48 ./
drwxr-xr-x 3 root root 4.0K Jul  5 16:34 ../
-rw-r--r-- 1 root root   14 Jul  5 16:34 .gitignore
-rwxr-xr-x 1 root root  735 Jul  5 16:34 packages.php*
-rw-r--r-- 1 root root 9.8M Jul  5 16:48 routes.php
-rwxr-xr-x 1 root root  14K Jul  5 16:34 services.php*
```

## Route cache without any encoding.
```
root@esteh:~/test# php artisan route:cache2
Route cache cleared!
Routes cached successfully!
root@esteh:~/test# ll bootstrap/cache -h
total 7.5M
drwxr-xr-x 2 root root 4.0K Jul  5 16:49 ./
drwxr-xr-x 3 root root 4.0K Jul  5 16:34 ../
-rw-r--r-- 1 root root   14 Jul  5 16:34 .gitignore
-rwxr-xr-x 1 root root  735 Jul  5 16:34 packages.php*
-rw-r--r-- 1 root root 7.5M Jul  5 16:49 routes.php
-rwxr-xr-x 1 root root  14K Jul  5 16:34 services.php*
root@esteh:~/test# 
```
