### PR TITLE
[6.0] Use repository interfaces instead of alias

### DIFF
--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -635,8 +635,8 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function () {
-            return new QueueRestartCommand;
+        $this->app->singleton('command.queue.restart', function ($app) {
+            return new QueueRestartCommand($app['cache.store']);
         });
     }
 
@@ -660,7 +660,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerQueueWorkCommand()
     {
         $this->app->singleton('command.queue.work', function ($app) {
-            return new QueueWorkCommand($app['queue.worker']);
+            return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
 

--- a/src/Illuminate/Queue/Console/RestartCommand.php
+++ b/src/Illuminate/Queue/Console/RestartCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Cache\Repository as Cache;
 
 class RestartCommand extends Command
 {
@@ -24,13 +25,33 @@ class RestartCommand extends Command
     protected $description = 'Restart queue worker daemons after their current job';
 
     /**
+     * The cache store implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
+     * Create a new queue restart command.
+     *
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
+     * @return void
+     */
+    public function __construct(Cache $cache)
+    {
+        parent::__construct();
+
+        $this->cache = $cache;
+    }
+
+    /**
      * Execute the console command.
      *
      * @return void
      */
     public function handle()
     {
-        $this->laravel['cache.store']->forever('illuminate:queue:restart', $this->currentTime());
+        $this->cache->forever('illuminate:queue:restart', $this->currentTime());
 
         $this->info('Broadcasting queue restart signal.');
     }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\WorkerOptions;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Contracts\Cache\Repository as Cache;
 
 class WorkCommand extends Command
 {
@@ -46,15 +47,24 @@ class WorkCommand extends Command
     protected $worker;
 
     /**
+     * The cache store implementation.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    protected $cache;
+
+    /**
      * Create a new queue work command.
      *
      * @param  \Illuminate\Queue\Worker  $worker
+     * @param  \Illuminate\Contracts\Cache\Repository  $cache
      * @return void
      */
-    public function __construct(Worker $worker)
+    public function __construct(Worker $worker, Cache $cache)
     {
         parent::__construct();
 
+        $this->cache = $cache;
         $this->worker = $worker;
     }
 
@@ -96,7 +106,7 @@ class WorkCommand extends Command
      */
     protected function runWorker($connection, $queue)
     {
-        $this->worker->setCache($this->laravel['cache.store']);
+        $this->worker->setCache($this->cache);
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()


### PR DESCRIPTION
This is a followup for https://github.com/laravel/framework/pull/29548

What this changes is using the interface directly. The main advantage this gives is to easily swap out the repository implementation with a custom one without having to rebind the alias to the container.