### PR TITLE
[6.0] Use Lang::trans() instead Lang::get()

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -57,11 +57,11 @@ class ResetPassword extends Notification
         }
 
         return (new MailMessage)
-            ->subject(Lang::get('Reset Password Notification'))
-            ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
-            ->action(Lang::get('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()], false)))
-            ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
-            ->line(Lang::get('If you did not request a password reset, no further action is required.'));
+            ->subject(Lang::trans('Reset Password Notification'))
+            ->line(Lang::trans('You are receiving this email because we received a password reset request for your account.'))
+            ->action(Lang::trans('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()], false)))
+            ->line(Lang::trans('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
+            ->line(Lang::trans('If you did not request a password reset, no further action is required.'));
     }
 
     /**

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -44,10 +44,10 @@ class VerifyEmail extends Notification
         }
 
         return (new MailMessage)
-            ->subject(Lang::get('Verify Email Address'))
-            ->line(Lang::get('Please click the button below to verify your email address.'))
-            ->action(Lang::get('Verify Email Address'), $verificationUrl)
-            ->line(Lang::get('If you did not create an account, no further action is required.'));
+            ->subject(Lang::trans('Verify Email Address'))
+            ->line(Lang::trans('Please click the button below to verify your email address.'))
+            ->action(Lang::trans('Verify Email Address'), $verificationUrl)
+            ->line(Lang::trans('If you did not create an account, no further action is required.'));
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -53,7 +53,7 @@ trait ThrottlesLogins
         );
 
         throw ValidationException::withMessages([
-            $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
+            $this->username() => [Lang::trans('auth.throttle', ['seconds' => $seconds])],
         ])->status(Response::HTTP_TOO_MANY_REQUESTS);
     }
 


### PR DESCRIPTION
`trans` is the original method of Translator interface while `get` is not (only exists on the current implementation). Use `trans` is safer and clearer.

For Example, if I build a package including implementation of TranslatorInterface but not define `get`, then rebind 'translator' in the container, the code will go wrong.

This is similar to `fire` from Event Dispatcher. https://github.com/laravel/framework/pull/26379