### PR TITLE
[5.9] Email verification extra security

### DIFF
--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -45,5 +45,4 @@ trait MustVerifyEmail
     {
         return $this->email;
     }
-
 }

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -35,4 +35,15 @@ trait MustVerifyEmail
     {
         $this->notify(new Notifications\VerifyEmail);
     }
+
+    /**
+     * Get the email address to verify
+     *
+     * @return string
+     */
+    public function getEmailForVerification()
+    {
+        return $this->email;
+    }
+
 }

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -37,7 +37,7 @@ trait MustVerifyEmail
     }
 
     /**
-     * Get the email address to verify
+     * Get the email address to verify.
      *
      * @return string
      */

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -61,7 +61,7 @@ class VerifyEmail extends Notification
         return URL::temporarySignedRoute(
             'verification.verify',
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
-            ['id' => $notifiable->getKey(), 'hash' => sha1($notifiable->email)]
+            ['id' => $notifiable->getKey(), 'hash' => hash('sha1', $notifiable->getEmailForVerification())]
         );
     }
 

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -61,7 +61,10 @@ class VerifyEmail extends Notification
         return URL::temporarySignedRoute(
             'verification.verify',
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
-            ['id' => $notifiable->getKey()]
+            [
+                'id' => $notifiable->getKey(),
+                'hash' => hash('sha1', $notifiable->email)
+            ]
         );
     }
 

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -61,10 +61,7 @@ class VerifyEmail extends Notification
         return URL::temporarySignedRoute(
             'verification.verify',
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
-            [
-                'id' => $notifiable->getKey(),
-                'hash' => hash('sha1', $notifiable->email)
-            ]
+            ['id' => $notifiable->getKey(), 'hash' => sha1($notifiable->email)]
         );
     }
 

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -26,7 +26,7 @@ interface MustVerifyEmail
     public function sendEmailVerificationNotification();
 
     /**
-     * Get the email address to verify
+     * Get the email address to verify.
      *
      * @return string
      */

--- a/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Contracts/Auth/MustVerifyEmail.php
@@ -24,4 +24,11 @@ interface MustVerifyEmail
      * @return void
      */
     public function sendEmailVerificationNotification();
+
+    /**
+     * Get the email address to verify
+     *
+     * @return string
+     */
+    public function getEmailForVerification();
 }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,7 +35,7 @@ trait VerifiesEmails
         if ($request->route('id') != $request->user()->getKey()) {
             throw new AuthorizationException;
         }
-        if ($request->route('hash') != hash('sha1', $request->user()->email)) {
+        if (!hash_equals(hash('sha1', $request->user()->email), $request->route('hash'))) {
             throw new AuthorizationException;
         }
 

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,6 +35,9 @@ trait VerifiesEmails
         if ($request->route('id') != $request->user()->getKey()) {
             throw new AuthorizationException;
         }
+        if ($request->route('hash') != hash('sha1', $request->user()->email)) {
+            throw new AuthorizationException;
+        }
 
         if ($request->user()->hasVerifiedEmail()) {
             return redirect($this->redirectPath());

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,10 +32,11 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if ($request->route('id') != $request->user()->getKey()) {
+        if (! hash_equals((string) $request->route('id'), (string) $request->user()->getKey())) {
             throw new AuthorizationException;
         }
-        if (! hash_equals(hash('sha1', $request->user()->getEmailForVerification()), $request->route('hash'))) {
+
+        if (! hash_equals((string) $request->route('hash'), sha1($request->user()->getEmailForVerification()))) {
             throw new AuthorizationException;
         }
 

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -35,7 +35,7 @@ trait VerifiesEmails
         if ($request->route('id') != $request->user()->getKey()) {
             throw new AuthorizationException;
         }
-        if (!hash_equals(hash('sha1', $request->user()->email), $request->route('hash'))) {
+        if (! hash_equals(hash('sha1', $request->user()->getEmailForVerification()), $request->route('hash'))) {
             throw new AuthorizationException;
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1191,7 +1191,7 @@ class Router implements RegistrarContract, BindingRegistrar
     public function emailVerification()
     {
         $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
-        $this->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
+        $this->get('email/verify/{id}/{hash}', 'Auth\VerificationController@verify')->name('verification.verify');
         $this->get('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
     }
 


### PR DESCRIPTION
**Problem:**

When a user changes his email address after the verification email has been sent, but before clicking on the verification link, the new email address is verified when the link is being used, without having proof that the user is actually able to access that email account. This is a security risk.

**Solution:**

To mitigate this, we need to include the email address being verified in the link, and check if it is unchanged.

To avoid personally identifying information being stored into the access logs, we need to hash the email address.