### PR TITLE
[5.8] Add INSERT IGNORE support to Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2646,6 +2646,40 @@ class Builder
             $this->cleanBindings(Arr::flatten($values, 1))
         );
     }
+    
+    /**
+     * Insert ignore a new record into the database.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function insertIgnore(array $values)
+    {
+        // Since every insert gets treated like a batch insert, we will make sure the
+        // bindings are structured in a way that is convenient when building these
+        // inserts statements by verifying these elements are actually an array.
+        if (empty($values)) {
+            return true;
+        }
+    
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+            
+                $values[$key] = $value;
+            }
+        }
+    
+        // Finally, we will run this query against the database connection and return
+        // the results. We will need to also flatten these bindings before running
+        // the query so they are all in one huge, flattened array for execution.
+        return $this->connection->insert(
+            $this->grammar->compileInsertIgnore($this, $values),
+            $this->cleanBindings(Arr::flatten($values, 1))
+        );
+    }
 
     /**
      * Insert a new record and get the value of the primary key.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2653,7 +2653,7 @@ class Builder
      * @param  array  $values
      * @return int
      */
-    public function insertIgnore(array $values)
+    public function insertOrIgnore(array $values)
     {
         // Since every insert gets treated like a batch insert, we will make sure the
         // bindings are structured in a way that is convenient when building these
@@ -2676,7 +2676,7 @@ class Builder
         // the results. We will need to also flatten these bindings before running
         // the query so they are all in one huge, flattened array for execution.
         return $this->connection->affectingStatement(
-            $this->grammar->compileInsertIgnore($this, $values),
+            $this->grammar->compileInsertOrIgnore($this, $values),
             $this->cleanBindings(Arr::flatten($values, 1))
         );
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2656,7 +2656,6 @@ class Builder
      */
     public function insertOrIgnore(array $values, $target = null)
     {
-
         if (empty($values)) {
             return 0;
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2651,7 +2651,7 @@ class Builder
      * Insert ignore a new record into the database.
      *
      * @param  array  $values
-     * @param  array  $target Only used for SqlServer
+     * @param  array|string|null  $target Only used for SqlServer
      * @return int
      */
     public function insertOrIgnore(array $values, $target = null)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2646,7 +2646,7 @@ class Builder
             $this->cleanBindings(Arr::flatten($values, 1))
         );
     }
-    
+
     /**
      * Insert ignore a new record into the database.
      *
@@ -2661,17 +2661,17 @@ class Builder
         if (empty($values)) {
             return 0;
         }
-    
+
         if (! is_array(reset($values))) {
             $values = [$values];
         } else {
             foreach ($values as $key => $value) {
                 ksort($value);
-            
+
                 $values[$key] = $value;
             }
         }
-    
+
         // Finally, we will run this query against the database connection and return
         // the results. We will need to also flatten these bindings before running
         // the query so they are all in one huge, flattened array for execution.

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2651,7 +2651,7 @@ class Builder
      * Insert ignore a new record into the database.
      *
      * @param  array  $values
-     * @return bool
+     * @return int
      */
     public function insertIgnore(array $values)
     {
@@ -2659,7 +2659,7 @@ class Builder
         // bindings are structured in a way that is convenient when building these
         // inserts statements by verifying these elements are actually an array.
         if (empty($values)) {
-            return true;
+            return 0;
         }
     
         if (! is_array(reset($values))) {
@@ -2675,7 +2675,7 @@ class Builder
         // Finally, we will run this query against the database connection and return
         // the results. We will need to also flatten these bindings before running
         // the query so they are all in one huge, flattened array for execution.
-        return $this->connection->insert(
+        return $this->connection->affectingStatement(
             $this->grammar->compileInsertIgnore($this, $values),
             $this->cleanBindings(Arr::flatten($values, 1))
         );

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2651,13 +2651,12 @@ class Builder
      * Insert ignore a new record into the database.
      *
      * @param  array  $values
+     * @param  array  $target Only used for SqlServer
      * @return int
      */
-    public function insertOrIgnore(array $values)
+    public function insertOrIgnore(array $values, $target = null)
     {
-        // Since every insert gets treated like a batch insert, we will make sure the
-        // bindings are structured in a way that is convenient when building these
-        // inserts statements by verifying these elements are actually an array.
+
         if (empty($values)) {
             return 0;
         }
@@ -2672,11 +2671,8 @@ class Builder
             }
         }
 
-        // Finally, we will run this query against the database connection and return
-        // the results. We will need to also flatten these bindings before running
-        // the query so they are all in one huge, flattened array for execution.
         return $this->connection->affectingStatement(
-            $this->grammar->compileInsertOrIgnore($this, $values),
+            $this->grammar->compileInsertOrIgnore($this, $values, (array) $target),
             $this->cleanBindings(Arr::flatten($values, 1))
         );
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -871,6 +871,18 @@ class Grammar extends BaseGrammar
 
         return "insert into $table ($columns) values $parameters";
     }
+    
+    /**
+     * Compile an insert ignore statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsertIgnore(Builder $query, array $values)
+    {
+        throw new RuntimeException('This database engine does not support INSERT IGNORE');
+    }
 
     /**
      * Compile an insert and get ID statement into SQL.
@@ -1068,7 +1080,7 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonSelector($value)
     {
-        throw new RuntimeException('This database engine does not support JSON operations.');
+        throw new RuntimeException('This database engine does not support JSON operations');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -879,7 +879,7 @@ class Grammar extends BaseGrammar
      * @param  array  $values
      * @return string
      */
-    public function compileInsertIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         throw new RuntimeException('This database engine does not support INSERT IGNORE');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -877,9 +877,10 @@ class Grammar extends BaseGrammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
+     * @param  array  $target
      * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values, array $target)
     {
         throw new RuntimeException('This database engine does not support insert or ignore.');
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -881,7 +881,7 @@ class Grammar extends BaseGrammar
      */
     public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        throw new RuntimeException('This database engine does not support INSERT IGNORE');
+        throw new RuntimeException('This database engine does not support insert or ignore.');
     }
 
     /**
@@ -1080,7 +1080,7 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonSelector($value)
     {
-        throw new RuntimeException('This database engine does not support JSON operations');
+        throw new RuntimeException('This database engine does not support JSON operations.');
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -871,7 +871,7 @@ class Grammar extends BaseGrammar
 
         return "insert into $table ($columns) values $parameters";
     }
-    
+
     /**
      * Compile an insert ignore statement into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -53,7 +53,7 @@ class MySqlGrammar extends Grammar
 
         return $sql;
     }
-    
+
     /**
      * Compile an insert ignore statement into SQL.
      *
@@ -63,9 +63,9 @@ class MySqlGrammar extends Grammar
      */
     public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        return substr_replace($this->compileInsert($query, $values),'insert ignore', 0, 6);
+        return substr_replace($this->compileInsert($query, $values), 'insert ignore', 0, 6);
     }
-    
+
     /**
      * Compile a "JSON contains" statement into SQL.
      *
@@ -118,7 +118,7 @@ class MySqlGrammar extends Grammar
     {
         return 'RAND('.$seed.')';
     }
-    
+
     /**
      * Compile the lock into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -53,7 +53,37 @@ class MySqlGrammar extends Grammar
 
         return $sql;
     }
-
+    
+    /**
+     * Compile an insert ignore statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsertIgnore(Builder $query, array $values)
+    {
+        // Essentially we will force every insert to be treated as a batch insert which
+        // simply makes creating the SQL easier for us since we can utilize the same
+        // basic routine regardless of an amount of records given to us to insert.
+        $table = $this->wrapTable($query->from);
+        
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+        
+        $columns = $this->columnize(array_keys(reset($values)));
+        
+        // We need to build a list of parameter place-holders of values that are bound
+        // to the query. Each insert should have the exact same amount of parameter
+        // bindings so we will loop through the record and parameterize them all.
+        $parameters = collect($values)->map(function ($record) {
+            return '('.$this->parameterize($record).')';
+        })->implode(', ');
+        
+        return "insert ignore into $table ($columns) values $parameters";
+    }
+    
     /**
      * Compile a "JSON contains" statement into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -63,7 +63,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        return substr_replace($this->compileInsert($query, $values), 'insert ignore', 0, 6);
+        return substr_replace($this->compileInsert($query, $values), ' ignore', 6, 0);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -108,31 +108,6 @@ class MySqlGrammar extends Grammar
     }
     
     /**
-     * Compile an insert ignore statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $values
-     * @return string
-     */
-    public function compileInsertIgnore(Builder $query, array $values)
-    {
-
-        $table = $this->wrapTable($query->from);
-    
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-    
-        $columns = $this->columnize(array_keys(reset($values)));
-    
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
-    
-        return "insert ignore into $table ($columns) values $parameters";
-    }
-    
-    /**
      * Compile the lock into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -63,25 +63,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileInsertIgnore(Builder $query, array $values)
     {
-        // Essentially we will force every insert to be treated as a batch insert which
-        // simply makes creating the SQL easier for us since we can utilize the same
-        // basic routine regardless of an amount of records given to us to insert.
-        $table = $this->wrapTable($query->from);
-        
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-        
-        $columns = $this->columnize(array_keys(reset($values)));
-        
-        // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the exact same amount of parameter
-        // bindings so we will loop through the record and parameterize them all.
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
-        
-        return "insert ignore into $table ($columns) values $parameters";
+        return substr_replace($this->compileInsert($query, $values),'insert ignore', 0, 6);
     }
     
     /**

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -61,7 +61,7 @@ class MySqlGrammar extends Grammar
      * @param  array  $values
      * @return string
      */
-    public function compileInsertIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         return substr_replace($this->compileInsert($query, $values),'insert ignore', 0, 6);
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -59,9 +59,10 @@ class MySqlGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
+     * @param  array  $target
      * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values, array $target)
     {
         return substr_replace($this->compileInsert($query, $values), ' ignore', 6, 0);
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -106,7 +106,32 @@ class MySqlGrammar extends Grammar
     {
         return 'RAND('.$seed.')';
     }
+    
+    /**
+     * Compile an insert ignore statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsertIgnore(Builder $query, array $values)
+    {
 
+        $table = $this->wrapTable($query->from);
+    
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+    
+        $columns = $this->columnize(array_keys(reset($values)));
+    
+        $parameters = collect($values)->map(function ($record) {
+            return '('.$this->parameterize($record).')';
+        })->implode(', ');
+    
+        return "insert ignore into $table ($columns) values $parameters";
+    }
+    
     /**
      * Compile the lock into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -194,6 +194,36 @@ class PostgresGrammar extends Grammar
                 ? "insert into {$table} DEFAULT VALUES"
                 : parent::compileInsert($query, $values);
     }
+    
+    /**
+     * Compile an insert ignore statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsertIgnore(Builder $query, array $values)
+    {
+        // Essentially we will force every insert to be treated as a batch insert which
+        // simply makes creating the SQL easier for us since we can utilize the same
+        // basic routine regardless of an amount of records given to us to insert.
+        $table = $this->wrapTable($query->from);
+        
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+        
+        $columns = $this->columnize(array_keys(reset($values)));
+        
+        // We need to build a list of parameter place-holders of values that are bound
+        // to the query. Each insert should have the exact same amount of parameter
+        // bindings so we will loop through the record and parameterize them all.
+        $parameters = collect($values)->map(function ($record) {
+            return '('.$this->parameterize($record).')';
+        })->implode(', ');
+        
+        return "insert into $table ($columns) values $parameters ON CONFLICT DO NOTHING";
+    }
 
     /**
      * Compile an insert and get ID statement into SQL.

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -204,25 +204,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileInsertIgnore(Builder $query, array $values)
     {
-        // Essentially we will force every insert to be treated as a batch insert which
-        // simply makes creating the SQL easier for us since we can utilize the same
-        // basic routine regardless of an amount of records given to us to insert.
-        $table = $this->wrapTable($query->from);
-        
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-        
-        $columns = $this->columnize(array_keys(reset($values)));
-        
-        // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the exact same amount of parameter
-        // bindings so we will loop through the record and parameterize them all.
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
-        
-        return "insert into $table ($columns) values $parameters on conflict do nothing";
+        return $this->compileInsert($query, $values).' on conflict do nothing';
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -194,7 +194,7 @@ class PostgresGrammar extends Grammar
                 ? "insert into {$table} DEFAULT VALUES"
                 : parent::compileInsert($query, $values);
     }
-    
+
     /**
      * Compile an insert ignore statement into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -222,7 +222,7 @@ class PostgresGrammar extends Grammar
             return '('.$this->parameterize($record).')';
         })->implode(', ');
         
-        return "insert into $table ($columns) values $parameters ON CONFLICT DO NOTHING";
+        return "insert into $table ($columns) values $parameters on conflict do nothing";
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -202,7 +202,7 @@ class PostgresGrammar extends Grammar
      * @param  array  $values
      * @return string
      */
-    public function compileInsertIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         return $this->compileInsert($query, $values).' on conflict do nothing';
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -200,9 +200,10 @@ class PostgresGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
+     * @param  array  $target
      * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values, array $target)
     {
         return $this->compileInsert($query, $values).' on conflict do nothing';
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -187,7 +187,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        return substr_replace($this->compileInsert($query, $values), 'insert or ignore', 0, 6);
+        return substr_replace($this->compileInsert($query, $values), ' or ignore', 6, 0);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -183,9 +183,10 @@ class SQLiteGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  array  $values
+     * @param  array  $target
      * @return string
      */
-    public function compileInsertOrIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values, array $target)
     {
         return substr_replace($this->compileInsert($query, $values), ' or ignore', 6, 0);
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -185,7 +185,7 @@ class SQLiteGrammar extends Grammar
      * @param  array  $values
      * @return string
      */
-    public function compileInsertIgnore(Builder $query, array $values)
+    public function compileInsertOrIgnore(Builder $query, array $values)
     {
         return substr_replace($this->compileInsert($query, $values),'insert or ignore', 0, 6);
     }

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -187,25 +187,7 @@ class SQLiteGrammar extends Grammar
      */
     public function compileInsertIgnore(Builder $query, array $values)
     {
-        // Essentially we will force every insert to be treated as a batch insert which
-        // simply makes creating the SQL easier for us since we can utilize the same
-        // basic routine regardless of an amount of records given to us to insert.
-        $table = $this->wrapTable($query->from);
-        
-        if (! is_array(reset($values))) {
-            $values = [$values];
-        }
-        
-        $columns = $this->columnize(array_keys(reset($values)));
-        
-        // We need to build a list of parameter place-holders of values that are bound
-        // to the query. Each insert should have the exact same amount of parameter
-        // bindings so we will loop through the record and parameterize them all.
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
-        
-        return "insert or ignore into $table ($columns) values $parameters";
+        return substr_replace($this->compileInsert($query, $values),'insert or ignore', 0, 6);
     }
     
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -177,7 +177,7 @@ class SQLiteGrammar extends Grammar
                 ? "insert into {$table} DEFAULT VALUES"
                 : parent::compileInsert($query, $values);
     }
-    
+
     /**
      * Compile an insert ignore statement into SQL.
      *
@@ -187,9 +187,9 @@ class SQLiteGrammar extends Grammar
      */
     public function compileInsertOrIgnore(Builder $query, array $values)
     {
-        return substr_replace($this->compileInsert($query, $values),'insert or ignore', 0, 6);
+        return substr_replace($this->compileInsert($query, $values), 'insert or ignore', 0, 6);
     }
-    
+
     /**
      * Compile an update statement into SQL.
      *

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -108,10 +108,9 @@ class SqlServerGrammar extends Grammar
      * @param \Illuminate\Database\Query\Builder $query
      * @param array $values
      * @param array $target
-     * @param array|null $update
      * @return string
      */
-    public function compileMerge(Builder $query, array $values, array $target, array $update = null)
+    public function compileMerge(Builder $query, array $values, array $target)
     {
         $columns = $this->columnize(array_keys(reset($values)));
 
@@ -127,18 +126,7 @@ class SqlServerGrammar extends Grammar
             return "{$this->wrap("laravel_source.$column")} = {$this->wrap("{$query->from}.$column")}";
         })->implode(' and ');
 
-        $sql .= "on $on ";
-
-        if ($update) {
-            $update = collect($update)->map(function ($value, $key) {
-                return is_numeric($key)
-                    ? $this->wrap($value).' = '.$this->wrap('laravel_source.'.$value)
-                    : $this->wrap($key).' = '.$this->parameter($value);
-            })->implode(', ');
-            $sql .= "when matched then update set $update ";
-        }
-
-        $sql .= "when not matched then insert ($columns) values ($columns);";
+        $sql .= "on $on when not matched then insert ($columns) values ($columns);";
 
         return $sql;
     }

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -90,6 +90,60 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile an "insert ignore" statement into SQL.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $values
+     * @param array $target
+     * @return string
+     */
+    public function compileInsertOrIgnore(Builder $query, array $values, array $target)
+    {
+        return $this->compileMerge($query, $values, $target);
+    }
+
+    /**
+     * Compile a "merge" statement into SQL.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param array $values
+     * @param array $target
+     * @param array|null $update
+     * @return string
+     */
+    public function compileMerge(Builder $query, array $values, array $target, array $update = null)
+    {
+        $columns = $this->columnize(array_keys(reset($values)));
+
+        $sql = "merge {$this->wrapTable($query->from)} ";
+
+        $parameters = collect($values)->map(function ($record) {
+            return "({$this->parameterize($record)})";
+        })->implode(', ');
+
+        $sql .= "using (values $parameters) {$this->wrapTable('laravel_source')} ($columns) ";
+
+        $on = collect($target)->map(function ($column) use ($query) {
+            return "{$this->wrap("laravel_source.$column")} = {$this->wrap("{$query->from}.$column")}";
+        })->implode(' and ');
+
+        $sql .= "on $on ";
+
+        if ($update) {
+            $update = collect($update)->map(function ($value, $key) {
+                return is_numeric($key)
+                    ? $this->wrap($value).' = '.$this->wrap('laravel_source.'.$value)
+                    : $this->wrap($key).' = '.$this->parameter($value);
+            })->implode(', ');
+            $sql .= "when matched then update set $update ";
+        }
+
+        $sql .= "when not matched then insert ($columns) values ($columns);";
+
+        return $sql;
+    }
+
+    /**
      * Compile a "where date" clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1867,46 +1867,46 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testInsertIgnoreMethod()
+    public function testInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
         
         $builder = $this->getBuilder();
-        $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
     
-    public function testMySqlInsertIgnoreMethod()
+    public function testMySqlInsertOrIgnoreMethod()
     {
         $builder = $this->getMySqlBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(1);
-        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
     
-    public function testPostgresInsertIgnoreMethod()
+    public function testPostgresInsertOrIgnoreMethod()
     {
         $builder = $this->getPostgresBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(1);
-        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
 
-    public function testSQLiteInsertIgnoreMethod()
+    public function testSQLiteInsertOrIgnoreMethod()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(1);
-        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
     
-    public function testSqlServerInsertIgnoreMethod()
+    public function testSqlServerInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
     
         $builder = $this->getSqlServerBuilder();
-        $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
 
     public function testInsertGetIdMethod()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1870,7 +1870,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
+        $this->expectExceptionMessage('This database engine does not support insert or ignore.');
 
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
@@ -1903,7 +1903,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSqlServerInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
+        $this->expectExceptionMessage('This database engine does not support insert or ignore.');
 
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1902,11 +1902,10 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testSqlServerInsertOrIgnoreMethod()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('This database engine does not support insert or ignore.');
-
         $builder = $this->getSqlServerBuilder();
-        $builder->from('users')->insertOrIgnore(['email' => 'foo']);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('merge [users] using (values (?)) [laravel_source] ([email]) on [laravel_source].[email] = [users].[email] when not matched then insert ([email]) values ([email]);', ['foo'])->andReturn(1);
+        $result = $builder->from('users')->insertOrIgnore(['email' => 'foo'], ['email']);
+        $this->assertEquals(1, $result);
     }
 
     public function testInsertGetIdMethod()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1879,25 +1879,25 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlInsertIgnoreMethod()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('insert')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(true);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
-        $this->assertTrue($result);
+        $this->assertEquals(1, $result);
     }
     
     public function testPostgresInsertIgnoreMethod()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(true);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
-        $this->assertTrue($result);
+        $this->assertEquals(1, $result);
     }
 
     public function testSQLiteInsertIgnoreMethod()
     {
         $builder = $this->getSQLiteBuilder();
-        $builder->getConnection()->shouldReceive('insert')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(true);
+        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
-        $this->assertTrue($result);
+        $this->assertEquals(1, $result);
     }
     
     public function testSqlServerInsertIgnoreMethod()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1871,11 +1871,11 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
-        
+
         $builder = $this->getBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }
-    
+
     public function testMySqlInsertOrIgnoreMethod()
     {
         $builder = $this->getMySqlBuilder();
@@ -1883,7 +1883,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
-    
+
     public function testPostgresInsertOrIgnoreMethod()
     {
         $builder = $this->getPostgresBuilder();
@@ -1899,12 +1899,12 @@ class DatabaseQueryBuilderTest extends TestCase
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
-    
+
     public function testSqlServerInsertOrIgnoreMethod()
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
-    
+
         $builder = $this->getSqlServerBuilder();
         $builder->from('users')->insertOrIgnore(['email' => 'foo']);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1879,7 +1879,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlInsertIgnoreMethod()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('insert')->once()->with('insert ignore into "users" ("email") values (?)', ['foo'])->andReturn(true);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(true);
         $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
         $this->assertTrue($result);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1887,7 +1887,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPostgresInsertIgnoreMethod()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) ON CONFLICT DO NOTHING', ['foo'])->andReturn(true);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(true);
         $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
         $this->assertTrue($result);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1867,6 +1867,48 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testInsertIgnoreMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
+        
+        $builder = $this->getBuilder();
+        $builder->from('users')->insertIgnore(['email' => 'foo']);
+    }
+    
+    public function testMySqlInsertIgnoreMethod()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert ignore into "users" ("email") values (?)', ['foo'])->andReturn(true);
+        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $this->assertTrue($result);
+    }
+    
+    public function testPostgresInsertIgnoreMethod()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) ON CONFLICT DO NOTHING', ['foo'])->andReturn(true);
+        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $this->assertTrue($result);
+    }
+
+    public function testSQLiteInsertIgnoreMethod()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(true);
+        $result = $builder->from('users')->insertIgnore(['email' => 'foo']);
+        $this->assertTrue($result);
+    }
+    
+    public function testSqlServerInsertIgnoreMethod()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('This database engine does not support INSERT IGNORE');
+    
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('users')->insertIgnore(['email' => 'foo']);
+    }
+
     public function testInsertGetIdMethod()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
This pull request adds insert or ignore support to Query Builder for the following database engines:

- MySQL - uses: `insert ignore`
- Postgres - uses: `on conflict do nothing`
- SQLite - uses: `insert or ignore`
- SqlServer - uses: `merge`

Example:

```php
DB::table('test')->insertOrIgnore([['id'=>1], ['id'=>2]]);
```

Others have voiced support for this feature: https://github.com/laravel/framework/issues/9612 
Also fixes https://github.com/laravel/ideas/issues/1762
