### PR TITLE
[6.0] AuthenticateSession middleware needs to call `Auth::logoutCurrentDevice` instead of `Auth::logout` 

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -87,7 +87,7 @@ class AuthenticateSession
      */
     protected function logout($request)
     {
-        $this->auth->logout();
+        $this->auth->logoutCurrentDevice();
 
         $request->session()->flush();
 


### PR DESCRIPTION
This PR is a complement of https://github.com/laravel/framework/pull/29397. 

So, in order to invoke the method `logoutOtherDevices` we need to enabled the middleware `Illuminate\Session\Middleware\AuthenticateSession`, which is commented by default, thus middleware calls the `Auth::logout()` when the user password's does not match, meaning the session was invalidated from other device then the user is logged out.

The problem is that by calling `Auth::logout` within this middleware will rotate the remember_token again, and from the device which should be kept logged in will then gets logout.

Here is a scenario explained: 
Im logged in from my home device with remember me, then Im logged in at Work with remember me too, then from home device I do logout other devices, my current device still logged in, this is the right behaviour at this point. But when open the device at work, so the middleware `Illuminate\Session\Middleware\AuthenticateSession` will see that the user's password was invalidated then I get logout of the application from that device, however the middleware will call `Auth::logout` which will then recycle the remember_token. Later on when I get back home and open the browser, guess what?, Im not logged in anymore because the remember_token has changed by work device.
