### PR TITLE
[6.0] Add getAttributeDefaultValue method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -341,7 +341,7 @@ trait HasAttributes
      */
     public function getAttributeValue($key)
     {
-        $value = $this->getAttributeFromArray($key);
+        $value = $this->getAttributeDefault($key);
 
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
@@ -369,12 +369,12 @@ trait HasAttributes
     }
 
     /**
-     * Get an attribute from the $attributes array.
+     * Get an attribute default value from the $attributes array.
      *
      * @param  string  $key
      * @return mixed
      */
-    protected function getAttributeFromArray($key)
+    public function getAttributeDefault($key)
     {
         if (isset($this->attributes[$key])) {
             return $this->attributes[$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -341,7 +341,7 @@ trait HasAttributes
      */
     public function getAttributeValue($key)
     {
-        $value = $this->getAttributeDefault($key);
+        $value = $this->getAttributeDefaultValue($key);
 
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
@@ -374,7 +374,7 @@ trait HasAttributes
      * @param  string  $key
      * @return mixed
      */
-    public function getAttributeDefault($key)
+    public function getAttributeDefaultValue($key)
     {
         if (isset($this->attributes[$key])) {
             return $this->attributes[$key];


### PR DESCRIPTION
This PR replaces protected `getAttributeFromArray` method with public `getAttributeDefaultValue` method.

I've found this requirement while developing PR: https://github.com/cybercog/laravel-love/pull/84

I have model which has default attribute value:
```php
class Reaction extends Model
{
    protected $attributes = [
        'power' => 1,
    ];
}
```

In Reaction observer's `creating` method if attribute not filled - I need to set attribute value equals to default value.
```php
public function creating(Reaction $reaction): void
{
    if ($reaction->isDirty('power') && is_null($reaction->getAttributeValue('power'))) {
        $reaction->setAttribute('power', 1);
    }
}
```

So I have to hardcode default value to `1` in observer instead of relying on model's default attribute value:

```php
public function creating(Reaction $reaction): void
{
    if ($reaction->isDirty('power') && is_null($reaction->getAttributeValue('power'))) {
        $reaction->setAttribute('power', $reaction->getAttributeDefaultValue('power'));
    }
}
```

*// Another one name I was thought about: `getAttributeDefault`.*