### PR TITLE
[6.0] Queue commands: Use cache repository, not manager

### DIFF
--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -30,7 +30,7 @@ class RestartCommand extends Command
      */
     public function handle()
     {
-        $this->laravel['cache']->forever('illuminate:queue:restart', $this->currentTime());
+        $this->laravel['cache.store']->forever('illuminate:queue:restart', $this->currentTime());
 
         $this->info('Broadcasting queue restart signal.');
     }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -96,7 +96,7 @@ class WorkCommand extends Command
      */
     protected function runWorker($connection, $queue)
     {
-        $this->worker->setCache($this->laravel['cache']->driver());
+        $this->worker->setCache($this->laravel['cache.store']);
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()


### PR DESCRIPTION
This makes it slightly easier to use the Queue component without a
full-blown `CacheManager` instance. After all, what's really needed
here is a cache repository implementation, so why not fetch that
directly from the controller.

In terms of functionality, everything should stay the same. The
cache manager proxies these methods to the default connection anyway.
There is a slight chance of change when developers overwrite the
`cache.store` binding. That is actually the idea. :)
