### PR TITLE
[5.8] Fix session issue when session.path is not root

### DIFF
--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -47,7 +47,7 @@ class StartSession
 
         $sessionCookiePath = config('session.path', '/');
         $sessionCookiePath = preg_replace('/^\//', '', $sessionCookiePath); //remove the first slash
-        if(!empty($sessionCookiePath) && !Str::startsWith($request->path(), $sessionCookiePath)) {
+        if (! empty($sessionCookiePath) && ! Str::startsWith($request->path(), $sessionCookiePath)) {
             return $next($request); //do not initialize session if path do not match
         }
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Session\SessionManager;
 use Illuminate\Contracts\Session\Session;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -42,6 +43,12 @@ class StartSession
     {
         if (! $this->sessionConfigured()) {
             return $next($request);
+        }
+
+        $sessionCookiePath = config('session.path', '/');
+        $sessionCookiePath = preg_replace('/^\//', '', $sessionCookiePath); //remove the first slash
+        if(!Str::startsWith($request->path(), $sessionCookiePath)) {
+            return $next($request); //do not initialize session if path do not match
         }
 
         // If a session driver has been configured, we will need to start the session here

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -45,7 +45,7 @@ class StartSession
             return $next($request);
         }
 
-        $sessionCookiePath = config('session.path', '/');
+        $sessionCookiePath = $this->manager->getSessionConfig()['path'];
         $sessionCookiePath = preg_replace('/^\//', '', $sessionCookiePath); //remove the first slash
         if (! empty($sessionCookiePath) && ! Str::startsWith($request->path(), $sessionCookiePath)) {
             return $next($request); //do not initialize session if path do not match

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -3,12 +3,12 @@
 namespace Illuminate\Session\Middleware;
 
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Session\SessionManager;
 use Illuminate\Contracts\Session\Session;
-use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -45,7 +45,7 @@ class StartSession
             return $next($request);
         }
 
-        $sessionCookiePath = $this->manager->getSessionConfig()['path'];
+        $sessionCookiePath = $this->manager->getSessionConfig()['path'] ?? '/';
         $sessionCookiePath = preg_replace('/^\//', '', $sessionCookiePath); //remove the first slash
         if (! empty($sessionCookiePath) && ! Str::startsWith($request->path(), $sessionCookiePath)) {
             return $next($request); //do not initialize session if path do not match

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -47,7 +47,7 @@ class StartSession
 
         $sessionCookiePath = config('session.path', '/');
         $sessionCookiePath = preg_replace('/^\//', '', $sessionCookiePath); //remove the first slash
-        if(!Str::startsWith($request->path(), $sessionCookiePath)) {
+        if(!empty($sessionCookiePath) && !Str::startsWith($request->path(), $sessionCookiePath)) {
             return $next($request); //do not initialize session if path do not match
         }
 

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -35,12 +35,14 @@ class ShareErrorsFromSession
      */
     public function handle($request, Closure $next)
     {
-        // If the current session has an "errors" variable bound to it, we will share
-        // its value with all view instances so the views can easily access errors
-        // without having to bind. An empty bag is set when there aren't errors.
-        $this->view->share(
-            'errors', $request->session()->get('errors') ?: new ViewErrorBag
-        );
+        if($request->hasSession()) {
+            // If the current session has an "errors" variable bound to it, we will share
+            // its value with all view instances so the views can easily access errors
+            // without having to bind. An empty bag is set when there aren't errors.
+            $this->view->share(
+                'errors', $request->session()->get('errors') ?: new ViewErrorBag
+            );
+        }
 
         // Putting the errors in the view for every view allows the developer to just
         // assume that some errors are always available, which is convenient since

--- a/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
+++ b/src/Illuminate/View/Middleware/ShareErrorsFromSession.php
@@ -35,7 +35,7 @@ class ShareErrorsFromSession
      */
     public function handle($request, Closure $next)
     {
-        if($request->hasSession()) {
+        if ($request->hasSession()) {
             // If the current session has an "errors" variable bound to it, we will share
             // its value with all view instances so the views can easily access errors
             // without having to bind. An empty bag is set when there aren't errors.


### PR DESCRIPTION
If we set the session path to a subdirectory, for example ```/backend``` then if we go to a page outside the ```/backend``` path-segment then the already initiated session from a previous route is not sent back to laravel, and laravel sends a new session-cookie, so the previous session will be overwritten.

With this fix the session only will be started, if we are within the path segment of ```session.path```.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
