### PR TITLE
[6.0] Alleviate session race problem

### DIFF
--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -4,7 +4,7 @@
 
 
 
-## [v5.8.29 (2019-07-30)](https://github.com/laravel/framework/compare/v5.8.29...v5.8.30)
+## [v5.8.30 (2019-07-30)](https://github.com/laravel/framework/compare/v5.8.29...v5.8.30)
 
 ### Added
 - Added `MakesHttpRequests::option()` and `MakesHttpRequests::optionJson()` methods ([#29258](https://github.com/laravel/framework/pull/29258))

--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -1,10 +1,19 @@
 # Release Notes for 5.8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v5.8.29...5.8)
+## [Unreleased](https://github.com/laravel/framework/compare/v5.8.30...5.8)
+
+
+
+## [v5.8.29 (2019-07-30)](https://github.com/laravel/framework/compare/v5.8.29...v5.8.30)
 
 ### Added
-- Added`MakesHttpRequests::option()` and `MakesHttpRequests::optionJson()` methods ([#29258](https://github.com/laravel/framework/pull/29258))
+- Added `MakesHttpRequests::option()` and `MakesHttpRequests::optionJson()` methods ([#29258](https://github.com/laravel/framework/pull/29258))
 - Added `Blueprint::uuidMorphs()` and `Blueprint::nullableUuidMorphs()` methods ([#29289](https://github.com/laravel/framework/pull/29289))
+- Added `MailgunTransport::getEndpoint()` and `MailgunTransport::setEndpoint()` methods ([#29312](https://github.com/laravel/framework/pull/29312))
+- Added `WEBP` to image validation rule ([#29309](https://github.com/laravel/framework/pull/29309))
+- Added `TestResponse::assertSessionHasInput()` method ([#29327](https://github.com/laravel/framework/pull/29327))
+- Added support for custom redis driver ([#29275](https://github.com/laravel/framework/pull/29275))
+- Added Postgres support for `collation()` on columns ([#29213](https://github.com/laravel/framework/pull/29213))
 
 ### Fixed
 - Fixed collections with JsonSerializable items and mixed values ([#29205](https://github.com/laravel/framework/pull/29205))
@@ -13,14 +22,15 @@
 - Fixed default theme for Markdown mails ([#29274](https://github.com/laravel/framework/pull/29274))
 - Fixed UPDATE queries with alias on SQLite ([#29276](https://github.com/laravel/framework/pull/29276))
 - Fixed UPDATE and DELETE queries with join bindings on PostgreSQL ([#29306](https://github.com/laravel/framework/pull/29306))
+- Fixed support of `DateTime` objects and `int` values in `orWhereDay()`, `orWhereMonth()`, `orWhereYear()` methods in the `Builder` ([#29317](https://github.com/laravel/framework/pull/29317))
+- Fixed DELETE queries with joins on PostgreSQL ([#29313](https://github.com/laravel/framework/pull/29313))
+- Prevented a job from firing if job marked as deleted ([#29204](https://github.com/laravel/framework/pull/29204), [1003c27](https://github.com/laravel/framework/commit/1003c27b73f11472c1ebdb9238b839aefddfb048))
+- Fixed model deserializing with custom `Model::newCollection()` ([#29196](https://github.com/laravel/framework/pull/29196))
 
 ### Reverted
 - Reverted: [Added possibility for `WithFaker::makeFaker()` use local `app.faker_locale` config](https://github.com/laravel/framework/pull/29123) ([#29250](https://github.com/laravel/framework/pull/29250))
 
-### TODO
-- tagged today breaks queue deserializing with Model::newCollection() ([#29196](https://github.com/laravel/framework/pull/29196))
-- Prevent a job from firing if it's been marked as deleted ([#29204](https://github.com/laravel/framework/pull/29204), [1003c27](https://github.com/laravel/framework/commit/1003c27b73f11472c1ebdb9238b839aefddfb048))
-- Add Postgres support for collation() on columns ([#29213](https://github.com/laravel/framework/pull/29213))
+### Changed
 - Allocate memory for error handling to allow handling memory exhaustion limits ([#29226](https://github.com/laravel/framework/pull/29226))
 - Teardown test suite after using fail() method ([#29267](https://github.com/laravel/framework/pull/29267))
 

--- a/src/Illuminate/Contracts/Redis/Connector.php
+++ b/src/Illuminate/Contracts/Redis/Connector.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Contracts\Redis;
+
+interface Connector
+{
+    /**
+     * Create a new clustered Predis connection.
+     *
+     * @param  array  $config
+     * @param  array  $options
+     * @return \Illuminate\Contracts\Redis\Connection
+     */
+    public function connect(array $config, array $options);
+
+    /**
+     * Create a new clustered Predis connection.
+     *
+     * @param  array  $config
+     * @param  array  $clusterOptions
+     * @param  array  $options
+     * @return \Illuminate\Contracts\Redis\Connection
+     */
+    public function connectToCluster(array $config, array $clusterOptions, array $options);
+}

--- a/src/Illuminate/Contracts/Redis/Connector.php
+++ b/src/Illuminate/Contracts/Redis/Connector.php
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Redis;
 interface Connector
 {
     /**
-     * Create a new clustered Predis connection.
+     * Create a new clustered redis connection.
      *
      * @param  array  $config
      * @param  array  $options
@@ -14,7 +14,7 @@ interface Connector
     public function connect(array $config, array $options);
 
     /**
-     * Create a new clustered Predis connection.
+     * Create a new clustered redis connection.
      *
      * @param  array  $config
      * @param  array  $clusterOptions

--- a/src/Illuminate/Contracts/Redis/Connector.php
+++ b/src/Illuminate/Contracts/Redis/Connector.php
@@ -9,7 +9,7 @@ interface Connector
      *
      * @param  array  $config
      * @param  array  $options
-     * @return \Illuminate\Contracts\Redis\Connection
+     * @return \Illuminate\Redis\Connections\Connection
      */
     public function connect(array $config, array $options);
 
@@ -19,7 +19,7 @@ interface Connector
      * @param  array  $config
      * @param  array  $clusterOptions
      * @param  array  $options
-     * @return \Illuminate\Contracts\Redis\Connection
+     * @return \Illuminate\Redis\Connections\Connection
      */
     public function connectToCluster(array $config, array $clusterOptions, array $options);
 }

--- a/src/Illuminate/Contracts/Redis/Connector.php
+++ b/src/Illuminate/Contracts/Redis/Connector.php
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Redis;
 interface Connector
 {
     /**
-     * Create a new clustered redis connection.
+     * Create a connection to a Redis cluster.
      *
      * @param  array  $config
      * @param  array  $options
@@ -14,7 +14,7 @@ interface Connector
     public function connect(array $config, array $options);
 
     /**
-     * Create a new clustered redis connection.
+     * Create a connection to a Redis instance.
      *
      * @param  array  $config
      * @param  array  $clusterOptions

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -203,7 +203,7 @@ trait AsPivot
     /**
      * Determine if the pivot model or given attributes has timestamp attributes.
      *
-     * @param  $attributes  array|null
+     * @param  array|null  $attributes
      * @return bool
      */
     public function hasTimestampAttributes($attributes = null)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -220,12 +220,12 @@ trait InteractsWithPivotTable
      */
     protected function updateExistingPivotUsingCustomClass($id, array $attributes, $touch)
     {
-        $updated = $this->getCurrentlyAttachedPivots()
+        $pivot = $this->getCurrentlyAttachedPivots()
                     ->where($this->foreignPivotKey, $this->parent->{$this->parentKey})
                     ->where($this->relatedPivotKey, $this->parseId($id))
-                    ->first()
-                    ->fill($attributes)
-                    ->isDirty();
+                    ->first();
+
+        $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
         $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -403,7 +403,7 @@ trait InteractsWithPivotTable
      * @param  string  $column
      * @return bool
      */
-    protected function hasPivotColumn($column)
+    public function hasPivotColumn($column)
     {
         return in_array($column, $this->pivotColumns);
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -29,7 +29,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '5.8.29';
+    const VERSION = '5.8.30';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -914,6 +914,41 @@ class TestResponse
     }
 
     /**
+     * Assert that the session has a given value in the flashed input array.
+     *
+     * @param  string|array  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function assertSessionHasInput($key, $value = null)
+    {
+        if (is_array($key)) {
+            foreach ($key as $k => $v) {
+                if (is_int($k)) {
+                    $this->assertSessionHasInput($v);
+                } else {
+                    $this->assertSessionHasInput($k, $v);
+                }
+            }
+
+            return $this;
+        }
+
+        if (is_null($value)) {
+            PHPUnit::assertTrue(
+                $this->session()->getOldInput($key),
+                "Session is missing expected key [{$key}]."
+            );
+        } elseif ($value instanceof Closure) {
+            PHPUnit::assertTrue($value($this->session()->getOldInput($key)));
+        } else {
+            PHPUnit::assertEquals($value, $this->session()->getOldInput($key));
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the session has the given errors.
      *
      * @param  string|array  $keys

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -682,9 +682,9 @@ class TestResponse
                     }
                 }
 
-                if (!$hasError) {
+                if (! $hasError) {
                     PHPUnit::fail(
-                        "Failed to find a validation error in the response for key and message: '$key' => '$value'" . PHP_EOL . PHP_EOL . $errorMessage
+                        "Failed to find a validation error in the response for key and message: '$key' => '$value'".PHP_EOL.PHP_EOL.$errorMessage
                     );
                 }
             }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -679,6 +679,7 @@ class TestResponse
                 foreach (Arr::wrap($jsonErrors[$key]) as $jsonErrorMessage) {
                     if (Str::contains($jsonErrorMessage, $value)) {
                         $hasError = true;
+                        break;
                     }
                 }
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -676,9 +676,11 @@ class TestResponse
 
             if (! is_int($key)) {
                 $hasError = false;
+
                 foreach (Arr::wrap($jsonErrors[$key]) as $jsonErrorMessage) {
                     if (Str::contains($jsonErrorMessage, $value)) {
                         $hasError = true;
+
                         break;
                     }
                 }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -675,15 +675,18 @@ class TestResponse
             );
 
             if (! is_int($key)) {
+                $hasError = false;
                 foreach (Arr::wrap($jsonErrors[$key]) as $jsonErrorMessage) {
                     if (Str::contains($jsonErrorMessage, $value)) {
-                        return $this;
+                        $hasError = true;
                     }
                 }
 
-                PHPUnit::fail(
-                    "Failed to find a validation error in the response for key and message: '$key' => '$value'".PHP_EOL.PHP_EOL.$errorMessage
-                );
+                if (!$hasError) {
+                    PHPUnit::fail(
+                        "Failed to find a validation error in the response for key and message: '$key' => '$value'" . PHP_EOL . PHP_EOL . $errorMessage
+                    );
+                }
             }
         }
 

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -422,8 +422,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $request;
         }
 
-        $content = $request->content;
-
         $newRequest = (new static)->duplicate(
             $request->query->all(), $request->request->all(), $request->attributes->all(),
             $request->cookies->all(), $request->files->all(), $request->server->all()
@@ -431,7 +429,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 
         $newRequest->headers->replace($request->headers->all());
 
-        $newRequest->content = $content;
+        $newRequest->content = $request->content;
 
         $newRequest->request = $newRequest->getInputSource();
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -140,9 +140,11 @@ class Worker
         // process if it is running too long because it has frozen. This uses the async
         // signals supported in recent versions of PHP to accomplish it conveniently.
         pcntl_signal(SIGALRM, function () use ($job, $options) {
-            $this->markJobAsFailedIfWillExceedMaxAttempts(
-                $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
-            );
+            if ($job) {
+                $this->markJobAsFailedIfWillExceedMaxAttempts(
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
+                );
+            }
 
             $this->kill(1);
         });

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -149,7 +149,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      *
      * @param  string  $key
      * @param  int  $count
-     * @param  $value  $value
+     * @param  mixed  $value
      * @return int|false
      */
     public function lrem($key, $count, $value)

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -100,7 +100,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      *
      * @param  string  $key
      * @param  dynamic  $dictionary
-     * @return int
+     * @return array
      */
     public function hmget($key, ...$dictionary)
     {

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -2,13 +2,14 @@
 
 namespace Illuminate\Redis\Connectors;
 
+use Illuminate\Contracts\Redis\Connector;
 use Redis;
 use RedisCluster;
 use Illuminate\Support\Arr;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 
-class PhpRedisConnector
+class PhpRedisConnector implements Connector
 {
     /**
      * Create a new clustered PhpRedis connection.

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Redis\Connectors;
 
-use Illuminate\Contracts\Redis\Connector;
 use Redis;
 use RedisCluster;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Redis\Connector;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Redis\Connectors;
 
+use Illuminate\Contracts\Redis\Connector;
 use Predis\Client;
 use Illuminate\Support\Arr;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Redis\Connections\PredisClusterConnection;
 
-class PredisConnector
+class PredisConnector implements Connector
 {
     /**
      * Create a new clustered Predis connection.

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Redis\Connectors;
 
-use Illuminate\Contracts\Redis\Connector;
 use Predis\Client;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Redis\Connector;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Redis\Connections\PredisClusterConnection;
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -246,7 +246,7 @@ trait ValidatesAttributes
                 return Date::parse($value);
             }
 
-            return new DateTime($value);
+            return date_create($value);
         } catch (Exception $e) {
             //
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -246,7 +246,7 @@ trait ValidatesAttributes
                 return Date::parse($value);
             }
 
-            return date_create($value);
+            return date_create($value) ?: null;
         } catch (Exception $e) {
             //
         }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -63,7 +63,7 @@ class AuthAccessGateTest extends TestCase
         $gate = new Gate(new Container, function () {
         });
 
-        $gate->before(function (?StdClass $user) {
+        $gate->before(function (?stdClass $user) {
             return true;
         });
 
@@ -75,7 +75,7 @@ class AuthAccessGateTest extends TestCase
         $gate = new Gate(new Container, function () {
         });
 
-        $gate->after(function (?StdClass $user) {
+        $gate->after(function (?stdClass $user) {
             return true;
         });
 
@@ -87,11 +87,11 @@ class AuthAccessGateTest extends TestCase
         $gate = new Gate(new Container, function () {
         });
 
-        $gate->define('foo', function (?StdClass $user) {
+        $gate->define('foo', function (?stdClass $user) {
             return true;
         });
 
-        $gate->define('bar', function (StdClass $user) {
+        $gate->define('bar', function (stdClass $user) {
             return false;
         });
 
@@ -148,19 +148,19 @@ class AuthAccessGateTest extends TestCase
         $gate = new Gate(new Container, function () {
         });
 
-        $gate->before(function (?StdClass $user) {
+        $gate->before(function (?stdClass $user) {
             $_SERVER['__laravel.gateBefore'] = true;
         });
 
-        $gate->after(function (?StdClass $user) {
+        $gate->after(function (?stdClass $user) {
             $_SERVER['__laravel.gateAfter'] = true;
         });
 
-        $gate->before(function (StdClass $user) {
+        $gate->before(function (stdClass $user) {
             $_SERVER['__laravel.gateBefore2'] = true;
         });
 
-        $gate->after(function (StdClass $user) {
+        $gate->after(function (stdClass $user) {
             $_SERVER['__laravel.gateAfter2'] = true;
         });
 
@@ -818,7 +818,7 @@ class AccessGateTestGuestNullableInvokable
 {
     public static $calledMethod = null;
 
-    public function __invoke(?StdClass $user)
+    public function __invoke(?stdClass $user)
     {
         static::$calledMethod = 'Nullable __invoke was called';
 
@@ -961,12 +961,12 @@ class AccessGateTestPolicyWithAllPermissions
 
 class AccessGateTestPolicyThatAllowsGuests
 {
-    public function before(?StdClass $user)
+    public function before(?stdClass $user)
     {
         $_SERVER['__laravel.testBefore'] = true;
     }
 
-    public function edit(?StdClass $user, AccessGateTestDummy $dummy)
+    public function edit(?stdClass $user, AccessGateTestDummy $dummy)
     {
         return true;
     }
@@ -979,12 +979,12 @@ class AccessGateTestPolicyThatAllowsGuests
 
 class AccessGateTestPolicyWithNonGuestBefore
 {
-    public function before(StdClass $user)
+    public function before(stdClass $user)
     {
         $_SERVER['__laravel.testBefore'] = true;
     }
 
-    public function edit(?StdClass $user, AccessGateTestDummy $dummy)
+    public function edit(?stdClass $user, AccessGateTestDummy $dummy)
     {
         return true;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -523,6 +523,22 @@ class FoundationTestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors(['one' => 'foo', 'two' => 'bar']);
     }
 
+    public function testAssertJsonValidationErrorMessagesMultipleMessagesCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $data = [
+            'status' => 'ok',
+            'errors' => ['one' => 'foo', 'two' => 'bar'],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors(['one' => 'foo', 'three' => 'baz']);
+    }
+
     public function testAssertJsonValidationErrorMessagesMixed()
     {
         $data = [

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -51,7 +51,7 @@ class HasherTest extends TestCase
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 
-    public function testBasicArgon2iVerification()
+    public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
 
@@ -64,7 +64,7 @@ class HasherTest extends TestCase
         (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
-    public function testBasicBcryptVerification()
+    public function testBasicArgon2iVerification()
     {
         $this->expectException(RuntimeException::class);
 

--- a/tests/Hashing/HasherTest.php
+++ b/tests/Hashing/HasherTest.php
@@ -51,7 +51,7 @@ class HasherTest extends TestCase
         $this->assertSame('argon2id', password_get_info($value)['algoName']);
     }
 
-    public function testBasicBcryptVerification()
+    public function testBasicArgon2iVerification()
     {
         $this->expectException(RuntimeException::class);
 
@@ -64,7 +64,7 @@ class HasherTest extends TestCase
         (new BcryptHasher(['verify' => true]))->check('password', $argonHashed);
     }
 
-    public function testBasicArgon2iVerification()
+    public function testBasicBcryptVerification()
     {
         $this->expectException(RuntimeException::class);
 

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -15,7 +15,7 @@ class HttpJsonResponseTest extends TestCase
     /**
      * @dataProvider setAndRetrieveDataProvider
      *
-     * @param  $data
+     * @param  mixed  $data
      */
     public function testSetAndRetrieveData($data): void
     {

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -68,7 +68,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param $driver
+     * @param  mixed  $driver
      *
      * @throws \Exception
      */

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Contracts\Redis\Connector;
+use Illuminate\Foundation\Application;
+use Illuminate\Redis\RedisManager;
+use PHPUnit\Framework\TestCase;
+
+class RedisManagerExtensionTest extends TestCase
+{
+    /**
+     * Redis manager instance.
+     *
+     * @var RedisManager
+     */
+    protected $redis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redis = new RedisManager(new Application(), 'my_custom_driver', [
+            'default' => [
+                'host' => 'some-host',
+                'port' => 'some-port',
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+            'clusters' => [
+                'my-cluster' => [
+                    [
+                        'host' => 'some-host',
+                        'port' => 'some-port',
+                        'database' => 5,
+                        'timeout' => 0.5,
+                    ]
+                ]
+            ]
+        ]);
+
+        $this->redis->extend('my_custom_driver', function () {
+            return new FakeRedisConnnector();
+        });
+    }
+
+    public function test_using_custom_redis_connector_with_single_redis_instance()
+    {
+        $this->assertEquals(
+            'my-redis-connection', $this->redis->resolve()
+        );
+    }
+
+    public function test_using_custom_redis_connector_with_redis_cluster_instance()
+    {
+        $this->assertEquals(
+            'my-redis-cluster-connection', $this->redis->resolve('my-cluster')
+        );
+    }
+}
+
+class FakeRedisConnnector implements Connector
+{
+    /**
+     * Create a new clustered Predis connection.
+     *
+     * @param array $config
+     * @param array $options
+     * @return \Illuminate\Contracts\Redis\Connection
+     */
+    public function connect(array $config, array $options)
+    {
+        return 'my-redis-connection';
+    }
+
+    /**
+     * Create a new clustered Predis connection.
+     *
+     * @param array $config
+     * @param array $clusterOptions
+     * @param array $options
+     * @return \Illuminate\Contracts\Redis\Connection
+     */
+    public function connectToCluster(array $config, array $clusterOptions, array $options)
+    {
+        return 'my-redis-cluster-connection';
+    }
+}

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Tests\Redis;
 
-use Illuminate\Contracts\Redis\Connector;
-use Illuminate\Foundation\Application;
-use Illuminate\Redis\RedisManager;
 use PHPUnit\Framework\TestCase;
+use Illuminate\Redis\RedisManager;
+use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Redis\Connector;
 
 class RedisManagerExtensionTest extends TestCase
 {
@@ -34,9 +34,9 @@ class RedisManagerExtensionTest extends TestCase
                         'port' => 'some-port',
                         'database' => 5,
                         'timeout' => 0.5,
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ]);
 
         $this->redis->extend('my_custom_driver', function () {


### PR DESCRIPTION
This is a re submission of #29399 
related issue : #18187 

This is a re submission of #29399 , With the difference that, now we always send the cookie to the client, no matter what.
This PR brings help to the issue, Only (and only) in cases where the session ID is not regenerated by the other concurrent request and only the session data is modified.

Also it may save an unnecessary I/O operation, at the end of the request.

I thought a lot, but I was not able to find a better solution to cover more cases, unfortunately.