### PR TITLE
[5.9] Fixes isDirty() for MySQL JSON cast columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1174,6 +1174,11 @@ trait HasAttributes
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===
                    $this->fromDateTime($original);
+        } elseif ($this->hasCast($key, 'json')) {
+            return empty(array_diff_assoc(
+                $this->castAttribute($key, $current),
+                $this->castAttribute($key, $original)
+            ));
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -92,6 +92,11 @@ class DatabaseEloquentModelTest extends TestCase
         $model->bar = '2017-03-18';
         $model->dateAttribute = '2017-03-18';
         $model->datetimeAttribute = '2017-03-23 22:17:00';
+        $model->jsonAttribute = [
+            'foo' => 1,
+            'bar' => 2,
+            'baz' => 3,
+        ];
         $model->syncOriginal();
 
         $model->boolAttribute = true;
@@ -99,6 +104,11 @@ class DatabaseEloquentModelTest extends TestCase
         $model->bar = '2017-03-18 00:00:00';
         $model->dateAttribute = '2017-03-18 00:00:00';
         $model->datetimeAttribute = null;
+        $model->jsonAttribute = [
+            'baz' => 3,
+            'foo' => 1,
+            'bar' => 2,
+        ];
 
         $this->assertTrue($model->isDirty());
         $this->assertTrue($model->isDirty('foo'));
@@ -106,6 +116,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty('boolAttribute'));
         $this->assertFalse($model->isDirty('dateAttribute'));
         $this->assertTrue($model->isDirty('datetimeAttribute'));
+        $this->assertFalse($model->isDirty('jsonAttribute'));
     }
 
     public function testCleanAttributes()


### PR DESCRIPTION
As per @taylorotwell, resubmitting laravel/framework#29208 to Master branch with correct spacing in `originalIsEquivalent()`

---
Currently, `isDirty()` would return true for JSON cast columns with equal key-value pairs that are input in an order other than their random stored order. The reason for this false positive is because of MySQL's behavior with JSON column types:

[From the MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/json.html#json-normalization):
> To make lookups more efficient, it also sorts the keys of a JSON object. You should be aware that the result of this ordering is subject to change and not guaranteed to be consistent across releases.

In plain English, this means that the array keys will often not be stored in the same order that they are input.

Behavior without the fix:
```
$model->jsonAttribute = [
    'foo' => 1,
    'bar' => 2,
    'baz' => 3,
];

$model->syncOriginal();

$model->jsonAttribute = [
    'baz' => 3,
    'foo' => 1,
    'bar' => 2,
];

$model->isDirty('jsonAttribute'); // true
```

The fix corrects this by checking for an empty result of `array_diff_assoc()` on JSON cast columns in `originalIsEquivalent()`. It also will fix the behavior for `getChanges()` (and naturally all other methods that depend on `getDirty()`).