### PR TITLE
[5.5] Fixed incorrect implementation of PSR-16

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -199,7 +199,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function set($key, $value, $ttl = null)
     {
-        $this->put($key, $value, $ttl === null ? null : $ttl / 60);
+        $this->put($key, $value, is_int($ttl) ? $ttl / 60 : null);
     }
 
     /**
@@ -225,7 +225,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function setMultiple($values, $ttl = null)
     {
-        $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl === null ? null : $ttl / 60);
+        $this->putMany(is_array($values) ? $values : iterator_to_array($values), is_int($ttl) ? $ttl / 60 : null);
     }
 
     /**

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -199,7 +199,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function set($key, $value, $ttl = null)
     {
-        $this->put($key, $value, $ttl);
+        $this->put($key, $value, $ttl === null ? null : $ttl / 60);
     }
 
     /**
@@ -225,7 +225,7 @@ class Repository implements CacheContract, ArrayAccess
      */
     public function setMultiple($values, $ttl = null)
     {
-        $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl);
+        $this->putMany(is_array($values) ? $values : iterator_to_array($values), $ttl === null ? null : $ttl / 60);
     }
 
     /**


### PR DESCRIPTION
You may have noticed StyleCI was down yesterday repeatedly. This was caused by this bug causing our cache expiration to be much too long which resulted in the redis hogging all the resources and ultimately bringing everything down with it. 48 hours expiration was being treated as 120 days instead!

[PSR-16](https://www.php-fig.org/psr/psr-16/) mandates that `set` and `setMultiple` have their TTL specified in seconds, but Laravel's `put` and `putMany` methods expect minutes, so a correct implementation must compensate for this by converting seconds to minutes before passing to `put` or `putMany`.

---

// cc @joecohens