### PR TITLE
[5.8] Prevent a job from firing if it's been marked as deleted

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobDeleted;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 
@@ -133,6 +134,10 @@ class WorkCommand extends Command
             $this->writeOutput($event->job, 'success');
         });
 
+        $this->laravel['events']->listen(JobDeleted::class, function ($event) {
+            $this->writeOutput($event->job, 'deleted');
+        });
+
         $this->laravel['events']->listen(JobFailed::class, function ($event) {
             $this->writeOutput($event->job, 'failed');
 
@@ -154,6 +159,8 @@ class WorkCommand extends Command
                 return $this->writeStatus($job, 'Processing', 'comment');
             case 'success':
                 return $this->writeStatus($job, 'Processed', 'info');
+            case 'deleted':
+                return $this->writeStatus($job, 'Deleted', 'info');
             case 'failed':
                 return $this->writeStatus($job, 'Failed', 'error');
         }

--- a/src/Illuminate/Queue/Events/JobDeleted.php
+++ b/src/Illuminate/Queue/Events/JobDeleted.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobDeleted
+{
+    /**
+     * The connection name.
+     *
+     * @var string
+     */
+    public $connectionName;
+
+    /**
+     * The job instance.
+     *
+     * @var \Illuminate\Contracts\Queue\Job
+     */
+    public $job;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    public function __construct($connectionName, $job)
+    {
+        $this->job = $job;
+        $this->connectionName = $connectionName;
+    }
+}

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -327,6 +327,7 @@ class Worker
 
             if ($job->isDeleted()) {
                 $this->raiseDeletedJobEvent($connectionName, $job);
+
                 return;
             }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -325,6 +325,11 @@ class Worker
                 $connectionName, $job, (int) $options->maxTries
             );
 
+            if ($job->isDeleted()) {
+                $this->raiseDeletedJobEvent($connectionName, $job);
+                return;
+            }
+
             // Here we will fire off the job and let it process. We will catch any exceptions so
             // they can be reported to the developers logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has finished.
@@ -469,6 +474,20 @@ class Worker
     protected function raiseAfterJobEvent($connectionName, $job)
     {
         $this->events->dispatch(new Events\JobProcessed(
+            $connectionName, $job
+        ));
+    }
+
+    /**
+     * Raise the deleted queue job event.
+     *
+     * @param  string  $connectionName
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @return void
+     */
+    protected function raiseDeletedJobEvent($connectionName, $job)
+    {
+        $this->events->dispatch(new Events\JobDeleted(
             $connectionName, $job
         ));
     }


### PR DESCRIPTION
During queue job processing an `Events\JobProcessing` event is fired, which makes it possible to `$job->delete()`, however, `$job->fire()` still happens even on the deleted job.

This adds a check to the processing of the job to prevent that, and fires an `Events\JobDeleted` event that can be listened for.

Also adds output to the `WorkCommand` to allow seeing that a job was deleted before processing completed.

Tests included.