### PR TITLE
[5.5] Bugfix flushing application on refresh

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Mockery;
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Console\Application as Artisan;
+use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
@@ -64,7 +64,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function setUp()
     {
-        if (! $this->app) {
+        if (!$this->app) {
             $this->refreshApplication();
         }
 
@@ -93,7 +93,7 @@ abstract class TestCase extends BaseTestCase
         }
         $this->app = $this->createApplication();
     }
-    
+
     /**
      * Removes the application instance.
      *
@@ -187,7 +187,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Register a callback to be run after the application is created.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return void
      */
     public function afterApplicationCreated(callable $callback)
@@ -202,7 +202,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Register a callback to be run before the application is destroyed.
      *
-     * @param  callable  $callback
+     * @param callable $callback
      * @return void
      */
     protected function beforeApplicationDestroyed(callable $callback)

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -88,7 +88,21 @@ abstract class TestCase extends BaseTestCase
      */
     protected function refreshApplication()
     {
+        if ($this->app) {
+            $this->clearApplication();
+        }
         $this->app = $this->createApplication();
+    }
+    
+    /**
+     * Removes the application instance.
+     *
+     * @return void
+     */
+    private function clearApplication()
+    {
+        $this->app->flush();
+        $this->app = null;
     }
 
     /**
@@ -139,9 +153,7 @@ abstract class TestCase extends BaseTestCase
                 call_user_func($callback);
             }
 
-            $this->app->flush();
-
-            $this->app = null;
+            $this->clearApplication();
         }
 
         $this->setUpHasRun = false;

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -188,6 +188,7 @@ abstract class TestCase extends BaseTestCase
      * Register a callback to be run after the application is created.
      *
      * @param callable $callback
+     *
      * @return void
      */
     public function afterApplicationCreated(callable $callback)
@@ -203,6 +204,7 @@ abstract class TestCase extends BaseTestCase
      * Register a callback to be run before the application is destroyed.
      *
      * @param callable $callback
+     *
      * @return void
      */
     protected function beforeApplicationDestroyed(callable $callback)


### PR DESCRIPTION
Flushes unused application when test case refreshes application instance.

While investigating a memory leakage when running PHPUnit tests I realized that the Application instance doesn't get cleared properly when the TestCase refreshes it (using $this->refeshApplication()).
When the flush() is added the memory_get_usage() function  and PHPUnit both report less memory at the end of all tests.

Since the (unused) Application should be flushed during application refresh and tearDown I've added a private function to make the code reusable. I think this function should remain private, only the refreshApplication should be exposed (already is). Getting the test case in a state without Application instance doesn't benefit the user.
Feel free to amend the function name.

I don't know what the expected behavior regarding the application related callbacks is. Those seem rather vague since the afterApplicationCreatedCallbacks are invoke even when the same application is used for the next test.

I'm using the Laravel 5.8, but this fix should also be done on 5.5, which is the latest LTS. A similar change should be applied to newer releases as well.