### PR TITLE
[5.8] Sync password facade and interface constants

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Support\Facades;
 
+use Illuminate\Contracts\Auth\PasswordBroker;
+
 /**
  * @method static string sendResetLink(array $credentials)
  * @method static mixed reset(array $credentials, \Closure $callback)
@@ -17,35 +19,35 @@ class Password extends Facade
      *
      * @var string
      */
-    const RESET_LINK_SENT = 'passwords.sent';
+    const RESET_LINK_SENT = PasswordBroker::RESET_LINK_SENT;
 
     /**
      * Constant representing a successfully reset password.
      *
      * @var string
      */
-    const PASSWORD_RESET = 'passwords.reset';
+    const PASSWORD_RESET = PasswordBroker::PASSWORD_RESET;
 
     /**
      * Constant representing the user not found response.
      *
      * @var string
      */
-    const INVALID_USER = 'passwords.user';
+    const INVALID_USER = PasswordBroker::INVALID_USER;
 
     /**
      * Constant representing an invalid password.
      *
      * @var string
      */
-    const INVALID_PASSWORD = 'passwords.password';
+    const INVALID_PASSWORD = PasswordBroker::INVALID_PASSWORD;
 
     /**
      * Constant representing an invalid token.
      *
      * @var string
      */
-    const INVALID_TOKEN = 'passwords.token';
+    const INVALID_TOKEN = PasswordBroker::INVALID_TOKEN;
 
     /**
      * Get the registered name of the component.


### PR DESCRIPTION
The password broker types are duplicate in Password facade. So, in this PR, I removed the duplicate types and link them to the original types of PasswordBroker interface to ensure they are synchronized.