### PR TITLE
[5.8] Use isProduction for ConfirmableTrait

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -48,7 +48,7 @@ trait ConfirmableTrait
     protected function getDefaultConfirmCallback()
     {
         return function () {
-            return $this->getLaravel()->environment() === 'production';
+            return $this->getLaravel()->isProduction();
         };
     }
 }

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -108,10 +108,7 @@ class ApplicationDatabaseMigrationStub extends Application
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }
-    }
 
-    public function environment(...$environments)
-    {
-        return 'development';
+        $this['env'] = 'development';
     }
 }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -96,10 +96,7 @@ class ApplicationDatabaseRefreshStub extends Application
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }
-    }
 
-    public function environment(...$environments)
-    {
-        return 'development';
+        $this['env'] = 'development';
     }
 }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -60,10 +60,7 @@ class ApplicationDatabaseResetStub extends Application
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }
-    }
 
-    public function environment(...$environments)
-    {
-        return 'development';
+        $this['env'] = 'development';
     }
 }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -86,10 +86,7 @@ class ApplicationDatabaseRollbackStub extends Application
         foreach ($data as $abstract => $instance) {
             $this->instance($abstract, $instance);
         }
-    }
 
-    public function environment(...$environments)
-    {
-        return 'development';
+        $this['env'] = 'development';
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -29,7 +29,7 @@ class SeedCommandTest extends TestCase
 
         $container = m::mock(Container::class);
         $container->shouldReceive('call');
-        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('isProduction')->once()->andReturn(false);
         $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
             new OutputStyle($input, $output)


### PR DESCRIPTION
`isProduction` method was added to Application https://github.com/laravel/framework/pull/28602. So, we have to use this method for ConfirmableTrait to sync environment checking.
