### PR TITLE
[5.8] Add less greedy mutator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -571,6 +571,12 @@ trait HasAttributes
             return $this->setMutatedAttributeValue($key, $value);
         }
 
+        // We can also apply a less greedy mutator which allows the developer
+        // to mutate the data before being handled by the defined castings.
+        elseif ($this->hasSetAndCastMutator($key)) {
+            $value = $this->setAndCastMutatedAttributeValue($key, $value);
+        }
+
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
@@ -615,6 +621,29 @@ trait HasAttributes
     protected function setMutatedAttributeValue($key, $value)
     {
         return $this->{'set'.Str::studly($key).'Attribute'}($value);
+    }
+
+    /**
+     * Determine if a set and cast mutator exists for an attribute.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function hasSetAndCastMutator($key)
+    {
+        return method_exists($this, 'setAndCast'.Str::studly($key).'Attribute');
+    }
+
+    /**
+     * Set the value of an attribute using its mutator and casting.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function setAndCastMutatedAttributeValue($key, $value)
+    {
+        return $this->{'setAndCast'.Str::studly($key).'Attribute'}($value);
     }
 
     /**


### PR DESCRIPTION
### Scenario

I have a `Product` that comes in multiple colors. Available colors are defined as a JSON field on the `products` table.  I cast the colors to a `Collection` in the model.

```php
class Product extends Model
{
    $casts = [
        'colors' => 'collection',
    ];
}
```

My CRUD forms use a `<textarea>` to accept a comma separated list of colors. When that data is submitted to my controller, I need to `explode` and then `trim` the colors.

```php
class ProductController
{
    public function store(Request $request)
    {
        $product = new Product;
        $product->colors = array_map('trim', explode(',', $request->input('colors')));
        $product->save();
    }

    public function update(Request $request, Product $product)
    {
        $product->colors = array_map('trim', explode(',', $request->input('colors')));
        $product->save();
    }
}
```

This is okay, but we can see we're duplicating some code here. If we could move the trimming (and maybe even the exploding if you like) into the Model, we would have 1 point of transformation for this data.

We could try to add a mutator to our model:

```php
class Product
{
    protected function setColorsAttribute($value)
    {
        $this->attributes['color'] = array_map('trim', $value);
    }
}
```

but due to the greediness of the mutator (https://github.com/laravel/framework/blob/5.8/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L571), we would need to reimplement the casting logic ourselves.

### Proposed Solution

This PR allows us to bypass this greediness with a slightly modified mutator method.

```php
class Product
{
    protected function setAndCastColorsAttribute($value)
    {
        return array_map('trim', $value);
    }
}
```

Since we are *returning* a value here, the Model can now continue to perform its normal casting logic after we are done with any changes we want to make to the input.

If you wanted to be so bold, you could even go a step further and accept both `array` and comma separated `string` inputs:

```php
class Product
{
    protected function setAndCastColorsAttribute($value)
    {
        if(is_array($value)) {
            return array_map('trim', $value);
        }
        return array_map('trim', explode(',', $value));
    }
}
```

Definitely open to naming suggestion here.  Will add tests if there's interest in the feature.

Would also be curious to know if the mutators were originally made this greedy intentionally.  Didn't have any luck finding info from old commits. If it wasn't intentional, maybe we discuss making the default be not greedy?