### PR TITLE
[5.8] Use date_create to prevent unsuppressible date validator warnings

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -246,7 +246,7 @@ trait ValidatesAttributes
                 return Date::parse($value);
             }
 
-            return new DateTime($value);
+            return date_create($value);
         } catch (Exception $e) {
             //
         }


### PR DESCRIPTION
Due to an [unresolved PHP bug](https://bugs.php.net/bug.php?id=67881) warnings are being triggered which cannot be caught or suppressed. The warning occurs when using a different property is used which is not parseable by the new `DateTime` instance. Applications like NewRelic pick up on these warnings and are logging them while there is no direct inconvenience for the users.

Replaced the `new DateTime` by [date_create](https://php.net/manual/en/function.date-create.php) which is an alias for the DateTime constructor but silences these kinds of warnings.

Fixes issue #27784  