### PR TITLE
[5.9] Don't throw exception from ->deny() and set the gate response on the …

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -31,7 +31,7 @@ class AuthorizationException extends Exception
     /**
      * Set the response from the gate.
      *
-     * @param \Illuminate\Auth\Access\Response $response
+     * @param  \Illuminate\Auth\Access\Response  $response
      * @return $this
      */
     public function setResponse($response)

--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -7,6 +7,13 @@ use Exception;
 class AuthorizationException extends Exception
 {
     /**
+     * The response from the gate.
+     *
+     * @var \Illuminate\Auth\Access\Response
+     */
+    protected $response;
+
+    /**
      * Create a new authorization exception instance.
      *
      * @param  string|null  $message
@@ -19,6 +26,29 @@ class AuthorizationException extends Exception
         parent::__construct($message, 0, $previous);
 
         $this->code = $code;
+    }
+
+    /**
+     * Set the response from the gate.
+     *
+     * @param \Illuminate\Auth\Access\Response $response
+     * @return $this
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+
+        return $this;
+    }
+
+    /**
+     * Get the response from the gate.
+     *
+     * @return \Illuminate\Auth\Access\Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 
     /**

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -21,12 +21,10 @@ trait HandlesAuthorization
      *
      * @param  string  $message
      * @param  mixed|null  $code
-     * @return void
-     *
-     * @throws \Illuminate\Auth\Access\AuthorizationException
+     * @return \Illuminate\Auth\Access\Response
      */
     protected function deny($message = 'This action is unauthorized.', $code = null)
     {
-        throw new AuthorizationException($message, $code);
+        return Response::deny($message, $code);
     }
 }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -116,7 +116,8 @@ class Response implements Arrayable
     public function authorize()
     {
         if ($this->denied()) {
-            throw new AuthorizationException($this->message(), $this->code());
+            throw (new AuthorizationException($this->message(), $this->code()))
+                ->setResponse($this);
         }
 
         return $this;

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -608,6 +608,20 @@ class AuthAccessGateTest extends TestCase
         $gate->authorize('create', new AccessGateTestDummy);
     }
 
+    public function test_policy_that_throws_authorization_exception_is_caught_in_inspect()
+    {
+        $gate = $this->getBasicGate();
+        
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyThrowingAuthorizationException::class);
+
+        $response = $gate->inspect('create', new AccessGateTestDummy);
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertEquals('Not allowed.', $response->message());
+        $this->assertEquals('some_code', $response->code());
+    }
+
     public function test_authorize_returns_allowed_response()
     {
         $gate = $this->getBasicGate(true);
@@ -1086,3 +1100,12 @@ class AccessGateTestPolicyWithDeniedResponseObject
         return Response::deny('Not allowed.', 'some_code');
     }
 }
+
+class AccessGateTestPolicyThrowingAuthorizationException
+{
+    public function create()
+    {
+        throw new AuthorizationException('Not allowed.', 'some_code');
+    }
+}
+

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -30,13 +30,15 @@ class AuthAccessResponseTest extends TestCase
 
     public function test_authorize_method_throws_authorization_exception_when_response_denied()
     {
-        $this->expectException(AuthorizationException::class);
-        $this->expectExceptionMessage('Some message.');
-        $this->expectExceptionCode('some_code');
-
         $response = Response::deny('Some message.', 'some_code');
 
-        $response->authorize();
+        try {
+            $response->authorize();
+        } catch (AuthorizationException $e) {
+            $this->assertEquals('Some message.', $e->getMessage());
+            $this->assertEquals('some_code', $e->getCode());
+            $this->assertEquals($response, $e->getResponse());
+        }
     }
 
     public function test_throw_if_needed_doesnt_throw_authorization_exception_when_response_allowed()

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Auth;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AuthHandlesAuthorizationTest extends TestCase
+{
+    use HandlesAuthorization;
+
+    public function test_allow_method()
+    {
+        $response = $this->allow('some message', 'some_code');
+
+        $this->assertTrue($response->allowed());
+        $this->assertFalse($response->denied());
+        $this->assertEquals('some message', $response->message());
+        $this->assertEquals('some_code', $response->code());
+    }
+
+    public function test_deny_method()
+    {
+        $response = $this->deny('some message', 'some_code');
+
+        $this->assertTrue($response->denied());
+        $this->assertFalse($response->allowed());
+        $this->assertEquals('some message', $response->message());
+        $this->assertEquals('some_code', $response->code());
+    }
+}


### PR DESCRIPTION
@taylorotwell after you merged the pull request for the access response/inspect changes you made a MINOR breaking change to the order of parameters for the `Response` class. This meant that anyone extending the `deny` method in their policy would have to change the order of parameters when creating a `Response` object. I don't have any objections to this, but just thought I'd make you aware and suggest a few other changes in this PR.

This PR provides a few benefits/changes:

* An exception is no longer thrown if you want to just inspect the gate response - originally calling `Gate::inspect()` would throw and then catch the exception, this is now longer the default case. It will only throw an exception when you use `Gate::authorize()` or call `$response->authorize()`
* Added the `response` onto the exception, in case it's needed/useful for the future. This aligns with other exceptions which set the associated model/class the exception relates to.

Just a bit more info on potential breaking changes with this - if developers are currently using policies directly and skipping the Gate then it could be a breaking change, but I would imagine this kind of usage is VERY unlikely but it maybe worth noting in the upgrade guide.

```php
// Anyone relying on the behaviour of policies `$this->deny()` to throw AuthorizationException need to be aware of this change.
$response = (new UserPolicy)->ban(Auth::user(), $user);
// It's worth noting that when using policies directly none of the before/after callbacks are run
// so anyone using policies directly like this have other problems as well
// just something to be aware of for the upgrade guide.

// If your determined to use policies directly, you can do:
$response = (new UserPolicy)->ban(Auth::user(), $user)->authorize();

// Or just use the gate as intended!
$response = Gate::authorize('ban', $user);
```