### PR TITLE
[6.0] Support PSR-6 as well as PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
-        "symfony/cache": "Required to psr-6 cache bridge (^4.3).",
+        "symfony/cache": "Required to PSR-6 cache bridge (^4.3).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.3).",
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.3).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.0",
         "predis/predis": "^1.1.1",
+        "symfony/cache": "^4.3",
         "symfony/css-selector": "^4.3",
         "symfony/dom-crawler": "^4.3",
         "true/punycode": "^2.1"
@@ -131,6 +132,7 @@
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
+        "symfony/cache": "Required to psr-6 cache bridge (^4.3).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.3).",
         "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.3).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Symfony\Component\Cache\Adapter\Psr16Adapter;
 
 class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
 {
@@ -22,6 +23,10 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
             return $app['cache']->driver();
         });
 
+        $this->app->singleton('cache.psr6', function ($app) {
+            return new Psr16Adapter($app['cache.store']);
+        });
+
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
@@ -35,7 +40,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'memcached.connector',
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector',
         ];
     }
 }

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Cache;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Contracts\Support\DeferrableProvider;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
 class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
 {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -32,7 +32,7 @@
         "illuminate/database": "Required to use the database cache driver (^6.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^6.0).",
         "illuminate/redis": "Required to use the redis cache driver (^6.0).",
-        "symfony/cache": "Required to psr-6 cache bridge (^4.3)."
+        "symfony/cache": "Required to PSR-6 cache bridge (^4.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -31,7 +31,8 @@
     "suggest": {
         "illuminate/database": "Required to use the database cache driver (^6.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^6.0).",
-        "illuminate/redis": "Required to use the redis cache driver (^6.0)."
+        "illuminate/redis": "Required to use the redis cache driver (^6.0).",
+        "symfony/cache": "Required to psr-6 cache bridge (^4.3)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1135,6 +1135,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'blade.compiler'       => [\Illuminate\View\Compilers\BladeCompiler::class],
             'cache'                => [\Illuminate\Cache\CacheManager::class, \Illuminate\Contracts\Cache\Factory::class],
             'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class, \Psr\SimpleCache\CacheInterface::class],
+            'cache.psr6'           => [\Symfony\Component\Cache\Adapter\Psr16Adapter::class, \Symfony\Component\Cache\Adapter\AdapterInterface::class, \Psr\Cache\CacheItemPoolInterface::class],
             'config'               => [\Illuminate\Config\Repository::class, \Illuminate\Contracts\Config\Repository::class],
             'cookie'               => [\Illuminate\Cookie\CookieJar::class, \Illuminate\Contracts\Cookie\Factory::class, \Illuminate\Contracts\Cookie\QueueingFactory::class],
             'encrypter'            => [\Illuminate\Encryption\Encrypter::class, \Illuminate\Contracts\Encryption\Encrypter::class],

--- a/tests/Integration/Foundation/DiscoverEventsTest.php
+++ b/tests/Integration/Foundation/DiscoverEventsTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Events\DiscoverEvents;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventOne;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Events\EventTwo;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener;
-use Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\Listener as ListenerAlias;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\AbstractListener;
 use Illuminate\Tests\Integration\Foundation\Fixtures\EventDiscovery\Listeners\ListenerInterface;
 


### PR DESCRIPTION
My last bugfix PR to L5.5 made me wonder if we should actually include this PSR-6 setup in the framework core, since there's basically no code for us to have to write to make it happen.

Previously, one could have PSR-16 cache instances injected by the container out of the box. With this PR, as long as the symfony/cache package is installed, PSR-6 cache instances can now be injected too, out of the box.

NB There are no adverse effects of aliasing classes that might not exist if the symfony/cache package is not installed. The `::class` notation doesn't do any autoloading or IO, and the container just sees everything as strings.