### PR TITLE
[6.0] Pass a Container instance to the Pipeline

### DIFF
--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -66,7 +66,7 @@ class CallQueuedHandler
      */
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
-        return app(Pipeline::class)->send($command)
+        return new Pipeline(Container::getInstance())->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
                     return $this->dispatcher->dispatchNow(

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -66,7 +66,7 @@ class CallQueuedHandler
      */
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
-        return (new Pipeline)->send($command)
+        return app(Pipeline::class)->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
                     return $this->dispatcher->dispatchNow(

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Exception;
 use ReflectionClass;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -67,7 +67,7 @@ class CallQueuedHandler
      */
     protected function dispatchThroughMiddleware(Job $job, $command)
     {
-        return new Pipeline(Container::getInstance())->send($command)
+        return (new Pipeline(Container::getInstance()))->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
                     return $this->dispatcher->dispatchNow(


### PR DESCRIPTION
This would allow Job Middleware to use Dependency Injection, instead of using `app()` or `resolve()`.

Otherwise, doing this will return a **RuntimeException**:

```php
public $middleware = [
    MyJobMiddleware::class
];
```
    RuntimeException : A container instance has not been passed to the Pipeline.