### PR TITLE
[5.8] Order how fields are initialized by length

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -55,8 +55,8 @@ class NotificationSender
     {
         $this->bus = $bus;
         $this->events = $events;
-        $this->manager = $manager;
         $this->locale = $locale;
+        $this->manager = $manager;
     }
 
     /**


### PR DESCRIPTION
This PR changes the order of how the fields get initialized so it reflects the "by-length" rule of Laravel. It helps to enhance the consistency of the framework.