### PR TITLE
[5.8] Trim eager loading relation column names

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1165,7 +1165,7 @@ class Builder
     protected function createSelectWithConstraint($name)
     {
         return [explode(':', $name)[0], function ($query) use ($name) {
-            $query->select(explode(',', explode(':', $name)[1]));
+            $query->select(array_map('trim', explode(',', explode(':', $name)[1])));
         }];
     }
 


### PR DESCRIPTION
When trying to eager load a specific relation columns, I must write the columns names separated by comma without spaces like this;
```php
$books = App\Book::with('author:id,name,email,title,city')->get();
```
But when writing comma separated columns with space it breaks with unknown column name (` name`) in field list.
```php
$books = App\Book::with('author:id, name, email, title, city')->get();
```

``SQLSTATE[42S22]: Column not found: 1054 Unknown column ' name' in 'field list' (SQL: select `id`, ` name` from `authors` where `authors`.`id` in (1) and `authors`.`deleted_at` is null)``

#### This PR creates select query with trimmed column names.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
