### PR TITLE
[5.8] Add createFromFile method to FileFactory

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -21,6 +21,20 @@ class FileFactory
     }
 
     /**
+     * Create a new fake file with content from the $inputFile.
+     *
+     * @param  string  $name
+     * @param  string  $inputFile
+     * @return  \Illuminate\Http\Testing\File
+     */
+    public function createFromFile($name, $inputFile)
+    {
+        return new File($name, tap(tmpfile(), function ($temp) use ($inputFile) {
+            fwrite($temp, file_get_contents($inputFile));
+        }));
+    }
+
+    /**
      * Create a new fake image.
      *
      * @param  string  $name

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -31,7 +31,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testCreateFromFile()
     {
-        $file = (new FileFactory)->createFromFile('test.txt', __DIR__ . '/fixtures/test.txt');
+        $file = (new FileFactory)->createFromFile('test.txt', __DIR__ .'/fixtures/test.txt');
 
         $this->assertEquals('This is a story about something that happened long ago when your grandfather was a child.',
             trim($file->get()));

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -28,4 +28,13 @@ class HttpTestingFileFactoryTest extends TestCase
         $this->assertSame(15, $info[0]);
         $this->assertSame(20, $info[1]);
     }
+
+    public function testCreateFromFile()
+    {
+        $file = (new FileFactory)->createFromFile('test.txt', __DIR__ . '/fixtures/test.txt');
+
+        $this->assertEquals('This is a story about something that happened long ago when your grandfather was a child.',
+            trim($file->get()));
+        $this->assertSame('test.txt', $file->name);
+    }
 }

--- a/tests/Http/HttpTestingFileFactoryTest.php
+++ b/tests/Http/HttpTestingFileFactoryTest.php
@@ -31,7 +31,7 @@ class HttpTestingFileFactoryTest extends TestCase
 
     public function testCreateFromFile()
     {
-        $file = (new FileFactory)->createFromFile('test.txt', __DIR__ .'/fixtures/test.txt');
+        $file = (new FileFactory)->createFromFile('test.txt', __DIR__.'/fixtures/test.txt');
 
         $this->assertEquals('This is a story about something that happened long ago when your grandfather was a child.',
             trim($file->get()));


### PR DESCRIPTION
This method creates a file for testing with a specific content read from the input file.

I've recently had a use case to test the file upload with Laravel, and wanted to use UploadedFile::fake()->create('document.txt', $sizeInKilobytes); but in my case the content of the file was stored in the database, so it was necessary to make assertions that the specific content has been saved to the database.

This method allows to create test file upload with known content read from other file:
`UploadedFile::fake()->createFromFile('test.txt', __DIR__ . '/fixtures/test.txt');`

This PR is related to the following issue: https://github.com/laravel/ideas/issues/1751