### PR TITLE
Add query builder "addSelectSub" method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -245,6 +245,25 @@ class Builder
     }
 
     /**
+     * Add a subselect expression to the query, ensuring to select all columns
+     * if the user hasn't already explicitly specified any columns.
+     *
+     * @param  string  $as
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function addSelectSub($as, $query)
+    {
+        if (is_null($this->columns)) {
+            $this->select($this->from.'.*');
+        }
+
+        return $this->selectSub($query, $as);
+    }
+
+    /**
      * Add a new "raw" select expression to the query.
      *
      * @param  string  $expression


### PR DESCRIPTION
> **NOTE: Don't merge this yet. 🚨
> Another approach was suggested to me, which I'd like to explore first.**

-----------------

This PR adds an improved sub select method to the query builder. There are two main issues with the current `selectSub($query, $as)` method (see below). And while it would be nice to just update this method, that would introduce a significant breaking change that's just not worth it.

### 1. **selectSub() has a less than ideal argument order**

Since sub queries are written as closures, it's _much_ nicer to have the column alias (`$as`) first. This is particularly important when you have longer, more complex sub queries.

### 2. **selectSub() requires you to specify columns**

When you add a sub query using `selectSub()` you must also now specify your columns (*), otherwise you'll *only* get the sub query column back, not all the columns on the table. This behaviour is somewhat confusing, and also adds extra work each time you use a sub select.

### Comparison of both methods

```php
// Using selectSub()
User::select('*')->selectSub(function ($query) {
    $query->select('column')
        ->from('table')
        ->limit(1);
}, 'whatever')->get();

// Using addSelectSub()
User::addSelectSub('whatever', function ($query) {
    $query->select('column')
        ->from('table')
        ->limit(1);
})->get();
```

### Motivation

I think sub queries are an under-utilized feature in Laravel. I think we can both improve the API and also add more documentation around sub queries.

For example, I have been using [sub queries to create dynamic relationships](https://reinink.ca/articles/dynamic-relationships-in-laravel-using-subqueries). Consider the following example:

```php
class User extends Model
{
    public function lastLogin()
    {
        return $this->belongsTo(Login::class);
    }

    public function scopeWithLastLogin($query)
    {
        $query->addSelectSub('last_login_id', Login::select('id')
            ->whereColumn('user_id', 'users.id')
            ->latest()
            ->limit(1)
        )->with('lastLogin');
    }
}

$users = User::withLastLogin()->get();
```