### PR TITLE
[5.8] Use table.* instead of * as default for selects

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2115,7 +2115,7 @@ class Builder
     public function get($columns = null)
     {
         if (is_null($columns)) {
-            $columns = [$this->from . '.*'];
+            $columns = [$this->from.'.*'];
         }
 
         return collect($this->onceWithColumns(Arr::wrap($columns), function () {
@@ -2243,7 +2243,7 @@ class Builder
     public function cursor()
     {
         if (is_null($this->columns)) {
-            $this->columns = [$this->from . '.*'];
+            $this->columns = [$this->from.'.*'];
         }
 
         return $this->connection->cursor(

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2112,8 +2112,12 @@ class Builder
      * @param  array|string  $columns
      * @return \Illuminate\Support\Collection
      */
-    public function get($columns = ['*'])
+    public function get($columns = null)
     {
+        if (is_null($columns)) {
+            $columns = [$this->from . '.*'];
+        }
+
         return collect($this->onceWithColumns(Arr::wrap($columns), function () {
             return $this->processor->processSelect($this, $this->runSelect());
         }));
@@ -2239,7 +2243,7 @@ class Builder
     public function cursor()
     {
         if (is_null($this->columns)) {
-            $this->columns = ['*'];
+            $this->columns = [$this->from . '.*'];
         }
 
         return $this->connection->cursor(

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -41,7 +41,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processSelect');
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
-            $this->assertEquals('select * from "users"', $sql);
+            $this->assertEquals('select "users".* from "users"', $sql);
         });
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
             $this->assertEquals('select "foo", "bar" from "users"', $sql);


### PR DESCRIPTION
When fetching an Eloquent model using a join query, it automatically uses `select *` which ends up using a joined models id as the main id, and causes unexpected issues when saving.

For example, if i used the following query to fetch a user: (I know this query doesn't make much sense, its just an example). 

```
$user = User::query()
    ->join('account', 'account.id', '=', 'user.account_id')
    ->where('account.id', '=', 7)
    ->first();
```

I would now like to change a column on the user model:

```
$user->name = 'Test';
$user->save();
```

Instead of updating the user i expected (e.g. 20), it actually updates user 7 (which is actually the account.id). 

I think this behaviour can easily cause unexpected bugs, and could be prevented with a safer default. 

--

This PR changes `->get()` and `->cursor()` to default to using `select "table".*` unless otherwise specified using the `->select()` method. 

Note: This will cause a breaking change for users that don't specify a select and rely on columns that are automatically returned by `select *`. 