### PR TITLE
Change Illuminate\Database\Query\Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -82,7 +82,7 @@ class Builder {
 	 *
 	 * @var array
 	 */
-	public $wheres;
+	public $wheres = array();
 
 	/**
 	 * The groupings for the query.


### PR DESCRIPTION
Make $wheres property an array by default to prevent count throwing errors in PHP 7.2 when called in addNestedWhereQuery.

This will allow the framework version 4.2 to be run on PHP 7.2 without issues after following this upgrade guide https://medium.com/@tomgrohl/making-laravel-4-2-work-with-php-7-2-e9149a9428c3.