### PR TITLE
[6.0] Implement Aws temporary url via CloudFront

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -235,8 +235,6 @@ class FilesystemManager implements FactoryContract
     {
         $cache = Arr::pull($config, 'cache');
 
-        $config = Arr::only($config, ['visibility', 'disable_asserts', 'url']);
-
         if ($cache) {
             $adapter = new CachedAdapter($adapter, $this->createCacheStore($cache));
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
this pull request will solve the issue https://github.com/laravel/framework/issues/26797
It help someone who use CloudFront to serve S3 files and want to get CloudFront Signed Url.
Please help me add cloudfront configuration into s3 disk in file \app\config\filesystems.php if this pull request has been merged

```
's3' => [
            'driver' => 's3',
            'key' => env('AWS_ACCESS_KEY_ID'),
            'secret' => env('AWS_SECRET_ACCESS_KEY'),
            'region' => env('AWS_DEFAULT_REGION'),
            'bucket' => env('AWS_BUCKET'),
            'url' => env('AWS_URL'),
            'serve_via_cloudfront' => env('AWS_S3_VIA_CLOUDFRONT'),
            'cloudfront' => [
                'protocol' => env('AWS_CLOUDFRONT_PROTOCOL'),
                'domain' => env('AWS_CLOUDFRONT_DOMAIN'),
                'key_pair_id' => env('AWS_CLOUDFRONT_KEY_PAIR_ID'),
                'private_key_path' => env('AWS_CLOUDFRONT_PRIVATE_KEY_PATH'),
            ],
        ]
```
and add those to .env.example file 
```
AWS_CLOUDFRONT_PROTOCOL=
AWS_CLOUDFRONT_DOMAIN=your_cloudfont_domain_name
AWS_CLOUDFRONT_KEY_PAIR_ID=your_key_pair_id
AWS_CLOUDFRONT_PRIVATE_KEY_PATH=path_to_private_key_file
AWS_S3_VIA_CLOUDFRONT=false
```
Set "AWS_S3_VIA_CLOUDFRONT" into "true" to get CloudFront Signed Url instead of S3 Pre-Signed Url