### PR TITLE
[5.8] Add ValidatesWhenResolvedTrait::passedValidation() callback

### DIFF
--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -26,7 +26,7 @@ trait ValidatesWhenResolvedTrait
             $this->failedValidation($instance);
         }
 
-        $this->afterValidation();
+        $this->passedValidation();
     }
 
     /**
@@ -44,7 +44,7 @@ trait ValidatesWhenResolvedTrait
      *
      * @return void
      */
-    protected function afterValidation()
+    protected function passedValidation()
     {
         // no default action
     }

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -36,17 +36,7 @@ trait ValidatesWhenResolvedTrait
      */
     protected function prepareForValidation()
     {
-        // no default action
-    }
-
-    /**
-     * Prepare the data for further processing.
-     *
-     * @return void
-     */
-    protected function passedValidation()
-    {
-        // no default action
+        //
     }
 
     /**
@@ -57,6 +47,16 @@ trait ValidatesWhenResolvedTrait
     protected function getValidatorInstance()
     {
         return $this->validator();
+    }
+
+    /**
+     * Handle a passed validation attempt.
+     *
+     * @return void
+     */
+    protected function passedValidation()
+    {
+        //
     }
 
     /**

--- a/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
+++ b/src/Illuminate/Validation/ValidatesWhenResolvedTrait.php
@@ -25,6 +25,8 @@ trait ValidatesWhenResolvedTrait
         if ($instance->fails()) {
             $this->failedValidation($instance);
         }
+
+        $this->afterValidation();
     }
 
     /**
@@ -33,6 +35,16 @@ trait ValidatesWhenResolvedTrait
      * @return void
      */
     protected function prepareForValidation()
+    {
+        // no default action
+    }
+
+    /**
+     * Prepare the data for further processing.
+     *
+     * @return void
+     */
+    protected function afterValidation()
     {
         // no default action
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -315,7 +315,7 @@ class FoundationTestFormRequestHooks extends FormRequest
         $this->replace(['name' => 'Taylor']);
     }
 
-    public function afterValidation()
+    public function passedValidation()
     {
         $this->replace(['name' => 'Adam']);
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -106,6 +106,15 @@ class FoundationFormRequestTest extends TestCase
         $this->createRequest([], FoundationTestFormRequestHooks::class)->validateResolved();
     }
 
+    public function test_after_validation_runs_after_validation()
+    {
+        $request = $this->createRequest([], FoundationTestFormRequestHooks::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Adam'], $request->all());
+    }
+
     /**
      * Catch the given exception thrown from the executor, and return it.
      *
@@ -304,5 +313,10 @@ class FoundationTestFormRequestHooks extends FormRequest
     public function prepareForValidation()
     {
         $this->replace(['name' => 'Taylor']);
+    }
+
+    public function afterValidation()
+    {
+        $this->replace(['name' => 'Adam']);
     }
 }


### PR DESCRIPTION
Similar to the `prepareForValidation()` callback, it would be quite handy to have a `afterValidation()` callback as well.

This would allow us to apply filters to request values, such as converting types without interfering with Laravel validation.