### PR TITLE
[6.0] Use proper type-hint for Console App constructor

### DIFF
--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -5,7 +5,6 @@ namespace Illuminate\Console;
 use Closure;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Container\Container;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,6 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Illuminate\Contracts\Foundation\Application as LaravelContract;
 use Illuminate\Contracts\Console\Application as ApplicationContract;
 
 class Application extends SymfonyApplication implements ApplicationContract
@@ -25,7 +25,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * The Laravel application instance.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $laravel;
 
@@ -53,17 +53,17 @@ class Application extends SymfonyApplication implements ApplicationContract
     /**
      * Create a new Artisan console application.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $laravel
+     * @param  \Illuminate\Contracts\Foundation\Application  $laravel
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
      * @param  string  $version
      * @return void
      */
-    public function __construct(Container $laravel, Dispatcher $events, $version)
+    public function __construct(LaravelContract $laravel, Dispatcher $events, $version)
     {
         parent::__construct('Laravel Framework', $version);
 
-        $this->laravel = $laravel;
         $this->events = $events;
+        $this->laravel = $laravel;
         $this->setAutoExit(false);
         $this->setCatchExceptions(false);
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -633,7 +633,7 @@ class Command extends SymfonyCommand
     /**
      * Set the Laravel application instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $laravel
+     * @param  \Illuminate\Contracts\Foundation\Application  $laravel
      * @return void
      */
     public function setLaravel($laravel)


### PR DESCRIPTION
The current Container type-hint isn't actually correct because the internals expect the full framework. You can see this in subsequential commands and setters as well. I replaced the type-hint and the contract references. This could be a breaking change for the ones implementing a custom console app.
