### PR TITLE
[5.8] Add ability to add translation runtime

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -101,6 +101,28 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         return $this->get($key, $replace, $locale);
     }
 
+
+    /**
+     * set the translation for the given key.
+     *
+     * @param string $key
+     * @param string $value
+     * @param string|null $locale
+     * @return void
+     */
+    public function set($key, $value, $locale = null)
+    {
+        [$namespace, $group, $item] = $this->parseKey($key);
+
+        $this->loaded = $this->loaded ?? [];
+        $this->loaded[$namespace] = $this->loaded[$namespace] ?? [];
+        $this->loaded[$namespace][$group] = $this->loaded[$namespace][$group] ?? [];
+        $this->loaded[$namespace][$group] = $this->loaded[$namespace][$group] ?? [];
+
+        Arr::set($this->loaded[$namespace][$group][$locale], $item, $value);
+    }
+
+
     /**
      * Get the translation for the given key.
      *

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -101,7 +101,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         return $this->get($key, $replace, $locale);
     }
 
-
     /**
      * set the translation for the given key.
      *
@@ -121,7 +120,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
 
         Arr::set($this->loaded[$namespace][$group][$locale], $item, $value);
     }
-
 
     /**
      * Get the translation for the given key.

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -179,6 +179,13 @@ class TranslationTranslatorTest extends TestCase
         $this->assertEquals('foo baz', $t->getFromJson('foo :message', ['message' => 'baz']));
     }
 
+    public function testSetTranslation()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->set('test.test', 'this is test', 'en');
+        $this->assertEquals('this is test', $t->get('test.test'));
+    }
+
     protected function getLoader()
     {
         return m::mock(Loader::class);


### PR DESCRIPTION
This PR adds the new method to the Translator. This way you can set translation runtime.
This way you can do stuff like this:
```
        \App::setLocale('en');
        app('translator')->set('test.test', 'this is test', 'en');
        $this->assertEquals('this is test',__('test.test'));
```

