### PR TITLE
[5.8] Fix DELETE queries with alias on SQLite

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2099,6 +2099,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('users.email', '=', 'foo')->orderBy('users.id')->limit(1)->delete();
         $this->assertEquals(1, $result);
 
+        $builder = $this->getSqliteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" as "u" where "rowid" in (select "u"."rowid" from "users" as "u" inner join "contacts" as "c" on "u"."id" = "c"."id")', [])->andReturn(1);
+        $result = $builder->from('users as u')->join('contacts as c', 'u.id', '=', 'c.id')->delete();
+        $this->assertEquals(1, $result);
+
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `email` = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();


### PR DESCRIPTION
`DELETE` queries with an alias don't work on SQLite:

```php
DB::table('users as u')->join('posts', 'posts.user_id', '=', 'u.id')->delete();

// expected
delete from "users" as "u" where "rowid" in (
  select "u"."rowid" from "users" as "u"
  inner join "posts" on "posts"."user_id" = "u"."id"
)

// actual
delete from "users" as "u" where "rowid" in (
  select "users" as "u.rowid" from "users" as "u"
         ^^^^^^^^^^^^^^^^^^^^
  inner join "posts" on "posts"."user_id" = "u"."id"
)
```

Fixes #29141.