### PR TITLE
[6.0] Default FormRequest authorize method to true

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -13,7 +13,7 @@ class DummyClass extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
In the last 3 years while I've been using Laravel I've had to use this method exactly once when a user was only allowed to create users with specific roles, thus i believe the method shouldn't be removed by default.

But i do believe that he default return value should be `true` instead of `false` for the simple reason that his method is hardly ever used to actually do authorization and having it at `true` skips getting an unexpected Unauthorized exception on those very frequent friday afternoons.