### PR TITLE
[5.8] Add more tests for illuminate/pipeline

### DIFF
--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -199,6 +199,16 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.parameters']);
     }
 
+    public function testItCanWorkWithNoPipe()
+    {
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([])
+            ->thenReturn();
+
+        $this->assertEquals('foo', $result);
+    }
+
     public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
     {
         $piped = function ($piped, $next) {


### PR DESCRIPTION
- In case a pipe returns early (without calling $next) at the middle of the way, tests should make sure that the following pipes are not silently executed by the library in any ways and it properly returns back to the previous layers, as it should. (which is not currently tested.)

- it is also better to strengthen the test related to: when we override the default "handle" method and make sure that the method is changed for all the pipes. (I mean, not only for the First pipe, but for All)

- Also check if an empty set of pipes are passed at run-time, there will be no error.