### PR TITLE
[5.9] Allow function calls on non-objects in higher order messaging

### DIFF
--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -57,6 +57,10 @@ class HigherOrderCollectionProxy
     public function __call($method, $parameters)
     {
         return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+            if (! is_object($value)) {
+                return $method($value, ...$parameters);
+            }
+
             return $value->{$method}(...$parameters);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2781,6 +2781,20 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
     }
 
+    public function testHigherOrderCollectionFunctionsOnNonObjects()
+    {
+        $collection = collect([null, 'bad@email', 'taylorotwell@gmail.com', 123]);
+
+        $this->assertEquals(
+            [2 => 'taylorotwell@gmail.com'],
+            $collection->filter->filter_var(FILTER_VALIDATE_EMAIL)->toArray()
+        );
+
+        $collection = collect([['a' => 'b', 'c' => 'd'], ['e' => 'f']]);
+
+        $this->assertEquals([['b', 'd'], ['f']], $collection->map->array_values()->toArray());
+    }
+
     public function testPartition()
     {
         $collection = new Collection(range(1, 10));


### PR DESCRIPTION
This PR adds the ability to call built-in PHP functions on scalar/null/array (non-object) types in a collection through Higher Order Messages.

## Example
```php
$collection = collect(['abc ', ' def  ', 'g h i  ', null]);

$collection->reject->is_null()->map->trim();

// Current:
 
PHP Error:  Call to a member function is_null() on string

// Output with this PR: 

=> Illuminate\Support\Collection {
     all: [
       "abc",
       "def",
       "g h i",
     ],
   }
```

I know you can pass methods to map simply like `$collection->map('trim')`; however the problem is the `key` is forwarded to the function as opposed to the value [Issue #25549](https://github.com/laravel/framework/issues/25549). The idea here would be for the methods to only be called on the value.

### Useful functions

* is_array
* is_bool
* is_int
* is_null
* is_numeric
* filter_var

```php

$collection = collect(['abc', 'def, 'jane@example.com', null]);

$collection->filter->filter_var(FILTER_VALIDATE_EMAIL);

/**
=> Illuminate\Support\Collection {
     all: [
       2 => "jane@example.com",
     ],
   }
**/

```
* dump (Can dump values to the dump server in the middle of a collection pipeline) 
* trim
* array_values
```php
collect([['a' => 'b', 'c' => 'd'], ['e' => 'f']])->map->array_values(); 

// Would output: [['b', 'd'], ['f']]
```

### Drawbacks

* Functions that are haystack, needle (value) as opposed to taking the value as the first parameter. (e.g. `explode()` or `strpos()`). However, I think there are enough valuable functions to promote adding this functionality to core.

### Change

We just need check if an item is not an object to cover scalar, null, and arrays in `Illuminate\Support\HigherOrderCollectionProxy`’s `__call` method. The only difference I see in behavior is passing null would fall in trying to call the function on null as opposed to a method being called from null (both would result in an error). I'm not sure if this would qualify as a BC, but this would be for 5.9) h/t @staudenmeir for the idea of using `! is_object()`