### PR TITLE
[5.9] Collection::reject() supports string callable

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1509,12 +1509,10 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function reject($callback = true)
     {
-        $useAsCallable = $this->useAsCallable($callback);
+        $isCallable = is_callable($callback);
 
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
-            return $useAsCallable
-                ? ! $callback($value, $key)
-                : $value != $callback;
+        return $this->filter(function ($value, $key) use ($callback, $isCallable) {
+            return $isCallable ? ! $callback($value, $key) : $value != $callback;
         });
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2161,6 +2161,9 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['primary' => 'foo', 'secondary' => 'bar'], $c->reject(function ($item, $key) {
             return $key == 'id';
         })->all());
+
+        $c = new Collection(['foo', '', null, 'bar']);
+        $this->assertEquals(['foo', 'bar'], $c->reject('blank')->values()->all());
     }
 
     public function testRejectWithoutAnArgumentRemovesTruthyValues()


### PR DESCRIPTION
Copy of https://github.com/laravel/framework/pull/29222 for master branch, as it could be a potential breaking change for those who filter against array values that match built-in/global methods.