### PR TITLE
[6.0] Fix Scheduler between method behavior

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -52,12 +52,20 @@ trait ManagesFrequencies
      */
     private function inTimeInterval($startTime, $endTime)
     {
-        return function () use ($startTime, $endTime) {
-            return Carbon::now($this->timezone)->between(
-                Carbon::parse($startTime, $this->timezone),
-                Carbon::parse($endTime, $this->timezone),
-                true
-            );
+        $now = Carbon::now($this->timezone);
+        $startTime = Carbon::parse($startTime, $this->timezone);
+        $endTime = Carbon::parse($endTime, $this->timezone);
+
+        if ($endTime->lessThan($startTime)) {
+            if ($startTime->greaterThan($now)) {
+                $startTime->subDay(1);
+            } else {
+                $endTime->addDay(1);
+            }
+        }
+
+        return function () use ($now, $startTime, $endTime) {
+            return $now->between($startTime, $endTime);
         };
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -99,22 +99,22 @@ class ConsoleScheduledEventTest extends TestCase
 
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->between('23:00', '10:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->between('8:00', '6:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->between('10:00', '8:00')->filtersPass($app));
     }
 
@@ -126,22 +126,22 @@ class ConsoleScheduledEventTest extends TestCase
 
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->unlessBetween('8:00', '10:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->unlessBetween('9:00', '9:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->unlessBetween('23:00', '10:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertFalse($event->unlessBetween('8:00', '6:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->unlessBetween('10:00', '11:00')->filtersPass($app));
 
-        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $event = new Event(m::mock(EventMutex::class), 'php foo', 'UTC');
         $this->assertTrue($event->unlessBetween('10:00', '8:00')->filtersPass($app));
     }
 }

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -96,15 +96,52 @@ class ConsoleScheduledEventTest extends TestCase
         $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
         $app->shouldReceive('isDownForMaintenance')->andReturn(false);
         $app->shouldReceive('environment')->andReturn('production');
+
         Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
 
-        $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $event->timezone('UTC');
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
         $this->assertTrue($event->between('8:00', '10:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
         $this->assertTrue($event->between('9:00', '9:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertTrue($event->between('23:00', '10:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertTrue($event->between('8:00', '6:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
         $this->assertFalse($event->between('10:00', '11:00')->filtersPass($app));
 
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertFalse($event->between('10:00', '8:00')->filtersPass($app));
+    }
+
+    public function testTimeUnlessBetweenChecks()
+    {
+        $app = m::mock(Application::class.'[isDownForMaintenance,environment]');
+        $app->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $app->shouldReceive('environment')->andReturn('production');
+
+        Carbon::setTestNow(Carbon::now()->startOfDay()->addHours(9));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
         $this->assertFalse($event->unlessBetween('8:00', '10:00')->filtersPass($app));
-        $this->assertTrue($event->unlessBetween('10:00', '11:00')->isDue($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertFalse($event->unlessBetween('9:00', '9:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertFalse($event->unlessBetween('23:00', '10:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertFalse($event->unlessBetween('8:00', '6:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertTrue($event->unlessBetween('10:00', '11:00')->filtersPass($app));
+
+        $event = (new Event(m::mock(EventMutex::class), 'php foo'))->timezone('UTC');
+        $this->assertTrue($event->unlessBetween('10:00', '8:00')->filtersPass($app));
     }
 }


### PR DESCRIPTION
This is a resent from the original PR by @laurencei here: https://github.com/laravel/framework/pull/28955

I'll just copy/paste @laurencei's description which already does a good job of explaining this PR:

--------

This resolves https://github.com/laravel/framework/issues/28943

**Q: What was this caused by?**

Carbon does some "under the hood" swaps when the end time is greater than the start time during a `between()` check. So when we pass in `$start = 23:00` & `$end = 03:00` - Carbon inverts those numbers since the date was always "today".

So we need to ensure that we've accounted for this before passing in the times and give Carbon a correct date range in addition to the time.


**Q: Why did you change some of the original tests?**

It turns out some of the original tests were incorrect, and were not actually "testing" what we thought they were.

In the original test suite, the `Event` class is mocked once per test function. But each subsequent test in the same function would "add" a new rule to the array stack, and therefore we were not testing them in isolation of each other.

This caused the later tests in the one function to be influenced by the earlier ones, and that caused some unexpected issues during the refactor. This is why @driesvints ran into some issues here https://github.com/laravel/framework/issues/28943#issuecomment-505453400

**Q: Why do you do check on the startTime vs "now"**

So we need to determine if we need to decrease the startTime date (when we've past that current time), or increase the endTime (when we've not gone past the start time). This helps handle the before/after midnight scenario.

I added some extra tests, with various scenarios to try to prove it works as expected.

Would be great if @aarondfrancis could test in his production to confirm this works before we merge this in.

It's been like this for literally years (maybe since 5.0) - so there's no rush here to merge - lets make sure we've all good...