### PR TITLE
[5.8] Less Greedy Mutator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -568,7 +568,11 @@ trait HasAttributes
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            return $this->setMutatedAttributeValue($key, $value);
+            $value = $this->setMutatedAttributeValue($key, $value);
+
+            if (is_null($value)) {
+                return $value;
+            }
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -578,7 +578,7 @@ trait HasAttributes
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
-        elseif ($value && $this->isDateAttribute($key)) {
+        if ($value && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -68,6 +68,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
+    public function testCastAttributeCanBeMutated()
+    {
+        $model = new EloquentModelStub;
+        $model->colors = ['green', ' red', 'blue ', ' orange ', ' p ink '];
+        $this->assertEquals(['green', 'red', 'blue', 'orange', 'p ink'], $model->colors->all());
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);
@@ -1952,6 +1959,7 @@ class EloquentModelStub extends Model
     protected $table = 'stub';
     protected $guarded = [];
     protected $morph_to_stub_type = EloquentModelSaveStub::class;
+    protected $casts = ['colors' => 'collection'];
 
     public function getListItemsAttribute($value)
     {
@@ -1971,6 +1979,11 @@ class EloquentModelStub extends Model
     public function setPasswordAttribute($value)
     {
         $this->attributes['password_hash'] = sha1($value);
+    }
+
+    public function setColorsAttribute($value)
+    {
+        return array_map('trim', $value);
     }
 
     public function publicIncrement($column, $amount = 1, $extra = [])


### PR DESCRIPTION
this is a retry of #29375.  it's much cleaner, and allows users to tie into existing mutator methods if they wish to utilize it.

currently mutators manually set values in the attributes property and return early in the `setAttribute()` method.  This behavior will continue unaffected with this change.

```php
class User
{
    public function setFirstNameAttribute($value)
    {
        $this->attributes['first_name'] = strtolower($value);
    }
}
```

However, now you can **`return`** a value from the mutator method instead, which will cause it to also run through any additional logic in the `setAttribute()` method.

```php
class User
{
    public function setFirstNameAttribute($value)
    {
        return strtolower($value);
    }
}
```

The most common use case is when we want to alter some data before it is passed to the normal casting logic.

```php
class Product
{
    protected $casts = ['colors' => 'collection'];

    public function setColorsAttribute($value)
    {
        return array_map('trim', $value);
    }
}
```

this maintains backwards compatibility because currently no values are returned from mutators, from which PHP will inherently return `null`.

https://www.php.net/manual/en/functions.returning-values.php
