### PR TITLE
[6.0] Split out logoutAllDevices method

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -487,10 +487,6 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
-            $this->cycleRememberToken($user);
-        }
-
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Logout($this->name, $user));
         }
@@ -501,6 +497,22 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         $this->user = null;
 
         $this->loggedOut = true;
+    }
+
+    /**
+     * Log the user out of the application on all devices.
+     *
+     * @return void
+     */
+    public function logoutAllDevices()
+    {
+        $user = $this->user();
+
+        if (! is_null($user) && ! empty($user->getRememberToken())) {
+            $this->cycleRememberToken($user);
+        }
+
+        $this->logout();
     }
 
     /**

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -220,11 +220,26 @@ class AuthenticationTest extends TestCase
         $this->assertTrue($this->app['auth']->check());
         $this->assertNotNull($this->app['auth']->user()->getRememberToken());
 
+        $this->app['auth']->logout();
+
+        $this->assertFalse($this->app['auth']->check());
+    }
+
+    public function test_logging_in_out_all_devices_via_attempt_remembering()
+    {
+        $this->assertTrue(
+            $this->app['auth']->attempt(['email' => 'email', 'password' => 'password'], true)
+        );
+        $this->assertInstanceOf(AuthenticationTestUser::class, $this->app['auth']->user());
+        $this->assertTrue($this->app['auth']->check());
+        $this->assertNotNull($this->app['auth']->user()->getRememberToken());
+
         $oldToken = $this->app['auth']->user()->getRememberToken();
         $user = $this->app['auth']->user();
 
-        $this->app['auth']->logout();
+        $this->app['auth']->logoutAllDevices();
 
+        $this->assertFalse($this->app['auth']->check());
         $this->assertNotNull($user->getRememberToken());
         $this->assertNotEquals($oldToken, $user->getRememberToken());
     }


### PR DESCRIPTION
This PR resolves the issue described in #29244 where logging out on one device will actually log you out on all devices. This seems like unexpected behaviour to me - most sites wouldn't log you out everywhere like this.

This changes the `logout` method to not cycle the remember token, and adds another method `logoutAllDevices` (which sits alongside `logoutOtherDevices`) so that developers can opt-in to this behaviour if that is what they are after.

In the linked issue Dries suggested adding `logoutCurrentDevice` instead - I'm happy to make that alternative PR if that's what you guys prefer - but I did want to suggest initially that I think this should be the default behaviour of `logout`.