### PR TITLE
[5.8] Fix exception message

### DIFF
--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -186,8 +186,8 @@ class ProviderRepository
      */
     public function writeManifest($manifest)
     {
-        if (! is_writable(dirname($this->manifestPath))) {
-            throw new Exception('The bootstrap/cache directory must be present and writable.');
+        if (! is_writable($dirname = dirname($this->manifestPath))) {
+            throw new Exception("The {$dirname} directory must be present and writable.");
         }
 
         $this->files->replace(

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Foundation;
 
+use Exception;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Filesystem\Filesystem;
@@ -86,5 +87,16 @@ class FoundationProviderRepositoryTest extends TestCase
         $result = $repo->writeManifest(['foo']);
 
         $this->assertEquals(['foo', 'when' => []], $result);
+    }
+
+    public function testWriteManifestThrowsExceptionIfManifestDirDoesntExist()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/^The (.*) directory must be present and writable.$/');
+
+        $repo = new ProviderRepository(m::mock(ApplicationContract::class), $files = m::mock(Filesystem::class), __DIR__.'/cache/services.php');
+        $files->shouldReceive('replace')->never();
+
+        $repo->writeManifest(['foo']);
     }
 }


### PR DESCRIPTION
The `manifestPath` property is a dependency of ProviderRepository and was provided by [Application::getCachedServicesPath()](https://github.com/laravel/framework/blob/843165228cd6057cd5e0bee4c3437e5bae3ff282/src/Illuminate/Foundation/Application.php#L904). It can be changed.

The current message exception is fixed and will be wrong if a developer changes his/her bootstrap/cace directory.

I also add a test for the case in which the directory doesn't exist.