### PR TITLE
[6.0] Remove unused property

### DIFF
--- a/src/Illuminate/Cache/NullStore.php
+++ b/src/Illuminate/Cache/NullStore.php
@@ -7,13 +7,6 @@ class NullStore extends TaggableStore
     use RetrievesMultipleKeys;
 
     /**
-     * The array of stored values.
-     *
-     * @var array
-     */
-    protected $storage = [];
-
-    /**
      * Retrieve an item from the cache by key.
      *
      * @param  string  $key


### PR DESCRIPTION
The `storage` property of NullStore hasn't been used.