### PR TITLE
[6.0] Merge job payloads correctly

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -235,9 +235,10 @@ abstract class Queue
     {
         if (! empty(static::$createPayloadCallbacks)) {
             foreach (static::$createPayloadCallbacks as $callback) {
-                $payload = array_merge($payload, call_user_func(
-                    $callback, $this->getConnectionName(), $queue, $payload
-                ));
+                $new = $callback($this->getConnectionName(), $queue, $payload);
+                foreach ($new as $key => $value) {
+                    $payload[$key] = array_merge($payload[$key] ?? [], $value);
+                }
             }
         }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -237,7 +237,11 @@ abstract class Queue
             foreach (static::$createPayloadCallbacks as $callback) {
                 $new = $callback($this->getConnectionName(), $queue, $payload);
                 foreach ($new as $key => $value) {
-                    $payload[$key] = array_merge($payload[$key] ?? [], $value);
+                    if (is_array($payload[$key] ?? []) && is_array($value)) {
+                        $payload[$key] = array_merge($payload[$key] ?? [], $value);
+                    } else {
+                        $payload[$key] = $value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Right now, calling

```php
$this->app['queue']->createPayloadUsing(function ($connection, $queue, $payload) {
    return [
        'tags' => [
            'some tag',
        ],
    ];
});
```

results in tags specified in the job's `tags()` method being overriden. I think the correct behavior would be merging the tags.

I would like to add tests as well, but I'm not sure where to place them, as there is no test class for the Queue abstract class.