### PR TITLE
[5.8] Added cumulative collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,19 +2,19 @@
 
 namespace Illuminate\Support;
 
-use stdClass;
-use Countable;
-use Exception;
 use ArrayAccess;
-use Traversable;
 use ArrayIterator;
 use CachingIterator;
-use JsonSerializable;
-use IteratorAggregate;
-use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Jsonable;
-use Symfony\Component\VarDumper\VarDumper;
+use Countable;
+use Exception;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Support\Traits\Macroable;
+use IteratorAggregate;
+use JsonSerializable;
+use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
+use Traversable;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -148,7 +148,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return !is_null($value);
         });
 
         if ($count = $items->count()) {
@@ -177,7 +177,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
             ->filter(function ($item) {
-                return ! is_null($item);
+                return !is_null($item);
             })->sort()->values();
 
         $count = $values->count();
@@ -288,7 +288,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            return !is_null($this->first($key));
         }
 
         return in_array($key, $this->items, true);
@@ -303,7 +303,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function crossJoin(...$lists)
     {
         return new static(Arr::crossJoin(
-            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
+            $this->items,
+            ...array_map([$this, 'getArrayableItems'], $lists)
         ));
     }
 
@@ -509,7 +510,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $callback = $this->valueRetriever($key);
 
             foreach ($this->items as $k => $v) {
-                if (! $callback($v, $k)) {
+                if (!$callback($v, $k)) {
                     return false;
                 }
             }
@@ -530,7 +531,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($keys instanceof self) {
             $keys = $keys->all();
-        } elseif (! is_array($keys)) {
+        } elseif (!is_array($keys)) {
             $keys = func_get_args();
         }
 
@@ -605,7 +606,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function unless($value, callable $callback, callable $default = null)
     {
-        return $this->when(! $value, $callback, $default);
+        return $this->when(!$value, $callback, $default);
     }
 
     /**
@@ -902,14 +903,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if (! is_array($groupKeys)) {
+            if (!is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
 
             foreach ($groupKeys as $groupKey) {
                 $groupKey = is_bool($groupKey) ? (int) $groupKey : $groupKey;
 
-                if (! array_key_exists($groupKey, $results)) {
+                if (!array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }
 
@@ -919,7 +920,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $result = new static($results);
 
-        if (! empty($nextGroups)) {
+        if (!empty($nextGroups)) {
             return $result->map->groupBy($nextGroups, $preserveKeys);
         }
 
@@ -962,7 +963,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {
-            if (! $this->offsetExists($value)) {
+            if (!$this->offsetExists($value)) {
                 return false;
             }
         }
@@ -1008,7 +1009,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function intersectByKeys($items)
     {
         return new static(array_intersect_key(
-            $this->items, $this->getArrayableItems($items)
+            $this->items,
+            $this->getArrayableItems($items)
         ));
     }
 
@@ -1029,7 +1031,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function isNotEmpty()
     {
-        return ! $this->isEmpty();
+        return !$this->isEmpty();
     }
 
     /**
@@ -1040,7 +1042,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     protected function useAsCallable($value)
     {
-        return ! is_string($value) && is_callable($value);
+        return !is_string($value) && is_callable($value);
     }
 
     /**
@@ -1070,7 +1072,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $finalItem = $collection->pop();
 
-        return $collection->implode($glue).$finalGlue.$finalItem;
+        return $collection->implode($glue) . $finalGlue . $finalItem;
     }
 
     /**
@@ -1156,7 +1158,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             $value = reset($pair);
 
-            if (! isset($dictionary[$key])) {
+            if (!isset($dictionary[$key])) {
                 $dictionary[$key] = [];
             }
 
@@ -1239,7 +1241,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return ! is_null($value);
+            return !is_null($value);
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
@@ -1304,7 +1306,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return !is_null($value);
         })->reduce(function ($result, $value) {
             return is_null($result) || $value < $result ? $value : $result;
         });
@@ -1386,7 +1388,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 : $this->operatorForWhere(...func_get_args());
 
         foreach ($this->items as $key => $item) {
-            $partitions[(int) ! $callback($item, $key)][$key] = $item;
+            $partitions[(int) !$callback($item, $key)][$key] = $item;
         }
 
         return new static($partitions);
@@ -1524,7 +1526,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable
-                ? ! $callback($value, $key)
+                ? !$callback($value, $key)
                 : $value != $callback;
         });
     }
@@ -1570,7 +1572,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function search($value, $strict = false)
     {
-        if (! $this->useAsCallable($value)) {
+        if (!$this->useAsCallable($value)) {
             return array_search($value, $this->items, $strict);
         }
 
@@ -2156,10 +2158,26 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __get($key)
     {
-        if (! in_array($key, static::$proxies)) {
+        if (!in_array($key, static::$proxies)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
         }
 
         return new HigherOrderCollectionProxy($this, $key);
+    }
+
+    /**
+     * Transforms the collection to its accumulated values.
+     *
+     * @return static
+     */
+    public function cumulative()
+    {
+        $cumulative = [];
+
+        $this->reduce(function ($carry, $item) use (&$cumulative) {
+            return $cumulative[] = $carry + $item;
+        }, 0);
+
+        return new static($cumulative);
     }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2,19 +2,19 @@
 
 namespace Illuminate\Support;
 
-use ArrayAccess;
-use ArrayIterator;
-use CachingIterator;
+use stdClass;
 use Countable;
 use Exception;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Traits\Macroable;
-use IteratorAggregate;
-use JsonSerializable;
-use stdClass;
-use Symfony\Component\VarDumper\VarDumper;
+use ArrayAccess;
 use Traversable;
+use ArrayIterator;
+use CachingIterator;
+use JsonSerializable;
+use IteratorAggregate;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Support\Jsonable;
+use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Contracts\Support\Arrayable;
 
 /**
  * @property-read HigherOrderCollectionProxy $average
@@ -148,7 +148,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return !is_null($value);
+            return ! is_null($value);
         });
 
         if ($count = $items->count()) {
@@ -177,7 +177,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
             ->filter(function ($item) {
-                return !is_null($item);
+                return ! is_null($item);
             })->sort()->values();
 
         $count = $values->count();
@@ -288,7 +288,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         if ($this->useAsCallable($key)) {
-            return !is_null($this->first($key));
+            return ! is_null($this->first($key));
         }
 
         return in_array($key, $this->items, true);
@@ -303,8 +303,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function crossJoin(...$lists)
     {
         return new static(Arr::crossJoin(
-            $this->items,
-            ...array_map([$this, 'getArrayableItems'], $lists)
+            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
         ));
     }
 
@@ -510,7 +509,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
             $callback = $this->valueRetriever($key);
 
             foreach ($this->items as $k => $v) {
-                if (!$callback($v, $k)) {
+                if (! $callback($v, $k)) {
                     return false;
                 }
             }
@@ -531,7 +530,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     {
         if ($keys instanceof self) {
             $keys = $keys->all();
-        } elseif (!is_array($keys)) {
+        } elseif (! is_array($keys)) {
             $keys = func_get_args();
         }
 
@@ -606,7 +605,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function unless($value, callable $callback, callable $default = null)
     {
-        return $this->when(!$value, $callback, $default);
+        return $this->when(! $value, $callback, $default);
     }
 
     /**
@@ -903,14 +902,14 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         foreach ($this->items as $key => $value) {
             $groupKeys = $groupBy($value, $key);
 
-            if (!is_array($groupKeys)) {
+            if (! is_array($groupKeys)) {
                 $groupKeys = [$groupKeys];
             }
 
             foreach ($groupKeys as $groupKey) {
                 $groupKey = is_bool($groupKey) ? (int) $groupKey : $groupKey;
 
-                if (!array_key_exists($groupKey, $results)) {
+                if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;
                 }
 
@@ -920,7 +919,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $result = new static($results);
 
-        if (!empty($nextGroups)) {
+        if (! empty($nextGroups)) {
             return $result->map->groupBy($nextGroups, $preserveKeys);
         }
 
@@ -963,7 +962,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $keys = is_array($key) ? $key : func_get_args();
 
         foreach ($keys as $value) {
-            if (!$this->offsetExists($value)) {
+            if (! $this->offsetExists($value)) {
                 return false;
             }
         }
@@ -1009,8 +1008,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     public function intersectByKeys($items)
     {
         return new static(array_intersect_key(
-            $this->items,
-            $this->getArrayableItems($items)
+            $this->items, $this->getArrayableItems($items)
         ));
     }
 
@@ -1031,7 +1029,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function isNotEmpty()
     {
-        return !$this->isEmpty();
+        return ! $this->isEmpty();
     }
 
     /**
@@ -1042,7 +1040,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     protected function useAsCallable($value)
     {
-        return !is_string($value) && is_callable($value);
+        return ! is_string($value) && is_callable($value);
     }
 
     /**
@@ -1072,7 +1070,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         $finalItem = $collection->pop();
 
-        return $collection->implode($glue) . $finalGlue . $finalItem;
+        return $collection->implode($glue).$finalGlue.$finalItem;
     }
 
     /**
@@ -1158,7 +1156,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
             $value = reset($pair);
 
-            if (!isset($dictionary[$key])) {
+            if (! isset($dictionary[$key])) {
                 $dictionary[$key] = [];
             }
 
@@ -1241,7 +1239,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return !is_null($value);
+            return ! is_null($value);
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
@@ -1306,7 +1304,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         return $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return !is_null($value);
+            return ! is_null($value);
         })->reduce(function ($result, $value) {
             return is_null($result) || $value < $result ? $value : $result;
         });
@@ -1388,7 +1386,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
                 : $this->operatorForWhere(...func_get_args());
 
         foreach ($this->items as $key => $item) {
-            $partitions[(int) !$callback($item, $key)][$key] = $item;
+            $partitions[(int) ! $callback($item, $key)][$key] = $item;
         }
 
         return new static($partitions);
@@ -1526,7 +1524,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
 
         return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable
-                ? !$callback($value, $key)
+                ? ! $callback($value, $key)
                 : $value != $callback;
         });
     }
@@ -1572,7 +1570,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function search($value, $strict = false)
     {
-        if (!$this->useAsCallable($value)) {
+        if (! $this->useAsCallable($value)) {
             return array_search($value, $this->items, $strict);
         }
 
@@ -2158,7 +2156,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function __get($key)
     {
-        if (!in_array($key, static::$proxies)) {
+        if (! in_array($key, static::$proxies)) {
             throw new Exception("Property [{$key}] does not exist on this collection instance.");
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2,21 +2,21 @@
 
 namespace Illuminate\Tests\Support;
 
-use stdClass;
-use Exception;
 use ArrayAccess;
-use ArrayObject;
-use Mockery as m;
 use ArrayIterator;
+use ArrayObject;
 use CachingIterator;
-use ReflectionClass;
-use JsonSerializable;
-use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use Exception;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Contracts\Support\Arrayable;
+use InvalidArgumentException;
+use JsonSerializable;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
 
 class SupportCollectionTest extends TestCase
 {
@@ -3189,6 +3189,12 @@ class SupportCollectionTest extends TestCase
     {
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
+    }
+
+    public function testReturnsCumulativeValues()
+    {
+        $collection = new Collection([1, 0, 0, 7, 3]);
+        $this->assertSame([1, 1, 1, 8, 11], $collection->cumulative()->toArray());
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2,21 +2,21 @@
 
 namespace Illuminate\Tests\Support;
 
-use ArrayAccess;
-use ArrayIterator;
-use ArrayObject;
-use CachingIterator;
+use stdClass;
 use Exception;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
+use ArrayAccess;
+use ArrayObject;
+use Mockery as m;
+use ArrayIterator;
+use CachingIterator;
+use ReflectionClass;
+use JsonSerializable;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use InvalidArgumentException;
-use JsonSerializable;
-use Mockery as m;
-use PHPUnit\Framework\TestCase;
-use ReflectionClass;
-use stdClass;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
 
 class SupportCollectionTest extends TestCase
 {


### PR DESCRIPTION
This PR adds a collection method that performs a cumulative calculation on the initial items.

Currently there are a lot of helping methods to perform various calculations, but none of them easily performs the behaviour that this new method presents without first having to initialize variables.

This method is a wrapper around the `reduce()` method but allows you to preserve the carry item in the final array.


### Use case
A lot of companies nowadays demand more data visualization through charts to display the accumulated results over time for their specific resources.

This would help those who, like me, constantly have to reach out for this kind of calculations but want to make them clean and as simple as possible.

As an example of a simple collection: `$collection = collect([1, 2, 0, 0, 5]);`

**Before:**

```php
    $initial = 0;

    return $collection->map(function ($value) use (&$initial) {
        return $initial += $value;
    }); // [1, 3, 3, 3, 8]
```

**After:**
```php
    return $collection->cumulative(); // [1, 3, 3, 3, 8]
```
