### PR TITLE
[6.0] Remove Nexmo routing

### DIFF
--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -48,8 +48,6 @@ trait RoutesNotifications
                 return $this->notifications();
             case 'mail':
                 return $this->email;
-            case 'nexmo':
-                return $this->phone_number;
         }
     }
 }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -49,7 +49,6 @@ class NotificationRoutesNotificationsTest extends TestCase
         $instance = new RoutesNotificationsTestInstance;
         $this->assertEquals('bar', $instance->routeNotificationFor('foo'));
         $this->assertEquals('taylor@laravel.com', $instance->routeNotificationFor('mail'));
-        $this->assertEquals('5555555555', $instance->routeNotificationFor('nexmo'));
     }
 }
 
@@ -58,7 +57,6 @@ class RoutesNotificationsTestInstance
     use RoutesNotifications;
 
     protected $email = 'taylor@laravel.com';
-    protected $phone_number = '5555555555';
 
     public function routeNotificationForFoo()
     {


### PR DESCRIPTION
After seeing https://github.com/laravel/framework/pull/29679 I noticed this was left over from when we removed the Nexmo notification channel from the core. After this change people will need to implement the routeNotificationForNexmo method themselves as they do for the Slack driver.

This is a breaking change for anyone using the Nexmo channel so this should be in the upgrade guide.

Updated the docs to highlight this new requirement as well: https://github.com/laravel/docs/pull/5387