### PR TITLE
[6.0] Update lang facade

### DIFF
--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -3,11 +3,10 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static mixed trans(string $key, array $replace = [], string $locale = null)
- * @method static string transChoice(string $key, int|array|\Countable $number, array $replace = [], string $locale = null)
+ * @method static mixed get(string $key, array $replace = [], string $locale = null, bool $fallback = true)
+ * @method static string choice(string $key, int|array|\Countable $number, array $replace = [], string $locale = null)
  * @method static string getLocale()
  * @method static void setLocale(string $locale)
- * @method static string|array|null get(string $key, array $replace = [], string $locale = null, bool $fallback = true)
  *
  * @see \Illuminate\Translation\Translator
  */


### PR DESCRIPTION
Lang facade has to be updated because of the translator changes from https://github.com/laravel/framework/pull/29529

- Remove `trans` method signature.
- Rename `transChoice` to `choice`.