### PR TITLE
[6.0] Re-submitting #28881 because its merge into master resulted in no files changed

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -105,6 +105,7 @@ trait AuthorizesRequests
     protected function resourceAbilityMap()
     {
         return [
+            'index' => 'viewAny',
             'show' => 'view',
             'create' => 'create',
             'store' => 'create',


### PR DESCRIPTION
When Taylor merged #28881 into master, the resulting commit changed no files (see ee5e4845b68648a75d4a78b10f68e74b675b6d3a). I suspect this happened because a PR for that change was previously merged into 5.8 and then reverted, and Git got confused.

Regardless, the change from #28881 is **not** currently in master, although I believe it's intended to be. I'm submitting this PR so someone can give merging it a second try.

(You'll probably need to use some special handling on the command line to merge this rather than using the GitHub web app, or the same thing will likely happen again.)