### PR TITLE
[5.8] Fix UPDATE and DELETE queries with join bindings on PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -365,10 +365,10 @@ class PostgresGrammar extends Grammar
                 : $value;
         })->all();
 
-        $cleanBindings = Arr::except($bindings, 'select');
+        $bindingsWithoutWhere = Arr::except($bindings, ['select', 'where']);
 
         return array_values(
-            array_merge($values, Arr::flatten($cleanBindings))
+            array_merge($values, $bindings['where'], Arr::flatten($bindingsWithoutWhere))
         );
     }
 
@@ -403,6 +403,21 @@ class PostgresGrammar extends Grammar
         $where = count($query->wheres) > 0 ? ' '.$this->compileUpdateWheres($query) : '';
 
         return trim("delete from {$table}{$using}{$where}");
+    }
+
+    /**
+     * Prepare the bindings for a delete statement.
+     *
+     * @param  array  $bindings
+     * @return array
+     */
+    public function prepareBindingsForDelete(array $bindings)
+    {
+        $bindingsWithoutWhere = Arr::except($bindings, ['select', 'where']);
+
+        return array_values(
+            array_merge($bindings['where'], Arr::flatten($bindingsWithoutWhere))
+        );
     }
 
     /**


### PR DESCRIPTION
On PostgreSQL, Laravel implements `UPDATE` and `DELETE` queries with joins by adding their constraints after the `WHERE` constraints. If both clauses have bindings, their order is incorrect:

```php
DB::table('comments')
    ->join('posts', function ($join) {
        $join->on('posts.id', '=', 'comments.commentable_id')
            ->where('comments.commentable_type', 'App\Post');
    })
    ->where('posts.active', 0)
    ->delete();
```

```sql
delete from "comments" USING "posts"
where "posts"."active" = 'App\Post'
  and "posts"."id" = "comments"."commentable_id"
  and "comments"."commentable_type" = 0
```

We have to put the `where` bindings before the `join` bindings.

We could also swap the constraints in the generated SQL, but that's quite cumbersome.