### PR TITLE
[5.8] Remove unneeded is_string() check from ConvertEmptyStringsToNull

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -9,7 +9,7 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed|null
+     * @return mixed
      */
     protected function transform($key, $value)
     {

--- a/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php
@@ -9,10 +9,10 @@ class ConvertEmptyStringsToNull extends TransformsRequest
      *
      * @param  string  $key
      * @param  mixed  $value
-     * @return mixed
+     * @return mixed|null
      */
     protected function transform($key, $value)
     {
-        return is_string($value) && $value === '' ? null : $value;
+        return $value === '' ? null : $value;
     }
 }

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+
+class ConvertEmptyStringsToNullTest extends TestCase
+{
+    public function testConvertEmptyStringsToNull() : void
+    {
+        $middleware = new ConvertEmptyStringsToNull();
+        $symfonyRequest = new SymfonyRequest([
+            'empty' => '',
+            'null' => null,
+            'toString' => new ToString(),
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertNull($request->get('empty'));
+            $this->assertNull($request->get('null'));
+            $this->assertInstanceOf(ToString::class, $request->get('toString'));
+        });
+    }
+}
+
+class ToString
+{
+    public function __toString()
+    {
+        return '';
+    }
+}

--- a/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
+++ b/tests/Foundation/Http/Middleware/ConvertEmptyStringsToNullTest.php
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 
 class ConvertEmptyStringsToNullTest extends TestCase
 {
-    public function testConvertEmptyStringsToNull() : void
+    public function testConvertEmptyStringsToNull()
     {
         $middleware = new ConvertEmptyStringsToNull();
         $symfonyRequest = new SymfonyRequest([


### PR DESCRIPTION
I think the `is_string()` check might have been put there to avoid calling `__toString()` when comparing against objects. That is only needed when using the `==` operator for comparison. The `===` operator does not attempt any coercion, so it is safe to drop the `is_string()` check.

This makes the code simpler and shaves off a few CPU cycles.

Added a test to ensure the behaviour of `ConvertEmptyStringsToNull` works as defined.