### PR TITLE
[5.8] Allow passing options to Storage::makeDirectory

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -646,11 +646,16 @@ class FilesystemAdapter implements FilesystemContract, CloudFilesystemContract
      * Create a directory.
      *
      * @param  string  $path
+     * @param  mixed  $options
      * @return bool
      */
-    public function makeDirectory($path)
+    public function makeDirectory($path, $options = [])
     {
-        return $this->driver->createDir($path);
+        $options = is_string($options)
+                     ? ['visibility' => $options]
+                     : (array) $options;
+
+        return $this->driver->createDir($path, $options);
     }
 
     /**


### PR DESCRIPTION
Added optional `$options` parameter for the `makeDirectory` method. The syntax and handling is the same as for the `put` method. This will allow to specify visibility.

I am not sure if the [signature](https://github.com/laravel/framework/blob/5.8/src/Illuminate/Contracts/Filesystem/Filesystem.php#L189) should be updated as well. That would make this into a breaking change, while adding a parameter with a default value to implementation still implements the same interface.