### PR TITLE
[5.8] Add only method to Session

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -173,7 +173,7 @@ class Store implements Session
      * @param  array  $keys
      * @return array
      */
-    public function only($keys)
+    public function only(array $keys)
     {
         return Arr::only($this->attributes, $keys);
     }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -168,6 +168,17 @@ class Store implements Session
     }
 
     /**
+     * Get a subset of the session data.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function only($keys)
+    {
+        return Arr::only($this->attributes, $keys);
+    }
+
+    /**
      * Checks if a key exists.
      *
      * @param  string|array  $key

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -211,6 +211,15 @@ class SessionStoreTest extends TestCase
         $this->assertFalse(array_search('foo', $session->get('_flash.old')));
     }
 
+    public function testOnly()
+    {
+        $session = $this->getSession();
+        $session->put('foo', 'bar');
+        $session->put('qu', 'ux');
+        $this->assertEquals(['foo' => 'bar', 'qu' => 'ux'], $session->all());
+        $this->assertEquals(['qu' => 'ux'], $session->only(['qu']));
+    }
+
     public function testReplace()
     {
         $session = $this->getSession();


### PR DESCRIPTION
I see a lot of use cases where you would only want to retrieve some values from the session store instead of all values.
I commonly use the `Arr::only` method combined with `session()->all()` when for example wanting to set data on `window` for the frontend. 

I've targeted 5.9 as it adds a new method to the `Session` interface.