### PR TITLE
[5.8] Fix expectsQuestion and expectsOutput assertions of PendingCommand fail when called twice with same text

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -165,6 +165,7 @@ class PendingCommand
 
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
+                ->once()
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     return $argument->getQuestion() == $question[0];
@@ -194,6 +195,7 @@ class PendingCommand
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')
+                ->once()
                 ->ordered()
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($i) {


### PR DESCRIPTION
In Laravel 5.8.30, when you have a console command calling ask twice or more with the same question
```php
$this->ask('Asking something');
$this->ask('Asking something');
```

and you try to test it
```php
$command = $this->artisan('console-command');
$command->expectsQuestion('Asking something', 'answer');
$command->expectsQuestion('Asking something', 'another answer');
$command->assertExitCode(0);
$command->run();
```

the test fails with an error like that
```
Question "Asking something" was not asked.
```

If you have another question between
```php
$this->ask('Asking something');
$this->ask('Put a number');
$this->ask('Asking something');
```
and test
```
$command = $this->artisan('create-song');
$command->expectsQuestion('Asking something', 'answer');
$command->expectsQuestion('Put a number', '7');
$command->expectsQuestion('Asking something', 'another answer');
$command->assertExitCode(0);
$command->run();
```
the error is more cryptic
```
Mockery\Exception\InvalidOrderException: Method Mockery_1_Illuminate_Console_OutputStyle::askQuestion(<Closure===true>)() called out of order: expected order 1, was 2
```

Also, the same happens with `expectsOutput` method.

This PR adds the call to `once()` method when creating the mock in PendingCommand, to avoid compare with the wrong mock when the question/output of multiples mocks are the same.

The `once()` method was deleted in #29267 , so maybe is necessary consider it.