### PR TITLE
[6.0] Replace string commands with class names

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -245,7 +245,7 @@ class Command extends SymfonyCommand
             return $this->getApplication()->find($command);
         }
 
-        $command = new $command;
+        $command = $this->laravel->make($command);
 
         if ($command instanceof SymfonyCommand) {
             $command->setApplication($this->getApplication());

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -4,7 +4,9 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\Console\WipeCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Database\Console\Seeds\SeedCommand;
 
 class FreshCommand extends Command
 {
@@ -37,14 +39,14 @@ class FreshCommand extends Command
 
         $database = $this->input->getOption('database');
 
-        $this->call('db:wipe', array_filter([
+        $this->call(WipeCommand::class, array_filter([
             '--database' => $database,
             '--drop-views' => $this->option('drop-views'),
             '--drop-types' => $this->option('drop-types'),
             '--force' => true,
         ]));
 
-        $this->call('migrate', array_filter([
+        $this->call(MigrateCommand::class, array_filter([
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
@@ -75,7 +77,7 @@ class FreshCommand extends Command
      */
     protected function runSeeder($database)
     {
-        $this->call('db:seed', array_filter([
+        $this->call(SeedCommand::class, array_filter([
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
             '--force' => true,

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Database\Console\Seeds\SeedCommand;
 
 class MigrateCommand extends BaseCommand
 {
@@ -75,7 +76,7 @@ class MigrateCommand extends BaseCommand
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.
         if ($this->option('seed') && ! $this->option('pretend')) {
-            $this->call('db:seed', ['--force' => true]);
+            $this->call(SeedCommand::class, ['--force' => true]);
         }
     }
 
@@ -89,7 +90,7 @@ class MigrateCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
-            $this->call('migrate:install', array_filter([
+            $this->call(InstallCommand::class, array_filter([
                 '--database' => $this->option('database'),
             ]));
         }

--- a/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/RefreshCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Console\Migrations;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Database\Console\Seeds\SeedCommand;
 
 class RefreshCommand extends Command
 {
@@ -56,7 +57,7 @@ class RefreshCommand extends Command
         // The refresh command is essentially just a brief aggregate of a few other of
         // the migration commands and just provides a convenient wrapper to execute
         // them in succession. We'll also see if we need to re-seed the database.
-        $this->call('migrate', array_filter([
+        $this->call(MigrateCommand::class, array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
@@ -78,7 +79,7 @@ class RefreshCommand extends Command
      */
     protected function runRollback($database, $path, $step)
     {
-        $this->call('migrate:rollback', array_filter([
+        $this->call(RollbackCommand::class, array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
@@ -96,7 +97,7 @@ class RefreshCommand extends Command
      */
     protected function runReset($database, $path)
     {
-        $this->call('migrate:reset', array_filter([
+        $this->call(ResetCommand::class, array_filter([
             '--database' => $database,
             '--path' => $path,
             '--realpath' => $this->input->getOption('realpath'),
@@ -122,7 +123,7 @@ class RefreshCommand extends Command
      */
     protected function runSeeder($database)
     {
-        $this->call('db:seed', array_filter([
+        $this->call(SeedCommand::class, array_filter([
             '--database' => $database,
             '--class' => $this->option('seeder') ?: 'DatabaseSeeder',
             '--force' => true,

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -53,7 +53,7 @@ class ConfigCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('config:clear');
+        $this->call(ConfigClearCommand::class);
 
         $config = $this->getFreshConfiguration();
 

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -28,7 +28,7 @@ class EventCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('event:clear');
+        $this->call(EventClearCommand::class);
 
         file_put_contents(
             $this->laravel->getCachedEventsPath(),

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -5,6 +5,9 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Routing\Console\ControllerMakeCommand;
+use Illuminate\Database\Console\Factories\FactoryMakeCommand;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
 
 class ModelMakeCommand extends GeneratorCommand
 {
@@ -69,7 +72,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $factory = Str::studly(class_basename($this->argument('name')));
 
-        $this->call('make:factory', [
+        $this->call(FactoryMakeCommand::class, [
             'name' => "{$factory}Factory",
             '--model' => $this->qualifyClass($this->getNameInput()),
         ]);
@@ -88,7 +91,7 @@ class ModelMakeCommand extends GeneratorCommand
             $table = Str::singular($table);
         }
 
-        $this->call('make:migration', [
+        $this->call(MigrateMakeCommand::class, [
             'name' => "create_{$table}_table",
             '--create' => $table,
         ]);
@@ -105,7 +108,7 @@ class ModelMakeCommand extends GeneratorCommand
 
         $modelName = $this->qualifyClass($this->getNameInput());
 
-        $this->call('make:controller', [
+        $this->call(ControllerMakeCommand::class, [
             'name' => "{$controller}Controller",
             '--model' => $this->option('resource') ? $modelName : null,
         ]);

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 
 class OptimizeClearCommand extends Command
 {
@@ -27,11 +28,11 @@ class OptimizeClearCommand extends Command
      */
     public function handle()
     {
-        $this->call('view:clear');
-        $this->call('cache:clear');
-        $this->call('route:clear');
-        $this->call('config:clear');
-        $this->call('clear-compiled');
+        $this->call(ViewClearCommand::class);
+        $this->call(CacheClearCommand::class);
+        $this->call(RouteClearCommand::class);
+        $this->call(ConfigClearCommand::class);
+        $this->call(ClearCompiledCommand::class);
 
         $this->info('Caches cleared successfully!');
     }

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -27,8 +27,8 @@ class OptimizeCommand extends Command
      */
     public function handle()
     {
-        $this->call('config:cache');
-        $this->call('route:cache');
+        $this->call(ConfigCacheCommand::class);
+        $this->call(RouteCacheCommand::class);
 
         $this->info('Files cached successfully!');
     }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -50,7 +50,7 @@ class RouteCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('route:clear');
+        $this->call(RouteClearCommand::class);
 
         $routes = $this->getFreshApplicationRoutes();
 

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -30,7 +30,7 @@ class ViewCacheCommand extends Command
      */
     public function handle()
     {
-        $this->call('view:clear');
+        $this->call(ViewClearCommand::class);
 
         $this->paths()->each(function ($path) {
             $this->compileViews($this->bladeFilesIn([$path]));

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Foundation\Console\ModelMakeCommand;
 
 class ControllerMakeCommand extends GeneratorCommand
 {
@@ -111,7 +112,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         if (! class_exists($parentModelClass)) {
             if ($this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $parentModelClass]);
+                $this->call(ModelMakeCommand::class, ['name' => $parentModelClass]);
             }
         }
 
@@ -134,7 +135,7 @@ class ControllerMakeCommand extends GeneratorCommand
 
         if (! class_exists($modelClass)) {
             if ($this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $modelClass]);
+                $this->call(ModelMakeCommand::class, ['name' => $modelClass]);
             }
         }
 


### PR DESCRIPTION
This is a follow-up for https://github.com/laravel/framework/pull/29624. By replacing these commands with their class names it's more clear which commands actually are called. When changes need to be made to any command signatures it can be done so in one place. When using an IDE it also allows for easy click through to these classes to inspect them and make use of any refactoring tools when change is needed.
