### PR TITLE
[6.0] Limit PHPUnit to version 8.0 and above.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "moontoast/math": "^1.1",
         "orchestra/testbench-core": "3.9.*",
         "pda/pheanstalk": "^4.0",
-        "phpunit/phpunit": "^7.5|^8.0",
+        "phpunit/phpunit": "^8.0",
         "predis/predis": "^1.1.1",
         "symfony/css-selector": "^4.3",
         "symfony/dom-crawler": "^4.3",


### PR DESCRIPTION
The changes has been done on `develop` branch for `laravel/laravel`. It is logical that we does this as well on `laravel/framework`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
