### PR TITLE
[5.8] Make Blueprint::morphs() shortcut more flexible

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1197,13 +1197,14 @@ class Blueprint
      *
      * @param  string  $name
      * @param  string|null  $indexName
+     * @param  string  $keyType
      * @return void
      */
-    public function morphs($name, $indexName = null)
+    public function morphs($name, $indexName = null, $keyType = 'unsignedBigInteger')
     {
         $this->string("{$name}_type");
 
-        $this->unsignedBigInteger("{$name}_id");
+        $this->{$keyType}("{$name}_id");
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }
@@ -1213,13 +1214,14 @@ class Blueprint
      *
      * @param  string  $name
      * @param  string|null  $indexName
+     * @param  string  $keyType
      * @return void
      */
-    public function nullableMorphs($name, $indexName = null)
+    public function nullableMorphs($name, $indexName = null, $keyType = 'unsignedBigInteger')
     {
         $this->string("{$name}_type")->nullable();
 
-        $this->unsignedBigInteger("{$name}_id")->nullable();
+        $this->{$keyType}("{$name}_id")->nullable();
 
         $this->index(["{$name}_type", "{$name}_id"], $indexName);
     }


### PR DESCRIPTION
`Blueprint::morphs()` is an awesome shortcut but becomes annoying when using other types of primary key like `unsignedInteger`, `uuid` or a `string`.

Plus, as demonstrated [here](https://github.com/laravel/framework/issues/24782) most people don't realize it's a polymorphic relationship if they didn't see the `morphs` call.

We can just create the fields and the index like suggested [here](https://github.com/laravel/framework/issues/24782#issuecomment-403536888)

```php
$table->string('foo_type');
$table->uuid('foo_id');
```

But I think this is the better approach! What do you think?

**does not break anything!**