### PR TITLE
[6.x] Adding relational support to Eloquent Factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -5,37 +5,10 @@ namespace Illuminate\Database\Eloquent;
 use ArrayAccess;
 use Faker\Generator as Faker;
 use Symfony\Component\Finder\Finder;
+use Illuminate\Database\Eloquent\Factory\StateManager;
 
 class Factory implements ArrayAccess
 {
-    /**
-     * The model definitions in the container.
-     *
-     * @var array
-     */
-    protected $definitions = [];
-
-    /**
-     * The registered model states.
-     *
-     * @var array
-     */
-    protected $states = [];
-
-    /**
-     * The registered after making callbacks.
-     *
-     * @var array
-     */
-    protected $afterMaking = [];
-
-    /**
-     * The registered after creating callbacks.
-     *
-     * @var array
-     */
-    protected $afterCreating = [];
-
     /**
      * The Faker instance for the builder.
      *
@@ -44,14 +17,23 @@ class Factory implements ArrayAccess
     protected $faker;
 
     /**
+     * The StateManager that holds all definitions.
+     *
+     * @var \Illuminate\Database\Eloquent\Factory\StateManager
+     */
+    protected $stateManager;
+
+    /**
      * Create a new factory instance.
      *
      * @param  \Faker\Generator  $faker
+     * @param  \Illuminate\Database\Eloquent\Factory\StateManager  $stateManager
      * @return void
      */
-    public function __construct(Faker $faker)
+    public function __construct(Faker $faker, StateManager $stateManager)
     {
         $this->faker = $faker;
+        $this->stateManager = $stateManager;
     }
 
     /**
@@ -65,7 +47,7 @@ class Factory implements ArrayAccess
     {
         $pathToFactories = $pathToFactories ?: database_path('factories');
 
-        return (new static($faker))->load($pathToFactories);
+        return (new static($faker, new StateManager()))->load($pathToFactories);
     }
 
     /**
@@ -91,7 +73,22 @@ class Factory implements ArrayAccess
      */
     public function define($class, callable $attributes, $name = 'default')
     {
-        $this->definitions[$class][$name] = $attributes;
+        $this->stateManager->define($class, $name, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Define a preset with a callable.
+     *
+     * @param  string  $class
+     * @param  string  $state
+     * @param  callable  $callable
+     * @return $this
+     */
+    public function preset($class, $state, callable $callable)
+    {
+        $this->stateManager->preset($class, $state, $callable);
 
         return $this;
     }
@@ -106,7 +103,7 @@ class Factory implements ArrayAccess
      */
     public function state($class, $state, $attributes)
     {
-        $this->states[$class][$state] = $attributes;
+        $this->stateManager->state($class, $state, $attributes);
 
         return $this;
     }
@@ -121,7 +118,7 @@ class Factory implements ArrayAccess
      */
     public function afterMaking($class, callable $callback, $name = 'default')
     {
-        $this->afterMaking[$class][$name][] = $callback;
+        $this->stateManager->afterMaking($class, $name, $callback);
 
         return $this;
     }
@@ -136,7 +133,9 @@ class Factory implements ArrayAccess
      */
     public function afterMakingState($class, $state, callable $callback)
     {
-        return $this->afterMaking($class, $callback, $state);
+        $this->stateManager->afterMaking($class, $state, $callback);
+
+        return $this;
     }
 
     /**
@@ -144,12 +143,12 @@ class Factory implements ArrayAccess
      *
      * @param  string  $class
      * @param  callable  $callback
-     * @param  string $name
+     * @param  string  $name
      * @return $this
      */
     public function afterCreating($class, callable $callback, $name = 'default')
     {
-        $this->afterCreating[$class][$name][] = $callback;
+        $this->stateManager->afterCreating($class, $name, $callback);
 
         return $this;
     }
@@ -164,7 +163,9 @@ class Factory implements ArrayAccess
      */
     public function afterCreatingState($class, $state, callable $callback)
     {
-        return $this->afterCreating($class, $callback, $state);
+        $this->stateManager->afterCreating($class, $state, $callback);
+
+        return $this;
     }
 
     /**
@@ -241,7 +242,7 @@ class Factory implements ArrayAccess
     public function raw($class, array $attributes = [], $name = 'default')
     {
         return array_merge(
-            call_user_func($this->definitions[$class][$name], $this->faker), $attributes
+            call_user_func($this->stateManager->getDefinition($class, $name), $this->faker), $attributes
         );
     }
 
@@ -254,10 +255,7 @@ class Factory implements ArrayAccess
      */
     public function of($class, $name = 'default')
     {
-        return new FactoryBuilder(
-            $class, $name, $this->definitions, $this->states,
-            $this->afterMaking, $this->afterCreating, $this->faker
-        );
+        return tap(new FactoryBuilder($class, $this->stateManager, $this->faker))->definition($name);
     }
 
     /**
@@ -287,7 +285,7 @@ class Factory implements ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset($this->definitions[$offset]);
+        return $this->stateManager->definitionExists($offset);
     }
 
     /**
@@ -321,6 +319,6 @@ class Factory implements ArrayAccess
      */
     public function offsetUnset($offset)
     {
-        unset($this->definitions[$offset]);
+        $this->stateManager->forgetDefinitions($offset);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Factory/BuildsRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Factory/BuildsRelationships.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factory;
+
+use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+
+trait BuildsRelationships
+{
+    /**
+     * The current batch no.
+     *
+     * @var int
+     */
+    protected $currentBatch = 0;
+
+    /**
+     * Requested relations.
+     *
+     * @var array
+     */
+    protected $relations = [];
+
+    /**
+     * Load a RelationRequest onto current FactoryBuilder.
+     *
+     * @param  \Illuminate\Database\Eloquent\Factory\RelationRequest  $request
+     * @return $this
+     */
+    public function loadRelation(RelationRequest $request)
+    {
+        $factory = $this->buildFactoryForRequest($request);
+
+        // Recursively create factories until no further nesting.
+        if ($request->hasNesting()) {
+            $factory->with($request->createNestedRequest());
+        } // Apply the request onto the newly created factory.
+        else {
+            $factory
+                ->fill($request->attributes)
+                ->presets($request->presets)
+                ->states($request->states)
+                ->when($request->amount, function ($factory, $amount) {
+                    $factory->times($amount);
+                })
+                ->when($request->builder, function ($factory, $builder) {
+                    $factory->tap($builder);
+                });
+        }
+
+        return $this;
+    }
+
+    /**
+     * Build a factory for given RelationRequest.
+     *
+     * @param  \Illuminate\Database\Eloquent\Factory\RelationRequest  $request
+     * @return static
+     */
+    protected function buildFactoryForRequest($request)
+    {
+        $relation = $request->getRelationName();
+        $batch = $request->getBatch();
+
+        return data_get($this->relations, "{$relation}.{$batch}", function () use ($request, $relation, $batch) {
+            return tap(app(Factory::class)->of($request->getRelatedClass()), function ($factory) use ($relation, $batch) {
+                $this->relations[$relation][$batch] = $factory;
+            });
+        });
+    }
+
+    /**
+     * Create all requested BelongsTo relations.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $child
+     * @return void
+     */
+    protected function createBelongsTo($child)
+    {
+        collect($this->relations)
+            ->filter($this->relationTypeIs(BelongsTo::class))
+            ->each(function ($batches, $relation) use ($child) {
+                foreach (array_slice($batches, 0, 1) as $factory) {
+                    $parent = $this->collectModel($factory->inheritConnection($this)->create());
+                    $child->$relation()->associate($parent);
+                }
+            });
+    }
+
+    /**
+     * Create all requested BelongsToMany relations.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $sibling
+     * @return void
+     */
+    protected function createBelongsToMany($sibling)
+    {
+        collect($this->relations)
+            ->filter($this->relationTypeIs(BelongsToMany::class))
+            ->each(function ($batches, $relation) use ($sibling) {
+                foreach ($batches as $factory) {
+                    $models = $this->collect($factory->inheritConnection($this)->create());
+                    $models->each(function ($model) use ($sibling, $relation, $factory) {
+                        $sibling->$relation()->save($model, $this->mergeAndExpandAttributes($factory->pivotAttributes));
+                    });
+                }
+            });
+    }
+
+    /**
+     * Create all requested HasMany relations.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @return void
+     */
+    protected function createHasMany($parent)
+    {
+        collect($this->relations)
+            ->filter($this->relationTypeIs(HasOneOrMany::class))
+            ->each(function ($batches, $relation) use ($parent) {
+                foreach ($batches as $factory) {
+                    // In case of morphOne / morphMany we'll need to set the morph type as well.
+                    if (($morphRelation = $this->newRelation($relation)) instanceof MorphOneOrMany) {
+                        $factory->fill([
+                            $morphRelation->getMorphType() => (new $this->class)->getMorphClass(),
+                        ]);
+                    }
+
+                    $factory->inheritConnection($this)->create([
+                        $parent->$relation()->getForeignKeyName() => $parent->$relation()->getParentKey(),
+                    ]);
+                }
+            });
+    }
+
+    /**
+     * Get closure that checks for a given relation-type.
+     *
+     * @param  string  $relationType
+     * @return \Closure
+     */
+    protected function relationTypeIs($relationType)
+    {
+        return function ($batches, $relation) use ($relationType) {
+            return $this->newRelation($relation) instanceof $relationType;
+        };
+    }
+
+    /**
+     * Create a new instance of the relationship.
+     *
+     * @param  string  $relationName
+     * @return \Illuminate\Database\Eloquent\Relations\Relation;
+     */
+    protected function newRelation($relationName)
+    {
+        return (new $this->class)->$relationName();
+    }
+
+    /**
+     * Inherit connection from a parent factory.
+     *
+     * @param  \Illuminate\Database\Eloquent\FactoryBuilder  $factory
+     * @return $this
+     */
+    protected function inheritConnection($factory)
+    {
+        if ($this->connection === null && (new $this->class)->getConnectionName() === null) {
+            return $this->connection($factory->connection);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Create a new batch of relations.
+     *
+     * @return $this
+     */
+    protected function newBatch()
+    {
+        $this->currentBatch++;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Factory/NormalizesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Factory/NormalizesAttributes.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factory;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait NormalizesAttributes
+{
+    /**
+     * Ensure a query result is returned as a collection.
+     *
+     * @param  mixed  $result
+     * @return \Illuminate\Support\Collection
+     */
+    protected function collect($result)
+    {
+        if ($result instanceof Model) {
+            $result = [$result];
+        }
+
+        return collect($result);
+    }
+
+    /**
+     * Ensure a query result is returned as a model.
+     *
+     * @param  mixed  $results
+     * @return Model
+     */
+    protected function collectModel($results)
+    {
+        return $this->collect($results)->first();
+    }
+
+    /**
+     * Ensure a subject is a callable.
+     *
+     * @param  mixed  $arg
+     * @return callable
+     */
+    protected function wrapCallable($arg)
+    {
+        if (! is_callable($arg) || is_string($arg)) {
+            return function () use ($arg) {
+                return $arg;
+            };
+        }
+
+        return $arg;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Factory/PrototypesModels.php
+++ b/src/Illuminate/Database/Eloquent/Factory/PrototypesModels.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factory;
+
+trait PrototypesModels
+{
+    /**
+     * Name of the definition.
+     *
+     * @var string
+     */
+    public $definition;
+
+    /**
+     * The states to apply.
+     *
+     * @var array
+     */
+    public $states = [];
+
+    /**
+     * The presets to apply.
+     *
+     * @var array
+     */
+    public $presets = [];
+
+    /**
+     * The number of models to build.
+     *
+     * @var int|null
+     */
+    public $amount;
+
+    /**
+     * Attributes to apply.
+     *
+     * @var array
+     */
+    public $attributes = [];
+
+    /**
+     * Attributes to apply to a pivot relation.
+     *
+     * @var array
+     */
+    public $pivotAttributes = [];
+}

--- a/src/Illuminate/Database/Eloquent/Factory/RelationRequest.php
+++ b/src/Illuminate/Database/Eloquent/Factory/RelationRequest.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factory;
+
+use Closure;
+use BadMethodCallException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class RelationRequest
+{
+    use PrototypesModels;
+
+    /**
+     * The parent model requesting relations.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $class;
+
+    /**
+     * The batch number.
+     *
+     * @var int
+     */
+    protected $batch;
+
+    /**
+     * The StateManager that holds all definitions.
+     *
+     * @var \Illuminate\Database\Eloquent\Factory\StateManager
+     */
+    protected $stateManager;
+
+    /**
+     * A cached name of the related model class.
+     *
+     * @var string|null
+     */
+    protected $cachedRelatedClass;
+
+    /**
+     * The (possibly nested) relations path.
+     *
+     * @var string
+     */
+    public $path;
+
+    /**
+     * The build function.
+     *
+     * @var callable|null
+     */
+    public $builder = null;
+
+    /**
+     * Create a new relationship request.
+     *
+     * @param  string  $class
+     * @param  int  $batch
+     * @param  \Illuminate\Database\Eloquent\Factory\StateManager  $stateManager
+     * @param  mixed  $args
+     * @return void
+     */
+    public function __construct($class, $batch, StateManager $stateManager, $args)
+    {
+        [$this->class, $this->batch, $this->stateManager] = [$class, $batch, $stateManager];
+
+        collect($args)
+            ->pipe(Closure::fromCallable([$this, 'findAndPopRelationName']))
+            ->tap(Closure::fromCallable([$this, 'failOnMissingRelation']))
+            ->each(Closure::fromCallable([$this, 'parseArgument']));
+    }
+
+    /**
+     * Create a new relationship request for nested relations.
+     *
+     * @return static
+     */
+    public function createNestedRequest()
+    {
+        $request = new static($this->getRelatedClass(), $this->batch, $this->stateManager, $this->getNestedPath());
+        $request->amount = $this->amount;
+        $request->attributes = $this->attributes;
+        $request->builder = $this->builder;
+        $request->states = $this->states;
+
+        return $request;
+    }
+
+    /**
+     * Get the current batch no.
+     *
+     * @return int
+     */
+    public function getBatch()
+    {
+        return $this->batch;
+    }
+
+    /**
+     * Get the nested path beyond immediate relation.
+     *
+     * @param  string|null  $path
+     * @return string
+     */
+    public function getNestedPath($path = null)
+    {
+        $nested = explode('.', $path ?: $this->path);
+
+        array_shift($nested);
+
+        return implode('.', $nested);
+    }
+
+    /**
+     * Get the class name of the related eloquent model.
+     *
+     * @return string
+     */
+    public function getRelatedClass()
+    {
+        $relation = $this->getRelationName();
+
+        return $this->cachedRelatedClass = $this->cachedRelatedClass
+            ?: get_class($this->model()->$relation()->getRelated());
+    }
+
+    /**
+     * Get the name of the immediate relation.
+     *
+     * @param  string|null  $path
+     * @return mixed
+     */
+    public function getRelationName($path = null)
+    {
+        $nested = explode('.', $path ?: $this->path);
+
+        return array_shift($nested);
+    }
+
+    /**
+     * Check if has nesting.
+     *
+     * @return bool
+     */
+    public function hasNesting()
+    {
+        return strpos($this->path, '.') !== false;
+    }
+
+    /**
+     * Loop through arguments to detect a relation name.
+     *
+     * @param  \Illuminate\Support\Collection  $args
+     * @return \Illuminate\Support\Collection
+     */
+    protected function findAndPopRelationName(Collection $args)
+    {
+        return $args->reject(function ($arg) {
+            if ($match = (is_string($arg) && $this->isValidRelation($arg))) {
+                $this->path = $arg;
+            }
+
+            return $match;
+        });
+    }
+
+    /**
+     * Check if a string represents a valid relation path.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    protected function isValidRelation($path)
+    {
+        $model = $this->model();
+        $relation = $this->getRelationName($path);
+
+        return method_exists($model, $relation) && $model->$relation() instanceof Relation;
+    }
+
+    /**
+     * Get an instance of the model class.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function model()
+    {
+        return new $this->class;
+    }
+
+    /**
+     * Parse each individual argument given to 'with'.
+     *
+     * @param  mixed  $arg
+     * @return void
+     */
+    protected function parseArgument($arg)
+    {
+        if (is_null($arg)) {
+            return;
+        }
+
+        if (is_numeric($arg)) {
+            $this->amount = $arg;
+
+            return;
+        }
+
+        if (is_array($arg) && ! isset($arg[0])) {
+            $this->attributes = $arg;
+
+            return;
+        }
+
+        if (is_callable($arg) && ! is_string($arg)) {
+            $this->builder = $arg;
+
+            return;
+        }
+
+        if (is_string($arg) && $this->isValidRelation($arg)) {
+            $this->path = $arg;
+
+            return;
+        }
+
+        if (is_string($arg) && $this->stateManager->definitionExists($this->getRelatedClass(), $arg)) {
+            $this->definition = $arg;
+
+            return;
+        }
+
+        if ($this->stateManager->presetsExists($this->getRelatedClass(), $arg)) {
+            $this->presets = array_merge($this->presets, Arr::wrap($arg));
+
+            return;
+        }
+
+        // If nothing else, we'll assume $arg represent some state.
+        return $this->states = array_merge($this->states, Arr::wrap($arg));
+    }
+
+    /**
+     * Fail build with a readable exception message.
+     *
+     * @param  \Illuminate\Support\Collection  $args
+     */
+    protected function failOnMissingRelation(Collection $args)
+    {
+        if (! $this->path) {
+            throw new BadMethodCallException(
+                'No matching relations could be found on model ['.$this->class.']. '.
+                'Following possible relation names was checked: '.
+                (
+                ($testedRelations = $this->getPossiblyIntendedRelationships($args))->isEmpty()
+                    ? '[NO POSSIBLE RELATION NAMES FOUND]'
+                    : '['.$testedRelations->implode(', ').']'
+                )
+            );
+        }
+    }
+
+    /**
+     * Give the developer a readable list of possibly args
+     * that they might have intended could be a relation,
+     * but was invalid. Helpful for debugging purposes.
+     *
+     * @param  \Illuminate\Support\Collection  $args
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getPossiblyIntendedRelationships(Collection $args)
+    {
+        return $args
+            ->filter(function ($arg) {
+                return is_string($arg) || is_null($arg);
+            })
+            ->map(function ($arg) {
+                return is_null($arg) ? 'NULL' : "'".$arg."'";
+            });
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Factory/StateManager.php
+++ b/src/Illuminate/Database/Eloquent/Factory/StateManager.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factory;
+
+class StateManager
+{
+    use NormalizesAttributes;
+
+    /**
+     * The model definitions in the container.
+     *
+     * @var array
+     */
+    protected $definitions = [];
+
+    /**
+     * The registered model presets.
+     *
+     * @var array
+     */
+    protected $presets = [];
+
+    /**
+     * The registered model states.
+     *
+     * @var array
+     */
+    protected $states = [];
+
+    /**
+     * The registered after making callbacks.
+     *
+     * @var array
+     */
+    public $afterMaking = [];
+
+    /**
+     * The registered after creating callbacks.
+     *
+     * @var array
+     */
+    public $afterCreating = [];
+
+    /**
+     * Define a class with a given short-name.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  callable|array  $builder
+     * @return $this
+     */
+    public function define($class, $name, $builder)
+    {
+        $this->definitions[$class][$name] = $this->wrapCallable($builder);
+
+        return $this;
+    }
+
+    /**
+     * Check if a definition exists.
+     *
+     * @param  string  $class
+     * @param  string|null  $name
+     * @return bool
+     */
+    public function definitionExists($class, $name = null)
+    {
+        return is_null($name)
+            ? isset($this->definitions[$class])
+            : isset($this->definitions[$class][$name]);
+    }
+
+    /**
+     * Delete an existing definition.
+     *
+     * @param  string  $class
+     * @return $this
+     */
+    public function forgetDefinitions($class)
+    {
+        unset($this->definitions[$class]);
+
+        return $this;
+    }
+
+    /**
+     * Get a definition.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @return \Closure
+     */
+    public function getDefinition($class, $name)
+    {
+        return data_get($this->definitions, "{$class}.{$name}") ?: $this->wrapCallable([]);
+    }
+
+    /**
+     * Define a preset that may later be used to configure a factory.
+     *
+     * @param  string  $class
+     * @param  string  $preset
+     * @param  callable|array  $builder
+     * @return $this
+     */
+    public function preset($class, $preset, $builder)
+    {
+        $this->presets[$class][$preset] = $this->wrapCallable($builder);
+
+        return $this;
+    }
+
+    /**
+     * Check if presets exists.
+     *
+     * @param  string  $class
+     * @param  string|array  $presets
+     * @return bool
+     */
+    public function presetsExists($class, $presets)
+    {
+        return collect($presets)->reject(function ($preset) use ($class) {
+            return data_get($this->presets, "{$class}.{$preset}") !== null;
+        })->isEmpty();
+    }
+
+    /**
+     * Get a preset.
+     *
+     * @param  string  $class
+     * @param  string  $preset
+     * @return \Closure
+     */
+    public function getPreset($class, $preset)
+    {
+        return data_get($this->presets, "{$class}.{$preset}");
+    }
+
+    /**
+     * Define a state with a given set of attributes.
+     *
+     * @param  string  $class
+     * @param  string  $state
+     * @param  callable|array  $builder
+     * @return $this
+     */
+    public function state($class, $state, $builder)
+    {
+        $this->states[$class][$state] = $this->wrapCallable($builder);
+
+        return $this;
+    }
+
+    /**
+     * Check if states exists.
+     *
+     * @param  string  $class
+     * @param  string|array  $states
+     * @return bool
+     */
+    public function statesExists($class, $states)
+    {
+        return collect($states)->reject(function ($states) use ($class) {
+            return data_get($this->states, "{$class}.{$states}") !== null;
+        })->isEmpty();
+    }
+
+    /**
+     * Get a state.
+     *
+     * @param  string  $class
+     * @param  string  $state
+     * @return \Closure
+     */
+    public function getState($class, $state)
+    {
+        return data_get($this->states, "{$class}.{$state}");
+    }
+
+    /**
+     * Define a callback to run after making a model.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterMaking($class, $name, callable $callback)
+    {
+        $this->afterMaking[$class][$name][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Define a callback to run after creating a model.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function afterCreating($class, $name, callable $callback)
+    {
+        $this->afterCreating[$class][$name][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Determine if a callback exists on a given model.
+     *
+     * @param  string  $class
+     * @param  string  $name
+     * @return bool
+     */
+    public function afterCallbackExists($class, $name)
+    {
+        return isset($this->afterMaking[$class][$name]) ||
+            isset($this->afterCreating[$class][$name]);
+    }
+}

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factory\StateManager;
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 
 /**
  * @group integration
@@ -31,7 +33,7 @@ class EloquentFactoryBuilderTest extends TestCase
             'prefix' => '',
         ]);
 
-        $factory = new Factory($app->make(Generator::class));
+        $factory = new EloquentFactory($app->make(Generator::class), new StateManager());
 
         $factory->define(FactoryBuildableUser::class, function (Generator $faker) {
             return [


### PR DESCRIPTION
This PR introduces a Eloquent-like relational support to the Factory:

```php
$team = factory(Team::class)->with(1, 'users')->create();
```

While similar features has been discussed in a previous PR (https://github.com/laravel/framework/pull/26811), this proposed implementation offers much more advanced features; most notably nested relations. 
It may also be considered an attempt of a general overhaul of the existing factory.

The source code for this PR has been developed, used and improved in this package for around half a year: [makeabledk/laravel-factory-enhanced](https://github.com/makeabledk/laravel-factory-enhanced).

## Motivation
A major part of testing is ‘setting up your world’, which often times includes creating multiple related models.

For instance, writing the equivalent of above example in today’s factory, would look something like the following:

```php
$team = factory(Team::class)->create();
$user = factory(User::class)->create();
$member = factory(TeamMember::class)->create([
    'team_id' => $team,
    'user_id' => $user,
]);
``` 

All of this may of course be tugged away in a pre-defined definition state - but for some cases each test is just too individual.
Being able to utilize existing relations on your models makes it a breeze to prepare tests with very few lines of code.

## New functionality introduced

### Relational support 
Example: Creating nested models with states

```php
factory(Team::class)    
    ->with(2, 'online', ‘servers')
    ->with(1, 'migrated', 'mysql', ‘servers.databases', ['name' => 'forge'])
    ->create();
```

Example: Creating customized relations with a closure. 

```php
factory(Team::class)    
    ->with(2, 'online', servers', function (FactoryBuilder $builder) {
        $builder
	    ->fill(function ($faker) {
	    	'name' => $faker->name
	    })
	    ->with(1, 'mysql', 'databases')
	    ->andWith(1, 'postgres', 'databases');
    })
    ->create();
```

In the above closure we may do anything we can normally do on the `FactoryBuilder` instance - even load on more nested relations. 
Also note that there is no particular order to the attributes given to the `with()` method. Feel free to do whichever reads better 👍


More examples can be found in the package readme: [makeabledk/laravel-factory-enhanced](https://github.com/makeabledk/laravel-factory-enhanced)


### Introducing presets
While we currently have definitions and states, none of these allow us to reuse more higher level configurations such as “a user with 1 small team that has 2 employees”.

For this purpose a new preset definition is introduced, and works like this:

```php
factory()->preset(User::class, 'businessOwner', function (FactoryBuilder $user, Generator $faker) {
    $user
        ->with(1, 'teams')
        ->with(2, 'teams.employees');
});
```

Now we may use the factory to create a `User` using that preset:

```php
factory(User::class)->preset(‘businessOwner’)->create();
```

Or on the fly in a relation:

```php
factory(Invoice::class)->with(‘businessOwner’, ‘user’)->create();
```

This is super powerful, as it allows the developer to make use of the full FactoryBuilder, instead of relying on it to only return attributes.

The main downside is that it introduces yet another type of ‘definition’ to the factory, making it a full 3 (define, state, preset).
I will be discussing this issue further in a later section ‘Future prospects’. 

### New methods on FactoryBuilder
Finally a handful of new helpers has been introduced:

- definition
- fill - fill attributes
- fillPivot - only applicable when loading a BelongsToMany relation.
- odds - add some randomness to the factory. Useful when seeding.
- preset
- presets
- tap
- when
- with
- andWith - allows for loading same the HasMany relation multiple times with different configuration.


## Compatibility 
The implementation for creating relations works for all relation types except

- HasManyThrough 
- MorphedByMany

While the implementation includes some heavy refactoring of the existing codebase, all public instance methods remains the same.
The refactoring seemed due and necessary to implement the new features in a sustainable manner.

The breaking changes are limited to

- `Factory::__construct` 
- `FactoryBuilder::__construct` 
- Protected methods

## Future prospects
Alternate heading: My personal wishlist.

Given how much has happened since Eloquent Factory was first introduced in v5.1, it is no wonder that certain parts of the codebase is starting feel a bit outdated at this point.

Here are a couple of my observations, after having familiarized myself quite thoroughly with the codebase through the better part of the past year.

### Cleaning out legacy helpers

The majority of the legacy seems to be in the ´Factory` class:

- ArrayAccess. It only works for definitions, and takes up 45 lines of code.
- All methods containing the words `create`, `make`, and `raw` are redundant. Simply `factory(User::class)->create()` instead. Also they exist twice as `createOf`.

At this point we would have removed 10 methods, and reduced from 321 to 198 lines of code in `Factory`.

The only responsibilities left of the `Factory` class is now: 

- Load definitions
- Instantiate new `FactoryBuilder`’s 

With this reduction of responsibility, it'd be up for discussion if the `StateManager` in this PR should just be re-implemented back into the factory.

If this is something the community would be supportive of, we could start by deprecating helpers in `v6.0`, and remove them in `v7.0`. 


### Streamlining definition types
At this point we have 3 different types of definitions  (included 1 introduced in this PR): 

- Definitions
- States
- Presets

States and definitions are basically completely interchangeable except, on the contrary to definitions, multiple states can be applied when factoring a model.

Internally both states and definitions could be implemented as presets, as they would simply need to be wrapped with a closure that fills the attributes on the `FactoryBuilder`.
The main problem with this is that they would share the same namespace, so a ‘default’ state would overwrite the ‘default’ definition.
The ‘afterCallbacks’ implementation already uses the same concept, so the main thing is that it may break some people’s codebases if they rely on this as a feature.
 
The above refactoring would still expose the same public API to keep breaking changes at the bare minimum.

Further down the line we could completely outphase the concept of ‘definition’, and simply have a ‘default’ state.

## TODO

Move and re-implement tests from https://github.com/makeabledk/laravel-factory-enhanced/tree/master/tests/Feature to this PR.

I will do this ASAP once I know that there is general support to bring this into the Laravel Core, as I've already spent too much time on getting this PR ready 😅 

There is 35 tests and 75 assertions for the source code, so everything is pretty well tested (in comparison to the existing 12 tests and 24 assertions). 

Hope you all like it - appreciate any feedback! 