### PR TITLE
[5.8] Add assertSessionHasInput to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -914,6 +914,41 @@ class TestResponse
     }
 
     /**
+     * Assert that the session has a given value in the flashed input array.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function assertSessionHasInput($key, $value = null)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k => $v) {
+                if (is_int($k)) {
+                    $this->assertSessionHasInput($v);
+                } else {
+                    $this->assertSessionHasInput($k, $v);
+                }
+            }
+
+            return $this;
+        }
+
+        if (is_null($value)) {
+            PHPUnit::assertTrue(
+                $this->session()->getOldInput($key),
+                "Session is missing expected key [{$key}]."
+            );
+        } elseif ($value instanceof Closure) {
+            PHPUnit::assertTrue($value($this->session()->getOldInput($key)));
+        } else {
+            PHPUnit::assertEquals($value, $this->session()->getOldInput($key));
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the session has the given errors.
      *
      * @param  string|array  $keys


### PR DESCRIPTION
This adds an `assertSessionHasInput()` helper method to the `TestReponse` class. Inline with the other _session_ assertions, it accepts an array or a key value pair to verify exists in the flashed session array input.

Although you can test this with the available assertions, this new assertion avoids writing brittle tests which rely on internal framework values like the `_old_input` key.

```php
$response->assertSessionHas('_old_input', [
    'connection_id' => $connection->id,
    'repository' => $repository,
    'source_branch' => $branch,
]);
```

Instead, you can now write:

```php
$response->assertSessionHasInput([
    'connection_id' => $connection->id,
    'repository' => $repository,
    'source_branch' => $branch,
]);
```