### PR TITLE
[5.8] Aws Instance Profile

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -109,7 +109,7 @@ class TransportManager extends Manager
      */
     protected function addSesCredentials(array $config)
     {
-        if ($config['key'] && $config['secret']) {
+        if (!empty($config['key']) && !empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -109,7 +109,7 @@ class TransportManager extends Manager
      */
     protected function addSesCredentials(array $config)
     {
-        if (!empty($config['key']) && !empty($config['secret'])) {
+        if (! empty($config['key']) && ! empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -18,7 +18,7 @@ class SqsConnector implements ConnectorInterface
     {
         $config = $this->getDefaultConfiguration($config);
 
-        if ($config['key'] && $config['secret']) {
+        if (!empty($config['key']) && empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 

--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -18,7 +18,7 @@ class SqsConnector implements ConnectorInterface
     {
         $config = $this->getDefaultConfiguration($config);
 
-        if (!empty($config['key']) && empty($config['secret'])) {
+        if (! empty($config['key']) && ! empty($config['secret'])) {
             $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
         }
 


### PR DESCRIPTION
### Problem
A user may want to supply the Aws credentials in the ~/.aws/credentials file or use the Instance Profile.
### Solution
Only pass credentials to the Aws Sdk when supplied by the config.  Otherwise, allow the Aws Sdk to use credentials supplied in ~/.aws/credentials or, if not found, the server's Instance Profile.