### PR TITLE
Fixed issue: [Call to a member function getConnectionName() on null] …

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -151,10 +151,13 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            $this->markJobAsFailedIfWillExceedMaxAttempts(
-                $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
-            );
-
+            // Check if the job exists in queue.
+            if($job) {
+                // Mark the job as failed.
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int)$options->maxTries, $this->maxAttemptsExceededException($job)
+                );
+            }
             $this->kill(1);
         });
 


### PR DESCRIPTION
No need to mark job as failed if there is no job in queue. 
`php artisan queue:work` was throwing error after timeout if there was not job in queue