### PR TITLE
[5.8] Fail assertSee and assertSeeText if value is null

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -393,6 +393,7 @@ class TestResponse
         if (is_null($value)) {
             PHPUnit::fail('Unable to assert see on a null value in response');
         }
+
         PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -361,7 +361,7 @@ class TestResponse
     public function assertSee($value)
     {
         if(is_null($value)){
-            PHPUnit::fail("Unable to assert see on a null value in response");
+            PHPUnit::fail('Unable to assert see on a null value in response');
         }
         PHPUnit::assertStringContainsString((string) $value, $this->getContent());
 
@@ -390,7 +390,7 @@ class TestResponse
     public function assertSeeText($value)
     {
         if(is_null($value)){
-            PHPUnit::fail("Unable to assert see on a null value in response");
+            PHPUnit::fail('Unable to assert see on a null value in response');
         }
         PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -360,6 +360,9 @@ class TestResponse
      */
     public function assertSee($value)
     {
+        if(is_null($value)){
+            PHPUnit::fail("Unable to assert see on a null value in response");
+        }
         PHPUnit::assertStringContainsString((string) $value, $this->getContent());
 
         return $this;
@@ -386,6 +389,9 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
+        if(is_null($value)){
+            PHPUnit::fail("Unable to assert see on a null value in response");
+        }
         PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
 
         return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -360,7 +360,7 @@ class TestResponse
      */
     public function assertSee($value)
     {
-        if(is_null($value)){
+        if (is_null($value)) {
             PHPUnit::fail('Unable to assert see on a null value in response');
         }
         PHPUnit::assertStringContainsString((string) $value, $this->getContent());
@@ -389,7 +389,7 @@ class TestResponse
      */
     public function assertSeeText($value)
     {
-        if(is_null($value)){
+        if (is_null($value)) {
             PHPUnit::fail('Unable to assert see on a null value in response');
         }
         PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -363,6 +363,7 @@ class TestResponse
         if (is_null($value)) {
             PHPUnit::fail('Unable to assert see on a null value in response');
         }
+
         PHPUnit::assertStringContainsString((string) $value, $this->getContent());
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -98,6 +98,28 @@ class FoundationTestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeTextWithNullCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>',
+        ]);
+
+        $response->assertSeeText(null);
+    }
+
+    public function testAssertSeeWithNullCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = $this->makeMockResponse([
+            'render' => 'foo<strong>bar</strong>',
+        ]);
+
+        $response->assertSee(null);
+    }
+
     public function testAssertSeeTextInOrder()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
Fixes issue where a null value is sent to ``assertSee`` or ``assertSeeText`` results in the test passing. As a null value, will always pass as valid.

Consider the following test, which is often given in examples. To list some model information on a page and follow Test Driven Development.
```

    public function testListCurrentModels()
    {
          $models = factory(Model::class, 5)->create();

          $response = $this->get('models');

          $response->assertSuccessful();

          $models->each(function(Model $model) use ($response){
              $response->assertSee($model->name);
          });

    }
```

If a model has been recently added using ``php artisan make:model -m -f`` and these have not been altered and the route 'models' exists. So that ``$response->assertSuccessful();`` passes.

As in this example ``$model->name`` does not exist on the model (not defined yet in migration or factory) this returns a null value. 
When checked using ``assertSee`` or ``assertSeeText`` on the response this passes. 

This occurs because the underlying check casts the null value to a string.
```
PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
```
This results in seeing ``""`` which ``assertStringContainsString`` passes. Which is why I'm submitting this pull request as otherwise any tests which are checking a null value are erroneous (in my opinion) and not adding any meaningful to the test results. 