### PR TITLE
[6.0] Make View class Htmlable

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -7,7 +7,6 @@ use ArrayAccess;
 use JsonSerializable;
 use IteratorAggregate;
 use Illuminate\Support\Collection;
-use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
@@ -73,7 +72,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return \Illuminate\Support\HtmlString
+     * @return \Illuminate\Contracts\Support\Htmlable
      */
     public function links($view = null, $data = [])
     {
@@ -85,14 +84,14 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return \Illuminate\Support\HtmlString
+     * @return \Illuminate\Contracts\Support\Htmlable
      */
     public function render($view = null, $data = [])
     {
-        return new HtmlString(static::viewFactory()->make($view ?: static::$defaultView, array_merge($data, [
+        return static::viewFactory()->make($view ?: static::$defaultView, array_merge($data, [
             'paginator' => $this,
             'elements' => $this->elements(),
-        ]))->render());
+        ]));
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -7,7 +7,6 @@ use ArrayAccess;
 use JsonSerializable;
 use IteratorAggregate;
 use Illuminate\Support\Collection;
-use Illuminate\Support\HtmlString;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
@@ -102,15 +101,13 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return string
+     * @return \Illuminate\Contracts\Support\Htmlable
      */
     public function render($view = null, $data = [])
     {
-        return new HtmlString(
-            static::viewFactory()->make($view ?: static::$defaultSimpleView, array_merge($data, [
-                'paginator' => $this,
-            ]))->render()
-        );
+        return static::viewFactory()->make($view ?: static::$defaultSimpleView, array_merge($data, [
+            'paginator' => $this,
+        ]));
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -10,12 +10,13 @@ use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\Support\MessageProvider;
 use Illuminate\Contracts\View\View as ViewContract;
 
-class View implements ArrayAccess, ViewContract
+class View implements ArrayAccess, Htmlable, ViewContract
 {
     use Macroable {
         __call as macroCall;
@@ -106,6 +107,11 @@ class View implements ArrayAccess, ViewContract
 
             throw $e;
         }
+    }
+
+    public function toHtml()
+    {
+        return $this->render();
     }
 
     /**


### PR DESCRIPTION
*Note: 6.0 version of #29593 as requested - though I've asked @GrahamCampbell to [clarify whether it's backwards compatible](https://github.com/laravel/framework/pull/29593#issuecomment-521893139) or not.*

By making `View` implement `Htmlable`, it's no longer necessary to call `new HtmlString($view->render())` before passing it to a view - e.g. in the `$paginator->render()` method.

There are two concrete examples of this in the Laravel Paginator classes (see code changes), and another in my [Laravel Breadcrumbs package](https://github.com/davejamesmiller/laravel-breadcrumbs/blob/b874be3e13f7bd672a260596127ccec4564dc03e/src/BreadcrumbsManager.php#L209-L211):

```php
$html = $this->viewFactory->make($view, compact('breadcrumbs'))->render();

return new HtmlString($html);
```

Becomes:

```php
return $this->viewFactory->make($view, compact('breadcrumbs'));
```

But those aren't the reason for suggesting the change - I'd also like to use it within an application to approximate [CakePHP's View Cells](https://book.cakephp.org/3.0/en/views/cells.html):

```php
class InboxCell
{
    public function display(...)
    {
        // ... calculate several things ...

       return view('cells.inbox', $data);
    }
}
```

```blade
@inject('inbox', 'App\ViewCells\InboxCell')

{{ $inbox->display(...) }}
```

(There are other ways I could achieve the same result, but this is the cleanest code I've come up with.)