### PR TITLE
[5.8] Fix UPDATE queries with alias

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -248,7 +248,7 @@ class PostgresGrammar extends Grammar
         // columns and convert it to a parameter value. Then we will concatenate a
         // list of the columns that can be added into this update query clauses.
         return collect($values)->map(function ($value, $key) use ($query) {
-            $column = Str::after($key, $query->from.'.');
+            $column = Str::after($key, '.');
 
             if ($this->isJsonSelector($key)) {
                 return $this->compileJsonUpdateColumn($column, $value);

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -190,7 +190,7 @@ class SQLiteGrammar extends Grammar
         $table = $this->wrapTable($query->from);
 
         $columns = collect($values)->map(function ($value, $key) use ($query) {
-            return $this->wrap(Str::after($key, $query->from.'.')).' = '.$this->parameter($value);
+            return $this->wrap(Str::after($key, '.')).' = '.$this->parameter($value);
         })->implode(', ');
 
         if (isset($query->joins) || isset($query->limit)) {


### PR DESCRIPTION
PostgreSQL and SQLite don't support `UPDATE` queries with qualified column names in the `SET` clause.

We are already removing the table name, but that doesn't work with an alias:

```php
DB::table('comments as c')
    ->join('posts as p', 'p.id', '=', 'c.post_id')
    ->where('p.active', 0)
    ->update(['c.active' => 0]);
```

```sql
update "comments" as "c" set "c"."active" = 0
from "posts" as "p"^         ^^^^
where "p"."active" = 0 and "p"."id" = "c"."post_id"
```

We can cover both cases by just taking everything after the dot.