### PR TITLE
[6.0] Add dot notation support for collection::get

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -873,8 +873,8 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        if ($this->offsetExists($key)) {
-            return $this->items[$key];
+        if ($key !== null) {
+            return Arr::get($this->items, $key, $default);
         }
 
         return value($default);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3127,6 +3127,25 @@ class SupportCollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
     }
+
+    public function testGet()
+    {
+        $collection = new Collection(['price' => 100]);
+        $this->assertEquals(100, $collection->get('price'));
+
+        $collection = new Collection(['products.desk' => ['price' => 100]]);
+        $this->assertEquals(['price' => 100], $collection->get('products.desk'));
+
+        $collection = new Collection(['products.desk' => ['price' => 100]]);
+        $this->assertEquals('xo', $collection->get('products', 'xo'));
+
+        $collection = new Collection(['products' => ['desk' => ['price' => 100]]]);
+        $this->assertEquals(['price' => 100], $collection->get('products.desk'));
+
+        $collection = new Collection(['foo' => null, 'bar' => ['baz' => null]]);
+        $this->assertNull($collection->get('foo', 'default'));
+        $this->assertNull($collection->get('bar.baz', 'default'));
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
For Laravel 6 I think its time to revisit the need for dot notation support in `get()`.

As mentioned in https://github.com/laravel/framework/pull/22554, this is a breaking change, but we should add this in the 6.0 release.
Right now the `get()` method is lacking something that feels basic when working with collections. 
With this PR `get(null)` still returns `null`.

