### PR TITLE
[5.9] PsyShell Casters: Move into framework

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelCaster.php
+++ b/src/Illuminate/Database/Eloquent/ModelCaster.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use Symfony\Component\VarDumper\Caster\Caster;
+
+class ModelCaster
+{
+    /**
+     * Get an array representing the properties of a model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return array
+     */
+    public static function cast($model)
+    {
+        $attributes = array_merge(
+            $model->getAttributes(), $model->getRelations()
+        );
+        $visible = array_flip(
+            $model->getVisible() ?: array_diff(array_keys($attributes), $model->getHidden())
+        );
+        $results = [];
+        foreach (array_intersect_key($attributes, $visible) as $key => $value) {
+            $results[(isset($visible[$key]) ? Caster::PREFIX_VIRTUAL : Caster::PREFIX_PROTECTED).$key] = $value;
+        }
+
+        return $results;
+    }
+}

--- a/src/Illuminate/Foundation/ApplicationCaster.php
+++ b/src/Illuminate/Foundation/ApplicationCaster.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Illuminate\Foundation;
+
+use Symfony\Component\VarDumper\Caster\Caster;
+
+class ApplicationCaster
+{
+    /**
+     * Application methods to include in the presenter.
+     *
+     * @var array
+     */
+    private static $appProperties = [
+        'configurationIsCached',
+        'environment',
+        'environmentFile',
+        'isLocal',
+        'routesAreCached',
+        'runningUnitTests',
+        'version',
+        'path',
+        'basePath',
+        'configPath',
+        'databasePath',
+        'langPath',
+        'publicPath',
+        'storagePath',
+        'bootstrapPath',
+    ];
+
+    /**
+     * Get an array representing the properties of an application.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    public static function cast($app)
+    {
+        $results = [];
+        foreach (self::$appProperties as $property) {
+            try {
+                $val = $app->$property();
+                if (! is_null($val)) {
+                    $results[Caster::PREFIX_VIRTUAL.$property] = $val;
+                }
+            } catch (Exception $e) {
+                //
+            }
+        }
+
+        return $results;
+    }
+}

--- a/src/Illuminate/Support/CollectionCaster.php
+++ b/src/Illuminate/Support/CollectionCaster.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Symfony\Component\VarDumper\Caster\Caster;
+
+class CollectionCaster
+{
+    /**
+     * Get an array representing the properties of a collection.
+     *
+     * @param  \Illuminate\Support\Collection  $collection
+     * @return array
+     */
+    public static function cast($collection)
+    {
+        return [
+            Caster::PREFIX_VIRTUAL.'all' => $collection->all(),
+        ];
+    }
+}


### PR DESCRIPTION
This takes the casters from https://github.com/laravel/tinker/blob/e3086ee8cb1f54a39ae8dcb72d1c37d10128997d/src/TinkerCaster.php and moves them into this code base.

The benefit of this is twofold:
1. Development of casters happens in the same code base as the class that it is casting.
2. Casters are available in the subtrees instead of in the tinker repository: So users can use them with their own PsyShell configurations (if they aren't using Tinker or the full framework).

See also: https://github.com/laravel/tinker/pull/70