### PR TITLE
Give ability to cast from mutator

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -560,12 +560,12 @@ trait HasAttributes
      * @param  mixed  $value
      * @return mixed
      */
-    public function setAttribute($key, $value)
+    public function setAttribute($key, $value, $ignoreMutator = false)
     {
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
-        if ($this->hasSetMutator($key)) {
+        if (!$ignoreMutator && $this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
         }
 


### PR DESCRIPTION
When in mutator, you want to cast array's or dates etc - why should you do this manually when you have a perfectly fine casting functionality that is not available due to "mutator" restriction.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
