### PR TITLE
[5.8] Change visibility to public for hasPivotColumn method by pactode

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -403,7 +403,7 @@ trait InteractsWithPivotTable
      * @param  string  $column
      * @return bool
      */
-    protected function hasPivotColumn($column)
+    public function hasPivotColumn($column)
     {
         return in_array($column, $this->pivotColumns);
     }


### PR DESCRIPTION
I was trying to do a check of whether a relation contains a specific pivot column. This is currently not possible. In order to fix this I suggest changing the visibility to public.

Example of usage:
```php
$relation = $model->somePivotRelation();

if ($relation->hasPivotColumn('position')) {
    // build a specific query containing that attribute
}
```

Let me know what you think about this.