### PR TITLE
[6.0] Bypass same type check for numeric comparisons

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -891,7 +891,11 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
+        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value > $comparedToValue;
+        }
+
+        if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
@@ -918,7 +922,11 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
+        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value < $comparedToValue;
+        }
+
+        if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
@@ -945,7 +953,11 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
+        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value >= $comparedToValue;
+        }
+
+        if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 
@@ -972,7 +984,11 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
+        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+            return $value <= $comparedToValue;
+        }
+
+        if (! $this->isSameType($value, $comparedToValue)) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -891,7 +891,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue)) {
+        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
             return false;
         }
 
@@ -918,7 +918,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue)) {
+        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
             return false;
         }
 
@@ -945,7 +945,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue)) {
+        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
             return false;
         }
 
@@ -972,7 +972,7 @@ trait ValidatesAttributes
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-        if (! $this->isSameType($value, $comparedToValue)) {
+        if (! $this->isSameType($value, $comparedToValue) && ! is_numeric($value) && ! is_numeric($comparedToValue)) {
             return false;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1088,8 +1088,20 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 'string'], ['lhs' => 'numeric|gt:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 10], ['lhs' => 'numeric|gt:rhs']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gt:rhs']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|gt:10']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gt:rhs']);
         $this->assertTrue($v->passes());
@@ -1117,7 +1129,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 'string'], ['lhs' => 'numeric|lt:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 10], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lt:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|lt:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|lt:10']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lt:rhs']);
@@ -1146,8 +1170,20 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 'string'], ['lhs' => 'numeric|gte:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 15], ['lhs' => 'numeric|gte:rhs']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|gte:rhs']);
         $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|gte:15']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|gte:15']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'gte:rhs']);
         $this->assertTrue($v->passes());
@@ -1175,7 +1211,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['lhs' => 15, 'rhs' => 'string'], ['lhs' => 'numeric|lte:rhs']);
         $this->assertTrue($v->fails());
 
+        $v = new Validator($trans, ['lhs' => 15.0, 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['lhs' => '15', 'rhs' => 15], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->passes());
+
         $v = new Validator($trans, ['lhs' => 15], ['lhs' => 'numeric|lte:rhs']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => 15.0], ['lhs' => 'numeric|lte:10']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($trans, ['lhs' => '15'], ['lhs' => 'numeric|lte:10']);
         $this->assertTrue($v->fails());
 
         $v = new Validator($trans, ['lhs' => 'longer string', 'rhs' => 'string'], ['lhs' => 'lte:rhs']);
@@ -3352,7 +3400,8 @@ class ValidationValidatorTest extends TestCase
     public function testCustomDependentValidators()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             [
                 ['name' => 'Jamie', 'age' => 27],
             ],
@@ -3408,37 +3457,51 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // string passes
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|String']);
+            ['foo' => 'Array', 'foo.*.name' => 'Required|String']
+        );
         $this->assertTrue($v->passes());
 
         // numeric fails
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|Numeric']);
+            ['foo' => 'Array', 'foo.*.name' => 'Required|Numeric']
+        );
         $this->assertFalse($v->passes());
 
         // nested array fails
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']);
+            ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']
+        );
         $this->assertFalse($v->passes());
 
         // multiple items passes
-        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String']]);
+        $v = new Validator(
+            $trans,
+            ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String']]
+        );
         $this->assertTrue($v->passes());
 
         // multiple items fails
-        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'Numeric']]);
+        $v = new Validator(
+            $trans,
+            ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'Numeric']]
+        );
         $this->assertFalse($v->passes());
 
         // nested arrays fails
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String'], 'foo.*.votes.*' => ['Required', 'Integer']]);
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String'], 'foo.*.votes.*' => ['Required', 'Integer']]
+        );
         $this->assertFalse($v->passes());
     }
 
@@ -3570,22 +3633,32 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'size:4']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator($trans,
-            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'min:3']);
+        $v = new Validator(
+            $trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]],
+            ['foo.*.bar' => 'min:3']
+        );
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,
-            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'between:3,6']);
+        $v = new Validator(
+            $trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]],
+            ['foo.*.bar' => 'between:3,6']
+        );
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo.*.votes' => ['Required', 'Size:2']]);
+            ['foo.*.votes' => ['Required', 'Size:2']]
+        );
         $this->assertTrue($v->passes());
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2, 3]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo.*.votes' => ['Required', 'Size:2']]);
+            ['foo.*.votes' => ['Required', 'Size:2']]
+        );
         $this->assertFalse($v->passes());
     }
 
@@ -4097,7 +4170,8 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             [
                 ['name' => 'John'],
                 ['name' => null],
@@ -4105,20 +4179,23 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 '*.name' => 'required',
-            ]);
+            ]
+        );
 
         $this->assertEquals($v->invalid(), [
             1 => ['name' => null],
             2 => ['name' => ''],
         ]);
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             [
                 'name' => '',
             ],
             [
                 'name' => 'required',
-            ]);
+            ]
+        );
 
         $this->assertEquals($v->invalid(), [
             'name' => '',
@@ -4129,7 +4206,8 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             [
                 ['name' => 'John'],
                 ['name' => null],
@@ -4138,14 +4216,16 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 '*.name' => 'required',
-            ]);
+            ]
+        );
 
         $this->assertEquals($v->valid(), [
             0 => ['name' => 'John'],
             3 => ['name' => 'Doe'],
         ]);
 
-        $v = new Validator($trans,
+        $v = new Validator(
+            $trans,
             [
                 'name' => 'Carlos',
                 'age' => 'unknown',
@@ -4155,7 +4235,8 @@ class ValidationValidatorTest extends TestCase
                 'name' => 'required',
                 'gender' => 'in:male,female',
                 'age' => 'required|int',
-            ]);
+            ]
+        );
 
         $this->assertEquals($v->valid(), [
             'name' => 'Carlos',
@@ -4538,7 +4619,8 @@ class ValidationValidatorTest extends TestCase
     public function getIlluminateArrayTranslator()
     {
         return new Translator(
-            new ArrayLoader, 'en'
+            new ArrayLoader,
+            'en'
         );
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3400,8 +3400,7 @@ class ValidationValidatorTest extends TestCase
     public function testCustomDependentValidators()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             [
                 ['name' => 'Jamie', 'age' => 27],
             ],
@@ -3457,51 +3456,37 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // string passes
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|String']
-        );
+            ['foo' => 'Array', 'foo.*.name' => 'Required|String']);
         $this->assertTrue($v->passes());
 
         // numeric fails
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|Numeric']
-        );
+            ['foo' => 'Array', 'foo.*.name' => 'Required|Numeric']);
         $this->assertFalse($v->passes());
 
         // nested array fails
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']
-        );
+            ['foo' => 'Array', 'foo.*.name' => 'Required|String', 'foo.*.votes.*' => 'Required|Integer']);
         $this->assertFalse($v->passes());
 
         // multiple items passes
-        $v = new Validator(
-            $trans,
-            ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String']]
-        );
+        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String']]);
         $this->assertTrue($v->passes());
 
         // multiple items fails
-        $v = new Validator(
-            $trans,
-            ['foo' => [['name' => 'first'], ['name' => 'second']]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'Numeric']]
-        );
+        $v = new Validator($trans, ['foo' => [['name' => 'first'], ['name' => 'second']]],
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'Numeric']]);
         $this->assertFalse($v->passes());
 
         // nested arrays fails
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String'], 'foo.*.votes.*' => ['Required', 'Integer']]
-        );
+            ['foo' => 'Array', 'foo.*.name' => ['Required', 'String'], 'foo.*.votes.*' => ['Required', 'Integer']]);
         $this->assertFalse($v->passes());
     }
 
@@ -3633,32 +3618,22 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'size:4']);
         $this->assertFalse($v->passes());
 
-        $v = new Validator(
-            $trans,
-            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]],
-            ['foo.*.bar' => 'min:3']
-        );
+        $v = new Validator($trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'min:3']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator(
-            $trans,
-            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]],
-            ['foo.*.bar' => 'between:3,6']
-        );
+        $v = new Validator($trans,
+            ['foo' => [['bar' => [1, 2, 3]], ['bar' => [1, 2, 3]]]], ['foo.*.bar' => 'between:3,6']);
         $this->assertTrue($v->passes());
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo.*.votes' => ['Required', 'Size:2']]
-        );
+            ['foo.*.votes' => ['Required', 'Size:2']]);
         $this->assertTrue($v->passes());
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             ['foo' => [['name' => 'first', 'votes' => [1, 2, 3]], ['name' => 'second', 'votes' => ['something', 2]]]],
-            ['foo.*.votes' => ['Required', 'Size:2']]
-        );
+            ['foo.*.votes' => ['Required', 'Size:2']]);
         $this->assertFalse($v->passes());
     }
 
@@ -4170,8 +4145,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             [
                 ['name' => 'John'],
                 ['name' => null],
@@ -4179,23 +4153,20 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 '*.name' => 'required',
-            ]
-        );
+            ]);
 
         $this->assertEquals($v->invalid(), [
             1 => ['name' => null],
             2 => ['name' => ''],
         ]);
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             [
                 'name' => '',
             ],
             [
                 'name' => 'required',
-            ]
-        );
+            ]);
 
         $this->assertEquals($v->invalid(), [
             'name' => '',
@@ -4206,8 +4177,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             [
                 ['name' => 'John'],
                 ['name' => null],
@@ -4216,16 +4186,14 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 '*.name' => 'required',
-            ]
-        );
+            ]);
 
         $this->assertEquals($v->valid(), [
             0 => ['name' => 'John'],
             3 => ['name' => 'Doe'],
         ]);
 
-        $v = new Validator(
-            $trans,
+        $v = new Validator($trans,
             [
                 'name' => 'Carlos',
                 'age' => 'unknown',
@@ -4235,8 +4203,7 @@ class ValidationValidatorTest extends TestCase
                 'name' => 'required',
                 'gender' => 'in:male,female',
                 'age' => 'required|int',
-            ]
-        );
+            ]);
 
         $this->assertEquals($v->valid(), [
             'name' => 'Carlos',
@@ -4619,8 +4586,7 @@ class ValidationValidatorTest extends TestCase
     public function getIlluminateArrayTranslator()
     {
         return new Translator(
-            new ArrayLoader,
-            'en'
+            new ArrayLoader, 'en'
         );
     }
 }


### PR DESCRIPTION
This is a resurrection of #25001.

This PR allows comparing integers, floats, and strings as long as the field contains the `numeric` rule and both fields actually pass `is_numeric()`.

```php
10 <= 20.5
20.50 >= 10
"10" >= 10
```