### PR TITLE
[5.8] Adds a check of all admissible `Accept` headers

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -53,7 +53,13 @@ trait InteractsWithContentTypes
     {
         $acceptable = $this->getAcceptableContentTypes();
 
-        return isset($acceptable[0]) && Str::contains($acceptable[0], ['/json', '+json']);
+        foreach ($acceptable as $type) {
+            if (Str::contains($type, ['/json', '+json'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Some API clients can send Accept headers in the format: `*/*, application/json`. 


Like:
![image](https://user-images.githubusercontent.com/2461257/60825745-0b2a8800-a1b5-11e9-8566-810c840b86be.png)


I think that in the `$request->wantsJson()` method it is worth checking all transferred header values, and not just the first.