### PR TITLE
[5.8] Avoid call to method alias

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -205,7 +205,7 @@ class Repository implements CacheContract, ArrayAccess
         $seconds = $this->getSeconds($ttl);
 
         if ($seconds <= 0) {
-            return $this->delete($key);
+            return $this->forget($key);
         }
 
         $result = $this->store->put($this->itemKey($key), $value, $seconds);


### PR DESCRIPTION
Quicker to directly call `forget`, since `delete` just proxies the call.