### PR TITLE
[5.8] Fix top level wildcard validation for 'distinct'

### DIFF
--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -131,7 +131,7 @@ class ValidationRuleParser
         foreach ($data as $key => $value) {
             if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
                 foreach ((array) $rules as $rule) {
-                    $this->implicitAttributes[$attribute][] = $key;
+                    $this->implicitAttributes[$attribute][] = strval($key);
 
                     $results = $this->mergeRules($results, $key, $rule);
                 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1899,6 +1899,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('There is a duplication!', $v->messages()->first('foo.1'));
     }
 
+    public function testValidateDistinctForTopLevelArrays()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [['foo' => 1], ['foo' => 1]], ['*' => 'array', '*.foo' => 'distinct']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, [['foo' => 'a'], ['foo' => 'A']], ['*' => 'array', '*.foo' => 'distinct:ignore_case']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, [['foo' => [['id' => 1]]], ['foo' => [['id' => 1]]]], ['*' => 'array', '*.foo' => 'array', '*.foo.*.id' => 'distinct']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateUnique()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1903,6 +1903,9 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
+        $v = new Validator($trans, ['foo', 'foo'], ['*' => 'distinct']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, [['foo' => 1], ['foo' => 1]], ['*' => 'array', '*.foo' => 'distinct']);
         $this->assertFalse($v->passes());
 
@@ -1911,6 +1914,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, [['foo' => [['id' => 1]]], ['foo' => [['id' => 1]]]], ['*' => 'array', '*.foo' => 'array', '*.foo.*.id' => 'distinct']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo', 'foo'], ['*' => 'distinct'], ['*.distinct' => 'There is a duplication!']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('There is a duplication!', $v->messages()->first('0'));
+        $this->assertEquals('There is a duplication!', $v->messages()->first('1'));
     }
 
     public function testValidateUnique()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When someone writes validation rules like this:
```
$array = [
    ['id' => 1],
    ['id' => 1],
];
$rules = [
    '*' => 'array',
    '*.id' => 'distinct',
];
Validator::make($array, $rules)->validate();
```
it doesn't work as expected. 
### Why?
The `implicitAttributes` array in `Validator` class stores the mapping of 'unparsed' rule to 'parsed' rule. 
For the given rule, it is like: 
```
[
  "*" => [
    0 => 0
    1 => 1
  ],
  "*.id" => [
    0 => "0.id"
    1 => "1.id"
  ]
]
```
So, when this array is searched to get the `key` of "0.id", it finds `*` instead of `*.id` because of loose comparison match between `"0.id"` and `0`. 
This scenario can be avoided if all the parsed rule are stored as `string`, which I did in this PR.
I've also added tests to verify the correctness of my solution.

This PR will fix #29190 
