### PR TITLE
[5.8] Add missing test for getRoutesByMethod

### DIFF
--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -190,6 +190,42 @@ class RouteCollectionTest extends TestCase
         $this->assertSame($routesByName, $this->routeCollection->getRoutesByName());
     }
 
+    public function testRouteCollectionCanGetRoutesByMethod()
+    {
+        $routes = [
+            'foo_index' => new Route('GET', 'foo/index', [
+                'uses' => 'FooController@index',
+                'as' => 'foo_index',
+            ]),
+            'foo_show' => new Route('GET', 'foo/show', [
+                'uses' => 'FooController@show',
+                'as' => 'foo_show',
+            ]),
+            'bar_create' => new Route('POST', 'bar', [
+                'uses' => 'BarController@create',
+                'as' => 'bar_create',
+            ]),
+        ];
+
+        $this->routeCollection->add($routes['foo_index']);
+        $this->routeCollection->add($routes['foo_show']);
+        $this->routeCollection->add($routes['bar_create']);
+
+        $this->assertSame([
+            'GET' => [
+                'foo/index' => $routes['foo_index'],
+                'foo/show' => $routes['foo_show'],
+            ],
+            'HEAD' => [
+                'foo/index' => $routes['foo_index'],
+                'foo/show' => $routes['foo_show'],
+            ],
+            'POST' => [
+                'bar' => $routes['bar_create'],
+            ],
+        ], $this->routeCollection->getRoutesByMethod());
+    }
+
     public function testRouteCollectionCleansUpOverwrittenRoutes()
     {
         // Create two routes with the same path and method.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add missing test for getRoutesByMethod.