### PR TITLE
[7.0] Remove deprecated daemon flag

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -22,7 +22,6 @@ class WorkCommand extends Command
     protected $signature = 'queue:work
                             {connection? : The name of the queue connection to work}
                             {--queue= : The names of the queues to work}
-                            {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--once : Only process the next job on the queue}
                             {--stop-when-empty : Stop when the queue is empty}
                             {--delay=0 : The number of seconds to delay failed jobs}


### PR DESCRIPTION
This has been deprecated since Laravel 5.3. Maybe Laravel 7.0 is the time to finally remove it?