### PR TITLE
[6.0] Depend on QueueManager contract

### DIFF
--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -247,16 +247,6 @@ class QueueManager implements FactoryContract, MonitorContract
     }
 
     /**
-     * Determine if the application is in maintenance mode.
-     *
-     * @return bool
-     */
-    public function isDownForMaintenance()
-    {
-        return $this->app->isDownForMaintenance();
-    }
-
-    /**
      * Dynamically pass calls to the default connection.
      *
      * @param  string  $method

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -161,8 +161,15 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
     protected function registerWorker()
     {
         $this->app->singleton('queue.worker', function () {
+            $isDownForMaintenance = function () {
+                return $this->app->isDownForMaintenance();
+            };
+
             return new Worker(
-                $this->app['queue'], $this->app['events'], $this->app[ExceptionHandler::class]
+                $this->app['queue'],
+                $this->app['events'],
+                $this->app[ExceptionHandler::class],
+                $isDownForMaintenance
             );
         });
     }
@@ -190,8 +197,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             $config = $this->app['config']['queue.failed'];
 
             return isset($config['table'])
-                        ? $this->databaseFailedJobProvider($config)
-                        : new NullFailedJobProvider;
+                ? $this->databaseFailedJobProvider($config)
+                : new NullFailedJobProvider;
         });
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -45,7 +45,7 @@ class Worker
     protected $exceptions;
 
     /**
-     * The maintenance mode check callable.
+     * The callback used to determine if the application is in maintenance mode.
      *
      * @var \callable
      */


### PR DESCRIPTION
TLDR: This is a very minor upgrade, just making sure that `Illuminate\Queue\Worker` depends on the interface instead of the concrete class for `Illuminate\Queue\QueueManager`.

As for the use case, for a package I'm building [here](https://github.com/nmokkenstorm/laravel-queue-statistics) I wanted general access to the QueueManager singleton, and decorate it with some extra functionality, but the Worker would yell at me for injecting a different concrete class.

@X-Coder264 raised a valid point [here](https://github.com/laravel/framework/pull/29225) when I targeted this change on 5.8, and earlier [here](https://github.com/laravel/framework/pull/27826), so I implemented his proposed change and targeted master / 5.9 now.

As a side note, I tried a few things to make this work without having to extend the default QueueManager class and replace it so the package could be plug & play. In the end I found [this article](https://medium.com/@orobogenius/extending-core-laravel-bindings-97f409140fc3) which told me I could extend core bindings. I couldn't find this in the documentation, would a PR for adding that be appreciated?