### PR TITLE
[6.0] Refactor DELETE queries

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -238,23 +238,6 @@ class MySqlGrammar extends Grammar
     }
 
     /**
-     * Compile a delete statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    public function compileDelete(Builder $query)
-    {
-        $table = $this->wrapTable($query->from);
-
-        $where = is_array($query->wheres) ? $this->compileWheres($query) : '';
-
-        return isset($query->joins)
-                    ? $this->compileDeleteWithJoins($query, $table, $where)
-                    : $this->compileDeleteWithoutJoins($query, $table, $where);
-    }
-
-    /**
      * Compile a delete query that does not use joins.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
@@ -262,9 +245,9 @@ class MySqlGrammar extends Grammar
      * @param  string  $where
      * @return string
      */
-    protected function compileDeleteWithoutJoins($query, $table, $where)
+    protected function compileDeleteWithoutJoins(Builder $query, $table, $where)
     {
-        $sql = trim("delete from {$table} {$where}");
+        $sql = parent::compileDeleteWithoutJoins($query, $table, $where);
 
         // When using MySQL, delete statements may contain order by statements and limits
         // so we will compile both of those here. Once we have finished compiling this
@@ -278,24 +261,6 @@ class MySqlGrammar extends Grammar
         }
 
         return $sql;
-    }
-
-    /**
-     * Compile a delete query that uses joins.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $table
-     * @param  string  $where
-     * @return string
-     */
-    protected function compileDeleteWithJoins($query, $table, $where)
-    {
-        $joins = ' '.$this->compileJoins($query, $query->joins);
-
-        $alias = stripos($table, ' as ') !== false
-                ? explode(' as ', $table)[1] : $table;
-
-        return trim("delete {$alias} from {$table}{$joins} {$where}");
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -304,9 +304,7 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $segments = preg_split('/\s+as\s+/i', $query->from);
-
-        $alias = $segments[1] ?? $segments[0];
+        $alias = last(preg_split('/\s+as\s+/i', $query->from));
 
         $selectSql = $this->compileSelect($query->select($alias.'.ctid'));
 
@@ -360,9 +358,7 @@ class PostgresGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
 
-        $segments = preg_split('/\s+as\s+/i', $query->from);
-
-        $alias = $segments[1] ?? $segments[0];
+        $alias = last(preg_split('/\s+as\s+/i', $query->from));
 
         $selectSql = $this->compileSelect($query->select($alias.'.ctid'));
 

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -193,9 +193,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function compileUpdateWithJoinsOrLimit(Builder $query, $columns)
     {
-        $segments = preg_split('/\s+as\s+/i', $query->from);
-
-        $alias = $segments[1] ?? $segments[0];
+        $alias = last(preg_split('/\s+as\s+/i', $query->from));
 
         $selectSql = parent::compileSelect($query->select($alias.'.rowid'));
 
@@ -230,9 +228,7 @@ class SQLiteGrammar extends Grammar
             return $this->compileDeleteWithJoinsOrLimit($query);
         }
 
-        $wheres = is_array($query->wheres) ? $this->compileWheres($query) : '';
-
-        return trim("delete from {$this->wrapTable($query->from)} $wheres");
+        return parent::compileDelete($query);
     }
 
     /**
@@ -243,13 +239,13 @@ class SQLiteGrammar extends Grammar
      */
     protected function compileDeleteWithJoinsOrLimit(Builder $query)
     {
-        $segments = preg_split('/\s+as\s+/i', $query->from);
+        $table = $this->wrapTable($query->from);
 
-        $alias = $segments[1] ?? $segments[0];
+        $alias = last(preg_split('/\s+as\s+/i', $query->from));
 
-        $selectSql = parent::compileSelect($query->select($alias.'.rowid'));
+        $selectSql = $this->compileSelect($query->select($alias.'.rowid'));
 
-        return "delete from {$this->wrapTable($query->from)} where {$this->wrap('rowid')} in ({$selectSql})";
+        return "delete from {$table} where {$this->wrap('rowid')} in ({$selectSql})";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -295,41 +295,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile a delete statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @return string
-     */
-    public function compileDelete(Builder $query)
-    {
-        $table = $this->wrapTable($query->from);
-
-        $where = is_array($query->wheres) ? $this->compileWheres($query) : '';
-
-        return isset($query->joins)
-                    ? $this->compileDeleteWithJoins($query, $table, $where)
-                    : trim("delete from {$table} {$where}");
-    }
-
-    /**
-     * Compile a delete statement with joins into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  string  $table
-     * @param  string  $where
-     * @return string
-     */
-    protected function compileDeleteWithJoins(Builder $query, $table, $where)
-    {
-        $joins = ' '.$this->compileJoins($query, $query->joins);
-
-        $alias = stripos($table, ' as ') !== false
-                ? explode(' as ', $table)[1] : $table;
-
-        return trim("delete {$alias} from {$table}{$joins} {$where}");
-    }
-
-    /**
      * Compile a truncate table statement into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query


### PR DESCRIPTION
We can move the shared code up to the base grammar and only override the relevant parts.