### PR TITLE
[6.0] Make it possible to have full classnames in route

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -531,6 +531,7 @@ class Router implements RegistrarContract, BindingRegistrar
         $group = end($this->groupStack);
 
         return isset($group['namespace']) && strpos($class, '\\') !== 0
+                && strpos($class, app()->getNamespace()) !== 0
                 ? $group['namespace'].'\\'.$class : $class;
     }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -436,7 +436,7 @@ class UrlGenerator implements UrlGeneratorContract
             $action = '\\'.implode('@', $action);
         }
 
-        if ($this->rootNamespace && strpos($action, '\\') !== 0) {
+        if ($this->rootNamespace && strpos($action, '\\') !== 0 && strpos($action, app()->getNamespace()) !== 0) {
             return $this->rootNamespace.'\\'.$action;
         } else {
             return trim($action, '\\');


### PR DESCRIPTION
After @freekmurze's talk at laraconUs, it inspired me to wanting to cleanup our routes, but as we have over 483 routes I was toying with the idea to make both worlds work.

This results in a fully backwards compatible route declaration. I have checked that any() and resources() work as expected.

**Benefits**
- FQDN in routes declaration 
- Make it easier to navigate around
- Helps IDE to find usages for refactoring, where before it couldn't


**Result**

Devs can add normal routes with an action: 
`Route::get('/user', 'UserController@index');
`

Or like @freekmurze suggested to use the FQDN where the controller class uses __invoke
`Route::get('/user', App\Http\Controllers\UserController::class);
`

This can be cheated today by adding a global namespace indicator, but doesn't look good.
`Route::get('/user', '\\' . App\Http\Controllers\UserController::class);
`

**But how?**

By checking if $action is a FQDN, note that this could fail if someone users the namespace **App** in their _controllers_ folder.



I'm PR:ing this to master as we're getting close to 6.0 and there is no rush to get it into 5.8.

**Failing unittest**

getAppNamespace doesn't seem to work in console environment. Tested with src/Illuminate/Console/DetectsApplicationNamespace.php trait as well, but it does the same as app()->getNamespace().

Think I need some pointers on this one to be able to fully test changes.