### PR TITLE
[5.8] Fix distinct validation for top level wildcard

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -443,7 +443,10 @@ class Validator implements ValidatorContract
     protected function getPrimaryAttribute($attribute)
     {
         foreach ($this->implicitAttributes as $unparsed => $parsed) {
-            if (in_array($attribute, $parsed)) {
+            if (
+                is_numeric($attribute) ?
+                in_array($attribute, $parsed) :
+                in_array($attribute, $parsed, true)) {
                 return $unparsed;
             }
         }


### PR DESCRIPTION
this pr fixes #29190 

there is a problem with in_array() in php.
when using it without strict mode enabled, it will work in a way that cause unexpected result in laravel validation for distinct array values.
example :
below code return true and makes bug:

`in_array( "0.id", [ 0, 1] );`

so in this pr i used strict mode just for string values.
if needle is string we can use in_array() in strict mode so finally getPrimaryAttribute method will return primary attribute correctly.
other way it will return  "*" for all cases.
if you reproduced it in laravel 5.8.30 with exactly values in the issue.
