### PR TITLE
[5.8] Tweak artisan:serve output

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -41,7 +41,7 @@ class ServeCommand extends Command
     {
         chdir(public_path());
 
-        $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
+        $this->line("<info>Laravel development server started:</info> http://{$this->host()}:{$this->port()}");
 
         passthru($this->serverCommand(), $status);
 


### PR DESCRIPTION
After running `artisan:serve`, in VS Code you will see the following output...

<img width="418" alt="before" src="https://user-images.githubusercontent.com/340752/60884139-1b3d7880-a244-11e9-8965-8c19b6331ac7.png">

..then if you hover over the URL, it highlights, but you can't click it, I presume because it is also picking up the closing arrow `>`.

<img width="418" alt="after" src="https://user-images.githubusercontent.com/340752/60884250-5fc91400-a244-11e9-9aba-f6878bd66572.png">

I guess you could argue this is a VS Code issue so should be fixed there rather than here, I don't know.

I also don't know if there is a 'technical' reason we are outputting the url wrapped with `< >` in the output.

Thanks