### PR TITLE
[5.8] [WIP] Add migrate:repeat console command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/RepeatCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RepeatCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Database\Console\Migrations;
+
+use Illuminate\Console\ConfirmableTrait;
+
+class RepeatCommand extends BaseCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'migrate:repeat';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rollback the last database migration & run it again';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $this->call('migrate:rollback');
+        $this->call('migrate');
+    }
+}


### PR DESCRIPTION
This PR introduces `migrate:repeat` command. Very useful when you already have database filled with data and need to develop new functionality without making `migrate:fresh --seed`. If new migration files has issues - you can change migration file, rollback previous migration and re-migrate the same file without losing previous database state.

After repeating the same sequence many times while designing new database tables in realtime I've ended with extra console command `migrate:repeat` which will call `migrate:rollback` & `migrate` right after it. Other names in my mind: `migrate:rerun`, `migrate:reup`.

If you like this concept - I'll add some more option flags to it and drop in some tests.