### PR TITLE
[5.8] Added support to restrict types on polymorphic relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -104,7 +104,7 @@ class MorphTo extends BelongsTo
         foreach ($models as $model) {
             $type = $model->{$this->morphType};
             if ($type && ($this->types == ['*'] || in_array($type, $this->types))) {
-                $this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
+                $this->dictionary[$type][$model->{$this->foreignKey}][] = $model;
             }
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -70,7 +70,7 @@ class MorphTo extends BelongsTo
     }
 
     /**
-     * Set the constraints for the allowed types of the relation
+     * Set the constraints for the allowed types of the relation.
      *
      * @param  array  $types
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -17,6 +17,13 @@ class MorphTo extends BelongsTo
     protected $morphType;
 
     /**
+     * Allowed type values for the relation.
+     *
+     * @var array
+     */
+    protected $types = ['*'];
+
+    /**
      * The models whose relations are being eager loaded.
      *
      * @var \Illuminate\Database\Eloquent\Collection
@@ -63,6 +70,19 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Set the constraints for the allowed types of the relation
+     *
+     * @param  array  $types
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function addTypeConstraints(array $types)
+    {
+        $this->types = $types;
+
+        return $this;
+    }
+
+    /**
      * Set the constraints for an eager load of the relation.
      *
      * @param  array  $models
@@ -82,7 +102,8 @@ class MorphTo extends BelongsTo
     protected function buildDictionary(Collection $models)
     {
         foreach ($models as $model) {
-            if ($model->{$this->morphType}) {
+            $type = $model->{$this->morphType};
+            if ($type && ($this->types == ['*'] || in_array($type, $this->types))) {
                 $this->dictionary[$model->{$this->morphType}][$model->{$this->foreignKey}][] = $model;
             }
         }


### PR DESCRIPTION
This PR adds the ability to pass an array of types to the morphTo relation if & when needed so that we can restrict the type of rows for which the relation needs to be loaded.

**Table Structure**

| type        | value |
|-------------|-------|
| post        | 4     |
| user        | 2     |
| likes_count | 100   |

In the above case, the row referring to the types 'post' & 'user' morphs to a certain row in respective tables but the row with 'likes_count' has a integer value and is not associated with any table.

**Scenario**
I have been working on a rule engine where I can store different formats of value like string, number, id etc into the value column. Now with the current implementation if a class for a respective type is not found then a "Matching class not found" error is thrown. Ideally we should be able to define the types that are allowed to have relation and those that we simply want to be skipped like rows with integer values which are not ids.

**After the Commit**
While making the morphTo relation we can also pass the allowed types for which we want the relation to be loaded.

```
public function attribute()
{
    return $this->morphTo('attribute', 'type', 'value')
        ->addTypeConstraints(['post', 'user']);
}
```
With the above code the attribute will only be loaded for when the type is either post or user and for all other scenarios it will be skipped.

**Backwards Compatibility**
The commit is fully backwards compatible because if the new function is not called then all the types values will be considered and the relation will be loaded for all of them.

There could be many more scenarios where we would want to store data in the table that can have different types of values and not every type of data can have a related table.