### PR TITLE
[5.9] Fix expects output bug

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -43,7 +43,7 @@ trait InteractsWithConsole
             return $this->app[Kernel::class]->call($command, $parameters);
         }
 
-        $this->beforeApplicationDestroyed(function () {
+        $this->afterApplicationDestroyed(function () {
             if (count($this->expectedQuestions)) {
                 $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
             }

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -163,6 +163,8 @@ class PendingCommand
             (new ArrayInput($this->parameters)), $this->createABufferedOutputMock(),
         ]);
 
+        $mock->_mockery_ignoreVerification = true;
+
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
                 ->once()
@@ -192,6 +194,8 @@ class PendingCommand
         $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
+
+        $mock->_mockery_ignoreVerification = true;
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -142,52 +142,52 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        if ($this->app) {
-            foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                call_user_func($callback);
+        try {
+            if ($this->app) {
+                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
+                }
+
+                $this->app->flush();
+                $this->app = null;
+
+                foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
+                }
+            }
+        } finally {
+            $this->setUpHasRun = false;
+
+            if (property_exists($this, 'serverVariables')) {
+                $this->serverVariables = [];
             }
 
-            $this->app->flush();
-
-            $this->app = null;
-        }
-
-        $this->setUpHasRun = false;
-
-        if (property_exists($this, 'serverVariables')) {
-            $this->serverVariables = [];
-        }
-
-        if (property_exists($this, 'defaultHeaders')) {
-            $this->defaultHeaders = [];
-        }
-
-        if (class_exists('Mockery')) {
-            if ($container = Mockery::getContainer()) {
-                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            if (property_exists($this, 'defaultHeaders')) {
+                $this->defaultHeaders = [];
             }
 
-            Mockery::close();
+            if (class_exists('Mockery')) {
+                if ($container = Mockery::getContainer()) {
+                    $this->addToAssertionCount($container->mockery_getExpectationCount());
+                }
+
+                Mockery::close();
+            }
+
+            if (class_exists(Carbon::class)) {
+                Carbon::setTestNow();
+            }
+
+            if (class_exists(CarbonImmutable::class)) {
+                CarbonImmutable::setTestNow();
+            }
+
+            $this->afterApplicationCreatedCallbacks = [];
+            $this->beforeApplicationDestroyedCallbacks = [];
+            $this->afterApplicationDestroyedCallbacks = [];
+
+            Artisan::forgetBootstrappers();
         }
-
-        if (class_exists(Carbon::class)) {
-            Carbon::setTestNow();
-        }
-
-        if (class_exists(CarbonImmutable::class)) {
-            CarbonImmutable::setTestNow();
-        }
-
-        $this->afterApplicationCreatedCallbacks = [];
-        $this->beforeApplicationDestroyedCallbacks = [];
-
-        Artisan::forgetBootstrappers();
-
-        foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
-            call_user_func($callback);
-        }
-
-        $this->afterApplicationDestroyedCallbacks = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -43,6 +43,13 @@ abstract class TestCase extends BaseTestCase
     protected $beforeApplicationDestroyedCallbacks = [];
 
     /**
+     * The callbacks that should be run after the application is destroyed.
+     *
+     * @var array
+     */
+    protected $afterApplicationDestroyedCallbacks = [];
+
+    /**
      * Indicates if we have made it through the base setUp function.
      *
      * @var bool
@@ -175,6 +182,12 @@ abstract class TestCase extends BaseTestCase
         $this->beforeApplicationDestroyedCallbacks = [];
 
         Artisan::forgetBootstrappers();
+
+        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+            call_user_func($callback);
+        }
+
+        $this->afterApplicationDestroyedCallbacks = [];
     }
 
     /**
@@ -201,5 +214,16 @@ abstract class TestCase extends BaseTestCase
     protected function beforeApplicationDestroyed(callable $callback)
     {
         $this->beforeApplicationDestroyedCallbacks[] = $callback;
+    }
+
+    /**
+     * Register a callback to be run after the application is destroyed.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    protected function afterApplicationDestroyed(callable $callback)
+    {
+        $this->afterApplicationDestroyedCallbacks[] = $callback;
     }
 }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -144,17 +144,15 @@ abstract class TestCase extends BaseTestCase
     {
         try {
             if ($this->app) {
-                try {
-                    foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                        call_user_func($callback);
-                    }
-                } finally {
-                    $this->app->flush();
-                    $this->app = null;
+                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+                    \rescue($callback, null, false);
+                }
 
-                    foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
-                        call_user_func($callback);
-                    }
+                $this->app->flush();
+                $this->app = null;
+
+                foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
                 }
             }
         } finally {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -183,7 +183,7 @@ abstract class TestCase extends BaseTestCase
 
         Artisan::forgetBootstrappers();
 
-        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+        foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
             call_user_func($callback);
         }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -144,15 +144,17 @@ abstract class TestCase extends BaseTestCase
     {
         try {
             if ($this->app) {
-                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                    call_user_func($callback);
-                }
+                try {
+                    foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+                        call_user_func($callback);
+                    }
+                } finally {
+                    $this->app->flush();
+                    $this->app = null;
 
-                $this->app->flush();
-                $this->app = null;
-
-                foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
-                    call_user_func($callback);
+                    foreach ($this->afterApplicationDestroyedCallbacks as $callback) {
+                        call_user_func($callback);
+                    }
                 }
             }
         } finally {
@@ -166,7 +168,7 @@ abstract class TestCase extends BaseTestCase
                 $this->defaultHeaders = [];
             }
 
-            if (class_exists('Mockery')) {
+            if (class_exists(Mockery::class)) {
                 if ($container = Mockery::getContainer()) {
                     $this->addToAssertionCount($container->mockery_getExpectationCount());
                 }


### PR DESCRIPTION
As discussed in #29248 

Here's the PR targeting Laravel 5.9 instead of 5.8 

This PR is fixing #29246 

I'm also going to open a pr on orchestral/testbench in order to make the tests pass.

---

### Steps to reproduce

The simplest way to reproduce it is to add this test into a brand new laravel application

```
laravel new expose-bug
cd expose-bug
php artisan make:test ExposeBugCommand
```

Paste this inside of the `tests/Feature/ExposeBugCommand.php` file.

```php
<?php

namespace Tests\Feature;

use Illuminate\Support\Facades\Artisan;
use Tests\TestCase;

class ExposeBugCommandTest extends TestCase
{
    protected function setUp(): void
    {
        parent::setUp();

        Artisan::command('hello', function () {
            $this->info('hello world');
        });
    }

    public function test_hello_says_hola_mundo()
    {
        $this->artisan('hello')
            ->expectsOutput('hola mundo');
    }

    public function test_hello_says_hello_world()
    {
        $this->artisan('hello')
            ->expectsOutput('hello world');
    }
}
```

```
phpunit
```

### Explanations

By simply looking at this test you can see that the first test method should fail and the second one pass. 

But if you run `phpunit` oddly both tests fails (1 failure and 1 exception)

Now if you run `phpunit --filter test_hello_says_hello_world` you'll see that running only the working test works.

What I have discovered is that `InteractsWithConsole` when used with `expectsOutput` is calling `this->fail()` inside of its `beforeApplicationDestroyedCallback` as `this->fails()` throws it is breaking the execution flow of the `tearDown` method and preventing it from properly tearing down the test suite.

Inside of the `tearDown` method there is a call to `Mockery::close()` but because of the `this->fail()` exception this line is never reached.

On subsequent tests `Mockery::close()` gets called and throws an error related to the previous test.

### Notifications

If there are other test traits using `this->fail()` in their callbacks then they are also preventing the test suite from properly tearing down and should be fixed. I can do that.

### PRs

We've been discussing the fix with @GrahamCampbell and @crynobone inside of these pr:

- #29248 
- #29252 
- https://github.com/orchestral/testbench-core/pull/25