### PR TITLE
[5.8] Add `scoped-slots` feature to Blade components

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -47,6 +47,29 @@ trait CompilesComponents
     }
 
     /**
+     * Compile the scoped-slot statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileScopedSlot($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php \$__env->scopedSlot({$expression} { ?>";
+    }
+
+    /**
+     * Compile the end-scoped-slot statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndScopedSlot()
+    {
+        return '<?php }); ?>';
+    }
+
+    /**
      * Compile the component-first statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -134,6 +134,18 @@ trait ManagesComponents
     }
 
     /**
+     * Start the scoped slot rendering process.
+     *
+     * @param  string  $name
+     * @param  callable  $renderFunction
+     * @return void
+     */
+    public function scopedSlot($name, $renderFunction)
+    {
+        $this->slots[$this->currentComponent()][$name] = $renderFunction;
+    }
+
+    /**
      * Get the index for the current component.
      *
      * @return int

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -25,4 +25,14 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->assertEquals('<?php $__env->endSlot(); ?>', $this->compiler->compileString('@endslot'));
     }
+
+    public function testScopedSlotsAreCompiled()
+    {
+        $this->assertEquals('<?php $__env->scopedSlot(\'foo\', function ($bar) { ?>', $this->compiler->compileString('@scopedslot(\'foo\', function ($bar))'));
+    }
+
+    public function testEndScopedSlotsAreCompiled()
+    {
+        $this->assertEquals('<?php }); ?>', $this->compiler->compileString('@endscopedslot'));
+    }
 }


### PR DESCRIPTION
#### Blade components scoped slots

I worked with Vue before and loved [the scoped slot feature](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots), which basically gives you possibility to pass "render" function to the component instead of giving it and already rendered HTML code. Recently I was developing a reusable table component in one of my projects and it made me realize that I really miss this feature in Laravel. Therefore I decided to give it a try and try to implement it. This is what I came up with:

`scopedslot` directive wraps up blade code that is compiled into a function declaration. It is later stored in component's `slots` array. 

*objects/index.blade.php*
```php
@component('components.list', ['objects' => $objects])
    @scopedslot('item', function ($object))
        <li>
            {{ $object->name }} 
            @if($object->isEditable)
                <a href="{{ route('objects.edit', $object->id) }}">{{ __('Edit') }}</a>
            @endif
        </li>
    @endscopedslot
@endcomponent
```

*components/list.blade.php*
```php
<ul>
    @foreach($objects as $object)
        {{ $item($object) }}
    @endforeach
</ul>
```

The most common use-case of scoped slots would be probably displaying items in foreach loop. However it would definitely give developers new possibilities.

[Here is an article](https://vuejsdevelopers.com/2017/10/02/vue-js-scoped-slots/) describing a concept of Vue's scoped slots feature and [here is a *Stack Overflow* question](https://stackoverflow.com/questions/50526057/passing-variable-from-component-into-a-slot) that could be resolved in more elegant way using scoped slots.

I would love to get some feedback on the feature itself and code I wrote as, although it works perfectly fine, I'm not sure of its "correctness". 
