### PR TITLE
[5.6] Fix typo in tests name

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -12,13 +12,13 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         m::close();
     }
 
-    public function testwithPivotValueMethodSetsWhereConditionsForFetching()
+    public function testWithPivotValueMethodSetsWhereConditionsForFetching()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);
     }
 
-    public function testwithPivotValueMethodSetsDefaultArgumentsForInsertion()
+    public function testWithPivotValueMethodSetsDefaultArgumentsForInsertion()
     {
         $relation = $this->getMockBuilder('Illuminate\Database\Eloquent\Relations\BelongsToMany')->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);


### PR DESCRIPTION
This PR fixes typo in 2 test methods names: `testwith` replaced to `testWith`.

These methods:
- `testwithPivotValueMethodSetsWhereConditionsForFetching`
- `testwithPivotValueMethodSetsDefaultArgumentsForInsertion`

Replaced with:
- `testWithPivotValueMethodSetsWhereConditionsForFetching`
- `testWithPivotValueMethodSetsDefaultArgumentsForInsertion`

I know that 5.6 has reached EOL this year, but this typo appeared in it initially and propagates to all later releases.

Do I need to create PRs with this fix to 5.7, 5.8 & master branch?