### PR TITLE
[7.x] [WIP] Switch from SwiftMailer to Symfony Mailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/finder": "^4.3",
         "symfony/http-foundation": "^4.3",
         "symfony/http-kernel": "^4.3",
+        "symfony/mailer": "^4.3",
         "symfony/process": "^4.3",
         "symfony/routing": "^4.3",
         "symfony/var-dumper": "^4.3",

--- a/src/Illuminate/Mail/Events/MessageSending.php
+++ b/src/Illuminate/Mail/Events/MessageSending.php
@@ -5,9 +5,9 @@ namespace Illuminate\Mail\Events;
 class MessageSending
 {
     /**
-     * The Swift message instance.
+     * The Symfony Email instance.
      *
-     * @var \Swift_Message
+     * @var \Symfony\Component\Mime\Email
      */
     public $message;
 
@@ -21,7 +21,7 @@ class MessageSending
     /**
      * Create a new event instance.
      *
-     * @param  \Swift_Message $message
+     * @param  \Symfony\Component\Mime\Email $message
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -5,9 +5,9 @@ namespace Illuminate\Mail\Events;
 class MessageSent
 {
     /**
-     * The Swift message instance.
+     * The Symfony Email instance.
      *
-     * @var \Swift_Message
+     * @var \Symfony\Component\Mime\Email
      */
     public $message;
 
@@ -21,7 +21,7 @@ class MessageSent
     /**
      * Create a new event instance.
      *
-     * @param  \Swift_Message  $message
+     * @param  \Symfony\Component\Mime\Email  $message
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -237,15 +237,20 @@ class Message
      * Embed a file in the message and get the CID.
      *
      * @param  string  $file
+     * @param  string|null  $name
+     * @param  string|null  $contentType
      * @return string
      */
-    public function embed($file)
+    public function embed($file, $name = null, $contentType = null)
     {
-        if (isset($this->embeddedFiles[$file])) {
-            return $this->embeddedFiles[$file];
+        $hash = sha1($file.$name.$contentType);
+        if (isset($this->embeddedFiles[$hash])) {
+            return $this->embeddedFiles[$hash];
         }
 
-        return $this->embeddedFiles[$file] = $this->email->embedFromPath($file);
+        $this->email->embedFromPath($file, $name, $contentType);
+
+        return $this->embeddedFiles[$hash] = 'cid:'.head($this->email->getAttachments())->getContentId();
     }
 
     /**

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -2,23 +2,24 @@
 
 namespace Illuminate\Mail;
 
-use Swift_Image;
-use Swift_Attachment;
+use Illuminate\Support\Arr;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\NamedAddress;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
- * @mixin \Swift_Message
+ * @mixin \Symfony\Component\Mime\Email
  */
 class Message
 {
     use ForwardsCalls;
 
     /**
-     * The Swift Message instance.
+     * The Symfony Email instance.
      *
-     * @var \Swift_Message
+     * @var \Symfony\Component\Mime\Email
      */
-    protected $swift;
+    protected $email;
 
     /**
      * CIDs of files embedded in the message.
@@ -30,12 +31,12 @@ class Message
     /**
      * Create a new message instance.
      *
-     * @param  \Swift_Message  $swift
+     * @param  \Symfony\Component\Mime\Email  $email
      * @return void
      */
-    public function __construct($swift)
+    public function __construct($email)
     {
-        $this->swift = $swift;
+        $this->email = $email;
     }
 
     /**
@@ -47,7 +48,7 @@ class Message
      */
     public function from($address, $name = null)
     {
-        $this->swift->setFrom($address, $name);
+        $this->email->from(...$this->createAddress($address, $name));
 
         return $this;
     }
@@ -61,7 +62,7 @@ class Message
      */
     public function sender($address, $name = null)
     {
-        $this->swift->setSender($address, $name);
+        $this->email->sender($address);
 
         return $this;
     }
@@ -74,7 +75,7 @@ class Message
      */
     public function returnPath($address)
     {
-        $this->swift->setReturnPath($address);
+        $this->email->returnPath($address);
 
         return $this;
     }
@@ -90,7 +91,7 @@ class Message
     public function to($address, $name = null, $override = false)
     {
         if ($override) {
-            $this->swift->setTo($address, $name);
+            $this->email->to(...$this->createAddress($address, $name));
 
             return $this;
         }
@@ -109,7 +110,7 @@ class Message
     public function cc($address, $name = null, $override = false)
     {
         if ($override) {
-            $this->swift->setCc($address, $name);
+            $this->email->cc(...$this->createAddress($address, $name));
 
             return $this;
         }
@@ -128,7 +129,7 @@ class Message
     public function bcc($address, $name = null, $override = false)
     {
         if ($override) {
-            $this->swift->setBcc($address, $name);
+            $this->email->bcc(...$this->createAddress($address, $name));
 
             return $this;
         }
@@ -159,9 +160,15 @@ class Message
     protected function addAddresses($address, $name, $type)
     {
         if (is_array($address)) {
-            $this->swift->{"set{$type}"}($address, $name);
+            $type = lcfirst($type);
+
+            $this->email->$type(
+                ...$this->createAddress($address, $name)
+            );
         } else {
-            $this->swift->{"add{$type}"}($address, $name);
+            $this->email->{"add{$type}"}(
+                ...$this->createAddress($address, $name)
+            );
         }
 
         return $this;
@@ -175,7 +182,7 @@ class Message
      */
     public function subject($subject)
     {
-        $this->swift->setSubject($subject);
+        $this->email->subject($subject);
 
         return $this;
     }
@@ -188,7 +195,7 @@ class Message
      */
     public function priority($level)
     {
-        $this->swift->setPriority($level);
+        $this->email->priority($level);
 
         return $this;
     }
@@ -202,20 +209,13 @@ class Message
      */
     public function attach($file, array $options = [])
     {
-        $attachment = $this->createAttachmentFromPath($file);
+        $this->email->attachFromPath(
+            $file,
+            Arr::get($options, 'as'),
+            Arr::get($options, 'mime')
+        );
 
-        return $this->prepAttachment($attachment, $options);
-    }
-
-    /**
-     * Create a Swift Attachment instance.
-     *
-     * @param  string  $file
-     * @return \Swift_Mime_Attachment
-     */
-    protected function createAttachmentFromPath($file)
-    {
-        return Swift_Attachment::fromPath($file);
+        return $this;
     }
 
     /**
@@ -228,21 +228,9 @@ class Message
      */
     public function attachData($data, $name, array $options = [])
     {
-        $attachment = $this->createAttachmentFromData($data, $name);
+        $this->email->attach($data, $name, Arr::get($options, 'mime'));
 
-        return $this->prepAttachment($attachment, $options);
-    }
-
-    /**
-     * Create a Swift Attachment instance from data.
-     *
-     * @param  string  $data
-     * @param  string  $name
-     * @return \Swift_Attachment
-     */
-    protected function createAttachmentFromData($data, $name)
-    {
-        return new Swift_Attachment($data, $name);
+        return $this;
     }
 
     /**
@@ -257,9 +245,7 @@ class Message
             return $this->embeddedFiles[$file];
         }
 
-        return $this->embeddedFiles[$file] = $this->swift->embed(
-            Swift_Image::fromPath($file)
-        );
+        return $this->embeddedFiles[$file] = $this->email->embedFromPath($file);
     }
 
     /**
@@ -272,51 +258,45 @@ class Message
      */
     public function embedData($data, $name, $contentType = null)
     {
-        $image = new Swift_Image($data, $name, $contentType);
-
-        return $this->swift->embed($image);
+        return $this->email->embed($data, $name, $contentType);
     }
 
     /**
-     * Prepare and attach the given attachment.
-     *
-     * @param  \Swift_Attachment  $attachment
-     * @param  array  $options
-     * @return $this
+     * @param  string|array  $address
+     * @param  string|null  $name
+     * @return array
      */
-    protected function prepAttachment($attachment, $options = [])
+    public function createAddress($address, $name = null)
     {
-        // First we will check for a MIME type on the message, which instructs the
-        // mail client on what type of attachment the file is so that it may be
-        // downloaded correctly by the user. The MIME option is not required.
-        if (isset($options['mime'])) {
-            $attachment->setContentType($options['mime']);
+        $addrs = [];
+
+        if (is_array($address)) {
+            foreach ($address as $email) {
+                $addrs[] = current($this->createAddress($email));
+            }
+        } else {
+            if ($name) {
+                $addrs[] = new NamedAddress($address, $name);
+            } else {
+                $addrs[] = new Address($address);
+            }
         }
 
-        // If an alternative name was given as an option, we will set that on this
-        // attachment so that it will be downloaded with the desired names from
-        // the developer, otherwise the default file names will get assigned.
-        if (isset($options['as'])) {
-            $attachment->setFilename($options['as']);
-        }
-
-        $this->swift->attach($attachment);
-
-        return $this;
+        return $addrs;
     }
 
     /**
-     * Get the underlying Swift Message instance.
+     * Get the underlying Symfony Email instance.
      *
-     * @return \Swift_Message
+     * @return \Symfony\Component\Mime\Email
      */
-    public function getSwiftMessage()
+    public function getSymfonyEmail()
     {
-        return $this->swift;
+        return $this->email;
     }
 
     /**
-     * Dynamically pass missing methods to the Swift instance.
+     * Dynamically pass missing methods to the Symfony Email instance.
      *
      * @param  string  $method
      * @param  array  $parameters
@@ -324,6 +304,6 @@ class Message
      */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo($this->swift, $method, $parameters);
+        return $this->forwardCallTo($this->email, $method, $parameters);
     }
 }

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Mail\Transport;
 
-use Swift_Mime_SimpleMessage;
 use Illuminate\Support\Collection;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\SmtpEnvelope;
 
 class ArrayTransport extends Transport
 {
@@ -27,13 +29,11 @@ class ArrayTransport extends Transport
     /**
      * {@inheritdoc}
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
     {
-        $this->beforeSendPerformed($message);
-
         $this->messages[] = $message;
 
-        return $this->numberOfRecipients($message);
+        return null;
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/LogTransport.php
+++ b/src/Illuminate/Mail/Transport/LogTransport.php
@@ -3,8 +3,9 @@
 namespace Illuminate\Mail\Transport;
 
 use Psr\Log\LoggerInterface;
-use Swift_Mime_SimpleMessage;
-use Swift_Mime_SimpleMimeEntity;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\SmtpEnvelope;
 
 class LogTransport extends Transport
 {
@@ -29,32 +30,11 @@ class LogTransport extends Transport
     /**
      * {@inheritdoc}
      */
-    public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
+    public function send(RawMessage $message, SmtpEnvelope $envelope = null): ?SentMessage
     {
-        $this->beforeSendPerformed($message);
+        $this->logger->debug($message->toString());
 
-        $this->logger->debug($this->getMimeEntityString($message));
-
-        $this->sendPerformed($message);
-
-        return $this->numberOfRecipients($message);
-    }
-
-    /**
-     * Get a loggable string out of a Swiftmailer entity.
-     *
-     * @param  \Swift_Mime_SimpleMimeEntity $entity
-     * @return string
-     */
-    protected function getMimeEntityString(Swift_Mime_SimpleMimeEntity $entity)
-    {
-        $string = (string) $entity->getHeaders().PHP_EOL.$entity->getBody();
-
-        foreach ($entity->getChildren() as $children) {
-            $string .= PHP_EOL.PHP_EOL.$this->getMimeEntityString($children);
-        }
-
-        return $string;
+        return null;
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -2,104 +2,18 @@
 
 namespace Illuminate\Mail\Transport;
 
-use Swift_Transport;
-use Swift_Events_SendEvent;
-use Swift_Mime_SimpleMessage;
-use Swift_Events_EventListener;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 
-abstract class Transport implements Swift_Transport
+abstract class Transport implements TransportInterface
 {
-    /**
-     * The plug-ins registered with the transport.
-     *
-     * @var array
-     */
-    public $plugins = [];
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isStarted()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function start()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function stop()
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function ping()
-    {
-        return true;
-    }
-
-    /**
-     * Register a plug-in with the transport.
-     *
-     * @param  \Swift_Events_EventListener  $plugin
-     * @return void
-     */
-    public function registerPlugin(Swift_Events_EventListener $plugin)
-    {
-        array_push($this->plugins, $plugin);
-    }
-
-    /**
-     * Iterate through registered plugins and execute plugins' methods.
-     *
-     * @param  \Swift_Mime_SimpleMessage  $message
-     * @return void
-     */
-    protected function beforeSendPerformed(Swift_Mime_SimpleMessage $message)
-    {
-        $event = new Swift_Events_SendEvent($this, $message);
-
-        foreach ($this->plugins as $plugin) {
-            if (method_exists($plugin, 'beforeSendPerformed')) {
-                $plugin->beforeSendPerformed($event);
-            }
-        }
-    }
-
-    /**
-     * Iterate through registered plugins and execute plugins' methods.
-     *
-     * @param  \Swift_Mime_SimpleMessage  $message
-     * @return void
-     */
-    protected function sendPerformed(Swift_Mime_SimpleMessage $message)
-    {
-        $event = new Swift_Events_SendEvent($this, $message);
-
-        foreach ($this->plugins as $plugin) {
-            if (method_exists($plugin, 'sendPerformed')) {
-                $plugin->sendPerformed($event);
-            }
-        }
-    }
-
     /**
      * Get the number of recipients.
      *
-     * @param  \Swift_Mime_SimpleMessage  $message
+     * @param  \Symfony\Component\Mime\Message  $message
      * @return int
      */
-    protected function numberOfRecipients(Swift_Mime_SimpleMessage $message)
+    protected function numberOfRecipients(Message $message)
     {
         return count(array_merge(
             (array) $message->getTo(), (array) $message->getCc(), (array) $message->getBcc()

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -8,20 +8,20 @@ use Psr\Log\LoggerInterface;
 use Illuminate\Log\LogManager;
 use Illuminate\Support\Manager;
 use GuzzleHttp\Client as HttpClient;
-use Swift_SmtpTransport as SmtpTransport;
 use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Postmark\Transport as PostmarkTransport;
 use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Swift_SendmailTransport as SendmailTransport;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport as SmtpTransport;
 
 class TransportManager extends Manager
 {
     /**
      * Create an instance of the SMTP Swift Transport driver.
      *
-     * @return \Swift_SmtpTransport
+     * @return \Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport
      */
     protected function createSmtpDriver()
     {
@@ -33,7 +33,8 @@ class TransportManager extends Manager
         $transport = new SmtpTransport($config['host'], $config['port']);
 
         if (isset($config['encryption'])) {
-            $transport->setEncryption($config['encryption']);
+            $stream = $transport->getStream();
+            $stream->setEncryption($config['encryption']);
         }
 
         // Once we have the transport we will check for the presence of a username
@@ -51,18 +52,20 @@ class TransportManager extends Manager
     /**
      * Configure the additional SMTP driver options.
      *
-     * @param  \Swift_SmtpTransport  $transport
+     * @param  \Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport  $transportTransport
      * @param  array  $config
-     * @return \Swift_SmtpTransport
+     * @return \Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport
      */
     protected function configureSmtpDriver($transport, $config)
     {
         if (isset($config['stream'])) {
-            $transport->setStreamOptions($config['stream']);
+            $stream = $transport->getStream();
+            $stream->setStreamOptions($config['stream']);
         }
 
         if (isset($config['source_ip'])) {
-            $transport->setSourceIp($config['source_ip']);
+            $stream = $transport->getStream();
+            $stream->setSourceIp($config['source_ip']);
         }
 
         if (isset($config['local_domain'])) {

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -22,6 +22,7 @@
         "illuminate/support": "5.9.*",
         "psr/log": "^1.0",
         "swiftmailer/swiftmailer": "^6.0",
+        "symfony/mailer": "^4.3",
         "tijsverkoyen/css-to-inline-styles": "^2.2.1"
     },
     "autoload": {

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -56,7 +56,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to('test@mail.com')->send(new TestMail);
 
         $this->assertStringContainsString('name',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -65,7 +65,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail);
 
         $this->assertStringContainsString('esm',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -80,7 +80,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to('test@mail.com')->locale('es')->send(new TimestampTestMail);
 
         $this->assertRegExp('/nombre (en|dentro de) (un|1) día/',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
 
         $this->assertEquals('en', Carbon::getLocale());
@@ -96,7 +96,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to($recipient)->send(new TestMail);
 
         $this->assertStringContainsString('esm',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -110,7 +110,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to($recipient)->locale('ar')->send(new TestMail);
 
         $this->assertStringContainsString('esm',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -129,7 +129,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to($toRecipient)->cc($ccRecipient)->send(new TestMail);
 
         $this->assertStringContainsString('esm',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -149,7 +149,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to($recipients)->send(new TestMail);
 
         $this->assertStringContainsString('name',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
     }
 
@@ -161,11 +161,11 @@ class SendingMailWithLocaleTest extends TestCase
         $this->assertEquals('en', app('translator')->getLocale());
 
         $this->assertStringContainsString('esm',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getHtmlBody()
         );
 
         $this->assertStringContainsString('name',
-            app('swift.transport')->messages()[1]->getBody()
+            app('symfony.transport')->messages()[1]->getHtmlBody()
         );
     }
 }

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -75,7 +75,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         NotificationFacade::send($user, new GreetingMailNotification);
 
         $this->assertStringContainsString('hello',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 
@@ -89,7 +89,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         NotificationFacade::locale('fr')->send($user, new GreetingMailNotification);
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 
@@ -109,11 +109,11 @@ class SendingNotificationsWithLocaleTest extends TestCase
         NotificationFacade::send($users, (new GreetingMailNotification)->locale('fr'));
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[1]->getBody()
+            app('symfony.transport')->messages()[1]->getBody()->toString()
         );
     }
 
@@ -127,7 +127,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         NotificationFacade::locale('fr')->send($user, new GreetingMailNotificationWithMailable);
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 
@@ -147,11 +147,11 @@ class SendingNotificationsWithLocaleTest extends TestCase
         $user->notify((new GreetingMailNotification)->locale('fr'));
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
 
         $this->assertRegExp('/dans (1|un) jour/',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
 
         $this->assertTrue($this->app->isLocale('en'));
@@ -169,7 +169,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         $recipient->notify(new GreetingMailNotification);
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 
@@ -194,13 +194,13 @@ class SendingNotificationsWithLocaleTest extends TestCase
         );
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
         $this->assertStringContainsString('hola',
-            app('swift.transport')->messages()[1]->getBody()
+            app('symfony.transport')->messages()[1]->getBody()->toString()
         );
         $this->assertStringContainsString('hi',
-            app('swift.transport')->messages()[2]->getBody()
+            app('symfony.transport')->messages()[2]->getBody()->toString()
         );
     }
 
@@ -216,7 +216,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         );
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 
@@ -232,7 +232,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
         );
 
         $this->assertStringContainsString('bonjour',
-            app('swift.transport')->messages()[0]->getBody()
+            app('symfony.transport')->messages()[0]->getBody()->toString()
         );
     }
 }

--- a/tests/Mail/MailLogTransportTest.php
+++ b/tests/Mail/MailLogTransportTest.php
@@ -19,7 +19,7 @@ class MailLogTransportTest extends TestCase
             'path' => 'mail.log',
         ]);
 
-        $manager = $this->app['swift.transport'];
+        $manager = $this->app['symfony.transport'];
 
         $transport = $manager->driver('log');
         $this->assertInstanceOf(LogTransport::class, $transport);
@@ -36,7 +36,7 @@ class MailLogTransportTest extends TestCase
     {
         $logger = $this->app->instance('log', new NullLogger());
 
-        $manager = $this->app['swift.transport'];
+        $manager = $this->app['symfony.transport'];
 
         $this->assertEquals($logger, $manager->driver('log')->logger());
     }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -5,16 +5,16 @@ namespace Illuminate\Tests\Mail;
 use stdClass;
 use Mockery as m;
 use Swift_Mailer;
-use Swift_Message;
 use Swift_Transport;
 use Illuminate\Mail\Mailer;
-use Swift_Mime_SimpleMessage;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Email;
 use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Mail\Transport\ArrayTransport;
 
 class MailMailerTest extends TestCase
 {
@@ -27,16 +27,15 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock(Swift_Mime_SimpleMessage::class);
+        $message = m::mock(Email::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
-        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
-        $message->shouldReceive('setFrom')->never();
-        $this->setSwiftMailer($mailer);
-        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
+        $message->shouldReceive('html')->once()->with('rendered.view');
+        $message->shouldReceive('from')->never();
+        $message->shouldReceive('getSymfonyEmail')->once()->andReturn($message);
+        $mailer->getTransport()->shouldReceive('send')->once()->with($message, []);
         $mailer->send('foo', ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
@@ -47,17 +46,16 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock(Swift_Mime_SimpleMessage::class);
+        $message = m::mock(Email::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
-        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
-        $message->shouldReceive('addPart')->once()->with('rendered.text', 'text/plain');
-        $message->shouldReceive('setFrom')->never();
-        $this->setSwiftMailer($mailer);
-        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
+        $message->shouldReceive('html')->once()->with('rendered.view');
+        $message->shouldReceive('text')->once()->with('rendered.text');
+        $message->shouldReceive('from')->never();
+        $message->shouldReceive('getSymfonyEmail')->once()->andReturn($message);
+        $mailer->getTransport()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['html' => new HtmlString('rendered.view'), 'text' => new HtmlString('rendered.text')], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
@@ -68,16 +66,15 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock(Swift_Mime_SimpleMessage::class);
+        $message = m::mock(Email::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->never();
         $view->shouldReceive('render')->never();
-        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
-        $message->shouldReceive('setFrom')->never();
-        $this->setSwiftMailer($mailer);
-        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
+        $message->shouldReceive('html')->once()->with('rendered.view');
+        $message->shouldReceive('from')->never();
+        $message->shouldReceive('getSymfonyEmail')->once()->andReturn($message);
+        $mailer->getTransport()->shouldReceive('send')->once()->with($message, []);
         $mailer->html('rendered.view', function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
@@ -88,18 +85,17 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock(Swift_Mime_SimpleMessage::class);
+        $message = m::mock(Email::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
-        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
-        $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
+        $message->shouldReceive('html')->once()->with('rendered.view');
+        $message->shouldReceive('text')->once()->with('rendered.view');
         $message->shouldReceive('setFrom')->never();
-        $this->setSwiftMailer($mailer);
-        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
+        $message->shouldReceive('getSymfonyEmail')->once()->andReturn($message);
+        $mailer->getTransport()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['foo', 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
@@ -110,18 +106,17 @@ class MailMailerTest extends TestCase
     {
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMockBuilder(Mailer::class)->setMethods(['createMessage'])->setConstructorArgs($this->getMocks())->getMock();
-        $message = m::mock(Swift_Mime_SimpleMessage::class);
+        $message = m::mock(Email::class);
         $mailer->expects($this->once())->method('createMessage')->will($this->returnValue($message));
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
         $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
-        $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
-        $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
+        $message->shouldReceive('html')->once()->with('rendered.view');
+        $message->shouldReceive('text')->once()->with('rendered.view');
         $message->shouldReceive('setFrom')->never();
-        $this->setSwiftMailer($mailer);
-        $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
+        $message->shouldReceive('getSymfonyEmail')->once()->andReturn($message);
+        $mailer->getTransport()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['html' => 'foo', 'text' => 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
@@ -135,10 +130,9 @@ class MailMailerTest extends TestCase
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
-        $this->setSwiftMailer($mailer);
         $mailer->alwaysFrom('taylorotwell@gmail.com', 'Taylor Otwell');
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
-            $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
+        $mailer->getTransport()->shouldReceive('send')->once()->with(m::type(Email::class), [])->andReturnUsing(function ($message) {
+            $this->assertEquals('Taylor Otwell <taylorotwell@gmail.com>', $message->getFrom()[0]->toString());
         });
         $mailer->send('foo', ['data'], function ($m) {
             //
@@ -147,6 +141,7 @@ class MailMailerTest extends TestCase
 
     public function testFailedRecipientsAreAppendedAndCanBeRetrieved()
     {
+        $this->markTestIncomplete();
         unset($_SERVER['__mailer.test']);
         $mailer = $this->getMailer();
         $mailer->getSwiftMailer()->shouldReceive('getTransport')->andReturn($transport = m::mock(Swift_Transport::class));
@@ -174,8 +169,7 @@ class MailMailerTest extends TestCase
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
-        $this->setSwiftMailer($mailer);
-        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), []);
+        $mailer->getTransport()->shouldReceive('send')->once()->with(m::type(Email::class), []);
         $mailer->send('foo', ['data'], function ($m) {
             //
         });
@@ -196,7 +190,7 @@ class MailMailerTest extends TestCase
 
     protected function getMailer($events = null)
     {
-        return new Mailer(m::mock(Factory::class), m::mock(Swift_Mailer::class), $events);
+        return new Mailer(m::mock(Factory::class), m::mock(ArrayTransport::class), $events);
     }
 
     public function setSwiftMailer($mailer)
@@ -212,7 +206,7 @@ class MailMailerTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock(Factory::class), m::mock(Swift_Mailer::class)];
+        return [m::mock(Factory::class), m::mock(ArrayTransport::class)];
     }
 }
 

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -13,6 +13,13 @@ use Illuminate\Mail\Transport\SesTransport;
 
 class MailSesTransportTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->markTestIncomplete();
+    }
+
     public function testGetTransport()
     {
         /** @var Application $app */

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Mail;
 
 use Mockery as m;
-use Swift_Mailer;
 use Illuminate\Mail\Mailer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
@@ -15,6 +14,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 
 class MailableQueuedTest extends TestCase
@@ -91,7 +91,7 @@ class MailableQueuedTest extends TestCase
 
     protected function getMocks()
     {
-        return [m::mock(Factory::class), m::mock(Swift_Mailer::class)];
+        return [m::mock(Factory::class), m::mock(ArrayTransport::class)];
     }
 }
 


### PR DESCRIPTION
Looking to replace SwiftMailer with Symfony's new [Mailer](https://symfony.com/doc/current/mailer.html) component. Useful slides at https://speakerdeck.com/fabpot/mailer

**To-do:**

- [x] Replace core SwiftMailer implementation
- [ ] Replace `SesTransport` with https://github.com/symfony/amazon-mailer and `MailgunTransport` with https://github.com/symfony/mailgun-mailer
- [x] Update tests

**Thoughts / issues:**

- `sender` does not allow for named senders. I'm wondering if we can pass through a `NamedAddress` though - but this means that the second parameter is unused.
- Can we implement a DSN system for Mail too?

**What does this break?**

- Any mention of `Swift`, i.e. I've renamed the `getSwiftMessage` method to `getSymfonyEmail` to reflect what we're getting back.
- SwiftMailer plugins will no longer work.
- `send()` currently returns the amount of addresses the email was sent to, but that's now no longer the case
- `Message@getFrom` no longer returns an array of sender email / name, instead it's formatted as `Name <Email>`
- When sending an email fails, you get an array of addresses which the email couldn't be sent to, this has currently been removed.