### PR TITLE
[5.8] Allow chaining on Query Builder dump() method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2992,7 +2992,7 @@ class Builder
     public function dump()
     {
         dump($this->toSql(), $this->getBindings());
-        
+
         return $this;
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2992,6 +2992,8 @@ class Builder
     public function dump()
     {
         dump($this->toSql(), $this->getBindings());
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This fixes a mistake in my previous PR to add this.

It currently isn't possible to chain onto the dump method.