### PR TITLE
[5.8] Bug Fix: Render `MailMessage` if `view` method was used

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -309,6 +309,12 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function render()
     {
+        if (isset($this->view)) {
+            return Container::getInstance()->make('mailer')->render(
+                $this->view, $this->data()
+            );
+        }
+
         return Container::getInstance()
             ->make(Markdown::class)
             ->render($this->markdown, $this->data());


### PR DESCRIPTION

MailMessage supports customizing its contents by setting lines of text or by using the `view` method to specify a custom template.

However, if you call `view` on MailMessage it will fail when calling `render`.

Steps to reproduce:
- Create a notification `php artisan make:notification InvoicePaid`.
- In the method `toMail`: return a new `MailMessage` with a custom view:
  ```php
  public function toMail($notifiable)
  {
      return (new MailMessage)->view(
          'emails.name', ['invoice' => $this->invoice]
      );
  }
  ```

- Add code to preview that notification:

  ```php
  Route::get('mail', function () {
      $invoice = App\Invoice::find(1);

      return (new App\Notifications\InvoicePaid($invoice))
                  ->toMail($invoice->user);
  });
  ```

It will result in the following error: `InvalidArgumentException
View [] not found.`

All code snippets were taken from https://laravel.com/docs/5.8/notifications
Specifically, [formatting-mail-messages](https://laravel.com/docs/5.8/notifications#formatting-mail-messages) and [previewing-mail-notifications](https://laravel.com/docs/5.8/notifications#previewing-mail-notifications) sections.