### PR TITLE
[5.8] Collection::reject() supports string callable

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1520,12 +1520,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function reject($callback = true)
     {
-        $useAsCallable = $this->useAsCallable($callback);
+        $isCallable = is_callable($callback);
 
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
-            return $useAsCallable
-                ? ! $callback($value, $key)
-                : $value != $callback;
+        return $this->filter(function ($value, $key) use ($callback, $isCallable) {
+            return $isCallable ? ! $callback($value, $key) : $value != $callback;
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2224,6 +2224,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['primary' => 'foo', 'secondary' => 'bar'], $c->reject(function ($item, $key) {
             return $key == 'id';
         })->all());
+
+        $c = new Collection(['foo', '', null, 'bar']);
+        $this->assertEquals(['foo', 'bar'], $c->reject('blank')->values()->all());
     }
 
     public function testRejectWithoutAnArgumentRemovesTruthyValues()


### PR DESCRIPTION
The current implementation's behavior is inconsistent with `Collection::filter()`,  which allows string callables for global helper/static methods.

## Example:

```php
$collection = collect(['a', '', null,'b']);

// Current: reject() performs a comparison between $value and 'blank' string literal

>>> $collection->reject('blank');
=> Illuminate\Support\Collection {#5774
     all: [
       "a",
       "",
       null,
       "b",
     ],
   }

// filter() works as intended:

>>> $collection->filter('blank');
=> Illuminate\Support\Collection {#5771
     all: [
       1 => "",
       2 => null,
     ],
   }

// After:

>>> $collection->reject('blank');
=> Illuminate\Support\Collection {#5774
     all: [
       0 => "a",
       3 => "b",
     ],
   }

```