### PR TITLE
[6.0] Revert temp fix for MailServiceProvider

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -30,20 +30,18 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerIlluminateMailer()
     {
-        $this->app->singleton('mailer', function () {
-            $config = $this->app->make('config')->get('mail');
+        $this->app->singleton('mailer', function ($app) {
+            $config = $app->make('config')->get('mail');
 
             // Once we have create the mailer instance, we will set a container instance
             // on the mailer. This allows us to resolve mailer classes via containers
             // for maximum testability on said classes instead of passing Closures.
             $mailer = new Mailer(
-                $this->app['view'],
-                $this->app['swift.mailer'],
-                $this->app['events']
+                $app['view'], $app['swift.mailer'], $app['events']
             );
 
-            if ($this->app->bound('queue')) {
-                $mailer->setQueue($this->app['queue']);
+            if ($app->bound('queue')) {
+                $mailer->setQueue($app['queue']);
             }
 
             // Next we will set all of the global addresses on this mailer, which allows
@@ -86,14 +84,14 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to
         // override this transporter instances during app start-up if necessary.
-        $this->app->singleton('swift.mailer', function () {
-            if ($domain = $this->app->make('config')->get('mail.domain')) {
+        $this->app->singleton('swift.mailer', function ($app) {
+            if ($domain = $app->make('config')->get('mail.domain')) {
                 Swift_DependencyContainer::getInstance()
                                 ->register('mime.idgenerator.idright')
                                 ->asValue($domain);
             }
 
-            return new Swift_Mailer($this->app['swift.transport']->driver());
+            return new Swift_Mailer($app['swift.transport']->driver());
         });
     }
 
@@ -104,8 +102,8 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSwiftTransport()
     {
-        $this->app->singleton('swift.transport', function () {
-            return new TransportManager($this->app);
+        $this->app->singleton('swift.transport', function ($app) {
+            return new TransportManager($app);
         });
     }
 
@@ -122,10 +120,10 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
             ], 'laravel-mail');
         }
 
-        $this->app->singleton(Markdown::class, function () {
-            $config = $this->app->make('config');
+        $this->app->singleton(Markdown::class, function ($app) {
+            $config = $app->make('config');
 
-            return new Markdown($this->app->make('view'), [
+            return new Markdown($app->make('view'), [
                 'theme' => $config->get('mail.markdown.theme', 'default'),
                 'paths' => $config->get('mail.markdown.paths', []),
             ]);


### PR DESCRIPTION
This reverts the temp fix for https://github.com/laravel/framework/issues/26819

The bug occured in Pre-PHP 7.3.2 installations and has since been fixed in later PHP versions.

Reverts this commit: https://github.com/laravel/framework/commit/36d343682d25570946ff22397a720727e0c1dcd7
