### PR TITLE
[5.5] Bugfix flushing application on refresh (attempt #2)

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -88,7 +88,22 @@ abstract class TestCase extends BaseTestCase
      */
     protected function refreshApplication()
     {
+        if ($this->app) {
+            $this->clearApplication();
+        }
+
         $this->app = $this->createApplication();
+    }
+
+    /**
+     * Removes the application instance.
+     *
+     * @return void
+     */
+    private function clearApplication()
+    {
+        $this->app->flush();
+        $this->app = null;
     }
 
     /**
@@ -139,9 +154,7 @@ abstract class TestCase extends BaseTestCase
                 call_user_func($callback);
             }
 
-            $this->app->flush();
-
-            $this->app = null;
+            $this->clearApplication();
         }
 
         $this->setUpHasRun = false;


### PR DESCRIPTION
Flushes unused application when test case refreshes application instance.

While investigating a memory leakage when running PHPUnit tests I realized that the Application instance doesn't get cleared properly when the TestCase refreshes it (using $this->refeshApplication()).
When the flush() is added the memory_get_usage() function and PHPUnit both report less memory at the end of all tests.

Since the (unused) Application should be flushed during application refresh and tearDown I've added a private function to make the code reusable. I think this function should remain private, only the refreshApplication should be exposed (already is). Getting the test case in a state without Application instance doesn't benefit the user.
Feel free to amend the function name.
Feel free to move the function location within the file.

I don't know what the expected behavior regarding the application related callbacks is. Those seem rather vague since the afterApplicationCreatedCallbacks are invoke even when the same application is used for the next test.

I'm using the Laravel 5.8, but this fix should also be done on 5.5, which is the latest LTS. A similar change should be applied to newer releases as well.