### PR TITLE
[6.0] Disabled SimpleMessage’s property and Message for render in Mailer

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailer.php
+++ b/src/Illuminate/Contracts/Mail/Mailer.php
@@ -35,9 +35,10 @@ interface Mailer
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
+     * @param  array $viewData
      * @return void
      */
-    public function send($view, array $data = [], $callback = null);
+    public function send($view, array $data = [], $callback = null, array $viewData = []);
 
     /**
      * Get the array of failed recipients.

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -156,7 +156,7 @@ class Mailable implements MailableContract, Renderable
                      ->buildSubject($message)
                      ->runCallbacks($message)
                      ->buildAttachments($message);
-            });
+            }, $this->viewData);
         });
     }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -193,7 +193,7 @@ class Mailer implements MailerContract, MailQueueContract
      */
     public function plain($view, array $data, $callback)
     {
-        return $this->send(['text' => $view], $data, $callback);
+        return $this->send(['text' => $view], $data, $callback, $data);
     }
 
     /**
@@ -201,9 +201,10 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string|array  $view
      * @param  array  $data
+     * @param  array  $viewData
      * @return string
      */
-    public function render($view, array $data = [])
+    public function render($view, array $data = [], array $viewData = [])
     {
         // First we need to parse the view, which could either be a string or an array
         // containing both an HTML and plain text versions of the view which should
@@ -212,7 +213,7 @@ class Mailer implements MailerContract, MailQueueContract
 
         $data['message'] = $this->createMessage();
 
-        return $this->renderView($view ?: $plain, $data);
+        return $this->renderView($view ?: $plain, $data, $viewData);
     }
 
     /**
@@ -221,9 +222,10 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
+     * @param array $viewData
      * @return void
      */
-    public function send($view, array $data = [], $callback = null)
+    public function send($view, array $data = [], $callback = null, array $viewData = [])
     {
         if ($view instanceof MailableContract) {
             return $this->sendMailable($view);
@@ -241,7 +243,7 @@ class Mailer implements MailerContract, MailQueueContract
         // to creating view based emails that are able to receive arrays of data.
         call_user_func($callback, $message);
 
-        $this->addContent($message, $view, $plain, $raw, $data);
+        $this->addContent($message, $view, $plain, $raw, $data, $viewData);
 
         // If a global "to" address has been set, we will set that address on the mail
         // message. This is primarily useful during local development in which each
@@ -318,18 +320,19 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  string  $plain
      * @param  string  $raw
      * @param  array  $data
+     * @param  array  $viewData
      * @return void
      */
-    protected function addContent($message, $view, $plain, $raw, $data)
+    protected function addContent($message, $view, $plain, $raw, $data, $viewData)
     {
         if (isset($view)) {
-            $message->setBody($this->renderView($view, $data), 'text/html');
+            $message->setBody($this->renderView($view, $data, $viewData), 'text/html');
         }
 
         if (isset($plain)) {
             $method = isset($view) ? 'addPart' : 'setBody';
 
-            $message->$method($this->renderView($plain, $data), 'text/plain');
+            $message->$method($this->renderView($plain, $data, $viewData), 'text/plain');
         }
 
         if (isset($raw)) {
@@ -344,13 +347,14 @@ class Mailer implements MailerContract, MailQueueContract
      *
      * @param  string  $view
      * @param  array  $data
+     * @param  array $viewData
      * @return string
      */
-    protected function renderView($view, $data)
+    protected function renderView($view, $data, $viewData)
     {
         return $view instanceof Htmlable
                         ? $view->toHtml()
-                        : $this->views->make($view, $data)->render();
+                        : $this->views->make($view, $data, $viewData)->render();
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -62,7 +62,8 @@ class MailChannel
         $this->mailer->send(
             $this->buildView($message),
             array_merge($message->data(), $this->additionalMessageData($notification)),
-            $this->messageBuilder($notifiable, $notification, $message)
+            $this->messageBuilder($notifiable, $notification, $message),
+            $message->viewData
         );
     }
 

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -280,9 +280,10 @@ class MailFake implements Mailer, MailQueue
      * @param  string|array  $view
      * @param  array  $data
      * @param  \Closure|string  $callback
+     * @param  array  $viewData
      * @return void
      */
-    public function send($view, array $data = [], $callback = null)
+    public function send($view, array $data = [], $callback = null, array $viewData = [])
     {
         if (! $view instanceof Mailable) {
             return;

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -103,7 +103,8 @@ class SendingMailNotificationsTest extends TestCase
                 $closure($message);
 
                 return true;
-            })
+            }),
+            []
         );
 
         $user->notify($notification);
@@ -147,7 +148,8 @@ class SendingMailNotificationsTest extends TestCase
                 $closure($message);
 
                 return true;
-            })
+            }),
+            []
         );
 
         $user->notify($notification);
@@ -180,7 +182,8 @@ class SendingMailNotificationsTest extends TestCase
                 $closure($message);
 
                 return true;
-            })
+            }),
+            []
         );
 
         $user->notify($notification);
@@ -213,7 +216,8 @@ class SendingMailNotificationsTest extends TestCase
                 $closure($message);
 
                 return true;
-            })
+            }),
+            []
         );
 
         $user->notify($notification);

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -30,7 +30,7 @@ class MailMailerTest extends TestCase
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message], ['data'])->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('setFrom')->never();
@@ -39,7 +39,7 @@ class MailMailerTest extends TestCase
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send('foo', ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
-        });
+        }, ['data']);
         unset($_SERVER['__mailer.test']);
     }
 
@@ -91,8 +91,8 @@ class MailMailerTest extends TestCase
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message], ['data'])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message], ['data'])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
@@ -102,7 +102,7 @@ class MailMailerTest extends TestCase
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['foo', 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
-        });
+        }, ['data']);
         unset($_SERVER['__mailer.test']);
     }
 
@@ -113,8 +113,8 @@ class MailMailerTest extends TestCase
         $message = m::mock(Swift_Mime_SimpleMessage::class);
         $mailer->expects($this->once())->method('createMessage')->willReturn($message);
         $view = m::mock(stdClass::class);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message])->andReturn($view);
-        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('foo', ['data', 'message' => $message], ['data'])->andReturn($view);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->with('bar', ['data', 'message' => $message], ['data'])->andReturn($view);
         $view->shouldReceive('render')->twice()->andReturn('rendered.view');
         $message->shouldReceive('setBody')->once()->with('rendered.view', 'text/html');
         $message->shouldReceive('addPart')->once()->with('rendered.view', 'text/plain');
@@ -124,7 +124,7 @@ class MailMailerTest extends TestCase
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['html' => 'foo', 'text' => 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
-        });
+        }, ['data']);
         unset($_SERVER['__mailer.test']);
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is related to [laravel/ideas#1792](https://github.com/laravel/ideas/issues/1792)

# Problem
In class extends Notification, I inserted array ['message' => 'hoge'] at view method's second param. 
Then I executed dd($message) in view blade file, but it’s not result I expected.

## For example
```php
return (new MailMessage())
    ->subject('email.hoge')
    ->view(
        'hoge',
        [
            'message' => 'huga'
        ]
    );
```

hoge.blade.php
```php
dd($message)
```

### Expected
`huga`

### Result
![スクリーンショット 2019-08-15 17 45 13](https://user-images.githubusercontent.com/21007314/63647738-a0cba800-c760-11e9-8c1d-c2d6783d9110.png)

# cause
when using Render method Illuminate\Mail\Mailer, `$data` includes "message" property and `SimpleMessage`’s property.
https://github.com/laravel/framework/blob/5eef06c7b6a21857a41c7eada53303a94b87edad/src/Illuminate/Mail/Mailer.php#L213
https://github.com/laravel/framework/blob/5eef06c7b6a21857a41c7eada53303a94b87edad/src/Illuminate/Notifications/Channels/MailChannel.php#L64

In other words, We can’t insert those keys in array at view method’s second param.
```
message
level
subject
greeting
salutation
introLines
outroLines
actionText
actionUrl
```

I think it’s not intuitive.
it shouldn’t know "message" and SimpleMessage’s property when render tamplate.


# What I changed?
I disabled SimpleMessage’s property and Message for render in src/Illuminate/Mail/Mailer.php.


