### PR TITLE
[5.8] Add getEndpoint and setEndpoint methods to the MailgunTransport class

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -189,7 +189,7 @@ class MailgunTransport extends Transport
     }
 
     /**
-     * Get the API end-point being used by the transport.
+     * Get the API endpoint being used by the transport.
      *
      * @return string
      */
@@ -199,7 +199,7 @@ class MailgunTransport extends Transport
     }
 
     /**
-     * Set the API end-point being used by the transport.
+     * Set the API endpoint being used by the transport.
      *
      * @param  string  $endpoint
      * @return string

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -187,4 +187,25 @@ class MailgunTransport extends Transport
     {
         return $this->domain = $domain;
     }
+
+    /**
+     * Get the API end-point being used by the transport.
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint;
+    }
+
+    /**
+     * Set the API end-point being used by the transport.
+     *
+     * @param  string  $endpoint
+     * @return string
+     */
+    public function setEndpoint($endpoint)
+    {
+        return $this->endpoint = $endpoint;
+    }
 }


### PR DESCRIPTION
If you need to switch (on the fly) your mailgun domain while sending emails you can do it by updating the MailgunTransport "domain" property using the setDomain() method. But if your mailgun domain region is EU, you should also change the endpoint property value from "api.mailgun.net" to "api.eu.mailgun.net". 

This PR adds setEndpoint method to MailgunTransport class, so you can do it like this (in your Mailable-class, for example):

```
$mailTransport = app()->make('mailer')->getSwiftMailer()->getTransport();
$mailTransport->setDomain('yourdomain.com');
$mailTransport->setEndpoint('api.eu.mailgun.net');
```