### PR TITLE
[6.0] Add the ability select a subquery using addSelect()

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -335,10 +335,23 @@ class Builder
      * Add a new select column to the query.
      *
      * @param  array|mixed  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string|null  $query
      * @return $this
      */
-    public function addSelect($column)
+    public function addSelect($column, $query = null)
     {
+        if (is_string($column) && (
+            $query instanceof self ||
+            $query instanceof EloquentBuilder ||
+            $query instanceof Closure
+        )) {
+            if (is_null($this->columns)) {
+                $this->select($this->from.'.*');
+            }
+
+            return $this->selectSub($query, $column);
+        }
+
         $column = is_array($column) ? $column : func_get_args();
 
         $this->columns = array_merge((array) $this->columns, $column);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -103,24 +103,6 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
         $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
-
-        $builder = $this->getBuilder();
-        $builder->select('foo')->addSelect('bar')->addSelect('baz', 'boom')->from('users');
-        $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
-
-        $builder = $this->getBuilder();
-        $builder->from('sub')->select(['foo', 'bar'])->addSelect('sub', function ($query) {
-            $query->from('two')->select('baz')->where('subkey', '=', 'subval');
-        });
-        $this->assertEquals('select "foo", "bar", (select "baz" from "two" where "subkey" = ?) as "sub" from "sub"', $builder->toSql());
-        $this->assertEquals(['subval'], $builder->getBindings());
-
-        $builder = $this->getBuilder();
-        $builder->from('sub')->addSelect('sub', function ($query) {
-            $query->from('two')->select('baz')->where('subkey', '=', 'subval');
-        });
-        $this->assertEquals('select "sub".*, (select "baz" from "two" where "subkey" = ?) as "sub" from "sub"', $builder->toSql());
-        $this->assertEquals(['subval'], $builder->getBindings());
     }
 
     public function testBasicSelectWithPrefix()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -103,6 +103,24 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
         $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('foo')->addSelect('bar')->addSelect('baz', 'boom')->from('users');
+        $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->from('sub')->select(['foo', 'bar'])->addSelect('sub', function ($query) {
+            $query->from('two')->select('baz')->where('subkey', '=', 'subval');
+        });
+        $this->assertEquals('select "foo", "bar", (select "baz" from "two" where "subkey" = ?) as "sub" from "sub"', $builder->toSql());
+        $this->assertEquals(['subval'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->from('sub')->addSelect('sub', function ($query) {
+            $query->from('two')->select('baz')->where('subkey', '=', 'subval');
+        });
+        $this->assertEquals('select "sub".*, (select "baz" from "two" where "subkey" = ?) as "sub" from "sub"', $builder->toSql());
+        $this->assertEquals(['subval'], $builder->getBindings());
     }
 
     public function testBasicSelectWithPrefix()

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -31,6 +31,51 @@ class QueryBuilderTest extends DatabaseTestCase
         ]);
     }
 
+    public function testSelect()
+    {
+        $expected = ['id' => '1', 'title' => 'Foo Post'];
+
+        $this->assertSame($expected, (array) DB::table('posts')->select('id', 'title')->first());
+        $this->assertSame($expected, (array) DB::table('posts')->select(['id', 'title'])->first());
+    }
+
+    public function testSelectReplacesExistingSelects()
+    {
+        $this->assertSame(
+            ['id' => '1', 'title' => 'Foo Post'],
+            (array) DB::table('posts')->select('content')->select(['id', 'title'])->first()
+        );
+    }
+
+    public function testSelectWithSubQuery()
+    {
+        $this->assertSame(
+            ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
+            (array) DB::table('posts')->select(['id', 'title', 'foo' => function ($query) {
+                $query->select('bar');
+            }])->first()
+        );
+    }
+
+    public function testAddSelect()
+    {
+        $expected = ['id' => '1', 'title' => 'Foo Post', 'content' => 'Lorem Ipsum.'];
+
+        $this->assertSame($expected, (array) DB::table('posts')->select('id')->addSelect('title', 'content')->first());
+        $this->assertSame($expected, (array) DB::table('posts')->select('id')->addSelect(['title', 'content'])->first());
+        $this->assertSame($expected, (array) DB::table('posts')->addSelect(['id', 'title', 'content'])->first());
+    }
+
+    public function testAddSelectWithSubQuery()
+    {
+        $this->assertSame(
+            ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
+            (array) DB::table('posts')->addSelect(['id', 'title', 'foo' => function ($query) {
+                $query->select('bar');
+            }])->first()
+        );
+    }
+
     public function testWhereDate()
     {
         $this->assertSame(1, DB::table('posts')->whereDate('created_at', '2018-01-02')->count());


### PR DESCRIPTION
This PR adds the ability to select a sub query directly from the `addSelect()` method. This is currently only possible to do via the `selectSub($query, $column)` method, which has a few issues:

## 1. **selectSub() has a less than ideal argument order**

Since sub queries are written as closures, it's _much_ nicer to have the column alias (`$as`) first. This is particularly important when you have longer, more complex sub queries.

With this change, the subquery is the second parameter:  `addSelect($as, $query)`

## 2. **selectSub() requires you to specify columns**

When you add a sub query using `selectSub()` you must also now specify your columns (*), otherwise you'll *only* get the sub query column back, not all the columns on the table. This behaviour is somewhat confusing, and also adds extra work each time you use a sub select.

With this change, if you pass a subquery to `addSelect()` as the second argument, it will automatically add `"table".*` to the query if you haven't already explicitly specified any columns. This is inline with the existing `withCount()` behaviour:

https://github.com/laravel/framework/blob/98d842542eb761b3aca67f3886e0ae9e6cadc4a4/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php#L360-L362

## 3. **selectSub() isn't consistent with the framework**

As a general rule, the query builder already automatically treats closures and query builder instances as sub queries. For example, if you pass a closure to the second argument in a `where()` clause, it will be treated as a sub query:

```php
User::where('id', function ($query) {
    $query->select(...);
});
```

However, currently, if you'd like to add a subquery select to your query, you have to use `selectSub()`. I believe making this possible via `addSelect()` is more natural, and more consistent with the framework in general.

## Motivation

I think sub queries are an under-utilized feature in Laravel. I think we can improve both the API and also add more documentation around sub queries. For example, I have been using [sub queries to create dynamic relationships](https://reinink.ca/articles/dynamic-relationships-in-laravel-using-subqueries). Consider the following example:

```php
class User extends Model
{
    public function lastLogin()
    {
        return $this->belongsTo(Login::class);
    }

    public function scopeWithLastLogin($query)
    {
        $query->addSelect('last_login_id', Login::select('id')
            ->whereColumn('user_id', 'users.id')
            ->latest()
            ->limit(1)
        )->with('lastLogin');
    }
}

$users = User::withLastLogin()->get();
$user->lastLogin->created_at;

/*
[
  [
    "id" => 1
    "first_name" => "Clark"
    "last_name" => "Kent"
    "email" => "clark@krypton.io"
    "last_login_id" => 666666666666
  ]
]
*/
```

## Future considerations

This PR adds this functionality in the simplest possible way. If the `addSelect()` method receives two arguments, and the first is a `string`, and the second is a valid subquery, then it treats it as a subquery.

However, the `addSelect()` method currently supports both arrays and multiple arguments as well. I could see this method being extended in the future to also allow that type of behaviour. For example:

```php
$users = User::select(['last_name', 'last_login_at' => Login::select('created_at')
    ->whereColumn('user_id', 'users.id')
    ->latest()
    ->limit(1)
]);
```

However, to keep things simple, I think it's better to just start here.