### PR TITLE
[6.0] Remove BelongsTo::update()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -194,17 +194,6 @@ class BelongsTo extends Relation
     }
 
     /**
-     * Update the parent model on the relationship.
-     *
-     * @param  array  $attributes
-     * @return mixed
-     */
-    public function update(array $attributes)
-    {
-        return $this->getResults()->fill($attributes)->save();
-    }
-
-    /**
      * Associate the model instance to the given parent.
      *
      * @param  \Illuminate\Database\Eloquent\Model|int|string  $model

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -65,17 +65,6 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->assertSame('taylor', $newModel->username);
     }
 
-    public function testUpdateMethodRetrievesModelAndUpdates()
-    {
-        $relation = $this->getRelation();
-        $mock = m::mock(Model::class);
-        $mock->shouldReceive('fill')->once()->with(['attributes'])->andReturn($mock);
-        $mock->shouldReceive('save')->once()->andReturn(true);
-        $relation->getQuery()->shouldReceive('first')->once()->andReturn($mock);
-
-        $this->assertTrue($relation->update(['attributes']));
-    }
-
     public function testEagerConstraintsAreProperlyAdded()
     {
         $relation = $this->getRelation();


### PR DESCRIPTION
`BelongsTo` is the only relationship that retrieves the related model before updating it: 
`$post->user()->update()` behaves the same way as `$post->user->update()`.

I think the behavior should be consistent among all relationships.

We need to document this change in the upgrade guide: The update no longer protects against mass assignment or fires events. If you need that, you may use `$post->user->update()`.