### PR TITLE
[5.8] Fix a typo in the endpoint property DocBlock in MailgunTransport class

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -29,7 +29,7 @@ class MailgunTransport extends Transport
     protected $domain;
 
     /**
-     * The Mailgun API end-point.
+     * The Mailgun API endpoint.
      *
      * @var string
      */


### PR DESCRIPTION
Connected with this commit: https://github.com/laravel/framework/pull/29312/commits/506806263209701b983c4739c27d804e68e5f43f