### PR TITLE
[5.8] Fix touching BelongsToMany relation without fireModelEvent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -674,6 +674,8 @@ trait HasRelationships
                 $this->$relation->touchOwners();
             } elseif ($this->$relation instanceof Collection) {
                 $this->$relation->each(function (Model $relation) {
+                    $relation->fireModelEvent('saved', false);
+
                     $relation->touchOwners();
                 });
             }


### PR DESCRIPTION
The laravel/scout can not observe BelongsToMany models, bacause the Illuminate\Database\Eloquent\Relations\BelongsToMany@touch updates touches relation by Illuminate\Database\Eloquent@update which not fire model event.