### PR TITLE
[6.0] Add tapEach() method to LazyCollection

### DIFF
--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1212,8 +1212,35 @@ class LazyCollection implements Enumerable
         return new static(function () use ($original, $limit) {
             $iterator = $original->getIterator();
 
-            for (; $iterator->valid() && $limit--; $iterator->next()) {
+            while ($limit--) {
+                if (! $iterator->valid()) {
+                    break;
+                }
+
                 yield $iterator->key() => $iterator->current();
+
+                if ($limit) {
+                    $iterator->next();
+                }
+            }
+        });
+    }
+
+    /**
+     * Pass each item in the collection to the given callback, lazily.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function tapEach(callable $callback)
+    {
+        $original = clone $this;
+
+        return new static(function () use ($original, $callback) {
+            foreach ($original as $key => $value) {
+                $callback($value, $key);
+
+                yield $key => $value;
             }
         });
     }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\LazyCollection;
+
+class SupportLazyCollectionTest extends TestCase
+{
+    public function testTapEach()
+    {
+        $data = LazyCollection::times(10);
+
+        $tapped = [];
+
+        $data = $data->tapEach(function ($value, $key) use (&$tapped) {
+            $tapped[$key] = $value;
+        });
+
+        $this->assertEmpty($tapped);
+
+        $data = $data->take(5)->all();
+
+        $this->assertSame([1, 2, 3, 4, 5], $data);
+        $this->assertSame([1, 2, 3, 4, 5], $tapped);
+    }
+}


### PR DESCRIPTION
Adds a ~`tapItems`~ `tapEach` method to the `LazyCollection` class, to lazily "tap" each item in the collection:

```php
LazyCollection::times(INF)
    ->tapEach(function ($value) {
        dump($value);
    })
    ->take(2)
    ->all();

// Logs:
// 1
// 2
```

You can think of it as `each`, but in a lazy fashion.

---

This `tapEach` is the same type of method as [the `tap` function in RxJS](https://www.learnrxjs.io/operators/utility/do.html).

I considered changing the lazy collection's `tap` method to work this way—since the standard `tap` functionality isn't really _that_ useful for lazy collections—but decided against it, if only for symmetry's sake.

---

While working on this, I actually discovered a bug in `take`: it enumerated one additional element than  was requested, which is just a waste. I fixed it.

I'm actually working on a PR to test that all methods in the `LazyCollection` are actually lazy, and don't enumerate more than they need to.

Those tests require this `tapEach` method, so I decided to send this as a separate PR.