### PR TITLE
[5.8] Add callable support to count collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2002,11 +2002,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Count the number of items in the collection.
      *
+     * @param callable|null $callback
+     *
      * @return int
      */
-    public function count()
+    public function count($callback = null)
     {
-        return count($this->items);
+        if (is_null($callback)) {
+            return count($this->items);
+        }
+
+        return $this->reduce(function ($count, $value) use ($callback) {
+            return $count + $callback($value);
+        }, 0);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -349,6 +349,28 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(CachingIterator::class, $c->getCachingIterator());
     }
 
+    public function testCount()
+    {
+        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $this->assertEquals(4, $c->count());
+
+        $c = new Collection([]);
+        $this->assertEquals(0, $c->count());
+    }
+
+    public function testCountWithCallable()
+    {
+        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $this->assertEquals(1, $c->count(function($value){
+            return $value === 'alice';
+        }));
+
+        $c = new Collection([]);
+        $this->assertEquals(0, $c->count(function($value){
+            return $value === 'alice';
+        }));
+    }
+
     public function testFilter()
     {
         $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -361,12 +361,12 @@ class SupportCollectionTest extends TestCase
     public function testCountWithCallable()
     {
         $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
-        $this->assertEquals(1, $c->count(function($value){
+        $this->assertEquals(1, $c->count(function ($value) {
             return $value === 'alice';
         }));
 
         $c = new Collection([]);
-        $this->assertEquals(0, $c->count(function($value){
+        $this->assertEquals(0, $c->count(function ($value) {
             return $value === 'alice';
         }));
     }


### PR DESCRIPTION
Let's say you want to count the users:
```php
$users->count();
```

What if we only want to count the admin users?
```php
$users->reduce(function ($count, User $user) {
      return $count + ($user->isAdmin() ? 1 : 0);
}, 0);
```

That's quite a lot code for such a simple operation! This PR adds support for a callable inside the count method of a collection. When a callable is true the count is raised, when false the count remains the same:

```php
$users->count(function (User $user) {
      return $user->isAdmin();
});
```

This PR has no side effects since previously the count method had no parameters and the original count method will be used when no callable is given.

Let me know what you think!