### PR TITLE
[5.8] Fix typo in test methods names

### DIFF
--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -15,13 +15,13 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         m::close();
     }
 
-    public function testwithPivotValueMethodSetsWhereConditionsForFetching()
+    public function testWithPivotValueMethodSetsWhereConditionsForFetching()
     {
         $relation = $this->getMockBuilder(BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);
     }
 
-    public function testwithPivotValueMethodSetsDefaultArgumentsForInsertion()
+    public function testWithPivotValueMethodSetsDefaultArgumentsForInsertion()
     {
         $relation = $this->getMockBuilder(BelongsToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $relation->withPivotValue(['is_admin' => 1]);


### PR DESCRIPTION
In continue to #29292 & #29283

This PR fixes typo in 2 test methods names: `testwith` replaced to `testWith`.

These methods:
- `testwithPivotValueMethodSetsWhereConditionsForFetching`
- `testwithPivotValueMethodSetsDefaultArgumentsForInsertion`

Replaced with:
- `testWithPivotValueMethodSetsWhereConditionsForFetching`
- `testWithPivotValueMethodSetsDefaultArgumentsForInsertion`