### PR TITLE
[5.8] Added tests for alias loader

### DIFF
--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -36,4 +36,34 @@ class FoundationAliasLoaderTest extends TestCase
         $loader = AliasLoader::getInstance(['foo' => 'baz']);
         $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
     }
+
+    public function testLoaderCanAliasAndLoadClasses()
+    {
+        $loader = AliasLoader::getInstance(['some_alias_foo_bar' => FoundationAliasLoaderStub::class]);
+
+        $result = $loader->load('some_alias_foo_bar');
+
+        $this->assertInstanceOf(FoundationAliasLoaderStub::class, new \some_alias_foo_bar);
+        $this->assertTrue($result);
+
+        $result2 = $loader->load('bar');
+        $this->assertNull($result2);
+    }
+
+    public function testSetAlias()
+    {
+        $loader = AliasLoader::getInstance();
+        $loader->setAliases(['some_alias_foo' => FoundationAliasLoaderStub::class]);
+
+        $result = $loader->load('some_alias_foo');
+
+        $fooObj = new \some_alias_foo;
+        $this->assertInstanceOf(FoundationAliasLoaderStub::class, $fooObj);
+        $this->assertTrue($result);
+    }
+}
+
+class FoundationAliasLoaderStub
+{
+    //
 }


### PR DESCRIPTION
It adds tests for `setAlias` and `load` methods, checking different aspects of their functionality.

Resubmit: #29156
On #29156 Tests were passing on my windows 10 system. but there was some tricky differences on the type of exception thrown in windows and unix environments, causing the tests to fail on travis.
I will investigate those cases.
