### PR TITLE
Fixed issue: Call to a member function getConnectionName() on null

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -151,10 +151,13 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            $this->markJobAsFailedIfWillExceedMaxAttempts(
-                $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
-            );
-
+            // Check if the job exists in queue.
+            if($job) {
+                // Mark the job as failed.
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int)$options->maxTries, $this->maxAttemptsExceededException($job)
+                );
+            }
             $this->kill(1);
         });
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -152,10 +152,10 @@ class Worker
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
             // Check if the job exists in queue.
-            if($job) {
+            if ($job) {
                 // Mark the job as failed.
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
-                    $job->getConnectionName(), $job, (int)$options->maxTries, $this->maxAttemptsExceededException($job)
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
                 );
             }
             $this->kill(1);


### PR DESCRIPTION
This PR is fixing [#29354](https://github.com/laravel/framework/issues/29354)

Since I have updated one of my laravel project to the latest framework I am facing the issue. 
The issue is because of the changes in [this commit](https://github.com/Hemant11111/framework/commit/c1263900c44deb463d2a0ab3c67df309bd7ba581) merged on `29-07-02`

**To reproduce the error just create a new laravel project with the latest framework**
```
composer create-project --prefer-dist laravel/laravel testing
```
 **and in the root folder of project just run the command**
```
php artisan queue:work --sleep=60 -v
```

if there is no pending job in the queue then we are getting this error.

```
Symfony\Component\Debug\Exception\FatalThrowableError  : Call to a member function getConnectionName() on null

  at /Users/hemant/Projects/laravel/testing/vendor/laravel/framework/src/Illuminate/Queue/Worker.php:144
    140|         // process if it is running too long because it has frozen. This uses the async
    141|         // signals supported in recent versions of PHP to accomplish it conveniently.
    142|         pcntl_signal(SIGALRM, function () use ($job, $options) {
    143|             $this->markJobAsFailedIfWillExceedMaxAttempts(
  > 144|                 $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
    145|             );
    146| 
    147|             $this->kill(1);
    148|         });
```

I am re-submitting the changes. please merge the changes so that I can pull the latest version with working code. if this PR also lacks an explanation then, please do test it at your end and make it working. Thanks

**Why it will not break any existing feature**
A needed check is added before marking the job as failed. If the $job is null then why we will want to mark the job as failed? And there is the possibility that the $job is null [If we don't have any pending job to be processed in queue].