### PR TITLE
[5.8] Fix `chunkById` when used after `orWhere`

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1961,7 +1961,11 @@ class Builder
         $this->orders = $this->removeExistingOrdersFor($column);
 
         if (! is_null($lastId)) {
-            $this->where($column, '<', $lastId);
+            $clonedQuery = clone $this;
+            $this->wheres = [];
+            $this->bindings['where'] = [];
+            $this->addNestedWhereQuery($clonedQuery)
+                ->where($column, '<', $lastId);
         }
 
         return $this->orderBy($column, 'desc')
@@ -1981,7 +1985,11 @@ class Builder
         $this->orders = $this->removeExistingOrdersFor($column);
 
         if (! is_null($lastId)) {
-            $this->where($column, '>', $lastId);
+            $clonedQuery = clone $this;
+            $this->wheres = [];
+            $this->bindings['where'] = [];
+            $this->addNestedWhereQuery($clonedQuery)
+                ->where($column, '>', $lastId);
         }
 
         return $this->orderBy($column, 'asc')


### PR DESCRIPTION
This PR fixes #29655

When using `chunkById` after `orWhere`, the condition is invalid, as it generates something like `WHERE a OR b AND id > N`, while it should be `WHERE (a OR b) AND id > N`.

---

This fix feels a tad inelegant, as I don't have much experience with how the query builder work internally.

I've tried using `cloneWithout(['wheres'])` to generate a new query without the original where clause, but it didn't work, and I haven't been able to find out why.

@staudenmeir you might have some ideas about how we could make that more elegant