### PR TITLE
[6.0] Replace Application contract with Container

### DIFF
--- a/src/Illuminate/Hashing/HashManager.php
+++ b/src/Illuminate/Hashing/HashManager.php
@@ -14,7 +14,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createBcryptDriver()
     {
-        return new BcryptHasher($this->app['config']['hashing.bcrypt'] ?? []);
+        return new BcryptHasher($this->config->get('hashing.bcrypt') ?? []);
     }
 
     /**
@@ -24,7 +24,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createArgonDriver()
     {
-        return new ArgonHasher($this->app['config']['hashing.argon'] ?? []);
+        return new ArgonHasher($this->config->get('hashing.argon') ?? []);
     }
 
     /**
@@ -34,7 +34,7 @@ class HashManager extends Manager implements Hasher
      */
     public function createArgon2idDriver()
     {
-        return new Argon2IdHasher($this->app['config']['hashing.argon'] ?? []);
+        return new Argon2IdHasher($this->config->get('hashing.argon') ?? []);
     }
 
     /**
@@ -92,6 +92,6 @@ class HashManager extends Manager implements Hasher
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['hashing.driver'] ?? 'bcrypt';
+        return $this->config->get('hashing.driver', 'bcrypt');
     }
 }

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -25,7 +25,7 @@ class TransportManager extends Manager
      */
     protected function createSmtpDriver()
     {
-        $config = $this->app->make('config')->get('mail');
+        $config = $this->config->get('mail');
 
         // The Swift SMTP transport instance will allow us to use any SMTP backend
         // for delivering mail such as Sendgrid, Amazon SES, or a custom server
@@ -79,7 +79,7 @@ class TransportManager extends Manager
      */
     protected function createSendmailDriver()
     {
-        return new SendmailTransport($this->app['config']['mail']['sendmail']);
+        return new SendmailTransport($this->config->get('mail.sendmail'));
     }
 
     /**
@@ -89,7 +89,7 @@ class TransportManager extends Manager
      */
     protected function createSesDriver()
     {
-        $config = array_merge($this->app['config']->get('services.ses', []), [
+        $config = array_merge($this->config->get('services.ses', []), [
             'version' => 'latest', 'service' => 'email',
         ]);
 
@@ -131,7 +131,7 @@ class TransportManager extends Manager
      */
     protected function createMailgunDriver()
     {
-        $config = $this->app['config']->get('services.mailgun', []);
+        $config = $this->config->get('services.mailgun', []);
 
         return new MailgunTransport(
             $this->guzzle($config),
@@ -149,7 +149,7 @@ class TransportManager extends Manager
     protected function createPostmarkDriver()
     {
         return new PostmarkTransport(
-            $this->app['config']->get('services.postmark.token')
+            $this->config->get('services.postmark.token')
         );
     }
 
@@ -160,10 +160,10 @@ class TransportManager extends Manager
      */
     protected function createLogDriver()
     {
-        $logger = $this->app->make(LoggerInterface::class);
+        $logger = $this->container->make(LoggerInterface::class);
 
         if ($logger instanceof LogManager) {
-            $logger = $logger->channel($this->app['config']['mail.log_channel']);
+            $logger = $logger->channel($this->config->get('mail.log_channel'));
         }
 
         return new LogTransport($logger);
@@ -199,7 +199,7 @@ class TransportManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['mail.driver'];
+        return $this->config->get('mail.driver');
     }
 
     /**
@@ -210,6 +210,6 @@ class TransportManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['mail.driver'] = $name;
+        $this->config->set('mail.driver', $name);
     }
 }

--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -35,7 +35,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     public function send($notifiables, $notification)
     {
         return (new NotificationSender(
-            $this, $this->app->make(Bus::class), $this->app->make(Dispatcher::class), $this->locale)
+            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
         )->send($notifiables, $notification);
     }
 
@@ -50,7 +50,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
     public function sendNow($notifiables, $notification, array $channels = null)
     {
         return (new NotificationSender(
-            $this, $this->app->make(Bus::class), $this->app->make(Dispatcher::class), $this->locale)
+            $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)
         )->sendNow($notifiables, $notification, $channels);
     }
 
@@ -72,7 +72,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     protected function createDatabaseDriver()
     {
-        return $this->app->make(Channels\DatabaseChannel::class);
+        return $this->container->make(Channels\DatabaseChannel::class);
     }
 
     /**
@@ -82,7 +82,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     protected function createBroadcastDriver()
     {
-        return $this->app->make(Channels\BroadcastChannel::class);
+        return $this->container->make(Channels\BroadcastChannel::class);
     }
 
     /**
@@ -92,7 +92,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      */
     protected function createMailDriver()
     {
-        return $this->app->make(Channels\MailChannel::class);
+        return $this->container->make(Channels\MailChannel::class);
     }
 
     /**
@@ -109,7 +109,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
             return parent::createDriver($driver);
         } catch (InvalidArgumentException $e) {
             if (class_exists($driver)) {
-                return $this->app->make($driver);
+                return $this->container->make($driver);
             }
 
             throw $e;

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -35,7 +35,7 @@ class SessionManager extends Manager
     protected function createCookieDriver()
     {
         return $this->buildSession(new CookieSessionHandler(
-            $this->app['cookie'], $this->app['config']['session.lifetime']
+            $this->container->make('cookie'), $this->config->get('session.lifetime')
         ));
     }
 
@@ -56,10 +56,10 @@ class SessionManager extends Manager
      */
     protected function createNativeDriver()
     {
-        $lifetime = $this->app['config']['session.lifetime'];
+        $lifetime = $this->config->get('session.lifetime');
 
         return $this->buildSession(new FileSessionHandler(
-            $this->app['files'], $this->app['config']['session.files'], $lifetime
+            $this->container->make('files'), $this->config->get('session.files'), $lifetime
         ));
     }
 
@@ -70,12 +70,12 @@ class SessionManager extends Manager
      */
     protected function createDatabaseDriver()
     {
-        $table = $this->app['config']['session.table'];
+        $table = $this->config->get('session.table');
 
-        $lifetime = $this->app['config']['session.lifetime'];
+        $lifetime = $this->config->get('session.lifetime');
 
         return $this->buildSession(new DatabaseSessionHandler(
-            $this->getDatabaseConnection(), $table, $lifetime, $this->app
+            $this->getDatabaseConnection(), $table, $lifetime, $this->container
         ));
     }
 
@@ -86,9 +86,9 @@ class SessionManager extends Manager
      */
     protected function getDatabaseConnection()
     {
-        $connection = $this->app['config']['session.connection'];
+        $connection = $this->config->get('session.connection');
 
-        return $this->app['db']->connection($connection);
+        return $this->container->make('db')->connection($connection);
     }
 
     /**
@@ -121,7 +121,7 @@ class SessionManager extends Manager
         $handler = $this->createCacheHandler('redis');
 
         $handler->getCache()->getStore()->setConnection(
-            $this->app['config']['session.connection']
+            $this->config->get('session.connection')
         );
 
         return $this->buildSession($handler);
@@ -156,11 +156,11 @@ class SessionManager extends Manager
      */
     protected function createCacheHandler($driver)
     {
-        $store = $this->app['config']->get('session.store') ?: $driver;
+        $store = $this->config->get('session.store') ?: $driver;
 
         return new CacheBasedSessionHandler(
-            clone $this->app['cache']->store($store),
-            $this->app['config']['session.lifetime']
+            clone $this->container->make('cache')->store($store),
+            $this->config->get('session.lifetime')
         );
     }
 
@@ -172,9 +172,9 @@ class SessionManager extends Manager
      */
     protected function buildSession($handler)
     {
-        return $this->app['config']['session.encrypt']
+        return $this->config->get('session.encrypt')
                 ? $this->buildEncryptedSession($handler)
-                : new Store($this->app['config']['session.cookie'], $handler);
+                : new Store($this->config->get('session.cookie'), $handler);
     }
 
     /**
@@ -186,7 +186,7 @@ class SessionManager extends Manager
     protected function buildEncryptedSession($handler)
     {
         return new EncryptedStore(
-            $this->app['config']['session.cookie'], $handler, $this->app['encrypter']
+            $this->config->get('session.cookie'), $handler, $this->container['encrypter']
         );
     }
 
@@ -197,7 +197,7 @@ class SessionManager extends Manager
      */
     public function getSessionConfig()
     {
-        return $this->app['config']['session'];
+        return $this->config->get('session');
     }
 
     /**
@@ -207,7 +207,7 @@ class SessionManager extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['session.driver'];
+        return $this->config->get('session.driver');
     }
 
     /**
@@ -218,6 +218,6 @@ class SessionManager extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['session.driver'] = $name;
+        $this->config->set('session.driver', $name);
     }
 }

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -4,15 +4,23 @@ namespace Illuminate\Support;
 
 use Closure;
 use InvalidArgumentException;
+use Illuminate\Contracts\Container\Container;
 
 abstract class Manager
 {
     /**
-     * The application instance.
+     * The container instance.
      *
-     * @var \Illuminate\Contracts\Container\Container|\Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Container\Container
      */
-    protected $app;
+    protected $container;
+
+    /**
+     * The config repository instance.
+     *
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    protected $config;
 
     /**
      * The registered custom driver creators.
@@ -31,12 +39,13 @@ abstract class Manager
     /**
      * Create a new manager instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container|\Illuminate\Contracts\Foundation\Application  $app
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @return void
      */
-    public function __construct($app)
+    public function __construct(Container $container)
     {
-        $this->app = $app;
+        $this->config = $container->make('config');
+        $this->container = $container;
     }
 
     /**
@@ -107,7 +116,7 @@ abstract class Manager
      */
     protected function callCustomCreator($driver)
     {
-        return $this->customCreators[$driver]($this->app);
+        return $this->customCreators[$driver]($this->container);
     }
 
     /**

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -6,27 +6,28 @@ use Swift_Message;
 use Aws\Ses\SesClient;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
-use Illuminate\Support\Collection;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
 use Illuminate\Mail\TransportManager;
-use Illuminate\Foundation\Application;
 use Illuminate\Mail\Transport\SesTransport;
 
 class MailSesTransportTest extends TestCase
 {
+    /** @group Foo */
     public function testGetTransport()
     {
-        /** @var Application $app */
-        $app = [
-            'config' => new Collection([
+        $container = new Container();
+        $container->singleton('config', function () {
+            return new Repository([
                 'services.ses' => [
-                    'key'    => 'foo',
+                    'key' => 'foo',
                     'secret' => 'bar',
                     'region' => 'us-east-1',
                 ],
-            ]),
-        ];
+            ]);
+        });
 
-        $manager = new TransportManager($app);
+        $manager = new TransportManager($container);
 
         /** @var SesTransport $transport */
         $transport = $manager->driver('ses');


### PR DESCRIPTION
This is a follow-up for https://github.com/laravel/framework/pull/29619

Mior correctly noted that Managers only need to have a container instance to function properly. The fact that the default container we inject here is an instance of the Laravel application is an implementation detail.

This PR contains no breaking changes other than renaming the $app property to $container. The new type-hint still allows for the current Application instance to be passed through but makes it clear that this could be any implementation of a container.

I've also made $config a dedicated property on the Manager class as it's widely used on our own adapters. This makes it easy to reference it. The container array calls were replaced by `make` methods because `ArrayAccess` isn't part of the Container contract (and it shouldn't be).
