### PR TITLE
[5.8] Alleviate session race condition problem

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -57,12 +57,14 @@ class StartSession
 
         $this->storeCurrentUrl($request, $session);
 
-        $this->addCookieToResponse($response, $session);
+        if ($this->manager->driver()->isDirty()) {
+            $this->addCookieToResponse($response, $session);
 
-        // Again, if the session has been configured we will need to close out the session
-        // so that the attributes may be persisted to some storage medium. We will also
-        // add the session identifier cookie to the application response headers now.
-        $this->saveSession($request);
+            // Again, if the session has been configured we will need to close out the session
+            // so that the attributes may be persisted to some storage medium. We will also
+            // add the session identifier cookie to the application response headers now.
+            $this->saveSession($request);
+        }
 
         return $response;
     }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -33,6 +33,13 @@ class Store implements Session
     protected $attributes = [];
 
     /**
+     * The session attributes when started.
+     *
+     * @var array
+     */
+    protected $originalAttributes = [];
+
+    /**
      * The session handler implementation.
      *
      * @var \SessionHandlerInterface
@@ -84,7 +91,7 @@ class Store implements Session
      */
     protected function loadSession()
     {
-        $this->attributes = array_merge($this->attributes, $this->readFromHandler());
+        $this->originalAttributes = $this->attributes = array_merge($this->attributes, $this->readFromHandler());
     }
 
     /**
@@ -668,5 +675,13 @@ class Store implements Session
         if ($this->handlerNeedsRequest()) {
             $this->handler->setRequest($request);
         }
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDirty()
+    {
+        return $this->originalAttributes !== $this->attributes;
     }
 }


### PR DESCRIPTION
There is an old problem with the race conditions happening when many requests hit the server, which is know from laravel 5.0 days up until now. 

For example these issues:
https://github.com/laravel/framework/issues/18187
https://github.com/laravel/framework/issues/14385

I think this PR can alleviate the problem. In case the ajax requests hit route which has nothing to do with writing data into session, we can solve the race condition.

### The Idea is:
Why to override the session data (and cookie) at the end of the request-response life cycle with the exact same thing? (which we currently do, whether the session data gets modified by the application code or not.)
This is the source of that bug, because this sometimes causes to lose session data.

The race condition is hard to explain in plain text, I can record screen-cast if the problem is blurry.
We also save some redundant I/O operations.
```
        |---request A----|
|---------request B-------------|

```

request A: writes data to session (which will be lost)
request B: only reads data from session.

when request B finishes, it overrides both `cookie` and `session` data, with the data it has loaded at the beginning of the request. So all the precious work of the request A is lost. 
(for example if request A logins in the user. when the response of B is sent back, the user is logged out again.)

But if they both try to read and write to session,I think we can Not do anything about it, that would be like a git merge conflict. 