### PR TITLE
[5.8] allowing injecting method result into Blade

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -18,6 +18,13 @@ trait CompilesInjections
 
         $service = trim($segments[1]);
 
+        if (strpos($service, '@')) {
+
+            list($service, $method) = explode('@', $service);
+
+            return "<?php \${$variable} = (app('{$service}'))->{$method}(); ?>";
+        }
+
         return "<?php \${$variable} = app('{$service}'); ?>";
     }
 }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -20,7 +20,7 @@ trait CompilesInjections
 
         if (strpos($service, '@')) {
 
-            list($service, $method) = explode('@', $service);
+            [$service, $method] = explode('@', $service);
 
             return "<?php \${$variable} = (app('{$service}'))->{$method}(); ?>";
         }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -19,7 +19,6 @@ trait CompilesInjections
         $service = trim($segments[1]);
 
         if (strpos($service, '@')) {
-
             [$service, $method] = explode('@', $service);
 
             return "<?php \${$variable} = (app('{$service}'))->{$method}(); ?>";


### PR DESCRIPTION
currently we can inject a class into blade with

```php
@inject('metrics', 'App\Services\MetricsService')
```

this change allows us to inject the result of a method from that class

```php
@inject('metrics', 'App\Services\MetricsService@monthlyRevenue')
```

please **do not** merge yet.  needs tests.  looking for some feedback.