### PR TITLE
[6.0] Handle arrays (only) when updating JSON columns

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -232,6 +232,8 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) && is_bool($value);
+        })->map(function ($value) {
+            return is_array($value) ? json_encode($value) : $value;
         })->all();
 
         return parent::prepareBindingsForUpdate($bindings, $values);

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -375,7 +375,7 @@ class PostgresGrammar extends Grammar
     public function prepareBindingsForUpdate(array $bindings, array $values)
     {
         $values = collect($values)->map(function ($value, $column) {
-            return $this->isJsonSelector($column) && ! $this->isExpression($value)
+            return is_array($value) || ($this->isJsonSelector($column) && ! $this->isExpression($value))
                 ? json_encode($value)
                 : $value;
         })->all();

--- a/src/Illuminate/Database/Query/JsonExpression.php
+++ b/src/Illuminate/Database/Query/JsonExpression.php
@@ -40,10 +40,10 @@ class JsonExpression extends Expression
             case 'integer':
             case 'double':
             case 'string':
-                return '?';
             case 'object':
-            case 'array':
                 return '?';
+            case 'array':
+                return 'cast(? as json)';
         }
 
         throw new InvalidArgumentException("JSON value is of illegal type: {$type}");

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2357,7 +2357,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->update(['options->language' => new Raw("'null'")]);
     }
 
-    public function testPostgresUpdateWrappingJsonArrayAndObject()
+    public function testPostgresUpdateWrappingJsonArray()
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('update')

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2286,6 +2286,31 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->where('active', '=', 1)->update(['meta->name->first_name' => 'John', 'meta->name->last_name' => 'Doe']);
     }
 
+    public function testMySqlUpdateWrappingJsonArray()
+    {
+        $grammar = new MySqlGrammar;
+        $processor = m::mock(Processor::class);
+
+        $connection = $this->createMock(ConnectionInterface::class);
+        $connection->expects($this->once())
+                    ->method('update')
+                    ->with(
+                        'update `users` set `options` = ?, `meta` = json_set(`meta`, \'$."tags"\', cast(? as json)), `group_id` = 45 where `active` = ?',
+                        [
+                            json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                            json_encode(['white', 'large']),
+                            1,
+                        ]
+                    );
+
+        $builder = new Builder($connection, $grammar, $processor);
+        $builder->from('users')->where('active', 1)->update([
+            'options' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'meta->tags' => ['white', 'large'],
+            'group_id' => new Raw('45'),
+        ]);
+    }
+
     public function testMySqlUpdateWithJsonPreparesBindingsCorrectly()
     {
         $grammar = new MySqlGrammar;
@@ -2330,6 +2355,22 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('update')
             ->with('update "users" set "options" = jsonb_set("options"::jsonb, \'{"language"}\', \'null\')', []);
         $builder->from('users')->update(['options->language' => new Raw("'null'")]);
+    }
+
+    public function testPostgresUpdateWrappingJsonArrayAndObject()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = ?, "meta" = jsonb_set("meta"::jsonb, \'{"tags"}\', ?), "group_id" = 45', [
+                json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                json_encode(['white', 'large']),
+            ]);
+
+        $builder->from('users')->update([
+            'options' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'meta->tags' => ['white', 'large'],
+            'group_id' => new Raw('45'),
+        ]);
     }
 
     public function testMySqlWrappingJsonWithString()


### PR DESCRIPTION
This is a resubmit of #29146 which allows using arrays when updating JSON columns.

The former PR was merged and later reverted because encoding objects values broke the update queries.

This PR handle array values only and not objects.