### PR TITLE
[6.0] Add logoutCurrentDevice method

### DIFF
--- a/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
+++ b/src/Illuminate/Auth/Events/CurrentDeviceLogout.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Auth\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+class CurrentDeviceLogout
+{
+    use SerializesModels;
+
+    /**
+     * The authentication guard name.
+     *
+     * @var string
+     */
+    public $guard;
+
+    /**
+     * The authenticated user.
+     *
+     * @var \Illuminate\Contracts\Auth\Authenticatable
+     */
+    public $user;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $guard
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
+     */
+    public function __construct($guard, $user)
+    {
+        $this->user = $user;
+        $this->guard = $guard;
+    }
+}

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -532,6 +532,32 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     }
 
     /**
+     * Log this session out for the current user.
+     *
+     * @return void
+     */
+    public function logoutCurrentDevice()
+    {
+        $user = $this->user();
+
+        // If we have an event dispatcher instance, we can fire off the logout event
+        // so any further processing can be done. This allows the developer to be
+        // listening for anytime a user signs out of this application manually.
+        $this->clearUserDataFromStorage();
+
+        if (isset($this->events)) {
+            $this->events->dispatch(new Events\CurrentDeviceLogout($this->name, $user));
+        }
+
+        // Once we have fired the logout event we will clear the users out of memory
+        // so they are no longer available as the user is no longer considered as
+        // being signed into this application and should not be available here.
+        $this->user = null;
+
+        $this->loggedOut = true;
+    }
+
+    /**
      * Invalidate other sessions for the current user.
      *
      * The application must be using the AuthenticateSession middleware.

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -229,6 +229,24 @@ class AuthenticationTest extends TestCase
         $this->assertNotEquals($oldToken, $user->getRememberToken());
     }
 
+    public function test_logging_in_out_current_device_via_remembering()
+    {
+        $this->assertTrue(
+            $this->app['auth']->attempt(['email' => 'email', 'password' => 'password'], true)
+        );
+        $this->assertInstanceOf(AuthenticationTestUser::class, $this->app['auth']->user());
+        $this->assertTrue($this->app['auth']->check());
+        $this->assertNotNull($this->app['auth']->user()->getRememberToken());
+
+        $oldToken = $this->app['auth']->user()->getRememberToken();
+        $user = $this->app['auth']->user();
+
+        $this->app['auth']->logoutCurrentDevice();
+
+        $this->assertNotNull($user->getRememberToken());
+        $this->assertEquals($oldToken, $user->getRememberToken());
+    }
+
     public function test_auth_via_attempt_remembering()
     {
         $provider = new EloquentUserProvider(app('hash'), AuthenticationTestUser::class);


### PR DESCRIPTION
Following on from #29376 I appreciate that there is a desire to not adjust the existing behaviour of the `logout` method. This takes the alternative approach of adding `logoutCurrentDevice` method - analogous to the existing `logoutOtherDevices` method - which allows this logout behaviour to be opted-in to if preferable.

I wasn't sure if your "no plans to modify this behaviour" was specific to changing the default functionality or related to changing the authentication guard at all, but put this together just in case it was the former.

Thanks!