### PR TITLE
[5.8] Add Postgres support for collation() on columns

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Expression;
  * @method ColumnDefinition autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method ColumnDefinition change() Change the column
  * @method ColumnDefinition charset(string $charset) Specify a character set for the column (MySQL)
- * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/SQL Server)
+ * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
  * @method ColumnDefinition comment(string $comment) Add a comment to the column (MySQL)
  * @method ColumnDefinition default(mixed $value) Specify a "default" value for the column
  * @method ColumnDefinition first() Place the column "first" in the table (MySQL)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -19,7 +19,7 @@ class PostgresGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Increment', 'Nullable', 'Default'];
+    protected $modifiers = ['Collate', 'Increment', 'Nullable', 'Default'];
 
     /**
      * The columns available as serials.
@@ -877,6 +877,20 @@ class PostgresGrammar extends Grammar
     private function formatPostGisType(string $type)
     {
         return "geography($type, 4326)";
+    }
+
+    /**
+     * Get the SQL for a collation column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCollate(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->collation)) {
+            return ' collate '.$this->wrapValue($column->collation);
+        }
     }
 
     /**

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -21,10 +21,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
+        $blueprint->string('name')->collation('nb_NO.utf8');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');


### PR DESCRIPTION
The MySQL and SQL Server schema builders already had support for setting collation on columns using the `collation()` methods. This PR adds Postgres support for the same functionality. Postgres have had support for collated columns since [version 9.1](https://www.postgresql.org/about/news/1349/) released in 2011.

```php
Schema::create('users', function (Blueprint $table) {
    $table->string('name')->collation('nb_NO.utf8');
});
```

I think could go safely onto 5.8?