### PR TITLE
[5.8] Fix n+1 problem in HasOneOrMany::updateOrCreate and BelongsToMany::updateOrCreate

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -484,7 +484,15 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        $instance = null;
+
+        // Use the models that have already been loaded by the parent. This will solve
+        // the n + 1 query problem for the developer and also increase performance.
+        if (empty($attributes)) {
+            $instance = $this->parent->getRelation($this->related->getTable())->first();
+        }
+
+        if (! $instance && is_null($instance = $this->where($attributes)->first())) {
             return $this->create($values, $joining, $touch);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -232,11 +232,22 @@ abstract class HasOneOrMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
-            $instance->fill($values);
+        $instance = null;
 
-            $instance->save();
-        });
+        // Use the models that have already been loaded by the parent. This will solve
+        // the n + 1 query problem for the developer and also increase performance.
+        if (empty($attributes)) {
+            $relation = $this->related->getTable();
+            $instance = $this->parent->getRelation($relation)->first();
+        }
+
+        $instance = $instance ?? $this->firstOrNew($attributes);
+
+        $instance->fill($values);
+
+        $instance->save();
+
+        return $instance;
     }
 
     /**

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -391,6 +391,13 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->tags()->updateOrCreate(['id' => 'asd'], ['name' => 'dives']);
         $this->assertNotNull($post->tags()->whereName('dives')->first());
+
+        $post = Post::with('tags')->first();
+
+        DB::enableQueryLog();
+        $post->tags()->updateOrCreate([], ['name' => 'vapor']);
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertEquals('vapor', $tag->fresh()->name);
     }
 
     public function test_sync_method()

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Integration\Database\EloquentBelongsToTest;
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -126,7 +126,6 @@ class User extends Model
     }
 }
 
-
 class Post extends Model
 {
     public $table = 'posts';


### PR DESCRIPTION
Our company had a problem with the speed of an endpoint. By `updateOrCreate()` there arises a n + 1 problem. `updateOrCreate()` does not take into account models that have already been loaded by the parent. This pr is the solution for n + 1 problems when the first parameter is an empty array.
