### PR TITLE
[5.8] Set Numeric value as Model Attribute

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -623,7 +623,7 @@ trait HasAttributes
      */
     protected function isDateAttribute($key)
     {
-        return in_array($key, $this->getDates(), true)   ||
+        return in_array($key, $this->getDates(), true) ||
                                     $this->isDateCastable($key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -562,6 +562,8 @@ trait HasAttributes
      */
     public function setAttribute($key, $value)
     {
+        $key = (string) $key;
+        
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -563,7 +563,6 @@ trait HasAttributes
     public function setAttribute($key, $value)
     {
         $key = (string) $key;
-        
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -562,7 +562,6 @@ trait HasAttributes
      */
     public function setAttribute($key, $value)
     {
-        $key = (string) $key;
         // First we will check for the presence of a mutator for the set operation
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
@@ -624,7 +623,7 @@ trait HasAttributes
      */
     protected function isDateAttribute($key)
     {
-        return in_array($key, $this->getDates()) ||
+        return in_array($key, $this->getDates(), true)   ||
                                     $this->isDateCastable($key);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -68,6 +68,14 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
+    public function testSetAttributeWithNumericKey()
+    {
+        $model = new EloquentDateModelStub();
+        $model->setAttribute(0, 'value');
+
+        $this->assertEquals([0 => 'value'], $model->getAttributes());
+    }
+
     public function testDirtyAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
If someone tries to set a Numeric value as a Model attribute, it will fail because of `isDateAttribute` methods loose comparison in `in_array` searching. 
The details described in reported issue. 
Simply casting all attributes to `string` in `setAttribute` method will resolve the issue.

This PR fixes issue #29702 