### PR TITLE
[5.8] Throw Error If Transaction Is Not Started While Commit

### DIFF
--- a/src/Illuminate/Database/Concerns/TransactionException.php
+++ b/src/Illuminate/Database/Concerns/TransactionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+use Exception;
+
+class TransactionException extends Exception
+{
+    //
+}

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -19,7 +19,6 @@ use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Database\Events\TransactionBeginning;
-use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 
@@ -201,9 +200,8 @@ class DatabaseConnectionTest extends TestCase
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
         $connection = $this->getMockConnection(['getName'], $pdo);
+        $connection->beginTransaction();
         $connection->expects($this->any())->method('getName')->will($this->returnValue('name'));
-        $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
         $connection->commit();
     }
 


### PR DESCRIPTION
This pull request has the solution to bug **User commit when there is no transaction started**
The current code never notify user that transaction is not started and they are trying to commit.

**Current 5.8 Code**
```php
        if ($this->transactions == 1) {
            $this->getPdo()->commit();
        }
        $this->transactions = max(0, $this->transactions - 1);
        $this->fireConnectionEvent('committed');
```

This could be disaster if someone forget to start transaction and they trying to commit, So changes in code will throw exception. That will indicate developer that they are trying to commit but no transaction has started yet.

**Changes done to code**
```php
        if ($this->transactions == 1) {
            $this->getPdo()->commit();
        } elseif ($this->transactions == 0) {
            throw new TransactionException;
        } else {
            $this->transactions = max(0, $this->transactions - 1);
            $this->fireConnectionEvent('committed');
        }
```

This issue is already reported here https://github.com/laravel/framework/issues/29505, and also this issue was mention earlier by @GrahamCampbell 

@taylorotwell  have look at this issue and it's PR.

