### PR TITLE
[6.0] Add freeze and freezeAt helpers

### DIFF
--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -6,5 +6,30 @@ use Carbon\Carbon as BaseCarbon;
 
 class Carbon extends BaseCarbon
 {
-    //
+    /**
+     * Temporarily freeze time for the closure.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function freeze(callable $callback)
+    {
+        static::freezeAt(static::now(), $callback);
+    }
+
+    /**
+     * Temporarily freeze time at the given time for the closure.
+     *
+     * @param  \Illuminate\Support\Carbon  $now
+     * @param  callable  $callback
+     * @return void
+     */
+    public static function freezeAt(self $now, callable $callback)
+    {
+        static::setTestNow($now);
+
+        $callback($now);
+
+        static::setTestNow();
+    }
 }

--- a/src/Illuminate/Support/Carbon.php
+++ b/src/Illuminate/Support/Carbon.php
@@ -28,8 +28,10 @@ class Carbon extends BaseCarbon
     {
         static::setTestNow($now);
 
-        $callback($now);
-
-        static::setTestNow();
+        try {
+            $callback($now);
+        } finally {
+            static::setTestNow();
+        }
     }
 }

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -25,7 +25,6 @@ class SupportCarbonTest extends TestCase
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow();
         Carbon::serializeUsing(null);
 
         parent::tearDown();

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -20,7 +20,7 @@ class SupportCarbonTest extends TestCase
     {
         parent::setUp();
 
-        Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
+        $this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC');
     }
 
     protected function tearDown(): void
@@ -45,7 +45,9 @@ class SupportCarbonTest extends TestCase
             return (int) ($this->diffInYears($dt, $abs) / 10);
         });
 
-        $this->assertSame(2, $this->now->diffInDecades(Carbon::now()->addYears(25)));
+        Carbon::freezeAt($this->now, function () {
+            $this->assertSame(2, $this->now->diffInDecades(Carbon::now()->addYears(25)));
+        });
     }
 
     public function testCarbonIsMacroableWhenCalledStatically()
@@ -54,7 +56,9 @@ class SupportCarbonTest extends TestCase
             return Carbon::now()->subDays(2)->setTime(12, 0, 0);
         });
 
-        $this->assertSame('2017-06-25 12:00:00', Carbon::twoDaysAgoAtNoon()->toDateTimeString());
+        Carbon::freezeAt($this->now, function () {
+            $this->assertSame('2017-06-25 12:00:00', Carbon::twoDaysAgoAtNoon()->toDateTimeString());
+        });
     }
 
     public function testCarbonRaisesExceptionWhenStaticMacroIsNotFound()
@@ -71,6 +75,13 @@ class SupportCarbonTest extends TestCase
         $this->expectExceptionMessage('nonExistingMacro does not exist.');
 
         Carbon::now()->nonExistingMacro();
+    }
+
+    public function testFreezeKeepsTimeFrozen()
+    {
+        Carbon::freeze(function ($now) {
+            $this->assertEquals(Carbon::now(), $now);
+        });
     }
 
     public function testCarbonAllowsCustomSerializer()


### PR DESCRIPTION
Not sure how willing you are to add helpers to the frameworks Carbon instance, and I fully appreciate that it's something that can be macro'd in, but thought it was worth proposing this in case it's helpful.

In a number of test cases I've got, they're dependent on time and I've used `Carbon::setTimeNow()` in order to set up the state in order to get the results I expect. However, you have to remember to always restore time by calling the method again without any arguments.

This adds two helper methods to Carbon which make it really easy to perform these sort of tests - or any sort of logic that requires freezing time - a little bit nicer and less prone to mistake.

```php
Carbon::freeze(function ($now) {
    // $now is the current time, frozen in the callback
});

$now = Carbon::subWeek();

Carbon::freezeAt($lastWeek, function ($now) {
    // $now is the same time last week, frozen in the callback
});
```