### PR TITLE
[5.8] Pair identity column types with increments

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -594,6 +594,71 @@ class Blueprint
     }
 
     /**
+     * Create a new non-incrementing column on the table with the "increments" data type.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     *
+     * @see increments()
+     */
+    public function identity($column)
+    {
+        return $this->unsignedInteger($column);
+    }
+
+    /**
+     * Create a new non-incrementing column on the table with the "tinyIncrements" data type.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     *
+     * @see tinyIncrements()
+     */
+    public function tinyIdentity($column)
+    {
+        return $this->unsignedTinyInteger($column);
+    }
+
+    /**
+     * Create a new non-incrementing column on the table with the "smallIncrements" data type.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     *
+     * @see smallIncrements()
+     */
+    public function smallIdentity($column)
+    {
+        return $this->unsignedSmallInteger($column);
+    }
+
+    /**
+     * Create a new non-incrementing column on the table with the "mediumIncrements" data type.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     *
+     * @see mediumIncrements()
+     */
+    public function mediumIdentity($column)
+    {
+        return $this->unsignedMediumInteger($column);
+    }
+
+    /**
+     * Create a new non-incrementing column on the table with the "bigIncrements" data type.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     *
+     * @see bigIncrements()
+     */
+    public function bigIdentity($column)
+    {
+        return $this->unsignedBigInteger($column);
+    }
+
+    /**
      * Create a new char column on the table.
      *
      * @param  string  $column


### PR DESCRIPTION
This provides a set of aliases to pair with the _increments_ column types. Since `increments` (now `bigIncrements`) is the default column type of _identity_ columns, it would be nice to have an expressive, complimentary column type for related columns.

This would help avoid column type mismatches when defining foreign keys as well as allow flexibility in the framework definitions between drivers and versions.

**Before:**
```php
Schema::create('comments', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->unsignedBigInteger('post_id');
});
```

**After:**
```php
Schema::create('comments', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->bigIdentity('post_id');
});
```
