### PR TITLE
Add search multidimensional collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1584,6 +1584,21 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
+     * Search a multidimensional collection for a given value in the given column and return the corresponding key if successful.
+     *
+     * @param  mixed  $value
+     * @param  string  $columnName
+     * @param  bool  $strict
+     * @return mixed
+     */
+    public function searchMultidimensional($value, $columnName, $strict = false)
+    {
+        $column = array_combine(array_keys($this->items), array_column($this->items, $columnName));
+
+        return array_search($value, $column, $strict);
+    }
+
+    /**
      * Get and remove the first item from the collection.
      *
      * @return mixed

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2291,6 +2291,36 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
+    public function testSearchMultidimensionalReturnsIndexOfFirstFoundItem()
+    {
+        $c = new Collection([['first' => 'Taylor', 'last' => 'Otwell'], ['first' => 'Jeffrey', 'last' => 'Way'], 3 => ['first' => 'Adam', 'last' => 'Wathan']]);
+
+        $this->assertEquals(0, $c->searchMultidimensional('Taylor', 'first'));
+        $this->assertEquals(1, $c->searchMultidimensional('Way', 'last'));
+        $this->assertEquals(3, $c->searchMultidimensional('Adam', 'first'));
+    }
+
+    public function testSearchMultidimensionalInStrictMode()
+    {
+        $c = new Collection([['bool' => false, 'number' => 1, 'array' => [], 'string' => '2'], 2 => ['bool' => true, 'number' => 3, 'array' => ['item'], 'string' => '4']]);
+
+        $this->assertFalse($c->searchMultidimensional('false', 'bool', true));
+        $this->assertFalse($c->searchMultidimensional('1', 'number', true));
+        $this->assertFalse($c->searchMultidimensional('item', 'array', true));
+        $this->assertFalse($c->searchMultidimensional(2, 'string', true));
+        $this->assertEquals(2, $c->searchMultidimensional(true, 'bool', true));
+        $this->assertEquals(2, $c->searchMultidimensional(3, 'number', true));
+        $this->assertEquals(2, $c->searchMultidimensional('4', 'string', true));
+    }
+
+    public function testSearchMultidimensionalReturnsFalseWhenItemIsNotFound()
+    {
+        $c = new Collection([['first' => 'Taylor', 'last' => 'Otwell'], ['first' => 'Jeffrey', 'last' => 'Way'], 3 => ['first' => 'Adam', 'last' => 'Wathan']]);
+
+        $this->assertFalse($c->searchMultidimensional('Matt', 'first'));
+        $this->assertFalse($c->searchMultidimensional('Stauffer', 'last'));
+    }
+
     public function testKeys()
     {
         $c = new Collection(['name' => 'taylor', 'framework' => 'laravel']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2302,13 +2302,15 @@ class SupportCollectionTest extends TestCase
 
     public function testSearchMultidimensionalInStrictMode()
     {
-        $c = new Collection([['bool' => false, 'number' => 1, 'array' => [], 'string' => '2'], 2 => ['bool' => true, 'number' => 3, 'array' => ['item'], 'string' => '4']]);
+        $c = new Collection([['bool' => true, 'number' => 1, 'array' => [], 'string' => '2'], 2 => ['bool' => false, 'number' => 3, 'array' => ['item'], 'string' => '4']]);
 
-        $this->assertFalse($c->searchMultidimensional('false', 'bool', true));
+        $this->assertFalse($c->searchMultidimensional('true', 'bool', true));
         $this->assertFalse($c->searchMultidimensional('1', 'number', true));
         $this->assertFalse($c->searchMultidimensional('item', 'array', true));
         $this->assertFalse($c->searchMultidimensional(2, 'string', true));
-        $this->assertEquals(2, $c->searchMultidimensional(true, 'bool', true));
+        $this->assertEquals(0, $c->searchMultidimensional('true', 'bool'));
+        $this->assertEquals(0, $c->searchMultidimensional('1', 'number'));
+        $this->assertEquals(2, $c->searchMultidimensional(false, 'bool', true));
         $this->assertEquals(2, $c->searchMultidimensional(3, 'number', true));
         $this->assertEquals(2, $c->searchMultidimensional('4', 'string', true));
     }


### PR DESCRIPTION
This method allows for searching in a multidimensional collection. Its arguments are the collection, the columnName on the collection that should be searched and whether or not the search should be in strict mode. 

I used `array_combine` to assure that the original collection keys are preserved. While this may make the method somewhat fragile, as the number of items in the original collection must match the number of items found with the given key (columnName), I believe it's the only sane way to handle this. Otherwise the method would return the keys of the newly created array, i.e. `array_column($this->items, $columnName)`, which, if the equality requirement mentioned above was not met, could have no meaning in the original collection. 

I also realize that this could be one lined like below, 

```
return array_search($value, array_combine(array_keys($this->items), array_column($this->items, $columnName)), $strict);
```

But, it's a lot easier to review and understand when it is broken into two parts, IMO. 

In a recent project with a lot of collection work, I found myself reaching for this type of utility quite a few times. 
