### PR TITLE
[5.8] Fixed queue jobs using SerializesModels losing order of passed in collections

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -67,9 +67,13 @@ trait SerializesAndRestoresModelIdentifiers
             return new EloquentCollection;
         }
 
-        return $this->getQueryForModelRestoration(
+        $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->useWritePdo()->get()->keyBy->getKey();
+
+        return new EloquentCollection(
+            collect($value->id)->map(function ($id) use ($collection) { return $collection[$id]; })
+        );
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\QueueableCollection;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 trait SerializesAndRestoresModelIdentifiers
 {
@@ -80,7 +80,9 @@ trait SerializesAndRestoresModelIdentifiers
         $collection = $collection->keyBy->getKey();
 
         return new EloquentCollection(
-            collect($value->id)->map(function ($id) use ($collection) { return $collection[$id]; })
+            collect($value->id)->map(function ($id) use ($collection) {
+                return $collection[$id];
+            })
         );
     }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -220,6 +220,21 @@ class ModelSerializationTest extends TestCase
 
         unserialize($serialized);
     }
+
+    public function test_it_serializes_a_collection_in_correct_order()
+    {
+        ModelSerializationTestUser::create([ 'email' => 'mohamed@laravel.com' ]);
+        ModelSerializationTestUser::create([ 'email' => 'taylor@laravel.com' ]);
+
+        $serialized = serialize(new CollectionSerializationTestClass(
+            ModelSerializationTestUser::orderByDesc('email')->get()
+        ));
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($unserialized->users->first()->email, 'taylor@laravel.com');
+        $this->assertEquals($unserialized->users->last()->email, 'mohamed@laravel.com');
+    }
 }
 
 class ModelSerializationTestUser extends Model
@@ -328,5 +343,17 @@ class ModelRelationSerializationTestClass
     public function __construct($order)
     {
         $this->order = $order;
+    }
+}
+
+class CollectionSerializationTestClass
+{
+    use SerializesModels;
+
+    public $users;
+
+    public function __construct($users)
+    {
+        $this->users = $users;
     }
 }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -223,8 +223,8 @@ class ModelSerializationTest extends TestCase
 
     public function test_it_serializes_a_collection_in_correct_order()
     {
-        ModelSerializationTestUser::create([ 'email' => 'mohamed@laravel.com' ]);
-        ModelSerializationTestUser::create([ 'email' => 'taylor@laravel.com' ]);
+        ModelSerializationTestUser::create(['email' => 'mohamed@laravel.com']);
+        ModelSerializationTestUser::create(['email' => 'taylor@laravel.com']);
 
         $serialized = serialize(new CollectionSerializationTestClass(
             ModelSerializationTestUser::orderByDesc('email')->get()


### PR DESCRIPTION
`SerializesModels` is a trait for queue jobs that converts passed in models and collections to keys on serialization and restores them back from database when unserialized.

The current implementation loses the intended order for passed in collections.

Eg. let's say we have a queue job exporting users sorted by email address.

```php
User::create([ 'email' => 'taylor@laravel.com' ]);
User::create([ 'email' => 'mohamed@laravel.com' ]);

$users = User::orderBy('name')->get();
// SELECT * FROM users ORDER BY name
// [ [ 'id' => 2, 'email' => 'mohamed@laravel.com ], [ 'id' => 1, 'email' => 'taylor@laravel.com' ] ]

$serialized = serialize(new Export($users));
```

Now on unserialization, Laravel doesn't know about the order clause and runs a simple WHERE IN query, which returns the records in the original order as inserted into db.

```php
$unserialized = unserialize($serialized);
// SELECT * FROM users WHERE id IN (2, 1)
// [ [ 'id' => 1, 'email' => 'taylor@laravel.com' ], [ 'id' => 2, 'email' => 'mohamed@laravel.com ] ]
```

The proposed fix adds an extra step where the restored collection is re-mapped based on the serialized collection of keys which is in the correct order, thus restoring the intended order.

Included an integration test demonstrating the issue.