### PR TITLE
[5.8] Use custom attributes in lt/lte/gt/gte rules messages

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -260,7 +260,7 @@ trait ReplacesAttributes
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
         if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
+            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
         return str_replace(':value', $this->getSize($attribute, $value), $message);
@@ -278,7 +278,7 @@ trait ReplacesAttributes
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
         if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
+            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
         return str_replace(':value', $this->getSize($attribute, $value), $message);
@@ -296,7 +296,7 @@ trait ReplacesAttributes
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
         if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
+            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
         return str_replace(':value', $this->getSize($attribute, $value), $message);
@@ -314,7 +314,7 @@ trait ReplacesAttributes
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
         if (is_null($value = $this->getValue($parameters[0]))) {
-            return str_replace(':value', $parameters[0], $message);
+            return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
         return str_replace(':value', $this->getSize($attribute, $value), $message);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1669,6 +1669,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('items'));
 
+        $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gt:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('minimum value', $v->messages()->first('max'));
+
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
         $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
@@ -1705,6 +1710,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lt:less']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lt:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
@@ -1743,6 +1753,11 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $this->assertEquals(5, $v->messages()->first('items'));
 
+        $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gte:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('minimum value', $v->messages()->first('max'));
+
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));
         $file->expects($this->any())->method('isValid')->will($this->returnValue(true));
@@ -1779,6 +1794,11 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['items' => 'abc', 'less' => 'ab'], ['items' => 'lte:less']);
         $this->assertFalse($v->passes());
         $this->assertEquals(2, $v->messages()->first('items'));
+
+        $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lte:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
+        $this->assertFalse($v->passes());
+        $v->messages()->setFormat(':message');
+        $this->assertEquals('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->will($this->returnValue(4072));


### PR DESCRIPTION
This PR fixes #29441

Consider these rules:
```
$rules = [
  'min' => 'numeric',
  'max' => 'numeric|gt:min,
];
```

And these custom attributes:
```
$customAttributes = [
  'min' => 'minimum value',
  'max' => 'maximum value',
];
```

With the following data:
```
$data = [
  'max' => 10,
];
```

Validation fails, with the following error message: `The maximum value must be greater than min.`

It completely ignored the custom attribute defined for `max`, and the message should be: `The maximum value must be greater than minimum value.`