### PR TITLE
[5.8] Update helpers.php make default urls relative

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -777,7 +777,7 @@ if (! function_exists('route')) {
      * @param  bool  $absolute
      * @return string
      */
-    function route($name, $parameters = [], $absolute = true)
+    function route($name, $parameters = [], $absolute = false)
     {
         return app('url')->route($name, $parameters, $absolute);
     }


### PR DESCRIPTION
make default urls relative

I have a dusk page class like this:
```php
    /**
     * Get the URL for the page.
     *
     * @return string
     */
    public function url()
    {
        return route('models.create');
    }
```

When I run the tests, I was reported
```
Actual path [/models/create] does not equal expected path [http://127.0.0.1/models/create].
Failed asserting that '/models/create' matches PCRE pattern "/^http\:\/\/127\.0\.0\.1\/models\/create$/u".
```

So I have to change my Page::url() to
```php
    public function url()
    {
        return route('models.create', [], false);
    }
```

Looks so ugly!

Through this PR, `route()` gives relative urls and so retative urls can be generated like:
```php
    route('name', ['parameters']);
```
and absolute urls
```php
    route('name', ['parameters'], 'absolute');
```

How about this?