### PR TITLE
[5.8] Add mergeRecursive() method on collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1259,6 +1259,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Recursively merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeRecursive($items)
+    {
+        return new static(array_merge_recursive($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @param  mixed  $values

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -680,10 +680,10 @@ class SupportCollectionTest extends TestCase
 
     public function testMergeRecursiveCollection()
     {
-        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $c = new Collection(['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b'], 'roles' => 'admin']]);
         $this->assertEquals(
-            ['name' => ['Hello', 'World'], 'id' => [1, 2]],
-            $c->mergeRecursive(new Collection(['name' => 'World', 'id' => 2]))->all()
+            ['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b', 'c'], 'roles' => ['admin', 'editor']]],
+            $c->mergeRecursive(new Collection(['meta' => ['tags' => ['c'], 'roles' => 'editor']]))->all()
         );
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -666,6 +666,27 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testMergeRecursiveNull()
+    {
+        $c = new Collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello'], $c->mergeRecursive(null)->all());
+    }
+
+    public function testMergeRecursiveArray()
+    {
+        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $this->assertEquals(['name' => 'Hello', 'id' => [1, 2]], $c->mergeRecursive(['id' => 2])->all());
+    }
+
+    public function testMergeRecursiveCollection()
+    {
+        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $this->assertEquals(
+            ['name' => ['Hello', 'World'], 'id' => [1, 2]],
+            $c->mergeRecursive(new Collection(['name' => 'World', 'id' => 2]))->all()
+        );
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
This PR implements the basic PHP `array_merge_recursive` behavior on the collection.

There can be some scenarios when a deep/recursive merge behavior is more appropriate than overriding the original collection items.