### PR TITLE
[5.8] Make updateExistingPivot() safe on non-existent pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -220,12 +220,12 @@ trait InteractsWithPivotTable
      */
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
-        $updated = $this->getCurrentlyAttachedPivots()
+        $pivot = $this->getCurrentlyAttachedPivots()
                     ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
                     ->where($this->relatedPivotKey, $this->parseId($id))
-                    ->first()
-                    ->fill($attributes)
-                    ->isDirty();
+                    ->first();
+
+        $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
         $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},


### PR DESCRIPTION
Fixes issue from [[5.8] Fix many to many sync results with custom pivot model by themsaid · Pull Request #28416 · laravel/framework](https://github.com/laravel/framework/pull/28416).

Currently, when we use `updateExistingPivot()` with a custom pivot class, the following code will be executed.

```php
$updated = $this->getCurrentlyAttachedPivots()
    ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
    ->where($this->relatedPivotKey, $this->parseId($id))
    ->first()
    ->fill($attributes)
    ->isDirty();
```

However, it is unsafe; If we call `updateExistingPivot()` for non-existent record, it will unexpectedly cause `FatalThrowableError`.

```
Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function fill() on null
  File "/var/www/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php", line xxx
```

This PR resolves this issue by fixing like this:

```php
$pivot = $this->getCurrentlyAttachedPivots()
    ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
    ->where($this->relatedPivotKey, $this->parseId($id))
    ->first();

$updated = $pivot ? $pivot->fill($attributes)->isDitry() : false;
```