### PR TITLE
[5.8] Add line break for plain text mails

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -43,7 +43,8 @@
 @if (! empty($salutation))
 {{ $salutation }}
 @else
-@lang('Regards'),<br>{{ config('app.name') }}
+@lang('Regards'),<br>
+{{ config('app.name') }}
 @endif
 
 {{-- Subcopy --}}


### PR DESCRIPTION
This change adds a manual line break in addition to the existing HTML-only `<br>` . Before this change the text in plain text mails was `Regards,Laravel` without a line break or space.

Since this file can be published not every user will get this fix, so perhaps it should be included in the upgrade notes.