### PR TITLE
[5.8] Correctly modify updated_at on custom pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -227,10 +227,14 @@ trait InteractsWithPivotTable
 
         $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
-        $this->newPivot([
+        $pivot = $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},
             $this->relatedPivotKey => $this->parseId($id),
-        ], true)->fill($attributes)->save();
+        ], true);
+
+        $pivot->timestamps = in_array($this->updatedAt(), $this->pivotColumns);
+
+        $pivot->fill($attributes)->save();
 
         if ($touch) {
             $this->touchIfTouching();

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -187,8 +187,14 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $tag = TagWithCustomPivot::create(['name' => Str::random()]);
 
         DB::table('posts_tags')->insert([
-            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty'],
+            [
+                'post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'empty',
+                'created_at' => '1507630210',
+                'updated_at' => '1507630210',
+            ],
         ]);
+
+        Carbon::setTestNow('2017-10-10 10:10:20'); // +10 seconds
 
         // Test on actually existing pivot
         $this->assertEquals(
@@ -197,6 +203,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertEquals('exclude', $tag->pivot->flag);
+            $this->assertEquals('1507630210', $tag->pivot->getAttributes()['created_at']);
+            $this->assertEquals('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
 
         // Test on non-existent pivot


### PR DESCRIPTION
This PR fixes #29321.

When we use default pivot, `updated_at` field is filled by `InteractsWithPivotTable::addTimestampToAttachment()` and the UPDATE query is directly executed on **Eloquent Builder**.

```php
if (in_array($this->updatedAt(), $this->pivotColumns)) {
    $attributes = $this->addTimestampsToAttachment($attributes, true);
}

$updated = $this->newPivotStatementForId($this->parseId($id))->update(
    $this->castAttributes($attributes)
);
```

When we use custom pivot class, the behavior is quitely different. `updated_at` field is filled using **Eloquent Model `$timestamps` feature.** `AsPivot::hasTimestampAttributes()` dynamically determines `$timestamps` whether attributes from `InteractsWithPivotTable::newPivot()` contains **`created_at`**  field.

```php
$instance->timestamps = $instance->hasTimestampAttributes($attributes);
```

```php
public function hasTimestampAttributes($attributes = null)
{
    return array_key_exists($this->getCreatedAtColumn(), $attributes ?? $this->attributes);
}
```

However, there is always no `created_at` attribute on updating. So we must set `$timestamps` after calling `InteractsWithPivotTable::newPivot()`.

```diff
- $this->newPivot([
-     $this->foreignPivotKey => $this->parent->{$this->parentKey},
-     $this->relatedPivotKey => $this->parseId($id),
- ], true)->fill($attributes)->save();
- 
+ $pivot = $this->newPivot([
+     $this->foreignPivotKey => $this->parent->{$this->parentKey},
+     $this->relatedPivotKey => $this->parseId($id),
+ ], true);
+ 
+ $pivot->timestamps = in_array($this->updatedAt(), $this->pivotColumns);
+ 
+ $pivot->fill($attributes)->save();
```