### PR TITLE
[5.5] Ensure artisan command context is forwarded to calls

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -239,9 +239,9 @@ class Command extends SymfonyCommand
     {
         $options = array_only($this->option(), ['no-interaction', 'ansi', 'no-ansi', 'quiet', 'verbose']);
 
-        collect($options)->mapWithKeys(function ($value, $key) {
+        return collect($options)->mapWithKeys(function ($value, $key) {
             return ["--{$key}" => $value];
-        })->all();
+        })->filter()->all();
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -223,11 +223,25 @@ class Command extends SymfonyCommand
      */
     protected function createInputFromArguments(array $arguments)
     {
-        return tap(new ArrayInput($arguments), function ($input) {
+        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
             if ($input->hasParameterOption(['--no-interaction'], true)) {
                 $input->setInteractive(false);
             }
         });
+    }
+
+    /**
+     * Get all of the context passed to the command.
+     *
+     * @return array
+     */
+    protected function context()
+    {
+        $options = array_only($this->option(), ['no-interaction', 'ansi', 'no-ansi', 'quiet', 'verbose']);
+
+        collect($options)->mapWithKeys(function ($value, $key) {
+            return ["--{$key}" => $value];
+        })->all();
     }
 
     /**


### PR DESCRIPTION
The PR is a backport of #27012 that originally was pushed to the 5.7 branch, and fixes #29456.

As the original PR did not contain any tests, I have not provided any either