### PR TITLE
[6.0] Fixed mismatching method signatures for unqueue in QueueingFactory

### DIFF
--- a/src/Illuminate/Contracts/Cookie/QueueingFactory.php
+++ b/src/Illuminate/Contracts/Cookie/QueueingFactory.php
@@ -16,8 +16,9 @@ interface QueueingFactory extends Factory
      * Remove a cookie from the queue.
      *
      * @param  string  $name
+     * @param  string|null  $path
      */
-    public function unqueue($name);
+    public function unqueue($name, $path = null);
 
     /**
      * Get the cookies which have been queued for the next request.

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -164,12 +164,14 @@ class CookieJar implements JarContract
     {
         if ($path === null) {
             unset($this->queued[$name]);
-        } else {
-            unset($this->queued[$name][$path]);
 
-            if (empty($this->queued[$name])) {
-                unset($this->queued[$name]);
-            }
+            return;
+        }
+
+        unset($this->queued[$name][$path]);
+
+        if (empty($this->queued[$name])) {
+            unset($this->queued[$name]);
         }
     }
 


### PR DESCRIPTION
This PR fixes the mismatching method signatures for the `unqueue` method in `QueueingFactory` and `CookieJar` I missed in the PR #29209.
Additionally, I removed the nested `if` statements in `unqueue` like @danilopinotti suggested.
