### PR TITLE
[5.8] Close mockery in the teardown method

### DIFF
--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -45,6 +45,11 @@ class RedisManagerExtensionTest extends TestCase
         });
     }
 
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
     public function test_using_custom_redis_connector_with_single_redis_instance()
     {
         $this->assertEquals(


### PR DESCRIPTION
Close mockery again in the teardown method.

By https://github.com/laravel/framework/pull/29455#discussion_r312043566