### PR TITLE
[5.8] Improve eager loading performance for MorphTo relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -123,7 +123,9 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
                             ));
 
-        return $query->whereIn(
+        $whereIn = $this->whereInMethod($this->parent, $ownerKey);
+
+        return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
         )->get();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -123,7 +123,7 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
                             ));
 
-        $whereIn = $this->whereInMethod($this->parent, $ownerKey);
+        $whereIn = $this->whereInMethod($instance, $ownerKey);
 
         return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)


### PR DESCRIPTION
Refering to PR #26434
I had the same issue, where the `whereIn` done in the query with my `morphTo` eager loading very slow.

I updated the `getResultsByType()` method in `Illuminate\Database\Eloquent\Relations\MorphTo.php` to use the same logic than the one in `addEagerConstraints()` method from `Illuminate\Database\Eloquent\Relations\HasOneOrMany.php`. By doing so, depending on the PK type the method uses `whereIntegerInRaw` or `whereIn`.

It decreased my query execution time from 1.8s for 34000 records to 12ms.

Also I found that on our project that is a 5.7 version, would it be possible to apply this PR to 5.7 as well ?