### PR TITLE
[5.8] Better error message for invalid pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -5,6 +5,7 @@ namespace Illuminate\Pipeline;
 use Closure;
 use RuntimeException;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Pipeline\Pipeline as PipelineContract;
@@ -143,7 +144,7 @@ class Pipeline implements PipelineContract
                     // otherwise we'll resolve the pipes out of the container and call it with
                     // the appropriate method and arguments, returning the results back out.
                     return $pipe($passable, $stack);
-                } elseif (! is_object($pipe)) {
+                } elseif (is_string($pipe)) {
                     [$name, $parameters] = $this->parsePipeString($pipe);
 
                     // If the pipe is a string we will parse the string and resolve the class out
@@ -152,11 +153,13 @@ class Pipeline implements PipelineContract
                     $pipe = $this->getContainer()->make($name);
 
                     $parameters = array_merge([$passable, $stack], $parameters);
-                } else {
+                } elseif (is_object($pipe)) {
                     // If the pipe is already an object we'll just make a callable and pass it to
                     // the pipe as-is. There is no need to do any extra parsing and formatting
                     // since the object we're given was already a fully instantiated object.
                     $parameters = [$passable, $stack];
+                } else {
+                    throw new InvalidArgumentException(sprintf('A pipe must be an object, a string or a callable. %s given', gettype($pipe)));
                 }
 
                 $response = method_exists($pipe, $this->method)

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Pipeline;
 
 use RuntimeException;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Container\Container;
@@ -246,6 +247,34 @@ class PipelineTest extends TestCase
 
         $this->assertEquals('foo', $result);
         $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testItThrowsInvalidArgumentExceptionWhenPipeIsOfSillyTypes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A pipe must be an object, a string or a callable. integer given');
+
+        $sillyPipe = 111;
+        (new Pipeline(new Container))
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $sillyPipe])
+            ->thenReturn();
+
+        unset($_SERVER['__test.pipe.one']);
+    }
+
+    public function testItThrowsInvalidArgumentExceptionWhenPipeIsOfSillyTypes2()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A pipe must be an object, a string or a callable. array given');
+
+        $sillyPipe = [123];
+        (new Pipeline(new Container))
+            ->send('foo')
+            ->through([PipelineTestPipeOne::class, $sillyPipe])
+            ->thenReturn();
 
         unset($_SERVER['__test.pipe.one']);
     }


### PR DESCRIPTION
Currently, if we pass a non-sensible value as a pipe (like an int, or null) it will end up in a region of code : `} elseif (! is_object($pipe)) { <here> }`  where only an 'string' can survive, and a vague error message is shown.

in case of `123` as a pipe :
![image](https://user-images.githubusercontent.com/6961695/63671815-ae7f3d00-c7f5-11e9-9582-ee2fcccb4967.png)


With more explicit type checking, we can detect invalid argument and have a clean exception message.

But I still think that we need the test #29729 for this PR. since some arrays are acceptable as callable pipes. (This PR can also pass that test)