### PR TITLE
[5.8] Collection method to Search for key of last occurrence

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1562,7 +1562,7 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
     }
 
     /**
-     * Search the collection for a given value and return the corresponding key if successful.
+     * Search the collection for a given value and return the key of its first occurrence if successful.
      *
      * @param  mixed  $value
      * @param  bool  $strict
@@ -1581,6 +1581,32 @@ class Collection implements ArrayAccess, Arrayable, Countable, IteratorAggregate
         }
 
         return false;
+    }
+
+    /**
+     * Search the collection for a given value and return the key of its last occurrence if successful.
+     *
+     * @param  mixed  $value
+     * @param  bool  $strict
+     * @return mixed
+     */
+    public function searchLast($value, $strict = false)
+    {
+        $result = false;
+
+        foreach ($this->items as $key => $item) {
+            if ($this->useAsCallable($value)) {
+                if (call_user_func($value, $item, $key)) {
+                    $result = $key;
+                }
+            } else {
+                if (($strict && $item === $value) || (! $strict && $item == $value)) {
+                    $result = $key;
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2291,6 +2291,48 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
+    public function testSearchLastReturnsIndexOfLastFoundItem()
+    {
+        $c = new Collection(['foo' => 'bar', 1, 2, 3, 4, 5, 2, 5, 'key' => 'bar']);
+
+        $this->assertEquals(5, $c->searchLast(2));
+        $this->assertEquals(5, $c->searchLast('2'));
+        $this->assertEquals('key', $c->searchLast('bar'));
+        $this->assertEquals(6, $c->searchLast(function ($value) {
+            return $value > 4;
+        }));
+        $this->assertEquals('key', $c->searchLast(function ($value) {
+            return ! is_numeric($value);
+        }));
+    }
+
+    public function testSearchLastInStrictMode()
+    {
+        $c = new Collection([false, 0, 1, [], 1, '', false]);
+
+        $this->assertFalse($c->searchLast('false', true));
+        $this->assertFalse($c->searchLast('1', true));
+        $this->assertEquals(6, $c->searchLast(false, true));
+        $this->assertEquals(1, $c->searchLast(0, true));
+        $this->assertEquals(4, $c->searchLast(1, true));
+        $this->assertEquals(3, $c->searchLast([], true));
+        $this->assertEquals(5, $c->searchLast('', true));
+    }
+
+    public function testSearchLastReturnsFalseWhenItemIsNotFound()
+    {
+        $c = new Collection([1, 2, 3, 4, 1, 'foo' => 'bar']);
+
+        $this->assertFalse($c->searchLast(6));
+        $this->assertFalse($c->searchLast('foo'));
+        $this->assertFalse($c->searchLast(function ($value) {
+            return $value < 1 && is_numeric($value);
+        }));
+        $this->assertFalse($c->searchLast(function ($value) {
+            return $value == 'nope';
+        }));
+    }
+
     public function testKeys()
     {
         $c = new Collection(['name' => 'taylor', 'framework' => 'laravel']);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`search` method in Collection returns the key of the **first** occurrence of the given item. 
In this PR, I've added a new method in Collection named `searchLast` which will return the key of the **last** occurrence of the given item.