### PR TITLE
[5.8] Multiple universal email recipients

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -72,7 +72,11 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
         if (is_array($address) && isset($address['address'])) {
             $mailer->{'always'.Str::studly($type)}($address['address'], $address['name']);
         }
+        elseif (is_array($address) && isset($address[0]) && $type === 'to'){
+            $mailer->{'always'.Str::studly($type)}($address);
+        }
     }
+
 
     /**
      * Register the Swift Mailer instance.

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -72,8 +72,9 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
         if (is_array($address) && isset($address['address'])) {
             $mailer->{'always'.Str::studly($type)}($address['address'], $address['name']);
         }
-        elseif (is_array($address) && isset($address[0]) && $type === 'to'){
-            $mailer->{'always'.Str::studly($type)}($address);
+        elseif ($address && $type === 'to'){
+            $addresses = explode(',', $address);
+            $mailer->alwaysTo($addresses);
         }
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -117,7 +117,7 @@ class Mailer implements MailerContract, MailQueueContract
     /**
      * Set the global to address and name.
      *
-     * @param  string  $address
+     * @param  string|array  $address
      * @param  string|null  $name
      * @return void
      */

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -123,7 +123,11 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function alwaysTo($address, $name = null)
     {
+        if(is_array($address)){
+          $this->to = $address;
+        }else{
         $this->to = compact('address', 'name');
+        }
     }
 
     /**
@@ -246,7 +250,7 @@ class Mailer implements MailerContract, MailQueueContract
         // If a global "to" address has been set, we will set that address on the mail
         // message. This is primarily useful during local development in which each
         // message should be delivered into a single mail address for inspection.
-        if (isset($this->to['address'])) {
+        if (isset($this->to['address']) || isset($this->to[0])) {
             $this->setGlobalToAndRemoveCcAndBcc($message);
         }
 
@@ -361,7 +365,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function setGlobalToAndRemoveCcAndBcc($message)
     {
-        $message->to($this->to['address'], $this->to['name'], true);
+        $message->to($this->to['address'] ?? $this->to, $this->to['name'] ?? null, true);
         $message->cc(null, null, true);
         $message->bcc(null, null, true);
     }

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -63,6 +63,12 @@ class MailMessageTest extends TestCase
         $this->assertInstanceOf(Message::class, $this->message->to('foo@bar.baz', 'Foo', true));
     }
 
+    public function testMultipleTosMethodWithOverride()
+    {
+        $this->swift->shouldReceive('setTo')->once()->with(['foo@bar.baz', 'foobar@baz.bar'], null);
+        $this->assertInstanceOf(Message::class, $this->message->to(['foo@bar.baz', 'foobar@baz.bar'], null, true));
+    }
+
     public function testCcMethod()
     {
         $this->swift->shouldReceive('addCc')->once()->with('foo@bar.baz', 'Foo');


### PR DESCRIPTION
When testing email there is currently an option to set a universal to address. It only supports having one recipient. Sometimes it may be helpful to be able to send to multiple recipients if you have multiple email addresses using different email clients. This way you can easily see the results in each email client without having to forward it to multiple email addresses.
This PR will allow for setting multiple recipients as a comma separated string. In config `mail.to`.
e.g. `'to' => 'email1,email2...'`
This is backwards compatible with the other way of passing an array with `address` and `name`. However, with multiple recipients it'll only support email addresses, since it'll become difficult to pass both name and address properly to SwiftMailer.