### PR TITLE
[5.8] Added ability to granulary set tries & timeout to Broadcast events

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -22,6 +22,20 @@ class BroadcastEvent implements ShouldQueue
     public $event;
 
     /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
      * Create a new job handler instance.
      *
      * @param  mixed  $event

--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -44,6 +44,8 @@ class BroadcastEvent implements ShouldQueue
     public function __construct($event)
     {
         $this->event = $event;
+        $this->tries = property_exists($event, 'tries') ? $event->tries : null;
+        $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
     }
 
     /**


### PR DESCRIPTION
Fixes #29656 

 - Allows individual variable setting of broadcast events for tries/timeout
