### PR TITLE
[6.0] Deprecate namespace trait

### DIFF
--- a/src/Illuminate/Console/DetectsApplicationNamespace.php
+++ b/src/Illuminate/Console/DetectsApplicationNamespace.php
@@ -5,7 +5,7 @@ namespace Illuminate\Console;
 use Illuminate\Container\Container;
 
 /**
- * @deprecated Usage of this trait is deprecated and it'll be removed in Laravel 7.0
+ * @deprecated Usage of this trait is deprecated and it will be removed in Laravel 7.0.
  */
 trait DetectsApplicationNamespace
 {

--- a/src/Illuminate/Console/DetectsApplicationNamespace.php
+++ b/src/Illuminate/Console/DetectsApplicationNamespace.php
@@ -4,6 +4,9 @@ namespace Illuminate\Console;
 
 use Illuminate\Container\Container;
 
+/**
+ * @deprecated Usage of this trait is deprecated and it'll be removed in Laravel 7.0
+ */
 trait DetectsApplicationNamespace
 {
     /**


### PR DESCRIPTION
Replaces https://github.com/laravel/framework/pull/29528

This trait isn't used so it doesn't makes sense to ship with it out of the box. Deprecating now and removing it in v7.0