### PR TITLE
[5.8] Add Redis 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ services:
 before_install:
   - phpenv config-rm xdebug.ini || true
   - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - printf "\n" | pecl install -f redis-4.3.0
+  - printf "\n" | pecl install -f redis
   - travis_retry composer self-update
   - mysql -e 'CREATE DATABASE forge;'
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -268,7 +268,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zinterstore($output, $keys, $options = [])
     {
-        return $this->command('zInter', [$output, $keys,
+        return $this->command('zinterstore', [$output, $keys,
             $options['weights'] ?? null,
             $options['aggregate'] ?? 'sum',
         ]);
@@ -284,7 +284,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zunionstore($output, $keys, $options = [])
     {
-        return $this->command('zUnion', [$output, $keys,
+        return $this->command('zunionstore', [$output, $keys,
             $options['weights'] ?? null,
             $options['aggregate'] ?? 'sum',
         ]);


### PR DESCRIPTION
These changes should be backwards compatible. I had to differentiate the tests between the PhpRedis and Predis connections because Predis doesn't seems to handle the 5.0 changes too well atm. And it doesn't seems to be maintained anymore...

Fixes https://github.com/laravel/framework/issues/29029