### PR TITLE
[5.8] 5.8.29 tagged today breaks queue deserializing with Model::newCollection()

### DIFF
--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -79,6 +79,7 @@ trait SerializesAndRestoresModelIdentifiers
         }
 
         $collection = $collection->keyBy->getKey();
+
         $collectionClass = get_class($collection);
 
         return new $collectionClass(

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -79,8 +79,9 @@ trait SerializesAndRestoresModelIdentifiers
         }
 
         $collection = $collection->keyBy->getKey();
+        $collectionClass = get_class($collection);
 
-        return new EloquentCollection(
+        return new $collectionClass(
             collect($value->id)->map(function ($id) use ($collection) {
                 return $collection[$id];
             })

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -235,6 +235,20 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($unserialized->users->first()->email, 'taylor@laravel.com');
         $this->assertEquals($unserialized->users->last()->email, 'mohamed@laravel.com');
     }
+
+    public function test_it_can_unserialize_custom_collection()
+    {
+        ModelSerializationTestCustomUser::create(['email' => 'mohamed@laravel.com']);
+        ModelSerializationTestCustomUser::create(['email' => 'taylor@laravel.com']);
+
+        $serialized = serialize(new CollectionSerializationTestClass(
+            ModelSerializationTestCustomUser::all()
+        ));
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf(ModelSerializationTestCustomUserCollection::class, $unserialized->users);
+    }
 }
 
 class ModelSerializationTestUser extends Model
@@ -242,6 +256,22 @@ class ModelSerializationTestUser extends Model
     public $table = 'users';
     public $guarded = ['id'];
     public $timestamps = false;
+}
+
+class ModelSerializationTestCustomUserCollection extends Collection
+{
+}
+
+class ModelSerializationTestCustomUser extends Model
+{
+    public $table = 'users';
+    public $guarded = ['id'];
+    public $timestamps = false;
+
+    public function newCollection(array $models = [])
+    {
+        return new ModelSerializationTestCustomUserCollection($models);
+    }
 }
 
 class Order extends Model


### PR DESCRIPTION
This change [pull request #29196](https://github.com/laravel/framework/pull/29136/files#diff-955cb662f7bf33d1dec2eee598ce800dR82) breaks queued jobs using `SerializesModels` that expect a custom collection. The above changes return an `EloquentCollection` when unserialized regardless of the model overriding `newCollection`.

Example:

```
<?php

namespace App\Jobs;

use App\Models\Collections\PostsCollection;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class DoSomethingToPosts extends Job implements ShouldQueue
{
    use InteractsWithQueue, SerializesModels;

    public $posts;

    public function __construct(PostsCollection $posts)
    {
        $this->posts = $posts;
    }

    public function handle()
    {
        // This object is now \Illuminate\Database\Eloquent\Collection,
        // not a PostsCollection instance.
        $this->posts;
    }
}
```

Thanks @derekmd for the tips on this PR