### PR TITLE
[5.8] Fix insertOrIgnore() and insertUsing() as Eloquent queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -71,7 +71,7 @@ class Builder
      * @var array
      */
     protected $passthru = [
-        'insert', 'insertGetId', 'getBindings', 'toSql', 'dump', 'dd',
+        'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
     ];
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -607,6 +607,21 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
 
         $this->assertEquals('foo', $builder->insert(['bar']));
+
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('insertOrIgnore')->once()->with(['bar'])->andReturn('foo');
+
+        $this->assertEquals('foo', $builder->insertOrIgnore(['bar']));
+
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'])->andReturn('foo');
+
+        $this->assertEquals('foo', $builder->insertGetId(['bar']));
+
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('insertUsing')->once()->with(['bar'], 'baz')->andReturn('foo');
+
+        $this->assertEquals('foo', $builder->insertUsing(['bar'], 'baz'));
     }
 
     public function testQueryScopes()


### PR DESCRIPTION
When being called as an Eloquent query, `insertOrIgnore()` and `insertUsing()` return the query builder instead of the actual result (number of affected rows / success):

```php
User::insertOrIgnore(['foo' => 'bar']);

User::insertUsing(['foo'], "select 'bar'");
```