### PR TITLE
[6.0] Deprecate Predis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
     "suggest": {
         "ext-pcntl": "Required to use all features of the queue worker.",
         "ext-posix": "Required to use all features of the queue worker.",
+        "ext-redis": "Required to use the redis cache and queue drivers.",
         "aws/aws-sdk-php": "Required to use the SQS queue driver and SES mail driver (^3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "filp/whoops": "Required for friendly error pages in development (^2.4).",
@@ -130,7 +131,6 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "nexmo/client": "Required to use the Nexmo transport (^1.0).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-        "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^4.3).",
         "symfony/css-selector": "Required to use some of the crawler integration testing tools (^4.3).",

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -235,7 +235,7 @@ class RedisStore extends TaggableStore implements LockProvider
     /**
      * Get the Redis connection instance.
      *
-     * @return \Predis\ClientInterface
+     * @return \Illuminate\Redis\Connections\Connection
      */
     public function connection()
     {

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -104,7 +104,7 @@ abstract class Connection
      * Run a command against the Redis database.
      *
      * @param  string  $method
-     * @param  array   $parameters
+     * @param  array  $parameters
      * @return mixed
      */
     public function command($method, array $parameters = [])

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -14,9 +14,9 @@ use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 abstract class Connection
 {
     /**
-     * The Predis client.
+     * The Redis client.
      *
-     * @var \Predis\Client
+     * @var \Redis
      */
     protected $client;
 

--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -8,9 +8,6 @@ use Illuminate\Redis\Events\CommandExecuted;
 use Illuminate\Redis\Limiters\DurationLimiterBuilder;
 use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 
-/**
- * @mixin \Predis\Client
- */
 abstract class Connection
 {
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -52,7 +52,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Determine if the given keys exist.
      *
-     * @param  dynamic  $keys
+     * @param  mixed  $keys
      * @return int
      */
     public function exists(...$keys)
@@ -99,7 +99,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * Get the value of the given hash fields.
      *
      * @param  string  $key
-     * @param  dynamic  $dictionary
+     * @param  mixed  $dictionary
      * @return array
      */
     public function hmget($key, ...$dictionary)
@@ -115,7 +115,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * Set the given hash fields to their respective values.
      *
      * @param  string  $key
-     * @param  dynamic  $dictionary
+     * @param  mixed  $dictionary
      * @return int
      */
     public function hmset($key, ...$dictionary)
@@ -160,7 +160,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Removes and returns the first element of the list stored at key.
      *
-     * @param  dynamic  $arguments
+     * @param  mixed  $arguments
      * @return array|null
      */
     public function blpop(...$arguments)
@@ -173,7 +173,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Removes and returns the last element of the list stored at key.
      *
-     * @param  dynamic  $arguments
+     * @param  mixed  $arguments
      * @return array|null
      */
     public function brpop(...$arguments)
@@ -199,7 +199,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * Add one or more members to a sorted set or update its score if it already exists.
      *
      * @param  string  $key
-     * @param  dynamic  $dictionary
+     * @param  mixed  $dictionary
      * @return int
      */
     public function zadd($key, ...$dictionary)

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Redis\Connections;
 
+/**
+ * @deprecated Maintenance of Predis has been abandoned by the original package and will be removed from Laravel in 7.0
+ */
 class PredisClusterConnection extends PredisConnection
 {
     //

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 
 /**
  * @mixin \Predis\Client
+ * @deprecated Maintenance of Predis has been abandoned by the original package and will be removed from Laravel in 7.0
  */
 class PredisConnection extends Connection implements ConnectionContract
 {

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -13,6 +13,13 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 class PredisConnection extends Connection implements ConnectionContract
 {
     /**
+     * The Predis client.
+     *
+     * @var \Predis\Client
+     */
+    protected $client;
+
+    /**
      * Create a new Predis connection.
      *
      * @param  \Predis\Client  $client

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -8,6 +8,9 @@ use Illuminate\Contracts\Redis\Connector;
 use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Redis\Connections\PredisClusterConnection;
 
+/**
+ * @deprecated Maintenance of Predis has been abandoned by the original package and will be removed from Laravel in 7.0
+ */
 class PredisConnector implements Connector
 {
     /**

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -95,8 +95,7 @@ class ConcurrencyLimiter
     /**
      * Attempt to acquire the lock.
      *
-     * @param string $id A unique identifier for this lock
-     *
+     * @param  string  $id  A unique identifier for this lock
      * @return mixed
      */
     protected function acquire($id)
@@ -136,8 +135,8 @@ LUA;
     /**
      * Release the lock.
      *
-     * @param  string $key
-     * @param  string $id
+     * @param  string  $key
+     * @param  string  $id
      * @return void
      */
     protected function release($key, $id)

--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -51,10 +51,10 @@ class DurationLimiter
     /**
      * Create a new duration limiter instance.
      *
-     * @param  \Illuminate\Redis\Connections\Connection $redis
-     * @param  string $name
-     * @param  int $maxLocks
-     * @param  int $decay
+     * @param  \Illuminate\Redis\Connections\Connection  $redis
+     * @param  string  $name
+     * @param  int  $maxLocks
+     * @param  int  $decay
      * @return void
      */
     public function __construct($redis, $name, $maxLocks, $decay)
@@ -68,8 +68,8 @@ class DurationLimiter
     /**
      * Attempt to acquire the lock for the given number of seconds.
      *
-     * @param  int $timeout
-     * @param  callable|null $callback
+     * @param  int  $timeout
+     * @param  callable|null  $callback
      * @return bool
      *
      * @throws \Illuminate\Contracts\Redis\LimiterTimeoutException


### PR DESCRIPTION
PR for https://github.com/laravel/ideas/issues/1779

Predis isn't maintained anymore and we're already seeing the first signs of bugs popping up with the new Redis 5 release. We should discourage people from using it and encourage people to use the native C extension instead. Deprecating Predis in 6.0 and removing it in 7.0 should be the plan.

Also cleaned up a few things and fixed an incorrect return type. 