### PR TITLE
[5.8] Fix UPDATE queries with alias on SQLite

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -194,12 +194,28 @@ class SQLiteGrammar extends Grammar
         })->implode(', ');
 
         if (isset($query->joins) || isset($query->limit)) {
-            $selectSql = parent::compileSelect($query->select("{$query->from}.rowid"));
-
-            return "update {$table} set $columns where {$this->wrap('rowid')} in ({$selectSql})";
+            return $this->compileUpdateWithJoinsOrLimit($query, $columns);
         }
 
         return trim("update {$table} set {$columns} {$this->compileWheres($query)}");
+    }
+
+    /**
+     * Compile an update statement with joins or limit into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $columns
+     * @return string
+     */
+    protected function compileUpdateWithJoinsOrLimit(Builder $query, $columns)
+    {
+        $segments = preg_split('/\s+as\s+/i', $query->from);
+
+        $alias = $segments[1] ?? $segments[0];
+
+        $selectSql = parent::compileSelect($query->select($alias.'.rowid'));
+
+        return "update {$this->wrapTable($query->from)} set {$columns} where {$this->wrap('rowid')} in ({$selectSql})";
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1979,6 +1979,11 @@ class DatabaseQueryBuilderTest extends TestCase
                 ->where('users.id', '=', 1);
         })->update(['email' => 'foo', 'name' => 'bar']);
         $this->assertEquals(1, $result);
+
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')->once()->with('update "users" as "u" set "email" = ?, "name" = ? where "rowid" in (select "u"."rowid" from "users" as "u" inner join "orders" as "o" on "u"."id" = "o"."user_id")', ['foo', 'bar'])->andReturn(1);
+        $result = $builder->from('users as u')->join('orders as o', 'u.id', '=', 'o.user_id')->update(['email' => 'foo', 'name' => 'bar']);
+        $this->assertEquals(1, $result);
     }
 
     public function testUpdateMethodWithJoinsAndAliasesOnSqlServer()


### PR DESCRIPTION
The issue from #29164 also affects `UPDATE` queries with an alias.


