### PR TITLE
[6.0] Add lazy collections and an enumerable contract

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -61,6 +61,16 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get a lazy collection for the items in this collection.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function lazy()
+    {
+        return new LazyCollection($this->items);
+    }
+
+    /**
      * Get the average value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -3,44 +3,14 @@
 namespace Illuminate\Support;
 
 use stdClass;
-use Countable;
-use Exception;
 use ArrayAccess;
-use Traversable;
 use ArrayIterator;
-use CachingIterator;
-use JsonSerializable;
-use IteratorAggregate;
 use Illuminate\Support\Traits\Macroable;
-use Illuminate\Contracts\Support\Jsonable;
-use Symfony\Component\VarDumper\VarDumper;
-use Illuminate\Contracts\Support\Arrayable;
-
-/**
- * @property-read HigherOrderCollectionProxy $average
- * @property-read HigherOrderCollectionProxy $avg
- * @property-read HigherOrderCollectionProxy $contains
- * @property-read HigherOrderCollectionProxy $each
- * @property-read HigherOrderCollectionProxy $every
- * @property-read HigherOrderCollectionProxy $filter
- * @property-read HigherOrderCollectionProxy $first
- * @property-read HigherOrderCollectionProxy $flatMap
- * @property-read HigherOrderCollectionProxy $groupBy
- * @property-read HigherOrderCollectionProxy $keyBy
- * @property-read HigherOrderCollectionProxy $map
- * @property-read HigherOrderCollectionProxy $max
- * @property-read HigherOrderCollectionProxy $min
- * @property-read HigherOrderCollectionProxy $partition
- * @property-read HigherOrderCollectionProxy $reject
- * @property-read HigherOrderCollectionProxy $sortBy
- * @property-read HigherOrderCollectionProxy $sortByDesc
- * @property-read HigherOrderCollectionProxy $sum
- * @property-read HigherOrderCollectionProxy $unique
- */
+use Illuminate\Support\Traits\EnumeratesValues;
 
 class Collection implements ArrayAccess, Enumerable
 {
-    use Macroable;
+    use EnumeratesValues, Macroable;
 
     /**
      * The items contained in the collection.
@@ -48,17 +18,6 @@ class Collection implements ArrayAccess, Enumerable
      * @var array
      */
     protected $items = [];
-
-    /**
-     * The methods that can be proxied.
-     *
-     * @var array
-     */
-    protected static $proxies = [
-        'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
-        'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
-        'reject', 'some', 'sortBy', 'sortByDesc', 'sum', 'unique',
-    ];
 
     /**
      * Create a new collection.
@@ -69,41 +28,6 @@ class Collection implements ArrayAccess, Enumerable
     public function __construct($items = [])
     {
         $this->items = $this->getArrayableItems($items);
-    }
-
-    /**
-     * Create a new collection instance if the value isn't one already.
-     *
-     * @param  mixed  $items
-     * @return static
-     */
-    public static function make($items = [])
-    {
-        return new static($items);
-    }
-
-    /**
-     * Wrap the given value in a collection if applicable.
-     *
-     * @param  mixed  $value
-     * @return static
-     */
-    public static function wrap($value)
-    {
-        return $value instanceof self
-            ? new static($value)
-            : new static(Arr::wrap($value));
-    }
-
-    /**
-     * Get the underlying items from the given collection if applicable.
-     *
-     * @param  array|static  $value
-     * @return array
-     */
-    public static function unwrap($value)
-    {
-        return $value instanceof self ? $value->all() : $value;
     }
 
     /**
@@ -155,17 +79,6 @@ class Collection implements ArrayAccess, Enumerable
         if ($count = $items->count()) {
             return $items->sum() / $count;
         }
-    }
-
-    /**
-     * Alias for the "avg" method.
-     *
-     * @param  callable|string|null  $callback
-     * @return mixed
-     */
-    public function average($callback = null)
-    {
-        return $this->avg($callback);
     }
 
     /**
@@ -238,19 +151,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Alias for the "contains" method.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function some($key, $operator = null, $value = null)
-    {
-        return $this->contains(...func_get_args());
-    }
-
-    /**
      * Determine if an item exists in the collection.
      *
      * @param  mixed  $key
@@ -274,28 +174,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Determine if an item exists in the collection using strict comparison.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function containsStrict($key, $value = null)
-    {
-        if (func_num_args() === 2) {
-            return $this->contains(function ($item) use ($key, $value) {
-                return data_get($item, $key) === $value;
-            });
-        }
-
-        if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
-        }
-
-        return in_array($key, $this->items, true);
-    }
-
-    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists
@@ -306,35 +184,6 @@ class Collection implements ArrayAccess, Enumerable
         return new static(Arr::crossJoin(
             $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
         ));
-    }
-
-    /**
-     * Dump the collection and end the script.
-     *
-     * @param  mixed  ...$args
-     * @return void
-     */
-    public function dd(...$args)
-    {
-        call_user_func_array([$this, 'dump'], $args);
-
-        die(1);
-    }
-
-    /**
-     * Dump the collection.
-     *
-     * @return $this
-     */
-    public function dump()
-    {
-        (new static(func_get_args()))
-            ->push($this)
-            ->each(function ($item) {
-                VarDumper::dump($item);
-            });
-
-        return $this;
     }
 
     /**
@@ -465,63 +314,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Execute a callback over each item.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function each(callable $callback)
-    {
-        foreach ($this->items as $key => $item) {
-            if ($callback($item, $key) === false) {
-                break;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Execute a callback over each nested chunk of items.
-     *
-     * @param  callable  $callback
-     * @return static
-     */
-    public function eachSpread(callable $callback)
-    {
-        return $this->each(function ($chunk, $key) use ($callback) {
-            $chunk[] = $key;
-
-            return $callback(...$chunk);
-        });
-    }
-
-    /**
-     * Determine if all items in the collection pass the given test.
-     *
-     * @param  string|callable  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return bool
-     */
-    public function every($key, $operator = null, $value = null)
-    {
-        if (func_num_args() === 1) {
-            $callback = $this->valueRetriever($key);
-
-            foreach ($this->items as $k => $v) {
-                if (! $callback($v, $k)) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        return $this->every($this->operatorForWhere(...func_get_args()));
-    }
-
-    /**
      * Get all items except for those with the specified keys.
      *
      * @param  \Illuminate\Support\Collection|mixed  $keys
@@ -529,7 +321,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function except($keys)
     {
-        if ($keys instanceof self) {
+        if ($keys instanceof Enumerable) {
             $keys = $keys->all();
         } elseif (! is_array($keys)) {
             $keys = func_get_args();
@@ -554,257 +346,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Apply the callback if the value is truthy.
-     *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function when($value, callable $callback, callable $default = null)
-    {
-        if ($value) {
-            return $callback($this, $value);
-        } elseif ($default) {
-            return $default($this, $value);
-        }
-
-        return $this;
-    }
-
-    /**
-     * Apply the callback if the collection is empty.
-     *
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function whenEmpty(callable $callback, callable $default = null)
-    {
-        return $this->when($this->isEmpty(), $callback, $default);
-    }
-
-    /**
-     * Apply the callback if the collection is not empty.
-     *
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function whenNotEmpty(callable $callback, callable $default = null)
-    {
-        return $this->when($this->isNotEmpty(), $callback, $default);
-    }
-
-    /**
-     * Apply the callback if the value is falsy.
-     *
-     * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function unless($value, callable $callback, callable $default = null)
-    {
-        return $this->when(! $value, $callback, $default);
-    }
-
-    /**
-     * Apply the callback unless the collection is empty.
-     *
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function unlessEmpty(callable $callback, callable $default = null)
-    {
-        return $this->whenNotEmpty($callback, $default);
-    }
-
-    /**
-     * Apply the callback unless the collection is not empty.
-     *
-     * @param  callable  $callback
-     * @param  callable  $default
-     * @return static|mixed
-     */
-    public function unlessNotEmpty(callable $callback, callable $default = null)
-    {
-        return $this->whenEmpty($callback, $default);
-    }
-
-    /**
-     * Filter items by the given key value pair.
-     *
-     * @param  string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return static
-     */
-    public function where($key, $operator = null, $value = null)
-    {
-        return $this->filter($this->operatorForWhere(...func_get_args()));
-    }
-
-    /**
-     * Get an operator checker callback.
-     *
-     * @param  string  $key
-     * @param  string  $operator
-     * @param  mixed  $value
-     * @return \Closure
-     */
-    protected function operatorForWhere($key, $operator = null, $value = null)
-    {
-        if (func_num_args() === 1) {
-            $value = true;
-
-            $operator = '=';
-        }
-
-        if (func_num_args() === 2) {
-            $value = $operator;
-
-            $operator = '=';
-        }
-
-        return function ($item) use ($key, $operator, $value) {
-            $retrieved = data_get($item, $key);
-
-            $strings = array_filter([$retrieved, $value], function ($value) {
-                return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
-            });
-
-            if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) == 1) {
-                return in_array($operator, ['!=', '<>', '!==']);
-            }
-
-            switch ($operator) {
-                default:
-                case '=':
-                case '==':  return $retrieved == $value;
-                case '!=':
-                case '<>':  return $retrieved != $value;
-                case '<':   return $retrieved < $value;
-                case '>':   return $retrieved > $value;
-                case '<=':  return $retrieved <= $value;
-                case '>=':  return $retrieved >= $value;
-                case '===': return $retrieved === $value;
-                case '!==': return $retrieved !== $value;
-            }
-        };
-    }
-
-    /**
-     * Filter items by the given key value pair using strict comparison.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return static
-     */
-    public function whereStrict($key, $value)
-    {
-        return $this->where($key, '===', $value);
-    }
-
-    /**
-     * Filter items by the given key value pair.
-     *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @param  bool  $strict
-     * @return static
-     */
-    public function whereIn($key, $values, $strict = false)
-    {
-        $values = $this->getArrayableItems($values);
-
-        return $this->filter(function ($item) use ($key, $values, $strict) {
-            return in_array(data_get($item, $key), $values, $strict);
-        });
-    }
-
-    /**
-     * Filter items by the given key value pair using strict comparison.
-     *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @return static
-     */
-    public function whereInStrict($key, $values)
-    {
-        return $this->whereIn($key, $values, true);
-    }
-
-    /**
-     * Filter items such that the value of the given key is between the given values.
-     *
-     * @param  string  $key
-     * @param  array  $values
-     * @return static
-     */
-    public function whereBetween($key, $values)
-    {
-        return $this->where($key, '>=', reset($values))->where($key, '<=', end($values));
-    }
-
-    /**
-     * Filter items such that the value of the given key is not between the given values.
-     *
-     * @param  string  $key
-     * @param  array  $values
-     * @return static
-     */
-    public function whereNotBetween($key, $values)
-    {
-        return $this->filter(function ($item) use ($key, $values) {
-            return data_get($item, $key) < reset($values) || data_get($item, $key) > end($values);
-        });
-    }
-
-    /**
-     * Filter items by the given key value pair.
-     *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @param  bool  $strict
-     * @return static
-     */
-    public function whereNotIn($key, $values, $strict = false)
-    {
-        $values = $this->getArrayableItems($values);
-
-        return $this->reject(function ($item) use ($key, $values, $strict) {
-            return in_array(data_get($item, $key), $values, $strict);
-        });
-    }
-
-    /**
-     * Filter items by the given key value pair using strict comparison.
-     *
-     * @param  string  $key
-     * @param  mixed  $values
-     * @return static
-     */
-    public function whereNotInStrict($key, $values)
-    {
-        return $this->whereNotIn($key, $values, true);
-    }
-
-    /**
-     * Filter the items, removing any items that don't match the given type.
-     *
-     * @param  string  $type
-     * @return static
-     */
-    public function whereInstanceOf($type)
-    {
-        return $this->filter(function ($value) use ($type) {
-            return $value instanceof $type;
-        });
-    }
-
-    /**
      * Get the first item from the collection passing the given truth test.
      *
      * @param  callable|null  $callback
@@ -814,19 +355,6 @@ class Collection implements ArrayAccess, Enumerable
     public function first(callable $callback = null, $default = null)
     {
         return Arr::first($this->items, $callback, $default);
-    }
-
-    /**
-     * Get the first item by the given key value pair.
-     *
-     * @param  string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return mixed
-     */
-    public function firstWhere($key, $operator = null, $value = null)
-    {
-        return $this->first($this->operatorForWhere(...func_get_args()));
     }
 
     /**
@@ -1024,27 +552,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Determine if the collection is not empty.
-     *
-     * @return bool
-     */
-    public function isNotEmpty()
-    {
-        return ! $this->isEmpty();
-    }
-
-    /**
-     * Determine if the given value is callable, but not a string.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function useAsCallable($value)
-    {
-        return ! is_string($value) && is_callable($value);
-    }
-
-    /**
      * Join all items from the collection using a string. The final items can use a separate glue string.
      *
      * @param  string  $glue
@@ -1124,21 +631,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Run a map over each nested chunk of items.
-     *
-     * @param  callable  $callback
-     * @return static
-     */
-    public function mapSpread(callable $callback)
-    {
-        return $this->map(function ($chunk, $key) use ($callback) {
-            $chunk[] = $key;
-
-            return $callback(...$chunk);
-        });
-    }
-
-    /**
      * Run a dictionary map over the items.
      *
      * The callback should return an associative array with a single key/value pair.
@@ -1168,21 +660,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Run a grouping map over the items.
-     *
-     * The callback should return an associative array with a single key/value pair.
-     *
-     * @param  callable  $callback
-     * @return static
-     */
-    public function mapToGroups(callable $callback)
-    {
-        $groups = $this->mapToDictionary($callback);
-
-        return $groups->map([$this, 'make']);
-    }
-
-    /**
      * Run an associative map over each of the items.
      *
      * The callback should return an associative array with a single key/value pair.
@@ -1203,49 +680,6 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return new static($result);
-    }
-
-    /**
-     * Map a collection and flatten the result by a single level.
-     *
-     * @param  callable  $callback
-     * @return static
-     */
-    public function flatMap(callable $callback)
-    {
-        return $this->map($callback)->collapse();
-    }
-
-    /**
-     * Map the values into a new class.
-     *
-     * @param  string  $class
-     * @return static
-     */
-    public function mapInto($class)
-    {
-        return $this->map(function ($value, $key) use ($class) {
-            return new $class($value, $key);
-        });
-    }
-
-    /**
-     * Get the max value of a given key.
-     *
-     * @param  callable|string|null  $callback
-     * @return mixed
-     */
-    public function max($callback = null)
-    {
-        $callback = $this->valueRetriever($callback);
-
-        return $this->filter(function ($value) {
-            return ! is_null($value);
-        })->reduce(function ($result, $item) use ($callback) {
-            $value = $callback($item);
-
-            return is_null($result) || $value > $result ? $value : $result;
-        });
     }
 
     /**
@@ -1293,25 +727,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get the min value of a given key.
-     *
-     * @param  callable|string|null  $callback
-     * @return mixed
-     */
-    public function min($callback = null)
-    {
-        $callback = $this->valueRetriever($callback);
-
-        return $this->map(function ($value) use ($callback) {
-            return $callback($value);
-        })->filter(function ($value) {
-            return ! is_null($value);
-        })->reduce(function ($result, $value) {
-            return is_null($result) || $value < $result ? $value : $result;
-        });
-    }
-
-    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -1347,61 +762,13 @@ class Collection implements ArrayAccess, Enumerable
             return new static($this->items);
         }
 
-        if ($keys instanceof self) {
+        if ($keys instanceof Enumerable) {
             $keys = $keys->all();
         }
 
         $keys = is_array($keys) ? $keys : func_get_args();
 
         return new static(Arr::only($this->items, $keys));
-    }
-
-    /**
-     * "Paginate" the collection by slicing it into a smaller collection.
-     *
-     * @param  int  $page
-     * @param  int  $perPage
-     * @return static
-     */
-    public function forPage($page, $perPage)
-    {
-        $offset = max(0, ($page - 1) * $perPage);
-
-        return $this->slice($offset, $perPage);
-    }
-
-    /**
-     * Partition the collection into two arrays using the given callback or key.
-     *
-     * @param  callable|string  $key
-     * @param  mixed  $operator
-     * @param  mixed  $value
-     * @return static
-     */
-    public function partition($key, $operator = null, $value = null)
-    {
-        $partitions = [new static, new static];
-
-        $callback = func_num_args() === 1
-                ? $this->valueRetriever($key)
-                : $this->operatorForWhere(...func_get_args());
-
-        foreach ($this->items as $key => $item) {
-            $partitions[(int) ! $callback($item, $key)][$key] = $item;
-        }
-
-        return new static($partitions);
-    }
-
-    /**
-     * Pass the collection to the given callback and return the result.
-     *
-     * @param  callable $callback
-     * @return mixed
-     */
-    public function pipe(callable $callback)
-    {
-        return $callback($this);
     }
 
     /**
@@ -1424,19 +791,6 @@ class Collection implements ArrayAccess, Enumerable
     public function prepend($value, $key = null)
     {
         $this->items = Arr::prepend($this->items, $value, $key);
-
-        return $this;
-    }
-
-    /**
-     * Push an item onto the end of the collection.
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function push($value)
-    {
-        $this->offsetSet(null, $value);
 
         return $this;
     }
@@ -1511,23 +865,6 @@ class Collection implements ArrayAccess, Enumerable
     public function reduce(callable $callback, $initial = null)
     {
         return array_reduce($this->items, $callback, $initial);
-    }
-
-    /**
-     * Create a collection of all elements that do not pass a given truth test.
-     *
-     * @param  callable|mixed  $callback
-     * @return static
-     */
-    public function reject($callback = true)
-    {
-        $useAsCallable = $this->useAsCallable($callback);
-
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
-            return $useAsCallable
-                ? ! $callback($value, $key)
-                : $value != $callback;
-        });
     }
 
     /**
@@ -1655,7 +992,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Chunk the underlying collection array.
+     * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
      * @return static
@@ -1783,25 +1120,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get the sum of the given values.
-     *
-     * @param  callable|string|null  $callback
-     * @return mixed
-     */
-    public function sum($callback = null)
-    {
-        if (is_null($callback)) {
-            return array_sum($this->items);
-        }
-
-        $callback = $this->valueRetriever($callback);
-
-        return $this->reduce(function ($result, $item) use ($callback) {
-            return $result + $callback($item);
-        }, 0);
-    }
-
-    /**
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
@@ -1814,19 +1132,6 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return $this->slice(0, $limit);
-    }
-
-    /**
-     * Pass the collection to the given callback and then return it.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function tap(callable $callback)
-    {
-        $callback(new static($this->items));
-
-        return $this;
     }
 
     /**
@@ -1843,39 +1148,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Return only unique items from the collection array.
-     *
-     * @param  string|callable|null  $key
-     * @param  bool  $strict
-     * @return static
-     */
-    public function unique($key = null, $strict = false)
-    {
-        $callback = $this->valueRetriever($key);
-
-        $exists = [];
-
-        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
-            if (in_array($id = $callback($item, $key), $exists, $strict)) {
-                return true;
-            }
-
-            $exists[] = $id;
-        });
-    }
-
-    /**
-     * Return only unique items from the collection array using strict comparison.
-     *
-     * @param  string|callable|null  $key
-     * @return static
-     */
-    public function uniqueStrict($key = null)
-    {
-        return $this->unique($key, true);
-    }
-
-    /**
      * Reset the keys on the underlying array.
      *
      * @return static
@@ -1883,23 +1155,6 @@ class Collection implements ArrayAccess, Enumerable
     public function values()
     {
         return new static(array_values($this->items));
-    }
-
-    /**
-     * Get a value retrieving callback.
-     *
-     * @param  callable|string|null  $value
-     * @return callable
-     */
-    protected function valueRetriever($value)
-    {
-        if ($this->useAsCallable($value)) {
-            return $value;
-        }
-
-        return function ($item) use ($value) {
-            return data_get($item, $value);
-        };
     }
 
     /**
@@ -1937,49 +1192,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get the collection of items as a plain array.
-     *
-     * @return array
-     */
-    public function toArray()
-    {
-        return array_map(function ($value) {
-            return $value instanceof Arrayable ? $value->toArray() : $value;
-        }, $this->items);
-    }
-
-    /**
-     * Convert the object into something JSON serializable.
-     *
-     * @return array
-     */
-    public function jsonSerialize()
-    {
-        return array_map(function ($value) {
-            if ($value instanceof JsonSerializable) {
-                return $value->jsonSerialize();
-            } elseif ($value instanceof Jsonable) {
-                return json_decode($value->toJson(), true);
-            } elseif ($value instanceof Arrayable) {
-                return $value->toArray();
-            }
-
-            return $value;
-        }, $this->items);
-    }
-
-    /**
-     * Get the collection of items as JSON.
-     *
-     * @param  int  $options
-     * @return string
-     */
-    public function toJson($options = 0)
-    {
-        return json_encode($this->jsonSerialize(), $options);
-    }
-
-    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator
@@ -1990,17 +1202,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get a CachingIterator instance.
-     *
-     * @param  int  $flags
-     * @return \CachingIterator
-     */
-    public function getCachingIterator($flags = CachingIterator::CALL_TOSTRING)
-    {
-        return new CachingIterator($this->getIterator(), $flags);
-    }
-
-    /**
      * Count the number of items in the collection.
      *
      * @return int
@@ -2008,25 +1209,6 @@ class Collection implements ArrayAccess, Enumerable
     public function count()
     {
         return count($this->items);
-    }
-
-    /**
-     * Count the number of items in the collection using a given truth test.
-     *
-     * @param  callable|null  $callback
-     * @return static
-     */
-    public function countBy($callback = null)
-    {
-        if (is_null($callback)) {
-            $callback = function ($value) {
-                return $value;
-            };
-        }
-
-        return new static($this->groupBy($callback)->map(function ($value) {
-            return $value->count();
-        }));
     }
 
     /**
@@ -2099,68 +1281,5 @@ class Collection implements ArrayAccess, Enumerable
     public function offsetUnset($key)
     {
         unset($this->items[$key]);
-    }
-
-    /**
-     * Convert the collection to its string representation.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return $this->toJson();
-    }
-
-    /**
-     * Results array of items from Collection or Arrayable.
-     *
-     * @param  mixed  $items
-     * @return array
-     */
-    protected function getArrayableItems($items)
-    {
-        if (is_array($items)) {
-            return $items;
-        } elseif ($items instanceof self) {
-            return $items->all();
-        } elseif ($items instanceof Arrayable) {
-            return $items->toArray();
-        } elseif ($items instanceof Jsonable) {
-            return json_decode($items->toJson(), true);
-        } elseif ($items instanceof JsonSerializable) {
-            return (array) $items->jsonSerialize();
-        } elseif ($items instanceof Traversable) {
-            return iterator_to_array($items);
-        }
-
-        return (array) $items;
-    }
-
-    /**
-     * Add a method to the list of proxied methods.
-     *
-     * @param  string  $method
-     * @return void
-     */
-    public static function proxy($method)
-    {
-        static::$proxies[] = $method;
-    }
-
-    /**
-     * Dynamically access collection proxies.
-     *
-     * @param  string  $key
-     * @return mixed
-     *
-     * @throws \Exception
-     */
-    public function __get($key)
-    {
-        if (! in_array($key, static::$proxies)) {
-            throw new Exception("Property [{$key}] does not exist on this collection instance.");
-        }
-
-        return new HigherOrderCollectionProxy($this, $key);
     }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -943,6 +943,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Skip the first {$count} items.
+     *
+     * @param  int  $count
+     * @return static
+     */
+    public function skip($count)
+    {
+        return $this->slice($count);
+    }
+
+    /**
      * Slice the underlying collection array.
      *
      * @param  int  $offset

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -37,7 +37,8 @@ use Illuminate\Contracts\Support\Arrayable;
  * @property-read HigherOrderCollectionProxy $sum
  * @property-read HigherOrderCollectionProxy $unique
  */
-class Collection implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable
+
+class Collection implements ArrayAccess, Enumerable
 {
     use Macroable;
 

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -768,6 +768,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function shuffle($seed = null);
 
     /**
+     * Skip the first {$count} items.
+     *
+     * @param  int  $count
+     * @return static
+     */
+    public function skip($count);
+
+    /**
      * Get a slice of items from the enumerable.
      *
      * @param  int  $offset

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -1,0 +1,979 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Countable;
+use JsonSerializable;
+use IteratorAggregate;
+use Illuminate\Contracts\Support\Jsonable;
+use Illuminate\Contracts\Support\Arrayable;
+
+interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
+{
+    /**
+     * Create a new collection instance if the value isn't one already.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public static function make($items = []);
+
+    /**
+     * Create a new instance by invoking the callback a given amount of times.
+     *
+     * @param  int  $number
+     * @param  callable  $callback
+     * @return static
+     */
+    public static function times($number, callable $callback = null);
+
+    /**
+     * Wrap the given value in a collection if applicable.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public static function wrap($value);
+
+    /**
+     * Get the underlying items from the given collection if applicable.
+     *
+     * @param  array|static  $value
+     * @return array
+     */
+    public static function unwrap($value);
+
+    /**
+     * Get all items in the enumerable.
+     *
+     * @return array
+     */
+    public function all();
+
+    /**
+     * Alias for the "avg" method.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function average($callback = null);
+
+    /**
+     * Get the median of a given key.
+     *
+     * @param  string|array|null $key
+     * @return mixed
+     */
+    public function median($key = null);
+
+    /**
+     * Get the mode of a given key.
+     *
+     * @param  string|array|null  $key
+     * @return array|null
+     */
+    public function mode($key = null);
+
+    /**
+     * Collapse the items into a single enumerable.
+     *
+     * @return static
+     */
+    public function collapse();
+
+    /**
+     * Alias for the "contains" method.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function some($key, $operator = null, $value = null);
+
+    /**
+     * Determine if an item exists, using strict comparison.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function containsStrict($key, $value = null);
+
+    /**
+     * Get the average value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function avg($callback = null);
+
+    /**
+     * Determine if an item exists in the enumerable.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function contains($key, $operator = null, $value = null);
+
+    /**
+     * Dump the collection and end the script.
+     *
+     * @param  mixed  ...$args
+     * @return void
+     */
+    public function dd(...$args);
+
+    /**
+     * Dump the collection.
+     *
+     * @return $this
+     */
+    public function dump();
+
+    /**
+     * Get the items that are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diff($items);
+
+    /**
+     * Get the items that are not present in the given items, using the callback.
+     *
+     * @param  mixed  $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffUsing($items, callable $callback);
+
+    /**
+     * Get the items whose keys and values are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diffAssoc($items);
+
+    /**
+     * Get the items whose keys and values are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffAssocUsing($items, callable $callback);
+
+    /**
+     * Get the items whose keys are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diffKeys($items);
+
+    /**
+     * Get the items whose keys are not present in the given items.
+     *
+     * @param  mixed   $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffKeysUsing($items, callable $callback);
+
+    /**
+     * Retrieve duplicate items.
+     *
+     * @param  callable|null  $callback
+     * @param  bool  $strict
+     * @return static
+     */
+    public function duplicates($callback = null, $strict = false);
+
+    /**
+     * Retrieve duplicate items using strict comparison.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function duplicatesStrict($callback = null);
+
+    /**
+     * Execute a callback over each item.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function each(callable $callback);
+
+    /**
+     * Execute a callback over each nested chunk of items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function eachSpread(callable $callback);
+
+    /**
+     * Determine if all items pass the given test.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function every($key, $operator = null, $value = null);
+
+    /**
+     * Get all items except for those with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function except($keys);
+
+    /**
+     * Run a filter over each of the items.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function filter(callable $callback = null);
+
+    /**
+     * Apply the callback if the value is truthy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function when($value, callable $callback, callable $default = null);
+
+    /**
+     * Apply the callback if the collection is empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function whenEmpty(callable $callback, callable $default = null);
+
+    /**
+     * Apply the callback if the collection is not empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function whenNotEmpty(callable $callback, callable $default = null);
+
+    /**
+     * Apply the callback if the value is falsy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unless($value, callable $callback, callable $default = null);
+
+    /**
+     * Apply the callback unless the collection is empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unlessEmpty(callable $callback, callable $default = null);
+
+    /**
+     * Apply the callback unless the collection is not empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unlessNotEmpty(callable $callback, callable $default = null);
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function where($key, $operator = null, $value = null);
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereStrict($key, $value);
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereIn($key, $values, $strict = false);
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @return static
+     */
+    public function whereInStrict($key, $values);
+
+    /**
+     * Filter items such that the value of the given key is between the given values.
+     *
+     * @param  string  $key
+     * @param  array  $values
+     * @return static
+     */
+    public function whereBetween($key, $values);
+
+    /**
+     * Filter items such that the value of the given key is not between the given values.
+     *
+     * @param  string  $key
+     * @param  array  $values
+     * @return static
+     */
+    public function whereNotBetween($key, $values);
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereNotIn($key, $values, $strict = false);
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @return static
+     */
+    public function whereNotInStrict($key, $values);
+
+    /**
+     * Filter the items, removing any items that don't match the given type.
+     *
+     * @param  string  $type
+     * @return static
+     */
+    public function whereInstanceOf($type);
+
+    /**
+     * Get the first item from the enumerable passing the given truth test.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function first(callable $callback = null, $default = null);
+
+    /**
+     * Get the first item by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function firstWhere($key, $operator = null, $value = null);
+
+    /**
+     * Flip the values with their keys.
+     *
+     * @return static
+     */
+    public function flip();
+
+    /**
+     * Remove an item by key.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function forget($keys);
+
+    /**
+     * Get an item from the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Group an associative array by a field or using a callback.
+     *
+     * @param  array|callable|string  $groupBy
+     * @param  bool  $preserveKeys
+     * @return static
+     */
+    public function groupBy($groupBy, $preserveKeys = false);
+
+    /**
+     * Key an associative array by a field or using a callback.
+     *
+     * @param  callable|string  $keyBy
+     * @return static
+     */
+    public function keyBy($keyBy);
+
+    /**
+     * Determine if an item exists in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function has($key);
+
+    /**
+     * Concatenate values of a given key as a string.
+     *
+     * @param  string  $value
+     * @param  string  $glue
+     * @return string
+     */
+    public function implode($value, $glue = null);
+
+    /**
+     * Intersect the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function intersect($items);
+
+    /**
+     * Intersect the collection with the given items by key.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function intersectByKeys($items);
+
+    /**
+     * Determine if the collection is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty();
+
+    /**
+     * Determine if the collection is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty();
+
+    /**
+     * Join all items from the collection using a string. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return string
+     */
+    public function join($glue, $finalGlue = '');
+
+    /**
+     * Get the keys of the collection items.
+     *
+     * @return static
+     */
+    public function keys();
+
+    /**
+     * Get the last item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function last(callable $callback = null, $default = null);
+
+    /**
+     * Run a map over each of the items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function map(callable $callback);
+
+    /**
+     * Run a map over each nested chunk of items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapSpread(callable $callback);
+
+    /**
+     * Run a dictionary map over the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapToDictionary(callable $callback);
+
+    /**
+     * Run a grouping map over the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapToGroups(callable $callback);
+
+    /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapWithKeys(callable $callback);
+
+    /**
+     * Map a collection and flatten the result by a single level.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function flatMap(callable $callback);
+
+    /**
+     * Map the values into a new class.
+     *
+     * @param  string  $class
+     * @return static
+     */
+    public function mapInto($class);
+
+    /**
+     * Merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function merge($items);
+
+    /**
+     * Recursively merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeRecursive($items);
+
+    /**
+     * Create a collection by using this collection for keys and another for its values.
+     *
+     * @param  mixed  $values
+     * @return static
+     */
+    public function combine($values);
+
+    /**
+     * Union the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function union($items);
+
+    /**
+     * Get the min value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function min($callback = null);
+
+    /**
+     * Get the max value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function max($callback = null);
+
+    /**
+     * Create a new collection consisting of every n-th element.
+     *
+     * @param  int  $step
+     * @param  int  $offset
+     * @return static
+     */
+    public function nth($step, $offset = 0);
+
+    /**
+     * Get the items with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function only($keys);
+
+    /**
+     * "Paginate" the collection by slicing it into a smaller collection.
+     *
+     * @param  int  $page
+     * @param  int  $perPage
+     * @return static
+     */
+    public function forPage($page, $perPage);
+
+    /**
+     * Partition the collection into two arrays using the given callback or key.
+     *
+     * @param  callable|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function partition($key, $operator = null, $value = null);
+
+    /**
+     * Get and remove the last item from the collection.
+     *
+     * @return mixed
+     */
+    public function pop();
+
+    /**
+     * Push an item onto the beginning of the collection.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $key
+     * @return $this
+     */
+    public function prepend($value, $key = null);
+
+    /**
+     * Push an item onto the end of the collection.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function push($value);
+
+    /**
+     * Push all of the given items onto the collection.
+     *
+     * @param  iterable  $source
+     * @return static
+     */
+    public function concat($source);
+
+    /**
+     * Put an item in the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function put($key, $value);
+
+    /**
+     * Get one or a specified number of items randomly from the collection.
+     *
+     * @param  int|null  $number
+     * @return static|mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function random($number = null);
+
+    /**
+     * Reduce the collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed  $initial
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null);
+
+    /**
+     * Replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replace($items);
+
+    /**
+     * Recursively replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replaceRecursive($items);
+
+    /**
+     * Reverse items order.
+     *
+     * @return static
+     */
+    public function reverse();
+
+    /**
+     * Search the collection for a given value and return the corresponding key if successful.
+     *
+     * @param  mixed  $value
+     * @param  bool  $strict
+     * @return mixed
+     */
+    public function search($value, $strict = false);
+
+    /**
+     * Get and remove the first item from the collection.
+     *
+     * @return mixed
+     */
+    public function shift();
+
+    /**
+     * Shuffle the items in the collection.
+     *
+     * @param  int  $seed
+     * @return static
+     */
+    public function shuffle($seed = null);
+
+    /**
+     * Get a slice of items from the enumerable.
+     *
+     * @param  int  $offset
+     * @param  int  $length
+     * @return static
+     */
+    public function slice($offset, $length = null);
+
+    /**
+     * Split a collection into a certain number of groups.
+     *
+     * @param  int  $numberOfGroups
+     * @return static
+     */
+    public function split($numberOfGroups);
+
+    /**
+     * Chunk the collection into chunks of the given size.
+     *
+     * @param  int  $size
+     * @return static
+     */
+    public function chunk($size);
+
+    /**
+     * Sort through each item with a callback.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function sort(callable $callback = null);
+
+    /**
+     * Sort the collection using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortBy($callback, $options = SORT_REGULAR, $descending = false);
+
+    /**
+     * Sort the collection in descending order using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @return static
+     */
+    public function sortByDesc($callback, $options = SORT_REGULAR);
+
+    /**
+     * Sort the collection keys.
+     *
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortKeys($options = SORT_REGULAR, $descending = false);
+
+    /**
+     * Sort the collection keys in descending order.
+     *
+     * @param  int $options
+     * @return static
+     */
+    public function sortKeysDesc($options = SORT_REGULAR);
+
+    /**
+     * Splice a portion of the underlying collection array.
+     *
+     * @param  int  $offset
+     * @param  int|null  $length
+     * @param  mixed  $replacement
+     * @return static
+     */
+    public function splice($offset, $length = null, $replacement = []);
+
+    /**
+     * Get the sum of the given values.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function sum($callback = null);
+
+    /**
+     * Take the first or last {$limit} items.
+     *
+     * @param  int  $limit
+     * @return static
+     */
+    public function take($limit);
+
+    /**
+     * Pass the collection to the given callback and then return it.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function tap(callable $callback);
+
+    /**
+     * Transform each item in the collection using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback);
+
+    /**
+     * Pass the enumerable to the given callback and return the result.
+     *
+     * @param  callable $callback
+     * @return mixed
+     */
+    public function pipe(callable $callback);
+
+    /**
+     * Get the values of a given key.
+     *
+     * @param  string|array  $value
+     * @param  string|null  $key
+     * @return static
+     */
+    public function pluck($value, $key = null);
+
+    /**
+     * Create a collection of all elements that do not pass a given truth test.
+     *
+     * @param  callable|mixed  $callback
+     * @return static
+     */
+    public function reject($callback = true);
+
+    /**
+     * Return only unique items from the collection array.
+     *
+     * @param  string|callable|null  $key
+     * @param  bool  $strict
+     * @return static
+     */
+    public function unique($key = null, $strict = false);
+
+    /**
+     * Return only unique items from the collection array using strict comparison.
+     *
+     * @param  string|callable|null  $key
+     * @return static
+     */
+    public function uniqueStrict($key = null);
+
+    /**
+     * Reset the keys on the underlying array.
+     *
+     * @return static
+     */
+    public function values();
+
+    /**
+     * Pad collection to the specified length with a value.
+     *
+     * @param  int  $size
+     * @param  mixed  $value
+     * @return static
+     */
+    public function pad($size, $value);
+
+    /**
+     * Count the number of items in the collection using a given truth test.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function countBy($callback = null);
+
+    /**
+     * Add an item to the collection.
+     *
+     * @param  mixed  $item
+     * @return $this
+     */
+    public function add($item);
+
+    /**
+     * Convert the collection to its string representation.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * Add a method to the list of proxied methods.
+     *
+     * @param  string  $method
+     * @return void
+     */
+    public static function proxy($method);
+
+    /**
+     * Dynamically access collection proxies.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function __get($key);
+}

--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Support;
 
 /**
- * @mixin \Illuminate\Support\Collection
+ * @mixin \Illuminate\Support\Enumerable
  */
 class HigherOrderCollectionProxy
 {
     /**
      * The collection being operated on.
      *
-     * @var \Illuminate\Support\Collection
+     * @var \Illuminate\Support\Enumerable
      */
     protected $collection;
 
@@ -24,11 +24,11 @@ class HigherOrderCollectionProxy
     /**
      * Create a new proxy instance.
      *
-     * @param  \Illuminate\Support\Collection  $collection
+     * @param  \Illuminate\Support\Enumerable  $collection
      * @param  string  $method
      * @return void
      */
-    public function __construct(Collection $collection, $method)
+    public function __construct(Enumerable $collection, $method)
     {
         $this->method = $method;
         $this->collection = $collection;

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1,0 +1,1419 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Closure;
+use stdClass;
+use ArrayIterator;
+use IteratorAggregate;
+use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\EnumeratesValues;
+
+class LazyCollection implements Enumerable
+{
+    use EnumeratesValues, Macroable;
+
+    /**
+     * The source from which to generate items.
+     *
+     * @var callable|static
+     */
+    public $source;
+
+    /**
+     * Create a new lazy collection instance.
+     *
+     * @param  mixed  $source
+     * @return void
+     */
+    public function __construct($source = null)
+    {
+        if ($source instanceof Closure || $source instanceof self) {
+            $this->source = $source;
+        } elseif (is_null($source)) {
+            $this->source = static::empty();
+        } else {
+            $this->source = $this->getArrayableItems($source);
+        }
+    }
+
+    /**
+     * Create a new instance with no items.
+     *
+     * @return static
+     */
+    public static function empty()
+    {
+        return new static([]);
+    }
+
+    /**
+     * Create a new instance by invoking the callback a given amount of times.
+     *
+     * @param  int  $number
+     * @param  callable  $callback
+     * @return static
+     */
+    public static function times($number, callable $callback = null)
+    {
+        if ($number < 1) {
+            return new static;
+        }
+
+        $instance = new static(function () use ($number) {
+            for ($current = 1; $current <= $number; $current++) {
+                yield $current;
+            }
+        });
+
+        return is_null($callback) ? $instance : $instance->map($callback);
+    }
+
+    /**
+     * Create an enumerable with the given range.
+     *
+     * @param  int  $from
+     * @param  int  $to
+     * @return static
+     */
+    public static function range($from, $to)
+    {
+        return new static(function () use ($from, $to) {
+            for (; $from <= $to; $from++) {
+                yield $from;
+            }
+        });
+    }
+
+    /**
+     * Get all items in the enumerable.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        if (is_array($this->source)) {
+            return $this->source;
+        }
+
+        return iterator_to_array($this->getIterator());
+    }
+
+    /**
+     * Collect the values into a collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect()
+    {
+        return new Collection($this->all());
+    }
+
+    /**
+     * Get the average value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function avg($callback = null)
+    {
+        return $this->collect()->avg($callback);
+    }
+
+    /**
+     * Get the median of a given key.
+     *
+     * @param  string|array|null $key
+     * @return mixed
+     */
+    public function median($key = null)
+    {
+        return $this->collect()->median($key);
+    }
+
+    /**
+     * Get the mode of a given key.
+     *
+     * @param  string|array|null  $key
+     * @return array|null
+     */
+    public function mode($key = null)
+    {
+        return $this->collect()->mode($key);
+    }
+
+    /**
+     * Collapse the collection of items into a single array.
+     *
+     * @return static
+     */
+    public function collapse()
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original) {
+            foreach ($original as $values) {
+                if (is_array($values) || $values instanceof Enumerable) {
+                    foreach ($values as $value) {
+                        yield $value;
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Determine if an item exists in the enumerable.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function contains($key, $operator = null, $value = null)
+    {
+        if (func_num_args() === 1 && $this->useAsCallable($key)) {
+            $placeholder = new stdClass;
+
+            return $this->first($key, $placeholder) !== $placeholder;
+        }
+
+        if (func_num_args() === 1) {
+            $needle = $key;
+
+            foreach ($this as $value) {
+                if ($value == $needle) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $this->contains($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Cross join the given iterables, returning all possible permutations.
+     *
+     * @param  array  ...$arrays
+     * @return static
+     */
+    public function crossJoin(...$arrays)
+    {
+        return $this->passthru('crossJoin', func_get_args());
+    }
+
+    /**
+     * Get the items that are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diff($items)
+    {
+        return $this->passthru('diff', func_get_args());
+    }
+
+    /**
+     * Get the items that are not present in the given items, using the callback.
+     *
+     * @param  mixed  $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffUsing($items, callable $callback)
+    {
+        return $this->passthru('diffUsing', func_get_args());
+    }
+
+    /**
+     * Get the items whose keys and values are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diffAssoc($items)
+    {
+        return $this->passthru('diffAssoc', func_get_args());
+    }
+
+    /**
+     * Get the items whose keys and values are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffAssocUsing($items, callable $callback)
+    {
+        return $this->passthru('diffAssocUsing', func_get_args());
+    }
+
+    /**
+     * Get the items whose keys are not present in the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function diffKeys($items)
+    {
+        return $this->passthru('diffKeys', func_get_args());
+    }
+
+    /**
+     * Get the items whose keys are not present in the given items.
+     *
+     * @param  mixed   $items
+     * @param  callable  $callback
+     * @return static
+     */
+    public function diffKeysUsing($items, callable $callback)
+    {
+        return $this->passthru('diffKeysUsing', func_get_args());
+    }
+
+    /**
+     * Retrieve duplicate items.
+     *
+     * @param  callable|null  $callback
+     * @param  bool  $strict
+     * @return static
+     */
+    public function duplicates($callback = null, $strict = false)
+    {
+        return $this->passthru('duplicates', func_get_args());
+    }
+
+    /**
+     * Retrieve duplicate items using strict comparison.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function duplicatesStrict($callback = null)
+    {
+        return $this->passthru('duplicatesStrict', func_get_args());
+    }
+
+    /**
+     * Get all items except for those with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function except($keys)
+    {
+        return $this->passthru('except', func_get_args());
+    }
+
+    /**
+     * Run a filter over each of the items.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function filter(callable $callback = null)
+    {
+        if (is_null($callback)) {
+            $callback = function ($value) {
+                return (bool) $value;
+            };
+        }
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $callback) {
+            foreach ($original as $key => $value) {
+                if ($callback($value, $key)) {
+                    yield $key => $value;
+                }
+            }
+        });
+    }
+
+    /**
+     * Get the first item from the enumerable passing the given truth test.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function first(callable $callback = null, $default = null)
+    {
+        $iterator = $this->getIterator();
+
+        if (is_null($callback)) {
+            if (! $iterator->valid()) {
+                return value($default);
+            }
+
+            return $iterator->current();
+        }
+
+        foreach ($iterator as $key => $value) {
+            if ($callback($value, $key)) {
+                return $value;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Get a flattened list of the items in the collection.
+     *
+     * @param  int  $depth
+     * @return static
+     */
+    public function flatten($depth = INF)
+    {
+        $original = clone $this;
+
+        $instance = new static(function () use ($original, $depth) {
+            foreach ($original as $item) {
+                if (! is_array($item) && ! $item instanceof Enumerable) {
+                    yield $item;
+                } elseif ($depth === 1) {
+                    yield from $item;
+                } else {
+                    yield from (new static($item))->flatten($depth - 1);
+                }
+            }
+        });
+
+        return $instance->values();
+    }
+
+    /**
+     * Flip the items in the collection.
+     *
+     * @return static
+     */
+    public function flip()
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original) {
+            foreach ($original as $key => $value) {
+                yield $value => $key;
+            }
+        });
+    }
+
+    /**
+     * Remove an item by key.
+     *
+     * @param  string|array  $keys
+     * @return $this
+     */
+    public function forget($keys)
+    {
+        $original = clone $this;
+
+        $this->source = function () use ($original, $keys) {
+            $keys = array_flip((array) $keys);
+
+            foreach ($original as $key => $value) {
+                if (! array_key_exists($key, $keys)) {
+                    yield $key => $value;
+                }
+            }
+        };
+
+        return $this;
+    }
+
+    /**
+     * Get an item by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        if (is_null($key)) {
+            return;
+        }
+
+        foreach ($this as $outerKey => $outerValue) {
+            if ($outerKey == $key) {
+                return $outerValue;
+            }
+        }
+
+        return value($default);
+    }
+
+    /**
+     * Group an associative array by a field or using a callback.
+     *
+     * @param  array|callable|string  $groupBy
+     * @param  bool  $preserveKeys
+     * @return static
+     */
+    public function groupBy($groupBy, $preserveKeys = false)
+    {
+        return $this->passthru('groupBy', func_get_args());
+    }
+
+    /**
+     * Key an associative array by a field or using a callback.
+     *
+     * @param  callable|string  $keyBy
+     * @return static
+     */
+    public function keyBy($keyBy)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $keyBy) {
+            $keyBy = $this->valueRetriever($keyBy);
+
+            foreach ($original as $key => $item) {
+                $resolvedKey = $keyBy($item, $key);
+
+                if (is_object($resolvedKey)) {
+                    $resolvedKey = (string) $resolvedKey;
+                }
+
+                yield $resolvedKey => $item;
+            }
+        });
+    }
+
+    /**
+     * Determine if an item exists in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function has($key)
+    {
+        $keys = array_flip(is_array($key) ? $key : func_get_args());
+        $count = count($keys);
+
+        foreach ($this as $key => $value) {
+            if (array_key_exists($key, $keys) && --$count == 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Concatenate values of a given key as a string.
+     *
+     * @param  string  $value
+     * @param  string  $glue
+     * @return string
+     */
+    public function implode($value, $glue = null)
+    {
+        return $this->collect()->implode(...func_get_args());
+    }
+
+    /**
+     * Intersect the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function intersect($items)
+    {
+        return $this->passthru('intersect', func_get_args());
+    }
+
+    /**
+     * Intersect the collection with the given items by key.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function intersectByKeys($items)
+    {
+        return $this->passthru('intersectByKeys', func_get_args());
+    }
+
+    /**
+     * Determine if the items is empty or not.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return ! $this->getIterator()->valid();
+    }
+
+    /**
+     * Join all items from the collection using a string. The final items can use a separate glue string.
+     *
+     * @param  string  $glue
+     * @param  string  $finalGlue
+     * @return string
+     */
+    public function join($glue, $finalGlue = '')
+    {
+        return $this->collect()->join(...func_get_args());
+    }
+
+    /**
+     * Get the keys of the collection items.
+     *
+     * @return static
+     */
+    public function keys()
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original) {
+            foreach ($original as $key => $value) {
+                yield $key;
+            }
+        });
+    }
+
+    /**
+     * Get the last item from the collection.
+     *
+     * @param  callable|null  $callback
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function last(callable $callback = null, $default = null)
+    {
+        $needle = $placeholder = new stdClass;
+
+        foreach ($this as $key => $value) {
+            if (is_null($callback) || $callback($value, $key)) {
+                $needle = $value;
+            }
+        }
+
+        return $needle === $placeholder ? value($default) : $needle;
+    }
+
+    /**
+     * Get the values of a given key.
+     *
+     * @param  string|array  $value
+     * @param  string|null  $key
+     * @return static
+     */
+    public function pluck($value, $key = null)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $value, $key) {
+            [$value, $key] = $this->explodePluckParameters($value, $key);
+
+            foreach ($original as $item) {
+                $itemValue = data_get($item, $value);
+
+                if (is_null($key)) {
+                    yield $itemValue;
+                } else {
+                    $itemKey = data_get($item, $key);
+
+                    if (is_object($itemKey) && method_exists($itemKey, '__toString')) {
+                        $itemKey = (string) $itemKey;
+                    }
+
+                    yield $itemKey => $itemValue;
+                }
+            }
+        });
+    }
+
+    /**
+     * Run a map over each of the items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $callback) {
+            foreach ($original as $key => $value) {
+                yield $key => $callback($value, $key);
+            }
+        });
+    }
+
+    /**
+     * Run a dictionary map over the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapToDictionary(callable $callback)
+    {
+        return $this->passthru('mapToDictionary', func_get_args());
+    }
+
+    /**
+     * Run an associative map over each of the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapWithKeys(callable $callback)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $callback) {
+            foreach ($original as $key => $value) {
+                yield from $callback($value, $key);
+            }
+        });
+    }
+
+    /**
+     * Merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function merge($items)
+    {
+        return $this->passthru('merge', func_get_args());
+    }
+
+    /**
+     * Recursively merge the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function mergeRecursive($items)
+    {
+        return $this->passthru('mergeRecursive', func_get_args());
+    }
+
+    /**
+     * Create a collection by using this collection for keys and another for its values.
+     *
+     * @param  mixed  $values
+     * @return static
+     */
+    public function combine($values)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $values) {
+            $values = $this->makeIterator($values);
+
+            $errorMessage = 'Both parameters should have an equal number of elements';
+
+            foreach ($original as $key) {
+                if (! $values->valid()) {
+                    trigger_error($errorMessage, E_USER_WARNING);
+
+                    break;
+                }
+
+                yield $key => $values->current();
+
+                $values->next();
+            }
+
+            if ($values->valid()) {
+                trigger_error($errorMessage, E_USER_WARNING);
+            }
+        });
+    }
+
+    /**
+     * Union the collection with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function union($items)
+    {
+        return $this->passthru('union', func_get_args());
+    }
+
+    /**
+     * Create a new collection consisting of every n-th element.
+     *
+     * @param  int  $step
+     * @param  int  $offset
+     * @return static
+     */
+    public function nth($step, $offset = 0)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $step, $offset) {
+            $position = 0;
+
+            foreach ($original as $item) {
+                if ($position % $step === $offset) {
+                    yield $item;
+                }
+
+                $position++;
+            }
+        });
+    }
+
+    /**
+     * Get the items with the specified keys.
+     *
+     * @param  mixed  $keys
+     * @return static
+     */
+    public function only($keys)
+    {
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        } elseif (! is_null($keys)) {
+            $keys = is_array($keys) ? $keys : func_get_args();
+        }
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $keys) {
+            if (is_null($keys)) {
+                yield from $original;
+            } else {
+                $keys = array_flip($keys);
+
+                foreach ($original as $key => $value) {
+                    if (array_key_exists($key, $keys)) {
+                        yield $key => $value;
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Get and remove the last item from the collection.
+     *
+     * @return mixed
+     */
+    public function pop()
+    {
+        $items = $this->collect();
+
+        $result = $items->pop();
+
+        $this->source = $items;
+
+        return $result;
+    }
+
+    /**
+     * Push an item onto the beginning of the collection.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $key
+     * @return $this
+     */
+    public function prepend($value, $key = null)
+    {
+        $original = clone $this;
+
+        $this->source = function () use ($original, $value, $key) {
+            $instance = new static(function () use ($original, $value, $key) {
+                yield $key => $value;
+
+                yield from $original;
+            });
+
+            if (is_null($key)) {
+                $instance = $instance->values();
+            }
+
+            yield from $instance;
+        };
+
+        return $this;
+    }
+
+    /**
+     * Push all of the given items onto the collection.
+     *
+     * @param  iterable  $source
+     * @return static
+     */
+    public function concat($source)
+    {
+        $original = clone $this;
+
+        return (new static(function () use ($original, $source) {
+            yield from $original;
+            yield from $source;
+        }))->values();
+    }
+
+    /**
+     * Put an item in the collection by key.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function put($key, $value)
+    {
+        $original = clone $this;
+
+        if (is_null($key)) {
+            $this->source = function () use ($original, $value) {
+                foreach ($original as $innerKey => $innerValue) {
+                    yield $innerKey => $innerValue;
+                }
+
+                yield $value;
+            };
+        } else {
+            $this->source = function () use ($original, $key, $value) {
+                $found = false;
+
+                foreach ($original as $innerKey => $innerValue) {
+                    if ($innerKey == $key) {
+                        yield $key => $value;
+
+                        $found = true;
+                    } else {
+                        yield $innerKey => $innerValue;
+                    }
+                }
+
+                if (! $found) {
+                    yield $key => $value;
+                }
+            };
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get one or a specified number of items randomly from the collection.
+     *
+     * @param  int|null  $number
+     * @return static|mixed
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function random($number = null)
+    {
+        $result = $this->collect()->random(...func_get_args());
+
+        return is_null($number) ? $result : new static($result);
+    }
+
+    /**
+     * Reduce the collection to a single value.
+     *
+     * @param  callable  $callback
+     * @param  mixed  $initial
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        $result = $initial;
+
+        foreach ($this as $value) {
+            $result = $callback($result, $value);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replace($items)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $items) {
+            $items = $this->getArrayableItems($items);
+            $usedItems = [];
+
+            foreach ($original as $key => $value) {
+                if (array_key_exists($key, $items)) {
+                    yield $key => $items[$key];
+
+                    $usedItems[$key] = true;
+                } else {
+                    yield $key => $value;
+                }
+            }
+
+            foreach ($items as $key => $value) {
+                if (! array_key_exists($key, $usedItems)) {
+                    yield $key => $value;
+                }
+            }
+        });
+    }
+
+    /**
+     * Recursively replace the collection items with the given items.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public function replaceRecursive($items)
+    {
+        return $this->passthru('replaceRecursive', func_get_args());
+    }
+
+    /**
+     * Reverse items order.
+     *
+     * @return static
+     */
+    public function reverse()
+    {
+        return $this->passthru('reverse', func_get_args());
+    }
+
+    /**
+     * Search the collection for a given value and return the corresponding key if successful.
+     *
+     * @param  mixed  $value
+     * @param  bool  $strict
+     * @return mixed
+     */
+    public function search($value, $strict = false)
+    {
+        $predicate = $this->useAsCallable($value)
+            ? $value
+            : function ($item) use ($value, $strict) {
+                return $strict ? $item === $value : $item == $value;
+            };
+
+        foreach ($this as $key => $item) {
+            if ($predicate($item, $key)) {
+                return $key;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get and remove the first item from the collection.
+     *
+     * @return mixed
+     */
+    public function shift()
+    {
+        return tap($this->first(), function () {
+            $this->source = $this->skip(1);
+        });
+    }
+
+    /**
+     * Shuffle the items in the collection.
+     *
+     * @param  int  $seed
+     * @return static
+     */
+    public function shuffle($seed = null)
+    {
+        return $this->passthru('shuffle', func_get_args());
+    }
+
+    /**
+     * Skip the first {$count} items.
+     *
+     * @param  int  $count
+     * @return static
+     */
+    public function skip($count)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $count) {
+            $iterator = $original->getIterator();
+
+            while ($iterator->valid() && $count--) {
+                $iterator->next();
+            }
+
+            while ($iterator->valid()) {
+                yield $iterator->key() => $iterator->current();
+
+                $iterator->next();
+            }
+        });
+    }
+
+    /**
+     * Get a slice of items from the enumerable.
+     *
+     * @param  int  $offset
+     * @param  int  $length
+     * @return static
+     */
+    public function slice($offset, $length = null)
+    {
+        if ($offset < 0 || $length < 0) {
+            return $this->passthru('slice', func_get_args());
+        }
+
+        $instance = $this->skip($offset);
+
+        return is_null($length) ? $instance : $instance->take($length);
+    }
+
+    /**
+     * Split a collection into a certain number of groups.
+     *
+     * @param  int  $numberOfGroups
+     * @return static
+     */
+    public function split($numberOfGroups)
+    {
+        return $this->passthru('split', func_get_args());
+    }
+
+    /**
+     * Chunk the collection into chunks of the given size.
+     *
+     * @param  int  $size
+     * @return static
+     */
+    public function chunk($size)
+    {
+        if ($size <= 0) {
+            return static::empty();
+        }
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $size) {
+            $iterator = $original->getIterator();
+
+            while ($iterator->valid()) {
+                $values = [];
+
+                for ($i = 0; $iterator->valid() && $i < $size; $i++, $iterator->next()) {
+                    $values[$iterator->key()] = $iterator->current();
+                }
+
+                yield new static($values);
+            }
+        });
+    }
+
+    /**
+     * Sort through each item with a callback.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function sort(callable $callback = null)
+    {
+        return $this->passthru('sort', func_get_args());
+    }
+
+    /**
+     * Sort the collection using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortBy($callback, $options = SORT_REGULAR, $descending = false)
+    {
+        return $this->passthru('sortBy', func_get_args());
+    }
+
+    /**
+     * Sort the collection in descending order using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @return static
+     */
+    public function sortByDesc($callback, $options = SORT_REGULAR)
+    {
+        return $this->passthru('sortByDesc', func_get_args());
+    }
+
+    /**
+     * Sort the collection keys.
+     *
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sortKeys($options = SORT_REGULAR, $descending = false)
+    {
+        return $this->passthru('sortKeys', func_get_args());
+    }
+
+    /**
+     * Sort the collection keys in descending order.
+     *
+     * @param  int $options
+     * @return static
+     */
+    public function sortKeysDesc($options = SORT_REGULAR)
+    {
+        return $this->passthru('sortKeysDesc', func_get_args());
+    }
+
+    /**
+     * Splice a portion of the underlying collection array.
+     *
+     * @param  int  $offset
+     * @param  int|null  $length
+     * @param  mixed  $replacement
+     * @return static
+     */
+    public function splice($offset, $length = null, $replacement = [])
+    {
+        $items = $this->collect();
+
+        $extracted = $items->splice(...func_get_args());
+
+        $this->source = function () use ($items) {
+            yield from $items;
+        };
+
+        return new static($extracted);
+    }
+
+    /**
+     * Take the first or last {$limit} items.
+     *
+     * @param  int  $limit
+     * @return static
+     */
+    public function take($limit)
+    {
+        if ($limit < 0) {
+            return $this->passthru('take', func_get_args());
+        }
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $limit) {
+            $iterator = $original->getIterator();
+
+            for (; $iterator->valid() && $limit--; $iterator->next()) {
+                yield $iterator->key() => $iterator->current();
+            }
+        });
+    }
+
+    /**
+     * Transform each item in the collection using a callback.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function transform(callable $callback)
+    {
+        $original = clone $this;
+
+        $this->source = function () use ($original, $callback) {
+            yield from $original->map($callback);
+        };
+
+        return $this;
+    }
+
+    /**
+     * Reset the keys on the underlying array.
+     *
+     * @return static
+     */
+    public function values()
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original) {
+            foreach ($original as $item) {
+                yield $item;
+            }
+        });
+    }
+
+    /**
+     * Zip the collection together with one or more arrays.
+     *
+     * e.g. new LazyCollection([1, 2, 3])->zip([4, 5, 6]);
+     *      => [[1, 4], [2, 5], [3, 6]]
+     *
+     * @param  mixed ...$items
+     * @return static
+     */
+    public function zip($items)
+    {
+        $iterables = func_get_args();
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $iterables) {
+            $iterators = Collection::make($iterables)->map(function ($iterable) {
+                return $this->makeIterator($iterable);
+            })->prepend($original->getIterator());
+
+            while ($iterators->contains->valid()) {
+                yield new static($iterators->map->current());
+
+                $iterators->each->next();
+            }
+        });
+    }
+
+    /**
+     * Pad collection to the specified length with a value.
+     *
+     * @param  int  $size
+     * @param  mixed  $value
+     * @return static
+     */
+    public function pad($size, $value)
+    {
+        if ($size < 0) {
+            return $this->passthru('pad', func_get_args());
+        }
+
+        $original = clone $this;
+
+        return new static(function () use ($original, $size, $value) {
+            $yielded = 0;
+
+            foreach ($original as $index => $item) {
+                yield $index => $item;
+
+                $yielded++;
+            }
+
+            while ($yielded++ < $size) {
+                yield $value;
+            }
+        });
+    }
+
+    /**
+     * Get the values iterator.
+     *
+     * @return \Traversable
+     */
+    public function getIterator()
+    {
+        return $this->makeIterator($this->source);
+    }
+
+    /**
+     * Count the number of items in the collection.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        if (is_array($this->source)) {
+            return count($this->source);
+        }
+
+        return iterator_count($this->getIterator());
+    }
+
+    /**
+     * Add an item to the collection.
+     *
+     * @param  mixed  $item
+     * @return $this
+     */
+    public function add($item)
+    {
+        $original = clone $this;
+
+        $this->source = function () use ($original, $item) {
+            foreach ($original as $value) {
+                yield $value;
+            }
+
+            yield $item;
+        };
+
+        return $this;
+    }
+
+    /**
+     * Make an iterator from the given source.
+     *
+     * @param  mixed  $source
+     * @return \Traversable
+     */
+    protected function makeIterator($source)
+    {
+        if ($source instanceof IteratorAggregate) {
+            return $source->getIterator();
+        }
+
+        if (is_array($source)) {
+            return new ArrayIterator($source);
+        }
+
+        return $source();
+    }
+
+    /**
+     * Explode the "value" and "key" arguments passed to "pluck".
+     *
+     * @param  string|array  $value
+     * @param  string|array|null  $key
+     * @return array
+     */
+    protected function explodePluckParameters($value, $key)
+    {
+        $value = is_string($value) ? explode('.', $value) : $value;
+
+        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+
+        return [$value, $key];
+    }
+
+    /**
+     * Pass this lazy collection through a method on the collection class.
+     *
+     * @param  string  $method
+     * @param  array  $params
+     * @return static
+     */
+    protected function passthru($method, array $params)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $method, $params) {
+            yield from $original->collect()->$method(...$params);
+        });
+    }
+
+    /**
+     * Finish cloning the collection instance.
+     *
+     * @return void
+     */
+    public function __clone()
+    {
+        if (! is_array($this->source)) {
+            $this->source = clone $this->source;
+        }
+    }
+}

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -1,0 +1,900 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Exception;
+use Traversable;
+use CachingIterator;
+use JsonSerializable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Enumerable;
+use Illuminate\Contracts\Support\Jsonable;
+use Symfony\Component\VarDumper\VarDumper;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\HigherOrderCollectionProxy;
+
+/**
+ * @property-read HigherOrderCollectionProxy $average
+ * @property-read HigherOrderCollectionProxy $avg
+ * @property-read HigherOrderCollectionProxy $contains
+ * @property-read HigherOrderCollectionProxy $each
+ * @property-read HigherOrderCollectionProxy $every
+ * @property-read HigherOrderCollectionProxy $filter
+ * @property-read HigherOrderCollectionProxy $first
+ * @property-read HigherOrderCollectionProxy $flatMap
+ * @property-read HigherOrderCollectionProxy $groupBy
+ * @property-read HigherOrderCollectionProxy $keyBy
+ * @property-read HigherOrderCollectionProxy $map
+ * @property-read HigherOrderCollectionProxy $max
+ * @property-read HigherOrderCollectionProxy $min
+ * @property-read HigherOrderCollectionProxy $partition
+ * @property-read HigherOrderCollectionProxy $reject
+ * @property-read HigherOrderCollectionProxy $sortBy
+ * @property-read HigherOrderCollectionProxy $sortByDesc
+ * @property-read HigherOrderCollectionProxy $sum
+ * @property-read HigherOrderCollectionProxy $unique
+ */
+trait EnumeratesValues
+{
+    /**
+     * The methods that can be proxied.
+     *
+     * @var array
+     */
+    protected static $proxies = [
+        'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
+        'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
+        'reject', 'some', 'sortBy', 'sortByDesc', 'sum', 'unique',
+    ];
+
+    /**
+     * Create a new collection instance if the value isn't one already.
+     *
+     * @param  mixed  $items
+     * @return static
+     */
+    public static function make($items = [])
+    {
+        return new static($items);
+    }
+
+    /**
+     * Wrap the given value in a collection if applicable.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public static function wrap($value)
+    {
+        return $value instanceof Enumerable
+            ? new static($value)
+            : new static(Arr::wrap($value));
+    }
+
+    /**
+     * Get the underlying items from the given collection if applicable.
+     *
+     * @param  array|static  $value
+     * @return array
+     */
+    public static function unwrap($value)
+    {
+        return $value instanceof Enumerable ? $value->all() : $value;
+    }
+
+    /**
+     * Alias for the "avg" method.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function average($callback = null)
+    {
+        return $this->avg($callback);
+    }
+
+    /**
+     * Alias for the "contains" method.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function some($key, $operator = null, $value = null)
+    {
+        return $this->contains(...func_get_args());
+    }
+
+    /**
+     * Determine if an item exists, using strict comparison.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function containsStrict($key, $value = null)
+    {
+        if (func_num_args() === 2) {
+            return $this->contains(function ($item) use ($key, $value) {
+                return data_get($item, $key) === $value;
+            });
+        }
+
+        if ($this->useAsCallable($key)) {
+            return ! is_null($this->first($key));
+        }
+
+        foreach ($this as $item) {
+            if ($item === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Dump the items and end the script.
+     *
+     * @param  mixed  ...$args
+     * @return void
+     */
+    public function dd(...$args)
+    {
+        call_user_func_array([$this, 'dump'], $args);
+
+        die(1);
+    }
+
+    /**
+     * Dump the items.
+     *
+     * @return $this
+     */
+    public function dump()
+    {
+        (new static(func_get_args()))
+            ->push($this)
+            ->each(function ($item) {
+                VarDumper::dump($item);
+            });
+
+        return $this;
+    }
+
+    /**
+     * Execute a callback over each item.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function each(callable $callback)
+    {
+        foreach ($this as $key => $item) {
+            if ($callback($item, $key) === false) {
+                break;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Execute a callback over each nested chunk of items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function eachSpread(callable $callback)
+    {
+        return $this->each(function ($chunk, $key) use ($callback) {
+            $chunk[] = $key;
+
+            return $callback(...$chunk);
+        });
+    }
+
+    /**
+     * Determine if all items pass the given test.
+     *
+     * @param  string|callable  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function every($key, $operator = null, $value = null)
+    {
+        if (func_num_args() === 1) {
+            $callback = $this->valueRetriever($key);
+
+            foreach ($this as $k => $v) {
+                if (! $callback($v, $k)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return $this->every($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Get the first item by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function firstWhere($key, $operator = null, $value = null)
+    {
+        return $this->first($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Determine if the collection is not empty.
+     *
+     * @return bool
+     */
+    public function isNotEmpty()
+    {
+        return ! $this->isEmpty();
+    }
+
+    /**
+     * Run a map over each nested chunk of items.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapSpread(callable $callback)
+    {
+        return $this->map(function ($chunk, $key) use ($callback) {
+            $chunk[] = $key;
+
+            return $callback(...$chunk);
+        });
+    }
+
+    /**
+     * Run a grouping map over the items.
+     *
+     * The callback should return an associative array with a single key/value pair.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function mapToGroups(callable $callback)
+    {
+        $groups = $this->mapToDictionary($callback);
+
+        return $groups->map([$this, 'make']);
+    }
+
+    /**
+     * Map a collection and flatten the result by a single level.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function flatMap(callable $callback)
+    {
+        return $this->map($callback)->collapse();
+    }
+
+    /**
+     * Map the values into a new class.
+     *
+     * @param  string  $class
+     * @return static
+     */
+    public function mapInto($class)
+    {
+        return $this->map(function ($value, $key) use ($class) {
+            return new $class($value, $key);
+        });
+    }
+
+    /**
+     * Get the min value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function min($callback = null)
+    {
+        $callback = $this->valueRetriever($callback);
+
+        return $this->map(function ($value) use ($callback) {
+            return $callback($value);
+        })->filter(function ($value) {
+            return ! is_null($value);
+        })->reduce(function ($result, $value) {
+            return is_null($result) || $value < $result ? $value : $result;
+        });
+    }
+
+    /**
+     * Get the max value of a given key.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function max($callback = null)
+    {
+        $callback = $this->valueRetriever($callback);
+
+        return $this->filter(function ($value) {
+            return ! is_null($value);
+        })->reduce(function ($result, $item) use ($callback) {
+            $value = $callback($item);
+
+            return is_null($result) || $value > $result ? $value : $result;
+        });
+    }
+
+    /**
+     * "Paginate" the collection by slicing it into a smaller collection.
+     *
+     * @param  int  $page
+     * @param  int  $perPage
+     * @return static
+     */
+    public function forPage($page, $perPage)
+    {
+        $offset = max(0, ($page - 1) * $perPage);
+
+        return $this->slice($offset, $perPage);
+    }
+
+    /**
+     * Partition the collection into two arrays using the given callback or key.
+     *
+     * @param  callable|string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function partition($key, $operator = null, $value = null)
+    {
+        $passed = [];
+        $failed = [];
+
+        $callback = func_num_args() === 1
+                ? $this->valueRetriever($key)
+                : $this->operatorForWhere(...func_get_args());
+
+        foreach ($this as $key => $item) {
+            if ($callback($item, $key)) {
+                $passed[$key] = $item;
+            } else {
+                $failed[$key] = $item;
+            }
+        }
+
+        return new static([new static($passed), new static($failed)]);
+    }
+
+    /**
+     * Push an item onto the end.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function push($value)
+    {
+        return $this->add($value);
+    }
+
+    /**
+     * Get the sum of the given values.
+     *
+     * @param  callable|string|null  $callback
+     * @return mixed
+     */
+    public function sum($callback = null)
+    {
+        if (is_null($callback)) {
+            $callback = function ($value) {
+                return $value;
+            };
+        } else {
+            $callback = $this->valueRetriever($callback);
+        }
+
+        return $this->reduce(function ($result, $item) use ($callback) {
+            return $result + $callback($item);
+        }, 0);
+    }
+
+    /**
+     * Apply the callback if the value is truthy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function when($value, callable $callback, callable $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value);
+        } elseif ($default) {
+            return $default($this, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback if the collection is empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function whenEmpty(callable $callback, callable $default = null)
+    {
+        return $this->when($this->isEmpty(), $callback, $default);
+    }
+
+    /**
+     * Apply the callback if the collection is not empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function whenNotEmpty(callable $callback, callable $default = null)
+    {
+        return $this->when($this->isNotEmpty(), $callback, $default);
+    }
+
+    /**
+     * Apply the callback if the value is falsy.
+     *
+     * @param  bool  $value
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unless($value, callable $callback, callable $default = null)
+    {
+        return $this->when(! $value, $callback, $default);
+    }
+
+    /**
+     * Apply the callback unless the collection is empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unlessEmpty(callable $callback, callable $default = null)
+    {
+        return $this->whenNotEmpty($callback, $default);
+    }
+
+    /**
+     * Apply the callback unless the collection is not empty.
+     *
+     * @param  callable  $callback
+     * @param  callable  $default
+     * @return static|mixed
+     */
+    public function unlessNotEmpty(callable $callback, callable $default = null)
+    {
+        return $this->whenEmpty($callback, $default);
+    }
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return static
+     */
+    public function where($key, $operator = null, $value = null)
+    {
+        return $this->filter($this->operatorForWhere(...func_get_args()));
+    }
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return static
+     */
+    public function whereStrict($key, $value)
+    {
+        return $this->where($key, '===', $value);
+    }
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereIn($key, $values, $strict = false)
+    {
+        $values = $this->getArrayableItems($values);
+
+        return $this->filter(function ($item) use ($key, $values, $strict) {
+            return in_array(data_get($item, $key), $values, $strict);
+        });
+    }
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @return static
+     */
+    public function whereInStrict($key, $values)
+    {
+        return $this->whereIn($key, $values, true);
+    }
+
+    /**
+     * Filter items such that the value of the given key is between the given values.
+     *
+     * @param  string  $key
+     * @param  array  $values
+     * @return static
+     */
+    public function whereBetween($key, $values)
+    {
+        return $this->where($key, '>=', reset($values))->where($key, '<=', end($values));
+    }
+
+    /**
+     * Filter items such that the value of the given key is not between the given values.
+     *
+     * @param  string  $key
+     * @param  array  $values
+     * @return static
+     */
+    public function whereNotBetween($key, $values)
+    {
+        return $this->filter(function ($item) use ($key, $values) {
+            return data_get($item, $key) < reset($values) || data_get($item, $key) > end($values);
+        });
+    }
+
+    /**
+     * Filter items by the given key value pair.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereNotIn($key, $values, $strict = false)
+    {
+        $values = $this->getArrayableItems($values);
+
+        return $this->reject(function ($item) use ($key, $values, $strict) {
+            return in_array(data_get($item, $key), $values, $strict);
+        });
+    }
+
+    /**
+     * Filter items by the given key value pair using strict comparison.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @return static
+     */
+    public function whereNotInStrict($key, $values)
+    {
+        return $this->whereNotIn($key, $values, true);
+    }
+
+    /**
+     * Filter the items, removing any items that don't match the given type.
+     *
+     * @param  string  $type
+     * @return static
+     */
+    public function whereInstanceOf($type)
+    {
+        return $this->filter(function ($value) use ($type) {
+            return $value instanceof $type;
+        });
+    }
+
+    /**
+     * Pass the collection to the given callback and return the result.
+     *
+     * @param  callable $callback
+     * @return mixed
+     */
+    public function pipe(callable $callback)
+    {
+        return $callback($this);
+    }
+
+    /**
+     * Pass the collection to the given callback and then return it.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function tap(callable $callback)
+    {
+        $callback(clone $this);
+
+        return $this;
+    }
+
+    /**
+     * Create a collection of all elements that do not pass a given truth test.
+     *
+     * @param  callable|mixed  $callback
+     * @return static
+     */
+    public function reject($callback = true)
+    {
+        $useAsCallable = $this->useAsCallable($callback);
+
+        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
+            return $useAsCallable
+                ? ! $callback($value, $key)
+                : $value != $callback;
+        });
+    }
+
+    /**
+     * Return only unique items from the collection array.
+     *
+     * @param  string|callable|null  $key
+     * @param  bool  $strict
+     * @return static
+     */
+    public function unique($key = null, $strict = false)
+    {
+        $callback = $this->valueRetriever($key);
+
+        $exists = [];
+
+        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
+            if (in_array($id = $callback($item, $key), $exists, $strict)) {
+                return true;
+            }
+
+            $exists[] = $id;
+        });
+    }
+
+    /**
+     * Return only unique items from the collection array using strict comparison.
+     *
+     * @param  string|callable|null  $key
+     * @return static
+     */
+    public function uniqueStrict($key = null)
+    {
+        return $this->unique($key, true);
+    }
+
+    /**
+     * Get the collection of items as a plain array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->map(function ($value) {
+            return $value instanceof Arrayable ? $value->toArray() : $value;
+        })->all();
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return array_map(function ($value) {
+            if ($value instanceof JsonSerializable) {
+                return $value->jsonSerialize();
+            } elseif ($value instanceof Jsonable) {
+                return json_decode($value->toJson(), true);
+            } elseif ($value instanceof Arrayable) {
+                return $value->toArray();
+            }
+
+            return $value;
+        }, $this->all());
+    }
+
+    /**
+     * Get the collection of items as JSON.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->jsonSerialize(), $options);
+    }
+
+    /**
+     * Get a CachingIterator instance.
+     *
+     * @param  int  $flags
+     * @return \CachingIterator
+     */
+    public function getCachingIterator($flags = CachingIterator::CALL_TOSTRING)
+    {
+        return new CachingIterator($this->getIterator(), $flags);
+    }
+
+    /**
+     * Count the number of items in the collection using a given truth test.
+     *
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public function countBy($callback = null)
+    {
+        if (is_null($callback)) {
+            $callback = function ($value) {
+                return $value;
+            };
+        }
+
+        return new static($this->groupBy($callback)->map(function ($value) {
+            return $value->count();
+        }));
+    }
+
+    /**
+     * Convert the collection to its string representation.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Add a method to the list of proxied methods.
+     *
+     * @param  string  $method
+     * @return void
+     */
+    public static function proxy($method)
+    {
+        static::$proxies[] = $method;
+    }
+
+    /**
+     * Dynamically access collection proxies.
+     *
+     * @param  string  $key
+     * @return mixed
+     *
+     * @throws \Exception
+     */
+    public function __get($key)
+    {
+        if (! in_array($key, static::$proxies)) {
+            throw new Exception("Property [{$key}] does not exist on this collection instance.");
+        }
+
+        return new HigherOrderCollectionProxy($this, $key);
+    }
+
+    /**
+     * Results array of items from Collection or Arrayable.
+     *
+     * @param  mixed  $items
+     * @return array
+     */
+    protected function getArrayableItems($items)
+    {
+        if (is_array($items)) {
+            return $items;
+        } elseif ($items instanceof Enumerable) {
+            return $items->all();
+        } elseif ($items instanceof Arrayable) {
+            return $items->toArray();
+        } elseif ($items instanceof Jsonable) {
+            return json_decode($items->toJson(), true);
+        } elseif ($items instanceof JsonSerializable) {
+            return (array) $items->jsonSerialize();
+        } elseif ($items instanceof Traversable) {
+            return iterator_to_array($items);
+        }
+
+        return (array) $items;
+    }
+
+    /**
+     * Get an operator checker callback.
+     *
+     * @param  string  $key
+     * @param  string  $operator
+     * @param  mixed  $value
+     * @return \Closure
+     */
+    protected function operatorForWhere($key, $operator = null, $value = null)
+    {
+        if (func_num_args() === 1) {
+            $value = true;
+
+            $operator = '=';
+        }
+
+        if (func_num_args() === 2) {
+            $value = $operator;
+
+            $operator = '=';
+        }
+
+        return function ($item) use ($key, $operator, $value) {
+            $retrieved = data_get($item, $key);
+
+            $strings = array_filter([$retrieved, $value], function ($value) {
+                return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
+            });
+
+            if (count($strings) < 2 && count(array_filter([$retrieved, $value], 'is_object')) == 1) {
+                return in_array($operator, ['!=', '<>', '!==']);
+            }
+
+            switch ($operator) {
+                default:
+                case '=':
+                case '==':  return $retrieved == $value;
+                case '!=':
+                case '<>':  return $retrieved != $value;
+                case '<':   return $retrieved < $value;
+                case '>':   return $retrieved > $value;
+                case '<=':  return $retrieved <= $value;
+                case '>=':  return $retrieved >= $value;
+                case '===': return $retrieved === $value;
+                case '!==': return $retrieved !== $value;
+            }
+        };
+    }
+
+    /**
+     * Determine if the given value is callable, but not a string.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function useAsCallable($value)
+    {
+        return ! is_string($value) && is_callable($value);
+    }
+
+    /**
+     * Get a value retrieving callback.
+     *
+     * @param  callable|string|null  $value
+     * @return callable
+     */
+    protected function valueRetriever($value)
+    {
+        if ($this->useAsCallable($value)) {
+            return $value;
+        }
+
+        return function ($item) use ($value) {
+            return data_get($item, $value);
+        };
+    }
+}

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -208,6 +208,18 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSkipMethod($collection)
+    {
+        $data = new $collection([1, 2, 3, 4, 5, 6]);
+
+        $data = $data->skip(4)->values();
+
+        $this->assertSame([5, 6], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGetArrayableItems($collection)
     {
         $data = new $collection;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 
@@ -3934,6 +3935,7 @@ class SupportCollectionTest extends TestCase
     {
         return [
             [Collection::class],
+            [LazyCollection::class],
         ];
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -20,40 +20,55 @@ use Illuminate\Contracts\Support\Arrayable;
 
 class SupportCollectionTest extends TestCase
 {
-    public function testFirstReturnsFirstItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstReturnsFirstItemInCollection($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals('foo', $c->first());
     }
 
-    public function testFirstWithCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstWithCallback($collection)
     {
-        $data = new Collection(['foo', 'bar', 'baz']);
+        $data = new $collection(['foo', 'bar', 'baz']);
         $result = $data->first(function ($value) {
             return $value === 'bar';
         });
         $this->assertEquals('bar', $result);
     }
 
-    public function testFirstWithCallbackAndDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstWithCallbackAndDefault($collection)
     {
-        $data = new Collection(['foo', 'bar']);
+        $data = new $collection(['foo', 'bar']);
         $result = $data->first(function ($value) {
             return $value === 'baz';
         }, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testFirstWithDefaultAndWithoutCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstWithDefaultAndWithoutCallback($collection)
     {
-        $data = new Collection;
+        $data = new $collection;
         $result = $data->first(null, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testFirstWhere()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFirstWhere($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['material' => 'paper', 'type' => 'book'],
             ['material' => 'rubber', 'type' => 'gasket'],
         ]);
@@ -64,15 +79,21 @@ class SupportCollectionTest extends TestCase
         $this->assertNull($data->firstWhere('nonexistant', 'key'));
     }
 
-    public function testLastReturnsLastItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testLastReturnsLastItemInCollection($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals('bar', $c->last());
     }
 
-    public function testLastWithCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testLastWithCallback($collection)
     {
-        $data = new Collection([100, 200, 300]);
+        $data = new $collection([100, 200, 300]);
         $result = $data->last(function ($value) {
             return $value < 250;
         });
@@ -83,150 +104,190 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(200, $result);
     }
 
-    public function testLastWithCallbackAndDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testLastWithCallbackAndDefault($collection)
     {
-        $data = new Collection(['foo', 'bar']);
+        $data = new $collection(['foo', 'bar']);
         $result = $data->last(function ($value) {
             return $value === 'baz';
         }, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testLastWithDefaultAndWithoutCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testLastWithDefaultAndWithoutCallback($collection)
     {
-        $data = new Collection;
+        $data = new $collection;
         $result = $data->last(null, 'default');
         $this->assertEquals('default', $result);
     }
 
-    public function testPopReturnsAndRemovesLastItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPopReturnsAndRemovesLastItemInCollection($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
 
         $this->assertEquals('bar', $c->pop());
         $this->assertEquals('foo', $c->first());
     }
 
-    public function testShiftReturnsAndRemovesFirstItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testShiftReturnsAndRemovesFirstItemInCollection($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $data = new $collection(['Taylor', 'Otwell']);
 
-        $this->assertEquals('foo', $c->shift());
-        $this->assertEquals('bar', $c->first());
+        $this->assertEquals('Taylor', $data->shift());
+        $this->assertEquals('Otwell', $data->first());
+        $this->assertEquals('Otwell', $data->shift());
+        $this->assertEquals(null, $data->first());
     }
 
-    public function testEmptyCollectionIsEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEmptyCollectionIsEmpty($collection)
     {
-        $c = new Collection;
+        $c = new $collection;
 
         $this->assertTrue($c->isEmpty());
     }
 
-    public function testEmptyCollectionIsNotEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEmptyCollectionIsNotEmpty($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
 
         $this->assertFalse($c->isEmpty());
         $this->assertTrue($c->isNotEmpty());
     }
 
-    public function testCollectionIsConstructed()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollectionIsConstructed($collection)
     {
-        $collection = new Collection('foo');
-        $this->assertSame(['foo'], $collection->all());
+        $data = new $collection('foo');
+        $this->assertSame(['foo'], $data->all());
 
-        $collection = new Collection(2);
-        $this->assertSame([2], $collection->all());
+        $data = new $collection(2);
+        $this->assertSame([2], $data->all());
 
-        $collection = new Collection(false);
-        $this->assertSame([false], $collection->all());
+        $data = new $collection(false);
+        $this->assertSame([false], $data->all());
 
-        $collection = new Collection(null);
-        $this->assertEmpty($collection->all());
+        $data = new $collection(null);
+        $this->assertEmpty($data->all());
 
-        $collection = new Collection;
-        $this->assertEmpty($collection->all());
+        $data = new $collection;
+        $this->assertEmpty($data->all());
     }
 
-    public function testCollectionShuffleWithSeed()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollectionShuffleWithSeed($collection)
     {
-        $collection = new Collection(range(0, 100, 10));
+        $data = new $collection(range(0, 100, 10));
 
-        $firstRandom = $collection->shuffle(1234);
-        $secondRandom = $collection->shuffle(1234);
+        $firstRandom = $data->shuffle(1234);
+        $secondRandom = $data->shuffle(1234);
 
         $this->assertEquals($firstRandom, $secondRandom);
     }
 
-    public function testGetArrayableItems()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetArrayableItems($collection)
     {
-        $collection = new Collection;
+        $data = new $collection;
 
         $class = new ReflectionClass($collection);
         $method = $class->getMethod('getArrayableItems');
         $method->setAccessible(true);
 
         $items = new TestArrayableObject;
-        $array = $method->invokeArgs($collection, [$items]);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
         $items = new TestJsonableObject;
-        $array = $method->invokeArgs($collection, [$items]);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
         $items = new TestJsonSerializeObject;
-        $array = $method->invokeArgs($collection, [$items]);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
         $items = new TestJsonSerializeWithScalarValueObject;
-        $array = $method->invokeArgs($collection, [$items]);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo'], $array);
 
-        $items = new Collection(['foo' => 'bar']);
-        $array = $method->invokeArgs($collection, [$items]);
+        $items = new $collection(['foo' => 'bar']);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
 
         $items = ['foo' => 'bar'];
-        $array = $method->invokeArgs($collection, [$items]);
+        $array = $method->invokeArgs($data, [$items]);
         $this->assertSame(['foo' => 'bar'], $array);
     }
 
-    public function testToArrayCallsToArrayOnEachItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testToArrayCallsToArrayOnEachItemInCollection($collection)
     {
         $item1 = m::mock(Arrayable::class);
         $item1->shouldReceive('toArray')->once()->andReturn('foo.array');
         $item2 = m::mock(Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
-        $c = new Collection([$item1, $item2]);
+        $c = new $collection([$item1, $item2]);
         $results = $c->toArray();
 
         $this->assertEquals(['foo.array', 'bar.array'], $results);
     }
 
-    public function testJsonSerializeCallsToArrayOrJsonSerializeOnEachItemInCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testJsonSerializeCallsToArrayOrJsonSerializeOnEachItemInCollection($collection)
     {
         $item1 = m::mock(JsonSerializable::class);
         $item1->shouldReceive('jsonSerialize')->once()->andReturn('foo.json');
         $item2 = m::mock(Arrayable::class);
         $item2->shouldReceive('toArray')->once()->andReturn('bar.array');
-        $c = new Collection([$item1, $item2]);
+        $c = new $collection([$item1, $item2]);
         $results = $c->jsonSerialize();
 
         $this->assertEquals(['foo.json', 'bar.array'], $results);
     }
 
-    public function testToJsonEncodesTheJsonSerializeResult()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testToJsonEncodesTheJsonSerializeResult($collection)
     {
-        $c = $this->getMockBuilder(Collection::class)->setMethods(['jsonSerialize'])->getMock();
+        $c = $this->getMockBuilder($collection)->setMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->willReturn('foo');
         $results = $c->toJson();
-
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), $results);
     }
 
-    public function testCastingToStringJsonEncodesTheToArrayResult()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCastingToStringJsonEncodesTheToArrayResult($collection)
     {
-        $c = $this->getMockBuilder(Collection::class)->setMethods(['jsonSerialize'])->getMock();
+        $c = $this->getMockBuilder($collection)->setMethods(['jsonSerialize'])->getMock();
         $c->expects($this->once())->method('jsonSerialize')->willReturn('foo');
 
         $this->assertJsonStringEqualsJsonString(json_encode('foo'), (string) $c);
@@ -279,58 +340,73 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse(isset($c[1]));
     }
 
-    public function testForgetSingleKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testForgetSingleKey($collection)
     {
-        $c = new Collection(['foo', 'bar']);
-        $c->forget(0);
+        $c = new $collection(['foo', 'bar']);
+        $c = $c->forget(0)->all();
         $this->assertFalse(isset($c['foo']));
 
-        $c = new Collection(['foo' => 'bar', 'baz' => 'qux']);
-        $c->forget('foo');
+        $c = new $collection(['foo' => 'bar', 'baz' => 'qux']);
+        $c = $c->forget('foo')->all();
         $this->assertFalse(isset($c['foo']));
     }
 
-    public function testForgetArrayOfKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testForgetArrayOfKeys($collection)
     {
-        $c = new Collection(['foo', 'bar', 'baz']);
-        $c->forget([0, 2]);
+        $c = new $collection(['foo', 'bar', 'baz']);
+        $c = $c->forget([0, 2])->all();
         $this->assertFalse(isset($c[0]));
         $this->assertFalse(isset($c[2]));
         $this->assertTrue(isset($c[1]));
 
-        $c = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
-        $c->forget(['foo', 'baz']);
+        $c = new $collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
+        $c = $c->forget(['foo', 'baz'])->all();
         $this->assertFalse(isset($c['foo']));
         $this->assertFalse(isset($c['baz']));
         $this->assertTrue(isset($c['name']));
     }
 
-    public function testCountable()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCountable($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertCount(2, $c);
     }
 
-    public function testCountableByWithoutPredicate()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCountableByWithoutPredicate($collection)
     {
-        $c = new Collection(['foo', 'foo', 'foo', 'bar', 'bar', 'foobar']);
+        $c = new $collection(['foo', 'foo', 'foo', 'bar', 'bar', 'foobar']);
         $this->assertEquals(['foo' => 3, 'bar' => 2, 'foobar' => 1], $c->countBy()->all());
 
-        $c = new Collection([true, true, false, false, false]);
+        $c = new $collection([true, true, false, false, false]);
         $this->assertEquals([true => 2, false => 3], $c->countBy()->all());
 
-        $c = new Collection([1, 5, 1, 5, 5, 1]);
+        $c = new $collection([1, 5, 1, 5, 5, 1]);
         $this->assertEquals([1 => 3, 5 => 3], $c->countBy()->all());
     }
 
-    public function testCountableByWithPredicate()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCountableByWithPredicate($collection)
     {
-        $c = new Collection(['alice', 'aaron', 'bob', 'carla']);
+        $c = new $collection(['alice', 'aaron', 'bob', 'carla']);
         $this->assertEquals(['a' => 2, 'b' => 1, 'c' => 1], $c->countBy(function ($name) {
             return substr($name, 0, 1);
         })->all());
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals([true => 2, false => 3], $c->countBy(function ($i) {
             return $i % 2 === 0;
         })->all());
@@ -343,31 +419,40 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo'], $c->getIterator()->getArrayCopy());
     }
 
-    public function testCachingIterator()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCachingIterator($collection)
     {
-        $c = new Collection(['foo']);
+        $c = new $collection(['foo']);
         $this->assertInstanceOf(CachingIterator::class, $c->getCachingIterator());
     }
 
-    public function testFilter()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFilter($collection)
     {
-        $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
+        $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
         $this->assertEquals([1 => ['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
             return $item['id'] == 2;
         })->all());
 
-        $c = new Collection(['', 'Hello', '', 'World']);
+        $c = new $collection(['', 'Hello', '', 'World']);
         $this->assertEquals(['Hello', 'World'], $c->filter()->values()->toArray());
 
-        $c = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $c = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
         $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(function ($item, $key) {
             return $key != 'id';
         })->all());
     }
 
-    public function testHigherOrderKeyBy()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderKeyBy($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             ['id' => 'id1', 'name' => 'first'],
             ['id' => 'id2', 'name' => 'second'],
         ]);
@@ -375,9 +460,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['id1' => 'first', 'id2' => 'second'], $c->keyBy->id->map->name->all());
     }
 
-    public function testHigherOrderUnique()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderUnique($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             ['id' => '1', 'name' => 'first'],
             ['id' => '1', 'name' => 'second'],
         ]);
@@ -385,9 +473,12 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->unique->id);
     }
 
-    public function testHigherOrderFilter()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderFilter($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             new class {
                 public $name = 'Alex';
 
@@ -409,9 +500,12 @@ class SupportCollectionTest extends TestCase
         $this->assertCount(1, $c->filter->active());
     }
 
-    public function testWhere()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhere($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
         $this->assertEquals(
             [['v' => 3], ['v' => '3']],
@@ -490,7 +584,7 @@ class SupportCollectionTest extends TestCase
             $c->where('v', '>', $object)->values()->all()
         );
 
-        $c = new Collection([['v' => 1], ['v' => $object]]);
+        $c = new $collection([['v' => 1], ['v' => $object]]);
         $this->assertEquals(
             [['v' => $object]],
             $c->where('v', $object)->values()->all()
@@ -506,28 +600,31 @@ class SupportCollectionTest extends TestCase
             $c->where('v', '<', null)->values()->all()
         );
 
-        $c = new Collection([['v' => 1], ['v' => new HtmlString('hello')]]);
+        $c = new $collection([['v' => 1], ['v' => new HtmlString('hello')]]);
         $this->assertEquals(
             [['v' => new HtmlString('hello')]],
             $c->where('v', 'hello')->values()->all()
         );
 
-        $c = new Collection([['v' => 1], ['v' => 'hello']]);
+        $c = new $collection([['v' => 1], ['v' => 'hello']]);
         $this->assertEquals(
             [['v' => 'hello']],
             $c->where('v', new HtmlString('hello'))->values()->all()
         );
 
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => null]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => null]]);
         $this->assertEquals(
             [['v' => 1], ['v' => 2]],
             $c->where('v')->values()->all()
         );
     }
 
-    public function testWhereStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereStrict($collection)
     {
-        $c = new Collection([['v' => 3], ['v' => '3']]);
+        $c = new $collection([['v' => 3], ['v' => '3']]);
 
         $this->assertEquals(
             [['v' => 3]],
@@ -535,47 +632,68 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testWhereInstanceOf()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereInstanceOf($collection)
     {
-        $c = new Collection([new stdClass, new stdClass, new Collection, new stdClass]);
+        $c = new $collection([new stdClass, new stdClass, new $collection, new stdClass]);
         $this->assertCount(3, $c->whereInstanceOf(stdClass::class));
     }
 
-    public function testWhereIn()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereIn($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 1], ['v' => 3], ['v' => '3']], $c->whereIn('v', [1, 3])->values()->all());
     }
 
-    public function testWhereInStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereInStrict($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 1], ['v' => 3]], $c->whereInStrict('v', [1, 3])->values()->all());
     }
 
-    public function testWhereNotIn()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNotIn($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 2], ['v' => 4]], $c->whereNotIn('v', [1, 3])->values()->all());
     }
 
-    public function testWhereNotInStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNotInStrict($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
         $this->assertEquals([['v' => 2], ['v' => '3'], ['v' => 4]], $c->whereNotInStrict('v', [1, 3])->values()->all());
     }
 
-    public function testValues()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValues($collection)
     {
-        $c = new Collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
+        $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
         $this->assertEquals([['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
             return $item['id'] == 2;
         })->values()->all());
     }
 
-    public function testBetween()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testBetween($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
         $this->assertEquals([['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]],
             $c->whereBetween('v', [2, 4])->values()->all());
@@ -583,292 +701,388 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([['v' => 3], ['v' => '3']], $c->whereBetween('v', [3, 3])->values()->all());
     }
 
-    public function testWhereNotBetween()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNotBetween($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
+        $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);
 
         $this->assertEquals([['v' => 1]], $c->whereNotBetween('v', [2, 4])->values()->all());
         $this->assertEquals([['v' => 2], ['v' => 3], ['v' => 3], ['v' => 4]], $c->whereNotBetween('v', [-1, 1])->values()->all());
         $this->assertEquals([['v' => 1], ['v' => '2'], ['v' => '4']], $c->whereNotBetween('v', [3, 3])->values()->all());
     }
 
-    public function testFlatten()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlatten($collection)
     {
         // Flat arrays are unaffected
-        $c = new Collection(['#foo', '#bar', '#baz']);
+        $c = new $collection(['#foo', '#bar', '#baz']);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Nested arrays are flattened with existing flat items
-        $c = new Collection([['#foo', '#bar'], '#baz']);
+        $c = new $collection([['#foo', '#bar'], '#baz']);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Sets of nested arrays are flattened
-        $c = new Collection([['#foo', '#bar'], ['#baz']]);
+        $c = new $collection([['#foo', '#bar'], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Deeply nested arrays are flattened
-        $c = new Collection([['#foo', ['#bar']], ['#baz']]);
+        $c = new $collection([['#foo', ['#bar']], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Nested collections are flattened alongside arrays
-        $c = new Collection([new Collection(['#foo', '#bar']), ['#baz']]);
+        $c = new $collection([new $collection(['#foo', '#bar']), ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Nested collections containing plain arrays are flattened
-        $c = new Collection([new Collection(['#foo', ['#bar']]), ['#baz']]);
+        $c = new $collection([new $collection(['#foo', ['#bar']]), ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Nested arrays containing collections are flattened
-        $c = new Collection([['#foo', new Collection(['#bar'])], ['#baz']]);
+        $c = new $collection([['#foo', new $collection(['#bar'])], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#baz'], $c->flatten()->all());
 
         // Nested arrays containing collections containing arrays are flattened
-        $c = new Collection([['#foo', new Collection(['#bar', ['#zap']])], ['#baz']]);
+        $c = new $collection([['#foo', new $collection(['#bar', ['#zap']])], ['#baz']]);
         $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], $c->flatten()->all());
     }
 
-    public function testFlattenWithDepth()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlattenWithDepth($collection)
     {
         // No depth flattens recursively
-        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $c = new $collection([['#foo', ['#bar', ['#baz']]], '#zap']);
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
 
         // Specifying a depth only flattens to that depth
-        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $c = new $collection([['#foo', ['#bar', ['#baz']]], '#zap']);
         $this->assertEquals(['#foo', ['#bar', ['#baz']], '#zap'], $c->flatten(1)->all());
 
-        $c = new Collection([['#foo', ['#bar', ['#baz']]], '#zap']);
+        $c = new $collection([['#foo', ['#bar', ['#baz']]], '#zap']);
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], $c->flatten(2)->all());
     }
 
-    public function testFlattenIgnoresKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlattenIgnoresKeys($collection)
     {
         // No depth ignores keys
-        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $c = new $collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten()->all());
 
         // Depth of 1 ignores keys
-        $c = new Collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
+        $c = new $collection(['#foo', ['key' => '#bar'], ['key' => '#baz'], 'key' => '#zap']);
         $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], $c->flatten(1)->all());
     }
 
-    public function testMergeNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeNull($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
+        $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello'], $c->merge(null)->all());
     }
 
-    public function testMergeArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeArray($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
+        $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->merge(['id' => 1])->all());
     }
 
-    public function testMergeCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeCollection($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
-        $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new Collection(['name' => 'World', 'id' => 1]))->all());
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'World', 'id' => 1], $c->merge(new $collection(['name' => 'World', 'id' => 1]))->all());
     }
 
-    public function testMergeRecursiveNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeRecursiveNull($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
+        $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello'], $c->mergeRecursive(null)->all());
     }
 
-    public function testMergeRecursiveArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeRecursiveArray($collection)
     {
-        $c = new Collection(['name' => 'Hello', 'id' => 1]);
+        $c = new $collection(['name' => 'Hello', 'id' => 1]);
         $this->assertEquals(['name' => 'Hello', 'id' => [1, 2]], $c->mergeRecursive(['id' => 2])->all());
     }
 
-    public function testMergeRecursiveCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMergeRecursiveCollection($collection)
     {
-        $c = new Collection(['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b'], 'roles' => 'admin']]);
+        $c = new $collection(['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b'], 'roles' => 'admin']]);
         $this->assertEquals(
             ['name' => 'Hello', 'id' => 1, 'meta' => ['tags' => ['a', 'b', 'c'], 'roles' => ['admin', 'editor']]],
-            $c->mergeRecursive(new Collection(['meta' => ['tags' => ['c'], 'roles' => 'editor']]))->all()
+            $c->mergeRecursive(new $collection(['meta' => ['tags' => ['c'], 'roles' => 'editor']]))->all()
         );
     }
 
-    public function testReplaceNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceNull($collection)
     {
-        $c = new Collection(['a', 'b', 'c']);
+        $c = new $collection(['a', 'b', 'c']);
         $this->assertEquals(['a', 'b', 'c'], $c->replace(null)->all());
     }
 
-    public function testReplaceArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceArray($collection)
     {
-        $c = new Collection(['a', 'b', 'c']);
+        $c = new $collection(['a', 'b', 'c']);
         $this->assertEquals(['a', 'd', 'e'], $c->replace([1 => 'd', 2 => 'e'])->all());
     }
 
-    public function testReplaceCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceCollection($collection)
     {
-        $c = new Collection(['a', 'b', 'c']);
+        $c = new $collection(['a', 'b', 'c']);
         $this->assertEquals(
             ['a', 'd', 'e'],
-            $c->replace(new Collection([1 => 'd', 2 => 'e']))->all()
+            $c->replace(new $collection([1 => 'd', 2 => 'e']))->all()
         );
     }
 
-    public function testReplaceRecursiveNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceRecursiveNull($collection)
     {
-        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $c = new $collection(['a', 'b', ['c', 'd']]);
         $this->assertEquals(['a', 'b', ['c', 'd']], $c->replaceRecursive(null)->all());
     }
 
-    public function testReplaceRecursiveArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceRecursiveArray($collection)
     {
-        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $c = new $collection(['a', 'b', ['c', 'd']]);
         $this->assertEquals(['z', 'b', ['c', 'e']], $c->replaceRecursive(['z', 2 => [1 => 'e']])->all());
     }
 
-    public function testReplaceRecursiveCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReplaceRecursiveCollection($collection)
     {
-        $c = new Collection(['a', 'b', ['c', 'd']]);
+        $c = new $collection(['a', 'b', ['c', 'd']]);
         $this->assertEquals(
             ['z', 'b', ['c', 'e']],
-            $c->replaceRecursive(new Collection(['z', 2 => [1 => 'e']]))->all()
+            $c->replaceRecursive(new $collection(['z', 2 => [1 => 'e']]))->all()
         );
     }
 
-    public function testUnionNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnionNull($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
+        $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello'], $c->union(null)->all());
     }
 
-    public function testUnionArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnionArray($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
+        $c = new $collection(['name' => 'Hello']);
         $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->union(['id' => 1])->all());
     }
 
-    public function testUnionCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnionCollection($collection)
     {
-        $c = new Collection(['name' => 'Hello']);
-        $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->union(new Collection(['name' => 'World', 'id' => 1]))->all());
+        $c = new $collection(['name' => 'Hello']);
+        $this->assertEquals(['name' => 'Hello', 'id' => 1], $c->union(new $collection(['name' => 'World', 'id' => 1]))->all());
     }
 
-    public function testDiffCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffCollection($collection)
     {
-        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
-        $this->assertEquals(['id' => 1], $c->diff(new Collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
+        $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
+        $this->assertEquals(['id' => 1], $c->diff(new $collection(['first_word' => 'Hello', 'last_word' => 'World']))->all());
     }
 
-    public function testDiffUsingWithCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffUsingWithCollection($collection)
     {
-        $c = new Collection(['en_GB', 'fr', 'HR']);
+        $c = new $collection(['en_GB', 'fr', 'HR']);
         // demonstrate that diffKeys wont support case insensitivity
-        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diff(new Collection(['en_gb', 'hr']))->values()->toArray());
+        $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diff(new $collection(['en_gb', 'hr']))->values()->toArray());
         // allow for case insensitive difference
-        $this->assertEquals(['fr'], $c->diffUsing(new Collection(['en_gb', 'hr']), 'strcasecmp')->values()->toArray());
+        $this->assertEquals(['fr'], $c->diffUsing(new $collection(['en_gb', 'hr']), 'strcasecmp')->values()->toArray());
     }
 
-    public function testDiffUsingWithNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffUsingWithNull($collection)
     {
-        $c = new Collection(['en_GB', 'fr', 'HR']);
+        $c = new $collection(['en_GB', 'fr', 'HR']);
         $this->assertEquals(['en_GB', 'fr', 'HR'], $c->diffUsing(null, 'strcasecmp')->values()->toArray());
     }
 
-    public function testDiffNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffNull($collection)
     {
-        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c->diff(null)->all());
     }
 
-    public function testDiffKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffKeys($collection)
     {
-        $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
-        $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello']);
+        $c1 = new $collection(['id' => 1, 'first_word' => 'Hello']);
+        $c2 = new $collection(['id' => 123, 'foo_bar' => 'Hello']);
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeys($c2)->all());
     }
 
-    public function testDiffKeysUsing()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffKeysUsing($collection)
     {
-        $c1 = new Collection(['id' => 1, 'first_word' => 'Hello']);
-        $c2 = new Collection(['ID' => 123, 'foo_bar' => 'Hello']);
+        $c1 = new $collection(['id' => 1, 'first_word' => 'Hello']);
+        $c2 = new $collection(['ID' => 123, 'foo_bar' => 'Hello']);
         // demonstrate that diffKeys wont support case insensitivity
         $this->assertEquals(['id'=>1, 'first_word'=> 'Hello'], $c1->diffKeys($c2)->all());
         // allow for case insensitive difference
         $this->assertEquals(['first_word' => 'Hello'], $c1->diffKeysUsing($c2, 'strcasecmp')->all());
     }
 
-    public function testDiffAssoc()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffAssoc($collection)
     {
-        $c1 = new Collection(['id' => 1, 'first_word' => 'Hello', 'not_affected' => 'value']);
-        $c2 = new Collection(['id' => 123, 'foo_bar' => 'Hello', 'not_affected' => 'value']);
+        $c1 = new $collection(['id' => 1, 'first_word' => 'Hello', 'not_affected' => 'value']);
+        $c2 = new $collection(['id' => 123, 'foo_bar' => 'Hello', 'not_affected' => 'value']);
         $this->assertEquals(['id' => 1, 'first_word' => 'Hello'], $c1->diffAssoc($c2)->all());
     }
 
-    public function testDiffAssocUsing()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDiffAssocUsing($collection)
     {
-        $c1 = new Collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
-        $c2 = new Collection(['A' => 'green', 'yellow', 'red']);
+        $c1 = new $collection(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red']);
+        $c2 = new $collection(['A' => 'green', 'yellow', 'red']);
         // demonstrate that the case of the keys will affect the output when diffAssoc is used
         $this->assertEquals(['a' => 'green', 'b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssoc($c2)->all());
         // allow for case insensitive difference
         $this->assertEquals(['b' => 'brown', 'c' => 'blue', 'red'], $c1->diffAssocUsing($c2, 'strcasecmp')->all());
     }
 
-    public function testDuplicates()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDuplicates($collection)
     {
-        $duplicates = Collection::make([1, 2, 1, 'laravel', null, 'laravel', 'php', null])->duplicates()->all();
+        $duplicates = $collection::make([1, 2, 1, 'laravel', null, 'laravel', 'php', null])->duplicates()->all();
         $this->assertSame([2 => 1, 5 => 'laravel', 7 => null], $duplicates);
 
         // does loose comparison
-        $duplicates = Collection::make([2, '2', [], null])->duplicates()->all();
+        $duplicates = $collection::make([2, '2', [], null])->duplicates()->all();
         $this->assertSame([1 => '2', 3 => null], $duplicates);
 
         // works with mix of primitives
-        $duplicates = Collection::make([1, '2', ['laravel'], ['laravel'], null, '2'])->duplicates()->all();
+        $duplicates = $collection::make([1, '2', ['laravel'], ['laravel'], null, '2'])->duplicates()->all();
         $this->assertSame([3 => ['laravel'], 5 => '2'], $duplicates);
 
         // works with mix of objects and primitives **excepts numbers**.
         $expected = new Collection(['laravel']);
-        $duplicates = Collection::make([new Collection(['laravel']), $expected, $expected, [], '2', '2'])->duplicates()->all();
+        $duplicates = $collection::make([new Collection(['laravel']), $expected, $expected, [], '2', '2'])->duplicates()->all();
         $this->assertSame([1 => $expected, 2 => $expected, 5 => '2'], $duplicates);
     }
 
-    public function testDuplicatesWithKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDuplicatesWithKey($collection)
     {
         $items = [['framework' => 'vue'], ['framework' => 'laravel'], ['framework' => 'laravel']];
-        $duplicates = Collection::make($items)->duplicates('framework')->all();
+        $duplicates = $collection::make($items)->duplicates('framework')->all();
         $this->assertSame([2 => 'laravel'], $duplicates);
     }
 
-    public function testDuplicatesWithCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDuplicatesWithCallback($collection)
     {
         $items = [['framework' => 'vue'], ['framework' => 'laravel'], ['framework' => 'laravel']];
-        $duplicates = Collection::make($items)->duplicates(function ($item) {
+        $duplicates = $collection::make($items)->duplicates(function ($item) {
             return $item['framework'];
         })->all();
         $this->assertSame([2 => 'laravel'], $duplicates);
     }
 
-    public function testDuplicatesWithStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDuplicatesWithStrict($collection)
     {
-        $duplicates = Collection::make([1, 2, 1, 'laravel', null, 'laravel', 'php', null])->duplicatesStrict()->all();
+        $duplicates = $collection::make([1, 2, 1, 'laravel', null, 'laravel', 'php', null])->duplicatesStrict()->all();
         $this->assertSame([2 => 1, 5 => 'laravel', 7 => null], $duplicates);
 
         // does strict comparison
-        $duplicates = Collection::make([2, '2', [], null])->duplicatesStrict()->all();
+        $duplicates = $collection::make([2, '2', [], null])->duplicatesStrict()->all();
         $this->assertSame([], $duplicates);
 
         // works with mix of primitives
-        $duplicates = Collection::make([1, '2', ['laravel'], ['laravel'], null, '2'])->duplicatesStrict()->all();
+        $duplicates = $collection::make([1, '2', ['laravel'], ['laravel'], null, '2'])->duplicatesStrict()->all();
         $this->assertSame([3 => ['laravel'], 5 => '2'], $duplicates);
 
         // works with mix of primitives, objects, and numbers
-        $expected = new Collection(['laravel']);
-        $duplicates = Collection::make([new Collection(['laravel']), $expected, $expected, [], '2', '2'])->duplicatesStrict()->all();
+        $expected = new $collection(['laravel']);
+        $duplicates = $collection::make([new $collection(['laravel']), $expected, $expected, [], '2', '2'])->duplicatesStrict()->all();
         $this->assertSame([2 => $expected, 5 => '2'], $duplicates);
     }
 
-    public function testEach()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEach($collection)
     {
-        $c = new Collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
+        $c = new $collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
 
         $result = [];
         $c->each(function ($item, $key) use (&$result) {
@@ -886,9 +1100,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 'foo' => 'bar'], $result);
     }
 
-    public function testEachSpread()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEachSpread($collection)
     {
-        $c = new Collection([[1, 'a'], [2, 'b']]);
+        $c = new $collection([[1, 'a'], [2, 'b']]);
 
         $result = [];
         $c->eachSpread(function ($number, $character) use (&$result) {
@@ -910,7 +1127,7 @@ class SupportCollectionTest extends TestCase
         });
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
 
-        $c = new Collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
+        $c = new $collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
         $result = [];
         $c->eachSpread(function ($number, $character, $key) use (&$result) {
             $result[] = [$number, $character, $key];
@@ -918,42 +1135,60 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
     }
 
-    public function testIntersectNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIntersectNull($collection)
     {
-        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
+        $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
         $this->assertEquals([], $c->intersect(null)->all());
     }
 
-    public function testIntersectCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIntersectCollection($collection)
     {
-        $c = new Collection(['id' => 1, 'first_word' => 'Hello']);
-        $this->assertEquals(['first_word' => 'Hello'], $c->intersect(new Collection(['first_world' => 'Hello', 'last_word' => 'World']))->all());
+        $c = new $collection(['id' => 1, 'first_word' => 'Hello']);
+        $this->assertEquals(['first_word' => 'Hello'], $c->intersect(new $collection(['first_world' => 'Hello', 'last_word' => 'World']))->all());
     }
 
-    public function testIntersectByKeysNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIntersectByKeysNull($collection)
     {
-        $c = new Collection(['name' => 'Mateus', 'age' => 18]);
+        $c = new $collection(['name' => 'Mateus', 'age' => 18]);
         $this->assertEquals([], $c->intersectByKeys(null)->all());
     }
 
-    public function testIntersectByKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testIntersectByKeys($collection)
     {
-        $c = new Collection(['name' => 'Mateus', 'age' => 18]);
-        $this->assertEquals(['name' => 'Mateus'], $c->intersectByKeys(new Collection(['name' => 'Mateus', 'surname' => 'Guimaraes']))->all());
+        $c = new $collection(['name' => 'Mateus', 'age' => 18]);
+        $this->assertEquals(['name' => 'Mateus'], $c->intersectByKeys(new $collection(['name' => 'Mateus', 'surname' => 'Guimaraes']))->all());
     }
 
-    public function testUnique()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnique($collection)
     {
-        $c = new Collection(['Hello', 'World', 'World']);
+        $c = new $collection(['Hello', 'World', 'World']);
         $this->assertEquals(['Hello', 'World'], $c->unique()->all());
 
-        $c = new Collection([[1, 2], [1, 2], [2, 3], [3, 4], [2, 3]]);
+        $c = new $collection([[1, 2], [1, 2], [2, 3], [3, 4], [2, 3]]);
         $this->assertEquals([[1, 2], [2, 3], [3, 4]], $c->unique()->values()->all());
     }
 
-    public function testUniqueWithCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUniqueWithCallback($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             1 => ['id' => 1, 'first' => 'Taylor', 'last' => 'Otwell'],
             2 => ['id' => 2, 'first' => 'Taylor', 'last' => 'Otwell'],
             3 => ['id' => 3, 'first' => 'Abigail', 'last' => 'Otwell'],
@@ -983,9 +1218,12 @@ class SupportCollectionTest extends TestCase
         })->all());
     }
 
-    public function testUniqueStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUniqueStrict($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             [
                 'id' => '0',
                 'name' => 'zero',
@@ -1012,43 +1250,55 @@ class SupportCollectionTest extends TestCase
         ], $c->uniqueStrict('id')->all());
     }
 
-    public function testCollapse()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollapse($collection)
     {
-        $data = new Collection([[$object1 = new stdClass], [$object2 = new stdClass]]);
+        $data = new $collection([[$object1 = new stdClass], [$object2 = new stdClass]]);
         $this->assertEquals([$object1, $object2], $data->collapse()->all());
     }
 
-    public function testCollapseWithNestedCollections()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollapseWithNestedCollections($collection)
     {
-        $data = new Collection([new Collection([1, 2, 3]), new Collection([4, 5, 6])]);
+        $data = new $collection([new $collection([1, 2, 3]), new $collection([4, 5, 6])]);
         $this->assertEquals([1, 2, 3, 4, 5, 6], $data->collapse()->all());
     }
 
-    public function testJoin()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testJoin($collection)
     {
-        $this->assertEquals('a, b, c', (new Collection(['a', 'b', 'c']))->join(', '));
+        $this->assertEquals('a, b, c', (new $collection(['a', 'b', 'c']))->join(', '));
 
-        $this->assertEquals('a, b and c', (new Collection(['a', 'b', 'c']))->join(', ', ' and '));
+        $this->assertEquals('a, b and c', (new $collection(['a', 'b', 'c']))->join(', ', ' and '));
 
-        $this->assertEquals('a and b', (new Collection(['a', 'b']))->join(', ', ' and '));
+        $this->assertEquals('a and b', (new $collection(['a', 'b']))->join(', ', ' and '));
 
-        $this->assertEquals('a', (new Collection(['a']))->join(', ', ' and '));
+        $this->assertEquals('a', (new $collection(['a']))->join(', ', ' and '));
 
-        $this->assertEquals('', (new Collection([]))->join(', ', ' and '));
+        $this->assertEquals('', (new $collection([]))->join(', ', ' and '));
     }
 
-    public function testCrossJoin()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCrossJoin($collection)
     {
         // Cross join with an array
         $this->assertEquals(
             [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
-            (new Collection([1, 2]))->crossJoin(['a', 'b'])->all()
+            (new $collection([1, 2]))->crossJoin(['a', 'b'])->all()
         );
 
         // Cross join with a collection
         $this->assertEquals(
             [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']],
-            (new Collection([1, 2]))->crossJoin(new Collection(['a', 'b']))->all()
+            (new $collection([1, 2]))->crossJoin(new $collection(['a', 'b']))->all()
         );
 
         // Cross join with 2 collections
@@ -1059,28 +1309,34 @@ class SupportCollectionTest extends TestCase
                 [2, 'a', 'I'], [2, 'a', 'II'],
                 [2, 'b', 'I'], [2, 'b', 'II'],
             ],
-            (new Collection([1, 2]))->crossJoin(
-                new Collection(['a', 'b']),
-                new Collection(['I', 'II'])
+            (new $collection([1, 2]))->crossJoin(
+                new $collection(['a', 'b']),
+                new $collection(['I', 'II'])
             )->all()
         );
     }
 
-    public function testSort()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSort($collection)
     {
-        $data = (new Collection([5, 3, 1, 2, 4]))->sort();
+        $data = (new $collection([5, 3, 1, 2, 4]))->sort();
         $this->assertEquals([1, 2, 3, 4, 5], $data->values()->all());
 
-        $data = (new Collection([-1, -3, -2, -4, -5, 0, 5, 3, 1, 2, 4]))->sort();
+        $data = (new $collection([-1, -3, -2, -4, -5, 0, 5, 3, 1, 2, 4]))->sort();
         $this->assertEquals([-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5], $data->values()->all());
 
-        $data = (new Collection(['foo', 'bar-10', 'bar-1']))->sort();
+        $data = (new $collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
     }
 
-    public function testSortWithCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortWithCallback($collection)
     {
-        $data = (new Collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {
+        $data = (new $collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {
             if ($a === $b) {
                 return 0;
             }
@@ -1091,16 +1347,19 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(range(1, 5), array_values($data->all()));
     }
 
-    public function testSortBy()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortBy($collection)
     {
-        $data = new Collection(['taylor', 'dayle']);
+        $data = new $collection(['taylor', 'dayle']);
         $data = $data->sortBy(function ($x) {
             return $x;
         });
 
         $this->assertEquals(['dayle', 'taylor'], array_values($data->all()));
 
-        $data = new Collection(['dayle', 'taylor']);
+        $data = new $collection(['dayle', 'taylor']);
         $data = $data->sortByDesc(function ($x) {
             return $x;
         });
@@ -1108,29 +1367,35 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], array_values($data->all()));
     }
 
-    public function testSortByString()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortByString($collection)
     {
-        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = new $collection([['name' => 'taylor'], ['name' => 'dayle']]);
         $data = $data->sortBy('name', SORT_STRING);
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
 
-        $data = new Collection([['name' => 'taylor'], ['name' => 'dayle']]);
+        $data = new $collection([['name' => 'taylor'], ['name' => 'dayle']]);
         $data = $data->sortBy('name', SORT_STRING);
 
         $this->assertEquals([['name' => 'dayle'], ['name' => 'taylor']], array_values($data->all()));
     }
 
-    public function testSortByAlwaysReturnsAssoc()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortByAlwaysReturnsAssoc($collection)
     {
-        $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
+        $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
         $data = $data->sortBy(function ($x) {
             return $x;
         });
 
         $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->all());
 
-        $data = new Collection(['taylor', 'dayle']);
+        $data = new $collection(['taylor', 'dayle']);
         $data = $data->sortBy(function ($x) {
             return $x;
         });
@@ -1138,80 +1403,104 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => 'dayle', 0 => 'taylor'], $data->all());
     }
 
-    public function testSortKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortKeys($collection)
     {
-        $data = new Collection(['b' => 'dayle', 'a' => 'taylor']);
+        $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);
 
         $this->assertSame(['a' => 'taylor', 'b' => 'dayle'], $data->sortKeys()->all());
     }
 
-    public function testSortKeysDesc()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortKeysDesc($collection)
     {
-        $data = new Collection(['a' => 'taylor', 'b' => 'dayle']);
+        $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
 
         $this->assertSame(['b' => 'dayle', 'a' => 'taylor'], $data->sortKeysDesc()->all());
     }
 
-    public function testReverse()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReverse($collection)
     {
-        $data = new Collection(['zaeed', 'alan']);
+        $data = new $collection(['zaeed', 'alan']);
         $reversed = $data->reverse();
 
         $this->assertSame([1 => 'alan', 0 => 'zaeed'], $reversed->all());
 
-        $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
         $reversed = $data->reverse();
 
         $this->assertSame(['framework' => 'laravel', 'name' => 'taylor'], $reversed->all());
     }
 
-    public function testFlip()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlip($collection)
     {
-        $data = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['taylor' => 'name', 'laravel' => 'framework'], $data->flip()->toArray());
     }
 
-    public function testChunk()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunk($collection)
     {
-        $data = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         $data = $data->chunk(3);
 
-        $this->assertInstanceOf(Collection::class, $data);
-        $this->assertInstanceOf(Collection::class, $data[0]);
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
         $this->assertCount(4, $data);
-        $this->assertEquals([1, 2, 3], $data[0]->toArray());
-        $this->assertEquals([9 => 10], $data[3]->toArray());
+        $this->assertEquals([1, 2, 3], $data->first()->toArray());
+        $this->assertEquals([9 => 10], $data->get(3)->toArray());
     }
 
-    public function testChunkWhenGivenZeroAsSize()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunkWhenGivenZeroAsSize($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         $this->assertEquals(
             [],
-            $collection->chunk(0)->toArray()
+            $data->chunk(0)->toArray()
         );
     }
 
-    public function testChunkWhenGivenLessThanZero()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunkWhenGivenLessThanZero($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         $this->assertEquals(
             [],
-            $collection->chunk(-1)->toArray()
+            $data->chunk(-1)->toArray()
         );
     }
 
-    public function testEvery()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEvery($collection)
     {
-        $c = new Collection([]);
+        $c = new $collection([]);
         $this->assertTrue($c->every('key', 'value'));
         $this->assertTrue($c->every(function () {
             return false;
         }));
 
-        $c = new Collection([['age' => 18], ['age' => 20], ['age' => 20]]);
+        $c = new $collection([['age' => 18], ['age' => 20], ['age' => 20]]);
         $this->assertFalse($c->every('age', 18));
         $this->assertTrue($c->every('age', '>=', 18));
         $this->assertTrue($c->every(function ($item) {
@@ -1221,20 +1510,23 @@ class SupportCollectionTest extends TestCase
             return $item['age'] >= 20;
         }));
 
-        $c = new Collection([null, null]);
+        $c = new $collection([null, null]);
         $this->assertTrue($c->every(function ($item) {
             return $item === null;
         }));
 
-        $c = new Collection([['active' => true], ['active' => true]]);
+        $c = new $collection([['active' => true], ['active' => true]]);
         $this->assertTrue($c->every('active'));
         $this->assertTrue($c->every->active);
         $this->assertFalse($c->push(['active' => false])->every->active);
     }
 
-    public function testExcept()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testExcept($collection)
     {
-        $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
+        $data = new $collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
         $this->assertEquals(['first' => 'Taylor'], $data->except(['last', 'email', 'missing'])->all());
         $this->assertEquals(['first' => 'Taylor'], $data->except('last', 'email', 'missing')->all());
@@ -1244,22 +1536,31 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->except('last')->all());
     }
 
-    public function testExceptSelf()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testExceptSelf($collection)
     {
-        $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell']);
+        $data = new $collection(['first' => 'Taylor', 'last' => 'Otwell']);
         $this->assertEquals(['first' => 'Taylor', 'last' => 'Otwell'], $data->except($data)->all());
     }
 
-    public function testPluckWithArrayAndObjectValues()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPluckWithArrayAndObjectValues($collection)
     {
-        $data = new Collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
+        $data = new $collection([(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], $data->pluck('email', 'name')->all());
         $this->assertEquals(['foo', 'bar'], $data->pluck('email')->all());
     }
 
-    public function testPluckWithArrayAccessValues()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPluckWithArrayAccessValues($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             new TestArrayAccessImplementation(['name' => 'taylor', 'email' => 'foo']),
             new TestArrayAccessImplementation(['name' => 'dayle', 'email' => 'bar']),
         ]);
@@ -1268,104 +1569,131 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $data->pluck('email')->all());
     }
 
-    public function testHas()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHas($collection)
     {
-        $data = new Collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
         $this->assertTrue($data->has('first'));
         $this->assertFalse($data->has('third'));
         $this->assertTrue($data->has(['first', 'second']));
         $this->assertFalse($data->has(['third', 'first']));
     }
 
-    public function testImplode()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testImplode($collection)
     {
-        $data = new Collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
+        $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
         $this->assertEquals('foobar', $data->implode('email'));
         $this->assertEquals('foo,bar', $data->implode('email', ','));
 
-        $data = new Collection(['taylor', 'dayle']);
+        $data = new $collection(['taylor', 'dayle']);
         $this->assertEquals('taylordayle', $data->implode(''));
         $this->assertEquals('taylor,dayle', $data->implode(','));
     }
 
-    public function testTake()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTake($collection)
     {
-        $data = new Collection(['taylor', 'dayle', 'shawn']);
+        $data = new $collection(['taylor', 'dayle', 'shawn']);
         $data = $data->take(2);
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
-    public function testPut()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPut($collection)
     {
-        $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
+        $data = new $collection(['name' => 'taylor', 'email' => 'foo']);
         $data = $data->put('name', 'dayle');
         $this->assertEquals(['name' => 'dayle', 'email' => 'foo'], $data->all());
     }
 
-    public function testPutWithNoKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPutWithNoKey($collection)
     {
-        $data = new Collection(['taylor', 'shawn']);
+        $data = new $collection(['taylor', 'shawn']);
         $data = $data->put(null, 'dayle');
         $this->assertEquals(['taylor', 'shawn', 'dayle'], $data->all());
     }
 
-    public function testRandom()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRandom($collection)
     {
-        $data = new Collection([1, 2, 3, 4, 5, 6]);
+        $data = new $collection([1, 2, 3, 4, 5, 6]);
 
         $random = $data->random();
         $this->assertIsInt($random);
         $this->assertContains($random, $data->all());
 
         $random = $data->random(0);
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(0, $random);
 
         $random = $data->random(1);
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(1, $random);
 
         $random = $data->random(2);
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
 
         $random = $data->random('0');
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(0, $random);
 
         $random = $data->random('1');
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(1, $random);
 
         $random = $data->random('2');
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(2, $random);
     }
 
-    public function testRandomOnEmptyCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRandomOnEmptyCollection($collection)
     {
-        $data = new Collection;
+        $data = new $collection;
 
         $random = $data->random(0);
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(0, $random);
 
         $random = $data->random('0');
-        $this->assertInstanceOf(Collection::class, $random);
+        $this->assertInstanceOf($collection, $random);
         $this->assertCount(0, $random);
     }
 
-    public function testTakeLast()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeLast($collection)
     {
-        $data = new Collection(['taylor', 'dayle', 'shawn']);
+        $data = new $collection(['taylor', 'dayle', 'shawn']);
         $data = $data->take(-2);
         $this->assertEquals([1 => 'dayle', 2 => 'shawn'], $data->all());
     }
 
-    public function testMacroable()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMacroable($collection)
     {
         // Foo() macro : unique values starting with A
-        Collection::macro('foo', function () {
+        $collection::macro('foo', function () {
             return $this->filter(function ($item) {
                 return strpos($item, 'a') === 0;
             })
@@ -1373,128 +1701,176 @@ class SupportCollectionTest extends TestCase
                 ->values();
         });
 
-        $c = new Collection(['a', 'a', 'aa', 'aaa', 'bar']);
+        $c = new $collection(['a', 'a', 'aa', 'aaa', 'bar']);
 
         $this->assertSame(['a', 'aa', 'aaa'], $c->foo()->all());
     }
 
-    public function testCanAddMethodsToProxy()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCanAddMethodsToProxy($collection)
     {
-        Collection::macro('adults', function ($callback) {
+        $collection::macro('adults', function ($callback) {
             return $this->filter(function ($item) use ($callback) {
                 return $callback($item) >= 18;
             });
         });
 
-        Collection::proxy('adults');
+        $collection::proxy('adults');
 
-        $c = new Collection([['age' => 3], ['age' => 12], ['age' => 18], ['age' => 56]]);
+        $c = new $collection([['age' => 3], ['age' => 12], ['age' => 18], ['age' => 56]]);
 
         $this->assertSame([['age' => 18], ['age' => 56]], $c->adults->age->values()->all());
     }
 
-    public function testMakeMethod()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMakeMethod($collection)
     {
-        $collection = Collection::make('foo');
-        $this->assertEquals(['foo'], $collection->all());
+        $data = $collection::make('foo');
+        $this->assertEquals(['foo'], $data->all());
     }
 
-    public function testMakeMethodFromNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMakeMethodFromNull($collection)
     {
-        $collection = Collection::make(null);
-        $this->assertEquals([], $collection->all());
+        $data = $collection::make(null);
+        $this->assertEquals([], $data->all());
 
-        $collection = Collection::make();
-        $this->assertEquals([], $collection->all());
+        $data = $collection::make();
+        $this->assertEquals([], $data->all());
     }
 
-    public function testMakeMethodFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMakeMethodFromCollection($collection)
     {
-        $firstCollection = Collection::make(['foo' => 'bar']);
-        $secondCollection = Collection::make($firstCollection);
+        $firstCollection = $collection::make(['foo' => 'bar']);
+        $secondCollection = $collection::make($firstCollection);
         $this->assertEquals(['foo' => 'bar'], $secondCollection->all());
     }
 
-    public function testMakeMethodFromArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMakeMethodFromArray($collection)
     {
-        $collection = Collection::make(['foo' => 'bar']);
-        $this->assertEquals(['foo' => 'bar'], $collection->all());
+        $data = $collection::make(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $data->all());
     }
 
-    public function testWrapWithScalar()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithScalar($collection)
     {
-        $collection = Collection::wrap('foo');
-        $this->assertEquals(['foo'], $collection->all());
+        $data = $collection::wrap('foo');
+        $this->assertEquals(['foo'], $data->all());
     }
 
-    public function testWrapWithArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithArray($collection)
     {
-        $collection = Collection::wrap(['foo']);
-        $this->assertEquals(['foo'], $collection->all());
+        $data = $collection::wrap(['foo']);
+        $this->assertEquals(['foo'], $data->all());
     }
 
-    public function testWrapWithArrayable()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithArrayable($collection)
     {
-        $collection = Collection::wrap($o = new TestArrayableObject);
-        $this->assertEquals([$o], $collection->all());
+        $data = $collection::wrap($o = new TestArrayableObject);
+        $this->assertEquals([$o], $data->all());
     }
 
-    public function testWrapWithJsonable()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithJsonable($collection)
     {
-        $collection = Collection::wrap($o = new TestJsonableObject);
-        $this->assertEquals([$o], $collection->all());
+        $data = $collection::wrap($o = new TestJsonableObject);
+        $this->assertEquals([$o], $data->all());
     }
 
-    public function testWrapWithJsonSerialize()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithJsonSerialize($collection)
     {
-        $collection = Collection::wrap($o = new TestJsonSerializeObject);
-        $this->assertEquals([$o], $collection->all());
+        $data = $collection::wrap($o = new TestJsonSerializeObject);
+        $this->assertEquals([$o], $data->all());
     }
 
-    public function testWrapWithCollectionClass()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithCollectionClass($collection)
     {
-        $collection = Collection::wrap(Collection::make(['foo']));
-        $this->assertEquals(['foo'], $collection->all());
+        $data = $collection::wrap($collection::make(['foo']));
+        $this->assertEquals(['foo'], $data->all());
     }
 
-    public function testWrapWithCollectionSubclass()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWrapWithCollectionSubclass($collection)
     {
-        $collection = TestCollectionSubclass::wrap(Collection::make(['foo']));
-        $this->assertEquals(['foo'], $collection->all());
-        $this->assertInstanceOf(TestCollectionSubclass::class, $collection);
+        $data = TestCollectionSubclass::wrap($collection::make(['foo']));
+        $this->assertEquals(['foo'], $data->all());
+        $this->assertInstanceOf(TestCollectionSubclass::class, $data);
     }
 
-    public function testUnwrapCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnwrapCollection($collection)
     {
-        $collection = new Collection(['foo']);
-        $this->assertEquals(['foo'], Collection::unwrap($collection));
+        $data = new $collection(['foo']);
+        $this->assertEquals(['foo'], $collection::unwrap($data));
     }
 
-    public function testUnwrapCollectionWithArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnwrapCollectionWithArray($collection)
     {
-        $this->assertEquals(['foo'], Collection::unwrap(['foo']));
+        $this->assertEquals(['foo'], $collection::unwrap(['foo']));
     }
 
-    public function testUnwrapCollectionWithScalar()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnwrapCollectionWithScalar($collection)
     {
-        $this->assertEquals('foo', Collection::unwrap('foo'));
+        $this->assertEquals('foo', $collection::unwrap('foo'));
     }
 
-    public function testTimesMethod()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTimesMethod($collection)
     {
-        $two = Collection::times(2, function ($number) {
+        $two = $collection::times(2, function ($number) {
             return 'slug-'.$number;
         });
 
-        $zero = Collection::times(0, function ($number) {
+        $zero = $collection::times(0, function ($number) {
             return 'slug-'.$number;
         });
 
-        $negative = Collection::times(-4, function ($number) {
+        $negative = $collection::times(-4, function ($number) {
             return 'slug-'.$number;
         });
 
-        $range = Collection::times(5);
+        $range = $collection::times(5);
 
         $this->assertEquals(['slug-1', 'slug-2'], $two->all());
         $this->assertTrue($zero->isEmpty());
@@ -1502,91 +1878,121 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(range(1, 5), $range->all());
     }
 
-    public function testConstructMakeFromObject()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMakeFromObject($collection)
     {
         $object = new stdClass;
         $object->foo = 'bar';
-        $collection = Collection::make($object);
-        $this->assertEquals(['foo' => 'bar'], $collection->all());
+        $data = $collection::make($object);
+        $this->assertEquals(['foo' => 'bar'], $data->all());
     }
 
-    public function testConstructMethod()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMethod($collection)
     {
-        $collection = new Collection('foo');
-        $this->assertEquals(['foo'], $collection->all());
+        $data = new $collection('foo');
+        $this->assertEquals(['foo'], $data->all());
     }
 
-    public function testConstructMethodFromNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMethodFromNull($collection)
     {
-        $collection = new Collection(null);
-        $this->assertEquals([], $collection->all());
+        $data = new $collection(null);
+        $this->assertEquals([], $data->all());
 
-        $collection = new Collection;
-        $this->assertEquals([], $collection->all());
+        $data = new $collection;
+        $this->assertEquals([], $data->all());
     }
 
-    public function testConstructMethodFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMethodFromCollection($collection)
     {
-        $firstCollection = new Collection(['foo' => 'bar']);
-        $secondCollection = new Collection($firstCollection);
+        $firstCollection = new $collection(['foo' => 'bar']);
+        $secondCollection = new $collection($firstCollection);
         $this->assertEquals(['foo' => 'bar'], $secondCollection->all());
     }
 
-    public function testConstructMethodFromArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMethodFromArray($collection)
     {
-        $collection = new Collection(['foo' => 'bar']);
-        $this->assertEquals(['foo' => 'bar'], $collection->all());
+        $data = new $collection(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $data->all());
     }
 
-    public function testConstructMethodFromObject()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConstructMethodFromObject($collection)
     {
         $object = new stdClass;
         $object->foo = 'bar';
-        $collection = new Collection($object);
-        $this->assertEquals(['foo' => 'bar'], $collection->all());
+        $data = new $collection($object);
+        $this->assertEquals(['foo' => 'bar'], $data->all());
     }
 
-    public function testSplice()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplice($collection)
     {
-        $data = new Collection(['foo', 'baz']);
+        $data = new $collection(['foo', 'baz']);
         $data->splice(1);
         $this->assertEquals(['foo'], $data->all());
 
-        $data = new Collection(['foo', 'baz']);
+        $data = new $collection(['foo', 'baz']);
         $data->splice(1, 0, 'bar');
         $this->assertEquals(['foo', 'bar', 'baz'], $data->all());
 
-        $data = new Collection(['foo', 'baz']);
+        $data = new $collection(['foo', 'baz']);
         $data->splice(1, 1);
         $this->assertEquals(['foo'], $data->all());
 
-        $data = new Collection(['foo', 'baz']);
+        $data = new $collection(['foo', 'baz']);
         $cut = $data->splice(1, 1, 'bar');
         $this->assertEquals(['foo', 'bar'], $data->all());
         $this->assertEquals(['baz'], $cut->all());
     }
 
-    public function testGetPluckValueWithAccessors()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetPluckValueWithAccessors($collection)
     {
         $model = new TestAccessorEloquentTestStub(['some' => 'foo']);
         $modelTwo = new TestAccessorEloquentTestStub(['some' => 'bar']);
-        $data = new Collection([$model, $modelTwo]);
+        $data = new $collection([$model, $modelTwo]);
 
         $this->assertEquals(['foo', 'bar'], $data->pluck('some')->all());
     }
 
-    public function testMap()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMap($collection)
     {
-        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data = new $collection(['first' => 'taylor', 'last' => 'otwell']);
         $data = $data->map(function ($item, $key) {
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
-    public function testMapSpread()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapSpread($collection)
     {
-        $c = new Collection([[1, 'a'], [2, 'b']]);
+        $c = new $collection([[1, 'a'], [2, 'b']]);
 
         $result = $c->mapSpread(function ($number, $character) {
             return "{$number}-{$character}";
@@ -1598,16 +2004,19 @@ class SupportCollectionTest extends TestCase
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
 
-        $c = new Collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
+        $c = new $collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
         $result = $c->mapSpread(function ($number, $character, $key) {
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
     }
 
-    public function testFlatMap()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testFlatMap($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
             ['name' => 'adam', 'hobbies' => ['music', 'powerlifting']],
         ]);
@@ -1617,9 +2026,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
     }
 
-    public function testMapToDictionary()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapToDictionary($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['id' => 1, 'name' => 'A'],
             ['id' => 2, 'name' => 'B'],
             ['id' => 3, 'name' => 'C'],
@@ -1630,14 +2042,17 @@ class SupportCollectionTest extends TestCase
             return [$item['name'] => $item['id']];
         });
 
-        $this->assertInstanceOf(Collection::class, $groups);
+        $this->assertInstanceOf($collection, $groups);
         $this->assertEquals(['A' => [1], 'B' => [2, 4], 'C' => [3]], $groups->toArray());
-        $this->assertIsArray($groups['A']);
+        $this->assertIsArray($groups->get('A'));
     }
 
-    public function testMapToDictionaryWithNumericKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapToDictionaryWithNumericKeys($collection)
     {
-        $data = new Collection([1, 2, 3, 2, 1]);
+        $data = new $collection([1, 2, 3, 2, 1]);
 
         $groups = $data->mapToDictionary(function ($item, $key) {
             return [$item => $key];
@@ -1646,9 +2061,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
     }
 
-    public function testMapToGroups()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapToGroups($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['id' => 1, 'name' => 'A'],
             ['id' => 2, 'name' => 'B'],
             ['id' => 3, 'name' => 'C'],
@@ -1659,14 +2077,17 @@ class SupportCollectionTest extends TestCase
             return [$item['name'] => $item['id']];
         });
 
-        $this->assertInstanceOf(Collection::class, $groups);
+        $this->assertInstanceOf($collection, $groups);
         $this->assertEquals(['A' => [1], 'B' => [2, 4], 'C' => [3]], $groups->toArray());
-        $this->assertInstanceOf(Collection::class, $groups['A']);
+        $this->assertInstanceOf($collection, $groups->get('A'));
     }
 
-    public function testMapToGroupsWithNumericKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapToGroupsWithNumericKeys($collection)
     {
-        $data = new Collection([1, 2, 3, 2, 1]);
+        $data = new $collection([1, 2, 3, 2, 1]);
 
         $groups = $data->mapToGroups(function ($item, $key) {
             return [$item => $key];
@@ -1675,9 +2096,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [0, 4], 2 => [1, 3], 3 => [2]], $groups->toArray());
     }
 
-    public function testMapWithKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapWithKeys($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['name' => 'Blastoise', 'type' => 'Water', 'idx' => 9],
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
@@ -1691,9 +2115,12 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysIntegerKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapWithKeysIntegerKeys($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['id' => 1, 'name' => 'A'],
             ['id' => 3, 'name' => 'B'],
             ['id' => 2, 'name' => 'C'],
@@ -1707,9 +2134,12 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysMultipleRows()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapWithKeysMultipleRows($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['id' => 1, 'name' => 'A'],
             ['id' => 2, 'name' => 'B'],
             ['id' => 3, 'name' => 'C'],
@@ -1730,9 +2160,12 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapWithKeysCallbackKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapWithKeysCallbackKey($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             3 => ['id' => 1, 'name' => 'A'],
             5 => ['id' => 3, 'name' => 'B'],
             4 => ['id' => 2, 'name' => 'C'],
@@ -1746,21 +2179,27 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testMapInto()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapInto($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             'first', 'second',
         ]);
 
         $data = $data->mapInto(TestCollectionMapIntoObject::class);
 
-        $this->assertEquals('first', $data[0]->value);
-        $this->assertEquals('second', $data[1]->value);
+        $this->assertEquals('first', $data->get(0)->value);
+        $this->assertEquals('second', $data->get(1)->value);
     }
 
-    public function testNth()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testNth($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             6 => 'a',
             4 => 'b',
             7 => 'c',
@@ -1775,9 +2214,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['d'], $data->nth(4, 3)->all());
     }
 
-    public function testMapWithKeysOverwritingKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMapWithKeysOverwritingKeys($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['id' => 1, 'name' => 'A'],
             ['id' => 2, 'name' => 'B'],
             ['id' => 1, 'name' => 'C'],
@@ -1794,18 +2236,24 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    public function testTransform()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTransform($collection)
     {
-        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data = new $collection(['first' => 'taylor', 'last' => 'otwell']);
         $data->transform(function ($item, $key) {
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
     }
 
-    public function testGroupByAttribute()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByAttribute($collection)
     {
-        $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+        $data = new $collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
         $result = $data->groupBy('rating');
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
@@ -1814,9 +2262,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
-    public function testGroupByAttributePreservingKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByAttributePreservingKeys($collection)
     {
-        $data = new Collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
+        $data = new $collection([10 => ['rating' => 1, 'url' => '1'],  20 => ['rating' => 1, 'url' => '1'],  30 => ['rating' => 2, 'url' => '2']]);
 
         $result = $data->groupBy('rating', true);
 
@@ -1828,9 +2279,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveSingleGroup()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByClosureWhereItemsHaveSingleGroup($collection)
     {
-        $data = new Collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
+        $data = new $collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
         $result = $data->groupBy(function ($item) {
             return $item['rating'];
@@ -1839,9 +2293,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1 => [['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1']], 2 => [['rating' => 2, 'url' => '2']]], $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByClosureWhereItemsHaveSingleGroupPreservingKeys($collection)
     {
-        $data = new Collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
+        $data = new $collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
 
         $result = $data->groupBy(function ($item) {
             return $item['rating'];
@@ -1855,9 +2312,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveMultipleGroups()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByClosureWhereItemsHaveMultipleGroups($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
             ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
             ['user' => 3, 'roles' => ['Role_1']],
@@ -1884,9 +2344,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByClosureWhereItemsHaveMultipleGroupsPreservingKeys($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             10 => ['user' => 1, 'roles' => ['Role_1', 'Role_3']],
             20 => ['user' => 2, 'roles' => ['Role_1', 'Role_2']],
             30 => ['user' => 3, 'roles' => ['Role_1']],
@@ -1913,9 +2376,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testGroupByMultiLevelAndClosurePreservingKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGroupByMultiLevelAndClosurePreservingKeys($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             10 => ['user' => 1, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_3']],
             20 => ['user' => 2, 'skilllevel' => 1, 'roles' => ['Role_1', 'Role_2']],
             30 => ['user' => 3, 'skilllevel' => 2, 'roles' => ['Role_1']],
@@ -1955,9 +2421,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals($expected_result, $result->toArray());
     }
 
-    public function testKeyByAttribute()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeyByAttribute($collection)
     {
-        $data = new Collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);
+        $data = new $collection([['rating' => 1, 'name' => '1'], ['rating' => 2, 'name' => '2'], ['rating' => 3, 'name' => '3']]);
 
         $result = $data->keyBy('rating');
         $this->assertEquals([1 => ['rating' => 1, 'name' => '1'], 2 => ['rating' => 2, 'name' => '2'], 3 => ['rating' => 3, 'name' => '3']], $result->all());
@@ -1968,9 +2437,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([2 => ['rating' => 1, 'name' => '1'], 4 => ['rating' => 2, 'name' => '2'], 6 => ['rating' => 3, 'name' => '3']], $result->all());
     }
 
-    public function testKeyByClosure()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeyByClosure($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
         ]);
@@ -1983,14 +2455,17 @@ class SupportCollectionTest extends TestCase
         ], $result->all());
     }
 
-    public function testKeyByObject()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeyByObject($collection)
     {
-        $data = new Collection([
+        $data = new $collection([
             ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
         ]);
-        $result = $data->keyBy(function ($item, $key) {
-            return new Collection([$key, $item['firstname'], $item['lastname']]);
+        $result = $data->keyBy(function ($item, $key) use ($collection) {
+            return new $collection([$key, $item['firstname'], $item['lastname']]);
         });
         $this->assertEquals([
             '[0,"Taylor","Otwell"]' => ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
@@ -1998,27 +2473,30 @@ class SupportCollectionTest extends TestCase
         ], $result->all());
     }
 
-    public function testContains()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContains($collection)
     {
-        $c = new Collection([1, 3, 5]);
+        $c = new $collection([1, 3, 5]);
 
         $this->assertTrue($c->contains(1));
         $this->assertTrue($c->contains('1'));
         $this->assertFalse($c->contains(2));
         $this->assertFalse($c->contains('2'));
 
-        $c = new Collection(['1']);
+        $c = new $collection(['1']);
         $this->assertTrue($c->contains('1'));
         $this->assertTrue($c->contains(1));
 
-        $c = new Collection([null]);
+        $c = new $collection([null]);
         $this->assertTrue($c->contains(false));
         $this->assertTrue($c->contains(null));
         $this->assertTrue($c->contains([]));
         $this->assertTrue($c->contains(0));
         $this->assertTrue($c->contains(''));
 
-        $c = new Collection([0]);
+        $c = new $collection([0]);
         $this->assertTrue($c->contains(0));
         $this->assertTrue($c->contains('0'));
         $this->assertTrue($c->contains(false));
@@ -2031,23 +2509,23 @@ class SupportCollectionTest extends TestCase
             return $value > 5;
         }));
 
-        $c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => 5]]);
 
         $this->assertTrue($c->contains('v', 1));
         $this->assertFalse($c->contains('v', 2));
 
-        $c = new Collection(['date', 'class', (object) ['foo' => 50]]);
+        $c = new $collection(['date', 'class', (object) ['foo' => 50]]);
 
         $this->assertTrue($c->contains('date'));
         $this->assertTrue($c->contains('class'));
         $this->assertFalse($c->contains('foo'));
 
-        $c = new Collection([['a' => false, 'b' => false], ['a' => true, 'b' => false]]);
+        $c = new $collection([['a' => false, 'b' => false], ['a' => true, 'b' => false]]);
 
         $this->assertTrue($c->contains->a);
         $this->assertFalse($c->contains->b);
 
-        $c = new Collection([
+        $c = new $collection([
             null, 1, 2,
         ]);
 
@@ -2056,9 +2534,12 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testSome()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSome($collection)
     {
-        $c = new Collection([1, 3, 5]);
+        $c = new $collection([1, 3, 5]);
 
         $this->assertTrue($c->some(1));
         $this->assertFalse($c->some(2));
@@ -2069,23 +2550,23 @@ class SupportCollectionTest extends TestCase
             return $value > 5;
         }));
 
-        $c = new Collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => 5]]);
 
         $this->assertTrue($c->some('v', 1));
         $this->assertFalse($c->some('v', 2));
 
-        $c = new Collection(['date', 'class', (object) ['foo' => 50]]);
+        $c = new $collection(['date', 'class', (object) ['foo' => 50]]);
 
         $this->assertTrue($c->some('date'));
         $this->assertTrue($c->some('class'));
         $this->assertFalse($c->some('foo'));
 
-        $c = new Collection([['a' => false, 'b' => false], ['a' => true, 'b' => false]]);
+        $c = new $collection([['a' => false, 'b' => false], ['a' => true, 'b' => false]]);
 
         $this->assertTrue($c->some->a);
         $this->assertFalse($c->some->b);
 
-        $c = new Collection([
+        $c = new $collection([
             null, 1, 2,
         ]);
 
@@ -2094,9 +2575,12 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testContainsStrict()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsStrict($collection)
     {
-        $c = new Collection([1, 3, 5, '02']);
+        $c = new $collection([1, 3, 5, '02']);
 
         $this->assertTrue($c->containsStrict(1));
         $this->assertFalse($c->containsStrict('1'));
@@ -2110,19 +2594,19 @@ class SupportCollectionTest extends TestCase
             return $value > 5;
         }));
 
-        $c = new Collection([0]);
+        $c = new $collection([0]);
         $this->assertTrue($c->containsStrict(0));
         $this->assertFalse($c->containsStrict('0'));
 
         $this->assertFalse($c->containsStrict(false));
         $this->assertFalse($c->containsStrict(null));
 
-        $c = new Collection([1, null]);
+        $c = new $collection([1, null]);
         $this->assertTrue($c->containsStrict(null));
         $this->assertFalse($c->containsStrict(0));
         $this->assertFalse($c->containsStrict(false));
 
-        $c = new Collection([['v' => 1], ['v' => 3], ['v' => '04'], ['v' => 5]]);
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => '04'], ['v' => 5]]);
 
         $this->assertTrue($c->containsStrict('v', 1));
         $this->assertFalse($c->containsStrict('v', 2));
@@ -2130,7 +2614,7 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->containsStrict('v', 4));
         $this->assertTrue($c->containsStrict('v', '04'));
 
-        $c = new Collection(['date', 'class', (object) ['foo' => 50], '']);
+        $c = new $collection(['date', 'class', (object) ['foo' => 50], '']);
 
         $this->assertTrue($c->containsStrict('date'));
         $this->assertTrue($c->containsStrict('class'));
@@ -2139,9 +2623,12 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->containsStrict(''));
     }
 
-    public function testContainsWithOperator()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testContainsWithOperator($collection)
     {
-        $c = new Collection([['v' => 1], ['v' => 3], ['v' => '4'], ['v' => 5]]);
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => '4'], ['v' => 5]]);
 
         $this->assertTrue($c->contains('v', '=', 4));
         $this->assertTrue($c->contains('v', '==', 4));
@@ -2149,32 +2636,44 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->contains('v', '>', 4));
     }
 
-    public function testGettingSumFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGettingSumFromCollection($collection)
     {
-        $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
+        $c = new $collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
         $this->assertEquals(100, $c->sum('foo'));
 
-        $c = new Collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
+        $c = new $collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
         $this->assertEquals(100, $c->sum(function ($i) {
             return $i->foo;
         }));
     }
 
-    public function testCanSumValuesWithoutACallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCanSumValuesWithoutACallback($collection)
     {
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals(15, $c->sum());
     }
 
-    public function testGettingSumFromEmptyCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGettingSumFromEmptyCollection($collection)
     {
-        $c = new Collection;
+        $c = new $collection;
         $this->assertEquals(0, $c->sum('foo'));
     }
 
-    public function testValueRetrieverAcceptsDotNotation()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValueRetrieverAcceptsDotNotation($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             (object) ['id' => 1, 'foo' => ['bar' => 'B']], (object) ['id' => 2, 'foo' => ['bar' => 'A']],
         ]);
 
@@ -2203,56 +2702,65 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('foo', $value);
     }
 
-    public function testRejectRemovesElementsPassingTruthTest()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRejectRemovesElementsPassingTruthTest($collection)
     {
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo'], $c->reject('bar')->values()->all());
 
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo'], $c->reject(function ($v) {
             return $v == 'bar';
         })->values()->all());
 
-        $c = new Collection(['foo', null]);
+        $c = new $collection(['foo', null]);
         $this->assertEquals(['foo'], $c->reject(null)->values()->all());
 
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $c->reject('baz')->values()->all());
 
-        $c = new Collection(['foo', 'bar']);
+        $c = new $collection(['foo', 'bar']);
         $this->assertEquals(['foo', 'bar'], $c->reject(function ($v) {
             return $v == 'baz';
         })->values()->all());
 
-        $c = new Collection(['id' => 1, 'primary' => 'foo', 'secondary' => 'bar']);
+        $c = new $collection(['id' => 1, 'primary' => 'foo', 'secondary' => 'bar']);
         $this->assertEquals(['primary' => 'foo', 'secondary' => 'bar'], $c->reject(function ($item, $key) {
             return $key == 'id';
         })->all());
     }
 
-    public function testRejectWithoutAnArgumentRemovesTruthyValues()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRejectWithoutAnArgumentRemovesTruthyValues($collection)
     {
-        $collection1 = new Collection([
+        $data1 = new $collection([
             false,
             true,
-            new Collection(),
+            new $collection(),
             0,
         ]);
-        $this->assertSame([0 => false, 3 => 0], $collection1->reject()->all());
+        $this->assertSame([0 => false, 3 => 0], $data1->reject()->all());
 
-        $collection2 = new Collection([
+        $data2 = new $collection([
             'a' => true,
             'b' => true,
             'c' => true,
         ]);
         $this->assertTrue(
-            $collection2->reject()->isEmpty()
+            $data2->reject()->isEmpty()
         );
     }
 
-    public function testSearchReturnsIndexOfFirstFoundItem()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSearchReturnsIndexOfFirstFoundItem($collection)
     {
-        $c = new Collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
+        $c = new $collection([1, 2, 3, 4, 5, 2, 5, 'foo' => 'bar']);
 
         $this->assertEquals(1, $c->search(2));
         $this->assertEquals(1, $c->search('2'));
@@ -2265,9 +2773,12 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testSearchInStrictMode()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSearchInStrictMode($collection)
     {
-        $c = new Collection([false, 0, 1, [], '']);
+        $c = new $collection([false, 0, 1, [], '']);
         $this->assertFalse($c->search('false', true));
         $this->assertFalse($c->search('1', true));
         $this->assertEquals(0, $c->search(false, true));
@@ -2277,9 +2788,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(4, $c->search('', true));
     }
 
-    public function testSearchReturnsFalseWhenItemIsNotFound()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSearchReturnsFalseWhenItemIsNotFound($collection)
     {
-        $c = new Collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
+        $c = new $collection([1, 2, 3, 4, 5, 'foo' => 'bar']);
 
         $this->assertFalse($c->search(6));
         $this->assertFalse($c->search('foo'));
@@ -2291,130 +2805,154 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
-    public function testKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testKeys($collection)
     {
-        $c = new Collection(['name' => 'taylor', 'framework' => 'laravel']);
+        $c = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['name', 'framework'], $c->keys()->all());
     }
 
-    public function testPaginate()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPaginate($collection)
     {
-        $c = new Collection(['one', 'two', 'three', 'four']);
+        $c = new $collection(['one', 'two', 'three', 'four']);
         $this->assertEquals(['one', 'two'], $c->forPage(0, 2)->all());
         $this->assertEquals(['one', 'two'], $c->forPage(1, 2)->all());
         $this->assertEquals([2 => 'three', 3 => 'four'], $c->forPage(2, 2)->all());
         $this->assertEquals([], $c->forPage(3, 2)->all());
     }
 
-    public function testPrepend()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPrepend($collection)
     {
-        $c = new Collection(['one', 'two', 'three', 'four']);
+        $c = new $collection(['one', 'two', 'three', 'four']);
         $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $c->prepend('zero')->all());
 
-        $c = new Collection(['one' => 1, 'two' => 2]);
+        $c = new $collection(['one' => 1, 'two' => 2]);
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $c->prepend(0, 'zero')->all());
     }
 
-    public function testZip()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testZip($collection)
     {
-        $c = new Collection([1, 2, 3]);
-        $c = $c->zip(new Collection([4, 5, 6]));
-        $this->assertInstanceOf(Collection::class, $c);
-        $this->assertInstanceOf(Collection::class, $c[0]);
-        $this->assertInstanceOf(Collection::class, $c[1]);
-        $this->assertInstanceOf(Collection::class, $c[2]);
+        $c = new $collection([1, 2, 3]);
+        $c = $c->zip(new $collection([4, 5, 6]));
+        $this->assertInstanceOf($collection, $c);
+        $this->assertInstanceOf($collection, $c->get(0));
+        $this->assertInstanceOf($collection, $c->get(1));
+        $this->assertInstanceOf($collection, $c->get(2));
         $this->assertCount(3, $c);
-        $this->assertEquals([1, 4], $c[0]->all());
-        $this->assertEquals([2, 5], $c[1]->all());
-        $this->assertEquals([3, 6], $c[2]->all());
+        $this->assertEquals([1, 4], $c->get(0)->all());
+        $this->assertEquals([2, 5], $c->get(1)->all());
+        $this->assertEquals([3, 6], $c->get(2)->all());
 
-        $c = new Collection([1, 2, 3]);
+        $c = new $collection([1, 2, 3]);
         $c = $c->zip([4, 5, 6], [7, 8, 9]);
         $this->assertCount(3, $c);
-        $this->assertEquals([1, 4, 7], $c[0]->all());
-        $this->assertEquals([2, 5, 8], $c[1]->all());
-        $this->assertEquals([3, 6, 9], $c[2]->all());
+        $this->assertEquals([1, 4, 7], $c->get(0)->all());
+        $this->assertEquals([2, 5, 8], $c->get(1)->all());
+        $this->assertEquals([3, 6, 9], $c->get(2)->all());
 
-        $c = new Collection([1, 2, 3]);
+        $c = new $collection([1, 2, 3]);
         $c = $c->zip([4, 5, 6], [7]);
         $this->assertCount(3, $c);
-        $this->assertEquals([1, 4, 7], $c[0]->all());
-        $this->assertEquals([2, 5, null], $c[1]->all());
-        $this->assertEquals([3, 6, null], $c[2]->all());
+        $this->assertEquals([1, 4, 7], $c->get(0)->all());
+        $this->assertEquals([2, 5, null], $c->get(1)->all());
+        $this->assertEquals([3, 6, null], $c->get(2)->all());
     }
 
-    public function testPadPadsArrayWithValue()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPadPadsArrayWithValue($collection)
     {
-        $c = new Collection([1, 2, 3]);
+        $c = new $collection([1, 2, 3]);
         $c = $c->pad(4, 0);
         $this->assertEquals([1, 2, 3, 0], $c->all());
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $c = $c->pad(4, 0);
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
 
-        $c = new Collection([1, 2, 3]);
+        $c = new $collection([1, 2, 3]);
         $c = $c->pad(-4, 0);
         $this->assertEquals([0, 1, 2, 3], $c->all());
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $c = $c->pad(-4, 0);
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
 
-    public function testGettingMaxItemsFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGettingMaxItemsFromCollection($collection)
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(20, $c->max(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(20, $c->max('foo'));
         $this->assertEquals(20, $c->max->foo);
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new $collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(20, $c->max('foo'));
         $this->assertEquals(20, $c->max->foo);
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals(5, $c->max());
 
-        $c = new Collection;
+        $c = new $collection;
         $this->assertNull($c->max());
     }
 
-    public function testGettingMinItemsFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGettingMinItemsFromCollection($collection)
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(10, $c->min(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new $collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
 
-        $c = new Collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
+        $c = new $collection([['foo' => 10], ['foo' => 20], ['foo' => null]]);
         $this->assertEquals(10, $c->min('foo'));
         $this->assertEquals(10, $c->min->foo);
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals(1, $c->min());
 
-        $c = new Collection([1, null, 3, 4, 5]);
+        $c = new $collection([1, null, 3, 4, 5]);
         $this->assertEquals(1, $c->min());
 
-        $c = new Collection([0, 1, 2, 3, 4]);
+        $c = new $collection([0, 1, 2, 3, 4]);
         $this->assertEquals(0, $c->min());
 
-        $c = new Collection;
+        $c = new $collection;
         $this->assertNull($c->min());
     }
 
-    public function testOnly()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testOnly($collection)
     {
-        $data = new Collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
+        $data = new $collection(['first' => 'Taylor', 'last' => 'Otwell', 'email' => 'taylorotwell@gmail.com']);
 
         $this->assertEquals($data->all(), $data->only(null)->all());
         $this->assertEquals(['first' => 'Taylor'], $data->only(['first', 'missing'])->all());
@@ -2426,36 +2964,42 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['first' => 'Taylor', 'email' => 'taylorotwell@gmail.com'], $data->only(collect(['first', 'email']))->all());
     }
 
-    public function testGettingAvgItemsFromCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGettingAvgItemsFromCollection($collection)
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(15, $c->avg(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);
 
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20], (object) ['foo' => null]]);
+        $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20], (object) ['foo' => null]]);
         $this->assertEquals(15, $c->avg(function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);
 
-        $c = new Collection([['foo' => 10], ['foo' => 20]]);
+        $c = new $collection([['foo' => 10], ['foo' => 20]]);
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);
 
-        $c = new Collection([1, 2, 3, 4, 5]);
+        $c = new $collection([1, 2, 3, 4, 5]);
         $this->assertEquals(3, $c->avg());
 
-        $c = new Collection;
+        $c = new $collection;
         $this->assertNull($c->avg());
     }
 
-    public function testJsonSerialize()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testJsonSerialize($collection)
     {
-        $c = new Collection([
+        $c = new $collection([
             new TestArrayableObject,
             new TestJsonableObject,
             new TestJsonSerializeObject,
@@ -2470,7 +3014,10 @@ class SupportCollectionTest extends TestCase
         ], $c->jsonSerialize());
     }
 
-    public function testCombineWithArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCombineWithArray($collection)
     {
         $expected = [
             1 => 4,
@@ -2478,13 +3025,16 @@ class SupportCollectionTest extends TestCase
             3 => 6,
         ];
 
-        $c = new Collection(array_keys($expected));
+        $c = new $collection(array_keys($expected));
         $actual = $c->combine(array_values($expected))->toArray();
 
         $this->assertSame($expected, $actual);
     }
 
-    public function testCombineWithCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCombineWithCollection($collection)
     {
         $expected = [
             1 => 4,
@@ -2492,14 +3042,17 @@ class SupportCollectionTest extends TestCase
             3 => 6,
         ];
 
-        $keyCollection = new Collection(array_keys($expected));
-        $valueCollection = new Collection(array_values($expected));
+        $keyCollection = new $collection(array_keys($expected));
+        $valueCollection = new $collection(array_values($expected));
         $actual = $keyCollection->combine($valueCollection)->toArray();
 
         $this->assertSame($expected, $actual);
     }
 
-    public function testConcatWithArray()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConcatWithArray($collection)
     {
         $expected = [
             0 => 4,
@@ -2516,15 +3069,18 @@ class SupportCollectionTest extends TestCase
             11 => 'Laroe',
         ];
 
-        $collection = new Collection([4, 5, 6]);
-        $collection = $collection->concat(['a', 'b', 'c']);
-        $collection = $collection->concat(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
-        $actual = $collection->concat(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'])->toArray();
+        $data = new $collection([4, 5, 6]);
+        $data = $data->concat(['a', 'b', 'c']);
+        $data = $data->concat(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $actual = $data->concat(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'])->toArray();
 
         $this->assertSame($expected, $actual);
     }
 
-    public function testConcatWithCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testConcatWithCollection($collection)
     {
         $expected = [
             0 => 4,
@@ -2541,9 +3097,9 @@ class SupportCollectionTest extends TestCase
             11 => 'Laroe',
         ];
 
-        $firstCollection = new Collection([4, 5, 6]);
-        $secondCollection = new Collection(['a', 'b', 'c']);
-        $thirdCollection = new Collection(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $firstCollection = new $collection([4, 5, 6]);
+        $secondCollection = new $collection(['a', 'b', 'c']);
+        $thirdCollection = new $collection(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
         $firstCollection = $firstCollection->concat($secondCollection);
         $firstCollection = $firstCollection->concat($thirdCollection);
         $actual = $firstCollection->concat($thirdCollection)->toArray();
@@ -2551,351 +3107,454 @@ class SupportCollectionTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testReduce()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testReduce($collection)
     {
-        $data = new Collection([1, 2, 3]);
+        $data = new $collection([1, 2, 3]);
         $this->assertEquals(6, $data->reduce(function ($carry, $element) {
             return $carry += $element;
         }));
     }
 
-    public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testRandomThrowsAnExceptionUsingAmountBiggerThanCollectionSize($collection)
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $data = new Collection([1, 2, 3]);
+        $data = new $collection([1, 2, 3]);
         $data->random(4);
     }
 
-    public function testPipe()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPipe($collection)
     {
-        $collection = new Collection([1, 2, 3]);
+        $data = new $collection([1, 2, 3]);
 
-        $this->assertEquals(6, $collection->pipe(function ($collection) {
-            return $collection->sum();
+        $this->assertEquals(6, $data->pipe(function ($data) {
+            return $data->sum();
         }));
     }
 
-    public function testMedianValueWithArrayCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMedianValueWithArrayCollection($collection)
     {
-        $collection = new Collection([1, 2, 2, 4]);
+        $data = new $collection([1, 2, 2, 4]);
 
-        $this->assertEquals(2, $collection->median());
+        $this->assertEquals(2, $data->median());
     }
 
-    public function testMedianValueByKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMedianValueByKey($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             (object) ['foo' => 1],
             (object) ['foo' => 2],
             (object) ['foo' => 2],
             (object) ['foo' => 4],
         ]);
-        $this->assertEquals(2, $collection->median('foo'));
+        $this->assertEquals(2, $data->median('foo'));
     }
 
-    public function testMedianOnCollectionWithNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMedianOnCollectionWithNull($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             (object) ['foo' => 1],
             (object) ['foo' => 2],
             (object) ['foo' => 4],
             (object) ['foo' => null],
         ]);
-        $this->assertEquals(2, $collection->median('foo'));
+        $this->assertEquals(2, $data->median('foo'));
     }
 
-    public function testEvenMedianCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testEvenMedianCollection($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             (object) ['foo' => 0],
             (object) ['foo' => 3],
         ]);
-        $this->assertEquals(1.5, $collection->median('foo'));
+        $this->assertEquals(1.5, $data->median('foo'));
     }
 
-    public function testMedianOutOfOrderCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMedianOutOfOrderCollection($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             (object) ['foo' => 0],
             (object) ['foo' => 5],
             (object) ['foo' => 3],
         ]);
-        $this->assertEquals(3, $collection->median('foo'));
+        $this->assertEquals(3, $data->median('foo'));
     }
 
-    public function testMedianOnEmptyCollectionReturnsNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMedianOnEmptyCollectionReturnsNull($collection)
     {
-        $collection = new Collection;
-        $this->assertNull($collection->median());
+        $data = new $collection;
+        $this->assertNull($data->median());
     }
 
-    public function testModeOnNullCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testModeOnNullCollection($collection)
     {
-        $collection = new Collection;
-        $this->assertNull($collection->mode());
+        $data = new $collection;
+        $this->assertNull($data->mode());
     }
 
-    public function testMode()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testMode($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 4, 5]);
-        $this->assertEquals([4], $collection->mode());
+        $data = new $collection([1, 2, 3, 4, 4, 5]);
+        $this->assertEquals([4], $data->mode());
     }
 
-    public function testModeValueByKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testModeValueByKey($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             (object) ['foo' => 1],
             (object) ['foo' => 1],
             (object) ['foo' => 2],
             (object) ['foo' => 4],
         ]);
-        $this->assertEquals([1], $collection->mode('foo'));
+        $this->assertEquals([1], $data->mode('foo'));
     }
 
-    public function testWithMultipleModeValues()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWithMultipleModeValues($collection)
     {
-        $collection = new Collection([1, 2, 2, 1]);
-        $this->assertEquals([1, 2], $collection->mode());
+        $data = new $collection([1, 2, 2, 1]);
+        $this->assertEquals([1, 2], $data->mode());
     }
 
-    public function testSliceOffset()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceOffset($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([4, 5, 6, 7, 8], $collection->slice(3)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([4, 5, 6, 7, 8], $data->slice(3)->values()->toArray());
     }
 
-    public function testSliceNegativeOffset()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceNegativeOffset($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([6, 7, 8], $collection->slice(-3)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([6, 7, 8], $data->slice(-3)->values()->toArray());
     }
 
-    public function testSliceOffsetAndLength()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceOffsetAndLength($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([4, 5, 6], $collection->slice(3, 3)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([4, 5, 6], $data->slice(3, 3)->values()->toArray());
     }
 
-    public function testSliceOffsetAndNegativeLength()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceOffsetAndNegativeLength($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([4, 5, 6, 7], $collection->slice(3, -1)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([4, 5, 6, 7], $data->slice(3, -1)->values()->toArray());
     }
 
-    public function testSliceNegativeOffsetAndLength()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceNegativeOffsetAndLength($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([4, 5, 6], $collection->slice(-5, 3)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([4, 5, 6], $data->slice(-5, 3)->values()->toArray());
     }
 
-    public function testSliceNegativeOffsetAndNegativeLength()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSliceNegativeOffsetAndNegativeLength($collection)
     {
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8]);
-        $this->assertEquals([3, 4, 5, 6], $collection->slice(-6, -2)->values()->toArray());
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8]);
+        $this->assertEquals([3, 4, 5, 6], $data->slice(-6, -2)->values()->toArray());
     }
 
-    public function testCollectionFromTraversable()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollectionFromTraversable($collection)
     {
-        $collection = new Collection(new ArrayObject([1, 2, 3]));
-        $this->assertEquals([1, 2, 3], $collection->toArray());
+        $data = new $collection(new ArrayObject([1, 2, 3]));
+        $this->assertEquals([1, 2, 3], $data->toArray());
     }
 
-    public function testCollectionFromTraversableWithKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollectionFromTraversableWithKeys($collection)
     {
-        $collection = new Collection(new ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
-        $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $collection->toArray());
+        $data = new $collection(new ArrayObject(['foo' => 1, 'bar' => 2, 'baz' => 3]));
+        $this->assertEquals(['foo' => 1, 'bar' => 2, 'baz' => 3], $data->toArray());
     }
 
-    public function testSplitCollectionWithADivisableCount()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionWithADivisableCount($collection)
     {
-        $collection = new Collection(['a', 'b', 'c', 'd']);
+        $data = new $collection(['a', 'b', 'c', 'd']);
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd']],
-            $collection->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
 
-        $collection = new Collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        $data = new $collection([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         $this->assertEquals(
             [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
-            $collection->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
     }
 
-    public function testSplitCollectionWithAnUndivisableCount()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionWithAnUndivisableCount($collection)
     {
-        $collection = new Collection(['a', 'b', 'c']);
+        $data = new $collection(['a', 'b', 'c']);
 
         $this->assertEquals(
             [['a', 'b'], ['c']],
-            $collection->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
     }
 
-    public function testSplitCollectionWithCountLessThenDivisor()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionWithCountLessThenDivisor($collection)
     {
-        $collection = new Collection(['a']);
+        $data = new $collection(['a']);
 
         $this->assertEquals(
             [['a']],
-            $collection->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
     }
 
-    public function testSplitCollectionIntoThreeWithCountOfFour()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionIntoThreeWithCountOfFour($collection)
     {
-        $collection = new Collection(['a', 'b', 'c', 'd']);
+        $data = new $collection(['a', 'b', 'c', 'd']);
 
         $this->assertEquals(
             [['a', 'b'], ['c'], ['d']],
-            $collection->split(3)->map(function (Collection $chunk) {
+            $data->split(3)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
     }
 
-    public function testSplitCollectionIntoThreeWithCountOfFive()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionIntoThreeWithCountOfFive($collection)
     {
-        $collection = new Collection(['a', 'b', 'c', 'd', 'e']);
+        $data = new $collection(['a', 'b', 'c', 'd', 'e']);
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd'], ['e']],
-            $collection->split(3)->map(function (Collection $chunk) {
+            $data->split(3)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
     }
 
-    public function testSplitCollectionIntoSixWithCountOfTen()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitCollectionIntoSixWithCountOfTen($collection)
     {
-        $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+        $data = new $collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i'], ['j']],
-            $collection->split(6)->map(function (Collection $chunk) {
+            $data->split(6)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
     }
 
-    public function testSplitEmptyCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSplitEmptyCollection($collection)
     {
-        $collection = new Collection;
+        $data = new $collection;
 
         $this->assertEquals(
             [],
-            $collection->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
     }
 
-    public function testHigherOrderCollectionGroupBy()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderCollectionGroupBy($collection)
     {
-        $collection = collect([
+        $data = new $collection([
             new TestSupportCollectionHigherOrderItem,
             new TestSupportCollectionHigherOrderItem('TAYLOR'),
             new TestSupportCollectionHigherOrderItem('foo'),
         ]);
 
         $this->assertEquals([
-            'taylor' => [$collection[0]],
-            'TAYLOR' => [$collection[1]],
-            'foo' => [$collection[2]],
-        ], $collection->groupBy->name->toArray());
+            'taylor' => [$data->get(0)],
+            'TAYLOR' => [$data->get(1)],
+            'foo' => [$data->get(2)],
+        ], $data->groupBy->name->toArray());
 
         $this->assertEquals([
-            'TAYLOR' => [$collection[0], $collection[1]],
-            'FOO' => [$collection[2]],
-        ], $collection->groupBy->uppercase()->toArray());
+            'TAYLOR' => [$data->get(0), $data->get(1)],
+            'FOO' => [$data->get(2)],
+        ], $data->groupBy->uppercase()->toArray());
     }
 
-    public function testHigherOrderCollectionMap()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderCollectionMap($collection)
     {
         $person1 = (object) ['name' => 'Taylor'];
         $person2 = (object) ['name' => 'Yaz'];
 
-        $collection = collect([$person1, $person2]);
+        $data = new $collection([$person1, $person2]);
 
-        $this->assertEquals(['Taylor', 'Yaz'], $collection->map->name->toArray());
+        $this->assertEquals(['Taylor', 'Yaz'], $data->map->name->toArray());
 
-        $collection = collect([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
+        $data = new $collection([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
 
-        $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
+        $this->assertEquals(['TAYLOR', 'TAYLOR'], $data->each->uppercase()->map->name->toArray());
     }
 
-    public function testHigherOrderCollectionMapFromArrays()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderCollectionMapFromArrays($collection)
     {
         $person1 = ['name' => 'Taylor'];
         $person2 = ['name' => 'Yaz'];
 
-        $collection = collect([$person1, $person2]);
+        $data = new $collection([$person1, $person2]);
 
-        $this->assertEquals(['Taylor', 'Yaz'], $collection->map->name->toArray());
+        $this->assertEquals(['Taylor', 'Yaz'], $data->map->name->toArray());
 
-        $collection = collect([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
+        $data = new $collection([new TestSupportCollectionHigherOrderItem, new TestSupportCollectionHigherOrderItem]);
 
-        $this->assertEquals(['TAYLOR', 'TAYLOR'], $collection->each->uppercase()->map->name->toArray());
+        $this->assertEquals(['TAYLOR', 'TAYLOR'], $data->each->uppercase()->map->name->toArray());
     }
 
-    public function testPartition()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartition($collection)
     {
-        $collection = new Collection(range(1, 10));
+        $data = new $collection(range(1, 10));
 
-        [$firstPartition, $secondPartition] = $collection->partition(function ($i) {
+        [$firstPartition, $secondPartition] = $data->partition(function ($i) {
             return $i <= 5;
-        });
+        })->all();
 
         $this->assertEquals([1, 2, 3, 4, 5], $firstPartition->values()->toArray());
         $this->assertEquals([6, 7, 8, 9, 10], $secondPartition->values()->toArray());
     }
 
-    public function testPartitionCallbackWithKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartitionCallbackWithKey($collection)
     {
-        $collection = new Collection(['zero', 'one', 'two', 'three']);
+        $data = new $collection(['zero', 'one', 'two', 'three']);
 
-        [$even, $odd] = $collection->partition(function ($item, $index) {
+        [$even, $odd] = $data->partition(function ($item, $index) {
             return $index % 2 === 0;
-        });
+        })->all();
 
         $this->assertEquals(['zero', 'two'], $even->values()->toArray());
-
         $this->assertEquals(['one', 'three'], $odd->values()->toArray());
     }
 
-    public function testPartitionByKey()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartitionByKey($collection)
     {
-        $courses = new Collection([
+        $courses = new $collection([
             ['free' => true, 'title' => 'Basic'], ['free' => false, 'title' => 'Premium'],
         ]);
 
-        [$free, $premium] = $courses->partition('free');
+        [$free, $premium] = $courses->partition('free')->all();
 
         $this->assertSame([['free' => true, 'title' => 'Basic']], $free->values()->toArray());
-
         $this->assertSame([['free' => false, 'title' => 'Premium']], $premium->values()->toArray());
     }
 
-    public function testPartitionWithOperators()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartitionWithOperators($collection)
     {
-        $collection = new Collection([
+        $data = new $collection([
             ['name' => 'Tim', 'age' => 17],
             ['name' => 'Agatha', 'age' => 62],
             ['name' => 'Kristina', 'age' => 33],
             ['name' => 'Tim', 'age' => 41],
         ]);
 
-        [$tims, $others] = $collection->partition('name', 'Tim');
+        [$tims, $others] = $data->partition('name', 'Tim')->all();
 
         $this->assertEquals($tims->values()->all(), [
             ['name' => 'Tim', 'age' => 17],
@@ -2907,7 +3566,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Kristina', 'age' => 33],
         ]);
 
-        [$adults, $minors] = $collection->partition('age', '>=', 18);
+        [$adults, $minors] = $data->partition('age', '>=', 18)->all();
 
         $this->assertEquals($adults->values()->all(), [
             ['name' => 'Agatha', 'age' => 62],
@@ -2920,279 +3579,350 @@ class SupportCollectionTest extends TestCase
         ]);
     }
 
-    public function testPartitionPreservesKeys()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartitionPreservesKeys($collection)
     {
-        $courses = new Collection([
+        $courses = new $collection([
             'a' => ['free' => true], 'b' => ['free' => false], 'c' => ['free' => true],
         ]);
 
-        [$free, $premium] = $courses->partition('free');
+        [$free, $premium] = $courses->partition('free')->all();
 
         $this->assertSame(['a' => ['free' => true], 'c' => ['free' => true]], $free->toArray());
-
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
 
-    public function testPartitionEmptyCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPartitionEmptyCollection($collection)
     {
-        $collection = new Collection;
+        $data = new $collection;
 
-        $this->assertCount(2, $collection->partition(function () {
+        $this->assertCount(2, $data->partition(function () {
             return true;
         }));
     }
 
-    public function testHigherOrderPartition()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHigherOrderPartition($collection)
     {
-        $courses = new Collection([
+        $courses = new $collection([
             'a' => ['free' => true], 'b' => ['free' => false], 'c' => ['free' => true],
         ]);
 
-        [$free, $premium] = $courses->partition->free;
+        [$free, $premium] = $courses->partition->free->all();
 
         $this->assertSame(['a' => ['free' => true], 'c' => ['free' => true]], $free->toArray());
 
         $this->assertSame(['b' => ['free' => false]], $premium->toArray());
     }
 
-    public function testTap()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTap($collection)
     {
-        $collection = new Collection([1, 2, 3]);
+        $data = new $collection([1, 2, 3]);
 
         $fromTap = [];
-        $collection = $collection->tap(function ($collection) use (&$fromTap) {
-            $fromTap = $collection->slice(0, 1)->toArray();
+        $data = $data->tap(function ($data) use (&$fromTap) {
+            $fromTap = $data->slice(0, 1)->toArray();
         });
 
         $this->assertSame([1], $fromTap);
-        $this->assertSame([1, 2, 3], $collection->toArray());
+        $this->assertSame([1, 2, 3], $data->toArray());
     }
 
-    public function testWhen()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhen($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->when('adam', function ($collection, $newName) {
-            return $collection->push($newName);
+        $data->when('adam', function ($data, $newName) {
+            return $data->push($newName);
         });
 
-        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->when(false, function ($collection) {
-            return $collection->push('adam');
+        $data->when(false, function ($collection) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['michael', 'tom'], $collection->toArray());
+        $this->assertSame(['michael', 'tom'], $data->toArray());
     }
 
-    public function testWhenDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->when(false, function ($collection) {
-            return $collection->push('adam');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->when(false, function ($data) {
+            return $data->push('adam');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
     }
 
-    public function testWhenEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenEmpty($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->whenEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->whenEmpty(function ($collection) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['michael', 'tom'], $collection->toArray());
+        $this->assertSame(['michael', 'tom'], $data->toArray());
 
-        $collection = new Collection;
+        $data = new $collection;
 
-        $collection->whenEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->whenEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['adam'], $collection->toArray());
+        $this->assertSame(['adam'], $data->toArray());
     }
 
-    public function testWhenEmptyDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenEmptyDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->whenEmpty(function ($collection) {
-            return $collection->push('adam');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->whenEmpty(function ($data) {
+            return $data->push('adam');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
     }
 
-    public function testWhenNotEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenNotEmpty($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->whenNotEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->whenNotEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
-        $collection = new Collection;
+        $data = new $collection;
 
-        $collection->whenNotEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->whenNotEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame([], $collection->toArray());
+        $this->assertSame([], $data->toArray());
     }
 
-    public function testWhenNotEmptyDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenNotEmptyDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->whenNotEmpty(function ($collection) {
-            return $collection->push('adam');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->whenNotEmpty(function ($data) {
+            return $data->push('adam');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
     }
 
-    public function testUnless()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnless($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unless(false, function ($collection) {
-            return $collection->push('caleb');
+        $data->unless(false, function ($data) {
+            return $data->push('caleb');
         });
 
-        $this->assertSame(['michael', 'tom', 'caleb'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'caleb'], $data->toArray());
 
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unless(true, function ($collection) {
-            return $collection->push('caleb');
+        $data->unless(true, function ($data) {
+            return $data->push('caleb');
         });
 
-        $this->assertSame(['michael', 'tom'], $collection->toArray());
+        $this->assertSame(['michael', 'tom'], $data->toArray());
     }
 
-    public function testUnlessDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unless(true, function ($collection) {
-            return $collection->push('caleb');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->unless(true, function ($data) {
+            return $data->push('caleb');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
     }
 
-    public function testUnlessEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessEmpty($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unlessEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->unlessEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
-        $collection = new Collection;
+        $data = new $collection;
 
-        $collection->unlessEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->unlessEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame([], $collection->toArray());
+        $this->assertSame([], $data->toArray());
     }
 
-    public function testUnlessEmptyDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessEmptyDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unlessEmpty(function ($collection) {
-            return $collection->push('adam');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->unlessEmpty(function ($data) {
+            return $data->push('adam');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'adam'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
     }
 
-    public function testUnlessNotEmpty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessNotEmpty($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unlessNotEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->unlessNotEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['michael', 'tom'], $collection->toArray());
+        $this->assertSame(['michael', 'tom'], $data->toArray());
 
-        $collection = new Collection;
+        $data = new $collection;
 
-        $collection->unlessNotEmpty(function ($collection) {
-            return $collection->push('adam');
+        $data->unlessNotEmpty(function ($data) {
+            return $data->push('adam');
         });
 
-        $this->assertSame(['adam'], $collection->toArray());
+        $this->assertSame(['adam'], $data->toArray());
     }
 
-    public function testUnlessNotEmptyDefault()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessNotEmptyDefault($collection)
     {
-        $collection = new Collection(['michael', 'tom']);
+        $data = new $collection(['michael', 'tom']);
 
-        $collection->unlessNotEmpty(function ($collection) {
-            return $collection->push('adam');
-        }, function ($collection) {
-            return $collection->push('taylor');
+        $data->unlessNotEmpty(function ($data) {
+            return $data->push('adam');
+        }, function ($data) {
+            return $data->push('taylor');
         });
 
-        $this->assertSame(['michael', 'tom', 'taylor'], $collection->toArray());
+        $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
     }
 
-    public function testHasReturnsValidResults()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testHasReturnsValidResults($collection)
     {
-        $collection = new Collection(['foo' => 'one', 'bar' => 'two', 1 => 'three']);
-        $this->assertTrue($collection->has('foo'));
-        $this->assertTrue($collection->has('foo', 'bar', 1));
-        $this->assertFalse($collection->has('foo', 'bar', 1, 'baz'));
-        $this->assertFalse($collection->has('baz'));
+        $data = new $collection(['foo' => 'one', 'bar' => 'two', 1 => 'three']);
+        $this->assertTrue($data->has('foo'));
+        $this->assertTrue($data->has('foo', 'bar', 1));
+        $this->assertFalse($data->has('foo', 'bar', 1, 'baz'));
+        $this->assertFalse($data->has('baz'));
     }
 
-    public function testPutAddsItemToCollection()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testPutAddsItemToCollection($collection)
     {
-        $collection = new Collection;
-        $this->assertSame([], $collection->toArray());
-        $collection->put('foo', 1);
-        $this->assertSame(['foo' => 1], $collection->toArray());
-        $collection->put('bar', ['nested' => 'two']);
-        $this->assertSame(['foo' => 1, 'bar' => ['nested' => 'two']], $collection->toArray());
-        $collection->put('foo', 3);
-        $this->assertSame(['foo' => 3, 'bar' => ['nested' => 'two']], $collection->toArray());
+        $data = new $collection;
+        $this->assertSame([], $data->toArray());
+        $data->put('foo', 1);
+        $this->assertSame(['foo' => 1], $data->toArray());
+        $data->put('bar', ['nested' => 'two']);
+        $this->assertSame(['foo' => 1, 'bar' => ['nested' => 'two']], $data->toArray());
+        $data->put('foo', 3);
+        $this->assertSame(['foo' => 3, 'bar' => ['nested' => 'two']], $data->toArray());
     }
 
-    public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testItThrowsExceptionWhenTryingToAccessNoProxyProperty($collection)
     {
-        $collection = new Collection;
+        $data = new $collection;
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Property [foo] does not exist on this collection instance.');
-        $collection->foo;
+        $data->foo;
     }
 
-    public function testGetWithNullReturnsNull()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testGetWithNullReturnsNull($collection)
     {
-        $collection = new Collection([1, 2, 3]);
-        $this->assertNull($collection->get(null));
+        $data = new $collection([1, 2, 3]);
+        $this->assertNull($data->get(null));
+    }
+
+    /**
+     * Provides each collection class, respectively.
+     *
+     * @return array
+     */
+    public function collectionClassProvider()
+    {
+        return [
+            [Collection::class],
+        ];
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -269,6 +269,18 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo.array', 'bar.array'], $results);
     }
 
+    public function testLazyReturnsLazyCollection()
+    {
+        $data = new Collection([1, 2, 3, 4, 5]);
+
+        $lazy = $data->lazy();
+
+        $data->add(6);
+
+        $this->assertInstanceOf(LazyCollection::class, $lazy);
+        $this->assertSame([1, 2, 3, 4, 5], $lazy->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR adds a new `LazyCollection` class and an `Enumerable` interface.

This is similar to Swift's [`LazyCollection`](https://developer.apple.com/documentation/swift/lazycollection) and C#.NET's [`IEnumerable`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.ienumerable?view=netframework-4.8).

[Here's a pithy post](https://medium.com/developermind/lightning-read-1-lazy-collections-in-swift-fa997564c1a3) describing the benefits of lazy collections.

---

This PR is purely additive. It does not affect the current `Collection` class, and is **fully backwards compatible**.

---

# Motivation

The `Collection` class is one of the most [underappreciated](https://twitter.com/joseph_silber/status/1055584839213170689) tools in the Laravel toolchain. It allows you to declaratively chain methods using its fluent API, mapping, filtering, tranforming, sorting and reducing its values in an extremely readable format.

However, this comes with two downsides:

1. Every additional method invocation creates a new array. If you're dealing with a collection with thousands (or even millions) of items, reallocating and garbage collecting such a huge array at every method call can be quite taxing.

2. The `Collection` class only works with a static list of items. If the items are being streamed (from an API, from the DB, or from lines in a multi-GB file), the collection class as it stands can't help us.

# Explanation

1. Whereas the existing `Collection` class wraps a native array, the new `LazyCollection` class wraps a native iterator, while still providing most of the methods that we know and love from a regular collection:

    ```php
    LazyCollection::times(INF)
        ->map(function ($number) {
            return $number ** 3;
        })
        ->filter(function ($number) {
            return $number % 2;
        })
        ->take(100)
        ->all();

        // [1, 27, 125, 343, 729, 1331, ...]
    ```

    This starts off by creating a lazy collection that has an infinite number of elements, maps those numbers, filters them, and then only takes 100 of them. Since the collection is a lazy collection, starting off with an infitine amount of elements is not a problem. No elements are actually generated until we pull them out of the collection. Since we finished our chain with `->take(100)`, it will stop generating new values after it generated 100 items that satisfy the filter.

    This isn't really a very useful example, but it serves as a simple demonstration of what's possible.

2. Let's look at a more realistic example. Imagine a remote products API. We're looking for a specific product, but the API unfortunately only has a single, paginated list of products. Here's how we would write this using a lazy collection:

    ```php
    $products = new LazyCollection(function () {
        do {
            $page = 1;

            $response = Client::get('products', $page++);

            yield from $response['products'];
        } while($response['hasMore']);
    });

    $product = $products->where('itemNumber', $itemNumber)->first();
    ```

    Using a lazy collection, we nicely abstracted the pagination, and ended up dealing with a simple collection on our end.

    (BTW, the `Collection` class has a `whereFirst(...)` method, to get the first item matching the given check without having to spin through the whole collection. With a lazy collection, this is of no concern; calling `->where(...)->first()` will stop enumerating the values as soon as any item matches).

3. Here's another example. The [query builder's `cursor()` method](https://github.com/laravel/framework/blob/7a34b0b7e0c66f72ea9ace9b7dbbf3a2cfb82462/src/Illuminate/Database/Query/Builder.php#L2239-L2248) lets us iterate over the records in the database without pulling them out all at once. It currently returns a simple `Generator`, which is a little crude. We could easily change it to return a `LazyCollection`:

    ```php
    public function cursor()
    {
        if (is_null($this->columns)) {
            $this->columns = ['*'];
        }

        return new LazyCollection(function () {
            yield from $this->connection->cursor(
                $this->toSql(), $this->getBindings(), ! $this->useWritePdo
            );
        });
    }
    ```

    This would allow us to treat the result of a cursor the same way as a regular `Collection` instance:

    ```php
    $postIds = Post::cursor()
        ->filter(function ($post) {
            return Gate::can('view', $post);
        })
        ->pluck('id')
        ->take(20)
        ->all();
    ```

    This will get the IDs of the first 20 posts that the user may view. Doing this with a native generator would be a lot more code, and far less readable.

4. Another use-case would be reading the lines of a multi-GB log file. Now imagine every log is 4 lines long, so we want to be able to easily read 4 lines, pass it off to a value object, and inspect it.

    ```php
    LazyCollection::make(function () {
        $handle = fopen('log.txt', 'r');

        while (($line = fgets($handle)) !== false) {
            yield $line;
        }
    })
    ->chunk(4)
    ->map(function ($lines) {
        return LogEntry::fromLines($lines);
    })
    ->each(function ($logEntry) {
        // Do what you gotta do with $logEntry
    });
    ```

I can keep going, but I think I've made my point. Lazy collections are of immense use whenever we're not dealing with an existing (finite) set of items.

# Implementation

The way this PR implements lazy collections is as follows:

- Create [a new `LazyCollection` class](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/LazyCollection.php), which implements most of the methods available on the `Collection` class, with identical functionality.

- Create [a new `Enumerable` interface](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/Enumerable.php), so that both collection classes can adhere to the same contract.

- Create [a new `EnumeratesValues` trait](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/Traits/EnumeratesValues.php). This houses all of the methods that have an identical implementation for both collection classes.

- In order to reuse as much code as possible, the `LazyCollection` class has 4 types of methods:

    1. Those that have an identical implementation to the `Collection` class. These methods are actually in the `EnumeratesValues` trait, and are shared between the two classes.
    
    2. Those for which it has [its own implementation](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/LazyCollection.php#L159-L172).
    
    3. Those methods, such as [sorting](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/LazyCollection.php#L1131-L1134) and [grouping](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/LazyCollection.php#L465-L468), which cannot be done incrementally; you need the full dataset in order to tranform the collection. In these cases, the lazy collection will defer to the standard collection class for the actual operation, _but only when the values are actually enumerated_. So long as no values are being pulled out of the lazy collection, no operation will run prematurely.

    4. Those [methods that don't return a collection](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/src/Illuminate/Support/LazyCollection.php#L522-L525). For example, the `implode` method. In these cases, it simply calls that method on the standard collection and returns its value.

- The `SupportCollectionTest` has been [updated](https://github.com/laravel/framework/blob/05ed86339d2e6d99e383861d3a5ae7492069c6ba/tests/Support/SupportCollectionTest.php#L3947-L3953) to use [PHPUnit data providers](https://phpunit.readthedocs.io/en/8.3/writing-tests-for-phpunit.html?highlight=data%20provider#data-providers), to make sure that both collection classes are tested.

# Commits

For cleanliness, for organization, and **to ease review of this PR**, the commits have been thoughtfully constructed and compartmentalized:

1. [Create `Enumerable` contract](https://github.com/laravel/framework/pull/29415/commits/b5956364b861258bd9018de31e13a8a02c327936) - this commit simply creates the new `Enumerable` contract, which contains all methods that will be common to both collection classes. It also moves the additional interfaces from the `Collection`'s `implements` clause to the `Enumerable`'s `extends` clause.

2. [Extract reusable methods into the `EnumeratesValues` trait](https://github.com/laravel/framework/pull/29415/commits/69df53fbfd4d73574ef2d23e4fa1a33051c006e7) -  this commit creates a new `EnumeratesValues` trait, and moves many of the `Collection`'s methods into that trait. This trait will later be shared with the `LazyCollection` class.

3. [Support all Enumerables in proxy](https://github.com/laravel/framework/pull/29415/commits/de31e579487a4a100447f05be401c2e02440f0be) - This simply switches the typehint for the `HigherOrderCollectionProxy` class from `Collection` to `Enumerable`, so that it'll support both collection classes.

4. [Use `collectionClassProvider` to inject the collection class into each test](https://github.com/laravel/framework/pull/29415/commits/dd06f5641deebb4f0d6487d91590b02588d301db) - To prepare the tests to test both implementations, we'll use [PHPUnit data providers](https://phpunit.readthedocs.io/en/8.3/writing-tests-for-phpunit.html?highlight=data%20provider#data-providers) to inject the collection class (as a string) into each test method that should test both implementations. Without changing the actual tests, every method now instantiates the class being passed into it, instead of the hard-coded `Collection` class.

5. [Add Enumerable skip() method](https://github.com/laravel/framework/pull/29415/commits/8fa0f8584c10e91d218729831703ee0ccee4f787) - Since `skip` is an important method for lazy collections, we'll first add it here to the `Collection` class, the `Enumerable` interface, and the tests.

6. [Create `LazyCollection` class](https://github.com/laravel/framework/pull/29415/commits/c634fb15b31f63f6cfa7752319e711249d0ad31f) - Finally, after all this preparation, we can actually create the implementation for the `LazyCollection`. To test it, [we simply add it as an entry in the `collectionClassProvider` method](https://github.com/laravel/framework/blob/1f8f584a18f1e1c52c8bb7908158fedb09567c58/tests/Support/SupportCollectionTest.php#L3951), and now all existing tests will also test those methods against the `LazyCollection` implementation!

7. [Add `lazy()` method to standard collection](https://github.com/laravel/framework/pull/29415/commits/05ed86339d2e6d99e383861d3a5ae7492069c6ba) - Finally, we add a `lazy()` method to the `Collection` class, to easily get a lazy collection from a regular collection.

Phew! I do hope that if this is merged, these precious commits won't be squashed into oblivion :stuck_out_tongue: 