### PR TITLE
[6.0] Fix UNION queries with ORDER BY bindings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -59,6 +59,7 @@ class Builder
         'having' => [],
         'order'  => [],
         'union'  => [],
+        'unionOrder' => [],
     ];
 
     /**
@@ -1804,7 +1805,7 @@ class Builder
 
             $column = new Expression('('.$query.')');
 
-            $this->addBinding($bindings, 'order');
+            $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
         }
 
         $direction = strtolower($direction);
@@ -1878,7 +1879,7 @@ class Builder
 
         $this->{$this->unions ? 'unionOrders' : 'orders'}[] = compact('type', 'sql');
 
-        $this->addBinding($bindings, 'order');
+        $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
 
         return $this;
     }


### PR DESCRIPTION
`UNION` queries with bindings in the `ORDER BY` clause are incorrect:

```php
DB::table('posts')->where('public', 1)
    ->unionAll(
        DB::table('videos')->where('public', 1)
    )
    ->orderByRaw('field(`category`, ?, ?)', ['news', 'opinion'])
    ->get();
```

```sql
(select * from `posts` where `public` = 1)
union all
(select * from `videos` where `public` = 'news')
order by field(`category`, 'opinion', 1) ^^^^^^
                           ^^^^^^^^^^^^
```

We need to add a separate section for those bindings.