### PR TITLE
[6.0] Reduce the stacktrace length by 1 line per middleware

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -3,10 +3,13 @@
 namespace Illuminate\Pipeline;
 
 use Closure;
+use Exception;
+use Throwable;
 use RuntimeException;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Responsable;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract
@@ -125,7 +128,13 @@ class Pipeline implements PipelineContract
     protected function prepareDestination(Closure $destination)
     {
         return function ($passable) use ($destination) {
-            return $destination($passable);
+            try {
+                return $destination($passable);
+            } catch (Exception $e) {
+                return $this->handleException($passable, $e);
+            } catch (Throwable $e) {
+                return $this->handleException($passable, new FatalThrowableError($e));
+            }
         };
     }
 
@@ -138,34 +147,40 @@ class Pipeline implements PipelineContract
     {
         return function ($stack, $pipe) {
             return function ($passable) use ($stack, $pipe) {
-                if (is_callable($pipe)) {
-                    // If the pipe is an instance of a Closure, we will just call it directly but
-                    // otherwise we'll resolve the pipes out of the container and call it with
-                    // the appropriate method and arguments, returning the results back out.
-                    return $pipe($passable, $stack);
-                } elseif (! is_object($pipe)) {
-                    [$name, $parameters] = $this->parsePipeString($pipe);
+                try {
+                    if (is_callable($pipe)) {
+                        // If the pipe is an instance of a Closure, we will just call it directly but
+                        // otherwise we'll resolve the pipes out of the container and call it with
+                        // the appropriate method and arguments, returning the results back out.
+                        return $pipe($passable, $stack);
+                    } elseif (! is_object($pipe)) {
+                        [$name, $parameters] = $this->parsePipeString($pipe);
 
-                    // If the pipe is a string we will parse the string and resolve the class out
-                    // of the dependency injection container. We can then build a callable and
-                    // execute the pipe function giving in the parameters that are required.
-                    $pipe = $this->getContainer()->make($name);
+                        // If the pipe is a string we will parse the string and resolve the class out
+                        // of the dependency injection container. We can then build a callable and
+                        // execute the pipe function giving in the parameters that are required.
+                        $pipe = $this->getContainer()->make($name);
 
-                    $parameters = array_merge([$passable, $stack], $parameters);
-                } else {
-                    // If the pipe is already an object we'll just make a callable and pass it to
-                    // the pipe as-is. There is no need to do any extra parsing and formatting
-                    // since the object we're given was already a fully instantiated object.
-                    $parameters = [$passable, $stack];
+                        $parameters = array_merge([$passable, $stack], $parameters);
+                    } else {
+                        // If the pipe is already an object we'll just make a callable and pass it to
+                        // the pipe as-is. There is no need to do any extra parsing and formatting
+                        // since the object we're given was already a fully instantiated object.
+                        $parameters = [$passable, $stack];
+                    }
+
+                    $response = method_exists($pipe, $this->method)
+                                    ? $pipe->{$this->method}(...$parameters)
+                                    : $pipe(...$parameters);
+
+                    return $response instanceof Responsable
+                                ? $response->toResponse($this->getContainer()->make(Request::class))
+                                : $response;
+                } catch (Exception $e) {
+                    return $this->handleException($passable, $e);
+                } catch (Throwable $e) {
+                    return $this->handleException($passable, new FatalThrowableError($e));
                 }
-
-                $response = method_exists($pipe, $this->method)
-                                ? $pipe->{$this->method}(...$parameters)
-                                : $pipe(...$parameters);
-
-                return $response instanceof Responsable
-                            ? $response->toResponse($this->getContainer()->make(Request::class))
-                            : $response;
             };
         };
     }
@@ -201,5 +216,19 @@ class Pipeline implements PipelineContract
         }
 
         return $this->container;
+    }
+
+    /**
+     * Handle the given exception.
+     *
+     * @param  mixed  $passable
+     * @param  \Exception  $e
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    protected function handleException($passable, Exception $e)
+    {
+        throw $e; // actually handled in the Routing Pipeline
     }
 }

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -2,13 +2,10 @@
 
 namespace Illuminate\Routing;
 
-use Closure;
 use Exception;
-use Throwable;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Pipeline\Pipeline as BasePipeline;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 /**
  * This extended pipeline catches any exceptions that occur during each slice.
@@ -17,49 +14,6 @@ use Symfony\Component\Debug\Exception\FatalThrowableError;
  */
 class Pipeline extends BasePipeline
 {
-    /**
-     * Get the final piece of the Closure onion.
-     *
-     * @param  \Closure  $destination
-     * @return \Closure
-     */
-    protected function prepareDestination(Closure $destination)
-    {
-        return function ($passable) use ($destination) {
-            try {
-                return $destination($passable);
-            } catch (Exception $e) {
-                return $this->handleException($passable, $e);
-            } catch (Throwable $e) {
-                return $this->handleException($passable, new FatalThrowableError($e));
-            }
-        };
-    }
-
-    /**
-     * Get a Closure that represents a slice of the application onion.
-     *
-     * @return \Closure
-     */
-    protected function carry()
-    {
-        return function ($stack, $pipe) {
-            return function ($passable) use ($stack, $pipe) {
-                try {
-                    $slice = parent::carry();
-
-                    $callable = $slice($stack, $pipe);
-
-                    return $callable($passable);
-                } catch (Exception $e) {
-                    return $this->handleException($passable, $e);
-                } catch (Throwable $e) {
-                    return $this->handleException($passable, new FatalThrowableError($e));
-                }
-            };
-        };
-    }
-
     /**
      * Handle the given exception.
      *


### PR DESCRIPTION
Hello team

What I suggest here is a minor quality of life improvement during development: it reduces the number of lines in the stacktrace for each middleware from 3 to 2.

On a basic installation of a Laravel app, the stacktrace (as show in the error log) of an exception thrown from a controller action goes from 51 lines to 40.

Currently when an exception is thrown, each middleware that have run takes 3 lines in the stacktrace.
One is for the middleware itself, one for the closure of the base Pipeline class, one for the closure of the Routing Pipeline.

The purpose of the routing Pipeline is to wrap the closure of the base pipeline class in a try/catch block and to send the exception to a method to do proper exception reporting/rendering and to send the response up the middleware stack that already ran.

My change moves the try/catch blocks to the base pipeline class allowing the the Routing Pipeline, to not overwrite the `prepareDestination()` and `carry()` methods.  
The exception isn't handled in the base pipeline (it just throws it again) but is handled as usual by the routing pipeline.

The effect is one less closure, and one less line in the stacktrace, per middleware, while exceptions are still properly handled and the generated response is passed up the middleware stack.

Thanks for your work !