### PR TITLE
[5.9] Handle wildcard values in required_with* rules

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1458,7 +1458,15 @@ trait ValidatesAttributes
     protected function anyFailingRequired(array $attributes)
     {
         foreach ($attributes as $key) {
-            if (! $this->validateRequired($key, $this->getValue($key))) {
+            if (Str::contains($key, '*')) {
+                $data = ValidationData::initializeAndGatherData($key, $this->data);
+
+                foreach ($data as $attribute => $item) {
+                    if (Str::is($key, $attribute) && ! $this->validateRequired($attribute, $item)) {
+                        return true;
+                    }
+                }
+            } elseif (! $this->validateRequired($key, $this->getValue($key))) {
                 return true;
             }
         }
@@ -1475,7 +1483,15 @@ trait ValidatesAttributes
     protected function allFailingRequired(array $attributes)
     {
         foreach ($attributes as $key) {
-            if ($this->validateRequired($key, $this->getValue($key))) {
+            if (Str::contains($key, '*')) {
+                $data = ValidationData::initializeAndGatherData($key, $this->data);
+
+                foreach ($data as $attribute => $item) {
+                    if (Str::is($key, $attribute) && $this->validateRequired($attribute, $item)) {
+                        return false;
+                    }
+                }
+            } elseif ($this->validateRequired($key, $this->getValue($key))) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1461,10 +1461,12 @@ trait ValidatesAttributes
             if (Str::contains($key, '*')) {
                 $data = ValidationData::initializeAndGatherData($key, $this->data);
 
-                foreach ($data as $attribute => $item) {
-                    if (Str::is($key, $attribute) && ! $this->validateRequired($attribute, $item)) {
-                        return true;
-                    }
+                $data = array_filter($data, function ($item, $attribute) use ($key) {
+                    return Str::is($key, $attribute) && $this->validateRequired($attribute, $item);
+                }, ARRAY_FILTER_USE_BOTH);
+
+                if (empty($data)) {
+                    return true;
                 }
             } elseif (! $this->validateRequired($key, $this->getValue($key))) {
                 return true;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -757,6 +757,12 @@ class ValidationValidatorTest extends TestCase
         $foo = new File('', false);
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'required_with:file']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['names' => [['foo' => 'Taylor']]], ['foo' => 'required_with:names.*.first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor']]], ['foo' => 'required_with:names.*.first']);
+        $this->assertFalse($v->passes());
     }
 
     public function testRequiredWithAll()
@@ -766,6 +772,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['first' => 'foo'], ['last' => 'required_with_all:first']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor', 'foo' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor', 'last' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
         $this->assertFalse($v->passes());
     }
 
@@ -820,6 +832,12 @@ class ValidationValidatorTest extends TestCase
         $file = new File('', false);
         $foo = new File('', false);
         $v = new Validator($trans, ['file' => $file, 'foo' => $foo], ['foo' => 'required_without:file']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor']]], ['foo' => 'required_without:names.*.first']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['names' => [['foo' => 'Taylor']]], ['foo' => 'required_without:names.*.first']);
         $this->assertFalse($v->passes());
     }
 
@@ -891,6 +909,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['f1' => 'foo', 'f2' => 'bar', 'f3' => 'baz'], $rules);
         $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor']]], ['foo' => 'required_without_all:names.*.first,names.*.last']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['names' => [['foo' => 'Taylor']]], ['foo' => 'required_without_all:names.*.first,names.*.last']);
+        $this->assertFalse($v->passes());
     }
 
     public function testRequiredIf()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -774,10 +774,10 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['first' => 'foo'], ['last' => 'required_with_all:first']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans, ['names' => [['first' => 'Taylor', 'foo' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor'], ['foo' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans, ['names' => [['first' => 'Taylor', 'last' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
+        $v = new Validator($trans, ['names' => [['first' => 'Taylor'], ['last' => 'Otwell']]], ['foo' => 'required_with_all:names.*.first,names.*.last']);
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
This PR – probably – solves #26957 and #26179. In brief:

Using wildcard attributes when validating with `require_with`, `require_with_all`, `require_without` and `require_without_all` rules, the validation passes, even the if requested attributes should not pass the truth test.

------------

**This PR's concept is valid only if the following rules should work like the description below**. This is my perception based on the tests and the documentation. The documentation is clear about normal fields, but the wildcard fields are hard to deduct.

**Note**: Also, I assume that keys could be spread between the subsets. It means the rules should examine the subsets together and not one by one.

#### [`required_with`](https://laravel.com/docs/master/validation#rule-required-with):
If in any subset the given key is present at least once then the value is required. For example:

**Rule**: `'foo' => 'required_with:names.*.first'`
**Value**: `'names' => [['first' => 'Taylor'], ['nick' => 'Jeff']]`
**Result**: `foo` should be required.

#### [`required_with_all`](https://laravel.com/docs/master/validation#rule-required-with-all): 
When mapping through the subsets and all the specified keys are present least once then the value is required. For example:

**Rule**: `'foo' => 'required_with_all:names.*.first,names.*.last'`
**Value**: `'names' => [['first' => 'Taylor'], ['last' => 'Jeff']]`
**Result**: `foo` should be required.

#### [`required_without`](https://laravel.com/docs/master/validation#rule-required-without):
If at least one key is not present when mapping through subsets, then the value is required. For example:

**Rule**: `'foo' => 'required_without:names.*.first,names.*.last'`
**Value**: `'names' => [['first' => 'Taylor'], ['nick' => 'Jeff']]`
**Result**: `foo` should be required.

#### [`required_without_all`](https://laravel.com/docs/master/validation#rule-required-without-all):
When mapping through the subsets and found non of the specified keys the value is required. For example:

**Rule**: `'foo' => 'required_without_all:names.*.first,names.*.last'`
**Value**: `'names' => [['nick' => 'Taylor'], ['alias' => 'Jeff']]`
**Result**: `foo` should be required.

There are more descriptive checks in the tests.

------------

**Also, I think this can be considered as a breaking change** since it can change the result of these validation rules in currently running applications.

**I'm up to any notices/ideas**, since describing how these validation rules should work in some situations can be quite tricky, so it's good to hear another point of views as well.