### PR TITLE
[5.9] Encryption Manager

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,7 +7,6 @@ about: 'Report a general framework issue. Please ensure your Laravel version is 
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:
-- Are you using `PDO::ATTR_EMULATE_PREPARES => true`: y/n
 
 ### Description:
 

--- a/src/Illuminate/Contracts/Encryption/Factory.php
+++ b/src/Illuminate/Contracts/Encryption/Factory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Contracts\Encryption;
+
+interface Factory
+{
+    /**
+     * Get a cache store instance by name.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Contracts\Encryption\Encrypter
+     */
+    public function encrypter($name = null);
+}

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Cookie\Middleware;
 
 use Closure;
-use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -12,9 +12,9 @@ use Illuminate\Contracts\Encryption\DecryptException;
 class EncryptCookies
 {
     /**
-     * The encrypter instance.
+     * The encryption manager instance.
      *
-     * @var \Illuminate\Encryption\EncryptionManager
+     * @var \Illuminate\Contracts\Encryption\Factory
      */
     protected $encrypter;
 

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -3,18 +3,18 @@
 namespace Illuminate\Cookie\Middleware;
 
 use Closure;
+use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Encryption\DecryptException;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
 class EncryptCookies
 {
     /**
      * The encrypter instance.
      *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
+     * @var \Illuminate\Encryption\EncryptionManager
      */
     protected $encrypter;
 
@@ -35,10 +35,10 @@ class EncryptCookies
     /**
      * Create a new CookieGuard instance.
      *
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  \Illuminate\Encryption\EncryptionManager  $encrypter
      * @return void
      */
-    public function __construct(EncrypterContract $encrypter)
+    public function __construct(EncryptionManager $encrypter)
     {
         $this->encrypter = $encrypter;
     }

--- a/src/Illuminate/Cookie/Middleware/EncryptCookies.php
+++ b/src/Illuminate/Cookie/Middleware/EncryptCookies.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 
 class EncryptCookies
 {
@@ -35,10 +36,10 @@ class EncryptCookies
     /**
      * Create a new CookieGuard instance.
      *
-     * @param  \Illuminate\Encryption\EncryptionManager  $encrypter
+     * @param \Illuminate\Contracts\Encryption\Factory $encrypter
      * @return void
      */
-    public function __construct(EncryptionManager $encrypter)
+    public function __construct(Encryption $encrypter)
     {
         $this->encrypter = $encrypter;
     }

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class EncryptionManager
+{
+    /**
+     * @var Application
+     */
+    protected $app;
+
+    /**
+     * @var Encrypter[]
+     */
+    protected $encrypters = [];
+
+    /**
+     * EncryptionManager constructor.
+     * @param Application $app
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * @param null $name
+     * @return Encrypter
+     */
+    public function encrypter($name = null)
+    {
+        $name = $name ?: $this->getDefaultEncrypter();
+
+        if (! isset($this->encrypter[$name])) {
+            $this->encrypters[$name] = $this->makeEncrypter($name);
+        }
+
+        return $this->encrypters[$name];
+    }
+
+    /**
+     * @param $name
+     * @return Encrypter
+     */
+    protected function makeEncrypter($name)
+    {
+        $config = $this->resolveConfiguration($name);
+        return new Encrypter($this->getKey($config), $config['cipher'] ?? 'AES-128-CBC');
+    }
+
+    /**
+     * @param $config
+     * @return bool|mixed|string
+     */
+    protected function getKey($config)
+    {
+        $key = tap($config['key'], function ($key) {
+            if (empty($key)) {
+                throw new RuntimeException(
+                    'No application encryption key has been specified.'
+                );
+            }
+        });
+
+        // If the key starts with "base64:", we will need to decode the key before handing
+        // it off to the encrypter. Keys may be base-64 encoded for presentation and we
+        // want to make sure to convert them back to the raw bytes before encrypting.
+        if (Str::startsWith($key, 'base64:')) {
+            $key = base64_decode(substr($key, 7));
+        }
+
+        return $key;
+    }
+
+    /**
+     * @param $name
+     * @return array
+     */
+    protected function resolveConfiguration($name)
+    {
+        $config = $this->app['config']['encryption.encrypters'];
+
+        if (! isset($config[$name])) {
+            throw new \InvalidArgumentException("Encrypter [{$name}] not configured.");
+        }
+
+        return $config[$name];
+    }
+
+    /**
+     * Get the default encrypter name.
+     *
+     * @return string
+     */
+    public function getDefaultEncrypter()
+    {
+        return $this->app['config']['encryption.default'];
+    }
+
+    /**
+     * Set the default encrypter name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setDefaultEncrypter($name)
+    {
+        $this->app['config']['encryption.default'] = $name;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEncrypters()
+    {
+        return $this->encrypters;
+    }
+
+    /**
+     * Dynamically pass methods to the default encrypter.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->encrypter()->$method(...$parameters);
+    }
+}

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Encryption;
 
-use InvalidArgumentException;
 use RuntimeException;
-use Illuminate\Contracts\Encryption\Factory as FactoryContract;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Illuminate\Contracts\Encryption\Factory as FactoryContract;
 
 class EncryptionManager implements FactoryContract
 {

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Encryption;
 
-use Illuminate\Foundation\Application;
-use Illuminate\Support\Str;
 use RuntimeException;
+use Illuminate\Support\Str;
+use Illuminate\Foundation\Application;
 
 class EncryptionManager
 {
@@ -49,6 +49,7 @@ class EncryptionManager
     protected function makeEncrypter($name)
     {
         $config = $this->resolveConfiguration($name);
+
         return new Encrypter($this->getKey($config), $config['cipher'] ?? 'AES-128-CBC');
     }
 

--- a/src/Illuminate/Encryption/EncryptionManager.php
+++ b/src/Illuminate/Encryption/EncryptionManager.php
@@ -2,34 +2,39 @@
 
 namespace Illuminate\Encryption;
 
+use InvalidArgumentException;
 use RuntimeException;
+use Illuminate\Contracts\Encryption\Factory as FactoryContract;
 use Illuminate\Support\Str;
-use Illuminate\Foundation\Application;
 
-class EncryptionManager
+class EncryptionManager implements FactoryContract
 {
     /**
-     * @var Application
+     * The application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
     /**
-     * @var Encrypter[]
+     * @var \Illuminate\Contracts\Encryption\Encrypter[]
      */
     protected $encrypters = [];
 
     /**
-     * EncryptionManager constructor.
-     * @param Application $app
+     * Create a new Encryption manager instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
      */
-    public function __construct(Application $app)
+    public function __construct($app)
     {
         $this->app = $app;
     }
 
     /**
-     * @param null $name
-     * @return Encrypter
+     * @param string|null $name
+     * @return \Illuminate\Contracts\Encryption\Encrypter
      */
     public function encrypter($name = null)
     {
@@ -43,8 +48,8 @@ class EncryptionManager
     }
 
     /**
-     * @param $name
-     * @return Encrypter
+     * @param string $name
+     * @return \Illuminate\Encryption\Encrypter
      */
     protected function makeEncrypter($name)
     {
@@ -54,8 +59,8 @@ class EncryptionManager
     }
 
     /**
-     * @param $config
-     * @return bool|mixed|string
+     * @param array $config
+     * @return string
      */
     protected function getKey($config)
     {
@@ -78,7 +83,7 @@ class EncryptionManager
     }
 
     /**
-     * @param $name
+     * @param string $name
      * @return array
      */
     protected function resolveConfiguration($name)
@@ -86,7 +91,7 @@ class EncryptionManager
         $config = $this->app['config']['encryption.encrypters'];
 
         if (! isset($config[$name])) {
-            throw new \InvalidArgumentException("Encrypter [{$name}] not configured.");
+            throw new InvalidArgumentException("Encrypter [{$name}] not configured.");
         }
 
         return $config[$name];

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -16,35 +16,10 @@ class EncryptionServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('encrypter', function ($app) {
-            $config = $app->make('config')->get('app');
-
-            // If the key starts with "base64:", we will need to decode the key before handing
-            // it off to the encrypter. Keys may be base-64 encoded for presentation and we
-            // want to make sure to convert them back to the raw bytes before encrypting.
-            if (Str::startsWith($key = $this->key($config), 'base64:')) {
-                $key = base64_decode(substr($key, 7));
-            }
-
-            return new Encrypter($key, $config['cipher']);
+            return new EncryptionManager($app);
         });
-    }
-
-    /**
-     * Extract the encryption key from the given configuration.
-     *
-     * @param  array  $config
-     * @return string
-     *
-     * @throws \RuntimeException
-     */
-    protected function key(array $config)
-    {
-        return tap($config['key'], function ($key) {
-            if (empty($key)) {
-                throw new RuntimeException(
-                    'No application encryption key has been specified.'
-                );
-            }
-        });
+//        $this->app->singleton('encrypter.default', function ($app) {
+//            return $app['encrypter']->encrypter();
+//        });
     }
 }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -18,8 +18,5 @@ class EncryptionServiceProvider extends ServiceProvider
         $this->app->singleton('encrypter', function ($app) {
             return new EncryptionManager($app);
         });
-//        $this->app->singleton('encrypter.default', function ($app) {
-//            return $app['encrypter']->encrypter();
-//        });
     }
 }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -17,4 +17,16 @@ class EncryptionServiceProvider extends ServiceProvider
             return new EncryptionManager($app);
         });
     }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            'encrypter',
+        ];
+    }
 }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Encryption;
 
-use RuntimeException;
-use Illuminate\Support\Str;
 use Illuminate\Support\ServiceProvider;
 
 class EncryptionServiceProvider extends ServiceProvider

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1137,7 +1137,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class, \Psr\SimpleCache\CacheInterface::class],
             'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
-            'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],
+            'encrypter'            => [\Illuminate\Encryption\EncryptionManager::class],
             'db'                   => [\Illuminate\Database\DatabaseManager::class],
             'db.connection'        => [\Illuminate\Database\Connection::class, \Illuminate\Database\ConnectionInterface::class],
             'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1137,7 +1137,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class, \Psr\SimpleCache\CacheInterface::class],
             'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
-            'encrypter'            => [\Illuminate\Encryption\EncryptionManager::class],
+            'encrypter'            => [\Illuminate\Encryption\EncryptionManager::class, \Illuminate\Contracts\Encryption\Factory::class],
             'db'                   => [\Illuminate\Database\DatabaseManager::class],
             'db.connection'        => [\Illuminate\Database\Connection::class, \Illuminate\Database\ConnectionInterface::class],
             'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -99,7 +99,7 @@ class KeyGenerateCommand extends Command
         // the new one, otherwise append the new key to the end of the file
         $newContents = preg_match($this->keyReplacementPattern(), $contents)
             ? preg_replace($this->keyReplacementPattern(), $line, $contents)
-            : $contents . PHP_EOL . $line;
+            : $contents.PHP_EOL.$line;
 
         file_put_contents($this->laravel->environmentFilePath(), $newContents);
     }
@@ -112,7 +112,8 @@ class KeyGenerateCommand extends Command
     protected function keyReplacementPattern()
     {
         $escaped = preg_quote('='.$this->getCurrentKey(), '/');
-        return "/^".$this->keyName()."{$escaped}/m";
+
+        return '/^'.$this->keyName()."{$escaped}/m";
     }
 
     /**
@@ -121,6 +122,7 @@ class KeyGenerateCommand extends Command
     protected function getCurrentKey()
     {
         $config = $this->getEncrypterConfig();
+
         return $config['key'] ?? null;
     }
 

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Console;
 
+use InvalidArgumentException;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Console\ConfirmableTrait;
-use InvalidArgumentException;
 
 class KeyGenerateCommand extends Command
 {

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Console\ConfirmableTrait;
+use InvalidArgumentException;
 
 class KeyGenerateCommand extends Command
 {
@@ -135,7 +136,7 @@ class KeyGenerateCommand extends Command
         $config = $this->laravel['config']['encryption.encrypters'];
 
         if (! isset($config[$name]) || ! is_array($config[$name])) {
-            throw new \InvalidArgumentException("Encrypter [{$name}] not configured.");
+            throw new InvalidArgumentException("Encrypter [{$name}] not configured.");
         }
 
         return $config[$name];

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -6,9 +6,9 @@ use Closure;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\TokenMismatchException;
-use Illuminate\Contracts\Encryption\Factory as Encryption;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 
 class VerifyCsrfToken
 {

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -4,9 +4,9 @@ namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\TokenMismatchException;
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 
@@ -24,7 +24,7 @@ class VerifyCsrfToken
     /**
      * The encrypter implementation.
      *
-     * @var \Illuminate\Encryption\EncryptionManager
+     * @var \Illuminate\Contracts\Encryption\Factory
      */
     protected $encrypter;
 
@@ -46,10 +46,10 @@ class VerifyCsrfToken
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Encryption\EncryptionManager  $encrypter
+     * @param  \Illuminate\Contracts\Encryption\Factory  $encrypter
      * @return void
      */
-    public function __construct(Application $app, EncryptionManager $encrypter)
+    public function __construct(Application $app, Encryption $encrypter)
     {
         $this->app = $app;
         $this->encrypter = $encrypter;

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
-use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Contracts\Foundation\Application;

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Foundation\Http\Middleware;
 
 use Closure;
+use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Support\InteractsWithTime;
 use Symfony\Component\HttpFoundation\Cookie;
-use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Cookie\Middleware\EncryptCookies;
@@ -24,7 +24,7 @@ class VerifyCsrfToken
     /**
      * The encrypter implementation.
      *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
+     * @var \Illuminate\Encryption\EncryptionManager
      */
     protected $encrypter;
 
@@ -46,10 +46,10 @@ class VerifyCsrfToken
      * Create a new middleware instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @param  \Illuminate\Contracts\Encryption\Encrypter  $encrypter
+     * @param  \Illuminate\Encryption\EncryptionManager  $encrypter
      * @return void
      */
-    public function __construct(Application $app, Encrypter $encrypter)
+    public function __construct(Application $app, EncryptionManager $encrypter)
     {
         $this->app = $app;
         $this->encrypter = $encrypter;

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Session;
 
+use Illuminate\Encryption\EncryptionManager;
 use SessionHandlerInterface;
 use Illuminate\Contracts\Encryption\DecryptException;
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 
 class EncryptedStore extends Store
 {
     /**
      * The encrypter instance.
      *
-     * @var \Illuminate\Contracts\Encryption\Encrypter
+     * @var \Illuminate\Encryption\EncryptionManager
      */
     protected $encrypter;
 
@@ -20,11 +20,11 @@ class EncryptedStore extends Store
      *
      * @param  string $name
      * @param  \SessionHandlerInterface $handler
-     * @param  \Illuminate\Contracts\Encryption\Encrypter $encrypter
+     * @param  \Illuminate\Encryption\EncryptionManager $encrypter
      * @param  string|null $id
      * @return void
      */
-    public function __construct($name, SessionHandlerInterface $handler, EncrypterContract $encrypter, $id = null)
+    public function __construct($name, SessionHandlerInterface $handler, EncryptionManager $encrypter, $id = null)
     {
         $this->encrypter = $encrypter;
 
@@ -60,7 +60,7 @@ class EncryptedStore extends Store
     /**
      * Get the encrypter instance.
      *
-     * @return \Illuminate\Contracts\Encryption\Encrypter
+     * @return \Illuminate\Encryption\EncryptionManager
      */
     public function getEncrypter()
     {

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -3,15 +3,15 @@
 namespace Illuminate\Session;
 
 use SessionHandlerInterface;
-use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 
 class EncryptedStore extends Store
 {
     /**
-     * The encrypter instance.
+     * The encryption manager instance.
      *
-     * @var \Illuminate\Encryption\EncryptionManager
+     * @var \Illuminate\Contracts\Encryption\Factory
      */
     protected $encrypter;
 
@@ -20,11 +20,11 @@ class EncryptedStore extends Store
      *
      * @param  string $name
      * @param  \SessionHandlerInterface $handler
-     * @param  \Illuminate\Encryption\EncryptionManager $encrypter
+     * @param  \Illuminate\Contracts\Encryption\Factory $encrypter
      * @param  string|null $id
      * @return void
      */
-    public function __construct($name, SessionHandlerInterface $handler, EncryptionManager $encrypter, $id = null)
+    public function __construct($name, SessionHandlerInterface $handler, Encryption $encrypter, $id = null)
     {
         $this->encrypter = $encrypter;
 
@@ -60,7 +60,7 @@ class EncryptedStore extends Store
     /**
      * Get the encrypter instance.
      *
-     * @return \Illuminate\Encryption\EncryptionManager
+     * @return \Illuminate\Contracts\Encryption\Factory
      */
     public function getEncrypter()
     {

--- a/src/Illuminate/Session/EncryptedStore.php
+++ b/src/Illuminate/Session/EncryptedStore.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Session;
 
-use Illuminate\Encryption\EncryptionManager;
 use SessionHandlerInterface;
+use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Contracts\Encryption\DecryptException;
 
 class EncryptedStore extends Store

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
-use Illuminate\Encryption\EncryptionManager;
+use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
@@ -12,10 +12,10 @@ use Illuminate\Events\Dispatcher;
 use Illuminate\Routing\Controller;
 use Illuminate\Container\Container;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Mockery as m;
 
 class EncryptCookiesTest extends TestCase
 {

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
-use Illuminate\Contracts\Encryption\Factory as Encryption;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -16,6 +15,7 @@ use Illuminate\Encryption\Encrypter;
 use Illuminate\Encryption\EncryptionManager;
 use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 
 class EncryptCookiesTest extends TestCase

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
+use Illuminate\Contracts\Encryption\Factory;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
+use Illuminate\Contracts\Encryption\Factory as Encryption;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -32,7 +33,7 @@ class EncryptCookiesTest extends TestCase
         parent::setUp();
 
         $container = new Container;
-        $container->singleton(EncryptionManager::class, function () {
+        $container->singleton(Encryption::class, function () {
             return tap(m::mock(EncryptionManager::class), function ($m) {
                 $m->shouldReceive('encrypt')->andReturnUsing(function ($arg) {
                     return (new Encrypter(str_repeat('a', 16)))->encrypt($arg);

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
-use Illuminate\Contracts\Encryption\Factory;
 use Mockery as m;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
-use Illuminate\Encryption\EncryptionManager;
 use RuntimeException;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Encryption\EncryptionServiceProvider;
 
 class EncryptionTest extends TestCase

--- a/tests/Integration/Encryption/EncryptionTest.php
+++ b/tests/Integration/Encryption/EncryptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Encryption;
 
+use Illuminate\Encryption\EncryptionManager;
 use RuntimeException;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
@@ -11,7 +12,9 @@ class EncryptionTest extends TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('app.key', 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=');
+        $app['config']->set('encryption.default', 'default');
+        $app['config']->set('encryption.encrypters.default.key', 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=');
+        $app['config']->set('encryption.encrypters.default.cipher', 'AES-256-CBC');
     }
 
     protected function getPackageProviders($app)
@@ -21,15 +24,37 @@ class EncryptionTest extends TestCase
 
     public function test_encryption_provider_bind()
     {
-        self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter'));
+        self::assertInstanceOf(EncryptionManager::class, $this->app->make('encrypter'));
+    }
+
+    public function test_encryption_manager_returns_encrypter()
+    {
+        self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter')->encrypter());
+    }
+
+    public function test_encryption_manager_returns_specific_encrypter()
+    {
+        $this->app['config']->set('encryption.encrypters.foo.key', 'base64:IUHRqAQ99pZ0A1MPjbuv1D6ff3jxv0GIvS2qIW4JNU4=');
+        $this->app['config']->set('encryption.encrypters.foo.cipher', 'AES-256-CBC');
+
+        self::assertInstanceOf(Encrypter::class, $this->app->make('encrypter')->encrypter('foo'));
     }
 
     public function test_encryption_will_not_be_instantiable_when_missing_app_key()
     {
         $this->expectException(RuntimeException::class);
 
-        $this->app['config']->set('app.key', null);
+        $this->app['config']->set('encryption.encrypters.default.key', null);
 
-        $this->app->make('encrypter');
+        $this->app->make('encrypter')->encrypter();
+    }
+
+    public function test_encryption_manager_will_not_return_encrypter_if_config_is_missing()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->app['config']->set('encryption.encrypters', null);
+
+        $this->app->make('encrypter')->encrypter();
     }
 }

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http\Middleware;
 
+use Illuminate\Encryption\EncryptionManager;
 use Illuminate\Http\Request;
+use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
 
@@ -15,7 +17,12 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         parent::setUp();
 
-        $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
+        $encryption = tap(m::mock(EncryptionManager::class), function ($m) {
+            $m->shouldReceive('encrypt')->andReturnUsing(function ($arg) {
+                return (new Encrypter(str_repeat('a', 16)))->encrypt($arg);
+            });
+        });
+        $this->stub = new VerifyCsrfTokenExceptStub(app(), $encryption);
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }
 

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Http\Middleware;
 
-use Illuminate\Encryption\EncryptionManager;
-use Illuminate\Http\Request;
 use Mockery as m;
+use Illuminate\Http\Request;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Encryption\Encrypter;
+use Illuminate\Encryption\EncryptionManager;
 
 class VerifyCsrfTokenExceptTest extends TestCase
 {

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Tests\Session;
 
-use Illuminate\Encryption\EncryptionManager;
 use Mockery as m;
 use ReflectionClass;
 use SessionHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Session\EncryptedStore;
-use Illuminate\Contracts\Encryption\Encrypter;
+use Illuminate\Encryption\EncryptionManager;
 
 class EncryptedSessionStoreTest extends TestCase
 {

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Session;
 
+use Illuminate\Encryption\EncryptionManager;
 use Mockery as m;
 use ReflectionClass;
 use SessionHandlerInterface;
@@ -56,7 +57,7 @@ class EncryptedSessionStoreTest extends TestCase
         return [
             $this->getSessionName(),
             m::mock(SessionHandlerInterface::class),
-            m::mock(Encrypter::class),
+            m::mock(EncryptionManager::class),
             $this->getSessionId(),
         ];
     }


### PR DESCRIPTION
Introduces the ability to define multiple encrypters with individual encryption keys. 

Currently, the only way to introduce new encrypters is to instantiate them yourself with `$encrypter = new \Illuminate\Encryption\Encrypter( $newKey, $cipher);`. Then if you need to use this new encrypter across your application that means abstracting this into a service provider and likely creating a new `Crypt`-like facade.

With this PR, our encrypter is placed behind an `EncryptionManager` which allows us to access multiple encrypters. This manager is modeled after the existing `DatabaseManger`, which allows direct access to the "default" encrypter.

This PR enables the following functionality:
```
# config/encryption.php
<?php
return [
    'default' => 'default',
    'encrypters' => [
        'default' => [
            'key' => env('APP_KEY'),
            'cipher' => 'AES-256-CBC',
        ],
        'my-encrypter' => [
            'key' => env('MY_ENCRYPTER_KEY'),
            'cipher' => 'AES-256-CBC',
        ],
    ]
];
```

```
 # Uses default encrypter
App::make('encrypter')->encrypt($data)
Crypt::encrypt($data)

# Uses "my-encrypter" for encryption
App::make('encrypter')->encrypter('my-encrypter')->encrypt($data)
Crypt::encrypter('my-encrypter')->encrypt($data)
```

With the addition of multiple encrypters, I've also included support for them in the `KeyGenerate` command. This command now accepts the name of the encrypter and the name of the variable in the environment file.

The only breaking change for this PR is the change in the configuration within the Laravel project (laravel/laravel#5054). Since the encryption manager passes function calls to the default encrypter no code changes are needed for existing usage of the `Crypt` facade, `crypt()` helper or the `encrypter` singleton. 