### PR TITLE
[5.8] Revert "[5.8] Add translation to EnsureEmailIsVerified Middleware"

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -22,7 +22,7 @@ class EnsureEmailIsVerified
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
-                    ? abort(403, __('Your email address is not verified.'))
+                    ? abort(403, 'Your email address is not verified.')
                     : Redirect::route($redirectToRoute ?: 'verification.notice');
         }
 


### PR DESCRIPTION
Reverts laravel/framework#29562

Reverting this because the `__` isn't available outside the Foundation component and abort messages should never be displayed to an end-user. These are converted into `HttpException` which are instances of `RuntimeException` and should be handled by the system.