### PR TITLE
[5.8] Add runtime for each migration to output

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -192,14 +192,18 @@ class Migrator
 
         $this->note("<comment>Migrating:</comment> {$name}");
 
+        $startTime = microtime(true);
+
         $this->runMigration($migration, 'up');
+
+        $runTime = round(microtime(true) - $startTime, 2);
 
         // Once we have run a migrations class, we will log that it was run in this
         // repository so that we don't try to run it next time we do a migration
         // in the application. A migration repository keeps the migrate order.
         $this->repository->log($name, $batch);
 
-        $this->note("<info>Migrated:</info>  {$name}");
+        $this->note("<info>Migrated:</info>  {$name} ({$runTime} seconds)");
     }
 
     /**
@@ -349,14 +353,18 @@ class Migrator
             return $this->pretendToRun($instance, 'down');
         }
 
+        $startTime = microtime(true);
+
         $this->runMigration($instance, 'down');
+
+        $runTime = round(microtime(true) - $startTime, 2);
 
         // Once we have successfully run the migration "down" we will remove it from
         // the migration repository so it will be considered to have not been run
         // by the application then will be able to fire by any later operation.
         $this->repository->delete($migration);
 
-        $this->note("<info>Rolled back:</info>  {$name}");
+        $this->note("<info>Rolled back:</info>  {$name} ({$runTime} seconds)");
     }
 
     /**


### PR DESCRIPTION
This adds the runtime for each individual migration to the output of the `artisan migrate` and `artisan migrate:rollback` commands. I find this useful to get an idea of how long each migration will take to run in various environments (dev, staging) before deploying to production.

Example output:

![Screen Shot 2019-07-12 at 4 26 25 pm](https://user-images.githubusercontent.com/52687/61122113-5067f600-a4e4-11e9-8239-f74e36274544.png)

