### PR TITLE
[optimization]adjust the default created_at and updated_at

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Schema;
 
 use Closure;
 use BadMethodCallException;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Fluent;
 use Illuminate\Database\Connection;
 use Illuminate\Support\Traits\Macroable;
@@ -981,9 +982,11 @@ class Blueprint
      */
     public function timestamps($precision = 0)
     {
-        $this->timestamp('created_at', $precision)->nullable();
+        $this->timestamp('created_at', $precision)->useCurrent();
 
-        $this->timestamp('updated_at', $precision)->nullable();
+        $this->timestamp('updated_at', $precision)->default(
+            new Expression('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP')
+        );
     }
 
     /**


### PR DESCRIPTION
Excuse me. I worried that there are operations that directly modify the table, bypassing the update of the model, causing created_at and updated_at not to update.

original
`
  `created_at` timestamp NULL DEFAULT NULL,
  `updated_at` timestamp NULL DEFAULT NULL,
`

Change the result :
`
  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
`