### PR TITLE
[5.8] Implement better email validation support

### DIFF
--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Validation\Concerns;
 
 use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Warning\Warning;
 use Egulias\EmailValidator\Exception\InvalidEmail;
 use Egulias\EmailValidator\Validation\EmailValidation;
-use Egulias\EmailValidator\Warning\Warning;
 
 class FilterEmailValidation implements EmailValidation
 {
@@ -29,7 +29,6 @@ class FilterEmailValidation implements EmailValidation
      */
     public function getError()
     {
-        return null;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Validation\Concerns;
+
+use Egulias\EmailValidator\EmailLexer;
+use Egulias\EmailValidator\Exception\InvalidEmail;
+use Egulias\EmailValidator\Validation\EmailValidation;
+use Egulias\EmailValidator\Warning\Warning;
+
+class FilterEmailValidation implements EmailValidation
+{
+    /**
+     * Returns true if the given email is valid.
+     *
+     * @param string $email The email you want to validate.
+     * @param EmailLexer $emailLexer The email lexer.
+     *
+     * @return bool
+     */
+    public function isValid($email, EmailLexer $emailLexer)
+    {
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
+     * Returns the validation error.
+     *
+     * @return InvalidEmail|null
+     */
+    public function getError()
+    {
+        return null;
+    }
+
+    /**
+     * Returns the validation warnings.
+     *
+     * @return Warning[]
+     */
+    public function getWarnings()
+    {
+        return [];
+    }
+}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2138,6 +2138,18 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateEmailWithStrictCheck()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@bar '], ['x' => 'email:strict']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateEmailWithFilterCheck()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@bar'], ['x' => 'email:filter']);
+        $this->assertFalse($v->passes());
+    }
+
     /**
      * @dataProvider validUrls
      */


### PR DESCRIPTION
These changes allow for multiple email validators to be added when checking for valid emails. This is a continuation of the previous PR: https://github.com/laravel/framework/pull/26503

Basically this allows for two things:

- Make use of multiple email validators provided by the egulias/email-validator package
- Use the previous (and much requested) filter_var validation

By default nothing's breaking because it'll still use the RFC validator to when no validators are passed to the email validation rule. But you can opt to include different ones or multiple ones:

    'email' => 'email:rfc,dns'

Or opt for the pre-5.8 behavior:

    'email' => 'email:filter'

Which will use `filter_var` to validate the email address. This should give people a little more flexibility when doing email validation.

PS: I wasn't sure if we should return something for the `getError` and `getWarnings` methods in the `FilterEmailValidation` class. I've left them with some defaults and everything seems to be working ok.