### PR TITLE
[5.8] Use fluent assertions

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -72,7 +72,7 @@ class EventsDispatcherTest extends TestCase
             $_SERVER['__event.test'] = $name;
         });
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
         $d->flush('update');
         $this->assertEquals('taylor', $_SERVER['__event.test']);
     }
@@ -136,7 +136,7 @@ class EventsDispatcherTest extends TestCase
         $d->forget('foo');
         $d->dispatch('foo');
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
     }
 
     public function testWildcardListenersCanBeRemoved()
@@ -149,7 +149,7 @@ class EventsDispatcherTest extends TestCase
         $d->forget('foo.*');
         $d->dispatch('foo.bar');
 
-        $this->assertFalse(isset($_SERVER['__event.test']));
+        $this->assertArrayNotHasKey('__event.test', $_SERVER);
     }
 
     public function testListenersCanBeFound()


### PR DESCRIPTION
Using fluent assertions is more readable.

```php
$this->assertArrayNotHasKey('__event.test', $_SERVER);
```
vs

```php
$this->assertFalse(isset($_SERVER['__event.test']));
```

