### PR TITLE
[5.8] Add --dry-run option to commands

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -286,6 +286,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     {
         return tap(parent::getDefaultInputDefinition(), function ($definition) {
             $definition->addOption($this->getEnvironmentOption());
+            $definition->addOption($this->getDryRunOption());
         });
     }
 
@@ -299,6 +300,18 @@ class Application extends SymfonyApplication implements ApplicationContract
         $message = 'The environment the command should run under';
 
         return new InputOption('--env', null, InputOption::VALUE_OPTIONAL, $message);
+    }
+
+    /**
+     * Get the global dry run option for the definition.
+     *
+     * @return \Symfony\Component\Console\Input\InputOption
+     */
+    protected function getDryRunOption()
+    {
+        $message = 'Hook to allow for conditionally previewing results of running the command.';
+
+        return new InputOption('--dry-run', null, InputOption::VALUE_NONE, $message);
     }
 
     /**


### PR DESCRIPTION
This adds a `--dry-run` option to the default command structure. The idea of this is that if you pass `--dry-run` when calling your command, then you can use it for performing logic checks within the command to conditionally execute certain pieces of code.

Example:

```php
// app/Console/Commands/UpdateUserStatus.php
public function handle()
{
    $users = User::where('status', $this->option('status'))->get();

    if ($this->option('dry-run')) {
        $this->error('Performing Dry Run. Would affect the following users...');
        // Show some output to preview the users affected

        return;
    }

    $users->each(function($user) {
        // some type of update on the user
    });

    $this->info('Done!');
}
```

**Affect on existing codebases**

If you have added `--dry-run` in the signature of an existing command, then this will just work as long as it has been declared as an option without a value. 

If the option is set to receive a value (i.e. `--dry-run=`, then an error message of `An option named "dry-run" already exists.` will be displayed.

If this feels too risky for existing codebases, I can change this to PR against `master`.