### PR TITLE
[5.9] Collection count callables

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1970,7 +1970,6 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      * Count the number of items in the collection.
      *
      * @param callable|null $callback
-     *
      * @return int
      */
     public function count($callback = null)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1969,11 +1969,19 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Count the number of items in the collection.
      *
+     * @param callable|null $callback
+     *
      * @return int
      */
-    public function count()
+    public function count($callback = null)
     {
-        return count($this->items);
+        if (is_null($callback)) {
+            return count($this->items);
+        }
+
+        return $this->reduce(function ($count, $value) use ($callback) {
+            return $count + $callback($value);
+        }, 0);
     }
 
     /**

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1969,7 +1969,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     /**
      * Count the number of items in the collection.
      *
-     * @param callable|null $callback
+     * @param  callable|null  $callback
      * @return int
      */
     public function count($callback = null)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -357,12 +357,12 @@ class SupportCollectionTest extends TestCase
     public function testCountWithCallable()
     {
         $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
-        $this->assertEquals(1, $c->count(function($value){
+        $this->assertEquals(1, $c->count(function ($value) {
             return $value === 'alice';
         }));
 
         $c = new Collection([]);
-        $this->assertEquals(0, $c->count(function($value){
+        $this->assertEquals(0, $c->count(function ($value) {
             return $value === 'alice';
         }));
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -345,6 +345,28 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf(CachingIterator::class, $c->getCachingIterator());
     }
 
+    public function testCount()
+    {
+        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $this->assertEquals(4, $c->count());
+
+        $c = new Collection([]);
+        $this->assertEquals(0, $c->count());
+    }
+
+    public function testCountWithCallable()
+    {
+        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $this->assertEquals(1, $c->count(function($value){
+            return $value === 'alice';
+        }));
+
+        $c = new Collection([]);
+        $this->assertEquals(0, $c->count(function($value){
+            return $value === 'alice';
+        }));
+    }
+
     public function testFilter()
     {
         $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);


### PR DESCRIPTION
Let's say you want to count the users:
```php
$users->count();
```

What if we only want to count the admin users?
```php
$users->filter(function (User $user) {
      return $user->isAdmin();
})->count();
```

Can't we make this nicer? This PR adds support for a callable inside the count method of a collection. When a callable is true the count is raised, when false the count remains the same:

```php
$users->count(function (User $user) {
      return $user->isAdmin();
});
```

The PR has some side-effects, when someone implemented their own version of `count()` it can break due to the extra parameter.

Let me know what you think!