### PR TITLE
[5.8] No CSRF token mismatch when trying to login again

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -70,7 +70,8 @@ class VerifyCsrfToken
             $this->isReading($request) ||
             $this->runningUnitTests() ||
             $this->inExceptArray($request) ||
-            $this->tokensMatch($request)
+            $this->tokensMatch($request) ||
+            $request->user() && $request->is('login')
         ) {
             return tap($next($request), function ($response) use ($request) {
                 if ($this->shouldAddXsrfTokenCookie()) {


### PR DESCRIPTION
When you've two tabs open and login in tab 1, next login in tab 2 you'll get a CSRF token mismatch which is logical but should not happen.