### PR TITLE
[5.8] Fix MySQL Schema Grammar $modifiers order

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -15,7 +15,7 @@ class MySqlGrammar extends Grammar
      * @var array
      */
     protected $modifiers = [
-        'Unsigned', 'VirtualAs', 'StoredAs', 'Charset', 'Collate', 'Nullable',
+        'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
         'Default', 'Increment', 'Comment', 'After', 'First', 'Srid',
     ];
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -434,6 +434,18 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
     }
 
+    public function testAddingGeneratedColumnWithCharset()
+    {
+        $blueprint = new Blueprint('links');
+        $blueprint->string('url', 2083)->charset('ascii');
+        $blueprint->string('url_hash_virtual', 64)->virtualAs('sha2(url, 256)')->charset('ascii');
+        $blueprint->string('url_hash_stored', 64)->storedAs('sha2(url, 256)')->charset('ascii');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
+    }
+
     public function testAddingString()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Charset/Collate must be placed before VirtualAs/StoredAs.

e.g.

```php
$table->string('hash', 64)->charset('ascii')->storedAs('sha2(url, 256)')
```

According to [Sequel Pro](https://www.sequelpro.com/), this is equivalent to:

```sql
`hash` varchar(64) CHARACTER SET ascii GENERATED ALWAYS AS (sha2(`url`,256)) STORED
```

Currently, however, this is compiled as (Syntax Error):

```sql
`hash` varchar(64) as (sha2(url, 256)) stored character set ascii
```