### PR TITLE
[5.8] Allow hourlyAt() to accept array of integers

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -122,10 +122,9 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run hourly at a given offset in the hour. The
-     * offset can be either an integer or an array of integers.
+     * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  int|array  $offset
+     * @param  array|int  $offset
      * @return $this
      */
     public function hourlyAt($offset)

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -131,6 +131,7 @@ trait ManagesFrequencies
     public function hourlyAt($offset)
     {
         $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
         return $this->spliceIntoPosition(1, $offset);
     }
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -122,13 +122,15 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run hourly at a given offset in the hour.
+     * Schedule the event to run hourly at a given offset in the hour. The
+     * offset can be either an integer or an array of integers.
      *
-     * @param  int  $offset
+     * @param  int|array  $offset
      * @return $this
      */
     public function hourlyAt($offset)
     {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
         return $this->spliceIntoPosition(1, $offset);
     }
 

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -47,6 +47,7 @@ class FrequencyTest extends TestCase
     {
         $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15,30,45])->getExpression());
     }
 
     public function testMonthlyOn()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -47,7 +47,7 @@ class FrequencyTest extends TestCase
     {
         $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
-        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15,30,45])->getExpression());
+        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
     public function testMonthlyOn()


### PR DESCRIPTION
This small PR expands the functionality of the `ManagesFrequencies::hourlyAt()` method to allow it to accept an array of integers instead of only a single integer. `FrequencyTest` class includes passing test for this addition.

This is a non-breaking enhancement because the `hourlyAt()` method does not typehint the offset value being passed in.

Benefit to users: finer control over granular execution schedules. The `hourlyAt()` method is not chainable, so in the follow example, the command would only be executed at the 45th minute:
```
$schedule->command('my:command')->hourlyAt(15)->hourlyAt(30)->hourlyAt(45)
```
With this PR, it is possible to declare whatever hourly granularity is needed for your use case:
```
$schedule->command(my:command')->hourlyAt([15, 30, 45]);
```