### PR TITLE
[5.8] Add refresh method into collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1933,6 +1933,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function pad($size, $value)
     {
         return new static(array_pad($this->items, $size, $value));
+    } 
+
+    /**
+     * Transform plain arrays to collection.
+     *
+     * @param  int $depth
+     * @return static
+     */
+    public function refresh($depth = INF)
+    {
+        return $this->map(function($item) use ($depth) {  
+
+            if($depth > 0 && (is_array($item) || $item instanceof self)) {
+                $collection = new static($this->getArrayableItems($item));
+
+                return $collection->refresh($depth - 1);
+            }
+
+            return $item;
+        }); 
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3190,6 +3190,94 @@ class SupportCollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
     }
+    
+    public function testRefresh()
+    {
+        $data = new Collection([
+            'firstname' => 'esmaiel', 
+            'lastname'  => 'zare',
+            'fullnames' => ['esmaiel', 'zare'],
+            'meta'  => [
+                'mail' => 'zarehesmaiel@gmail.com',
+                'numbers' => [
+                    'phone' => '00000000',
+                    'mobile'=> '00000000',
+                ]
+            ]
+        ]);
+
+        $data = $data->refresh();
+
+        $wanted = [
+            'firstname' => 'esmaiel', 
+            'lastname'  => 'zare',
+            'fullnames' => new Collection(['esmaiel', 'zare']),
+            'meta'  => new Collection([
+                'mail' => 'zarehesmaiel@gmail.com',
+                'numbers' => new Collection([
+                    'phone' => '00000000',
+                    'mobile'=> '00000000',
+                ])
+            ])
+        ];
+
+        $this->assertEquals($wanted, $data->all());
+    }
+
+    public function testRefreshWithDepth()
+    {
+        $data = new Collection([
+            'firstname' => 'esmaiel', 
+            'lastname'  => 'zare',
+            'fullnames' => ['esmaiel', 'zare'],
+            'meta'  => [
+                'mail' => 'zarehesmaiel@gmail.com',
+                'numbers' => [
+                    'phone' => '00000000',
+                    'mobile'=> '00000000',
+                ]
+            ],
+            'history' => new Collection([
+                'history1', 'history2'
+            ])
+        ]); 
+
+        $oneDepth = [
+            'firstname' => 'esmaiel', 
+            'lastname'  => 'zare',
+            'fullnames' => new Collection(['esmaiel', 'zare']),
+            'meta'  => new Collection([
+                'mail' => 'zarehesmaiel@gmail.com',
+                'numbers' => [
+                    'phone' => '00000000',
+                    'mobile'=> '00000000',
+                ]
+            ]),
+            'history' => new Collection([
+                'history1', 'history2'
+            ])
+        ]; 
+
+        $twoDepth = [
+            'firstname' => 'esmaiel', 
+            'lastname'  => 'zare',
+            'fullnames' => new Collection(['esmaiel', 'zare']),
+            'meta'  => new Collection([
+                'mail' => 'zarehesmaiel@gmail.com',
+                'numbers' => new Collection([
+                    'phone' => '00000000',
+                    'mobile'=> '00000000',
+                ])
+            ]),
+            'history' => new Collection([
+                'history1', 'history2'
+            ])
+        ];
+
+        $this->assertEquals($oneDepth, $data->refresh(1)->all()); 
+        $this->assertEquals($twoDepth, $data->refresh(2)->all());
+        $this->assertEquals($twoDepth, $data->refresh(1)->refresh(2)->all());
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
when created a collection from multidimensional array, all sub arrays will be plain.this method will iterate over each item and convert them into collection instance
example:

``` 
collect([
    'one' => 'one',
    'two' => [
            'three' => 'three'
    ],
])->dd()
```
will return 
```
Collection([ 
    'one' => 'one',
    'two' => [
            'three' => 'three'
    ], 
])
```
but 

```
collect([
    'one' => 'one',
    'two' => [
            'three' => 'three'
    ],
])->refresh()->dd()

```
will return 

```
Collection([ 
    'one' => 'one',
    'two' => Collection([
            'three' => 'three'
    ]), 
])
```