### PR TITLE
[6.0] Adds Arr::any() method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -39,6 +39,28 @@ class Arr
     }
 
     /**
+     * Returns true if any element of the array is truthy. If not, returns false.
+     *
+     * @param  $array  $array
+     * @param  callable|null  $callback
+     * @return bool
+     */
+    public static function any($array, callable $callback = null)
+    {
+        $callback = $callback ?: function ($value) {
+            return $value;
+        };
+
+        foreach ($array as $value) {
+            if ($callback($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Collapse an array of arrays into a single array.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -41,7 +41,7 @@ class Arr
     /**
      * Returns true if any element of the array is truthy. If not, returns false.
      *
-     * @param  $array  $array
+     * @param  array  $array
      * @param  callable|null  $callback
      * @return bool
      */

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -61,6 +61,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Returns true if any element of the collection is truthy. If not, returns false.
+     *
+     * @param  callable|null  $callback
+     * @return bool
+     */
+    public function any(callable $callback = null)
+    {
+        return Arr::any($this->items, $callback);
+    }
+
+    /**
      * Get a lazy collection for the items in this collection.
      *
      * @return \Illuminate\Support\LazyCollection

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -34,6 +34,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
     }
 
+    public function testAny()
+    {
+        $this->assertTrue(Arr::any([0, 1]));
+        $this->assertFalse(Arr::any([0, 1], function ($item) {
+            return $item === 2;
+        }));
+
+        $this->assertTrue(Arr::any([0, 1, 2], function ($item) {
+            return $item === 2;
+        }));
+    }
+
     public function testCollapse()
     {
         $data = [['foo', 'bar'], ['baz']];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -127,6 +127,22 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals('default', $result);
     }
 
+    public function testAny()
+    {
+        $data = new Collection();
+        $this->assertFalse($data->any());
+        $data->add('foo');
+        $this->assertTrue($data->any());
+
+        $callback = function ($item) {
+            return $item === 'bar';
+        };
+
+        $this->assertFalse($data->any($callback));
+        $data->add('bar');
+        $this->assertTrue($data->any($callback));
+    }
+
     public function testPopReturnsAndRemovesLastItemInCollection()
     {
         $c = new Collection(['foo', 'bar']);


### PR DESCRIPTION
This pull request adds the **`any`** method to the `Arr` support helper and the `Collection` support class. The `any` method returns `true` if any element of the iterable is truthy. If not, returns false.

This is a Python inspired function: [docs.python.org/3/library/functions.html#any](https://docs.python.org/3/library/functions.html#any).

Usage:
```php
// Check if a list should be displayed if there is a product price lower than 100
$shouldDisplayList = $products->any(function ($product) {
    return $product->price < 100;
});

// Check if any product is free
Arr::any($products->map->isFree);
```

What do you guys think? If sounds good for the `v6.0` release, I can see how this fits with eloquent and update the docs.