### PR TITLE
[5.8] Teardown test suite after using fail() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -163,11 +163,8 @@ class PendingCommand
             (new ArrayInput($this->parameters)), $this->createABufferedOutputMock(),
         ]);
 
-        $mock->_mockery_ignoreVerification = true;
-
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
-                ->once()
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     return $argument->getQuestion() == $question[0];
@@ -195,11 +192,8 @@ class PendingCommand
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
 
-        $mock->_mockery_ignoreVerification = true;
-
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')
-                ->once()
                 ->ordered()
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($i) {

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -163,6 +163,8 @@ class PendingCommand
             (new ArrayInput($this->parameters)), $this->createABufferedOutputMock(),
         ]);
 
+        $mock->_mockery_ignoreVerification = true;
+
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
                 ->once()
@@ -192,6 +194,8 @@ class PendingCommand
         $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
+
+        $mock->_mockery_ignoreVerification = true;
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -43,7 +43,7 @@ abstract class TestCase extends BaseTestCase
     protected $beforeApplicationDestroyedCallbacks = [];
 
     /**
-     * The exception thrown while running a callback.
+     * The exception thrown while running an application destruction callback.
      *
      * @var \Throwable
      */

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -135,46 +135,50 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        if ($this->app) {
-            foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                call_user_func($callback);
+        try {
+            if ($this->app) {
+                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+                    call_user_func($callback);
+                }
+            }
+        } finally {
+            if ($this->app) {
+                $this->app->flush();
+
+                $this->app = null;
             }
 
-            $this->app->flush();
+            $this->setUpHasRun = false;
 
-            $this->app = null;
-        }
-
-        $this->setUpHasRun = false;
-
-        if (property_exists($this, 'serverVariables')) {
-            $this->serverVariables = [];
-        }
-
-        if (property_exists($this, 'defaultHeaders')) {
-            $this->defaultHeaders = [];
-        }
-
-        if (class_exists('Mockery')) {
-            if ($container = Mockery::getContainer()) {
-                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            if (property_exists($this, 'serverVariables')) {
+                $this->serverVariables = [];
             }
 
-            Mockery::close();
+            if (property_exists($this, 'defaultHeaders')) {
+                $this->defaultHeaders = [];
+            }
+
+            if (class_exists('Mockery')) {
+                if ($container = Mockery::getContainer()) {
+                    $this->addToAssertionCount($container->mockery_getExpectationCount());
+                }
+
+                Mockery::close();
+            }
+
+            if (class_exists(Carbon::class)) {
+                Carbon::setTestNow();
+            }
+
+            if (class_exists(CarbonImmutable::class)) {
+                CarbonImmutable::setTestNow();
+            }
+
+            $this->afterApplicationCreatedCallbacks = [];
+            $this->beforeApplicationDestroyedCallbacks = [];
+
+            Artisan::forgetBootstrappers();
         }
-
-        if (class_exists(Carbon::class)) {
-            Carbon::setTestNow();
-        }
-
-        if (class_exists(CarbonImmutable::class)) {
-            CarbonImmutable::setTestNow();
-        }
-
-        $this->afterApplicationCreatedCallbacks = [];
-        $this->beforeApplicationDestroyedCallbacks = [];
-
-        Artisan::forgetBootstrappers();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -43,6 +43,13 @@ abstract class TestCase extends BaseTestCase
     protected $beforeApplicationDestroyedCallbacks = [];
 
     /**
+     * The exception thrown while running a callback.
+     *
+     * @var \Throwable
+     */
+    protected $callbackException;
+
+    /**
      * Indicates if we have made it through the base setUp function.
      *
      * @var bool
@@ -135,49 +142,65 @@ abstract class TestCase extends BaseTestCase
      */
     protected function tearDown(): void
     {
-        try {
-            if ($this->app) {
-                foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-                    call_user_func($callback);
+        if ($this->app) {
+            $this->callBeforeApplicationDestroyedCallbacks();
+
+            $this->app->flush();
+
+            $this->app = null;
+        }
+
+        $this->setUpHasRun = false;
+
+        if (property_exists($this, 'serverVariables')) {
+            $this->serverVariables = [];
+        }
+
+        if (property_exists($this, 'defaultHeaders')) {
+            $this->defaultHeaders = [];
+        }
+
+        if (class_exists('Mockery')) {
+            if ($container = Mockery::getContainer()) {
+                $this->addToAssertionCount($container->mockery_getExpectationCount());
+            }
+
+            Mockery::close();
+        }
+
+        if (class_exists(Carbon::class)) {
+            Carbon::setTestNow();
+        }
+
+        if (class_exists(CarbonImmutable::class)) {
+            CarbonImmutable::setTestNow();
+        }
+
+        $this->afterApplicationCreatedCallbacks = [];
+        $this->beforeApplicationDestroyedCallbacks = [];
+
+        Artisan::forgetBootstrappers();
+
+        if ($this->callbackException) {
+            throw $this->callbackException;
+        }
+    }
+
+    /**
+     * Handle the application's pre-destruction callbacks.
+     *
+     * @return void
+     */
+    protected function callBeforeApplicationDestroyedCallbacks()
+    {
+        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+            try {
+                call_user_func($callback);
+            } catch (\Throwable $e) {
+                if (! $this->callbackException) {
+                    $this->callbackException = $e;
                 }
             }
-        } finally {
-            if ($this->app) {
-                $this->app->flush();
-
-                $this->app = null;
-            }
-
-            $this->setUpHasRun = false;
-
-            if (property_exists($this, 'serverVariables')) {
-                $this->serverVariables = [];
-            }
-
-            if (property_exists($this, 'defaultHeaders')) {
-                $this->defaultHeaders = [];
-            }
-
-            if (class_exists('Mockery')) {
-                if ($container = Mockery::getContainer()) {
-                    $this->addToAssertionCount($container->mockery_getExpectationCount());
-                }
-
-                Mockery::close();
-            }
-
-            if (class_exists(Carbon::class)) {
-                Carbon::setTestNow();
-            }
-
-            if (class_exists(CarbonImmutable::class)) {
-                CarbonImmutable::setTestNow();
-            }
-
-            $this->afterApplicationCreatedCallbacks = [];
-            $this->beforeApplicationDestroyedCallbacks = [];
-
-            Artisan::forgetBootstrappers();
         }
     }
 

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -187,24 +187,6 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
-     * Handle the application's pre-destruction callbacks.
-     *
-     * @return void
-     */
-    protected function callBeforeApplicationDestroyedCallbacks()
-    {
-        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
-            try {
-                call_user_func($callback);
-            } catch (\Throwable $e) {
-                if (! $this->callbackException) {
-                    $this->callbackException = $e;
-                }
-            }
-        }
-    }
-
-    /**
      * Register a callback to be run after the application is created.
      *
      * @param  callable  $callback
@@ -228,5 +210,23 @@ abstract class TestCase extends BaseTestCase
     protected function beforeApplicationDestroyed(callable $callback)
     {
         $this->beforeApplicationDestroyedCallbacks[] = $callback;
+    }
+
+    /**
+     * Execute the application's pre-destruction callbacks.
+     *
+     * @return void
+     */
+    protected function callBeforeApplicationDestroyedCallbacks()
+    {
+        foreach ($this->beforeApplicationDestroyedCallbacks as $callback) {
+            try {
+                call_user_func($callback);
+            } catch (\Throwable $e) {
+                if (! $this->callbackException) {
+                    $this->callbackException = $e;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR has 2 changes:

1. Ensures all `beforeApplicationDestroyedCallbacks` are called by catching any exceptions thrown during one of the callbacks.
2. It removes the `once()` method so mockery doesn't run verifications on the count, this will allow our mechanism to handle failure using `$this->fail()`;