### PR TITLE
[5.8] Responsable check moved to Route Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -159,13 +159,9 @@ class Pipeline implements PipelineContract
                     $parameters = [$passable, $stack];
                 }
 
-                $response = method_exists($pipe, $this->method)
+                return method_exists($pipe, $this->method)
                                 ? $pipe->{$this->method}(...$parameters)
                                 : $pipe(...$parameters);
-
-                return $response instanceof Responsable
-                            ? $response->toResponse($this->getContainer()->make(Request::class))
-                            : $response;
             };
         };
     }

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -4,9 +4,7 @@ namespace Illuminate\Pipeline;
 
 use Closure;
 use RuntimeException;
-use Illuminate\Http\Request;
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Exception;
+use Illuminate\Contracts\Support\Responsable;
 use Throwable;
 use Illuminate\Http\Request;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -50,7 +51,11 @@ class Pipeline extends BasePipeline
 
                     $callable = $slice($stack, $pipe);
 
-                    return $callable($passable);
+                    $response = $callable($passable);
+
+                    return $response instanceof Responsable
+                        ? $response->toResponse($this->getContainer()->make(Request::class))
+                        : $response;
                 } catch (Exception $e) {
                     return $this->handleException($passable, $e);
                 } catch (Throwable $e) {

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -4,9 +4,9 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Exception;
-use Illuminate\Contracts\Support\Responsable;
 use Throwable;
 use Illuminate\Http\Request;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Pipeline\Pipeline as BasePipeline;
 use Symfony\Component\Debug\Exception\FatalThrowableError;

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -6,7 +6,6 @@ use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Support\Responsable;
 
 class PipelineTest extends TestCase
 {

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -65,23 +65,6 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.one']);
     }
 
-    public function testPipelineUsageWithResponsableObjects()
-    {
-        $result = (new Pipeline(new Container))
-            ->send('foo')
-            ->through([new PipelineTestPipeResponsable])
-            ->then(
-                function ($piped) {
-                    return $piped;
-                }
-            );
-
-        $this->assertEquals('bar', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.responsable']);
-
-        unset($_SERVER['__test.pipe.responsable']);
-    }
-
     public function testPipelineUsageWithCallable()
     {
         $function = function ($piped, $next) {
@@ -192,14 +175,6 @@ class PipelineTestPipeOne
     }
 }
 
-class PipeResponsable implements Responsable
-{
-    public function toResponse($request)
-    {
-        return 'bar';
-    }
-}
-
 class PipelineTestPipeTwo
 {
     public function __invoke($piped, $next)
@@ -207,16 +182,6 @@ class PipelineTestPipeTwo
         $_SERVER['__test.pipe.one'] = $piped;
 
         return $next($piped);
-    }
-}
-
-class PipelineTestPipeResponsable
-{
-    public function handle($piped, $next)
-    {
-        $_SERVER['__test.pipe.responsable'] = $piped;
-
-        return new PipeResponsable;
     }
 }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -22,8 +22,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Auth\Middleware\Authorize;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Contracts\Routing\Registrar;
-use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -220,7 +220,6 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello caught', $response);
     }
 
-
     public function testReturnsResponseWhenMiddlewareReturnsResponsable()
     {
         $router = $this->getRouter();
@@ -237,7 +236,6 @@ class RoutingRouteTest extends TestCase
             $router->dispatch(Request::create('foo/bar', 'GET'))->getContent()
         );
     }
-
 
     public function testDefinedClosureMiddleware()
     {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1937,5 +1937,4 @@ class ResponsableResponse implements Responsable
     {
         return new Response('bar');
     }
-
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1937,4 +1937,5 @@ class ResponsableResponse implements Responsable
     {
         return new Response('bar');
     }
+
 }


### PR DESCRIPTION
This is a more elegant solution to #24156.

Responsable check is now done on the Route Pipeline. This cleans the Base Pipeline class, avoiding unwanted behaviour when using it with Responsable objects.

Also added a test to check if a Middleware that returns a Responsable (instead of keep going with the pipeline) transforms it to a Response.

Pardon the commits, I was sure has hell I was following the style and had my 5 seconds of fury on the keyboard. Also, I don't know how to combine all the commits into one.