### PR TITLE
[5.8] Procedural date creation returned false

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -246,7 +246,7 @@ trait ValidatesAttributes
                 return Date::parse($value);
             }
 
-            return date_create($value);
+            return date_create($value) ?: null;
         } catch (Exception $e) {
             //
         }


### PR DESCRIPTION
`date_create` returns `false` instead of `null` on failure. To keep everything as intended we convert it no `null` when it fails. There are no other expected falsy results coming from this function on the successful execution of it.

Related to pull request #29342.

Have a great weekend!