### PR TITLE
[5.8] Use the base Pipeline class instead of the Routing Pipeline to run middleware to reduce stacktrace length

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -5,7 +5,7 @@ namespace Illuminate\Foundation\Http;
 use Exception;
 use Throwable;
 use Illuminate\Routing\Router;
-use Illuminate\Routing\Pipeline;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Foundation\Application;

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -124,6 +124,10 @@ class Kernel implements KernelContract
             $response = $this->renderException($request, $e);
         }
 
+        if (isset($e) && method_exists($response, 'withException')) {
+            $response->withException($e);
+        }
+
         $this->app['events']->dispatch(
             new Events\RequestHandled($request, $response)
         );

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;


### PR DESCRIPTION
Hello team

What I suggest here is a minor quality of life improvement during development: it reduces the number of lines in the stacktrace for each middleware from 3 to 2.

On a basic installation of a Laravel app, the stacktrace (as show in the error log) of an exception thrown from a controller action goes from 51 lines to 40.

---

Currently when an exception is thrown, each middleware that have run takes 3 lines in the stacktrace.  
One is for the middleware itself, one for the closure of the base Pipeline class, one for the closure of the Routing Pipeline.

The purpose of the routing Pipeline is to wrap the closure of the base pipeline class in a try/catch block to do proper exception reporting and rendering.

However, regarding the middleware, using the Routing Pipeline for that purpose is not necessary since the same level of reporting and rendering can be achieved by the try/catch block already in place in the Kernel's `handle()` method.

Thanks for your work !