### PR TITLE
[6.0] Allow mutators and accessors to execute casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -343,26 +343,26 @@ trait HasAttributes
     {
         $value = $this->getAttributeFromArray($key);
 
-        // If the attribute has a get mutator, we will call that then return what
-        // it returns as the value, which is useful for transforming values on
-        // retrieval from the model to a form that is more useful for usage.
-        if ($this->hasGetMutator($key)) {
-            return $this->mutateAttribute($key, $value);
-        }
-
         // If the attribute exists within the cast array, we will convert it to
         // an appropriate native PHP type dependant upon the associated value
         // given with the key in the pair. Dayle made this comment line up.
         if ($this->hasCast($key)) {
-            return $this->castAttribute($key, $value);
+            $value = $this->castAttribute($key, $value);
         }
 
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
+        elseif (in_array($key, $this->getDates()) &&
             ! is_null($value)) {
-            return $this->asDateTime($value);
+            $value = $this->asDateTime($value);
+        }
+
+        // If the attribute has a get mutator, we will call that then return what
+        // it returns as the value, which is useful for transforming values on
+        // retrieval from the model to a form that is more useful for usage.
+        if ($this->hasGetMutator($key)) {
+            $value = $this->mutateAttribute($key, $value);
         }
 
         return $value;
@@ -564,7 +564,7 @@ trait HasAttributes
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed
+     * @return $this
      */
     public function setAttribute($key, $value)
     {
@@ -572,13 +572,13 @@ trait HasAttributes
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            return $this->setMutatedAttributeValue($key, $value);
+            $value = $this->setMutatedAttributeValue($key, $value);
         }
 
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
-        elseif ($value && $this->isDateAttribute($key)) {
+        if ($value && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
         }
 
@@ -590,10 +590,10 @@ trait HasAttributes
         // attribute's underlying array. This takes care of properly nesting an
         // attribute in the array's value in the case of deeply nested items.
         if (Str::contains($key, '->')) {
-            return $this->fillJsonAttribute($key, $value);
+            $this->fillJsonAttribute($key, $value);
+        } else {
+            $this->attributes[$key] = $value;
         }
-
-        $this->attributes[$key] = $value;
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -130,7 +130,7 @@ class DatabaseEloquentModelTest extends TestCase
         $attributes = $model->getAttributes();
 
         // ensure password attribute was not set to null
-        $this->assertNull($attributes['password']);
+        $this->assertEquals('', $attributes['password']);
         $this->assertEquals('******', $model->password);
 
         $hash = 'e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4';
@@ -2000,7 +2000,7 @@ class EloquentModelStub extends Model
     {
         $this->attributes['password_hash'] = sha1($value);
 
-        return null;
+        return '';
     }
 
     public function getColorsAttribute($value)


### PR DESCRIPTION
There are 2 parts to a piece of data. There is the **value** and the **type**.  You can have simple data like an *integer* of *12*, or you can have complex data like a *Collection* of *`['red', 'green', 'blue']`*.  Laravel's casting system strictly handles the **type** aspect of the data, converting back and forth between native PHP types and valid data store types.  Eloquent's *mutators* and *accessors* tend to be more on the **value** side of things, although they can dip into type manipulation, especially when a native casting doesn't exist.

A problem occurs, however, if we try to use castings together with mutators or accessors.  Mutators and accessors 'short circuit' any other behavior in the `setAttribute()` and `getAttribute()` methods, meaning casting can no longer occur.  This PR solves that problem by allowing casted attributes to work together with mutators and accessors.

Rather than returning immediately when a cast, mutator, or accessor is hit, we allow the data to be passed through the pipeline, and be manipulated by each piece.

For *setting* fields:

+ If a mutator exists, we mutate and pass along the value.
+ If the field is a date attribute, we convert the value to our desired date format and pass along the value.
+ If the field is JSON castable, we cast it to JSON, and pass along the value.
+ We take the final value and set the field on the internal `attributes` property.

For *getting* fields:

+ Retrieve the value from the internal `attributes` property.
+ If the field is castable, we cast it to the desired type and pass along the value.
+ Otherwise if the field is a date, we cast it to a Carbon object and pass along the value.
+ Now that we have the data in our desired PHP *type*, if there is an accessor we will pass the data through in to be adjusted as needed.
+ Finally, we return it to the user.

By following this pipeline/middleware style pattern it allows the developer to avoid duplicating casting logic, and focus on manipulating the **value** of their data.

### Usage

There will be some minor changes developers will have to make to their Models.  Currently in mutators, the developer will directly set the value of a field on the internal `attributes` property.

```php
class User extends Model
{
    public function setPasswordAttribute($value)
    {
        $this->attributes['password'] = sha1($value);
    }
}
```

Now you will `return` values from mutators.  I think one nice side benefit of this is the programmer no longer needs to be concerned with the internal workings of the Model. Previously, the user needed to know Eloquent stored data in the `attributes` array.  Also, by exposing that internal representation to users, we are now more bound to it, making it more difficult for us to refactor it.

```php
class User extends Model
{
    public function setPasswordAttribute($value)
    {
        return sha1($value);
    }
}
```

Keen eyed observers will note that previously the key we set on the model did not necessarily need to match our mutator.  In fact, some of our tests even do this.

```php
class User extends Model
{
    public function setPasswordAttribute($value)
    {
        $this->attributes['hashed_password'] = sha1($value);
    }
}
```

However, you can still do this if you like. By default, no return will set the 'password' attribute to `null`, or you can still be explicit about a return value to set the 'password' property, too.

```php
class User extends Model
{
    public function setPasswordAttribute($value)
    {
        $this->attributes['hashed_password'] = sha1($value);

        return '';
    }
}
```

I would go one step further and say you should not directly set something on the attributes property.

```php
class User extends Model
{
    public function setPasswordAttribute($value)
    {
        $this->hashed_password = sha1($value);

        return '';
    }
}
```

### Benefits

- Allows business logic to be pulled into the Models, out of places like Controllers or Jobs.
- The developer does not have to reimplement casting logic for attributes that have mutators or accessors.
- Developer does not access the internal Model property `attributes` directly, making possible refactors less damaging.

### Backwards Compatibility Changes

2 changes will need to be made by the developer when upgrading to Laravel 6.0 for their code to work with this change.

+ Update any *mutators* to `return` a value, rather than setting it directly on the `attributes` property. If they don't, their field will be set as `null`.
+ Remove any casting logic from mutators or accessors of cast fields, to avoid duplicate casting.

### Examples

Let's say we have a `Product` model with a `colors` attribute.  The `colors` are cast as a `Collection`.  We have a textarea where users can enter comma separated values. We need to explode the string into separate colors and trim any whitespace.  Previously we may have handled this in our Controller.

```php
class ProductController
{
    public function store(Request $request)
    {
        $product = new Product;
        $product->colors = array_map('trim', explode(',', $request->input('colors')));
        $product->save();
    }

    public function update(Request $request, Product $product)
    {
        $product->colors = array_map('trim', explode(',', $request->input('colors')));
        $product->save();
    }
}
```

Now we can move that duplicated logic into the Model:

```php
class Product extends Model
{
    protected $casts = ['colors' => 'collection'];

    protected function setColorsAttribute($value)
    {
        if(is_array($value)) {
            return array_map('trim', $value);
        }

        return array_map('trim', explode(',', $value));
    }
}
```

---

I understand this would be an impactful PR due to how important Eloquent is to everything we do. More than happy to answer any questions, or address any concerns about it.  I'm encouraged by the fact I had to change ***very little*** in the tests for this to work. Aside from the additional test I added, I only needed to change 2 lines.  One to `return` a value from the mutator, and one for a mutator where the field name did not match the actual changed property.

Thanks!