### PR TITLE
[6.0] Add the ability to order by subqueries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1761,7 +1761,7 @@ class Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @param  string  $direction
      * @return $this
      *
@@ -1769,6 +1769,16 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
+        if ($column instanceof self ||
+            $column instanceof EloquentBuilder ||
+            $column instanceof Closure) {
+            [$query, $bindings] = $this->createSub($column);
+
+            $column = new Expression('('.$query.')');
+
+            $this->addBinding($bindings, 'order');
+        }
+
         $direction = strtolower($direction);
 
         if (! in_array($direction, ['asc', 'desc'], true)) {


### PR DESCRIPTION
This PR adds the ability to order by subqueries  using the existing `orderBy($column, $direction = 'asc')` and `orderByDesc($column)` methods.

Previously this was only possible using `orderByRaw()`, but that's dangerous, as the direction (`asc`/`desc`) cannot be set with a binding, meaning developers were responsible for verifying and inserting the direction into the query themselves.

Here are a couple examples of how this can be useful.

```php
// Order users by their last login date
$users = User::orderBy(function ($query) {
    $query->select('created_at')
        ->from('logins')
        ->whereColumn('user_id', 'users.id')
        ->latest()
        ->limit(1);
})->get();

// Order courses by the start date of the first lesson
$courses = Course::orderBy(
    Lesson::select('starts_at')
        ->whereColumn('course_id', 'courses.id')
        ->oldest('starts_at')
        ->limit(1)
)->get();
```

Note, `orderBy()` now accepts subqueries in three possible formats:

- `Illuminate\Database\Query\Builder`
- `Illuminate\Database\Eloquent\Builder`
- `Closure`

This is the exact same approach as what's done in the `whereIn()` method:

https://github.com/laravel/framework/blob/df60917f85cccc489b5223397c1cac9d58acc7ef/src/Illuminate/Database/Query/Builder.php#L856-L864