### PR TITLE
[5.9] Queue cookies with same name and distinct paths

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -147,7 +147,7 @@ class CookieJar implements JarContract
             $cookie = call_user_func_array([$this, 'make'], $parameters);
         }
 
-        if (!isset($this->queued[$cookie->getName()])) {
+        if (! isset($this->queued[$cookie->getName()])) {
             $this->queued[$cookie->getName()] = [];
         }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -166,8 +166,13 @@ class CookieJar implements JarContract
     {
         if ($path === null) {
             unset($this->queued[$name]);
+            return;
         } else {
             unset($this->queued[$name][$path]);
+
+            if (empty($this->queued[$name])) {
+                unset($this->queued[$name]);
+            }
         }
     }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -166,7 +166,6 @@ class CookieJar implements JarContract
     {
         if ($path === null) {
             unset($this->queued[$name]);
-            return;
         } else {
             unset($this->queued[$name][$path]);
 

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -196,6 +196,7 @@ class CookieTest extends TestCase
     {
         $property = (new \ReflectionObject($cookieJar))->getProperty('queued');
         $property->setAccessible(true);
+
         return $property->getValue($cookieJar);
     }
 }

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -133,7 +133,16 @@ class CookieTest extends TestCase
         $cookieJar->queue($cookieOne);
         $cookieJar->queue($cookieTwo);
         $cookieJar->unqueue('foo', '/path');
-        $this->assertEquals(['foo' => ['/' => $cookieTwo]], $this->getProtectedPropertyValue($cookieJar, 'queued'));
+        $this->assertEquals(['foo' => ['/' => $cookieTwo]], $this->getQueuedPropertyValue($cookieJar));
+    }
+
+    public function testUnqueueOnlyCookieForName(): void
+    {
+        $cookieJar = $this->getCreator();
+        $cookie = $cookieJar->make('foo', 'bar', 0, '/path');
+        $cookieJar->queue($cookie);
+        $cookieJar->unqueue('foo', '/path');
+        $this->assertEmpty($this->getQueuedPropertyValue($cookieJar));
     }
 
     public function testCookieJarIsMacroable()
@@ -150,7 +159,7 @@ class CookieTest extends TestCase
         $cookieJar = $this->getCreator();
         $cookie = $cookieJar->make('foo', 'bar', 0, '/path');
         $cookieJar->queue($cookie);
-        $this->assertEquals(['foo' => ['/path' => $cookie]], $this->getProtectedPropertyValue($cookieJar, 'queued'));
+        $this->assertEquals(['foo' => ['/path' => $cookie]], $this->getQueuedPropertyValue($cookieJar));
     }
 
     public function testQueueWithCreatingNewCookie(): void
@@ -159,7 +168,7 @@ class CookieTest extends TestCase
         $cookieJar->queue('foo', 'bar', 0, '/path');
         $this->assertEquals(
             ['foo' => ['/path' => new Cookie('foo', 'bar', 0, '/path')]],
-            $this->getProtectedPropertyValue($cookieJar, 'queued')
+            $this->getQueuedPropertyValue($cookieJar)
         );
     }
 
@@ -183,9 +192,9 @@ class CookieTest extends TestCase
         return new CookieJar;
     }
 
-    private function getProtectedPropertyValue(CookieJar $cookieJar, string $propertyName)
+    private function getQueuedPropertyValue(CookieJar $cookieJar)
     {
-        $property = (new \ReflectionObject($cookieJar))->getProperty($propertyName);
+        $property = (new \ReflectionObject($cookieJar))->getProperty('queued');
         $property->setAccessible(true);
         return $property->getValue($cookieJar);
     }

--- a/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
+++ b/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
@@ -12,9 +12,6 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 class AddQueuedCookiesToResponseTest extends TestCase
 {
 
-    /**
-     * @return void
-     */
     public function testHandle(): void
     {
         $cookieJar = new CookieJar();

--- a/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
+++ b/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Cookie\Middleware;
+
+use Illuminate\Cookie\CookieJar;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+class AddQueuedCookiesToResponseTest extends TestCase
+{
+
+    /**
+     * @return void
+     */
+    public function testHandle(): void
+    {
+        $cookieJar = new CookieJar();
+        $cookieOne = $cookieJar->make('foo', 'bar', 0, '/path');
+        $cookieTwo = $cookieJar->make('foo', 'rab', 0, '/');
+        $cookieJar->queue($cookieOne);
+        $cookieJar->queue($cookieTwo);
+        $addQueueCookiesToResponseMiddleware = new AddQueuedCookiesToResponse($cookieJar);
+        $next = function (Request $request) {
+            return new Response();
+        };
+        $this->assertEquals(
+            [
+                '' => [
+                    '/path' => [
+                        'foo' => $cookieOne
+                    ],
+                    '/' => [
+                        'foo' => $cookieTwo
+                    ]
+                ],
+            ],
+            $addQueueCookiesToResponseMiddleware->handle(new Request(), $next)->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY)
+        );
+    }
+}

--- a/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
+++ b/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
@@ -11,7 +11,6 @@ use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 
 class AddQueuedCookiesToResponseTest extends TestCase
 {
-
     public function testHandle(): void
     {
         $cookieJar = new CookieJar();

--- a/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
+++ b/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
@@ -2,12 +2,12 @@
 
 namespace Illuminate\Tests\Cookie\Middleware;
 
-use Illuminate\Cookie\CookieJar;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Cookie\CookieJar;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 
 class AddQueuedCookiesToResponseTest extends TestCase
 {
@@ -27,11 +27,11 @@ class AddQueuedCookiesToResponseTest extends TestCase
             [
                 '' => [
                     '/path' => [
-                        'foo' => $cookieOne
+                        'foo' => $cookieOne,
                     ],
                     '/' => [
-                        'foo' => $cookieTwo
-                    ]
+                        'foo' => $cookieTwo,
+                    ],
                 ],
             ],
             $addQueueCookiesToResponseMiddleware->handle(new Request(), $next)->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY)


### PR DESCRIPTION
This PR will make it possible to queue cookies with the same name and distinct paths.
Currently, cookies with the same name and distinct paths would be overwritten by the last added, described in issue #28592.
The `$queued` array is now two-dimensional: `$queued[$cookieName][$cookiePath]`. 
I added the optional parameter `$path` to the methods `queued`, `hasQueued` and `unqueue`. Without the parameter, this methods will behave like before and return/check/remove the last added cookie for the specified cookie name.
The changes won't be completely backwards compatible because the structure of the `$queued` array changed and I couldn't add an optional parameter to the `getQueued` method. This method will return the queued cookies flattened, so the array won't contain the cookie names as keys. 