### PR TITLE
[6.0] Remove mutating methods from lazy collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -806,6 +806,19 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Push an item onto the end of the collection.
+     *
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function push($value)
+    {
+        $this->items[] = $value;
+
+        return $this;
+    }
+
+    /**
      * Push all of the given items onto the collection.
      *
      * @param  iterable  $source

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -409,14 +409,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function flip();
 
     /**
-     * Remove an item by key.
-     *
-     * @param  string|array  $keys
-     * @return $this
-     */
-    public function forget($keys);
-
-    /**
      * Get an item from the collection by key.
      *
      * @param  mixed  $key
@@ -661,45 +653,12 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function partition($key, $operator = null, $value = null);
 
     /**
-     * Get and remove the last item from the collection.
-     *
-     * @return mixed
-     */
-    public function pop();
-
-    /**
-     * Push an item onto the beginning of the collection.
-     *
-     * @param  mixed  $value
-     * @param  mixed  $key
-     * @return $this
-     */
-    public function prepend($value, $key = null);
-
-    /**
-     * Push an item onto the end of the collection.
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function push($value);
-
-    /**
      * Push all of the given items onto the collection.
      *
      * @param  iterable  $source
      * @return static
      */
     public function concat($source);
-
-    /**
-     * Put an item in the collection by key.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function put($key, $value);
 
     /**
      * Get one or a specified number of items randomly from the collection.
@@ -751,13 +710,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return mixed
      */
     public function search($value, $strict = false);
-
-    /**
-     * Get and remove the first item from the collection.
-     *
-     * @return mixed
-     */
-    public function shift();
 
     /**
      * Shuffle the items in the collection.
@@ -845,16 +797,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function sortKeysDesc($options = SORT_REGULAR);
 
     /**
-     * Splice a portion of the underlying collection array.
-     *
-     * @param  int  $offset
-     * @param  int|null  $length
-     * @param  mixed  $replacement
-     * @return static
-     */
-    public function splice($offset, $length = null, $replacement = []);
-
-    /**
      * Get the sum of the given values.
      *
      * @param  callable|string|null  $callback
@@ -877,14 +819,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return $this
      */
     public function tap(callable $callback);
-
-    /**
-     * Transform each item in the collection using a callback.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function transform(callable $callback);
 
     /**
      * Pass the enumerable to the given callback and return the result.
@@ -951,14 +885,6 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @return static
      */
     public function countBy($callback = null);
-
-    /**
-     * Add an item to the collection.
-     *
-     * @param  mixed  $item
-     * @return $this
-     */
-    public function add($item);
 
     /**
      * Convert the collection to its string representation.

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -149,10 +149,8 @@ class LazyCollection implements Enumerable
      */
     public function collapse()
     {
-        $original = clone $this;
-
-        return new static(function () use ($original) {
-            foreach ($original as $values) {
+        return new static(function () {
+            foreach ($this as $values) {
                 if (is_array($values) || $values instanceof Enumerable) {
                     foreach ($values as $value) {
                         yield $value;
@@ -321,10 +319,8 @@ class LazyCollection implements Enumerable
             };
         }
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $callback) {
-            foreach ($original as $key => $value) {
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $value) {
                 if ($callback($value, $key)) {
                     yield $key => $value;
                 }
@@ -368,10 +364,8 @@ class LazyCollection implements Enumerable
      */
     public function flatten($depth = INF)
     {
-        $original = clone $this;
-
-        $instance = new static(function () use ($original, $depth) {
-            foreach ($original as $item) {
+        $instance = new static(function () use ($depth) {
+            foreach ($this as $item) {
                 if (! is_array($item) && ! $item instanceof Enumerable) {
                     yield $item;
                 } elseif ($depth === 1) {
@@ -392,10 +386,8 @@ class LazyCollection implements Enumerable
      */
     public function flip()
     {
-        $original = clone $this;
-
-        return new static(function () use ($original) {
-            foreach ($original as $key => $value) {
+        return new static(function () {
+            foreach ($this as $key => $value) {
                 yield $value => $key;
             }
         });
@@ -443,12 +435,10 @@ class LazyCollection implements Enumerable
      */
     public function keyBy($keyBy)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $keyBy) {
+        return new static(function () use ($keyBy) {
             $keyBy = $this->valueRetriever($keyBy);
 
-            foreach ($original as $key => $item) {
+            foreach ($this as $key => $item) {
                 $resolvedKey = $keyBy($item, $key);
 
                 if (is_object($resolvedKey)) {
@@ -543,10 +533,8 @@ class LazyCollection implements Enumerable
      */
     public function keys()
     {
-        $original = clone $this;
-
-        return new static(function () use ($original) {
-            foreach ($original as $key => $value) {
+        return new static(function () {
+            foreach ($this as $key => $value) {
                 yield $key;
             }
         });
@@ -581,12 +569,10 @@ class LazyCollection implements Enumerable
      */
     public function pluck($value, $key = null)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $value, $key) {
+        return new static(function () use ($value, $key) {
             [$value, $key] = $this->explodePluckParameters($value, $key);
 
-            foreach ($original as $item) {
+            foreach ($this as $item) {
                 $itemValue = data_get($item, $value);
 
                 if (is_null($key)) {
@@ -612,10 +598,8 @@ class LazyCollection implements Enumerable
      */
     public function map(callable $callback)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $callback) {
-            foreach ($original as $key => $value) {
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $value) {
                 yield $key => $callback($value, $key);
             }
         });
@@ -644,10 +628,8 @@ class LazyCollection implements Enumerable
      */
     public function mapWithKeys(callable $callback)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $callback) {
-            foreach ($original as $key => $value) {
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $value) {
                 yield from $callback($value, $key);
             }
         });
@@ -683,14 +665,12 @@ class LazyCollection implements Enumerable
      */
     public function combine($values)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $values) {
+        return new static(function () use ($values) {
             $values = $this->makeIterator($values);
 
             $errorMessage = 'Both parameters should have an equal number of elements';
 
-            foreach ($original as $key) {
+            foreach ($this as $key) {
                 if (! $values->valid()) {
                     trigger_error($errorMessage, E_USER_WARNING);
 
@@ -728,12 +708,10 @@ class LazyCollection implements Enumerable
      */
     public function nth($step, $offset = 0)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $step, $offset) {
+        return new static(function () use ($step, $offset) {
             $position = 0;
 
-            foreach ($original as $item) {
+            foreach ($this as $item) {
                 if ($position % $step === $offset) {
                     yield $item;
                 }
@@ -757,15 +735,13 @@ class LazyCollection implements Enumerable
             $keys = is_array($keys) ? $keys : func_get_args();
         }
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $keys) {
+        return new static(function () use ($keys) {
             if (is_null($keys)) {
-                yield from $original;
+                yield from $this;
             } else {
                 $keys = array_flip($keys);
 
-                foreach ($original as $key => $value) {
+                foreach ($this as $key => $value) {
                     if (array_key_exists($key, $keys)) {
                         yield $key => $value;
 
@@ -788,10 +764,8 @@ class LazyCollection implements Enumerable
      */
     public function concat($source)
     {
-        $original = clone $this;
-
-        return (new static(function () use ($original, $source) {
-            yield from $original;
+        return (new static(function () use ($source) {
+            yield from $this;
             yield from $source;
         }))->values();
     }
@@ -837,12 +811,10 @@ class LazyCollection implements Enumerable
      */
     public function replace($items)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $items) {
+        return new static(function () use ($items) {
             $items = $this->getArrayableItems($items);
 
-            foreach ($original as $key => $value) {
+            foreach ($this as $key => $value) {
                 if (array_key_exists($key, $items)) {
                     yield $key => $items[$key];
 
@@ -922,10 +894,8 @@ class LazyCollection implements Enumerable
      */
     public function skip($count)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $count) {
-            $iterator = $original->getIterator();
+        return new static(function () use ($count) {
+            $iterator = $this->getIterator();
 
             while ($iterator->valid() && $count--) {
                 $iterator->next();
@@ -980,10 +950,8 @@ class LazyCollection implements Enumerable
             return static::empty();
         }
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $size) {
-            $iterator = $original->getIterator();
+        return new static(function () use ($size) {
+            $iterator = $this->getIterator();
 
             while ($iterator->valid()) {
                 $chunk = [];
@@ -1080,10 +1048,8 @@ class LazyCollection implements Enumerable
             return $this->passthru('take', func_get_args());
         }
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $limit) {
-            $iterator = $original->getIterator();
+        return new static(function () use ($limit) {
+            $iterator = $this->getIterator();
 
             while ($limit--) {
                 if (! $iterator->valid()) {
@@ -1107,10 +1073,8 @@ class LazyCollection implements Enumerable
      */
     public function tapEach(callable $callback)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $callback) {
-            foreach ($original as $key => $value) {
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $value) {
                 $callback($value, $key);
 
                 yield $key => $value;
@@ -1125,10 +1089,8 @@ class LazyCollection implements Enumerable
      */
     public function values()
     {
-        $original = clone $this;
-
-        return new static(function () use ($original) {
-            foreach ($original as $item) {
+        return new static(function () {
+            foreach ($this as $item) {
                 yield $item;
             }
         });
@@ -1147,12 +1109,10 @@ class LazyCollection implements Enumerable
     {
         $iterables = func_get_args();
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $iterables) {
+        return new static(function () use ($iterables) {
             $iterators = Collection::make($iterables)->map(function ($iterable) {
                 return $this->makeIterator($iterable);
-            })->prepend($original->getIterator());
+            })->prepend($this->getIterator());
 
             while ($iterators->contains->valid()) {
                 yield new static($iterators->map->current());
@@ -1175,12 +1135,10 @@ class LazyCollection implements Enumerable
             return $this->passthru('pad', func_get_args());
         }
 
-        $original = clone $this;
-
-        return new static(function () use ($original, $size, $value) {
+        return new static(function () use ($size, $value) {
             $yielded = 0;
 
-            foreach ($original as $index => $item) {
+            foreach ($this as $index => $item) {
                 yield $index => $item;
 
                 $yielded++;
@@ -1260,22 +1218,8 @@ class LazyCollection implements Enumerable
      */
     protected function passthru($method, array $params)
     {
-        $original = clone $this;
-
-        return new static(function () use ($original, $method, $params) {
-            yield from $original->collect()->$method(...$params);
+        return new static(function () use ($method, $params) {
+            yield from $this->collect()->$method(...$params);
         });
-    }
-
-    /**
-     * Finish cloning the collection instance.
-     *
-     * @return void
-     */
-    public function __clone()
-    {
-        if (! is_array($this->source)) {
-            $this->source = clone $this->source;
-        }
     }
 }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -402,29 +402,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Remove an item by key.
-     *
-     * @param  string|array  $keys
-     * @return $this
-     */
-    public function forget($keys)
-    {
-        $original = clone $this;
-
-        $this->source = function () use ($original, $keys) {
-            $keys = array_flip((array) $keys);
-
-            foreach ($original as $key => $value) {
-                if (! array_key_exists($key, $keys)) {
-                    yield $key => $value;
-                }
-            }
-        };
-
-        return $this;
-    }
-
-    /**
      * Get an item by key.
      *
      * @param  mixed  $key
@@ -804,50 +781,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Get and remove the last item from the collection.
-     *
-     * @return mixed
-     */
-    public function pop()
-    {
-        $items = $this->collect();
-
-        $result = $items->pop();
-
-        $this->source = $items;
-
-        return $result;
-    }
-
-    /**
-     * Push an item onto the beginning of the collection.
-     *
-     * @param  mixed  $value
-     * @param  mixed  $key
-     * @return $this
-     */
-    public function prepend($value, $key = null)
-    {
-        $original = clone $this;
-
-        $this->source = function () use ($original, $value, $key) {
-            $instance = new static(function () use ($original, $value, $key) {
-                yield $key => $value;
-
-                yield from $original;
-            });
-
-            if (is_null($key)) {
-                $instance = $instance->values();
-            }
-
-            yield from $instance;
-        };
-
-        return $this;
-    }
-
-    /**
      * Push all of the given items onto the collection.
      *
      * @param  iterable  $source
@@ -861,48 +794,6 @@ class LazyCollection implements Enumerable
             yield from $original;
             yield from $source;
         }))->values();
-    }
-
-    /**
-     * Put an item in the collection by key.
-     *
-     * @param  mixed  $key
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function put($key, $value)
-    {
-        $original = clone $this;
-
-        if (is_null($key)) {
-            $this->source = function () use ($original, $value) {
-                foreach ($original as $innerKey => $innerValue) {
-                    yield $innerKey => $innerValue;
-                }
-
-                yield $value;
-            };
-        } else {
-            $this->source = function () use ($original, $key, $value) {
-                $found = false;
-
-                foreach ($original as $innerKey => $innerValue) {
-                    if ($innerKey == $key) {
-                        yield $key => $value;
-
-                        $found = true;
-                    } else {
-                        yield $innerKey => $innerValue;
-                    }
-                }
-
-                if (! $found) {
-                    yield $key => $value;
-                }
-            };
-        }
-
-        return $this;
     }
 
     /**
@@ -1010,18 +901,6 @@ class LazyCollection implements Enumerable
         }
 
         return false;
-    }
-
-    /**
-     * Get and remove the first item from the collection.
-     *
-     * @return mixed
-     */
-    public function shift()
-    {
-        return tap($this->first(), function () {
-            $this->source = $this->skip(1);
-        });
     }
 
     /**
@@ -1190,27 +1069,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Splice a portion of the underlying collection array.
-     *
-     * @param  int  $offset
-     * @param  int|null  $length
-     * @param  mixed  $replacement
-     * @return static
-     */
-    public function splice($offset, $length = null, $replacement = [])
-    {
-        $items = $this->collect();
-
-        $extracted = $items->splice(...func_get_args());
-
-        $this->source = function () use ($items) {
-            yield from $items;
-        };
-
-        return new static($extracted);
-    }
-
-    /**
      * Take the first or last {$limit} items.
      *
      * @param  int  $limit
@@ -1258,23 +1116,6 @@ class LazyCollection implements Enumerable
                 yield $key => $value;
             }
         });
-    }
-
-    /**
-     * Transform each item in the collection using a callback.
-     *
-     * @param  callable  $callback
-     * @return $this
-     */
-    public function transform(callable $callback)
-    {
-        $original = clone $this;
-
-        $this->source = function () use ($original, $callback) {
-            yield from $original->map($callback);
-        };
-
-        return $this;
     }
 
     /**
@@ -1373,27 +1214,6 @@ class LazyCollection implements Enumerable
         }
 
         return iterator_count($this->getIterator());
-    }
-
-    /**
-     * Add an item to the collection.
-     *
-     * @param  mixed  $item
-     * @return $this
-     */
-    public function add($item)
-    {
-        $original = clone $this;
-
-        $this->source = function () use ($original, $item) {
-            foreach ($original as $value) {
-                yield $value;
-            }
-
-            yield $item;
-        };
-
-        return $this;
     }
 
     /**

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -378,17 +378,6 @@ trait EnumeratesValues
     }
 
     /**
-     * Push an item onto the end.
-     *
-     * @param  mixed  $value
-     * @return $this
-     */
-    public function push($value)
-    {
-        return $this->add($value);
-    }
-
-    /**
      * Get the sum of the given values.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -127,23 +127,17 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testPopReturnsAndRemovesLastItemInCollection($collection)
+    public function testPopReturnsAndRemovesLastItemInCollection()
     {
-        $c = new $collection(['foo', 'bar']);
+        $c = new Collection(['foo', 'bar']);
 
         $this->assertEquals('bar', $c->pop());
         $this->assertEquals('foo', $c->first());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testShiftReturnsAndRemovesFirstItemInCollection($collection)
+    public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
-        $data = new $collection(['Taylor', 'Otwell']);
+        $data = new Collection(['Taylor', 'Otwell']);
 
         $this->assertEquals('Taylor', $data->shift());
         $this->assertEquals('Otwell', $data->first());
@@ -365,32 +359,26 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse(isset($c[1]));
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testForgetSingleKey($collection)
+    public function testForgetSingleKey()
     {
-        $c = new $collection(['foo', 'bar']);
+        $c = new Collection(['foo', 'bar']);
         $c = $c->forget(0)->all();
         $this->assertFalse(isset($c['foo']));
 
-        $c = new $collection(['foo' => 'bar', 'baz' => 'qux']);
+        $c = new Collection(['foo' => 'bar', 'baz' => 'qux']);
         $c = $c->forget('foo')->all();
         $this->assertFalse(isset($c['foo']));
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testForgetArrayOfKeys($collection)
+    public function testForgetArrayOfKeys()
     {
-        $c = new $collection(['foo', 'bar', 'baz']);
+        $c = new Collection(['foo', 'bar', 'baz']);
         $c = $c->forget([0, 2])->all();
         $this->assertFalse(isset($c[0]));
         $this->assertFalse(isset($c[2]));
         $this->assertTrue(isset($c[1]));
 
-        $c = new $collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
+        $c = new Collection(['name' => 'taylor', 'foo' => 'bar', 'baz' => 'qux']);
         $c = $c->forget(['foo', 'baz'])->all();
         $this->assertFalse(isset($c['foo']));
         $this->assertFalse(isset($c['baz']));
@@ -1543,7 +1531,7 @@ class SupportCollectionTest extends TestCase
         $c = new $collection([['active' => true], ['active' => true]]);
         $this->assertTrue($c->every('active'));
         $this->assertTrue($c->every->active);
-        $this->assertFalse($c->push(['active' => false])->every->active);
+        $this->assertFalse($c->concat([['active' => false]])->every->active);
     }
 
     /**
@@ -1630,22 +1618,16 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testPut($collection)
+    public function testPut()
     {
-        $data = new $collection(['name' => 'taylor', 'email' => 'foo']);
+        $data = new Collection(['name' => 'taylor', 'email' => 'foo']);
         $data = $data->put('name', 'dayle');
         $this->assertEquals(['name' => 'dayle', 'email' => 'foo'], $data->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testPutWithNoKey($collection)
+    public function testPutWithNoKey()
     {
-        $data = new $collection(['taylor', 'shawn']);
+        $data = new Collection(['taylor', 'shawn']);
         $data = $data->put(null, 'dayle');
         $this->assertEquals(['taylor', 'shawn', 'dayle'], $data->all());
     }
@@ -1965,24 +1947,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $data->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testSplice($collection)
+    public function testSplice()
     {
-        $data = new $collection(['foo', 'baz']);
+        $data = new Collection(['foo', 'baz']);
         $data->splice(1);
         $this->assertEquals(['foo'], $data->all());
 
-        $data = new $collection(['foo', 'baz']);
+        $data = new Collection(['foo', 'baz']);
         $data->splice(1, 0, 'bar');
         $this->assertEquals(['foo', 'bar', 'baz'], $data->all());
 
-        $data = new $collection(['foo', 'baz']);
+        $data = new Collection(['foo', 'baz']);
         $data->splice(1, 1);
         $this->assertEquals(['foo'], $data->all());
 
-        $data = new $collection(['foo', 'baz']);
+        $data = new Collection(['foo', 'baz']);
         $cut = $data->splice(1, 1, 'bar');
         $this->assertEquals(['foo', 'bar'], $data->all());
         $this->assertEquals(['baz'], $cut->all());
@@ -2261,12 +2240,9 @@ class SupportCollectionTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testTransform($collection)
+    public function testTransform()
     {
-        $data = new $collection(['first' => 'taylor', 'last' => 'otwell']);
+        $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
         $data->transform(function ($item, $key) {
             return $key.'-'.strrev($item);
         });
@@ -2851,15 +2827,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([], $c->forPage(3, 2)->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testPrepend($collection)
+    public function testPrepend()
     {
-        $c = new $collection(['one', 'two', 'three', 'four']);
+        $c = new Collection(['one', 'two', 'three', 'four']);
         $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $c->prepend('zero')->all());
 
-        $c = new $collection(['one' => 1, 'two' => 2]);
+        $c = new Collection(['one' => 1, 'two' => 2]);
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $c->prepend(0, 'zero')->all());
     }
 
@@ -3670,16 +3643,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->when('adam', function ($data, $newName) {
-            return $data->push($newName);
+        $data = $data->when('adam', function ($data, $newName) {
+            return $data->concat([$newName]);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
         $data = new $collection(['michael', 'tom']);
 
-        $data->when(false, function ($collection) {
-            return $data->push('adam');
+        $data = $data->when(false, function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
@@ -3692,10 +3665,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->when(false, function ($data) {
-            return $data->push('adam');
+        $data = $data->when(false, function ($data) {
+            return $data->concat(['adam']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
@@ -3708,16 +3681,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->whenEmpty(function ($collection) {
-            return $data->push('adam');
+        $data = $data->whenEmpty(function ($collection) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
 
         $data = new $collection;
 
-        $data->whenEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->whenEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['adam'], $data->toArray());
@@ -3730,10 +3703,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->whenEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->whenEmpty(function ($data) {
+            return $data->concat(['adam']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
@@ -3746,16 +3719,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->whenNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->whenNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
         $data = new $collection;
 
-        $data->whenNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->whenNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame([], $data->toArray());
@@ -3768,10 +3741,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->whenNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->whenNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
@@ -3784,16 +3757,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unless(false, function ($data) {
-            return $data->push('caleb');
+        $data = $data->unless(false, function ($data) {
+            return $data->concat(['caleb']);
         });
 
         $this->assertSame(['michael', 'tom', 'caleb'], $data->toArray());
 
         $data = new $collection(['michael', 'tom']);
 
-        $data->unless(true, function ($data) {
-            return $data->push('caleb');
+        $data = $data->unless(true, function ($data) {
+            return $data->concat(['caleb']);
         });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
@@ -3806,10 +3779,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unless(true, function ($data) {
-            return $data->push('caleb');
+        $data = $data->unless(true, function ($data) {
+            return $data->concat(['caleb']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
@@ -3822,16 +3795,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unlessEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 
         $data = new $collection;
 
-        $data->unlessEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame([], $data->toArray());
@@ -3844,10 +3817,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unlessEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessEmpty(function ($data) {
+            return $data->concat(['adam']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
@@ -3860,16 +3833,16 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unlessNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
 
         $data = new $collection;
 
-        $data->unlessNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         });
 
         $this->assertSame(['adam'], $data->toArray());
@@ -3882,10 +3855,10 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data->unlessNotEmpty(function ($data) {
-            return $data->push('adam');
+        $data = $data->unlessNotEmpty(function ($data) {
+            return $data->concat(['adam']);
         }, function ($data) {
-            return $data->push('taylor');
+            return $data->concat(['taylor']);
         });
 
         $this->assertSame(['michael', 'tom', 'taylor'], $data->toArray());
@@ -3903,12 +3876,9 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($data->has('baz'));
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testPutAddsItemToCollection($collection)
+    public function testPutAddsItemToCollection()
     {
-        $data = new $collection;
+        $data = new Collection;
         $this->assertSame([], $data->toArray());
         $data->put('foo', 1);
         $this->assertSame(['foo' => 1], $data->toArray());

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -8,17 +8,6 @@ use Illuminate\Support\LazyCollection;
 
 class SupportLazyCollectionIsLazyTest extends TestCase
 {
-    public function testAddIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->add(11);
-        });
-
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->add(11)->take(2)->all();
-        });
-    }
-
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {
@@ -379,17 +368,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testForgetIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->forget(5);
-        });
-
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->forget(5)->all();
-        });
-    }
-
     public function testForPageIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {
@@ -727,47 +705,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testPopEnumeratesOnce()
-    {
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->pop();
-            $collection->all();
-        });
-    }
-
-    public function testPrependIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->prepend(0);
-        });
-
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->prepend(0)->all();
-        });
-    }
-
-    public function testPushIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->push(11);
-        });
-
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->push(11)->take(2)->all();
-        });
-    }
-
-    public function testPutIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->put(20, 'a');
-        });
-
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->put(20, 'a')->all();
-        });
-    }
-
     public function testRandomEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {
@@ -857,20 +794,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
         $this->assertEnumeratesOnce(function ($collection) {
             $collection->search('missing');
-        });
-    }
-
-    public function testShiftIsLazy()
-    {
-        $this->assertEnumerates(1, function ($collection) {
-            $collection->shift();
-        });
-
-        $data = $this->make([1, 2, 3, 4, 5]);
-
-        $this->assertEnumeratesCollection($data, 6, function ($collection) {
-            $collection->shift();
-            $collection->all();
         });
     }
 
@@ -995,13 +918,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
-    public function testSpliceEnumeratesOnce()
-    {
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->splice(2);
-        });
-    }
-
     public function testSplitIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {
@@ -1075,21 +991,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $this->assertEnumeratesOnce(function ($collection) {
             $collection->toJson();
-        });
-    }
-
-    public function testTransformIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->transform(function ($value) {
-                return $value * 2;
-            });
-        });
-
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->transform(function ($value) {
-                return $value * 2;
-            })->all();
         });
     }
 
@@ -1247,9 +1148,10 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testWhereInstanceOfIsLazy()
     {
-        $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]])
-                     ->mapInto(stdClass::class)
-                     ->prepend(['a' => 0]);
+        $data = $this->make(['a' => 0])->concat(
+            $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]])
+                 ->mapInto(stdClass::class)
+         );
 
         $this->assertDoesNotEnumerateCollection($data, function ($collection) {
             $collection->whereInstanceOf(stdClass::class);


### PR DESCRIPTION
The removed methods are:

- `add($item)`
- `forget($keys)`
- `pop()`
- `prepend($value, $key = null)`
- `push($value)`
- `put($key, $value)`
- `shift()`
- `splice($offset, $length = null, $replacement = [])`
- `transform(callable $callback)`

I originally added them for feature-parity with the regular collection class, but after giving it some more thought I realized that it doesn't really make sense.

1. It's very easy to accidentally enumerate values twice, or accidentally enumerate the whole collection.

2. [After removing mutation](https://github.com/laravel/framework/commit/4365561e5e5ad3b088d1752c6c6bb5bab652a5db), I was able to [simplify the code](https://github.com/laravel/framework/commit/68359835771a43ee2432735b0d25de8d8c41b02c) quite a bit.

---

# Alternative

Some of these methods could theoretically be implemented without mutation, by just returning a new collection.

However, I believe that would lead to a lot of confusion, since the regular collection class _does_ get mutated with these methods.