### PR TITLE
[5.8] Fix worker timeout handler when there is no job processing

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -140,9 +140,11 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            $this->markJobAsFailedIfWillExceedMaxAttempts(
-                $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
-            );
+            if ($job) {
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
+                );
+            }
 
             $this->kill(1);
         });


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/laravel/framework/pull/29024#issuecomment-516327931

The queue worker timeout handler may be called with a null `$job` if the timeout is reached when there is no job processing (perhaps it took too long to fetch the next job in the worker loop). This fix checks to make sure there is a job before attempting to mark the as failed if it will exceed the maximum number of attempts.