### PR TITLE
[6.0] Change react preset example stub to functional component

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
+++ b/src/Illuminate/Foundation/Console/Presets/react-stubs/Example.js
@@ -1,23 +1,23 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 
-export default class Example extends Component {
-    render() {
-        return (
-            <div className="container">
-                <div className="row justify-content-center">
-                    <div className="col-md-8">
-                        <div className="card">
-                            <div className="card-header">Example Component</div>
+function Example() {
+    return (
+        <div className="container">
+            <div className="row justify-content-center">
+                <div className="col-md-8">
+                    <div className="card">
+                        <div className="card-header">Example Component</div>
 
-                            <div className="card-body">I'm an example component!</div>
-                        </div>
+                        <div className="card-body">I'm an example component!</div>
                     </div>
                 </div>
             </div>
-        );
-    }
+        </div>
+    );
 }
+
+export default Example;
 
 if (document.getElementById('example')) {
     ReactDOM.render(<Example />, document.getElementById('example'));


### PR DESCRIPTION
Changed the Example.js component in react preset stub to a functional component.

**Why?**

Since React is encouraging functional components over class components, I believe it will be nice to encourage people use it that way in Laravel too.

Create react app also changed it so why don't we follow their steps? ;)