### PR TITLE
[5.8] Fix collections with JsonSerializable items and mixed values

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2127,7 +2127,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);
         } elseif ($items instanceof JsonSerializable) {
-            return $items->jsonSerialize();
+            return (array) $items->jsonSerialize();
         } elseif ($items instanceof Traversable) {
             return iterator_to_array($items);
         }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -178,6 +178,10 @@ class SupportCollectionTest extends TestCase
         $array = $method->invokeArgs($collection, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
+        $items = new TestJsonSerializeWithScalarValueObject;
+        $array = $method->invokeArgs($collection, [$items]);
+        $this->assertSame(['foo'], $array);
+
         $items = new Collection(['foo' => 'bar']);
         $array = $method->invokeArgs($collection, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
@@ -3294,6 +3298,14 @@ class TestJsonSerializeObject implements JsonSerializable
     public function jsonSerialize()
     {
         return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonSerializeWithScalarValueObject implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return 'foo';
     }
 }
 


### PR DESCRIPTION
#11739 added support for collections with `JsonSerializable` items.

It only considered cases where [`jsonSerialize()`](https://www.php.net/manual/en/jsonserializable.jsonserialize.php) returns an array, but the method can return `mixed` values.

If it does, you end up with an invalid collection where `$items` is not an array:

```php
collect(new Carbon);

// expected
Collection { ▼
  #items: array:1 [▼
    0 => "2019-07-17T16:24:29.660974Z"
  ]
}

// actual
Collection { ▼
  #items: "2019-07-17T16:24:29.660974Z"
}
```

Fixes #29187.