### PR TITLE
[5.8] Add support for whereColumn between 2 other columns

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -781,7 +781,7 @@ class Builder
                 ->orWhereColumn($first, '>', array_shift($second));
             });
         }
-        
+
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -778,7 +778,7 @@ class Builder
         } elseif (strtolower($operator) === 'not between') {
             return $this->where(function ($query) use ($first, $second) {
                 $query->whereColumn($first, '<', array_shift($second))
-                ->orWhereColumn($first, '>', array_shift($second));
+                    ->orWhereColumn($first, '>', array_shift($second));
             });
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -768,6 +768,20 @@ class Builder
             return $this->addArrayOfWheres($first, $boolean, 'whereColumn');
         }
 
+        // If the given operator is "between" or "not between"
+        // build the conditional statements
+        if (strtolower($operator) === 'between') {
+            return $this->where(function ($query) use ($first, $second) {
+                $query->whereColumn($first, '>=', array_shift($second))
+                    ->whereColumn($first, '<=', array_shift($second));
+            });
+        } elseif (strtolower($operator) === 'not between') {
+            return $this->where(function ($query) use ($first, $second) {
+                $query->whereColumn($first, '<', array_shift($second))
+                ->orWhereColumn($first, '>', array_shift($second));
+            });
+        }
+        
         // If the given operator is not found in the list of valid operators we will
         // assume that the developer is just short-cutting the '=' operators and
         // we will set the operators to '=' and set the values appropriately.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -756,6 +756,16 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereColumn('updated_at', '>', 'created_at');
         $this->assertEquals('select * from "users" where "updated_at" > "created_at"', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereColumn('age', 'between', ['min_age', 'max_age']);
+        $this->assertEquals('select * from "users" where ("age" >= "min_age" and "age" <= "max_age")', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orWhereColumn('age', 'not between', ['min_age', 'max_age']);
+        $this->assertEquals('select * from "users" where ("age" < "min_age" or "age" > "max_age")', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testArrayWhereColumn()
@@ -768,6 +778,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn($conditions);
         $this->assertEquals('select * from "users" where ("first_name" = "last_name" and "updated_at" > "created_at")', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+
+        $conditions = [
+            ['age', 'between', ['min_age', 'max_age']],
+            ['age', 'not between', ['min_age', 'max_age']],
+        ];
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->whereColumn($conditions);
+        $expectedSql = 'select * from "users" where (("age" >= "min_age" and "age" <= "max_age") and ("age" < "min_age" or "age" > "max_age"))';
+        $this->assertEquals($expectedSql, $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 


### PR DESCRIPTION
Exaple:
```php
$query = Event::select('*')
    ->selectSub(
        User::whereColumn('events.visible_after', 'between', ['users.contract_start_at', 'users.contract_end_at'])
            ->where('id', Auth::id());
    , 'show_preview');
```