### PR TITLE
[6.0] Don't force predis/predis with the illuminate/redis component

### DIFF
--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -16,13 +16,16 @@
     "require": {
         "php": "^7.2",
         "illuminate/contracts": "^6.0",
-        "illuminate/support": "^6.0",
-        "predis/predis": "^1.0"
+        "illuminate/support": "^6.0"
     },
     "autoload": {
         "psr-4": {
             "Illuminate\\Redis\\": ""
         }
+    },
+    "suggest": {
+        "ext-redis": "Required to use the phpredis connector.",
+        "predis/predis": "Required to use the predis connector (^1.0).",
     },
     "extra": {
         "branch-alias": {

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -25,7 +25,7 @@
     },
     "suggest": {
         "ext-redis": "Required to use the phpredis connector.",
-        "predis/predis": "Required to use the predis connector (^1.0).",
+        "predis/predis": "Required to use the predis connector (^1.0)."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
I also suggest that in Laravel 7.0, we delete the suggest block from illuminate/redis, and just move `ext-redis` to require for that component.