### PR TITLE
[7.0] Added native support for attribute encryption

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -202,7 +202,7 @@ trait HasAttributes
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
-            
+
             if ($attributes[$key] instanceof Arrayable) {
                 $attributes[$key] = $attributes[$key]->toArray();
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -202,6 +202,10 @@ trait HasAttributes
             if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
+            
+            if ($attributes[$key] instanceof Arrayable) {
+                $attributes[$key] = $attributes[$key]->toArray();
+            }
         }
 
         return $attributes;


### PR DESCRIPTION
This PR is created so that models can have native attribute encryption, in the same way that they can be cast.

A brief example might be something like the following:

```PHP
class User extends Model
{
    $encrypt = [
        'email'
    ];
}
```

Notice how we now have an array property on the model that can will encrypt and decrypt all attributes that are referenced within that array.  
In our example, there is no need to create a getter/setter for the attributes that are required to be encrypted and will help reduce clutter of the model, especially if there are multiple columns that require encryption.