### PR TITLE
[6.0] Quick fix for #29411

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     - php: 7.3
     - php: 7.3
       env: SETUP=lowest
+    - php: 7.4snapshot
+    - php: 7.4snapshot
+      env: SETUP=lowest
 
 cache:
   directories:

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -81,7 +81,7 @@ trait Macroable
         }
 
         if (static::$macros[$method] instanceof Closure) {
-            return call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
+            return @call_user_func_array(Closure::bind(static::$macros[$method], null, static::class), $parameters);
         }
 
         return call_user_func_array(static::$macros[$method], $parameters);
@@ -107,7 +107,7 @@ trait Macroable
         $macro = static::$macros[$method];
 
         if ($macro instanceof Closure) {
-            return call_user_func_array($macro->bindTo($this, static::class), $parameters);
+            return @call_user_func_array($macro->bindTo($this, static::class), $parameters);
         }
 
         return call_user_func_array($macro, $parameters);


### PR DESCRIPTION
PHP deprecate closure unbinding since PHP 7.4.0 and throws:
`Unbinding $this of closure is deprecated`

This is a temporary fix to let macros works on PHP 7.4