### PR TITLE
[5.8] Move Worker.php registerTimeoutHandler to condition

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -107,14 +107,13 @@ class Worker
                 $this->manager->connection($connectionName), $queue
             );
 
-            if ($this->supportsAsyncSignals()) {
-                $this->registerTimeoutHandler($job, $options);
-            }
-
             // If the daemon should run (not in maintenance mode, etc.), then we can run
             // fire off this job for processing. Otherwise, we will need to sleep the
             // worker so no more jobs are processed until they should be processed.
             if ($job) {
+                if ($this->supportsAsyncSignals()) {
+                    $this->registerTimeoutHandler($job, $options);
+                }
                 $this->runJob($job, $connectionName, $options);
             } else {
                 $this->sleep($options->sleep);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -114,6 +114,7 @@ class Worker
                 if ($this->supportsAsyncSignals()) {
                     $this->registerTimeoutHandler($job, $options);
                 }
+
                 $this->runJob($job, $connectionName, $options);
             } else {
                 $this->sleep($options->sleep);


### PR DESCRIPTION
Sometimes after horizon paused (horizon:pause) occurs a error:
Call to a member function getConnectionName() on null
/vendor/laravel/framework/src/Illuminate/Queue/Worker.php:144

because registerTimeoutHandler uses $job variable, but where are no conditions that check if it is not null.