### PR TITLE
[5.8] Add trans_if to the helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -879,6 +879,31 @@ if (! function_exists('trans')) {
     }
 }
 
+if (! function_exists('trans_if')) {
+    /**
+     * Translate the given message based on the condition.
+     *
+     * @param bool $condition
+     * @param string $keyTrue
+     * @param string $keyFalse
+     * @param array $replaceTrue
+     * @param array $replaceFalse
+     * @param null $locale
+     * @return \Illuminate\Contracts\Translation\Translator|string|array|null
+     */
+    function trans_if(bool $condition, string $keyTrue, string $keyFalse, array $replaceTrue = [], array $replaceFalse = [], $locale = null)
+    {
+        if (is_null($keyTrue) && is_null($keyFalse)) {
+            return app('translator');
+        }
+
+        $key = ($condition === true) ? $keyTrue : $keyFalse;
+        $replace = ($condition === true) ? $replaceTrue : $replaceFalse;
+
+        return app('translator')->trans($key, $replace, $locale);
+    }
+}
+
 if (! function_exists('trans_choice')) {
     /**
      * Translates the given message based on a count.


### PR DESCRIPTION
Hey guys 🙌🏼,

Today I came across a situation where I needed to translate a string based on a specific condition, so, inside blade template, I had something like this:
```php
if ($user->isAdmin())
    trans('user.hello-admin')
else
    trans('user.hello-user')

```
I was thinking why don't we have a helper that it can handle both situations, something like `trans_if`:
```php
trans_if($user->isAdmin(), 'user.hello-admin', 'user.hello-user')
```

> I know using ternary could make the if statement shorter, but is still an if statement.

