### PR TITLE
[6.0] Support unsigned integer type in SQLite using check constraint

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -16,7 +16,7 @@ class SQLiteGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Nullable', 'Default', 'Increment'];
+    protected $modifiers = ['Nullable', 'Default', 'Increment', 'Unsigned'];
 
     /**
      * The columns available as serials.
@@ -855,6 +855,20 @@ class SQLiteGrammar extends Grammar
     {
         if (in_array($column->type, $this->serials) && $column->autoIncrement) {
             return ' primary key autoincrement';
+        }
+    }
+
+    /**
+     * Get the SQL for an unsigned column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyUnsigned(Blueprint $blueprint, Fluent $column)
+    {
+        if ($column->unsigned) {
+            return ' CHECK("'.$column->name.'" >= 0)';
         }
     }
 }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -27,7 +27,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertEquals('create table "users" ("id" integer not null primary key autoincrement CHECK("id" >= 0), "email" varchar not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -36,7 +36,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $this->assertCount(2, $statements);
         $expected = [
-            'alter table "users" add column "id" integer not null primary key autoincrement',
+            'alter table "users" add column "id" integer not null primary key autoincrement CHECK("id" >= 0)',
             'alter table "users" add column "email" varchar not null',
         ];
         $this->assertEquals($expected, $statements);
@@ -52,7 +52,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertEquals('create temporary table "users" ("id" integer not null primary key autoincrement CHECK("id" >= 0), "email" varchar not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -258,7 +258,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement CHECK("id" >= 0)', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -268,7 +268,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement CHECK("id" >= 0)', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -278,7 +278,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement CHECK("id" >= 0)', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -288,7 +288,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement CHECK("id" >= 0)', $statements[0]);
     }
 
     public function testAddingString()


### PR DESCRIPTION
Currently for SQLite, unsigned integer types are created as integers without notice / errors during migration. This creates confusions and problems when a workflow that relies on the column being always positive turns out to be negative as well.

By adding a check constraint for the column to be always >= 0, we could enforce the unsigned rule similar to MySQL, which is especially useful when using SQLite in testing environment but MySQL in dev + production environment. 

This allows us to atomically subtract value from the column and rely on the database to throw us exceptions, instead of handling in the app level which is not atomic.

Recreated on `master` per instruction on https://github.com/laravel/framework/pull/29318