### PR TITLE
[5.8] Fix Encryption typo

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -40,7 +40,7 @@ class Encrypter implements EncrypterContract
             $this->key = $key;
             $this->cipher = $cipher;
         } else {
-            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+            throw new RuntimeException('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key length.');
         }
     }
 

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -46,10 +46,10 @@ class EncrypterTest extends TestCase
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
 
-    public function testDoNoAllowLongerKey()
+    public function testDoNotAllowLongerKey()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key length.');
 
         new Encrypter(str_repeat('z', 32));
     }
@@ -57,7 +57,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLength()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key length.');
 
         new Encrypter(str_repeat('a', 5));
     }
@@ -65,7 +65,7 @@ class EncrypterTest extends TestCase
     public function testWithBadKeyLengthAlternativeCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key length.');
 
         new Encrypter(str_repeat('a', 16), 'AES-256-CFB8');
     }
@@ -73,7 +73,7 @@ class EncrypterTest extends TestCase
     public function testWithUnsupportedCipher()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key lengths.');
+        $this->expectExceptionMessage('The only supported ciphers are AES-128-CBC and AES-256-CBC with the correct key length.');
 
         new Encrypter(str_repeat('c', 16), 'AES-256-CFB8');
     }


### PR DESCRIPTION
This PR fixes 2 small typo mistakes below:
- "key lengths" => "key length"
- "testDoNoAllowLongerKey" => "testDoNotAllowLongerKey"