### PR TITLE
[6.0] Job Middleware

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Bus;
 
+use Illuminate\Support\Arr;
+
 trait Queueable
 {
     /**
@@ -38,6 +40,11 @@ trait Queueable
      * @var \DateTimeInterface|\DateInterval|int|null
      */
     public $delay;
+
+    /**
+     * The middleware the job should be dispatched through.
+     */
+    public $middleware = [];
 
     /**
      * The jobs that should run if this job is successful.
@@ -109,6 +116,29 @@ trait Queueable
     public function delay($delay)
     {
         $this->delay = $delay;
+
+        return $this;
+    }
+
+    /**
+     * Get the middleware the job should be dispatched through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return $this->middleware ?: [];
+    }
+
+    /**
+     * Specify the middleware the job should be dispatched through.
+     *
+     * @param  array|object
+     * @return $this
+     */
+    public function through($middleware)
+    {
+        $this->middleware = Arr::wrap($middleware);
 
         return $this;
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -46,13 +46,7 @@ class CallQueuedHandler
             return $this->handleModelNotFound($job, $e);
         }
 
-        (new Pipeline)->send($command)
-                ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
-                ->then(function ($command) use ($job) {
-                    $this->dispatcher->dispatchNow(
-                        $command, $this->resolveHandler($job, $command)
-                    );
-                });
+        $this->dispatchThroughMiddleware($job, $command);
 
         if (! $job->hasFailed() && ! $job->isReleased()) {
             $this->ensureNextJobInChainIsDispatched($command);
@@ -61,6 +55,24 @@ class CallQueuedHandler
         if (! $job->isDeletedOrReleased()) {
             $job->delete();
         }
+    }
+
+    /**
+     * Dispatch the given job / command through its specified middleware.
+     *
+     * @param  \Illuminate\Contracts\Queue\Job  $job
+     * @param  mixed  $command
+     * @return mixed
+     */
+    protected function dispatchThroughMiddleware(Job $job, $command)
+    {
+        return (new Pipeline)->send($command)
+                ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
+                ->then(function ($command) use ($job) {
+                    return $this->dispatcher->dispatchNow(
+                        $command, $this->resolveHandler($job, $command)
+                    );
+                });
     }
 
     /**

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -21,6 +21,7 @@
         "illuminate/contracts": "^6.0",
         "illuminate/database": "^6.0",
         "illuminate/filesystem": "^6.0",
+        "illuminate/pipeline": "^6.0",
         "illuminate/support": "^6.0",
         "opis/closure": "^3.1",
         "symfony/debug": "^4.3",

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -160,9 +160,10 @@ class CallQueuedHandlerTestJobWithMiddleware
                 public function handle($command, $next)
                 {
                     CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = $command;
+
                     return $next($command);
                 }
-            }
+            },
         ];
     }
 }
@@ -187,6 +188,7 @@ class TestJobMiddleware
     public function handle($command, $next)
     {
         $_SERVER['__test.dispatchMiddleware'] = true;
+
         return $next($command);
     }
 }

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Queue;
 
 use Mockery as m;
+use Illuminate\Bus\Queueable;
 use Illuminate\Bus\Dispatcher;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Contracts\Queue\Job;
@@ -42,6 +43,55 @@ class CallQueuedHandlerTest extends TestCase
         ]);
 
         $this->assertTrue(CallQueuedHandlerTestJob::$handled);
+    }
+
+    public function test_job_can_be_dispatched_through_middleware()
+    {
+        CallQueuedHandlerTestJobWithMiddleware::$handled = false;
+        CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = null;
+
+        $instance = new CallQueuedHandler(new Dispatcher(app()));
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $instance->call($job, [
+            'command' => serialize($command = new CallQueuedHandlerTestJobWithMiddleware),
+        ]);
+
+        $this->assertInstanceOf(CallQueuedHandlerTestJobWithMiddleware::class, CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand);
+        $this->assertTrue(CallQueuedHandlerTestJobWithMiddleware::$handled);
+    }
+
+    public function test_job_can_be_dispatched_through_middleware_on_dispatch()
+    {
+        $_SERVER['__test.dispatchMiddleware'] = false;
+        CallQueuedHandlerTestJobWithMiddleware::$handled = false;
+        CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = null;
+
+        $instance = new CallQueuedHandler(new Dispatcher(app()));
+
+        $job = m::mock(Job::class);
+        $job->shouldReceive('hasFailed')->andReturn(false);
+        $job->shouldReceive('isDeleted')->andReturn(false);
+        $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
+        $job->shouldReceive('delete')->once();
+
+        $command = $command = new CallQueuedHandlerTestJobWithMiddleware;
+        $command->through([new TestJobMiddleware]);
+
+        $instance->call($job, [
+            'command' => serialize($command),
+        ]);
+
+        $this->assertInstanceOf(CallQueuedHandlerTestJobWithMiddleware::class, CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand);
+        $this->assertTrue(CallQueuedHandlerTestJobWithMiddleware::$handled);
+        $this->assertTrue($_SERVER['__test.dispatchMiddleware']);
     }
 
     public function test_job_is_marked_as_failed_if_model_not_found_exception_is_thrown()
@@ -91,6 +141,32 @@ class CallQueuedHandlerTestJob
     }
 }
 
+class CallQueuedHandlerTestJobWithMiddleware
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+    public static $middlewareCommand;
+
+    public function handle()
+    {
+        static::$handled = true;
+    }
+
+    public function middleware()
+    {
+        return [
+            new class {
+                public function handle($command, $next)
+                {
+                    CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = $command;
+                    return $next($command);
+                }
+            }
+        ];
+    }
+}
+
 class CallQueuedHandlerExceptionThrower
 {
     public $deleteWhenMissingModels = true;
@@ -103,5 +179,14 @@ class CallQueuedHandlerExceptionThrower
     public function __wakeup()
     {
         throw new ModelNotFoundException('Foo');
+    }
+}
+
+class TestJobMiddleware
+{
+    public function handle($command, $next)
+    {
+        $_SERVER['__test.dispatchMiddleware'] = true;
+        return $next($command);
     }
 }


### PR DESCRIPTION
This adds an easy way to have job specific middleware for queued jobs. Global job middleware were actually already possible by calling `Bus::pipeThrough([])` in a service provider during the application boot process.

Middleware may be specified for a job by defining a `middleware` method on the job which returns an array of middleware objects:

```php
public function middleware()
{
     return [new SomeMiddleware];
}
```

Middleware look like this:

```php
class SomeMiddleware
{
    public function handle($command, $next)
    {
        // Do something...

        return $next($command);
    }
}
```

These middleware provide a convenient location to wrap jobs in some logic before they are executed. 

You may also specify middleware when dispatching the job. These middleware will be merged with any middleware returned by the middleware method:

```php
SomeJob::dispatch()->through([new SomeMiddleware]);
```