### PR TITLE
[5.8] Migrator Event before detecting migrations

### DIFF
--- a/src/Illuminate/Database/Events/MigrationsStarting.php
+++ b/src/Illuminate/Database/Events/MigrationsStarting.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContract;
+
+class MigrationsStarting implements MigrationEventContract
+{
+    /**
+     * An array of paths used by the migrator
+     *
+     * @var array
+     */
+    public $paths;
+
+    /**
+     * An array of options used by the migrator
+     *
+     * @var array
+     */
+    public $options;
+
+    /**
+     * Create a new MigrationsStarting instance.
+     *
+     * @param  array  $paths
+     * @param  array  $options
+     * @return void
+     */
+    public function __construct(array &$paths, array &$options)
+    {
+        $this->paths = $paths;
+        $this->options = $options;
+    }
+}

--- a/src/Illuminate/Database/Events/MigrationsStarting.php
+++ b/src/Illuminate/Database/Events/MigrationsStarting.php
@@ -7,14 +7,14 @@ use Illuminate\Contracts\Database\Events\MigrationEvent as MigrationEventContrac
 class MigrationsStarting implements MigrationEventContract
 {
     /**
-     * An array of paths used by the migrator
+     * An array of paths used by the migrator.
      *
      * @var array
      */
     public $paths;
 
     /**
-     * An array of options used by the migrator
+     * An array of options used by the migrator.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Events\MigrationEnded;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\MigrationStarted;
 use Illuminate\Database\Events\MigrationsStarted;
+use Illuminate\Database\Events\MigrationsStarting;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 
 class Migrator
@@ -94,6 +95,8 @@ class Migrator
      */
     public function run($paths = [], array $options = [])
     {
+        $this->fireMigrationEvent(new MigrationsStarting($paths, $options));
+
         // Once we grab all of the migration files for the path, we will compare them
         // against the migrations that have already been run for this package then
         // run each of the outstanding migrations against a database connection.
@@ -215,6 +218,8 @@ class Migrator
      */
     public function rollback($paths = [], array $options = [])
     {
+        $this->fireMigrationEvent(new MigrationsStarting($paths, $options));
+
         // We want to pull in the last batch of migrations that ran on the previous
         // migration operation. We'll then reverse those migrations and run each
         // of them "down" to reverse the last migration "operation" which ran.

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Database\Events\MigrationsStarting;
+
+class MigratorEventsTest extends DatabaseTestCase
+{
+    protected function migrateOptions()
+    {
+        return [
+            '--path' => realpath(__DIR__.'/stubs/'),
+            '--realpath' => true,
+        ];
+    }
+
+    public function test_migratios_starting_fired_on_migrate()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationsStarting::class, function (MigrationsStarting $event){
+            return in_array(realpath(__DIR__.'/stubs/'), $event->paths);
+        });
+    }
+}

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -21,7 +21,7 @@ class MigratorEventsTest extends DatabaseTestCase
 
         $this->artisan('migrate', $this->migrateOptions());
 
-        Event::assertDispatched(MigrationsStarting::class, function (MigrationsStarting $event){
+        Event::assertDispatched(MigrationsStarting::class, function (MigrationsStarting $event) {
             return in_array(realpath(__DIR__.'/stubs/'), $event->paths);
         });
     }


### PR DESCRIPTION
Allows for providing paths on runtime.

This has been discussed/talked about in #28342 and #29503.

## Problem / Situation
I've been building a system that uses different databases and different sets of migrations. It's been quite a challenge to make some things work, but the migrations have been the biggest issue. The migrations for databases other than the main database are quite easily loaded as we'll get the paths before, resolve the migrator, and then pass our paths to it.

However, when wanting to run things on the main database (simply by using artisan migrate), you won't have any way to adjust the paths (or migrations) on the fly. Whenever the Migrator gets resolved (which is before a lot of events like CommandStarting), it already has all its paths and only paths provided by the --path option will be taken into account.

You don't always want to provide paths upfront through the command line, but want to adjust them later on. This PR allows you to do that by providing events to listen to where you can adjust the most important variables for the migrator.

This helps with a few things:
- Systems that use different databases (with different sets of migrations)
- Support for other Design Patterns (like DDD)

PS: Hope I provided enough information, always open for discussion, additions, changes. Thanks for all the work you guys do on Laravel!