### PR TITLE
[6.0] Update to orchestra/testbench-core ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.0",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "3.9.*",
+        "orchestra/testbench-core": "^4.0",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^7.5|^8.0",
         "predis/predis": "^1.1.1",


### PR DESCRIPTION
We'll be following Laravel semver release. So 6.x should be compatible with 4.x

Ideally I would like to remove `phpunit/phpunit` `7.5` support for this release as well but that's another discussion.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
