### PR TITLE
[5.8]Add content length to header

### DIFF
--- a/src/Illuminate/Http/Response.php
+++ b/src/Illuminate/Http/Response.php
@@ -43,6 +43,7 @@ class Response extends BaseResponse
         }
 
         parent::setContent($content);
+        $this->header('Content-Length', strlen($content));
 
         return $this;
     }


### PR DESCRIPTION
[This issue was fixed](https://github.com/laravel/framework/issues/29227)
I added the content length to the header, cause on head request it can not be identified by the web server.