### PR TITLE
[5.9] Don't set default message when denying policy, move "This action is unauthorized" message to exception.

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -21,9 +21,9 @@ class AuthorizationException extends Exception
      * @param  \Exception|null  $previous
      * @return void
      */
-    public function __construct($message = '', $code = null, Exception $previous = null)
+    public function __construct($message = null, $code = null, Exception $previous = null)
     {
-        parent::__construct($message, 0, $previous);
+        parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
 
         $this->code = $code;
     }

--- a/src/Illuminate/Auth/Access/HandlesAuthorization.php
+++ b/src/Illuminate/Auth/Access/HandlesAuthorization.php
@@ -23,7 +23,7 @@ trait HandlesAuthorization
      * @param  mixed|null  $code
      * @return \Illuminate\Auth\Access\Response
      */
-    protected function deny($message = 'This action is unauthorized.', $code = null)
+    protected function deny($message = null, $code = null)
     {
         return Response::deny($message, $code);
     }

--- a/src/Illuminate/Auth/Access/Response.php
+++ b/src/Illuminate/Auth/Access/Response.php
@@ -61,7 +61,7 @@ class Response implements Arrayable
      * @param mixed $code
      * @return \Illuminate\Auth\Access\Response
      */
-    public static function deny($message = 'This action is unauthorized.', $code = null)
+    public static function deny($message = null, $code = null)
     {
         return new static(false, $message, $code);
     }

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -175,7 +175,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     protected function failedAuthorization()
     {
-        throw new AuthorizationException('This action is unauthorized.');
+        throw new AuthorizationException;
     }
 
     /**

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -28,6 +28,13 @@ class AuthAccessResponseTest extends TestCase
         $this->assertEquals('some_code', $response->code());
     }
 
+    public function test_deny_method_with_no_message_returns_null()
+    {
+        $response = Response::deny();
+
+        $this->assertNull($response->message());
+    }
+
     public function test_authorize_method_throws_authorization_exception_when_response_denied()
     {
         $response = Response::deny('Some message.', 'some_code');
@@ -38,6 +45,17 @@ class AuthAccessResponseTest extends TestCase
             $this->assertEquals('Some message.', $e->getMessage());
             $this->assertEquals('some_code', $e->getCode());
             $this->assertEquals($response, $e->response());
+        }
+    }
+
+    public function test_authorize_method_throws_authorization_exception_with_default_message()
+    {
+        $response = Response::deny();
+
+        try {
+            $response->authorize();
+        } catch (AuthorizationException $e) {
+            $this->assertEquals('This action is unauthorized.', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
This minor PR brings these improvements:

* Makes it possible to determine if a policy returned with an error message or not. Currently it's not possible to easily know if a policy came back with a defined message or if it was just set as the default one ("This action is unauthorized") - with this PR the response message will be `null` by default if no message was supplied.
* The `AuthorizationException` still sets the default error message if nothing was explicitly returned from the policy.