### PR TITLE
[5.8] Revert "[5.8] WithFaker use local faker config"

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -42,6 +42,6 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        return Factory::create($locale ?? config('app.faker_locale') ?? Factory::DEFAULT_LOCALE);
+        return Factory::create($locale ?? Factory::DEFAULT_LOCALE);
     }
 }


### PR DESCRIPTION
Reverts laravel/framework#29123 because it already exists on `master` due to an earlier PR, and was targetting 5.9 instead of 5.8 because it was a breaking change.