### PR TITLE
[5.8] Add db:wipe Artisan command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -37,21 +37,12 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        if ($this->option('drop-views')) {
-            $this->dropAllViews($database);
-
-            $this->info('Dropped all views successfully.');
-        }
-
-        $this->dropAllTables($database);
-
-        $this->info('Dropped all tables successfully.');
-
-        if ($this->option('drop-types')) {
-            $this->dropAllTypes($database);
-
-            $this->info('Dropped all types successfully.');
-        }
+        $this->call('db:wipe', array_filter([
+            '--database' => $database,
+            '--drop-views' => $this->option('drop-views'),
+            '--drop-types' => $this->option('drop-types'),
+            '--force' => true,
+        ]));
 
         $this->call('migrate', array_filter([
             '--database' => $database,

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -58,45 +58,6 @@ class FreshCommand extends Command
     }
 
     /**
-     * Drop all of the database tables.
-     *
-     * @param  string  $database
-     * @return void
-     */
-    protected function dropAllTables($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllTables();
-    }
-
-    /**
-     * Drop all of the database views.
-     *
-     * @param  string  $database
-     * @return void
-     */
-    protected function dropAllViews($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllViews();
-    }
-
-    /**
-     * Drop all of the database types.
-     *
-     * @param string $database
-     * @return void
-     */
-    protected function dropAllTypes($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllTypes();
-    }
-
-    /**
      * Determine if the developer has requested database seeding.
      *
      * @return bool

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -22,7 +22,7 @@ class WipeCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Drop all tables & views';
+    protected $description = 'Drop all tables, views & types';
 
     /**
      * Execute the console command.

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -86,6 +86,8 @@ class WipeCommand extends Command
 
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
 
+            ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
+
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
         ];
     }

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Input\InputOption;
+
+class WipeCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'db:wipe';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Drop all tables & views';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $database = $this->input->getOption('database');
+
+        if ($this->option('drop-views')) {
+            $this->dropAllViews($database);
+
+            $this->info('Dropped all views successfully.');
+        }
+
+        $this->dropAllTables($database);
+
+        $this->info('Dropped all tables successfully.');
+    }
+
+    /**
+     * Drop all of the database tables.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllTables($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTables();
+    }
+
+    /**
+     * Drop all of the database views.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllViews($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllViews();
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+
+            ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
+    }
+}

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -46,6 +46,12 @@ class WipeCommand extends Command
         $this->dropAllTables($database);
 
         $this->info('Dropped all tables successfully.');
+
+        if ($this->option('drop-types')) {
+            $this->dropAllTypes($database);
+
+            $this->info('Dropped all types successfully.');
+        }
     }
 
     /**
@@ -72,6 +78,19 @@ class WipeCommand extends Command
         $this->laravel['db']->connection($database)
                     ->getSchemaBuilder()
                     ->dropAllViews();
+    }
+
+    /**
+     * Drop all of the database types.
+     *
+     * @param string $database
+     * @return void
+     */
+    protected function dropAllTypes($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTypes();
     }
 
     /**

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
@@ -90,6 +91,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ClearResets' => 'command.auth.resets.clear',
         'ConfigCache' => 'command.config.cache',
         'ConfigClear' => 'command.config.clear',
+        'DbWipe' => 'command.db.wipe',
         'Down' => 'command.down',
         'Environment' => 'command.environment',
         'EventCache' => 'command.event.cache',
@@ -333,6 +335,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.controller.make', function ($app) {
             return new ControllerMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbWipeCommand()
+    {
+        $this->app->singleton('command.db.wipe', function () {
+            return new WipeCommand;
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
 use Illuminate\Auth\Console\AuthMakeCommand;
+use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;


### PR DESCRIPTION
This PR adds `db:wipe {--database=} {--drop-views} {--drop-types} {--force}` Artisan command.

While developing automated migration & backup restoration process I found very useful to have a quick way to drop all the tables, views and types. It prevents database corruption because of foreign keys and allows to implement full backup restoration on application level.

You could say that there is a `migrate:reset` command. Yes it is, but it's very slow on many migrations amount because it iterates thru the `migrations` table and executes `down` method for each migration. But more important thing that `down` method could be missing if migrations designed to go only up or there is no dropping foreign keys in them. Reset progress will be broken and database became corrupted. You wouldn't be able to run `migrate:reset` again and you will be forced to drop all tables, views & types directly in database.