### PR TITLE
[5.8] Fix variable names in alias method

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -134,13 +134,13 @@ class AliasLoader
     /**
      * Add an alias to the loader.
      *
-     * @param  string  $class
      * @param  string  $alias
+     * @param  string  $class
      * @return void
      */
-    public function alias($class, $alias)
+    public function alias($alias, $class)
     {
-        $this->aliases[$class] = $alias;
+        $this->aliases[$alias] = $class;
     }
 
     /**


### PR DESCRIPTION
If we take a close look, it is obvious that the variable names are wrong.
The first one is the Alias, and the second one is the Original class name.

Sample working usage : 
```php
AliasLoader::getInstance()->alias('DB', DB::class);
```
we should pass original class path as the second argument.

Also it contradicts what we have on line 80 : 
**https://github.com/laravel/framework/blob/1003c27b73f11472c1ebdb9238b839aefddfb048/src/Illuminate/Foundation/AliasLoader.php#L80**

Definition of native class_alias :
![image](https://user-images.githubusercontent.com/6961695/61580036-6f890800-ab22-11e9-9221-adecd82ec8a2.png)



I think it is not a change in method signature and does not pose any problems for people overriding it, hence I created this on to 5.8. (Please tell me if I am wrong, and this should be on 5.9)
