### PR TITLE
[6.0] Try to unify the query builder select behaviour

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -357,10 +357,6 @@ trait QueriesRelationships
             return $this;
         }
 
-        if (is_null($this->query->columns)) {
-            $this->query->select([$this->query->from.'.*']);
-        }
-
         $relations = is_array($relations) ? $relations : func_get_args();
 
         foreach ($this->parseWithRelations($relations) as $name => $constraints) {

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -485,8 +485,12 @@ class HasManyThrough extends Relation
     {
         $builder = $this->query->applyScopes();
 
-        return $builder->addSelect(
-            $this->shouldSelect($builder->getQuery()->columns ? [] : $columns)
+        if ($builder->getQuery()->columns && $columns == ['*']) {
+            $columns = $builder->getQuery()->columns;
+        }
+
+        return $builder->select(
+            $this->shouldSelect($columns)
         );
     }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -239,9 +239,11 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        return $this->selectRaw(
-            '('.$query.') as '.$this->grammar->wrap($as), $bindings
-        );
+        $this->addSelect(new Expression('('.$query.') as '.$this->grammar->wrap($as)));
+
+        $this->addBinding($bindings, 'select');
+
+        return $this;
     }
 
     /**
@@ -253,7 +255,7 @@ class Builder
      */
     public function selectRaw($expression, array $bindings = [])
     {
-        $this->addSelect(new Expression($expression));
+        $this->select(new Expression($expression));
 
         if ($bindings) {
             $this->addBinding($bindings, 'select');
@@ -339,6 +341,10 @@ class Builder
      */
     public function addSelect($column)
     {
+        if (is_null($this->columns)) {
+            $this->select([$this->from.'.*']);
+        }
+
         $column = is_array($column) ? $column : func_get_args();
 
         $this->columns = array_merge((array) $this->columns, $column);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1842,7 +1842,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'post');
         $count = $builder->count();
         $this->assertEquals(1, $count);
-        $this->assertEquals('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->columns[0]->getValue());
+        $this->assertEquals('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->columns[1]->getValue());
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -52,10 +52,10 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
         $comments = Comment::with(['commentable' => function ($query) {
             $query->selectSub(function ($query) {
                 $query->select('id');
-            }, 'id');
+            }, 'post_id');
         }])->get();
 
-        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+        $this->assertEquals(1, $comments[0]->commentable->id);
     }
 
     public function testAddSelect()
@@ -64,7 +64,7 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
             $query->addSelect('id');
         }])->get();
 
-        $this->assertEquals(['id' => 1], $comments[0]->commentable->getAttributes());
+        $this->assertEquals(1, $comments[0]->commentable->id);
     }
 
     public function testLazyLoading()


### PR DESCRIPTION
This PR attempts to standardize the query builder "select" behaviour in Laravel.

## Why

Currently the `addSelect()` method actually behaves like `select()` if no previous columns have been defined. This is confusing, since adding a column **shouldn't inadvertently REMOVE all other columns**. Further, this creates issues when adding subqueries, which are (almost) always intended to be *added* to all the columns.

## The change

This automatically adds `table.*` in the `addSelect()` method if no other columns have been defined yet.

## More work

Right now I try to (mostly) maintain existing behaviour for `selectSub()` and `selectRaw()`, but ideally we would actually have two methods for each:

```php
$query->selectSub();        // Replaces the current selection with a sub select.
$query->addSelectSub();     // Adds a new sub select to the existing columns.
$query->selectRaw();        // Replaces the current selection with a raw select.
$query->addSelectRaw();     // Adds a new raw select to the existing columns.
```

## Breaking changes

- `selectRaw()` now works like `select()`, meaning it replaces all existing columns, and doesn't get added to them.
- `addSelect`() now adds `table.*` to queries if no columns were previously set.
- Not entirely sure what the implications of my changes to `HasManyThrough`. I've got the tests passing, but I'm still not super confident in it.