### PR TITLE
[5.8] Add optional enforceOrderBy flag for DB Chunk

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -21,9 +21,7 @@ trait BuildsQueries
         if ($enforceOrderBy) {
             $this->enforceOrderBy();
         }
-        
         $page = 1;
-        
         do {
             // We'll execute the query for the given page and get the results. If there are
             // no results we can just break and return from here. When there are results

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -21,7 +21,9 @@ trait BuildsQueries
         if ($enforceOrderBy) {
             $this->enforceOrderBy();
         }
+        
         $page = 1;
+        
         do {
             // We'll execute the query for the given page and get the results. If there are
             // no results we can just break and return from here. When there are results

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -13,12 +13,12 @@ trait BuildsQueries
      *
      * @param  int  $count
      * @param  callable  $callback
-     * @param  boolean  $enforceOrderBy
+     * @param  bool  $enforceOrderBy
      * @return bool
      */
     public function chunk($count, callable $callback, $enforceOrderBy = true)
     {
-        if ( $enforceOrderBy ) {
+        if ($enforceOrderBy) {
             $this->enforceOrderBy();
         }
         

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -23,7 +23,7 @@ trait BuildsQueries
         }
         
         $page = 1;
-
+        
         do {
             // We'll execute the query for the given page and get the results. If there are
             // no results we can just break and return from here. When there are results

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -13,12 +13,15 @@ trait BuildsQueries
      *
      * @param  int  $count
      * @param  callable  $callback
+     * @param  boolean  $enforceOrderBy
      * @return bool
      */
-    public function chunk($count, callable $callback)
+    public function chunk($count, callable $callback, $enforceOrderBy = true)
     {
-        $this->enforceOrderBy();
-
+        if ( $enforceOrderBy ) {
+            $this->enforceOrderBy();
+        }
+        
         $page = 1;
 
         do {


### PR DESCRIPTION
I don't always want to order by when chunking through data - specially for dumping static data to third party products like Google BigQuery.

Adding the additional boolean with a default of true doesn't change any existing behaviour and allows you to declare a true or false after the callback.

Example

```php
DB::connection($dbConnection)
                ->table($source)
                ->chunk( $chunk, function ($row) use ($bigQ, $temp) {
                    $data = $bigQ->prepareData($row);
                    $bigQ->insert($temp, $data);
                }, false); 
```
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
