### PR TITLE
[5.9] Handle array and object values when updating JSON fields

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -76,7 +76,8 @@ class MySqlConnection extends Connection
     {
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
-                is_string($key) ? $key : $key + 1, $value,
+                is_string($key) ? $key : $key + 1,
+                is_array($value) || is_object($value) ? json_encode($value) : $value,
                 is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -76,8 +76,7 @@ class MySqlConnection extends Connection
     {
         foreach ($bindings as $key => $value) {
             $statement->bindValue(
-                is_string($key) ? $key : $key + 1,
-                is_array($value) || is_object($value) ? json_encode($value) : $value,
+                is_string($key) ? $key : $key + 1, $value,
                 is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
             );
         }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -217,7 +217,7 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) && is_bool($value);
-        })->map(function ($value, $column) {
+        })->map(function ($value) {
             return ! $this->isExpression($value) && (is_array($value) || is_object($value))
                 ? json_encode($value)
                 : $value;

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -217,6 +217,10 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) && is_bool($value);
+        })->map(function ($value, $column) {
+            return ! $this->isExpression($value) && (is_array($value) || is_object($value))
+                ? json_encode($value)
+                : $value;
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -387,7 +387,7 @@ class PostgresGrammar extends Grammar
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = collect($values)->map(function ($value, $column) {
-            return $this->isJsonSelector($column) && ! $this->isExpression($value)
+            return ! $this->isExpression($value) && ($this->isJsonSelector($column) || is_array($value) || is_object($value))
                 ? json_encode($value)
                 : $value;
         })->all();

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -387,7 +387,7 @@ class PostgresGrammar extends Grammar
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = collect($values)->map(function ($value, $column) {
-            return $this->isJsonSelector($column) && ! $this->isExpression($value)
+            return ! $this->isExpression($value) && (is_array($value) || is_object($value))
                 ? json_encode($value)
                 : $value;
         })->all();

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -387,7 +387,7 @@ class PostgresGrammar extends Grammar
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = collect($values)->map(function ($value, $column) {
-            return ! $this->isExpression($value) && (is_array($value) || is_object($value))
+            return $this->isJsonSelector($column) && ! $this->isExpression($value)
                 ? json_encode($value)
                 : $value;
         })->all();

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -43,7 +43,7 @@ class JsonExpression extends Expression
                 return '?';
             case 'object':
             case 'array':
-                return 'json_merge(?, "[]")';
+                return 'json_extract(?, "$")';
         }
 
         throw new InvalidArgumentException("JSON value is of illegal type: {$type}");

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -43,7 +43,7 @@ class JsonExpression extends Expression
                 return '?';
             case 'object':
             case 'array':
-                return 'json_extract(?, "$")';
+                return 'cast(? as json)';
         }
 
         throw new InvalidArgumentException("JSON value is of illegal type: {$type}");

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -43,7 +43,7 @@ class JsonExpression extends Expression
                 return '?';
             case 'object':
             case 'array':
-                return '?';
+                return 'json_merge(?, "[]")';
         }
 
         throw new InvalidArgumentException("JSON value is of illegal type: {$type}");

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2193,7 +2193,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
-                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_merge(?, "[]")) where `active` = ?',
+                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_extract(?, "$")) where `active` = ?',
                         [['white', 'black', 'yellow'], 1]
                     );
 
@@ -2210,7 +2210,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
-                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_merge(?, "[]")) where `active` = ?',
+                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_extract(?, "$")) where `active` = ?',
                         [['color' => 'white', 'size' => 'large'], 1]
                     );
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2261,7 +2261,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('update')
             ->with('update "users" set "options" = ?, "meta" = jsonb_set("meta"::jsonb, \'{"tags"}\', ?), "group_id" = 45', [
                 json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
-                json_encode(['white', 'large'])
+                json_encode(['white', 'large']),
             ]);
 
         $builder->from('users')->update([

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2184,7 +2184,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('active', '=', 1)->update(['meta->name->first_name' => 'John', 'meta->name->last_name' => 'Doe']);
     }
 
-    public function testMySqlUpdateWrappingJsonArray()
+    public function testMySqlUpdateWrappingJsonArrayAndObject()
     {
         $grammar = new MySqlGrammar;
         $processor = m::mock(Processor::class);
@@ -2193,29 +2193,20 @@ class DatabaseQueryBuilderTest extends TestCase
         $connection->expects($this->once())
                     ->method('update')
                     ->with(
-                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_extract(?, "$")) where `active` = ?',
-                        [['white', 'black', 'yellow'], 1]
+                        'update `users` set `options` = ?, `meta` = json_set(`meta`, \'$."tags"\', cast(? as json)), `group_id` = 45 where `active` = ?',
+                        [
+                            json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                            json_encode(['white', 'large']),
+                            1,
+                        ]
                     );
 
         $builder = new Builder($connection, $grammar, $processor);
-        $builder->from('users')->where('active', '=', 1)->update(['meta->tags' => ['white', 'black', 'yellow']]);
-    }
-
-    public function testMySqlUpdateWrappingJsonObject()
-    {
-        $grammar = new MySqlGrammar;
-        $processor = m::mock(Processor::class);
-
-        $connection = $this->createMock(ConnectionInterface::class);
-        $connection->expects($this->once())
-                    ->method('update')
-                    ->with(
-                        'update `users` set `meta` = json_set(`meta`, \'$."tags"\', json_extract(?, "$")) where `active` = ?',
-                        [['color' => 'white', 'size' => 'large'], 1]
-                    );
-
-        $builder = new Builder($connection, $grammar, $processor);
-        $builder->from('users')->where('active', 1)->update(['meta->tags' => ['color' => 'white', 'size' => 'large']]);
+        $builder->from('users')->where('active', 1)->update([
+            'options' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'meta->tags' => ['white', 'large'],
+            'group_id' => new Raw('45'),
+        ]);
     }
 
     public function testMySqlUpdateWithJsonPreparesBindingsCorrectly()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2246,7 +2246,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')
-            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['John']);
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['"John"']);
         $builder->from('users')->update(['users.options->name->first_name' => 'John']);
 
         $builder = $this->getPostgresBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2246,7 +2246,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')
-            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['"John"']);
+            ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"name","first_name"}\', ?)', ['John']);
         $builder->from('users')->update(['users.options->name->first_name' => 'John']);
 
         $builder = $this->getPostgresBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2255,6 +2255,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->update(['options->language' => new Raw("'null'")]);
     }
 
+    public function testPostgresUpdateWrappingJsonArrayAndObject()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = ?, "meta" = jsonb_set("meta"::jsonb, \'{"tags"}\', ?), "group_id" = 45', [
+                json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                json_encode(['white', 'large'])
+            ]);
+
+        $builder->from('users')->update([
+            'options' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'meta->tags' => ['white', 'large'],
+            'group_id' => new Raw('45'),
+        ]);
+    }
+
     public function testMySqlWrappingJsonWithString()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
This PR allows passing array/object values to the query builder when updating JSON columns.

I recently faced some scenarios where I had to bulk update some model's JSON field with the same array values. But currenty, it's not possible to bulk update JSON fields. When running code like this:

```php
// Works (because of the different parameter binding)
App\Post::first()->update(['meta' => ['options' => ['foo' => 'bar']]]);
App\Post::first()->update(['meta->options' => ['foo' => 'bar']]);


// Does not work
App\Post::latest()->take(10)->update(['meta' => ['options' => ['foo' => 'bar']]]);
App\Post::latest()->take(10)->update(['meta->options' => ['foo' => 'bar']]);
```
It throws this exception: `Illuminate/Database/QueryException with message 'PHP Notice:  Array to string conversion...'`.

> This means, I need to update the models individually, so instead of one update query I have a query for every model update.

This is thrown because PDO's `bindValue` method accepts string or numeric values only. So, when we are passing an array value, it tries to convert it to a string.

One side of the solution would be casting the array to JSON and save it like that. So, using `json_encode()` in the `MySqlConnection` solves the error.

But when we are updating subfields (`meta->options`), this saves the value as a string a not a proper JSON object/array. It means it will be wrapped in quotes, and when we try to retrieve the model's JSON field, it will be a string instead of an array – even if we cast it in the model. Especially with nested resources. In this case, the result is:

```
// In DB
{"options": "{\"foo\":\"bar\"}"}

// After retrieving the model
['options' => '{"foo": "bar"}']
```

Because of this, we need to handle the value on the DB side as well. The `JsonExpression` now binds the parameter as it is, but adding the `json_extract()` function for array and object values would cover the other side as well.

By using `json_extract(?, "$")`, – which does nothing else but extracts the whole JSON – the properly formatted JSON document gets saved in the database. This means when we retrieve a model, we get the array properly instead of a string.

```
// In DB
{"options": {"foo": "bar"}}

// After retrieving the model
['options' => ['foo' => 'bar']]
```

> The `->` operator is an alias for `json_extract` and supported by MySql and MariaDB as well.

If we are saving an array value to a non-JSON field, it will be still converted to a string and saved in the DB, instead of getting an error.

This approach works with numeric/associative arrays and objects as well.

-------------

**This is a suggestion/idea based on a situation I faced in some projects.** However, I can't really estimate if it's a common issue or quite specific. So, I gladly hear some ideas/thoughts if this is a valid and useful addition or not.

This PR refers to an old PRs of mine, #23685, but now I added more tests and replaced the deprecated `json_merge()` function with the supported `json_extract()`.