### PR TITLE
[5.9] Use POST method when re-sending email verfication.

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1192,7 +1192,7 @@ class Router implements RegistrarContract, BindingRegistrar
     {
         $this->get('email/verify', 'Auth\VerificationController@show')->name('verification.notice');
         $this->get('email/verify/{id}', 'Auth\VerificationController@verify')->name('verification.verify');
-        $this->get('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
+        $this->post('email/resend', 'Auth\VerificationController@resend')->name('verification.resend');
     }
 
     /**


### PR DESCRIPTION
This route should ideally be a POST request in order to prevent csrf attacks.

I've also made a [PR to the UI repository](https://github.com/laravel/ui/pull/12) to make this a POST request by default in the scaffolding there. It's a minor breaking change imo but worth making this change for 5.9.