### PR TITLE
[6.0] Throw exception when attempting to override gate result in after callback if previously sent.

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Access;
 
 use Exception;
+use LogicException;
 use ReflectionClass;
 use ReflectionFunction;
 use Illuminate\Support\Arr;
@@ -496,8 +497,8 @@ class Gate implements GateContract
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string  $ability
      * @param  array  $arguments
-     * @param  bool  $result
-     * @return bool|null
+     * @param  mixed  $result
+     * @return mixed
      */
     protected function callAfterCallbacks($user, $ability, array $arguments, $result)
     {
@@ -507,6 +508,10 @@ class Gate implements GateContract
             }
 
             $afterResult = $after($user, $ability, $result, $arguments);
+
+            if (! is_null($result) && ! is_null($afterResult)) {
+                throw new LogicException('Cannot override permission result in after callback because a result has already been sent in either a before callback or previous policy check.');
+            }
 
             $result = $result ?? $afterResult;
         }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -287,40 +287,38 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->allows('null'));
     }
 
-    public function testAfterCallbacksDoNotOverridePreviousResult()
+    public function testAfterCallbacksThrowsExceptionWhenHasPreviousResult()
     {
         $gate = $this->getBasicGate();
-
-        $gate->define('deny', function ($user) {
-            return false;
-        });
 
         $gate->define('allow', function ($user) {
             return true;
         });
 
         $gate->after(function ($user, $ability, $result) {
-            return ! $result;
+            return false;
         });
 
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot override permission result in after callback because a result has already been sent in either a before callback or previous policy check.');
         $this->assertTrue($gate->allows('allow'));
-        $this->assertTrue($gate->denies('deny'));
     }
 
-    public function testAfterCallbacksDoNotOverrideEachOther()
+    public function testAfterCallbacksThrowsExceptionWhenHasPreviousResultForMultipleAfterCallbacks()
     {
         $gate = $this->getBasicGate();
 
         $gate->after(function ($user, $ability, $result) {
-            return $ability == 'allow';
+            return false;
         });
 
         $gate->after(function ($user, $ability, $result) {
-            return ! $result;
+            return true;
         });
 
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot override permission result in after callback because a result has already been sent in either a before callback or previous policy check.');
         $this->assertTrue($gate->allows('allow'));
-        $this->assertTrue($gate->denies('deny'));
     }
 
     public function testCurrentUserThatIsOnGateAlwaysInjectedIntoClosureCallbacks()


### PR DESCRIPTION
Currently when you return a non-value from a policy check or before callback AND a value from an after callback, it'll silently ignore the after callback result. This can create subtle / obscure bugs in your application because you can be fooled into thinking because you returned a result in the after callback it'll override your existing permission result, this isn't always the case.

Motivation behind this PR was in response to [this tweet](https://twitter.com/beausimensen/status/1161345835684306945) where there is a bit of a difference in behaviour between how `before` and `after` work - in the before callback you *can* essentially override the result from the policy check, but in the after callback you can ONLY override it if it came back with a `null` value.

This PR helps make it immediately obvious in your code that your returned value in the `after` callback won't have any effect because a result was previously sent. Code examples:

**Current/Previous Behaviour:**
```php
Gate::define('allow', function ($user) {
    return true;
});

Gate::after(function ($user, $ability, $result) {
    // This is silently ignored because permission has previously been granted.
    return false;
});
```

**New Behaviour with this PR:**

```php
Gate::define('allow', function ($user) {
    return true;
});

Gate::after(function ($user, $ability, $result) {
    // This will throw a "LogicException" because you cannot override $result with false.
    // You need to check if $result is null before sending back a non-null result.
    return false;

    // Sending back a null result won't cause any exceptions, it's essentially a non-op.
    return null;
});
```

Sending to 6.0 because this is a breaking change if people are relying on it to silently ignore values sent from after callbacks. The upgrade guide would state that if you are using after callbacks, and you are sending a result back, you need to check `$result` is `null` because otherwise you won't be able to alter the result - it'll throw a `LogicException`.