### PR TITLE
[6.0] Add getInstance method to the job class

### DIFF
--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -308,6 +308,16 @@ abstract class Job
     }
 
     /**
+     * Get the job handler instance.
+     *
+     * @return mixed
+     */
+    public function getInstance()
+    {
+        return $this->instance;
+    }
+
+    /**
      * Get the service container instance.
      *
      * @return \Illuminate\Container\Container


### PR DESCRIPTION
### Description

This pull request aims to add `getInstace` method to the queue job class.

### Why

It is useful to get the underlying job instance when testing with phpunit, instead of mocking, I'm using [localstack](https://github.com/localstack/localstack).

By listening to the Queue worker events (for example `JobProcessed`) I will be able to get the job handler.

```php
// Listen for the job to be processed.
$this->app['events']->listen(JobProcessed::class, function ($event) {
    $this->job = $event->job;
});

// Run work command.
$this->artisan('queue:work', ['--once' => true]);

// Get the job handler.
$subscriber = $this->job->getInstance();

self::assertNotNull($subscriber);

self::assertTrue($this->job->isDeleted());
```