### PR TITLE
[6.0] Option to define the environment in which a migration should run

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -492,7 +492,7 @@ class Migrator
     }
 
     /**
-     * Check if file has to run in current environment
+     * Check if file has to run in current environment.
      *
      * @param $file
      * @return bool
@@ -503,14 +503,14 @@ class Migrator
     }
 
     /**
-     * Get the environment name from file
+     * Get the environment name from file.
      *
      * @param $file
      * @return string
      */
     public function getEnvironmentName($file)
     {
-        if(preg_match('/\.(.*)\.php$/', $file, $matches)) {
+        if (preg_match('/\.(.*)\.php$/', $file, $matches)) {
             $environment = $matches[1];
         }
 
@@ -518,7 +518,7 @@ class Migrator
     }
 
     /**
-     * Remove the environment name from migration path
+     * Remove the environment name from migration path.
      *
      * @param $path
      * @return string


### PR DESCRIPTION
With the proliferation of tools or services that may vary according to the development environment, it might be interesting to have the ability to define the environment in which a specific migration should run.

This PR adds the ability to **define the environment in the name of the migration file**:

```
migration_name.environment.php
```

For example:

```
2014_10_12_000000_create_logs_table.local.php
```

- If the environment is not defined in the filename, the migration always runs as now.
- If defined, the environment is compared with the current environment and executed if match.

I don't see any potential problem generated by this feature, the official syntax generated by `make:migration` and the guidelines set a format that does not create conflict with this change.

First PR ever 😅