### PR TITLE
[5.8] Depend on QueueManager contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -7,7 +7,6 @@ about: 'Report a general framework issue. Please ensure your Laravel version is 
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
 - Database Driver & Version:
-- Are you using `PDO::ATTR_EMULATE_PREPARES => true`: y/n
 
 ### Description:
 

--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v5.8.27...5.8)
 
+### Added
+- Make TestResponse tappable ([#29033](https://github.com/laravel/framework/pull/29033))
+- Added `Support\Collection::mergeRecursive()` method ([#29084](https://github.com/laravel/framework/pull/29084))
+- Added `Support\Collection::replace()` and `Support\Collection::replaceRecursive()` methods ([#29088](https://github.com/laravel/framework/pull/29088))
+
+### Fixed
+- Fixed cache repository setMultiple with an iterator ([#29039](https://github.com/laravel/framework/pull/29039))
+- Fixed cache repository getMultiple implementation ([#29047](https://github.com/laravel/framework/pull/29047))
+
+### TODO
+- Fail job immediately after it timeouts if it wont be retried ([#29024](https://github.com/laravel/framework/pull/29024))
+
 
 ## [v5.8.27 (2019-07-02)](https://github.com/laravel/framework/compare/v5.8.26...v5.8.27)
 

--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -1,18 +1,27 @@
 # Release Notes for 5.8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v5.8.28...5.8)
+## [Unreleased](https://github.com/laravel/framework/compare/v5.8.29...5.8)
+
+
+## [v5.8.29 (2019-07-16)](https://github.com/laravel/framework/compare/v5.8.28...v5.8.29)
 
 ### Added
 - Added possibility for `WithFaker::makeFaker()` use local `app.faker_locale` config ([#29123](https://github.com/laravel/framework/pull/29123))
 - Added ability to set theme for mail notifications ([#29132](https://github.com/laravel/framework/pull/29132))
 - Added runtime for each migration to output ([#29149](https://github.com/laravel/framework/pull/29149))
 - Added possibility for `whereNull` and `whereNotNull` to accept array columns argument ([#29154](https://github.com/laravel/framework/pull/29154))
+- Allowed `Console\Scheduling\ManagesFrequencies::hourlyAt()` to accept array of integers ([#29173](https://github.com/laravel/framework/pull/29173))
 
 ### Performance
 - Improved eager loading performance for MorphTo relation ([#29129](https://github.com/laravel/framework/pull/29129))
 
 ### Fixed
 - Fixed `Builder::whereDay()` and `Builder::whereMonth()` with raw expressions
+- Fixed DELETE queries with alias on SQLite ([#29164](https://github.com/laravel/framework/pull/29164))
+- Fixed queue jobs using SerializesModels losing order of passed in collections ([#29136](https://github.com/laravel/framework/pull/29136))
+- Fixed conditional binding for nested optional dependencies ([#29180](https://github.com/laravel/framework/pull/29180))
+- Fixed: validator not failing on custom rule when message is null ([#29174](https://github.com/laravel/framework/pull/29174))
+- Fixed DELETE query bindings ([#29165](https://github.com/laravel/framework/pull/29165))
 
 
 ## [v5.8.28 (2019-07-09)](https://github.com/laravel/framework/compare/v5.8.27...v5.8.28)

--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v5.8.28...5.8)
 
+### Added
+- Added possibility for `WithFaker::makeFaker()` use local `app.faker_locale` config ([#29123](https://github.com/laravel/framework/pull/29123))
+- Added ability to set theme for mail notifications ([#29132](https://github.com/laravel/framework/pull/29132))
+- Added runtime for each migration to output ([#29149](https://github.com/laravel/framework/pull/29149))
+- Added possibility for `whereNull` and `whereNotNull` to accept array columns argument ([#29154](https://github.com/laravel/framework/pull/29154))
+
+### Performance
+- Improved eager loading performance for MorphTo relation ([#29129](https://github.com/laravel/framework/pull/29129))
+
+### Fixed
+- Fixed `Builder::whereDay()` and `Builder::whereMonth()` with raw expressions
 
 
 ## [v5.8.28 (2019-07-09)](https://github.com/laravel/framework/compare/v5.8.27...v5.8.28)

--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -1,17 +1,25 @@
 # Release Notes for 5.8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v5.8.27...5.8)
+## [Unreleased](https://github.com/laravel/framework/compare/v5.8.28...5.8)
+
+
+
+## [v5.8.28 (2019-07-09)](https://github.com/laravel/framework/compare/v5.8.27...v5.8.28)
 
 ### Added
 - Make TestResponse tappable ([#29033](https://github.com/laravel/framework/pull/29033))
 - Added `Support\Collection::mergeRecursive()` method ([#29084](https://github.com/laravel/framework/pull/29084))
 - Added `Support\Collection::replace()` and `Support\Collection::replaceRecursive()` methods ([#29088](https://github.com/laravel/framework/pull/29088))
+- Added `Session\Store::only()` method ([#29107](https://github.com/laravel/framework/pull/29107))
 
 ### Fixed
 - Fixed cache repository setMultiple with an iterator ([#29039](https://github.com/laravel/framework/pull/29039))
 - Fixed cache repository getMultiple implementation ([#29047](https://github.com/laravel/framework/pull/29047))
 
-### TODO
+### Reverted
+- Reverted [Fixed: app.stub for jquery components loading](https://github.com/laravel/framework/pull/29001) ([#29109](https://github.com/laravel/framework/pull/29109))
+
+### Changed
 - Fail job immediately after it timeouts if it wont be retried ([#29024](https://github.com/laravel/framework/pull/29024))
 
 

--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Scripts -->
+    <script src="{{ asset('js/app.js') }}" defer></script>
+
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="//fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+
+    <!-- Styles -->
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+</head>
+<body>
+    <div id="app">
+        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+            <div class="container">
+                <a class="navbar-brand" href="{{ url('/') }}">
+                    {{ config('app.name', 'Laravel') }}
+                </a>
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+
+                <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                    <!-- Left Side Of Navbar -->
+                    <ul class="navbar-nav mr-auto">
+
+                    </ul>
+
+                    <!-- Right Side Of Navbar -->
+                    <ul class="navbar-nav ml-auto">
+                        <!-- Authentication Links -->
+                        @guest
+                            <li class="nav-item">
+                                <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>
+                            </li>
+                            @if (Route::has('register'))
+                                <li class="nav-item">
+                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Register') }}</a>
+                                </li>
+                            @endif
+                        @else
+                            <li class="nav-item dropdown">
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                                    {{ Auth::user()->name }} <span class="caret"></span>
+                                </a>
+
+                                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                                    <a class="dropdown-item" href="{{ route('logout') }}"
+                                       onclick="event.preventDefault();
+                                                     document.getElementById('logout-form').submit();">
+                                        {{ __('Logout') }}
+                                    </a>
+
+                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                                        @csrf
+                                    </form>
+                                </div>
+                            </li>
+                        @endguest
+                    </ul>
+                </div>
+            </div>
+        </nav>
+
+        <main class="py-4">
+            @yield('content')
+        </main>
+    </div>
+</body>
+</html>

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -134,17 +134,13 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function getMultiple($keys, $default = null)
     {
-        if (is_null($default)) {
-            return $this->many($keys);
-        }
+        $defaults = [];
 
         foreach ($keys as $key) {
-            if (! isset($default[$key])) {
-                $default[$key] = null;
-            }
+            $defaults[$key] = $default;
         }
 
-        return $this->many($default);
+        return $this->many($defaults);
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -122,10 +122,9 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run hourly at a given offset in the hour. The
-     * offset can be either an integer or an array of integers.
+     * Schedule the event to run hourly at a given offset in the hour.
      *
-     * @param  int|array  $offset
+     * @param  array|int  $offset
      * @return $this
      */
     public function hourlyAt($offset)

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -131,6 +131,7 @@ trait ManagesFrequencies
     public function hourlyAt($offset)
     {
         $offset = is_array($offset) ? implode(',', $offset) : $offset;
+
         return $this->spliceIntoPosition(1, $offset);
     }
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -122,13 +122,15 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run hourly at a given offset in the hour.
+     * Schedule the event to run hourly at a given offset in the hour. The
+     * offset can be either an integer or an array of integers.
      *
-     * @param  int  $offset
+     * @param  int|array  $offset
      * @return $this
      */
     public function hourlyAt($offset)
     {
+        $offset = is_array($offset) ? implode(',', $offset) : $offset;
         return $this->spliceIntoPosition(1, $offset);
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -835,8 +835,7 @@ class Container implements ArrayAccess, ContainerContract
         // new instance of this class, injecting the created dependencies in.
         try {
             $instances = $this->resolveDependencies($dependencies);
-        }
-        catch (BindingResolutionException $e) {
+        } catch (BindingResolutionException $e) {
             array_pop($this->buildStack);
             throw $e;
         }

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -949,6 +949,7 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
+                array_pop($this->buildStack);
                 return $parameter->getDefaultValue();
             }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -642,7 +642,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException;
+            throw new EntryNotFoundException($id);
         }
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -833,9 +833,13 @@ class Container implements ArrayAccess, ContainerContract
         // Once we have all the constructor's parameters we can create each of the
         // dependency instances and then use the reflection instances to make a
         // new instance of this class, injecting the created dependencies in.
-        $instances = $this->resolveDependencies(
-            $dependencies
-        );
+        try {
+            $instances = $this->resolveDependencies($dependencies);
+        }
+        catch (BindingResolutionException $e) {
+            array_pop($this->buildStack);
+            throw $e;
+        }
 
         array_pop($this->buildStack);
 
@@ -949,7 +953,6 @@ class Container implements ArrayAccess, ContainerContract
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
             if ($parameter->isOptional()) {
-                array_pop($this->buildStack);
                 return $parameter->getDefaultValue();
             }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -837,6 +837,7 @@ class Container implements ArrayAccess, ContainerContract
             $instances = $this->resolveDependencies($dependencies);
         } catch (BindingResolutionException $e) {
             array_pop($this->buildStack);
+
             throw $e;
         }
 

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,6 +1,6 @@
 <?php
 
-/* @var $factory \Illuminate\Database\Eloquent\Factory */
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use NamespacedDummyModel;
 use Faker\Generator as Faker;

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -123,7 +123,9 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
                             ));
 
-        return $query->whereIn(
+        $whereIn = $this->whereInMethod($this->parent, $ownerKey);
+
+        return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
         )->get();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -123,7 +123,7 @@ class MorphTo extends BelongsTo
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
                             ));
 
-        $whereIn = $this->whereInMethod($this->parent, $ownerKey);
+        $whereIn = $this->whereInMethod($instance, $ownerKey);
 
         return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -192,14 +192,18 @@ class Migrator
 
         $this->note("<comment>Migrating:</comment> {$name}");
 
+        $startTime = microtime(true);
+
         $this->runMigration($migration, 'up');
+
+        $runTime = round(microtime(true) - $startTime, 2);
 
         // Once we have run a migrations class, we will log that it was run in this
         // repository so that we don't try to run it next time we do a migration
         // in the application. A migration repository keeps the migrate order.
         $this->repository->log($name, $batch);
 
-        $this->note("<info>Migrated:</info>  {$name}");
+        $this->note("<info>Migrated:</info>  {$name} ({$runTime} seconds)");
     }
 
     /**
@@ -349,14 +353,18 @@ class Migrator
             return $this->pretendToRun($instance, 'down');
         }
 
+        $startTime = microtime(true);
+
         $this->runMigration($instance, 'down');
+
+        $runTime = round(microtime(true) - $startTime, 2);
 
         // Once we have successfully run the migration "down" we will remove it from
         // the migration repository so it will be considered to have not been run
         // by the application then will be able to fire by any later operation.
         $this->repository->delete($migration);
 
-        $this->note("<info>Rolled back:</info>  {$name}");
+        $this->note("<info>Rolled back:</info>  {$name} ({$runTime} seconds)");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1161,7 +1161,9 @@ class Builder
             $value = $value->format('d');
         }
 
-        $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+        if (! $value instanceof Expression) {
+            $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+        }
 
         return $this->addDateBasedWhere('Day', $column, $operator, $value, $boolean);
     }
@@ -1202,7 +1204,9 @@ class Builder
             $value = $value->format('m');
         }
 
-        $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+        if (! $value instanceof Expression) {
+            $value = str_pad($value, 2, '0', STR_PAD_LEFT);
+        }
 
         return $this->addDateBasedWhere('Month', $column, $operator, $value, $boolean);
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -959,7 +959,7 @@ class Builder
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string|array  $column
+     * @param  string|array  $columns
      * @param  string  $boolean
      * @param  bool    $not
      * @return $this

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -959,16 +959,18 @@ class Builder
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string  $column
+     * @param  string|array  $column
      * @param  string  $boolean
      * @param  bool    $not
      * @return $this
      */
-    public function whereNull($column, $boolean = 'and', $not = false)
+    public function whereNull($columns, $boolean = 'and', $not = false)
     {
         $type = $not ? 'NotNull' : 'Null';
 
-        $this->wheres[] = compact('type', 'column', 'boolean');
+        foreach (Arr::wrap($columns) as $column) {
+            $this->wheres[] = compact('type', 'column', 'boolean');
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -952,7 +952,9 @@ class Grammar extends BaseGrammar
      */
     public function prepareBindingsForDelete(array $bindings)
     {
-        return Arr::flatten($bindings);
+        return Arr::flatten(
+            Arr::except($bindings, 'select')
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Query\Grammars;
 
-use Illuminate\Support\Arr;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JsonExpression;
 
@@ -241,21 +240,6 @@ class MySqlGrammar extends Grammar
         return isset($query->joins)
                     ? $this->compileDeleteWithJoins($query, $table, $where)
                     : $this->compileDeleteWithoutJoins($query, $table, $where);
-    }
-
-    /**
-     * Prepare the bindings for a delete statement.
-     *
-     * @param  array  $bindings
-     * @return array
-     */
-    public function prepareBindingsForDelete(array $bindings)
-    {
-        $cleanBindings = Arr::except($bindings, ['join', 'select']);
-
-        return array_values(
-            array_merge($bindings['join'], Arr::flatten($cleanBindings))
-        );
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Expression;
  * @method ColumnDefinition autoIncrement() Set INTEGER columns as auto-increment (primary key)
  * @method ColumnDefinition change() Change the column
  * @method ColumnDefinition charset(string $charset) Specify a character set for the column (MySQL)
- * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/SQL Server)
+ * @method ColumnDefinition collation(string $collation) Specify a collation for the column (MySQL/PostgreSQL/SQL Server)
  * @method ColumnDefinition comment(string $comment) Add a comment to the column (MySQL)
  * @method ColumnDefinition default(mixed $value) Specify a "default" value for the column
  * @method ColumnDefinition first() Place the column "first" in the table (MySQL)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -19,7 +19,7 @@ class PostgresGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Increment', 'Nullable', 'Default'];
+    protected $modifiers = ['Collate', 'Increment', 'Nullable', 'Default'];
 
     /**
      * The columns available as serials.
@@ -877,6 +877,20 @@ class PostgresGrammar extends Grammar
     private function formatPostGisType(string $type)
     {
         return "geography($type, 4326)";
+    }
+
+    /**
+     * Get the SQL for a collation column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyCollate(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->collation)) {
+            return ' collate '.$this->wrapValue($column->collation);
+        }
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -42,6 +42,6 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        return Factory::create($locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE));
+        return Factory::create($locale ?? config('app.faker_locale') ?? Factory::DEFAULT_LOCALE);
     }
 }

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -93,6 +93,10 @@ class MailChannel
             return $message->view;
         }
 
+        if (property_exists($message, 'theme') && ! is_null($message->theme)) {
+            $this->markdown->theme($message->theme);
+        }
+
         return [
             'html' => $this->markdown->render($message->markdown, $message->data()),
             'text' => $this->markdown->renderText($message->markdown, $message->data()),

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -32,6 +32,13 @@ class MailMessage extends SimpleMessage implements Renderable
     public $markdown = 'notifications::email';
 
     /**
+     * The current theme being used when generating emails.
+     *
+     * @var string|null
+     */
+    public $theme = 'default';
+
+    /**
      * The "from" information for the message.
      *
      * @var array
@@ -130,6 +137,19 @@ class MailMessage extends SimpleMessage implements Renderable
     public function template($template)
     {
         $this->markdown = $template;
+
+        return $this;
+    }
+
+    /**
+     * Set the theme to use with the markdown template.
+     *
+     * @param  string  $theme
+     * @return $this
+     */
+    public function theme($theme)
+    {
+        $this->theme = $theme;
 
         return $this;
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -142,7 +142,7 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
-     * Set the theme to use with the markdown template.
+     * Set the theme to use with the Markdown template.
      *
      * @param  string  $theme
      * @return $this

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -79,6 +79,7 @@ trait SerializesAndRestoresModelIdentifiers
         }
 
         $collection = $collection->keyBy->getKey();
+
         $collectionClass = get_class($collection);
 
         return new $collectionClass(

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -73,7 +73,8 @@ trait SerializesAndRestoresModelIdentifiers
             (new $value->class)->setConnection($value->connection), $value->id
         )->useWritePdo()->get();
 
-        if (is_a($value->class, Pivot::class, true) || in_array(AsPivot::class, class_uses($value->class))) {
+        if (is_a($value->class, Pivot::class, true) ||
+            in_array(AsPivot::class, class_uses($value->class))) {
             return $collection;
         }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -67,9 +67,13 @@ trait SerializesAndRestoresModelIdentifiers
             return new EloquentCollection;
         }
 
-        return $this->getQueryForModelRestoration(
+        $collection = $this->getQueryForModelRestoration(
             (new $value->class)->setConnection($value->connection), $value->id
-        )->useWritePdo()->get();
+        )->useWritePdo()->get()->keyBy->getKey();
+
+        return new EloquentCollection(
+            collect($value->id)->map(function ($id) use ($collection) { return $collection[$id]; })
+        );
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -3,11 +3,11 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\QueueableCollection;
-use Illuminate\Database\Eloquent\Collection as EloquentCollection;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 trait SerializesAndRestoresModelIdentifiers
 {
@@ -80,7 +80,9 @@ trait SerializesAndRestoresModelIdentifiers
         $collection = $collection->keyBy->getKey();
 
         return new EloquentCollection(
-            collect($value->id)->map(function ($id) use ($collection) { return $collection[$id]; })
+            collect($value->id)->map(function ($id) use ($collection) {
+                return $collection[$id];
+            })
         );
     }
 

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -79,8 +79,9 @@ trait SerializesAndRestoresModelIdentifiers
         }
 
         $collection = $collection->keyBy->getKey();
+        $collectionClass = get_class($collection);
 
-        return new EloquentCollection(
+        return new $collectionClass(
             collect($value->id)->map(function ($id) use ($collection) {
                 return $collection[$id];
             })

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -327,9 +327,7 @@ class Worker
             );
 
             if ($job->isDeleted()) {
-                $this->raiseAfterJobEvent($connectionName, $job);
-
-                return;
+                return $this->raiseAfterJobEvent($connectionName, $job);
             }
 
             // Here we will fire off the job and let it process. We will catch any exceptions so

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -326,6 +326,12 @@ class Worker
                 $connectionName, $job, (int) $options->maxTries
             );
 
+            if ($job->isDeleted()) {
+                $this->raiseAfterJobEvent($connectionName, $job);
+
+                return;
+            }
+
             // Here we will fire off the job and let it process. We will catch any exceptions so
             // they can be reported to the developers logs, etc. Once the job is finished the
             // proper events will be fired to let any listeners know this job has finished.

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\DetectsLostConnections;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Contracts\Queue\Factory as QueueManager;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Illuminate\Contracts\Cache\Repository as CacheContract;
 
@@ -18,7 +19,7 @@ class Worker
     /**
      * The queue manager instance.
      *
-     * @var \Illuminate\Queue\QueueManager
+     * @var \Illuminate\Contracts\Queue\Factory
      */
     protected $manager;
 
@@ -60,7 +61,7 @@ class Worker
     /**
      * Create a new queue worker.
      *
-     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @param  \Illuminate\Contracts\Queue\Factory $manager
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  \Illuminate\Contracts\Debug\ExceptionHandler  $exceptions
      * @return void
@@ -636,7 +637,7 @@ class Worker
     /**
      * Set the queue manager instance.
      *
-     * @param  \Illuminate\Queue\QueueManager  $manager
+     * @param  \Illuminate\Contracts\Queue\Factory $manager
      * @return void
      */
     public function setManager(QueueManager $manager)

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -173,7 +173,7 @@ class Store implements Session
      * @param  array  $keys
      * @return array
      */
-    public function only($keys)
+    public function only(array $keys)
     {
         return Arr::only($this->attributes, $keys);
     }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -168,6 +168,17 @@ class Store implements Session
     }
 
     /**
+     * Get a subset of the session data.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function only($keys)
+    {
+        return Arr::only($this->attributes, $keys);
+    }
+
+    /**
      * Checks if a key exists.
      *
      * @param  string|array  $key

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -2127,7 +2127,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         } elseif ($items instanceof Jsonable) {
             return json_decode($items->toJson(), true);
         } elseif ($items instanceof JsonSerializable) {
-            return $items->jsonSerialize();
+            return (array) $items->jsonSerialize();
         } elseif ($items instanceof Traversable) {
             return iterator_to_array($items);
         }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1530,6 +1530,28 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replace($items)
+    {
+        return new static(array_replace($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
+     * Recursively replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replaceRecursive($items)
+    {
+        return new static(array_replace_recursive($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
      * Reverse items order.
      *
      * @return static

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1259,6 +1259,17 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Recursively merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeRecursive($items)
+    {
+        return new static(array_merge_recursive($this->items, $this->getArrayableItems($items)));
+    }
+
+    /**
      * Create a collection by using this collection for keys and another for its values.
      *
      * @param  mixed  $values

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -572,7 +572,7 @@ class Validator implements ValidatorContract
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
-            $messages = (array) $rule->message();
+            $messages = $rule->message() ? (array) $rule->message() : [get_class($rule)];
 
             foreach ($messages as $message) {
                 $this->messages->add($attribute, $this->makeReplacements(

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -276,11 +276,11 @@ class CacheRepositoryTest extends TestCase
     public function testGettingMultipleValuesFromCache()
     {
         $keys = ['key1', 'key2', 'key3'];
-        $default = ['key2' => 5];
+        $default = 5;
 
         $repo = $this->getRepository();
-        $repo->getStore()->shouldReceive('many')->once()->with(['key2', 'key1', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
-        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => null], $repo->getMultiple($keys, $default));
+        $repo->getStore()->shouldReceive('many')->once()->with(['key1', 'key2', 'key3'])->andReturn(['key1' => 1, 'key2' => null, 'key3' => null]);
+        $this->assertEquals(['key1' => 1, 'key2' => 5, 'key3' => 5], $repo->getMultiple($keys, $default));
     }
 
     public function testRemovingMultipleKeys()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -47,6 +47,7 @@ class FrequencyTest extends TestCase
     {
         $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15,30,45])->getExpression());
     }
 
     public function testMonthlyOn()

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -47,7 +47,7 @@ class FrequencyTest extends TestCase
     {
         $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
         $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
-        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15,30,45])->getExpression());
+        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
     public function testMonthlyOn()

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -210,7 +210,6 @@ class ContextualBindingTest extends TestCase
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $two->impl);
     }
 
-
     public function testContextualBindingWorksForNestedPrimitiveResolvingForMultipleClassesInjection()
     {
         $container = new Container;

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -215,22 +215,22 @@ class ContextualBindingTest extends TestCase
     {
         $container = new Container;
 
-        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextPrimitiveTwo::class)->give(function() {
-            return new ContainerTestContextPrimitiveTwo('test');
+        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function() {
+            return new ContainerTestContextInjectTwo(new ContainerContextImplementationStubTwo);
         });
 
         $resolvedInstance = $container->make(ContainerTestContextInjectTwoInstances::class);
         $this->assertInstanceOf(
-            ContainerTestContextWithNestedOptionalDependencyStubWithPrimitive::class,
+            ContainerTestContextWithOptionalInnerDependency::class,
             $resolvedInstance->implOne
         );
         $this->assertNull($resolvedInstance->implOne->inner);
 
         $this->assertInstanceOf(
-            ContainerTestContextPrimitiveTwo::class,
+            ContainerTestContextInjectTwo::class,
             $resolvedInstance->implTwo
         );
-        $this->assertEquals($resolvedInstance->implTwo->primitive, 'test');
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->implTwo->impl);
     }
 }
 
@@ -294,39 +294,19 @@ class ContainerTestContextInjectTwoInstances
     public $implOne;
     public $implTwo;
 
-    public function __construct(ContainerTestContextWithNestedOptionalDependencyStubWithPrimitive $implOne, ContainerTestContextPrimitiveTwo $implTwo)
+    public function __construct(ContainerTestContextWithOptionalInnerDependency $implOne, ContainerTestContextInjectTwo $implTwo)
     {
         $this->implOne = $implOne;
         $this->implTwo = $implTwo;
     }
 }
 
-class ContainerTestContextWithNestedOptionalDependencyStubWithPrimitive
+class ContainerTestContextWithOptionalInnerDependency
 {
     public $inner;
 
-    public function __construct(ContainerTestContextPrimitiveOne $inner = null)
+    public function __construct(ContainerTestContextInjectOne $inner = null)
     {
         $this->inner = $inner;
-    }
-}
-
-class ContainerTestContextPrimitiveOne
-{
-    public $primitive;
-
-    public function __construct(string $primitive)
-    {
-        $this->primitive = $primitive;
-    }
-}
-
-class ContainerTestContextPrimitiveTwo
-{
-    public $primitive;
-
-    public function __construct(string $primitive)
-    {
-        $this->primitive = $primitive;
     }
 }

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -213,7 +213,8 @@ class ContextualBindingTest extends TestCase
     public function testContextualBindingWorksForNestedPrimitiveResolvingForMultipleClassesInjection()
     {
         $container = new Container;
-        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function() {
+
+        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function () {
             return new ContainerTestContextInjectTwo(new ContainerContextImplementationStubTwo);
         });
 

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -213,8 +213,6 @@ class ContextualBindingTest extends TestCase
     public function testContextualBindingWorksForNestedPrimitiveResolvingForMultipleClassesInjection()
     {
         $container = new Container;
-
-
         $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function() {
             return new ContainerTestContextInjectTwo(new ContainerContextImplementationStubTwo);
         });

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -214,6 +214,7 @@ class ContextualBindingTest extends TestCase
     {
         $container = new Container;
 
+
         $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function() {
             return new ContainerTestContextInjectTwo(new ContainerContextImplementationStubTwo);
         });

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -210,7 +210,7 @@ class ContextualBindingTest extends TestCase
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $two->impl);
     }
 
-    public function testContextualBindingWorksForNestedPrimitiveResolvingForMultipleClassesInjection()
+    public function testContextualBindingWorksForNestedOptionalDependencies()
     {
         $container = new Container;
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -21,10 +21,11 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->create();
         $blueprint->increments('id');
         $blueprint->string('email');
+        $blueprint->string('name')->collation('nb_NO.utf8');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2087,6 +2087,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->delete(1);
         $this->assertEquals(1, $result);
 
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "users"."id" = ?', [1])->andReturn(1);
+        $result = $builder->from('users')->selectRaw('?', ['ignore'])->delete(1);
+        $this->assertEquals(1, $result);
+
         $builder = $this->getSqliteBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" where "rowid" in (select "users"."rowid" from "users" where "email" = ? order by "id" asc limit 1)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->where('email', '=', 'foo')->orderBy('id')->take(1)->delete();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -338,7 +338,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals('select * from `users` where `id` = ? or month(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('users')->where('id', 1)->orWhereyear('created_at', 1);
+        $builder->select('*')->from('users')->where('id', 1)->orWhereYear('created_at', 1);
         $this->assertEquals('select * from `users` where `id` = ? or year(`created_at`) = ?', $builder->toSql());
     }
 
@@ -347,6 +347,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'))->where('admin', true);
         $this->assertEquals([true], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereDay('created_at', new Raw('NOW()'));
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereMonth('created_at', new Raw('NOW()'));
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereYear('created_at', new Raw('NOW()'));
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testWhereDateMySql()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -981,6 +981,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testArrayWhereNulls()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNull(['id', 'expires_at']);
+        $this->assertEquals('select * from "users" where "id" is null and "expires_at" is null', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull(['id', 'expires_at']);
+        $this->assertEquals('select * from "users" where "id" = ? or "id" is null or "expires_at" is null', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
     public function testBasicWhereNotNulls()
     {
         $builder = $this->getBuilder();
@@ -991,6 +1004,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
         $this->assertEquals('select * from "users" where "id" > ? or "id" is not null', $builder->toSql());
+        $this->assertEquals([0 => 1], $builder->getBindings());
+    }
+
+    public function testArrayWhereNotNulls()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereNotNull(['id', 'expires_at']);
+        $this->assertEquals('select * from "users" where "id" is not null and "expires_at" is not null', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull(['id', 'expires_at']);
+        $this->assertEquals('select * from "users" where "id" > ? or "id" is not null or "expires_at" is not null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2110,6 +2110,11 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('users.email', '=', 'foo')->orderBy('users.id')->limit(1)->delete();
         $this->assertEquals(1, $result);
 
+        $builder = $this->getSqliteBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" as "u" where "rowid" in (select "u"."rowid" from "users" as "u" inner join "contacts" as "c" on "u"."id" = "c"."id")', [])->andReturn(1);
+        $result = $builder->from('users as u')->join('contacts as c', 'u.id', '=', 'c.id')->delete();
+        $this->assertEquals(1, $result);
+
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('delete')->once()->with('delete `users` from `users` inner join `contacts` on `users`.`id` = `contacts`.`id` where `email` = ?', ['foo'])->andReturn(1);
         $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->where('email', '=', 'foo')->orderBy('id')->limit(1)->delete();

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -23,4 +23,17 @@ class FoundationAliasLoaderTest extends TestCase
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
         $this->assertSame($loader, AliasLoader::getInstance());
     }
+
+    public function testLoaderCanBeCreatedAndRegisteredMergingAliases()
+    {
+        $loader = AliasLoader::getInstance(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
+
+        $loader = AliasLoader::getInstance(['foo2' => 'bar2']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases());
+
+        // override keys
+        $loader = AliasLoader::getInstance(['foo' => 'baz']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
+    }
 }

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -36,4 +36,34 @@ class FoundationAliasLoaderTest extends TestCase
         $loader = AliasLoader::getInstance(['foo' => 'baz']);
         $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
     }
+
+    public function testLoaderCanAliasAndLoadClasses()
+    {
+        $loader = AliasLoader::getInstance(['some_alias_foo_bar' => FoundationAliasLoaderStub::class]);
+
+        $result = $loader->load('some_alias_foo_bar');
+
+        $this->assertInstanceOf(FoundationAliasLoaderStub::class, new \some_alias_foo_bar);
+        $this->assertTrue($result);
+
+        $result2 = $loader->load('bar');
+        $this->assertNull($result2);
+    }
+
+    public function testSetAlias()
+    {
+        $loader = AliasLoader::getInstance();
+        $loader->setAliases(['some_alias_foo' => FoundationAliasLoaderStub::class]);
+
+        $result = $loader->load('some_alias_foo');
+
+        $fooObj = new \some_alias_foo;
+        $this->assertInstanceOf(FoundationAliasLoaderStub::class, $fooObj);
+        $this->assertTrue($result);
+    }
+}
+
+class FoundationAliasLoaderStub
+{
+    //
 }

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -74,6 +74,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->once()->andReturnSelf();
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -118,6 +119,7 @@ class SendingMailNotificationsTest extends TestCase
             'name' => 'Taylor Otwell',
         ]);
 
+        $this->markdown->shouldReceive('theme')->once()->andReturnSelf();
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -161,6 +163,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->once()->andReturnSelf();
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 
@@ -194,6 +197,7 @@ class SendingMailNotificationsTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
+        $this->markdown->shouldReceive('theme')->once()->andReturnSelf();
         $this->markdown->shouldReceive('render')->once()->andReturn('htmlContent');
         $this->markdown->shouldReceive('renderText')->once()->andReturn('textContent');
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -220,6 +220,21 @@ class ModelSerializationTest extends TestCase
 
         unserialize($serialized);
     }
+
+    public function test_it_serializes_a_collection_in_correct_order()
+    {
+        ModelSerializationTestUser::create([ 'email' => 'mohamed@laravel.com' ]);
+        ModelSerializationTestUser::create([ 'email' => 'taylor@laravel.com' ]);
+
+        $serialized = serialize(new CollectionSerializationTestClass(
+            ModelSerializationTestUser::orderByDesc('email')->get()
+        ));
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($unserialized->users->first()->email, 'taylor@laravel.com');
+        $this->assertEquals($unserialized->users->last()->email, 'mohamed@laravel.com');
+    }
 }
 
 class ModelSerializationTestUser extends Model
@@ -328,5 +343,17 @@ class ModelRelationSerializationTestClass
     public function __construct($order)
     {
         $this->order = $order;
+    }
+}
+
+class CollectionSerializationTestClass
+{
+    use SerializesModels;
+
+    public $users;
+
+    public function __construct($users)
+    {
+        $this->users = $users;
     }
 }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -223,8 +223,8 @@ class ModelSerializationTest extends TestCase
 
     public function test_it_serializes_a_collection_in_correct_order()
     {
-        ModelSerializationTestUser::create([ 'email' => 'mohamed@laravel.com' ]);
-        ModelSerializationTestUser::create([ 'email' => 'taylor@laravel.com' ]);
+        ModelSerializationTestUser::create(['email' => 'mohamed@laravel.com']);
+        ModelSerializationTestUser::create(['email' => 'taylor@laravel.com']);
 
         $serialized = serialize(new CollectionSerializationTestClass(
             ModelSerializationTestUser::orderByDesc('email')->get()

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -235,6 +235,20 @@ class ModelSerializationTest extends TestCase
         $this->assertEquals($unserialized->users->first()->email, 'taylor@laravel.com');
         $this->assertEquals($unserialized->users->last()->email, 'mohamed@laravel.com');
     }
+
+    public function test_it_can_unserialize_custom_collection()
+    {
+        ModelSerializationTestCustomUser::create(['email' => 'mohamed@laravel.com']);
+        ModelSerializationTestCustomUser::create(['email' => 'taylor@laravel.com']);
+
+        $serialized = serialize(new CollectionSerializationTestClass(
+            ModelSerializationTestCustomUser::all()
+        ));
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertInstanceOf(ModelSerializationTestCustomUserCollection::class, $unserialized->users);
+    }
 }
 
 class ModelSerializationTestUser extends Model
@@ -242,6 +256,22 @@ class ModelSerializationTestUser extends Model
     public $table = 'users';
     public $guarded = ['id'];
     public $timestamps = false;
+}
+
+class ModelSerializationTestCustomUserCollection extends Collection
+{
+}
+
+class ModelSerializationTestCustomUser extends Model
+{
+    public $table = 'users';
+    public $guarded = ['id'];
+    public $timestamps = false;
+
+    public function newCollection(array $models = [])
+    {
+        return new ModelSerializationTestCustomUserCollection($models);
+    }
 }
 
 class Order extends Model

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -258,6 +258,22 @@ class QueueWorkerTest extends TestCase
         $this->assertEquals(10, $job->releaseAfter);
     }
 
+    public function test_job_does_not_fire_if_deleted()
+    {
+        $job = new WorkerFakeJob(function () {
+            return true;
+        });
+
+        $worker = $this->getWorker('default', ['queue' => [$job]]);
+        $job->delete();
+        $worker->runNextJob('default', 'queue', $this->workerOptions());
+
+        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->once();
+        $this->assertFalse($job->hasFailed());
+        $this->assertFalse($job->isReleased());
+        $this->assertTrue($job->isDeleted());
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -211,6 +211,15 @@ class SessionStoreTest extends TestCase
         $this->assertFalse(array_search('foo', $session->get('_flash.old')));
     }
 
+    public function testOnly()
+    {
+        $session = $this->getSession();
+        $session->put('foo', 'bar');
+        $session->put('qu', 'ux');
+        $this->assertEquals(['foo' => 'bar', 'qu' => 'ux'], $session->all());
+        $this->assertEquals(['qu' => 'ux'], $session->only(['qu']));
+    }
+
     public function testReplace()
     {
         $session = $this->getSession();

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -178,6 +178,10 @@ class SupportCollectionTest extends TestCase
         $array = $method->invokeArgs($collection, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
+        $items = new TestJsonSerializeWithScalarValueObject;
+        $array = $method->invokeArgs($collection, [$items]);
+        $this->assertSame(['foo'], $array);
+
         $items = new Collection(['foo' => 'bar']);
         $array = $method->invokeArgs($collection, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
@@ -3294,6 +3298,14 @@ class TestJsonSerializeObject implements JsonSerializable
     public function jsonSerialize()
     {
         return ['foo' => 'bar'];
+    }
+}
+
+class TestJsonSerializeWithScalarValueObject implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return 'foo';
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -702,7 +702,10 @@ class SupportCollectionTest extends TestCase
     public function testReplaceCollection()
     {
         $c = new Collection(['a', 'b', 'c']);
-        $this->assertEquals(['a', 'd', 'e'], $c->replace(new Collection([1 => 'd', 2 => 'e']))->all());
+        $this->assertEquals(
+            ['a', 'd', 'e'],
+            $c->replace(new Collection([1 => 'd', 2 => 'e']))->all()
+        );
     }
 
     public function testReplaceRecursiveNull()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -680,10 +680,10 @@ class SupportCollectionTest extends TestCase
 
     public function testMergeRecursiveCollection()
     {
-        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $c = new Collection(['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b'], 'roles' => 'admin']]);
         $this->assertEquals(
-            ['name' => ['Hello', 'World'], 'id' => [1, 2]],
-            $c->mergeRecursive(new Collection(['name' => 'World', 'id' => 2]))->all()
+            ['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b', 'c'], 'roles' => ['admin', 'editor']]],
+            $c->mergeRecursive(new Collection(['meta' => ['tags' => ['c'], 'roles' => 'editor']]))->all()
         );
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -666,6 +666,27 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
     }
 
+    public function testMergeRecursiveNull()
+    {
+        $c = new Collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello'], $c->mergeRecursive(null)->all());
+    }
+
+    public function testMergeRecursiveArray()
+    {
+        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $this->assertEquals(['name' => 'Hello', 'id' => [1, 2]], $c->mergeRecursive(['id' => 2])->all());
+    }
+
+    public function testMergeRecursiveCollection()
+    {
+        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $this->assertEquals(
+            ['name' => ['Hello', 'World'], 'id' => [1, 2]],
+            $c->mergeRecursive(new Collection(['name' => 'World', 'id' => 2]))->all()
+        );
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -687,6 +687,45 @@ class SupportCollectionTest extends TestCase
         );
     }
 
+    public function testReplaceNull()
+    {
+        $c = new Collection(['a', 'b', 'c']);
+        $this->assertEquals(['a', 'b', 'c'], $c->replace(null)->all());
+    }
+
+    public function testReplaceArray()
+    {
+        $c = new Collection(['a', 'b', 'c']);
+        $this->assertEquals(['a', 'd', 'e'], $c->replace([1 => 'd', 2 => 'e'])->all());
+    }
+
+    public function testReplaceCollection()
+    {
+        $c = new Collection(['a', 'b', 'c']);
+        $this->assertEquals(['a', 'd', 'e'], $c->replace(new Collection([1 => 'd', 2 => 'e']))->all());
+    }
+
+    public function testReplaceRecursiveNull()
+    {
+        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $this->assertEquals(['a', 'b', ['c', 'd']], $c->replaceRecursive(null)->all());
+    }
+
+    public function testReplaceRecursiveArray()
+    {
+        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $this->assertEquals(['z', 'b', ['c', 'e']], $c->replaceRecursive(['z', 2 => [1 => 'e']])->all());
+    }
+
+    public function testReplaceRecursiveCollection()
+    {
+        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $this->assertEquals(
+            ['z', 'b', ['c', 'e']],
+            $c->replaceRecursive(new Collection(['z', 2 => [1 => 'e']]))->all()
+        );
+    }
+
     public function testUnionNull()
     {
         $c = new Collection(['name' => 'Hello']);


### PR DESCRIPTION
A very minor upgrade, just making the `Illuminate\Queue\Worker` depend on the interface instead of the concrete class for `Illuminate\Queue\QueueManager`. Other than the Manager, the constructor of the Worker depends on two other interfaces, which to me seems to be the way to go here.

For a package I'm building [here](https://github.com/nmokkenstorm/laravel-queue-statistics) I wanted general access to the QueueManager singleton to decorate it with some extra functionality, but the Worker would yell at me for injecting a different concrete class.

As a side note, I tried a few things to make this work without having to extend the default QueueManager class and replace it so the package could be plug & play. In the end I found [this article](https://medium.com/@orobogenius/extending-core-laravel-bindings-97f409140fc3) which told me I could extend core bindings. I couldn't find this in the documentation, would a PR  for adding that be appreciated?