### PR TITLE
[6.0] alleviate session race condition

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -36,13 +36,6 @@ class Password extends Facade
     const INVALID_USER = PasswordBroker::INVALID_USER;
 
     /**
-     * Constant representing an invalid password.
-     *
-     * @var string
-     */
-    const INVALID_PASSWORD = PasswordBroker::INVALID_PASSWORD;
-
-    /**
      * Constant representing an invalid token.
      *
      * @var string

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -150,7 +150,7 @@ class SessionStoreTest extends TestCase
         $this->assertFalse($session->isStarted());
     }
 
-    public function testSessionIsReSavedWhenNothingHasChanged()
+    public function testSessionIsNotReSavedWhenNothingHasChanged()
     {
         $session = $this->getSession();
         $session->getHandler()->shouldReceive('read')->once()->andReturn(serialize([


### PR DESCRIPTION
related issue : #18187 

If the first first serialized string we receive from the session store (after a read operation) is exactly the same as the final final string we are delivering back to the session store, we can skip the write operation.
Because at best it does not change any thing, or worse it will override the precious work of a concurrent request.

This PR brings help to the issue, only (and only) in cases where the session ID is not regenerated by the other concurrent request and only the session data is modified.
because the cookie is always sent and contains the session id of the dominant request.

For example if the concurrent request performs a `login` the session data is still being lost.
because the cookie would not be able to find the new session by it's id.