### PR TITLE
[5.8] Prevent scheduled task from being interrupted by ping transfer exception

### DIFF
--- a/tests/Console/Scheduling/EventPingTest.php
+++ b/tests/Console/Scheduling/EventPingTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Mockery as m;
+use GuzzleHttp\HandlerStack;
+use Orchestra\Testbench\TestCase;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Client as HttpClient;
+use Illuminate\Console\Scheduling\Event;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Console\Scheduling\EventMutex;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+
+class EventPingTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testPingRescuesTransferExceptions()
+    {
+        $this->spy(ExceptionHandler::class)
+            ->shouldReceive('report')
+            ->once()
+            ->with(m::type(ServerException::class));
+
+        $clientMock = new HttpClient([
+            'handler' => HandlerStack::create(
+                new MockHandler([new Psr7Response(500)])
+            )
+        ]);
+
+        $this->app->instance(HttpClient::class, $clientMock);
+
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $thenCalled = false;
+
+        $event->pingBefore('https://httpstat.us/500')
+            ->then(function () use (&$thenCalled) {
+                $thenCalled = true;
+            });
+
+        $event->callBeforeCallbacks($this->app->make(Container::class));
+        $event->callAfterCallbacks($this->app->make(Container::class));
+
+        $this->assertTrue($thenCalled);
+    }
+}

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -26,7 +26,7 @@ class EventPingTest extends TestCase
         m::close();
     }
 
-    public function sdsdsdstestPingRescuesTransferExceptions()
+    public function testPingRescuesTransferExceptions()
     {
         $this->spy(ExceptionHandler::class)
             ->shouldReceive('report')

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Console\Scheduling;
+namespace Illuminate\Tests\Integration\Console\Scheduling;
 
 use Mockery as m;
 use GuzzleHttp\HandlerStack;
@@ -14,27 +14,32 @@ use Illuminate\Console\Scheduling\EventMutex;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 
+/**
+ * @group integration
+ */
 class EventPingTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
         m::close();
     }
 
-    public function testPingRescuesTransferExceptions()
+    public function sdsdsdstestPingRescuesTransferExceptions()
     {
         $this->spy(ExceptionHandler::class)
             ->shouldReceive('report')
             ->once()
             ->with(m::type(ServerException::class));
 
-        $clientMock = new HttpClient([
+        $httpMock = new HttpClient([
             'handler' => HandlerStack::create(
                 new MockHandler([new Psr7Response(500)])
-            )
+            ),
         ]);
 
-        $this->app->instance(HttpClient::class, $clientMock);
+        $this->swap(HttpClient::class, $httpMock);
 
         $event = new Event(m::mock(EventMutex::class), 'php -i');
 


### PR DESCRIPTION
When notifying an external service - any exceptions raised by the Guzzle client will prevent the scheduled task, or after hooks from being executed. This PR will rescue any transfer exceptions (connection timeout, DNS errors, server errors, client errors, etc) and allow execution to continue.

Example:

```php
    /**
     * Define the application's command schedule.
     *
     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
     * @return void
     */
    protected function schedule(Schedule $schedule)
    {
        $schedule->command('example')
            ->everyMinute()
            ->pingBefore('httpstat.us/500')
            ->after(function () {
                Log::info('after() hook executed');
            });
    }

    /**
     * Register the commands for the application.
     *
     * @return void
     */
    protected function commands()
    {
        Artisan::command('example', function () {
            Log::info('example command executed');
        });
    }
```
