### PR TITLE
[5.9] Add ability to define models with 'strict property' getter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\PropertyNotFoundException;
 
 trait HasAttributes
 {
@@ -29,6 +30,13 @@ trait HasAttributes
      * @var array
      */
     protected $original = [];
+
+    /**
+     * Indicates whether to throw an exception when accessing undefined properties.
+     *
+     * @var bool
+     */
+    protected $strictProperties = false;
 
     /**
      * The changed model attributes.
@@ -326,7 +334,13 @@ trait HasAttributes
             return;
         }
 
-        return $this->getRelationValue($key);
+        if ($this->relationLoaded($key) || method_exists($this, $key)) {
+            return $this->getRelationValue($key);
+        }
+
+        if ($this->strictProperties) {
+            throw PropertyNotFoundException::make($this, $key);
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1543,7 +1543,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        try {
+            return ! is_null($this->getAttribute($offset));
+        } catch (PropertyNotFoundException $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/PropertyNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/PropertyNotFoundException.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class PropertyNotFoundException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * The name of the property.
+     *
+     * @var string
+     */
+    public $property;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  mixed  $model
+     * @param  string  $property
+     * @return static
+     */
+    public static function make($model, $property)
+    {
+        $class = get_class($model);
+
+        $instance = new static("Call to undefined property [{$property}] on model [{$class}].");
+
+        $instance->model = $model;
+        $instance->property = $property;
+
+        return $instance;
+    }
+}


### PR DESCRIPTION
### Background

By default PHP will throw an exception when you attempt to access an unknown/undefined property:

```php
$obj = new stdClass;
$obj->i_will_throw_an_exception;
```

### The current problem

Models however will allow this behaviour which can sometimes cause some nasty bugs in your code. Take for example this rather innocent looking example:

```php
namespace App\Http\Middleware;

use Closure;

class CheckAccountStatus
{
	public function handle($request, Closure $next)
	{
		if ($request->user()->banned) {
			return redirect()->route('banned');
		}

		return $request($next);
	}
}
```

See anything wrong with this? On the face of it looks like this code is pretty flawless but let's see what happens when someone actually get's logged in:

```php
Auth::login(User::select(['id', 'username', 'name', 'created_at'])->where('username', 'gary')->first());
```

Although this may seem like a bit of a construed example, as in reality you wouldn't do a partial select on some fields when logging in, but it goes to show that some innocent looking code can go massively wrong just by silently returning `null` from models for properties that haven't been defined at all.

### Another example

A simple mistake that goes unnoticed because of silent errors can make it into production:

```php
// 'paid' isn't defined on the model, it's actually paid_at.
// Again, visually an innocent looking bit of code
// but can have some dire consequences. 😫
if (! $invoice->paid) {
  return DebtCollectors::sendTo($user);
}
```

### Yet another example

Let's say your database sets a default value for a certain column in MySQL (maybe not considered best practise, but it's still a common paradigm)

```php
Schema::create('members', function($table) {
   $table->increments('id');
   $table->string('name');
   $table->string('account_type', 20)->default('regular');
});
```

When you create a new model:

```php
$member = Member::create(['name' => 'Gary']);

// This will come back with "null" but the database has it set as "regular"
// Often this creates some weird obscurities in your code that are sometimes hard to catch
// If this had errored, you would know to load a fresh model from the database
// to make sure the field is loaded.
dd($member->account_type); // null.
```

## Solution with this PR

With this PR, you can opt-in to strict properties on your model:

```php
class Invoice extends Eloquent {
   protected $strictProperties = true;
}
```

Upon accessing any undefined properties it will now throw a `PropertyNotFoundException`. In the case of the above examples, you would of instantly caught any of the above issues early during development.


![image](https://user-images.githubusercontent.com/1702638/60750170-78af9c00-9f9c-11e9-9843-c9ce95ebf36e.png)

I've implemented this in production and have been suprised how many coding obscurities this has revealed.

I understand this can be implemented in your own userland code by overloading the `getAttribute` method, but I think this strict opt-in approach to accessing properties would benefit the community overall, so hope you will consider this PR for inclusion in Laravel.