### PR TITLE
[6.0] Adding support for custom error bags in the @error Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php
@@ -14,9 +14,11 @@ trait CompilesErrors
     {
         $expression = $this->stripParentheses($expression);
 
-        return '<?php if ($errors->has('.$expression.')) :
-if (isset($message)) { $messageCache = $message; }
-$message = $errors->first('.$expression.'); ?>';
+        return '<?php $__args = ['.$expression.'];
+$__bag = $errors->getBag($__args[1] ?? \'default\');
+if ($__bag->has($__args[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__args[0]); ?>';
     }
 
     /**
@@ -28,7 +30,8 @@ $message = $errors->first('.$expression.'); ?>';
     protected function compileEnderror($expression)
     {
         return '<?php unset($message);
-if (isset($messageCache)) { $message = $messageCache; }
-endif; ?>';
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__args, $__bag); ?>';
     }
 }

--- a/tests/View/Blade/BladeErrorTest.php
+++ b/tests/View/Blade/BladeErrorTest.php
@@ -11,14 +11,37 @@ class BladeErrorTest extends AbstractBladeTestCase
     <span>{{ $message }}</span>
 @enderror';
         $expected = '
-<?php if ($errors->has(\'email\')) :
-if (isset($message)) { $messageCache = $message; }
-$message = $errors->first(\'email\'); ?>
+<?php $__args = [\'email\'];
+$__bag = $errors->getBag($__args[1] ?? \'default\');
+if ($__bag->has($__args[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__args[0]); ?>
     <span><?php echo e($message); ?></span>
 <?php unset($message);
-if (isset($messageCache)) { $message = $messageCache; }
-endif; ?>';
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__args, $__bag); ?>';
 
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testErrorsWithBagsAreCompiled()
+    {
+        $string = '
+@error(\'email\', \'customBag\')
+    <span>{{ $message }}</span>
+@enderror';
+        $expected = '
+<?php $__args = [\'email\', \'customBag\'];
+$__bag = $errors->getBag($__args[1] ?? \'default\');
+if ($__bag->has($__args[0])) :
+if (isset($message)) { $__messageOriginal = $message; }
+$message = $__bag->first($__args[0]); ?>
+    <span><?php echo e($message); ?></span>
+<?php unset($message);
+if (isset($__messageOriginal)) { $message = $__messageOriginal; }
+endif;
+unset($__args, $__bag); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
This change adds a new parameter to the @error directive to choose the message bag being used. Useful when there are multiple forms with separate fields/validation on the same page (e.g. shared login/register page.)

The change should be backwards compatible as it only adds an extra parameter, which when left off defaults to the old behavior of using the default error bag (named 'default'.)

I wasn't sure on the best way to parse out the second parameter, so if anyone has any suggestions on a better way to do it, I'm all ears.

My current approach uses two variables staring with `$__` which then get cleaned up at the end. I also renamed the `$messageCache` variable that stored the previous value of `$message` to `$__messageOriginal` to match this style, if you'd prefer me to leave that unchanged I can revert it.

I've also updated the related test to test the new parameter.

**Examples:**
```blade
{{-- unchanged previous behavior, uses 'default' error bag --}}
@error('field')
    <span>{{ $message }}</span>
@enderror

{{-- new parameter to select the 'register' error bag --}}
@error('field', 'register')
    <span>{{ $message }}</span>
@enderror

{{-- similarly to select the 'login' error bag --}}
@error('field', 'login')
    <span>{{ $message }}</span>
@enderror
```