### PR TITLE
[6.0] Nexmo is not relevant suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,6 @@
         "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
-        "nexmo/client": "Required to use the Nexmo transport (^1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",


### PR DESCRIPTION
It's will be automatically install if you require https://github.com/laravel/nexmo-notification-channel

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
