### PR TITLE
[5.8] RedisStore should not use PHP's [un]serialize() functions if value is already a string.

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return is_numeric($value) ? $value : serialize($value);
+        return is_numeric($value) || is_string($value) ? $value : serialize($value);
     }
 
     /**
@@ -303,6 +303,6 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
-        return is_numeric($value) ? $value : unserialize($value);
+        return is_numeric($value) || (@unserialize($value) === false) ? $value : unserialize($value);
     }
 }

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return is_numeric($value) || is_string($value) ? $value : serialize($value);
+        return (is_numeric($value) || is_string($value)) && @unserialize($value) === false ? $value : serialize($value);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,13 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return (is_numeric($value) || is_string($value)) && @unserialize($value) === false ? $value : serialize($value);
+        $isSerialized = true;
+        try {
+            $isSerialized = unserialize($value) !== false;
+        } catch (\ErrorException $e) {
+            $isSerialized = false;
+        }
+        return (is_numeric($value) || is_string($value)) && !$isSerialized ? $value : serialize($value);
     }
 
     /**
@@ -303,6 +309,12 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function unserialize($value)
     {
-        return is_numeric($value) || (@unserialize($value) === false) ? $value : unserialize($value);
+        $isSerialized = true;
+        try {
+            $isSerialized = unserialize($value) !== false;
+        } catch (\ErrorException $e) {
+            $isSerialized = false;
+        }
+        return is_numeric($value) || (!$isSerialized) ? $value : unserialize($value);
     }
 }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -36,9 +36,9 @@ class CacheRedisStoreTest extends TestCase
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
         $redis->getRedis()->shouldReceive('mget')->once()->with(['prefix:foo', 'prefix:fizz', 'prefix:norf', 'prefix:null'])
             ->andReturn([
-                serialize('bar'),
-                serialize('buzz'),
-                serialize('quz'),
+                'bar',
+                'buzz',
+                'quz',
                 null,
             ]);
 
@@ -62,7 +62,7 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('foo'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, 'foo')->andReturn('OK');
         $result = $redis->put('foo', 'foo', 60);
         $this->assertTrue($result);
     }
@@ -74,9 +74,9 @@ class CacheRedisStoreTest extends TestCase
         $connection = $redis->getRedis();
         $connection->shouldReceive('connection')->with('default')->andReturn($redis->getRedis());
         $connection->shouldReceive('multi')->once();
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, serialize('bar'))->andReturn('OK');
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60, serialize('qux'))->andReturn('OK');
-        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60, serialize('norf'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:foo', 60, 'bar')->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:baz', 60, 'qux')->andReturn('OK');
+        $redis->getRedis()->shouldReceive('setex')->once()->with('prefix:bar', 60, 'norf')->andReturn('OK');
         $connection->shouldReceive('exec')->once();
 
         $result = $redis->putMany([
@@ -116,7 +116,7 @@ class CacheRedisStoreTest extends TestCase
     {
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
-        $redis->getRedis()->shouldReceive('set')->once()->with('prefix:foo', serialize('foo'))->andReturn('OK');
+        $redis->getRedis()->shouldReceive('set')->once()->with('prefix:foo', 'foo')->andReturn('OK');
         $result = $redis->forever('foo', 'foo', 60);
         $this->assertTrue($result);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is basically the implementation of this old feature request: https://github.com/laravel/ideas/issues/608

My companies application has some parts in a couple different languages and uses Redis to communicate. Because of this, we manually serialize to JSON before storage.

Since Redis supports strings natively, this patch will pass a string as-is to Redis without executing serialize() against it. When pulling from Redis, it will check if the data is numeric or unserializable and pass the value back to the caller as-is if that's the case, or unserialize() otherwise.
