### PR TITLE
[5.8] Allocate memory for error handling to allow handling memory exhaustion limits

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -12,6 +12,8 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class HandleExceptions
 {
+    static $reservedMemory;
+
     /**
      * The application instance.
      *
@@ -27,6 +29,8 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
+        self::$reservedMemory = str_repeat('x', 10240);
+
         $this->app = $app;
 
         error_reporting(-1);
@@ -78,6 +82,7 @@ class HandleExceptions
         }
 
         try {
+            self::$reservedMemory = null;
             $this->getExceptionHandler()->report($e);
         } catch (Exception $e) {
             //

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -12,7 +12,7 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class HandleExceptions
 {
-    static $reservedMemory;
+    public static $reservedMemory;
 
     /**
      * The application instance.


### PR DESCRIPTION
Allots 10kb of memory for "memory exhaustion" errors.

It lets the application give a more descriptive error than the default Fatal Error that is thrown for memory exhaustion. 

The concept was taken from Symfony's error handler: https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/ErrorHandler/ErrorHandler.php.