### PR TITLE
[6.0] Remove duplicate password length check

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -172,7 +172,7 @@ class PasswordBroker implements PasswordBrokerContract
             $credentials['password_confirmation'],
         ];
 
-        return $password === $confirm && mb_strlen($password) >= 8;
+        return $password === $confirm && mb_strlen($password) > 0;
     }
 
     /**

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -94,17 +94,6 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordsLessThanEightCharacters()
-    {
-        $creds = ['password' => 'abcdefg', 'password_confirmation' => 'abcdefg'];
-        $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(CanResetPassword::class));
-
-        $this->assertEquals(PasswordBrokerContract::INVALID_PASSWORD, $broker->reset($creds, function () {
-            //
-        }));
-    }
-
     public function testRedirectReturnedByRemindWhenPasswordDoesntPassValidator()
     {
         $creds = ['password' => 'abcdef', 'password_confirmation' => 'abcdef'];


### PR DESCRIPTION
This removes duplicate (and hardcoded) length check from the PasswordBroker. At the moment this is duplicated in the ResetsPasswords trait where it can be customized by overwriting the rules method and the PasswordBroker where it cannot be adjusted. A length of 8 is a sensible default to have (see https://github.com/laravel/framework/pull/25957) but allowing people to overwrite when needed allows people to modify as they see fit.

I've left the rules in user land (laravel/laravel repo & ResetsPassword trait) as is because it still makes sense to ship with a default length in user land.