### PR TITLE
[6.0] Default to phpredis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,6 +76,7 @@
         "tightenco/collect": "<5.5.33"
     },
     "require-dev": {
+        "ext-redis": "*",
         "aws/aws-sdk-php": "^3.0",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,6 @@
         "tightenco/collect": "<5.5.33"
     },
     "require-dev": {
-        "ext-redis": "*",
         "aws/aws-sdk-php": "^3.0",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.4",

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -52,7 +52,7 @@ trait InteractsWithRedis
         }
 
         try {
-            $this->redis['predis']->connection()->flushdb();
+            $this->redis['phpredis']->connection()->flushdb();
         } catch (Exception $e) {
             if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
                 static::$connectionFailedOnceWithDefaultsSkip = true;
@@ -68,7 +68,7 @@ trait InteractsWithRedis
      */
     public function tearDownRedis()
     {
-        $this->redis['predis']->connection()->flushdb();
+        $this->redis['phpredis']->connection()->flushdb();
 
         foreach ($this->redisDriverProvider() as $driver) {
             $this->redis[$driver[0]]->connection()->disconnect();
@@ -82,15 +82,10 @@ trait InteractsWithRedis
      */
     public function redisDriverProvider()
     {
-        $providers = [
+        return [
             ['predis'],
+            ['phpredis'],
         ];
-
-        if (extension_loaded('redis')) {
-            $providers[] = ['phpredis'];
-        }
-
-        return $providers;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -38,6 +38,7 @@ trait InteractsWithRedis
 
             return;
         }
+
         if (static::$connectionFailedOnceWithDefaultsSkip) {
             $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -33,7 +33,7 @@ trait InteractsWithRedis
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 
-        if (!extension_loaded('redis')) {
+        if (! extension_loaded('redis')) {
             $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
 
             return;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -33,6 +33,11 @@ trait InteractsWithRedis
         $host = getenv('REDIS_HOST') ?: '127.0.0.1';
         $port = getenv('REDIS_PORT') ?: 6379;
 
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
+
+            return;
+        }
         if (static::$connectionFailedOnceWithDefaultsSkip) {
             $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
 

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -18,7 +18,7 @@ class RedisServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('redis', function ($app) {
             $config = $app->make('config')->get('database.redis', []);
 
-            return new RedisManager($app, Arr::pull($config, 'client', 'predis'), $config);
+            return new RedisManager($app, Arr::pull($config, 'client', 'phpredis'), $config);
         });
 
         $this->app->bind('redis.connection', function ($app) {

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -81,7 +81,7 @@ class RedisQueueIntegrationTest extends TestCase
             $this->assertEquals(12, unserialize(json_decode($this->queue->pop()->getRawBody())->data->command)->i);
         } elseif ($pid == 0) {
             $this->setUpRedis();
-            $this->setQueue('predis');
+            $this->setQueue('phpredis');
             sleep(1);
             $this->queue->push(new RedisQueueIntegrationTestJob(12));
             die;

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -142,7 +142,7 @@ class ConcurrentLimiterTest extends TestCase
 
     private function redis()
     {
-        return $this->redis['predis']->connection();
+        return $this->redis['phpredis']->connection();
     }
 }
 

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -85,6 +85,6 @@ class DurationLimiterTest extends TestCase
 
     private function redis()
     {
-        return $this->redis['predis']->connection();
+        return $this->redis['phpredis']->connection();
     }
 }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -18,14 +18,6 @@ class RedisConnectionTest extends TestCase
     {
         parent::setUp();
         $this->setUpRedis();
-
-        if (! isset($this->redis['phpredis'])) {
-            $this->markTestSkipped('PhpRedis should be enabled to run the tests');
-        }
-
-        if (! isset($this->redis['predis'])) {
-            $this->markTestSkipped('Predis should be enabled to run the tests');
-        }
     }
 
     protected function tearDown(): void
@@ -562,38 +554,36 @@ class RedisConnectionTest extends TestCase
             'phpredis' => $this->redis['phpredis']->connection(),
         ];
 
-        if (extension_loaded('redis')) {
-            $host = getenv('REDIS_HOST') ?: '127.0.0.1';
-            $port = getenv('REDIS_PORT') ?: 6379;
+        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
+        $port = getenv('REDIS_PORT') ?: 6379;
 
-            $prefixedPhpredis = new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'url' => "redis://user@$host:$port",
-                    'host' => 'overwrittenByUrl',
-                    'port' => 'overwrittenByUrl',
-                    'database' => 5,
-                    'options' => ['prefix' => 'laravel:'],
-                    'timeout' => 0.5,
-                ],
-            ]);
+        $prefixedPhpredis = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'default' => [
+                'url' => "redis://user@$host:$port",
+                'host' => 'overwrittenByUrl',
+                'port' => 'overwrittenByUrl',
+                'database' => 5,
+                'options' => ['prefix' => 'laravel:'],
+                'timeout' => 0.5,
+            ],
+        ]);
 
-            $persistentPhpRedis = new RedisManager(new Application, 'phpredis', [
-                'cluster' => false,
-                'default' => [
-                    'host' => $host,
-                    'port' => $port,
-                    'database' => 6,
-                    'options' => ['prefix' => 'laravel:'],
-                    'timeout' => 0.5,
-                    'persistent' => true,
-                    'persistent_id' => 'laravel',
-                ],
-            ]);
+        $persistentPhpRedis = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'database' => 6,
+                'options' => ['prefix' => 'laravel:'],
+                'timeout' => 0.5,
+                'persistent' => true,
+                'persistent_id' => 'laravel',
+            ],
+        ]);
 
-            $connections[] = $prefixedPhpredis->connection();
-            $connections['persistent'] = $persistentPhpRedis->connection();
-        }
+        $connections[] = $prefixedPhpredis->connection();
+        $connections['persistent'] = $persistentPhpRedis->connection();
 
         return $connections;
     }


### PR DESCRIPTION
The current redis service provider binds the `predis` connection as the default, rather than `phpredis`. I've updated this default.

Additionally, the tests use predis rather than phpredis, whenever they don't care about the driver. We should switch this to phpredis, so when we remove predis in L7.0, the tests don't need changing again.