### PR TITLE
[5.8] Cast model attribute to \ArrayObject

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use ArrayObject;
 use LogicException;
 use DateTimeInterface;
 use Carbon\CarbonInterface;
@@ -499,6 +500,8 @@ trait HasAttributes
             case 'array':
             case 'json':
                 return $this->fromJson($value);
+            case 'array_object':
+                return $this->asArrayObject($this->fromJson($value));
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
             case 'date':
@@ -692,6 +695,18 @@ trait HasAttributes
         }
 
         return $value;
+    }
+
+    /**
+     * Decode the given array into ArrayObject
+     *
+     * @param array $value
+     *
+     * @return ArrayObject|null
+     */
+    protected function asArrayObject($value)
+    {
+        return new ArrayObject($value, ArrayObject::ARRAY_AS_PROPS | ArrayObject::STD_PROP_LIST);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -698,7 +698,7 @@ trait HasAttributes
     }
 
     /**
-     * Decode the given array into ArrayObject
+     * Decode the given array into ArrayObject.
      *
      * @param array $value
      *

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -700,9 +700,9 @@ trait HasAttributes
     /**
      * Decode the given array into ArrayObject.
      *
-     * @param array $value
+     * @param array|object $value
      *
-     * @return ArrayObject|null
+     * @return ArrayObject
      */
     protected function asArrayObject($value)
     {

--- a/tests/Database/EloquentModelArrayObjectCastingTest.php
+++ b/tests/Database/EloquentModelArrayObjectCastingTest.php
@@ -9,7 +9,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 /**
  * @group integration
  */
-class EloquentModelDateCastingTest extends DatabaseTestCase
+class EloquentModelArrayObjectCastingTest extends DatabaseTestCase
 {
     public function setUp()
     {

--- a/tests/Database/EloquentModelArrayObjectCastingTest.php
+++ b/tests/Database/EloquentModelArrayObjectCastingTest.php
@@ -38,6 +38,9 @@ class TestModelCastArrayObject extends Model
     public $table = 'test_model1';
     public $timestamps = false;
 
+    protected $guarded = ['id'];
+    protected $fillable = ['array_object_field'];
+
     public $casts = [
         'array_object_field' => 'array_object',
     ];

--- a/tests/Database/EloquentModelArrayObjectCastingTest.php
+++ b/tests/Database/EloquentModelArrayObjectCastingTest.php
@@ -23,7 +23,7 @@ class EloquentModelArrayObjectCastingTest extends DatabaseTestCase
 
     public function test_cast_array_object()
     {
-        $user = TestModel1::create([
+        $user = TestModelCastArrayObject::create([
             'array_object_field' => '{"a":"1", "b":2}',
         ]);
 
@@ -33,7 +33,7 @@ class EloquentModelArrayObjectCastingTest extends DatabaseTestCase
     }
 }
 
-class TestModel1 extends Model
+class TestModelCastArrayObject extends Model
 {
     public $table = 'test_model1';
     public $timestamps = false;

--- a/tests/Database/EloquentModelArrayObjectCastingTest.php
+++ b/tests/Database/EloquentModelArrayObjectCastingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelDateCastingTest;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentModelDateCastingTest extends DatabaseTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->json('array_object_field')->nullable();
+        });
+    }
+
+    public function test_cast_array_object()
+    {
+        $user = TestModel1::create([
+            'array_object_field' => '{"a":"1", "b":2}',
+        ]);
+
+        $this->assertInstanceOf(\ArrayObject::class, $user->array_object_field);
+        $this->assertSame('1', $user->array_object_field['a']);
+        $this->assertSame(2, $user->array_object_field->b);
+    }
+}
+
+class TestModel1 extends Model
+{
+    public $table = 'test_model1';
+    public $timestamps = false;
+
+    public $casts = [
+        'array_object_field' => 'array_object',
+    ];
+}

--- a/tests/Database/EloquentModelArrayObjectCastingTest.php
+++ b/tests/Database/EloquentModelArrayObjectCastingTest.php
@@ -11,7 +11,7 @@ use Illuminate\Tests\Integration\Database\DatabaseTestCase;
  */
 class EloquentModelArrayObjectCastingTest extends DatabaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -11,7 +11,7 @@ class FoundationAliasLoaderTest extends TestCase
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
+        $this->assertSame(array_intersect(['foo' => 'bar'], $loader->getAliases()), ['foo' => 'bar']);
         $this->assertFalse($loader->isRegistered());
         $loader->register();
 
@@ -27,14 +27,15 @@ class FoundationAliasLoaderTest extends TestCase
     public function testLoaderCanBeCreatedAndRegisteredMergingAliases()
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
-        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
+
+        $this->assertSame(array_intersect(['foo' => 'bar'], $loader->getAliases()), ['foo' => 'bar']);
 
         $loader = AliasLoader::getInstance(['foo2' => 'bar2']);
-        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases());
+        $this->assertSame(array_intersect(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases()), ['foo2' => 'bar2', 'foo' => 'bar']);
 
         // override keys
         $loader = AliasLoader::getInstance(['foo' => 'baz']);
-        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
+        $this->assertSame(array_intersect(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases()), ['foo2' => 'bar2', 'foo' => 'baz']);
     }
 
     public function testLoaderCanAliasAndLoadClasses()

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -12,10 +12,6 @@ class FoundationAliasLoaderTest extends TestCase
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
 
         $this->assertSame(array_intersect(['foo' => 'bar'], $loader->getAliases()), ['foo' => 'bar']);
-        $this->assertFalse($loader->isRegistered());
-        $loader->register();
-
-        $this->assertTrue($loader->isRegistered());
     }
 
     public function testGetInstanceCreatesOneInstance()

--- a/tests/Foundation/FoundationAliasLoaderTest.php
+++ b/tests/Foundation/FoundationAliasLoaderTest.php
@@ -11,7 +11,11 @@ class FoundationAliasLoaderTest extends TestCase
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
 
-        $this->assertSame(array_intersect(['foo' => 'bar'], $loader->getAliases()), ['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
+        $this->assertFalse($loader->isRegistered());
+        $loader->register();
+
+        $this->assertTrue($loader->isRegistered());
     }
 
     public function testGetInstanceCreatesOneInstance()
@@ -23,15 +27,14 @@ class FoundationAliasLoaderTest extends TestCase
     public function testLoaderCanBeCreatedAndRegisteredMergingAliases()
     {
         $loader = AliasLoader::getInstance(['foo' => 'bar']);
-
-        $this->assertSame(array_intersect(['foo' => 'bar'], $loader->getAliases()), ['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $loader->getAliases());
 
         $loader = AliasLoader::getInstance(['foo2' => 'bar2']);
-        $this->assertSame(array_intersect(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases()), ['foo2' => 'bar2', 'foo' => 'bar']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'bar'], $loader->getAliases());
 
         // override keys
         $loader = AliasLoader::getInstance(['foo' => 'baz']);
-        $this->assertSame(array_intersect(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases()), ['foo2' => 'bar2', 'foo' => 'baz']);
+        $this->assertEquals(['foo2' => 'bar2', 'foo' => 'baz'], $loader->getAliases());
     }
 
     public function testLoaderCanAliasAndLoadClasses()


### PR DESCRIPTION
The PR adds possibility to cast model attribute to \ArrayObject via $casts property.

`
public $casts = [
        'data' => 'array_object',
    ];
`

Usage example from test

```
        $user = TestModel1::create([
            'array_object_field' => '{"a":"1", "b":2}',
        ]);
        $this->assertInstanceOf(\ArrayObject::class, $user->array_object_field);
        $this->assertSame('1', $user->array_object_field['a']);
        $this->assertSame(2, $user->array_object_field->b);
```