### PR TITLE
[5.8] Array cache forget should return false on missing key

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -110,9 +110,13 @@ class ArrayStore extends TaggableStore
      */
     public function forget($key)
     {
-        unset($this->storage[$key]);
+        if (array_key_exists($key, $this->storage)) {
+            unset($this->storage[$key]);
 
-        return true;
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -87,8 +87,9 @@ class CacheArrayStoreTest extends TestCase
     {
         $store = new ArrayStore;
         $store->put('foo', 'bar', 10);
-        $store->forget('foo');
+        $this->assertTrue($store->forget('foo'));
         $this->assertNull($store->get('foo'));
+        $this->assertFalse($store->forget('foo'));
     }
 
     public function testItemsCanBeFlushed()


### PR DESCRIPTION
The `array` cache driver currently returns `true` for all `forget()` calls. I think it should return `false` if there was no matching key, to better match the other drivers like `memcached` and `redis`.

I based this PR to 5.8 given anyone checking the return value of forget is probably expecting this behaviour? Not sure if this is BC incompatible enough to warrant pushing it to 6.0.

I am using the return value of `forget` to show whether a nonce is valid, so was expecting a `true` (and for the nonce to then be removed), and subsequent `false`'s which works fine via the `redis` and `memcached` drivers, but not in the tests which use `array`.