### PR TITLE
[5.8] Update command constructor

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -102,18 +102,15 @@ class Command extends SymfonyCommand
             $this->configureUsingFluentDefinition();
         } else {
             parent::__construct($this->name);
+
+            $this->specifyParameters();
         }
 
         // Once we have constructed the command, we'll set the description and other
-        // related properties of the command. If a signature wasn't used to build
-        // the command we'll set the arguments and the options on this command.
+        // related properties of the command.
         $this->setDescription($this->description);
 
         $this->setHidden($this->isHidden());
-
-        if (! isset($this->signature)) {
-            $this->specifyParameters();
-        }
     }
 
     /**


### PR DESCRIPTION
The `configureUsingFluentDefinition` method does 3 things including configure name, arguments and options. So, if the `signature` property is not set, we just do these things manually by two statements below.

```php
parent::__construct($this->name);

$this->specifyParameters();
``` 

No need to add `! isset($this->signature)` check. See the example code with comments for more details.

```php
<?php

/**
 * Create a new console command instance.
 *
 * @return void
 */
public function __construct()
{
    if (isset($this->signature)) { // Check whether signature is set
        $this->configureUsingFluentDefinition();
    } else {
        parent::__construct($this->name);
    }

    // some other stuff
    
    if (! isset($this->signature)) { // Check whether signature is not set.
        $this->specifyParameters();
    }
}
```