### PR TITLE
[5.8] Add Request::validate() macro test coverage

### DIFF
--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Validation;
+
+use Illuminate\Http\Request;
+use Orchestra\Testbench\TestCase;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * @group integration
+ */
+class RequestValidationTest extends TestCase
+{
+    public function testValidateMacro()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+
+        $validated = $request->validate(['name' => 'string']);
+
+        $this->assertSame(['name' => 'Taylor'], $validated);
+    }
+
+    public function testValidateMacroWhenItFails()
+    {
+        $this->expectException(ValidationException::class);
+
+        $request = Request::create('/', 'GET', ['name' => null]);
+
+        $request->validate(['name' => 'string']);
+    }
+}


### PR DESCRIPTION
https://github.com/laravel/framework/pull/29482 revealed `Request::validate()` was never called in the test suite.

Since PHP 7.4 is potentially introducing breaking changes to Laravel macros, add test coverage to `Request::validate()` registered in `FoundationServiceProvider`. (https://github.com/laravel/framework/pull/19063)

> Additional framework macro `Request::hasValidSignature()` is already covered by `UrlSigningTest`.