### PR TITLE
[6.0] Add Artisan db:wipe command

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -37,21 +37,12 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        if ($this->option('drop-views')) {
-            $this->dropAllViews($database);
-
-            $this->info('Dropped all views successfully.');
-        }
-
-        $this->dropAllTables($database);
-
-        $this->info('Dropped all tables successfully.');
-
-        if ($this->option('drop-types')) {
-            $this->dropAllTypes($database);
-
-            $this->info('Dropped all types successfully.');
-        }
+        $this->call('db:wipe', array_filter([
+            '--database' => $database,
+            '--drop-views' => $this->option('drop-views'),
+            '--drop-types' => $this->option('drop-types'),
+            '--force' => true,
+        ]));
 
         $this->call('migrate', array_filter([
             '--database' => $database,
@@ -64,45 +55,6 @@ class FreshCommand extends Command
         if ($this->needsSeeding()) {
             $this->runSeeder($database);
         }
-    }
-
-    /**
-     * Drop all of the database tables.
-     *
-     * @param  string  $database
-     * @return void
-     */
-    protected function dropAllTables($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllTables();
-    }
-
-    /**
-     * Drop all of the database views.
-     *
-     * @param  string  $database
-     * @return void
-     */
-    protected function dropAllViews($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllViews();
-    }
-
-    /**
-     * Drop all of the database types.
-     *
-     * @param string $database
-     * @return void
-     */
-    protected function dropAllTypes($database)
-    {
-        $this->laravel['db']->connection($database)
-                    ->getSchemaBuilder()
-                    ->dropAllTypes();
     }
 
     /**

--- a/src/Illuminate/Database/Console/WipeCommand.php
+++ b/src/Illuminate/Database/Console/WipeCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Input\InputOption;
+
+class WipeCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'db:wipe';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Drop all tables, views & types';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $database = $this->input->getOption('database');
+
+        if ($this->option('drop-views')) {
+            $this->dropAllViews($database);
+
+            $this->info('Dropped all views successfully.');
+        }
+
+        $this->dropAllTables($database);
+
+        $this->info('Dropped all tables successfully.');
+
+        if ($this->option('drop-types')) {
+            $this->dropAllTypes($database);
+
+            $this->info('Dropped all types successfully.');
+        }
+    }
+
+    /**
+     * Drop all of the database tables.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllTables($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTables();
+    }
+
+    /**
+     * Drop all of the database views.
+     *
+     * @param  string  $database
+     * @return void
+     */
+    protected function dropAllViews($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllViews();
+    }
+
+    /**
+     * Drop all of the database types.
+     *
+     * @param string $database
+     * @return void
+     */
+    protected function dropAllTypes($database)
+    {
+        $this->laravel['db']->connection($database)
+                    ->getSchemaBuilder()
+                    ->dropAllTypes();
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
+            ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Queue\Console\TableCommand;
+use Illuminate\Database\Console\WipeCommand;
 use Illuminate\Foundation\Console\UpCommand;
 use Illuminate\Foundation\Console\DownCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
@@ -80,6 +81,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ClearResets' => 'command.auth.resets.clear',
         'ConfigCache' => 'command.config.cache',
         'ConfigClear' => 'command.config.clear',
+        'DbWipe' => 'command.db.wipe',
         'Down' => 'command.down',
         'Environment' => 'command.environment',
         'EventCache' => 'command.event.cache',
@@ -289,6 +291,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.controller.make', function ($app) {
             return new ControllerMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbWipeCommand()
+    {
+        $this->app->singleton('command.db.wipe', function () {
+            return new WipeCommand;
         });
     }
 


### PR DESCRIPTION
Resubmitting #29616 because of breaking changes.

This PR adds `db:wipe {--database=} {--drop-views} {--drop-types} {--force}` Artisan command.

While developing automated migration & backup restoration process I found very useful to have a quick way to drop all the tables, views and types. It prevents database corruption because of foreign keys and allows to implement full backup restoration on application level.

You could say that there is a `migrate:reset` command. Yes it is, but it's very slow on many migrations amount because it iterates thru the `migrations` table and executes `down` method for each migration. But more important thing that `down` method could be missing if migrations designed to go only up or there is no dropping foreign keys in them. Reset progress will be broken and database became corrupted. You wouldn't be able to run `migrate:reset` again and you will be forced to drop all tables, views & types directly in database.

To not duplicate functionality I've made `migrate:fresh` command simpler. Now it just calls `db:wipe` and then `migrate`.

Related PRs: #15281
Related Issues: #12805