### PR TITLE
[5.8] Remove unnecessary environment detection

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -393,7 +393,7 @@ class LogManager implements LoggerInterface
      */
     protected function getFallbackChannelName()
     {
-        return $this->app->bound('env') ? $this->app->environment() : 'production';
+        return $this->app->environment();
     }
 
     /**


### PR DESCRIPTION
in `Illuminate\Foundation\Bootstrap\LoadConfiguration` :
```php
$app->detectEnvironment(function () use ($config) {
        return $config->get('app.env', 'production');
});

```
The default environment is production.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
