### PR TITLE
Add query builder "orderBySub" and "orderBySubDesc" methods

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1817,6 +1817,31 @@ class Builder
     }
 
     /**
+     * Add an "order by" subquery clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @param  string  $direction
+     * @return $this
+     */
+    public function orderBySub($query, $direction = 'asc')
+    {
+        [$query, $bindings] = $this->createSub($query);
+
+        return $this->addBinding($bindings, 'order')->orderBy(new Expression('('.$query.')'), $direction);
+    }
+
+    /**
+     * Add a descending "order by" subquery clause to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
+     * @return $this
+     */
+    public function orderBySubDesc($query)
+    {
+        return $this->orderBySub($query, 'desc');
+    }
+
+    /**
      * Put the query's results in random order.
      *
      * @param  string  $seed


### PR DESCRIPTION
> **NOTE: Don't merge this yet. 🚨
> Another approach was suggested to me, which I'd like to explore first.**

-----------------

This PR adds two new methods to the query builder to allow ordering by sub queries. This includes a new `orderBySub($query, $direction)` method and a shortcut `orderBySubDesc($query)` method, similar to `orderByDesc($column)`.

Previously this was only possible using `orderByRaw()`, but that's dangerous, because the direction (`asc`/`desc`) cannot be used as a binding, meaning developers were responsible for verifying the direction themselves.

These two methods intentionally use `orderBy()` instead of `orderByRaw()` to take advantage of the direction check that exists in that method.

Here are a couple examples of how this can be useful:

```php
// Order users by their last login date
$users = User::orderBySub(function ($query) {
    $query->select('created_at')
        ->from('logins')
        ->whereColumn('user_id', 'users.id')
        ->latest()
        ->limit(1);
})->get();

// Order courses by the start date of the first lesson
$courses = Course::orderBySub(
    Lesson::select('starts_at')
        ->whereColumn('course_id', 'courses.id')
        ->oldest('starts_at')
        ->limit(1)
)->get();
```