### PR TITLE
[6.0] Update Translator interface

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -5,12 +5,23 @@ namespace Illuminate\Contracts\Translation;
 interface Translator
 {
     /**
+     * Get the translation for the given key.
+     *
+     * @param  string  $key
+     * @param  array   $replace
+     * @param  string|null  $locale
+     * @param  bool  $fallback
+     * @return string|array
+     */
+    public function get($key, array $replace = [], $locale = null, $fallback = true);
+
+    /**
      * Get the translation for a given key.
      *
      * @param  string  $key
      * @param  array   $replace
      * @param  string|null  $locale
-     * @return mixed
+     * @return string|array
      */
     public function trans($key, array $replace = [], $locale = null);
 


### PR DESCRIPTION
Because the framework prefers `Lang::get()` method to `Lang::trans()` method, we have to update the translator interface by adding one more method called `get`. By the way, I help to fix the `trans` method dockblock that have to return a string or an array, not null.

For more details, see the Mr. Otwell's comment [here](https://github.com/laravel/framework/pull/29502).

We shouldn't remove the `trans` method because it has been used in tons of existing projects or libraries.
