### PR TITLE
[5.8] Update Migrator events

### DIFF
--- a/src/Illuminate/Database/Events/MigrationsEnded.php
+++ b/src/Illuminate/Database/Events/MigrationsEnded.php
@@ -2,9 +2,8 @@
 
 namespace Illuminate\Database\Events;
 
-use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
 
-class MigrationsEnded implements MigrationEventContract
+class MigrationsEnded extends MigrationsEvent
 {
     //
 }

--- a/src/Illuminate/Database/Events/MigrationsEnded.php
+++ b/src/Illuminate/Database/Events/MigrationsEnded.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Events;
 
-
 class MigrationsEnded extends MigrationsEvent
 {
     //

--- a/src/Illuminate/Database/Events/MigrationsEvent.php
+++ b/src/Illuminate/Database/Events/MigrationsEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
+
+abstract class MigrationsEvent implements MigrationEventContract
+{
+    /**
+     * An array containing the migration objects.
+     *
+     * @var array
+     */
+    public $migrations = [];
+
+    /**
+     * The migration method that was called.
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  array  $migrations
+     * @param  string  $method
+     * @return void
+     */
+    public function __construct(array $migrations, $method)
+    {
+        $this->method = $method;
+        $this->migrations = $migrations;
+    }
+}

--- a/src/Illuminate/Database/Events/MigrationsStarted.php
+++ b/src/Illuminate/Database/Events/MigrationsStarted.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Database\Events;
 
-use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
-
-class MigrationsStarted implements MigrationEventContract
+class MigrationsStarted extends MigrationsEvent
 {
     //
 }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Database;
 
 use Mockery as m;
+use CreateUsersTable;
 use Illuminate\Support\Str;
+use CreatePasswordResetsTable;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Container\Container;
@@ -68,8 +70,8 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->assertTrue($this->db->schema()->hasTable('users'));
         $this->assertTrue($this->db->schema()->hasTable('password_resets'));
 
-        $this->assertTrue(Str::contains($ran[0], 'users'));
-        $this->assertTrue(Str::contains($ran[1], 'password_resets'));
+        $this->assertTrue($ran[0] instanceof CreateUsersTable);
+        $this->assertTrue($ran[1] instanceof CreatePasswordResetsTable);
     }
 
     public function testMigrationsCanBeRolledBack()

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -2,12 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Events\MigrationEnded;
-use Illuminate\Database\Events\MigrationsEnded;
-use Illuminate\Database\Events\MigrationStarted;
-use Illuminate\Database\Events\MigrationsStarted;
 
 class MigrateWithRealpathTest extends DatabaseTestCase
 {
@@ -39,28 +34,5 @@ class MigrateWithRealpathTest extends DatabaseTestCase
             'migration' => '2014_10_12_000000_create_members_table',
             'batch' => 1,
         ]);
-    }
-
-    public function test_migration_events_are_fired()
-    {
-        Event::fake();
-
-        Event::listen(MigrationsStarted::class, function ($event) {
-            return $this->assertInstanceOf(MigrationsStarted::class, $event);
-        });
-
-        Event::listen(MigrationsEnded::class, function ($event) {
-            return $this->assertInstanceOf(MigrationsEnded::class, $event);
-        });
-
-        Event::listen(MigrationStarted::class, function ($event) {
-            return $this->assertInstanceOf(MigrationStarted::class, $event);
-        });
-
-        Event::listen(MigrationEnded::class, function ($event) {
-            return $this->assertInstanceOf(MigrationEnded::class, $event);
-        });
-
-        $this->artisan('migrate');
     }
 }

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Events\MigrationEnded;
+use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Database\Events\MigrationStarted;
+use Illuminate\Database\Events\MigrationsStarted;
+
+class MigratorEventsTest extends DatabaseTestCase
+{
+    protected function migrateOptions()
+    {
+        return [
+            '--path' => realpath(__DIR__.'/stubs/'),
+            '--realpath' => true,
+        ];
+    }
+
+    public function test_migration_events_are_fired()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationsStarted::class, 2);
+        Event::assertDispatched(MigrationsEnded::class, 2);
+        Event::assertDispatched(MigrationStarted::class, 2);
+        Event::assertDispatched(MigrationEnded::class, 2);
+    }
+
+    public function test_migration_events_contain_the_migration_and_method()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationStarted::class, function ($event) {
+            return $event->method == 'up' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationStarted::class, function ($event) {
+            return $event->method == 'down' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationEnded::class, function ($event) {
+            return $event->method == 'up' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationEnded::class, function ($event) {
+            return $event->method == 'down' && $event->migration instanceof Migration;
+        });
+    }
+
+    public function test_migrations_events_contain_the_migration_and_method()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method == 'up' && count($event->migrations) === 1 && $event->migrations[0] instanceof Migration;
+        });
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method == 'down' && count($event->migrations) === 1 && $event->migrations[0] instanceof Migration;
+        });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method == 'up' && count($event->migrations) === 1 && $event->migrations[0] instanceof Migration;
+        });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method == 'down' && count($event->migrations) === 1 && $event->migrations[0] instanceof Migration;
+        });
+    }
+
+    public function test_migration_events_are_fired_when_no_migrations_are_to_be_ran()
+    {
+        Event::fake();
+
+        $this->artisan('migrate');
+        $this->artisan('migrate:rollback');
+
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method == 'up' && count($event->migrations) === 0;
+        });
+        Event::assertDispatched(MigrationsStarted::class, function ($event) {
+            return $event->method == 'down' && count($event->migrations) === 0;
+        });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method == 'up' && count($event->migrations) === 0;
+        });
+        Event::assertDispatched(MigrationsEnded::class, function ($event) {
+            return $event->method == 'down' && count($event->migrations) === 0;
+        });
+        Event::assertNotDispatched(MigrationStarted::class);
+        Event::assertNotDispatched(MigrationEnded::class);
+    }
+}

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -74,7 +74,7 @@ class MigratorEventsTest extends DatabaseTestCase
         });
     }
 
-    public function test_migration_events_are_fired_when_no_migrations_are_to_be_ran()
+    public function test_migration_events_are_still_fired_when_no_migrations_need_to_be_migrated()
     {
         Event::fake();
 


### PR DESCRIPTION
This PR is created because of the discussion starting from this comment: https://github.com/laravel/framework/pull/28342#issuecomment-513246684

**A quick summary of the discussed:**

Currently the migration event `MigrationsEnded` is not fired when there are no migrations to run. However the `MigrationsStarted` event will always be fired, so to be consistent the `MigrationsEnded` event should be fired as well.

Also, the `MigrationsStarted` event now contains all migrations to run and the single `MigrationStarted` and `MigrationEnded` contain their single migration that's about to be executed.

To also pass all migrations to the `MigrationsStarted` event the classes had to be resolved earlier in the code, which you'll see happening in this PR.

**My use case (copied from the discussion):**

Let's say we have a multilingual cms system where users can manage the mailings that are sent by that system. When a new mailing is added we'll make a custom migration that'll run the following:

```php
    public function up($locale)
    {
        Mailing::create([
            'locale' => $locale,
            'key' => 'subscribed',
            'template' => 'A new mailing',
        ]);
    }
```

To have the above work we need the normal migrations to be run first, otherwise, the `mailings` table would not exist.

Now if we have configured `['en', 'nl', 'de']` as locales for that cms the above is executed 3 times, each time with a different `$locale`.

Of course, the mailing would be added with an English template for all 3 locales, but now the user can edit the template for NL and de in the cms.

(Some tests failed but had nothing to do with my edits, so I'm guessing that a Windows perk. I'll see what Travis thinks of that..)