### PR TITLE
[5.8] Add the proper columns for a polymorphic table (using uuid for the {$name}_id column)

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1225,6 +1225,38 @@ class Blueprint
     }
 
     /**
+     * Add the proper columns for a polymorphic table (using uuid for the {$name}_id column).
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function uuidMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type");
+
+        $this->uuid("{$name}_id");
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add nullable columns for a polymorphic table (using uuid for the {$name}_id column).
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function nullableUuidMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type")->nullable();
+
+        $this->uuid("{$name}_id")->nullable();
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
      * Adds the `remember_token` column to the table.
      *
      * @return \Illuminate\Database\Schema\ColumnDefinition

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1225,7 +1225,7 @@ class Blueprint
     }
 
     /**
-     * Add the proper columns for a polymorphic table (using uuid for the {$name}_id column).
+     * Add the proper columns for a polymorphic table using UUIDs.
      *
      * @param  string  $name
      * @param  string|null  $indexName
@@ -1241,7 +1241,7 @@ class Blueprint
     }
 
     /**
-     * Add nullable columns for a polymorphic table (using uuid for the {$name}_id column).
+     * Add nullable columns for a polymorphic table using UUIDs.
      *
      * @param  string  $name
      * @param  string|null  $indexName


### PR DESCRIPTION
This allows creating polymorphic columns with the id being uuid without the need to manually create individual columns and index them afterward.