### PR TITLE
[6.0] Remove duplicate trans methods on Translator

### DIFF
--- a/src/Illuminate/Contracts/Translation/Translator.php
+++ b/src/Illuminate/Contracts/Translation/Translator.php
@@ -12,7 +12,7 @@ interface Translator
      * @param  string|null  $locale
      * @return mixed
      */
-    public function trans($key, array $replace = [], $locale = null);
+    public function get($key, array $replace = [], $locale = null);
 
     /**
      * Get a translation according to an integer value.
@@ -23,7 +23,7 @@ interface Translator
      * @param  string|null  $locale
      * @return string
      */
-    public function transChoice($key, $number, array $replace = [], $locale = null);
+    public function choice($key, $number, array $replace = [], $locale = null);
 
     /**
      * Get the default locale being used.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -875,7 +875,7 @@ if (! function_exists('trans')) {
             return app('translator');
         }
 
-        return app('translator')->trans($key, $replace, $locale);
+        return app('translator')->get($key, $replace, $locale);
     }
 }
 
@@ -891,7 +891,7 @@ if (! function_exists('trans_choice')) {
      */
     function trans_choice($key, $number, array $replace = [], $locale = null)
     {
-        return app('translator')->transChoice($key, $number, $replace, $locale);
+        return app('translator')->choice($key, $number, $replace, $locale);
     }
 }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -89,19 +89,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     }
 
     /**
-     * Get the translation for a given key.
-     *
-     * @param  string  $key
-     * @param  array   $replace
-     * @param  string|null  $locale
-     * @return string|array
-     */
-    public function trans($key, array $replace = [], $locale = null)
-    {
-        return $this->get($key, $replace, $locale);
-    }
-
-    /**
      * Get the translation for the given key.
      *
      * @param  string  $key
@@ -145,20 +132,6 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
         return $this->makeReplacements($line ?: $key, $replace);
-    }
-
-    /**
-     * Get a translation according to an integer value.
-     *
-     * @param  string  $key
-     * @param  int|array|\Countable  $number
-     * @param  array   $replace
-     * @param  string|null  $locale
-     * @return string
-     */
-    public function transChoice($key, $number, array $replace = [], $locale = null)
-    {
-        return $this->choice($key, $number, $replace, $locale);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -54,7 +54,7 @@ trait FormatsMessages
         // messages out of the translator service for this validation rule.
         $key = "validation.{$lowerRule}";
 
-        if ($key != ($value = $this->translator->trans($key))) {
+        if ($key != ($value = $this->translator->get($key))) {
             return $value;
         }
 
@@ -113,7 +113,7 @@ trait FormatsMessages
      */
     protected function getCustomMessageFromTranslator($key)
     {
-        if (($message = $this->translator->trans($key)) !== $key) {
+        if (($message = $this->translator->get($key)) !== $key) {
             return $message;
         }
 
@@ -125,7 +125,7 @@ trait FormatsMessages
         );
 
         return $this->getWildcardCustomMessages(Arr::dot(
-            (array) $this->translator->trans('validation.custom')
+            (array) $this->translator->get('validation.custom')
         ), $shortKey, $key);
     }
 
@@ -166,7 +166,7 @@ trait FormatsMessages
 
         $key = "validation.{$lowerRule}.{$type}";
 
-        return $this->translator->trans($key);
+        return $this->translator->get($key);
     }
 
     /**
@@ -264,7 +264,7 @@ trait FormatsMessages
      */
     protected function getAttributeFromTranslations($name)
     {
-        return Arr::get($this->translator->trans('validation.attributes'), $name);
+        return Arr::get($this->translator->get('validation.attributes'), $name);
     }
 
     /**
@@ -316,7 +316,7 @@ trait FormatsMessages
 
         $key = "validation.values.{$attribute}.{$value}";
 
-        if (($line = $this->translator->trans($key)) !== $key) {
+        if (($line = $this->translator->get($key)) !== $key) {
             return $line;
         }
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -158,7 +158,7 @@ class FoundationFormRequestTest extends TestCase
      */
     protected function createValidationFactory($container)
     {
-        $translator = m::mock(Translator::class)->shouldReceive('trans')
+        $translator = m::mock(Translator::class)->shouldReceive('get')
                        ->zeroOrMoreTimes()->andReturn('error')->getMock();
 
         return new ValidationFactory($translator, $container);

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -71,7 +71,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
-        $this->assertSame('breeze <p>test</p>', $t->trans('foo.bar', [], 'en'));
+        $this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -112,7 +112,7 @@ class ValidationValidatorTest extends TestCase
     public function testHasNotFailedValidationRules()
     {
         $trans = $this->getTranslator();
-        $trans->shouldReceive('trans')->never();
+        $trans->shouldReceive('get')->never();
         $v = new Validator($trans, ['foo' => 'taylor'], ['name' => 'Confirmed']);
         $this->assertTrue($v->passes());
         $this->assertEmpty($v->failed());
@@ -121,7 +121,7 @@ class ValidationValidatorTest extends TestCase
     public function testSometimesCanSkipRequiredRules()
     {
         $trans = $this->getTranslator();
-        $trans->shouldReceive('trans')->never();
+        $trans->shouldReceive('get')->never();
         $v = new Validator($trans, [], ['name' => 'sometimes|required']);
         $this->assertTrue($v->passes());
         $this->assertEmpty($v->failed());
@@ -130,7 +130,7 @@ class ValidationValidatorTest extends TestCase
     public function testInValidatableRulesReturnsValid()
     {
         $trans = $this->getTranslator();
-        $trans->shouldReceive('trans')->never();
+        $trans->shouldReceive('get')->never();
         $v = new Validator($trans, ['foo' => 'taylor'], ['name' => 'Confirmed']);
         $this->assertTrue($v->passes());
     }


### PR DESCRIPTION
This removes the duplicate trans and transChoice methods on the Translator class since these are already implemented as "get" and "choice".

The helpers stay unaffected.

Replaces https://github.com/laravel/framework/pull/29516
