### PR TITLE
[5.8] Use real classname for seeders

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -35,11 +35,13 @@ abstract class Seeder
         $classes = Arr::wrap($class);
 
         foreach ($classes as $class) {
+            $seeder = $this->resolve($class);
+
             if ($silent === false && isset($this->command)) {
-                $this->command->getOutput()->writeln("<info>Seeding:</info> $class");
+                $this->command->getOutput()->writeln('<info>Seeding:</info> '.get_class($seeder));
             }
 
-            $this->resolve($class)->__invoke();
+            $seeder->__invoke();
         }
 
         return $this;


### PR DESCRIPTION
This way, if a programmer decides to override (example below) a seeder in a container, an actual class name is printed instead of the parent class name.

Example:

I'm working on a multi-tenant app, where each tenant has its own "configuration" folder (contains a service provider and some additional classes such as seeders for example). I can choose which configuration is enabled by tweaking an environment variable.

```php
class PostsSeeder {}

class TenantAPostsSeeder extends PostsSeeder {}
```

With this change, I'll be able to tell which seeder is actually being executed when I run `php artisan db:seed`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
