### PR TITLE
[6.0] Register ConnectionResolverInterface as core alias

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1138,7 +1138,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
             'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],
-            'db'                   => [\Illuminate\Database\DatabaseManager::class],
+            'db'                   => [\Illuminate\Database\DatabaseManager::class, \Illuminate\Database\ConnectionResolverInterface::class],
             'db.connection'        => [\Illuminate\Database\Connection::class, \Illuminate\Database\ConnectionInterface::class],
             'events'               => [\Illuminate\Events\Dispatcher::class, \Illuminate\Contracts\Events\Dispatcher::class],
             'files'                => [\Illuminate\Filesystem\Filesystem::class],

--- a/tests/Integration/Foundation/CoreContainerAliasesTest.php
+++ b/tests/Integration/Foundation/CoreContainerAliasesTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Orchestra\Testbench\TestCase;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\ConnectionResolverInterface;
+
+class CoreContainerAliasesTest extends TestCase
+{
+    public function test_it_can_resolve_core_container_aliases()
+    {
+        $this->assertInstanceOf(DatabaseManager::class, $this->app->make(ConnectionResolverInterface::class));
+    }
+}


### PR DESCRIPTION
This will allow us to resolve the interface rather than the concrete implementation from the container.

Basically allows:

```php
public function __constructor(ConnectionResolverInterface $resolver)
```

Instead of:

```php
public function __constructor(DatabaseManager $resolver)
```