### PR TITLE
[5.8] Correct test methods names

### DIFF
--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -51,7 +51,7 @@ class HasherTest extends TestCase
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 
-    public function testBasicBcryptVerification()
+    public function testBasicArgon2iVerification()
     {
         $this->expectException(RuntimeException::class);
 
@@ -64,7 +64,7 @@ class HasherTest extends TestCase
         (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
-    public function testBasicArgon2iVerification()
+    public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
 


### PR DESCRIPTION
There is small mistake in HasherTest.
- HasherTest::testBasicArgon2iVerification()  currently tests BcryptHasher.
- HasherTest::testBasicBcryptVerification() currently tests ArgonHasher.

This PR helps to correct them.