### PR TITLE
[5.8] Fix orWhereDay(), orWhereMonth() and orWhereYear()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1221,7 +1221,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addDateBasedWhere('Day', $column, $operator, $value, 'or');
+        return $this->whereDay($column, $operator, $value, 'or');
     }
 
     /**
@@ -1264,7 +1264,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addDateBasedWhere('Month', $column, $operator, $value, 'or');
+        return $this->whereMonth($column, $operator, $value, 'or');
     }
 
     /**
@@ -1303,7 +1303,7 @@ class Builder
             $value, $operator, func_num_args() === 2
         );
 
-        return $this->addDateBasedWhere('Year', $column, $operator, $value, 'or');
+        return $this->whereYear($column, $operator, $value, 'or');
     }
 
     /**

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -19,6 +19,7 @@ class QueryBuilderTest extends DatabaseTestCase
         parent::setUp();
 
         Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
             $table->string('title');
             $table->text('content');
             $table->timestamp('created_at');
@@ -36,11 +37,24 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereDate('created_at', new Carbon('2018-01-02'))->count());
     }
 
+    public function testOrWhereDate()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDate('created_at', '2018-01-02')->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDate('created_at', new Carbon('2018-01-02'))->count());
+    }
+
     public function testWhereDay()
     {
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', '02')->count());
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', 2)->count());
         $this->assertSame(1, DB::table('posts')->whereDay('created_at', new Carbon('2018-01-02'))->count());
+    }
+
+    public function testOrWhereDay()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDay('created_at', '02')->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDay('created_at', 2)->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereDay('created_at', new Carbon('2018-01-02'))->count());
     }
 
     public function testWhereMonth()
@@ -50,6 +64,13 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereMonth('created_at', new Carbon('2018-01-02'))->count());
     }
 
+    public function testOrWhereMonth()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereMonth('created_at', '01')->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereMonth('created_at', 1)->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereMonth('created_at', new Carbon('2018-01-02'))->count());
+    }
+
     public function testWhereYear()
     {
         $this->assertSame(1, DB::table('posts')->whereYear('created_at', '2018')->count());
@@ -57,10 +78,23 @@ class QueryBuilderTest extends DatabaseTestCase
         $this->assertSame(1, DB::table('posts')->whereYear('created_at', new Carbon('2018-01-02'))->count());
     }
 
+    public function testOrWhereYear()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereYear('created_at', '2018')->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereYear('created_at', 2018)->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereYear('created_at', new Carbon('2018-01-02'))->count());
+    }
+
     public function testWhereTime()
     {
         $this->assertSame(1, DB::table('posts')->whereTime('created_at', '03:04:05')->count());
         $this->assertSame(1, DB::table('posts')->whereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
+    }
+
+    public function testOrWhereTime()
+    {
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereTime('created_at', '03:04:05')->count());
+        $this->assertSame(2, DB::table('posts')->where('id', 1)->orWhereTime('created_at', new Carbon('2018-01-02 03:04:05'))->count());
     }
 
     public function testPaginateWithSpecificColumns()


### PR DESCRIPTION
`orWhereDay()`, `orWhereMonth()` and `orWhereYear()` call `addDateBasedWhere()` instead of their "base" methods. As a result, they don't support `DateTime` objects (#25315) or integer values (#28185).