### PR TITLE
[6.0] Allow to call Artisan FQCN commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -656,16 +656,20 @@ class Command extends SymfonyCommand
      */
     private function resolveCommand($command)
     {
+        if (!class_exists($command)) {
+            return $this->getApplication()->find($command);
+        }
+
+        $command = new $command;
+
         if ($command instanceof SymfonyCommand) {
-            return $command;
+            $command->setApplication($this->getApplication());
         }
 
-        if (class_exists($command)) {
-            $command = new $command;
+        if ($command instanceof Command) {
             $command->setLaravel($this->getLaravel());
-            return $command;
         }
 
-        return $this->getApplication()->find($command);
+        return $command;
     }
 }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -656,7 +656,7 @@ class Command extends SymfonyCommand
      */
     private function resolveCommand($command)
     {
-        if (!class_exists($command)) {
+        if (! class_exists($command)) {
             return $this->getApplication()->find($command);
         }
 
@@ -666,7 +666,7 @@ class Command extends SymfonyCommand
             $command->setApplication($this->getApplication());
         }
 
-        if ($command instanceof Command) {
+        if ($command instanceof self) {
             $command->setLaravel($this->getLaravel());
         }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -195,8 +195,8 @@ class Command extends SymfonyCommand
     /**
      * Call another console command.
      *
-     * @param  string|\Symfony\Component\Console\Command\Command  $command
-     * @param  array   $arguments
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  array  $arguments
      * @return int
      */
     public function call($command, array $arguments = [])
@@ -207,8 +207,8 @@ class Command extends SymfonyCommand
     /**
      * Call another console command silently.
      *
-     * @param  string|\Symfony\Component\Console\Command\Command  $command
-     * @param  array   $arguments
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  array  $arguments
      * @return int
      */
     public function callSilent($command, array $arguments = [])
@@ -636,9 +636,9 @@ class Command extends SymfonyCommand
     /**
      * Runs the console command.
      *
-     * @param string|\Symfony\Component\Console\Command\Command $command
-     * @param array $arguments
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Command\Command|string $command
+     * @param  array  $arguments
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return int
      */
     private function runCommand($command, array $arguments, OutputInterface $output)
@@ -653,7 +653,7 @@ class Command extends SymfonyCommand
     /**
      * Resolve console command instance.
      *
-     * @param string|\Symfony\Component\Console\Command\Command $command
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
      * @return \Symfony\Component\Console\Command\Command
      */
     private function resolveCommand($command)

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -641,8 +641,10 @@ class Command extends SymfonyCommand
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return int
      */
-    private function runCommand($command, array $arguments, OutputInterface $output): int
+    private function runCommand($command, array $arguments, OutputInterface $output)
     {
+        $arguments['command'] = $command;
+
         return $this->resolveCommand($command)->run(
             $this->createInputFromArguments($arguments), $output
         );

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -195,33 +195,25 @@ class Command extends SymfonyCommand
     /**
      * Call another console command.
      *
-     * @param  string  $command
+     * @param  string|\Symfony\Component\Console\Command\Command  $command
      * @param  array   $arguments
      * @return int
      */
     public function call($command, array $arguments = [])
     {
-        $arguments['command'] = $command;
-
-        return $this->getApplication()->find($command)->run(
-            $this->createInputFromArguments($arguments), $this->output
-        );
+        return $this->runCommand($command, $arguments, $this->output);
     }
 
     /**
      * Call another console command silently.
      *
-     * @param  string  $command
+     * @param  string|\Symfony\Component\Console\Command\Command  $command
      * @param  array   $arguments
      * @return int
      */
     public function callSilent($command, array $arguments = [])
     {
-        $arguments['command'] = $command;
-
-        return $this->getApplication()->find($command)->run(
-            $this->createInputFromArguments($arguments), new NullOutput
-        );
+        return $this->runCommand($command, $arguments, new NullOutput);
     }
 
     /**
@@ -639,5 +631,41 @@ class Command extends SymfonyCommand
     public function setLaravel($laravel)
     {
         $this->laravel = $laravel;
+    }
+
+    /**
+     * Runs the console command.
+     *
+     * @param string|\Symfony\Component\Console\Command\Command $command
+     * @param array $arguments
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int
+     */
+    private function runCommand($command, array $arguments, OutputInterface $output): int
+    {
+        return $this->resolveCommand($command)->run(
+            $this->createInputFromArguments($arguments), $output
+        );
+    }
+
+    /**
+     * Resolve console command instance.
+     *
+     * @param string|\Symfony\Component\Console\Command\Command $command
+     * @return \Symfony\Component\Console\Command\Command
+     */
+    private function resolveCommand($command)
+    {
+        if ($command instanceof SymfonyCommand) {
+            return $command;
+        }
+
+        if (class_exists($command)) {
+            $command = new $command;
+            $command->setLaravel($this->getLaravel());
+            return $command;
+        }
+
+        return $this->getApplication()->find($command);
     }
 }


### PR DESCRIPTION
This PR adds ability to call FQCN commands.

```php
$this->call(\Illuminate\Database\Console\Seeds\SeedCommand::class, [
    '--class' => ExampleSeeder::class,
]);

$this->callSilent(\Illuminate\Database\Console\Seeds\SeedCommand::class, [
    '--class' => ExampleSeeder::class,
]);
```
The same as:

```php
$this->call('db:seed', [
    '--class' => ExampleSeeder::class,
]);

$this->callSilent('db:seed', [
    '--class' => ExampleSeeder::class,
]);
```

## Motivation

I want to have a collection of console commands which wouldn't be registered in application but still be callable. This may be useful for automated application deployment & migrations processes when you have one registered command which will run many unregistered sub-commands.