### PR TITLE
[6.0] Allows pass option to presigned request for temporary request on s3

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -533,6 +533,8 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function getAwsTemporaryUrl($adapter, $path, $expiration, $options)
     {
         $client = $adapter->getClient();
+        $requestOptions = $options['request_options'] ?? [];
+        unset($options['request_options']);
 
         $command = $client->getCommand('GetObject', array_merge([
             'Bucket' => $adapter->getBucket(),
@@ -540,7 +542,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         ], $options));
 
         return (string) $client->createPresignedRequest(
-            $command, $expiration
+            $command, $expiration, $requestOptions
         )->getUri();
     }
 


### PR DESCRIPTION
This PR adds the ability to pass the options to pre-signed request on s3.

## Usage

```php

Storage::disk('s3')->temporaryUrl(
    '/some/path',
    '+1 days',
    ['request_options' => ['start_time' => Carbon::today()->startOfDay()]]
);
```