### PR TITLE
[5.8] Elaborate entry not found exception

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -627,7 +627,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException;
+            throw new EntryNotFoundException($id);
         }
     }
 


### PR DESCRIPTION
Elaborate entry not found exception with which entry that could not be found. Working in a CLI environment then the `EntryNotFoundException` gives you very poor information. Currently, this is what I get in the console:

```bash
PHP Fatal error:  Uncaught Illuminate\Container\EntryNotFoundException in /app/vendor/illuminate/container/Container.php:630
Stack trace:
#0 /app/src/scripts/AddAllDeliveryTerm/AddAllDeliveryTermServiceProvider.php(74): Illuminate\Container\Container->get('Stockfiller\\Scr...')
#1 /app/vendor/illuminate/container/Container.php(787): Stockfiller\Scripts\AddAllDeliveryTerm\AddAllDeliveryTermServiceProvider->Stockfiller\Scripts\AddAllDeliveryTerm\{closure}(Object(Illuminate\Container\Container), Array)
#2 /app/vendor/illuminate/container/Container.php(667): Illuminate\Container\Container->build(Object(Closure))
#3 /app/vendor/illuminate/container/Container.php(624): Illuminate\Container\Container->resolve('Stockfiller\\Scr...')
#4 /app/src/scripts/AddAllDeliveryTerm/AddAllDeliveryTermServiceProvider.php(63): Illuminate\Container\Container->get('Stockfiller\\Scr...')
#5 /app/vendor/illuminate/container/Container.php(787): Stockfiller\Scripts\AddAllDeliveryTerm\AddAllDeliveryTermServiceProvider->Stockfiller\Scripts\AddAllDeliveryTe in /app/vendor/illuminate/container/Container.php on line 630
```

This minor change will help tremendously in these kinds of situations.