### PR TITLE
[5.8] Ignore classes which are not instantiable during event discovery

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -42,6 +42,10 @@ class DiscoverEvents
                 static::classFromFile($listener, $basePath)
             );
 
+            if (! $listener->isInstantiable()) {
+                continue;
+            }
+
             foreach ($listener->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
                 if (! Str::is('handle*', $method->name) ||
                     ! isset($method->getParameters()[0])) {

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -7,12 +7,16 @@ use Illuminate\Foundation\Events\DiscoverEvents;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
 
 class DiscoverEventsTest extends TestCase
 {
     public function test_events_can_be_discovered()
     {
         class_alias(Listener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener');
+        class_alias(AbstractListener::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener');
+        class_alias(ListenerInterface::class, 'Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface');
 
         $events = DiscoverEvents::within(__DIR__.'/Fixtures/EventDiscovery/Listeners', getcwd());
 

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/AbstractListener.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/AbstractListener.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+abstract class AbstractListener
+{
+    abstract public function handle(EventOne $event);
+}

--- a/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/ListenerInterface.php
+++ b/tests/Integration/Foundation/Fixtures/EventDiscovery/Listeners/ListenerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
+
+interface ListenerInterface
+{
+    public function handle(EventOne $event);
+}


### PR DESCRIPTION
If you enable auto discovery of events and listeners, the framework tries to attach abstract classes and interfaces to the events, which triggers a BindingResolutionException with the following message:

> Target [App\Listeners\AbstractListener] is not instantiable

With this pull request, an extra check is performed to make sure the listener is instantiable. This prevents a BindingResolutionException.