### PR TITLE
[6.0] Add `chunkStartingWith` and `chunkEndingWith` collection methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1034,6 +1034,34 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Chunk the collection into chunks that
+     * start with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkStartingWith(callable $callback)
+    {
+        return new static(
+            $this->lazy()->chunkStartingWith($callback)->mapInto(static::class)
+        );
+    }
+
+    /**
+     * Chunk the collection into chunks that
+     * end with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkEndingWith(callable $callback)
+    {
+        return new static(
+            $this->lazy()->chunkEndingWith($callback)->mapInto(static::class)
+        );
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -801,6 +801,24 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function chunk($size);
 
     /**
+     * Chunk the collection into chunks that
+     * start with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkStartingWith(callable $callback);
+
+    /**
+     * Chunk the collection into chunks that
+     * end with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkEndingWith(callable $callback);
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null  $callback

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1131,6 +1131,62 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Chunk the collection into chunks that
+     * start with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkStartingWith(callable $callback)
+    {
+        return new static(function () use ($callback) {
+            $chunk = [];
+
+            foreach ($this as $key => $value) {
+                if ($callback($value, $key) && ! empty($chunk)) {
+                    yield new static($chunk);
+
+                    $chunk = [];
+                }
+
+                $chunk[$key] = $value;
+            }
+
+            if (! empty($chunk)) {
+                yield new static($chunk);
+            }
+        });
+    }
+
+    /**
+     * Chunk the collection into chunks that
+     * end with an item passing the given test.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkEndingWith(callable $callback)
+    {
+        return new static(function () use ($callback) {
+            $chunk = [];
+
+            foreach ($this as $key => $value) {
+                $chunk[$key] = $value;
+
+                if ($callback($value, $key) && ! empty($chunk)) {
+                    yield new static($chunk);
+
+                    $chunk = [];
+                }
+            }
+
+            if (! empty($chunk)) {
+                yield new static($chunk);
+            }
+        });
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1517,6 +1517,40 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkStartingWith($collection)
+    {
+        $data = new $collection(
+            ['header', 1, 2, 'header', 1, 'header', 'header']
+        );
+
+        $this->assertEquals(
+            [['header', 1, 2], ['header', 1], ['header'], ['header']],
+            $data->chunkStartingWith(function ($value, $key) {
+                return $value == 'header';
+            })->map->values()->toArray()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunkEndingWith($collection)
+    {
+        $data = new $collection(
+            ['footer', 1, 2, 'footer', 1, 'footer', 1, 2]
+        );
+
+        $this->assertEquals(
+            [['footer'], [1, 2, 'footer'], [1, 'footer'], [1, 2]],
+            $data->chunkEndingWith(function ($value, $key) {
+                return $value == 'footer';
+            })->map->values()->toArray()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testEvery($collection)
     {
         $c = new $collection([]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -30,6 +30,36 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testChunkEndingWithIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->chunkEndingWith(function ($value) {
+                return $value % 5 == 0;
+            });
+        });
+
+        $this->assertEnumerates(15, function ($collection) {
+            $collection->chunkEndingWith(function ($value) {
+                return $value % 5 == 0;
+            })->take(3)->all();
+        });
+    }
+
+    public function testChunkStartingWithIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->chunkStartingWith(function ($value) {
+                return $value % 5 == 0;
+            });
+        });
+
+        $this->assertEnumerates(15, function ($collection) {
+            $collection->chunkStartingWith(function ($value) {
+                return $value % 5 == 0;
+            })->take(3)->all();
+        });
+    }
+
     public function testCollapseIsLazy()
     {
         $collection = LazyCollection::make([


### PR DESCRIPTION
These methods let you chunk the collection using a callback.

For example, let's say we're trying to process one of Laravel's log files:

```php
LazyCollection::make(function () {
    $handle = fopen('log.txt', 'r');

    while (($line = fgets($handle)) !== false) {
        yield $line;
    }
})
->chunkStartingWith(function ($line) {
    // All Laravel logs start with a timestamp
    // with this format: [2019-08-21 23:54:33]
    return preg_match('^\[\d\{4}-\d\d-\d\d \d\d:\d\d:\d\d\]', $line);
})
->map(function ($lines) {
    return LogEntry::fromLines($lines);
})
->each(function ($logEntry) {
    // Do what you gotta do with $logEntry
});
```

Using `chunkStartingWith`, we're returning `true` wherever we want to start a new chunk; in this case, when the line starts with something like `[2019-08-21 23:54:33]`.