### PR TITLE
[5.8] Bugfix custom pivot model when used in updated event

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -227,10 +227,9 @@ trait InteractsWithPivotTable
 
         $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
-        $this->newPivot([
-            $this->foreignPivotKey => $this->parent->{$this->parentKey},
-            $this->relatedPivotKey => $this->parseId($id),
-        ], true)->fill($attributes)->save();
+        if ($updated) {
+            $pivot->save();
+        }
 
         if ($touch) {
             $this->touchIfTouching();
@@ -478,7 +477,9 @@ trait InteractsWithPivotTable
         return $this->currentlyAttached ?: $this->newPivotQuery()->get()->map(function ($record) {
             $class = $this->using ? $this->using : Pivot::class;
 
-            return (new $class)->setRawAttributes((array) $record, true);
+            $pivot = $class::fromRawAttributes($this->parent, (array) $record, $this->getTable(), true);
+
+            return $pivot->setPivotKeys($this->foreignPivotKey, $this->relatedPivotKey);
         });
     }
 

--- a/tests/Integration/Database/EloquentCustomPivotCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCustomEventsTest.php
@@ -58,10 +58,10 @@ class EloquentCustomPivotCustomEventsTest extends DatabaseTestCase
 
         $this->assertSame(
             [
-                'user_id' => "1",
-                'project_id' => "1",
+                'user_id' => '1',
+                'project_id' => '1',
                 'permissions' => '["foo","bar"]',
-                'role' => 'Lead Developer'
+                'role' => 'Lead Developer',
             ],
             $_SERVER['pivot_attributes']
         );
@@ -83,7 +83,7 @@ class EloquentCustomPivotCustomEventsTest extends DatabaseTestCase
 
         $project->collaborators()->updateExistingPivot($user->id, ['role' => 'Lead Developer']);
 
-        $this->assertSame(['role' => 'Lead Developer'],$_SERVER['pivot_dirty_attributes']);
+        $this->assertSame(['role' => 'Lead Developer'], $_SERVER['pivot_dirty_attributes']);
     }
 }
 

--- a/tests/Integration/Database/EloquentCustomPivotCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCustomEventsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @group integration
+ */
+class EloquentCustomPivotCustomEventsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('email');
+        });
+
+        Schema::create('projects', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('project_users', function (Blueprint $table) {
+            $table->integer('user_id');
+            $table->integer('project_id');
+            $table->text('permissions');
+            $table->string('role')->nullable();
+        });
+
+        Event::listen(CustomPivotEvent::class, function (CustomPivotEvent $customPivotEvent) {
+            $_SERVER['pivot_attributes'] = $customPivotEvent->pivot->getAttributes();
+            $_SERVER['pivot_dirty_attributes'] = $customPivotEvent->pivot->getDirty();
+        });
+    }
+
+    public function testCustomPivotUpdateEventHasExistingAttributes()
+    {
+        $_SERVER['pivot_attributes'] = false;
+
+        $user = CustomPivotCustomEventsTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = CustomPivotCustomEventsTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach($user, ['permissions' => ['foo', 'bar']]);
+
+        $project->collaborators()->updateExistingPivot($user->id, ['role' => 'Lead Developer']);
+
+        $this->assertSame(
+            [
+                'user_id' => "1",
+                'project_id' => "1",
+                'permissions' => '["foo","bar"]',
+                'role' => 'Lead Developer'
+            ],
+            $_SERVER['pivot_attributes']
+        );
+    }
+
+    public function testCustomPivotUpdateEventHasDirtyCorrect()
+    {
+        $_SERVER['pivot_attributes'] = false;
+
+        $user = CustomPivotCustomEventsTestUser::forceCreate([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $project = CustomPivotCustomEventsTestProject::forceCreate([
+            'name' => 'Test Project',
+        ]);
+
+        $project->collaborators()->attach($user, ['permissions' => ['foo', 'bar'], 'role' => 'Developer']);
+
+        $project->collaborators()->updateExistingPivot($user->id, ['role' => 'Lead Developer']);
+
+        $this->assertSame(['role' => 'Lead Developer'],$_SERVER['pivot_dirty_attributes']);
+    }
+}
+
+class CustomPivotCustomEventsTestUser extends Model
+{
+    public $table = 'users';
+    public $timestamps = false;
+}
+
+class CustomPivotCustomEventsTestProject extends Model
+{
+    public $table = 'projects';
+    public $timestamps = false;
+
+    public function collaborators()
+    {
+        return $this->belongsToMany(
+            CustomPivotCustomEventsTestUser::class, 'project_users', 'project_id', 'user_id'
+        )->using(CustomPivotCustomEventsTestCollaborator::class)->withPivot('role', 'permissions');
+    }
+}
+
+class CustomPivotCustomEventsTestCollaborator extends Pivot
+{
+    public $dispatchesEvents = ['updated' => CustomPivotEvent::class];
+    protected $casts = [
+        'permissions' => 'json',
+    ];
+}
+
+class CustomPivotEvent
+{
+    public $pivot;
+
+    public function __construct(CustomPivotCustomEventsTestCollaborator $pivot)
+    {
+        $this->pivot = $pivot;
+    }
+}


### PR DESCRIPTION
This PR fixes #29678 and may possibly fix #29636 

## Problem
Custom pivot classes were missing attributes as well as information on what was changed/dirty when used with a custom updated event. This is happening because in `updateExistingPivotUsingCustomClass()` `save()` is called on a newly generated pivot model rather than the existing attached pivot model. Because of this the "new" pivot model is passed into the updating event and it is lacking any other attributes that weren't passed to be updated aside from the keys necessary to perform the update.

When attempting to fix this problem I also ran into another problem which is that  `getCurrentlyAttachedPivots()` was generating a pivot object that was missing some information (table, connection, timestamps).

## Solution
Instead of generating a new pivot object to run save on it is run on the pivot returned from `getCurrentlyAttachedPivots()`, this should retain all the additional attributes that weren't specifically updated in this call.

In `getCurrentlyAttachedPivots()` I've essentially copied the instantiation style of `newPivot()` so that the object generated will not just have the attributes from the database but also get the proper table name and connection information. 
