### PR TITLE
[6.0] DomCrawler and CssSelector are actually browser-kit deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,8 +88,6 @@
         "phpunit/phpunit": "^8.0",
         "predis/predis": "^1.1.1",
         "symfony/cache": "^4.3",
-        "symfony/css-selector": "^4.3",
-        "symfony/dom-crawler": "^4.3",
         "true/punycode": "^2.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -133,8 +133,6 @@
         "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^4.3).",
-        "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.3).",
-        "symfony/dom-crawler": "Required to use most of the crawler integration testing tools (^4.3).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },


### PR DESCRIPTION
Unless you require https://github.com/laravel/browser-kit-testing this is not needed by any developer to use the Framework.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
