### PR TITLE
[5.8] Fix DELETE queries with joins on PostgreSQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -400,9 +400,9 @@ class PostgresGrammar extends Grammar
             return $this->wrapTable($join->table);
         })->implode(', ');
 
-        $where = count($query->wheres) > 0 ? ' '.$this->compileUpdateWheres($query) : '';
+        $where = $this->compileUpdateWheres($query);
 
-        return trim("delete from {$table}{$using}{$where}");
+        return trim("delete from {$table}{$using} {$where}");
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2183,6 +2183,11 @@ class DatabaseQueryBuilderTest extends TestCase
             })->where('name', 'baz')
             ->delete();
         $this->assertEquals(1, $result);
+
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('delete')->once()->with('delete from "users" USING "contacts" where "users"."id" = "contacts"."id"', [])->andReturn(1);
+        $result = $builder->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->delete();
+        $this->assertEquals(1, $result);
     }
 
     public function testTruncateMethod()


### PR DESCRIPTION
On PostgreSQL, Laravel implements `DELETE` queries with joins by adding their constraints after the `WHERE` constraints. If a query only has joins, the constraints aren't compiled:

```php
DB::table('comments')
    ->join('posts', function ($join) {
        $join->on('posts.id', '=', 'comments.post_id')
            ->where('posts.active', 0);
    })
    ->delete();
```

```sql
# expected
delete from "comments" USING "posts"
where "posts"."id" = "comments"."post_id" and "posts"."active" = 0

# actual
delete from "comments" USING "posts"
```