### PR TITLE
[5.8] Only remove the event mutex if it was created

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -90,7 +90,7 @@ class CallbackEvent extends Event
      */
     protected function removeMutex()
     {
-        if ($this->description) {
+        if ($this->description && $this->withoutOverlapping) {
             $this->mutex->forget($this);
         }
     }


### PR DESCRIPTION
The purpose of this PR is to fix an issue that **throws PHP Fatal errors when running the scheduler in a test**.

## Description of the issue

- **Given** a scheduled `CallbackEvent` with a description (i.e. using the `name()` method)
- **When** we run the scheduler in a test using `$this->artisan('schedule:run')`
- **Then** the test passes but it throws PHP Fatal errors (see image below)

![EA-0k1NXsAEY_Qw](https://user-images.githubusercontent.com/3642397/62394173-55a8e580-b564-11e9-9355-daf2e1bfc91b.jpeg)

Note that, since `$schedule->job()` is syntactic sugar for `$schedule->call()->name()`, the same issue occurs when scheduling a job. Please see issue #29394 for more information including the steps to reproduce on a fresh Laravel install.

## The origin of the problem

The PHP Fatal errors are thrown when removing the mutex of a `CallbackEvent`. ([see source](https://github.com/laravel/framework/blob/dd1a1edfcc1114d74a9d9ab662c81f9de37d7aba/src/Illuminate/Console/Scheduling/CallbackEvent.php#L91-L96))

```php
protected function removeMutex()
{
    if ($this->description) {
        $this->mutex->forget($this);
    }
}
```

As you can see we only remove the mutex if a description was provided. However, since we are not using the `withoutOverlapping` option, that mutex was never created in the first place. ([see source](https://github.com/laravel/framework/blob/dd1a1edfcc1114d74a9d9ab662c81f9de37d7aba/src/Illuminate/Console/Scheduling/CallbackEvent.php#L58-L61))

```php
if ($this->description && $this->withoutOverlapping &&
    ! $this->mutex->create($this)) {
    return;
}
```

## The solution

Making sure that the conditions of creating and removing an event mutex are identical fixes our issue.

```php
protected function removeMutex()
{
    if ($this->description && $this->withoutOverlapping) {
        $this->mutex->forget($this);
    }
}
```

Fix #29394 