### PR TITLE
[6.0] Refactor INSERT queries

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -838,6 +838,10 @@ class Grammar extends BaseGrammar
         // basic routine regardless of an amount of records given to us to insert.
         $table = $this->wrapTable($query->from);
 
+        if (empty($values)) {
+            return "insert into {$table} default values";
+        }
+
         if (! is_array(reset($values))) {
             $values = [$values];
         }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -125,6 +125,22 @@ class MySqlGrammar extends Grammar
     }
 
     /**
+     * Compile an insert statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsert(Builder $query, array $values)
+    {
+        if (empty($values)) {
+            $values = [[]];
+        }
+
+        return parent::compileInsert($query, $values);
+    }
+
+    /**
      * Compile an update statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -211,18 +211,6 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function compileInsert(Builder $query, array $values)
-    {
-        $table = $this->wrapTable($query->from);
-
-        return empty($values)
-                ? "insert into {$table} DEFAULT VALUES"
-                : parent::compileInsert($query, $values);
-    }
-
-    /**
      * Compile an insert and get ID statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -163,22 +163,6 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
-     * Compile an insert statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $values
-     * @return string
-     */
-    public function compileInsert(Builder $query, array $values)
-    {
-        $table = $this->wrapTable($query->from);
-
-        return empty($values)
-                ? "insert into {$table} DEFAULT VALUES"
-                : parent::compileInsert($query, $values);
-    }
-
-    /**
      * Compile an update statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1856,6 +1856,25 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testInsertGetIdWithEmptyValues()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into `users` () values ()', [], null);
+        $builder->from('users')->insertGetId([]);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" default values returning "id"', [], null);
+        $builder->from('users')->insertGetId([]);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" default values', [], null);
+        $builder->from('users')->insertGetId([]);
+
+        $builder = $this->getSqlServerBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into [users] default values', [], null);
+        $builder->from('users')->insertGetId([]);
+    }
+
     public function testInsertMethodRespectsRawBindings()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Empty `INSERT` queries require different syntaxes depending on the database:

```php
class User extends Model
{
    public $timestamps = false;
}

Schema::create('users', function (Blueprint $table) {
    $table->increments('id');
    $table->string('name')->nullable();
});

User::create([]);
```

```sql
insert into `tests` () values ()   # MySQL

insert into "tests" default values # PostgreSQL, SQLite, SQL Server
```

Laravel doesn't yet support this query on SQL Server. We can fix that and use the opportunity for some refactoring. Since three databases use the `default values` syntax, we can make it default and only override the implementation for MySQL.

I targeted 5.9, but it shouldn't be a breaking change unless someone implements a custom query grammar and expects `compileInsert()` to return the MySQL syntax.
