### PR TITLE
[5.8] Fix formatting of DocBlock in factory.stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,6 +1,6 @@
 <?php
 
-/* @var $factory \Illuminate\Database\Eloquent\Factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use NamespacedDummyModel;
 use Faker\Generator as Faker;


### PR DESCRIPTION
This change allows all IDEs to properly parse the imported variable. 

Before it was invalid because [a DocBlock should always start with `/**` (two asterisks)](https://docs.phpdoc.org/guides/docblocks.html#anatomy-of-a-docblock), and [the syntax for `@var`](https://docs.phpdoc.org/references/phpdoc/tags/var.html#syntax) was in the wrong order.

It's a non-breaking change because we're just updating a comment, and it will only benefit users who generate factories after the PR is merged. 