### PR TITLE
[5.8] Fix command output/questions expectations

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -165,6 +165,7 @@ class PendingCommand
 
         foreach ($this->test->expectedQuestions as $i => $question) {
             $mock->shouldReceive('askQuestion')
+                ->once()
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
                     return $argument->getQuestion() == $question[0];
@@ -194,6 +195,7 @@ class PendingCommand
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')
+                ->once()
                 ->ordered()
                 ->with($output, Mockery::any())
                 ->andReturnUsing(function () use ($i) {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing;
 
+use Illuminate\Support\Str;
 use Mockery;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
@@ -165,7 +166,13 @@ abstract class TestCase extends BaseTestCase
                 $this->addToAssertionCount($container->mockery_getExpectationCount());
             }
 
-            Mockery::close();
+            try{
+                Mockery::close();
+            }catch(\Throwable $e){
+                if(! Str::contains($e->getMessage(), ['doWrite', 'askQuestion'])){
+                    throw $e;
+                }
+            }
         }
 
         if (class_exists(Carbon::class)) {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -2,12 +2,13 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Support\Str;
 use Mockery;
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
+use Mockery\Exception\InvalidCountException;
 use Illuminate\Console\Application as Artisan;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
@@ -166,10 +167,10 @@ abstract class TestCase extends BaseTestCase
                 $this->addToAssertionCount($container->mockery_getExpectationCount());
             }
 
-            try{
+            try {
                 Mockery::close();
-            }catch(\Throwable $e){
-                if(! Str::contains($e->getMessage(), ['doWrite', 'askQuestion'])){
+            } catch (InvalidCountException $e) {
+                if (! Str::contains($e->getMethodName(), ['doWrite', 'askQuestion'])) {
                     throw $e;
                 }
             }

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -4,8 +4,8 @@ namespace Illuminate\Foundation\Testing;
 
 use Mockery;
 use Carbon\Carbon;
-use Illuminate\Support\Str;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Database\Eloquent\Model;
 use Mockery\Exception\InvalidCountException;


### PR DESCRIPTION
As reported in https://github.com/laravel/framework/issues/29521, when  trying to test that a question was asked multiple times or output was printed multiple times, the out of order exception is thrown.

This PR brings back the use of `once()`. However, it handles the Mockery exception thrown so instead of people seeing:

```
Mockery\Exception\InvalidCountException: Method doWrite('hola mundo', <Any>) from Mockery_0_Symfony_Component_Console_Output_BufferedOutput should be called
 exactly 1 times but called 0 times.
```

People see:

```
Output "hola mundo" was not printed.
```