### PR TITLE
[5.8] Revert "Correct test methods names" as the original names were correct

### DIFF
--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -51,7 +51,7 @@ class HasherTest extends TestCase
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 
-    public function testBasicArgon2iVerification()
+    public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
 
@@ -64,7 +64,7 @@ class HasherTest extends TestCase
         (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
-    public function testBasicBcryptVerification()
+    public function testBasicArgon2iVerification()
     {
         $this->expectException(RuntimeException::class);
 


### PR DESCRIPTION
This reverts #29346 I believe these test methods were named correctly originally.

https://github.com/laravel/framework/blob/8e9cf5497849d3292c3c7ed265488d855b30afb1/tests/Hashing/HasherTest.php#L54-L65

The key line here for the test appears to be:
https://github.com/laravel/framework/blob/8e9cf5497849d3292c3c7ed265488d855b30afb1/tests/Hashing/HasherTest.php#L64

We're creating a BcryptHasher with a verification check, passing it an argon hash with an identical plaintext, and making sure that the verification check gets tripped because it's not a bcrypt hash being passed to the check function.

The verification that is actually being tested with this method is the BcryptHasher verification and can be seen here:
https://github.com/laravel/framework/blob/8e9cf5497849d3292c3c7ed265488d855b30afb1/src/Illuminate/Hashing/BcryptHasher.php#L70-L72

Likewise for the other method that had its name changed.
 