### PR TITLE
[6.0] Return number of inserted rows from insert()

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -100,12 +100,12 @@ class DatabaseStore implements Store
         $expiration = $this->getTime() + $seconds;
 
         try {
-            return $this->table()->insert(compact('key', 'value', 'expiration'));
+            $affected = $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (Exception $e) {
-            $result = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
-
-            return $result > 0;
+            $affected = $this->table()->where('key', $key)->update(compact('value', 'expiration'));
         }
+
+        return $affected > 0;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -405,11 +405,11 @@ class Connection implements ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @return bool
+     * @return int
      */
     public function insert($query, $bindings = [])
     {
-        return $this->statement($query, $bindings);
+        return $this->affectingStatement($query, $bindings);
     }
 
     /**

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -58,7 +58,7 @@ interface ConnectionInterface
      *
      * @param  string  $query
      * @param  array   $bindings
-     * @return bool
+     * @return int
      */
     public function insert($query, $bindings = []);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2580,7 +2580,7 @@ class Builder
      * Insert a new record into the database.
      *
      * @param  array  $values
-     * @return bool
+     * @return int
      */
     public function insert(array $values)
     {
@@ -2588,7 +2588,7 @@ class Builder
         // bindings are structured in a way that is convenient when building these
         // inserts statements by verifying these elements are actually an array.
         if (empty($values)) {
-            return true;
+            return 0;
         }
 
         if (! is_array(reset($values))) {
@@ -2636,7 +2636,7 @@ class Builder
             }
         }
 
-        return $this->connection->affectingStatement(
+        return $this->connection->insert(
             $this->grammar->compileInsertOrIgnore($this, $values),
             $this->cleanBindings(Arr::flatten($values, 1))
         );
@@ -2669,7 +2669,7 @@ class Builder
     {
         [$sql, $bindings] = $this->createSub($query);
 
-        return $this->connection->affectingStatement(
+        return $this->connection->insert(
             $this->grammar->compileInsertUsing($this, $columns, $sql),
             $this->cleanBindings($bindings)
         );
@@ -2695,7 +2695,7 @@ class Builder
      *
      * @param  array  $attributes
      * @param  array  $values
-     * @return bool
+     * @return int
      */
     public function updateOrInsert(array $attributes, array $values = [])
     {
@@ -2704,10 +2704,10 @@ class Builder
         }
 
         if (empty($values)) {
-            return true;
+            return 0;
         }
 
-        return (bool) $this->take(1)->update($values);
+        return $this->take(1)->update($values);
     }
 
     /**

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -142,14 +142,14 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      *
      * @param  string  $sessionId
      * @param  string  $payload
-     * @return bool|null
+     * @return int
      */
     protected function performInsert($sessionId, $payload)
     {
         try {
             return $this->getQuery()->insert(Arr::set($payload, 'id', $sessionId));
         } catch (QueryException $e) {
-            $this->performUpdate($sessionId, $payload);
+            return $this->performUpdate($sessionId, $payload);
         }
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -76,10 +76,10 @@ class DatabaseConnectionTest extends TestCase
         $this->assertIsNumeric($log[0]['time']);
     }
 
-    public function testInsertCallsTheStatementMethod()
+    public function testInsertCallsTheAffectingStatementMethod()
     {
-        $connection = $this->getMockConnection(['statement']);
-        $connection->expects($this->once())->method('statement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
+        $connection = $this->getMockConnection(['affectingStatement']);
+        $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
         $results = $connection->insert('foo', ['bar']);
         $this->assertEquals('baz', $results);
     }

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -959,24 +959,24 @@ class DatabaseEloquentIntegrationTest extends TestCase
     public function testMultiInsertsWithDifferentValues()
     {
         $date = '1970-01-01';
-        $result = EloquentTestPost::insert([
+        $affected = EloquentTestPost::insert([
             ['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
             ['user_id' => 2, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
         ]);
 
-        $this->assertTrue($result);
+        $this->assertEquals(2, $affected);
         $this->assertEquals(2, EloquentTestPost::count());
     }
 
     public function testMultiInsertsWithSameValues()
     {
         $date = '1970-01-01';
-        $result = EloquentTestPost::insert([
+        $affected = EloquentTestPost::insert([
             ['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
             ['user_id' => 1, 'name' => 'Post', 'created_at' => $date, 'updated_at' => $date],
         ]);
 
-        $this->assertTrue($result);
+        $this->assertEquals(2, $affected);
         $this->assertEquals(2, EloquentTestPost::count());
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1905,7 +1905,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testInsertUsingMethod()
     {
         $builder = $this->getBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "table1" ("foo") select "bar" from "table2" where "foreign_id" = ?', [5])->andReturn(1);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "table1" ("foo") select "bar" from "table2" where "foreign_id" = ?', [5])->andReturn(1);
 
         $result = $builder->from('table1')->insertUsing(
             ['foo'],
@@ -1928,7 +1928,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlInsertOrIgnoreMethod()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(1);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert ignore into `users` (`email`) values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
@@ -1936,7 +1936,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testPostgresInsertOrIgnoreMethod()
     {
         $builder = $this->getPostgresBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(1);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert into "users" ("email") values (?) on conflict do nothing', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
@@ -1944,7 +1944,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testSQLiteInsertOrIgnoreMethod()
     {
         $builder = $this->getSQLiteBuilder();
-        $builder->getConnection()->shouldReceive('affectingStatement')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(1);
+        $builder->getConnection()->shouldReceive('insert')->once()->with('insert or ignore into "users" ("email") values (?)', ['foo'])->andReturn(1);
         $result = $builder->from('users')->insertOrIgnore(['email' => 'foo']);
         $this->assertEquals(1, $result);
     }
@@ -2165,9 +2165,9 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
         $builder->shouldReceive('exists')->once()->andReturn(false);
-        $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(true);
+        $builder->shouldReceive('insert')->once()->with(['email' => 'foo', 'name' => 'bar'])->andReturn(1);
 
-        $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
+        $this->assertEquals(1, $builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
 
         $builder = m::mock(Builder::class.'[where,exists,update]', [
             m::mock(ConnectionInterface::class),
@@ -2180,7 +2180,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('take')->andReturnSelf();
         $builder->shouldReceive('update')->once()->with(['name' => 'bar'])->andReturn(1);
 
-        $this->assertTrue($builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
+        $this->assertEquals(1, $builder->updateOrInsert(['email' => 'foo'], ['name' => 'bar']));
     }
 
     public function testUpdateOrInsertMethodWorksWithEmptyUpdateValues()
@@ -2194,7 +2194,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->shouldReceive('where')->once()->with(['email' => 'foo'])->andReturn(m::self());
         $builder->shouldReceive('exists')->once()->andReturn(true);
 
-        $this->assertTrue($builder->updateOrInsert(['email' => 'foo']));
+        $this->assertEquals(0, $builder->updateOrInsert(['email' => 'foo']));
         $builder->shouldNotHaveReceived('update');
     }
 


### PR DESCRIPTION
With `insertOrIgnore()` and `insertUsing()` returning the number of inserted rows, I think we should also adjust `insert()` to be consistent.

At the moment, the method returns a boolean success value that is not particularly helpful. You always get `true` or an exception if the query fails. I also think returning `0` makes more sense than `true` when the provided values are empty.

The PR adjusts `insert()` in `Builder`, `Connection` and `ConnectionInterface`. It also changes the return values of `updateOrInsert()` and an internal `DatabaseSessionHandler` method.