### PR TITLE
[5.8] fixes #29181

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -204,11 +204,10 @@ trait QueriesRelationships
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->all();
         }
-        
+
         foreach ($types as &$type) {
             $type = Relation::getMorphedModel($type) ?? $type;
         }
-        
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
             foreach ($types as $type) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -203,11 +203,12 @@ trait QueriesRelationships
 
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->all();
-
-            foreach ($types as &$type) {
-                $type = Relation::getMorphedModel($type) ?? $type;
-            }
         }
+        
+        foreach ($types as &$type) {
+            $type = Relation::getMorphedModel($type) ?? $type;
+        }
+        
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
             foreach ($types as $type) {


### PR DESCRIPTION
Fixes the morphed model type mapping when type(s) are provided in `whereHasMorph`

```php
// AppServiceProvider
Relation::morphMap([
    'posts' => 'App\Post',
]);
```

```php
$comments = App\Comment::whereHasMorph(
    'commentable', 
    ['post'], 
    function (Builder $query) {
        $query->where('title', 'like', 'foo%');
    }
)->get();
```