### PR TITLE
[5.8] Add additional error message for clear cache issues

### DIFF
--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -63,7 +63,11 @@ class ClearCommand extends Command
         $this->laravel['events']->dispatch(
             'cache:clearing', [$this->argument('store'), $this->tags()]
         );
-
+            
+        if (! $this->files->exists($storagePath = storage_path('framework/cache/data'))) {
+            return $this->error('Failed to clear cache since the data folder does not exist');
+        }
+        
         $successful = $this->cache()->flush();
 
         $this->flushFacades();


### PR DESCRIPTION
`Failed to clear cache. Make sure you have the appropriate permissions` 

Is not correct if the issue is the `data` folder is missing

In my example it was deleted during a build and from there 
```
php artisan cache:clear
```

Gave an error which is not correct
"Failed to clear cache. Make sure you have the appropriate permissions"


This will keep the user from trying chmod which will not solve the issue