### PR TITLE
[5.8] Fix expects output bug

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -43,7 +43,7 @@ trait InteractsWithConsole
             return $this->app[Kernel::class]->call($command, $parameters);
         }
 
-        $this->beforeApplicationDestroyed(function () {
+        $this->afterApplicationDestroyed(function () {
             if (count($this->expectedQuestions)) {
                 $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
             }

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -163,6 +163,8 @@ class PendingCommand
             (new ArrayInput($this->parameters)), $this->createABufferedOutputMock(),
         ]);
 
+        $mock->_mockery_ignoreVerification = true;
+
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
                 ->once()
@@ -192,6 +194,8 @@ class PendingCommand
         $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
+
+        $mock->_mockery_ignoreVerification = true;
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -142,52 +142,52 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        if ($this->app) {
-            foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                call_user_func($callback);
+        try {
+            if ($this->app) {
+                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
+                }
+
+                $this->app->flush();
+                $this->app = null;
+
+                foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
+                }
+            }
+        } finally {
+            $this->setUpHasRun = false;
+
+            if (property_exists($this, 'serverVariables')) {
+                $this->serverVariables = [];
             }
 
-            $this->app->flush();
-
-            $this->app = null;
-        }
-
-        $this->setUpHasRun = false;
-
-        if (property_exists($this, 'serverVariables')) {
-            $this->serverVariables = [];
-        }
-
-        if (property_exists($this, 'defaultHeaders')) {
-            $this->defaultHeaders = [];
-        }
-
-        if (class_exists('Mockery')) {
-            if ($container = Mockery::getContainer()) {
-                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            if (property_exists($this, 'defaultHeaders')) {
+                $this->defaultHeaders = [];
             }
 
-            Mockery::close();
+            if (class_exists('Mockery')) {
+                if ($container = Mockery::getContainer()) {
+                    $this->addToAssertionCount($container->mockery_getExpectationCount());
+                }
+
+                Mockery::close();
+            }
+
+            if (class_exists(Carbon::class)) {
+                Carbon::setTestNow();
+            }
+
+            if (class_exists(CarbonImmutable::class)) {
+                CarbonImmutable::setTestNow();
+            }
+
+            $this->afterApplicationCreatedCallbacks = [];
+            $this->beforeApplicationDestroyedCallbacks = [];
+            $this->afterApplicationDestroyedCallbacks = [];
+
+            Artisan::forgetBootstrappers();
         }
-
-        if (class_exists(Carbon::class)) {
-            Carbon::setTestNow();
-        }
-
-        if (class_exists(CarbonImmutable::class)) {
-            CarbonImmutable::setTestNow();
-        }
-
-        $this->afterApplicationCreatedCallbacks = [];
-        $this->beforeApplicationDestroyedCallbacks = [];
-
-        Artisan::forgetBootstrappers();
-
-        foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
-            call_user_func($callback);
-        }
-
-        $this->afterApplicationDestroyedCallbacks = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -43,6 +43,13 @@ abstract class TestCase extends BaseTestCase
     protected $beforeApplicationDestroyedCallbacks = [];
 
     /**
+     * The callbacks that should be run after the application is destroyed.
+     *
+     * @var array
+     */
+    protected $afterApplicationDestroyedCallbacks = [];
+
+    /**
      * Indicates if we have made it through the base setUp function.
      *
      * @var bool
@@ -175,6 +182,12 @@ abstract class TestCase extends BaseTestCase
         $this->beforeApplicationDestroyedCallbacks = [];
 
         Artisan::forgetBootstrappers();
+
+        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+            call_user_func($callback);
+        }
+
+        $this->afterApplicationDestroyedCallbacks = [];
     }
 
     /**
@@ -201,5 +214,16 @@ abstract class TestCase extends BaseTestCase
     protected function beforeApplicationDestroyed(callable $callback)
     {
         $this->beforeApplicationDestroyedCallbacks[] = $callback;
+    }
+
+    /**
+     * Register a callback to be run after the application is destroyed.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function afterApplicationDestroyed(callable $callback)
+    {
+        $this->afterApplicationDestroyedCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -183,7 +183,7 @@ abstract class TestCase extends BaseTestCase
 
         Artisan::forgetBootstrappers();
 
-        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+        foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
             call_user_func($callback);
         }
 


### PR DESCRIPTION
Hey,

I found a bit of time to implement the afterApplicationDestroyed callback system that I talked about in #29246.

So this pr solves #29246.

I am not sure about the place where I call the afterApplicationDestroyed callbacks, maybe they could be called a bit earlier?

If you want to see the code in action it is used in the https://github.com/paulhenri-l/laravel-command-test-bug repository on the `test-fix` branch.