### PR TITLE
[5.8] Fix invalid link expiry count in ResetPassword

### DIFF
--- a/src/Illuminate/Auth/Notifications/ResetPassword.php
+++ b/src/Illuminate/Auth/Notifications/ResetPassword.php
@@ -60,7 +60,7 @@ class ResetPassword extends Notification
             ->subject(Lang::getFromJson('Reset Password Notification'))
             ->line(Lang::getFromJson('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::getFromJson('Reset Password'), url(config('app.url').route('password.reset', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()], false)))
-            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.users.expire')]))
+            ->line(Lang::getFromJson('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.'.config('auth.defaults.passwords').'.expire')]))
             ->line(Lang::getFromJson('If you did not request a password reset, no further action is required.'));
     }
 


### PR DESCRIPTION
The default `ResetPassword` notification has a line about when the password reset link will expire introduced in 5.8. It takes it's value directly from the auth config.

This PR removes the fixed `users` password configuration key and uses the correct default key specified in the configs.

This does not fix the same issue when no default configs is used for creating the token.