### PR TITLE
Upgraded Monolog from v1.12 to v1.24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.0",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
-        "monolog/monolog": "^1.12",
+        "monolog/monolog": "^1.24",
         "nesbot/carbon": "^1.26.3 || ^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I've upgraded the `monolog/monolog` package from v1.12 to v1.24.

This change will hopefully mean developers will be able to make use of new Monolog features like Telegram logging. #29119 is the issue related to this change.

I've done a straight upgrade with Composer. Let me know if there are any other changes that are required to do the upgrade.
