### PR TITLE
[5.8]add increment and decrement multiple columns methods.And add tests.

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2758,6 +2758,60 @@ class Builder
     }
 
     /**
+     * Increment multiple column's value by given amount array.
+     *
+     * @param  array   $values
+     * @param  array   $extra
+     * @return int
+     */
+    public function incrementMultiple(array $values, array $extra = [])
+    {
+        $columns = [];
+
+        foreach ($values as $column => $amount) {
+            
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException('Non-numeric value passed to incrementMultiple method.');
+            }
+
+            $wrapped = $this->grammar->wrap($column);
+
+            $columns[$column] = $this->raw("$wrapped + $amount");
+        }
+
+        $columns = array_merge($columns, $extra);
+
+        return $this->update($columns);
+    }
+
+    /**
+     * Decrement multiple column's value by given amount array.
+     *
+     * @param  array   $values
+     * @param  array   $extra
+     * @return int
+     */
+    public function decrementMultiple(array $values, array $extra = [])
+    {
+        $columns = [];
+
+        foreach ($values as $column => $amount) {
+
+            if (! is_numeric($amount)) {
+                throw new InvalidArgumentException('Non-numeric value passed to decrementMultiple method.');
+            }
+
+            $wrapped = $this->grammar->wrap($column);
+
+            $columns[$column] = $this->raw("$wrapped - $amount");
+        }
+
+        $columns = array_merge($columns, $extra);
+
+        return $this->update($columns);
+    }
+
+    /**
      * Delete a record from the database.
      *
      * @param  mixed  $id

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1540,6 +1540,46 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('category'));
     }
 
+    public function testIncrementMultipleOnExistingModelCallsQueryAndSetsAttribute()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 2;
+        $model->category = 3;
+        $model->name = 4;
+
+        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->andReturn($query);
+        $query->shouldReceive('increment');
+
+        $model->publicIncrementMultiple(['foo' => 1, 'category' => 1], ['name' => 5]);
+        $this->assertEquals(3, $model->foo);
+        $this->assertEquals(4, $model->category);
+        $this->assertTrue($model->isDirty('name'));
+    }
+
+    public function testDecrementMultipleOnExistingModelCallsQueryAndSetsAttribute()
+    {
+        $model = m::mock(EloquentModelStub::class.'[newQueryWithoutRelationships]');
+        $model->exists = true;
+        $model->id = 1;
+        $model->syncOriginalAttribute('id');
+        $model->foo = 2;
+        $model->category = 3;
+        $model->name = 4;
+
+        $model->shouldReceive('newQueryWithoutRelationships')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->andReturn($query);
+        $query->shouldReceive('increment');
+
+        $model->publicDecrementMultiple(['foo' => 1, 'category' => 1], ['name' => 5]);
+        $this->assertEquals(1, $model->foo);
+        $this->assertEquals(2, $model->category);
+        $this->assertTrue($model->isDirty('name'));
+    }
+
     public function testRelationshipTouchOwnersIsPropagated()
     {
         $relation = $this->getMockBuilder(BelongsTo::class)->setMethods(['touch'])->disableOriginalConstructor()->getMock();
@@ -1976,6 +2016,16 @@ class EloquentModelStub extends Model
     public function publicIncrement($column, $amount = 1, $extra = [])
     {
         return $this->increment($column, $amount, $extra);
+    }
+
+    public function publicIncrementMultiple($values, $extra = [])
+    {
+        return $this->incrementMultiple($values, $extra);
+    }
+
+    public function publicDecrementMultiple($values, $extra = [])
+    {
+        return $this->decrementMultiple($values, $extra);
     }
 
     public function belongsToStub()


### PR DESCRIPTION
it would be helpful if it was possible to increment multiple columns when updating something like
`Model::where('id', 2) -> incrementMultiple( ['count' => 2, 'times' => 3] )`
ps: To solve this @[problem](https://github.com/laravel/ideas/issues/1766)
