### PR TITLE
[5.8] Prevent a job from firing if it's been marked as deleted

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -325,6 +325,12 @@ class Worker
                 $connectionName, $job, (int) $options->maxTries
             );
 
+            if ($job->isDeleted()) {
+                $this->raiseAfterJobEvent($connectionName, $job);
+
+                return;
+            }
+
             // Here we will fire off the job and let it process. We will catch any exceptions so
             // they can be reported to the developers logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has finished.

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -258,6 +258,22 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(10, $job->releaseAfter);
     }
 
+    public function test_job_does_not_fire_if_deleted()
+    {
+        $job = new WorkerFakeJob(function () {
+            return true;
+        });
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $job->delete();
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->once();
+        $this->assertFalse($job->hasFailed());
+        $this->assertFalse($job->isReleased());
+        $this->assertTrue($job->isDeleted());
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
See #29152 for previous discussion.

During queue job processing an Events\JobProcessing event is fired, which makes it possible to $job->delete(), however, $job->fire() still happens even on the deleted job.

This adds a check to the processing of the job to prevent that, though still fires an Events\JobProcessed event.

Tests included.