### PR TITLE
[6.0] Throw an exception when attribute/relation isn't exist/set

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -402,6 +402,10 @@ trait HasAttributes
         if (method_exists($this, $key)) {
             return $this->getRelationshipFromMethod($key);
         }
+
+        // If there is no matches, throws the Exception like a regular PHP class does.
+        $class = get_class($this);
+        trigger_error("Undefined attribute or relation: $class::$key");
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -58,8 +58,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->name = 'foo';
         $this->assertEquals('foo', $model->name);
         $this->assertTrue(isset($model->name));
-        unset($model->name);
-        $this->assertFalse(isset($model->name));
+        $this->expectException(\PHPUnit\Framework\Error\Notice::class);
+        $model->unexisting_field;
 
         // test mutation
         $model->list_items = ['name' => 'taylor'];


### PR DESCRIPTION
First of all, thanks for a great framework! :)

This request brings some  less error-prone code to Eloquent `HasAttributes` trait. 

Currently If there is neither relation nor an attribute with given name (e.g. `$this->something_weird`) it just silently returns `null` value. This can bring a lot of bugs, actually I faced this issue my own.

If you can see the algorithm it tries to detect if it's an attribute/method. And if it's not it says `Ok, this is relation`, but this may be just a `typo` or something like that.

I understand the usability of such setters, for example you can store some temporary state (actually for this case the getter will work fine even after this change), but I can't see any benefit of returning `null` without any warnings/exceptions.

Plus, this behaviour is similar to what `PHP` does, e.g.

```
class A
{
}

$a = new A();
$a->b; //PHP Notice:  Undefined property: A::$b in php shell code on line 1
```

I haven't patched all the tests, just wanted to show the idea, if it's okay and reasonable for you as well, I'l do the job.