### PR TITLE
[5.8] Fix replaceRouteParameters() for query-string parameters

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -197,9 +197,16 @@ class RouteUrlGenerator
         $path = $this->replaceNamedParameters($path, $parameters);
 
         $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+            // Reset numeric keys on $parameters so we can
+            // retrieve the first non-associative element
+            // using Arr::pull($parameters, 0)
+            $parameters = array_merge($parameters);
+
             return (empty($parameters) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
-                        : array_shift($parameters);
+                        // Use only non-associative elements, so we don't
+                        // replace parameters that were meant for query string.
+                        : Arr::pull($parameters, 0);
         }, $path);
 
         return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');


### PR DESCRIPTION
I am working on a search-engine application. It has routes that use optional route-parameters in combination with query-string parameters.

One of my routes looks like this

    Route::get('/{location?}', 'ProfileController@index')->name('profiles.index');

The URL-strings for search-results pages may look something like these:

- `http://homestead.local/London?age=30`
- `http://homestead.local/?status[0]=single&status[1]=married`

The last one searches for profiles in any location whose statuses are either 'single' or 'married'.

In my controller, I wanted to redirect to a route using given query-string parameters. For example, if I wanted to redirect to the 2nd example from above, I might have attempted something like this:

    return redirect()->route('profiles.index', ['status' => ['single', 'married']]);

Doing so resulted in an _"Array to string conversion"_ ErrorException.

I noticed `replaceRouteParameters()` in `Illuminate/Routing/RouteUrlGenerator` uses `array_shift($parameters)` to pull the first element from the `$parameters` array and put it in place of the optional `location` route parameter. This breaks when the first element is an array.

In the example above, the intention was not to use the `location` parameter at all. The given parameters were meant to be used as the query-string.

A workaround was to explicitly specify an empty `location` like this:

    return redirect()->route('profiles.index', ['status' => ['single', 'married'], 'location' => '']);

In the pull-request I've made changes to `replaceRouteParameters()` such that it better accommodates query-string parameters.

It should work with combinations of query-string and route parameters. It assumes that any associative elements in `$parameters` that haven't already been filtered in `replaceNamedParameters()` are referring to query-string parameters and should not be used for route-parameter replacement.

I've used `Arr::pull($parameters, 0)` instead of `array_shift($parameters)` to pull the first non-associative element. Arr::pull does not reset the array keys, so I've used `$parameters = array_merge($parameters)` to reset the numeric keys before each replacement.

###### This is my first ever pull request on Github. Please excuse me if I did anything wrong. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->