### PR TITLE
[5.8] Adds missing tests for loader getInstance static method

### DIFF
--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -23,4 +23,17 @@ class FoundationAliasLoaderTest extends TestCase
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
         $this->assertSame($loader, AliasLoader::getInstance());
     }
+
+    public function testLoaderCanBeCreatedAndRegisteredMergingAliases()
+    {
+        $loader = AliasLoader::getInstance(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
+
+        $loader = AliasLoader::getInstance(['foo2' => 'bar2']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases());
+
+        // override keys
+        $loader = AliasLoader::getInstance(['foo' => 'baz']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
+    }
 }


### PR DESCRIPTION
Merging aspect of the constructor function `AliasLoader::getInstance` has no tests at all. 