### PR TITLE
[6.0] Remove new password validation from broker

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -26,21 +26,13 @@ class PasswordBroker implements PasswordBrokerContract
     protected $users;
 
     /**
-     * The custom password validator callback.
-     *
-     * @var \Closure
-     */
-    protected $passwordValidator;
-
-    /**
      * Create a new password broker instance.
      *
      * @param  \Illuminate\Auth\Passwords\TokenRepositoryInterface  $tokens
      * @param  \Illuminate\Contracts\Auth\UserProvider  $users
      * @return void
      */
-    public function __construct(TokenRepositoryInterface $tokens,
-                                UserProvider $users)
+    public function __construct(TokenRepositoryInterface $tokens, UserProvider $users)
     {
         $this->users = $users;
         $this->tokens = $tokens;
@@ -82,11 +74,11 @@ class PasswordBroker implements PasswordBrokerContract
      */
     public function reset(array $credentials, Closure $callback)
     {
+        $user = $this->validateReset($credentials);
+
         // If the responses from the validate method is not a user instance, we will
         // assume that it is a redirect and simply return it from this method and
         // the user is properly redirected having an error message on the post.
-        $user = $this->validateReset($credentials);
-
         if (! $user instanceof CanResetPasswordContract) {
             return $user;
         }
@@ -115,64 +107,11 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
-        if (! $this->validateNewPassword($credentials)) {
-            return static::INVALID_PASSWORD;
-        }
-
         if (! $this->tokens->exists($user, $credentials['token'])) {
             return static::INVALID_TOKEN;
         }
 
         return $user;
-    }
-
-    /**
-     * Set a custom password validator.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public function validator(Closure $callback)
-    {
-        $this->passwordValidator = $callback;
-    }
-
-    /**
-     * Determine if the passwords match for the request.
-     *
-     * @param  array  $credentials
-     * @return bool
-     */
-    public function validateNewPassword(array $credentials)
-    {
-        if (isset($this->passwordValidator)) {
-            [$password, $confirm] = [
-                $credentials['password'],
-                $credentials['password_confirmation'],
-            ];
-
-            return call_user_func(
-                $this->passwordValidator, $credentials
-            ) && $password === $confirm;
-        }
-
-        return $this->validatePasswordWithDefaults($credentials);
-    }
-
-    /**
-     * Determine if the passwords are valid for the request.
-     *
-     * @param  array  $credentials
-     * @return bool
-     */
-    protected function validatePasswordWithDefaults(array $credentials)
-    {
-        [$password, $confirm] = [
-            $credentials['password'],
-            $credentials['password_confirmation'],
-        ];
-
-        return $password === $confirm && mb_strlen($password) > 0;
     }
 
     /**

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -28,13 +28,6 @@ interface PasswordBroker
     const INVALID_USER = 'passwords.user';
 
     /**
-     * Constant representing an invalid password.
-     *
-     * @var string
-     */
-    const INVALID_PASSWORD = 'passwords.password';
-
-    /**
      * Constant representing an invalid token.
      *
      * @var string
@@ -57,20 +50,4 @@ interface PasswordBroker
      * @return mixed
      */
     public function reset(array $credentials, Closure $callback);
-
-    /**
-     * Set a custom password validator.
-     *
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public function validator(Closure $callback);
-
-    /**
-     * Determine if the passwords match for the request.
-     *
-     * @param  array  $credentials
-     * @return bool
-     */
-    public function validateNewPassword(array $credentials);
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -72,48 +72,11 @@ class AuthPasswordBrokerTest extends TestCase
         }));
     }
 
-    public function testRedirectReturnedByRemindWhenPasswordsDontMatch()
-    {
-        $creds = ['password' => 'foo', 'password_confirmation' => 'bar'];
-        $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(CanResetPassword::class));
-
-        $this->assertEquals(PasswordBrokerContract::INVALID_PASSWORD, $broker->reset($creds, function () {
-            //
-        }));
-    }
-
-    public function testRedirectReturnedByRemindWhenPasswordNotSet()
-    {
-        $creds = ['password' => null, 'password_confirmation' => null];
-        $broker = $this->getBroker($mocks = $this->getMocks());
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(CanResetPassword::class));
-
-        $this->assertEquals(PasswordBrokerContract::INVALID_PASSWORD, $broker->reset($creds, function () {
-            //
-        }));
-    }
-
-    public function testRedirectReturnedByRemindWhenPasswordDoesntPassValidator()
-    {
-        $creds = ['password' => 'abcdef', 'password_confirmation' => 'abcdef'];
-        $broker = $this->getBroker($mocks = $this->getMocks());
-        $broker->validator(function ($credentials) {
-            return strlen($credentials['password']) >= 7;
-        });
-        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with($creds)->andReturn($user = m::mock(CanResetPassword::class));
-
-        $this->assertEquals(PasswordBrokerContract::INVALID_PASSWORD, $broker->reset($creds, function () {
-            //
-        }));
-    }
-
     public function testRedirectReturnedByRemindWhenRecordDoesntExistInTable()
     {
         $creds = ['token' => 'token'];
-        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['validateNewPassword'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
+        $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock(CanResetPassword::class));
-        $broker->expects($this->once())->method('validateNewPassword')->will($this->returnValue(true));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
         $this->assertEquals(PasswordBrokerContract::INVALID_TOKEN, $broker->reset($creds, function () {


### PR DESCRIPTION
These changes remove all hardcoded validation for a new password from the PasswordBroker. The reason for this is because this is a hardcoded constraint in validation and thus limits people from building password reset forms with their specific flow. The validation is already done within the ResetsPassword trait and is only duplicated in the Broker. The Broker also seems like the wrong place to do this as it only facilitates the retrieval of the user and the token validation (which is still the correct place for these two).

This also allows us to remove the https://github.com/laravel/laravel/blob/develop/resources/lang/en/passwords.php#L16 language line.

This basically doesn't contain any breaking changes for people's apps other than the api changes and if people were already overriding this behavior. Existing apps with the default Auth scaffolding will continue to work as-is.

See https://github.com/laravel/framework/pull/25957#issuecomment-519662680