### PR TITLE
Add case sensitive bool to Str contains

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -105,7 +105,7 @@ class Str
     public static function contains($haystack, $needles, $caseSensitive = true)
     {
         $func = $caseSensitive
-            ? 'mb_strpos' : 'stripos';
+            ? 'mb_strpos' : 'mb_stripos';
 
         foreach ((array) $needles as $needle) {
             if ($needle !== '' && call_user_func($func, $haystack, $needle) !== false) {

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -99,12 +99,16 @@ class Str
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      */
-    public static function contains($haystack, $needles)
+    public static function contains($haystack, $needles, $caseSensitive = true)
     {
+        $func = $caseSensitive
+            ? 'mb_strpos' : 'stripos';
+
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if ($needle !== '' && call_user_func($func, $haystack, $needle) !== false) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -901,13 +901,14 @@ if (! function_exists('str_contains')) {
      *
      * @param  string  $haystack
      * @param  string|array  $needles
+     * @param  bool  $caseSensitive
      * @return bool
      *
      * @deprecated Str::contains() should be used directly instead. Will be removed in Laravel 6.0.
      */
-    function str_contains($haystack, $needles)
+    function str_contains($haystack, $needles, $caseSensitive = true)
     {
-        return Str::contains($haystack, $needles);
+        return Str::contains($haystack, $needles, $caseSensitive);
     }
 }
 

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -124,9 +124,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::contains('taylor', 'taylor'));
         $this->assertTrue(Str::contains('taylor', ['ylo']));
         $this->assertTrue(Str::contains('taylor', ['xxx', 'ylo']));
+        $this->assertTrue(Str::contains('Taylor', 'taylor', false));
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
+        $this->assertFalse(Str::contains('Taylor', 'taylor'));
     }
 
     public function testStrContainsAll()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adds the ability to pass a boolean as the third argument for `Str::contains` that will determine if [`mb_strpos`][mb_strpos] or [`mb_stripos`][mb_stripos] is used.

```php
Str::contains('GitHub', 'hub'); // false
Str::contains('GitHub', 'hub', true); // false
Str::contains('GitHub', 'hub', false) // true
```

[mb_strpos]: https://php.net/manual/en/function.mb-strpos.php
[mb_stripos]: https://php.net/manual/en/function.mb-stripos.php