### PR TITLE
Fix : RedisDB destroy on app cache flush

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -214,8 +214,10 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function flush()
     {
-        $this->connection()->flushdb();
-
+        $application_keys=$this->connection()->keys($this->prefix.'*');
+	    foreach ($application_keys as $key) {
+		    $this->connection()->del($key);
+	    }
         return true;
     }
 


### PR DESCRIPTION
Fix Redis all DB drop (even other applications DB), by using the cache prefix, only clear the application cache.
Redis is not used like mysql and many server configuration use the same redis DB for many websites, so cache flush should clear only keys begining by the cache prefix, and don't drop the database.
Improvement : We can add a config option to choose between DB drop or only prefix drop.
It breaks nothing because all cache keys are stored with the prefix.