### PR TITLE
[6.0] Use assertSame for string assertions

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -227,7 +227,7 @@ class AuthAccessGateTest extends TestCase
             return true;
         });
         $gate->before(function ($user, $ability) {
-            $this->assertEquals('foo', $ability);
+            $this->assertSame('foo', $ability);
 
             return false;
         });
@@ -627,8 +627,8 @@ class AuthAccessGateTest extends TestCase
 
         $this->assertTrue($response->denied());
         $this->assertFalse($response->allowed());
-        $this->assertEquals('Not allowed.', $response->message());
-        $this->assertEquals('some_code', $response->code());
+        $this->assertSame('Not allowed.', $response->message());
+        $this->assertSame('some_code', $response->code());
     }
 
     public function testAuthorizeReturnsAllowedResponse()
@@ -669,7 +669,7 @@ class AuthAccessGateTest extends TestCase
         $response = $gate->inspect('view', new AccessGateTestDummy);
 
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals('Not allowed to view as it is not published.', $response->message());
+        $this->assertSame('Not allowed to view as it is not published.', $response->message());
         $this->assertFalse($response->allowed());
         $this->assertTrue($response->denied());
         $this->assertEquals($response->code(), 'unpublished');
@@ -812,22 +812,22 @@ class AuthAccessGateTest extends TestCase
         AccessGateTestClassForGuest::$calledMethod = '';
 
         $this->assertTrue($gate->check('foo'));
-        $this->assertEquals('foo was called', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertSame('foo was called', AccessGateTestClassForGuest::$calledMethod);
 
         $this->assertTrue($gate->check('static_foo'));
-        $this->assertEquals('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertSame('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
 
         $this->assertTrue($gate->check('bar'));
-        $this->assertEquals('bar got invoked', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertSame('bar got invoked', AccessGateTestClassForGuest::$calledMethod);
 
         $this->assertTrue($gate->check('static_@foo'));
-        $this->assertEquals('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
+        $this->assertSame('static foo was invoked', AccessGateTestClassForGuest::$calledMethod);
 
         $this->assertTrue($gate->check('invokable'));
-        $this->assertEquals('__invoke was called', AccessGateTestGuestInvokableClass::$calledMethod);
+        $this->assertSame('__invoke was called', AccessGateTestGuestInvokableClass::$calledMethod);
 
         $this->assertTrue($gate->check('nullable_invokable'));
-        $this->assertEquals('Nullable __invoke was called', AccessGateTestGuestNullableInvokable::$calledMethod);
+        $this->assertSame('Nullable __invoke was called', AccessGateTestGuestNullableInvokable::$calledMethod);
 
         $this->assertFalse($gate->check('absent_invokable'));
     }

--- a/tests/Auth/AuthAccessResponseTest.php
+++ b/tests/Auth/AuthAccessResponseTest.php
@@ -14,8 +14,8 @@ class AuthAccessResponseTest extends TestCase
 
         $this->assertTrue($response->allowed());
         $this->assertFalse($response->denied());
-        $this->assertEquals('some message', $response->message());
-        $this->assertEquals('some_code', $response->code());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
     }
 
     public function testDenyMethod()
@@ -24,8 +24,8 @@ class AuthAccessResponseTest extends TestCase
 
         $this->assertTrue($response->denied());
         $this->assertFalse($response->allowed());
-        $this->assertEquals('some message', $response->message());
-        $this->assertEquals('some_code', $response->code());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
     }
 
     public function testDenyMethodWithNoMessageReturnsNull()
@@ -42,8 +42,8 @@ class AuthAccessResponseTest extends TestCase
         try {
             $response->authorize();
         } catch (AuthorizationException $e) {
-            $this->assertEquals('Some message.', $e->getMessage());
-            $this->assertEquals('some_code', $e->getCode());
+            $this->assertSame('Some message.', $e->getMessage());
+            $this->assertSame('some_code', $e->getCode());
             $this->assertEquals($response, $e->response());
         }
     }
@@ -55,7 +55,7 @@ class AuthAccessResponseTest extends TestCase
         try {
             $response->authorize();
         } catch (AuthorizationException $e) {
-            $this->assertEquals('This action is unauthorized.', $e->getMessage());
+            $this->assertSame('This action is unauthorized.', $e->getMessage());
         }
     }
 

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -29,7 +29,7 @@ class AuthDatabaseUserProviderTest extends TestCase
 
         $this->assertInstanceOf(GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
-        $this->assertEquals('Dayle', $user->name);
+        $this->assertSame('Dayle', $user->name);
     }
 
     public function testRetrieveByIDReturnsNullWhenUserIsNotFound()
@@ -99,7 +99,7 @@ class AuthDatabaseUserProviderTest extends TestCase
 
         $this->assertInstanceOf(GenericUser::class, $user);
         $this->assertEquals(1, $user->getAuthIdentifier());
-        $this->assertEquals('taylor', $user->name);
+        $this->assertSame('taylor', $user->name);
     }
 
     public function testRetrieveByCredentialsReturnsNullWhenUserIsFound()

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -27,7 +27,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveById(1);
 
-        $this->assertEquals('bar', $user);
+        $this->assertSame('bar', $user);
     }
 
     public function testRetrieveByTokenReturnsUser()
@@ -89,7 +89,7 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider->expects($this->once())->method('createModel')->willReturn($mock);
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
-        $this->assertEquals('bar', $user);
+        $this->assertSame('bar', $user);
     }
 
     public function testCredentialValidation()

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -143,7 +143,7 @@ class AuthGuardTest extends TestCase
             return 'bar';
         });
 
-        $this->assertEquals(
+        $this->assertSame(
             'bar', $guard->foo()
         );
     }

--- a/tests/Auth/AuthHandlesAuthorizationTest.php
+++ b/tests/Auth/AuthHandlesAuthorizationTest.php
@@ -15,8 +15,8 @@ class AuthHandlesAuthorizationTest extends TestCase
 
         $this->assertTrue($response->allowed());
         $this->assertFalse($response->denied());
-        $this->assertEquals('some message', $response->message());
-        $this->assertEquals('some_code', $response->code());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
     }
 
     public function testDenyMethod()
@@ -25,7 +25,7 @@ class AuthHandlesAuthorizationTest extends TestCase
 
         $this->assertTrue($response->denied());
         $this->assertFalse($response->allowed());
-        $this->assertEquals('some message', $response->message());
-        $this->assertEquals('some_code', $response->code());
+        $this->assertSame('some message', $response->message());
+        $this->assertSame('some_code', $response->code());
     }
 }

--- a/tests/Auth/AuthorizesResourcesTest.php
+++ b/tests/Auth/AuthorizesResourcesTest.php
@@ -69,7 +69,7 @@ class AuthorizesResourcesTest extends TestCase
         $router->aliasMiddleware('can', AuthorizesResourcesMiddleware::class);
         $router->get($method)->uses(AuthorizesResourcesController::class.'@'.$method);
 
-        $this->assertEquals(
+        $this->assertSame(
             'caught '.$middleware,
             $router->dispatch(Request::create($method, 'GET'))->getContent(),
             "The [{$middleware}] middleware was not registered for method [{$method}]"

--- a/tests/Cache/CacheApcStoreTest.php
+++ b/tests/Cache/CacheApcStoreTest.php
@@ -21,7 +21,7 @@ class CacheApcStoreTest extends TestCase
         $apc = $this->getMockBuilder(ApcWrapper::class)->setMethods(['get'])->getMock();
         $apc->expects($this->once())->method('get')->willReturn('bar');
         $store = new ApcStore($apc);
-        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertSame('bar', $store->get('foo'));
     }
 
     public function testGetMultipleReturnsNullWhenNotFoundAndValueWhenFound()

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -13,7 +13,7 @@ class CacheArrayStoreTest extends TestCase
         $store = new ArrayStore;
         $result = $store->put('foo', 'bar', 10);
         $this->assertTrue($result);
-        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertSame('bar', $store->get('foo'));
     }
 
     public function testMultipleItemsCanBeSetAndRetrieved()

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -49,7 +49,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => serialize('bar'), 'expiration' => 999999999999999]);
 
-        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertSame('bar', $store->get('foo'));
     }
 
     public function testValueIsReturnedOnPostgres()
@@ -60,7 +60,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['value' => base64_encode(serialize('bar')), 'expiration' => 999999999999999]);
 
-        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertSame('bar', $store->get('foo'));
     }
 
     public function testValueIsInsertedWhenNoExceptionsAreThrown()

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -47,13 +47,13 @@ class CacheEventsTest extends TestCase
         $this->assertNull($repository->get('foo'));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['key' => 'baz', 'value' => 'qux']));
-        $this->assertEquals('qux', $repository->get('baz'));
+        $this->assertSame('qux', $repository->get('baz'));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
         $this->assertNull($repository->tags('taylor')->get('foo'));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['key' => 'baz', 'value' => 'qux', 'tags' => ['taylor']]));
-        $this->assertEquals('qux', $repository->tags('taylor')->get('baz'));
+        $this->assertSame('qux', $repository->tags('taylor')->get('baz'));
     }
 
     public function testPullTriggersEvents()
@@ -63,7 +63,7 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['key' => 'baz', 'value' => 'qux']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['key' => 'baz']));
-        $this->assertEquals('qux', $repository->pull('baz'));
+        $this->assertSame('qux', $repository->pull('baz'));
     }
 
     public function testPullTriggersEventsUsingTags()
@@ -73,7 +73,7 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheHit::class, ['key' => 'baz', 'value' => 'qux', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyForgotten::class, ['key' => 'baz', 'tags' => ['taylor']]));
-        $this->assertEquals('qux', $repository->tags('taylor')->pull('baz'));
+        $this->assertSame('qux', $repository->tags('taylor')->pull('baz'));
     }
 
     public function testPutTriggersEvents()
@@ -121,13 +121,13 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
-        $this->assertEquals('bar', $repository->remember('foo', 99, function () {
+        $this->assertSame('bar', $repository->remember('foo', 99, function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
-        $this->assertEquals('bar', $repository->tags('taylor')->remember('foo', 99, function () {
+        $this->assertSame('bar', $repository->tags('taylor')->remember('foo', 99, function () {
             return 'bar';
         }));
     }
@@ -139,13 +139,13 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null]));
-        $this->assertEquals('bar', $repository->rememberForever('foo', function () {
+        $this->assertSame('bar', $repository->rememberForever('foo', function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
-        $this->assertEquals('bar', $repository->tags('taylor')->rememberForever('foo', function () {
+        $this->assertSame('bar', $repository->tags('taylor')->rememberForever('foo', function () {
             return 'bar';
         }));
     }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -63,7 +63,7 @@ class CacheFileStoreTest extends TestCase
         $contents = '9999999999'.serialize('Hello World');
         $files->expects($this->once())->method('get')->willReturn($contents);
         $store = new FileStore($files, __DIR__);
-        $this->assertEquals('Hello World', $store->get('foo'));
+        $this->assertSame('Hello World', $store->get('foo'));
     }
 
     public function testStoreItemProperlyStoresValues()
@@ -99,7 +99,7 @@ class CacheFileStoreTest extends TestCase
         $store->forever('foo', 'Hello World');
         $store->increment('foo');
         $files->expects($this->once())->method('get')->willReturn($contents);
-        $this->assertEquals('Hello World', $store->get('foo'));
+        $this->assertSame('Hello World', $store->get('foo'));
     }
 
     public function testIncrementDoesNotExtendCacheLife()

--- a/tests/Cache/CacheMemcachedStoreTest.php
+++ b/tests/Cache/CacheMemcachedStoreTest.php
@@ -33,7 +33,7 @@ class CacheMemcachedStoreTest extends TestCase
         $memcache->expects($this->once())->method('get')->willReturn('bar');
         $memcache->expects($this->once())->method('getResultCode')->willReturn(0);
         $store = new MemcachedStore($memcache);
-        $this->assertEquals('bar', $store->get('foo'));
+        $this->assertSame('bar', $store->get('foo'));
     }
 
     public function testMemcacheGetMultiValuesAreReturnedWithCorrectKeys()
@@ -143,9 +143,9 @@ class CacheMemcachedStoreTest extends TestCase
         }
 
         $store = new MemcachedStore(new Memcached, 'bar');
-        $this->assertEquals('bar:', $store->getPrefix());
+        $this->assertSame('bar:', $store->getPrefix());
         $store->setPrefix('foo');
-        $this->assertEquals('foo:', $store->getPrefix());
+        $this->assertSame('foo:', $store->getPrefix());
         $store->setPrefix(null);
         $this->assertEmpty($store->getPrefix());
     }

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -27,7 +27,7 @@ class CacheRedisStoreTest extends TestCase
         $redis = $this->getRedis();
         $redis->getRedis()->shouldReceive('connection')->once()->with('default')->andReturn($redis->getRedis());
         $redis->getRedis()->shouldReceive('get')->once()->with('prefix:foo')->andReturn(serialize('foo'));
-        $this->assertEquals('foo', $redis->get('foo'));
+        $this->assertSame('foo', $redis->get('foo'));
     }
 
     public function testRedisMultipleValuesAreReturned()
@@ -44,9 +44,9 @@ class CacheRedisStoreTest extends TestCase
 
         $results = $redis->many(['foo', 'fizz', 'norf', 'null']);
 
-        $this->assertEquals('bar', $results['foo']);
-        $this->assertEquals('buzz', $results['fizz']);
-        $this->assertEquals('quz', $results['norf']);
+        $this->assertSame('bar', $results['foo']);
+        $this->assertSame('buzz', $results['fizz']);
+        $this->assertSame('quz', $results['norf']);
         $this->assertNull($results['null']);
     }
 
@@ -141,9 +141,9 @@ class CacheRedisStoreTest extends TestCase
     public function testGetAndSetPrefix()
     {
         $redis = $this->getRedis();
-        $this->assertEquals('prefix:', $redis->getPrefix());
+        $this->assertSame('prefix:', $redis->getPrefix());
         $redis->setPrefix('foo');
-        $this->assertEquals('foo:', $redis->getPrefix());
+        $this->assertSame('foo:', $redis->getPrefix());
         $redis->setPrefix(null);
         $this->assertEmpty($redis->getPrefix());
     }

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -28,7 +28,7 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->with('foo')->andReturn('bar');
-        $this->assertEquals('bar', $repo->get('foo'));
+        $this->assertSame('bar', $repo->get('foo'));
     }
 
     public function testGetReturnsMultipleValuesFromCacheWhenGivenAnArray()
@@ -49,8 +49,8 @@ class CacheRepositoryTest extends TestCase
     {
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
-        $this->assertEquals('bar', $repo->get('foo', 'bar'));
-        $this->assertEquals('baz', $repo->get('boom', function () {
+        $this->assertSame('bar', $repo->get('foo', 'bar'));
+        $this->assertSame('baz', $repo->get('boom', function () {
             return 'baz';
         }));
     }
@@ -92,7 +92,7 @@ class CacheRepositoryTest extends TestCase
         $result = $repo->remember('foo', 10, function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
 
         /*
          * Use Carbon object...
@@ -106,11 +106,11 @@ class CacheRepositoryTest extends TestCase
         $result = $repo->remember('foo', Carbon::now()->addMinutes(10)->addSeconds(2), function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
         $result = $repo->remember('baz', Carbon::now()->addMinutes(10)->subSeconds(2), function () {
             return 'qux';
         });
-        $this->assertEquals('qux', $result);
+        $this->assertSame('qux', $result);
     }
 
     public function testRememberForeverMethodCallsForeverAndReturnsDefault()
@@ -121,7 +121,7 @@ class CacheRepositoryTest extends TestCase
         $result = $repo->rememberForever('foo', function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
     }
 
     public function testPuttingMultipleItemsInCache()

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -24,7 +24,7 @@ class CacheTaggedCacheTest extends TestCase
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
         $store->tags($tags)->put('foo', 'bar', 10);
-        $this->assertEquals('bar', $store->tags($tags)->get('foo'));
+        $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
     public function testCacheCanBeSetWithDatetimeArgument()
@@ -34,7 +34,7 @@ class CacheTaggedCacheTest extends TestCase
         $duration = new DateTime;
         $duration->add(new DateInterval('PT10M'));
         $store->tags($tags)->put('foo', 'bar', $duration);
-        $this->assertEquals('bar', $store->tags($tags)->get('foo'));
+        $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
     public function testCacheSavedWithMultipleTagsCanBeFlushed()
@@ -46,14 +46,14 @@ class CacheTaggedCacheTest extends TestCase
         $store->tags($tags2)->put('foo', 'bar', 10);
         $store->tags('zap')->flush();
         $this->assertNull($store->tags($tags1)->get('foo'));
-        $this->assertEquals('bar', $store->tags($tags2)->get('foo'));
+        $this->assertSame('bar', $store->tags($tags2)->get('foo'));
     }
 
     public function testTagsWithStringArgument()
     {
         $store = new ArrayStore;
         $store->tags('bop')->put('foo', 'bar', 10);
-        $this->assertEquals('bar', $store->tags('bop')->get('foo'));
+        $this->assertSame('bar', $store->tags('bop')->get('foo'));
     }
 
     public function testTagsWithIncrementCanBeFlushed()
@@ -79,7 +79,7 @@ class CacheTaggedCacheTest extends TestCase
         $store = new ArrayStore;
         $tags = ['bop', 'zap'];
         $store->tags($tags)->forever('foo', 'bar');
-        $this->assertEquals('bar', $store->tags($tags)->get('foo'));
+        $this->assertSame('bar', $store->tags($tags)->get('foo'));
     }
 
     public function testRedisCacheTagsPushForeverKeysCorrectly()

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -61,14 +61,14 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule->exec('path/to/command', ['-1 minute']);
 
         $events = $schedule->events();
-        $this->assertEquals('path/to/command', $events[0]->command);
-        $this->assertEquals('path/to/command -f --foo="bar"', $events[1]->command);
-        $this->assertEquals('path/to/command -f', $events[2]->command);
-        $this->assertEquals("path/to/command --foo={$escape}bar{$escape}", $events[3]->command);
-        $this->assertEquals("path/to/command -f --foo={$escape}bar{$escape}", $events[4]->command);
-        $this->assertEquals("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
-        $this->assertEquals("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
-        $this->assertEquals("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
+        $this->assertSame('path/to/command', $events[0]->command);
+        $this->assertSame('path/to/command -f --foo="bar"', $events[1]->command);
+        $this->assertSame('path/to/command -f', $events[2]->command);
+        $this->assertSame("path/to/command --foo={$escape}bar{$escape}", $events[3]->command);
+        $this->assertSame("path/to/command -f --foo={$escape}bar{$escape}", $events[4]->command);
+        $this->assertSame("path/to/command --title={$escape}A {$escapeReal}real{$escapeReal} test{$escape}", $events[5]->command);
+        $this->assertSame("path/to/command {$escape}one{$escape} {$escape}two{$escape}", $events[6]->command);
+        $this->assertSame("path/to/command {$escape}-1 minute{$escape}", $events[7]->command);
     }
 
     public function testExecCreatesNewCommandWithTimezone()
@@ -76,12 +76,12 @@ class ConsoleEventSchedulerTest extends TestCase
         $schedule = new Schedule('UTC');
         $schedule->exec('path/to/command');
         $events = $schedule->events();
-        $this->assertEquals('UTC', $events[0]->timezone);
+        $this->assertSame('UTC', $events[0]->timezone);
 
         $schedule = new Schedule('Asia/Tokyo');
         $schedule->exec('path/to/command');
         $events = $schedule->events();
-        $this->assertEquals('Asia/Tokyo', $events[0]->timezone);
+        $this->assertSame('Asia/Tokyo', $events[0]->timezone);
     }
 
     public function testCommandCreatesNewArtisanCommand()

--- a/tests/Console/ConsoleParserTest.php
+++ b/tests/Console/ConsoleParserTest.php
@@ -12,43 +12,43 @@ class ConsoleParserTest extends TestCase
     {
         $results = Parser::parse('command:name');
 
-        $this->assertEquals('command:name', $results[0]);
+        $this->assertSame('command:name', $results[0]);
 
         $results = Parser::parse('command:name {argument} {--option}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('argument', $results[1][0]->getName());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertFalse($results[2][0]->acceptValue());
 
         $results = Parser::parse('command:name {argument*} {--option=}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('argument', $results[1][0]->getName());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
         $this->assertTrue($results[1][0]->isArray());
         $this->assertTrue($results[1][0]->isRequired());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertTrue($results[2][0]->acceptValue());
 
         $results = Parser::parse('command:name {argument?*} {--option=*}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('argument', $results[1][0]->getName());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
         $this->assertTrue($results[1][0]->isArray());
         $this->assertFalse($results[1][0]->isRequired());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
 
         $results = Parser::parse('command:name {argument?* : The argument description.}    {--option=* : The option description.}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('argument', $results[1][0]->getName());
-        $this->assertEquals('The argument description.', $results[1][0]->getDescription());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
+        $this->assertSame('The argument description.', $results[1][0]->getDescription());
         $this->assertTrue($results[1][0]->isArray());
         $this->assertFalse($results[1][0]->isRequired());
-        $this->assertEquals('option', $results[2][0]->getName());
-        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description.', $results[2][0]->getDescription());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
 
@@ -56,13 +56,13 @@ class ConsoleParserTest extends TestCase
             {argument?* : The argument description.}
             {--option=* : The option description.}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('argument', $results[1][0]->getName());
-        $this->assertEquals('The argument description.', $results[1][0]->getDescription());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('argument', $results[1][0]->getName());
+        $this->assertSame('The argument description.', $results[1][0]->getDescription());
         $this->assertTrue($results[1][0]->isArray());
         $this->assertFalse($results[1][0]->isRequired());
-        $this->assertEquals('option', $results[2][0]->getName());
-        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description.', $results[2][0]->getDescription());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
     }
@@ -71,40 +71,40 @@ class ConsoleParserTest extends TestCase
     {
         $results = Parser::parse('command:name {--o|option}');
 
-        $this->assertEquals('o', $results[2][0]->getShortcut());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertFalse($results[2][0]->acceptValue());
 
         $results = Parser::parse('command:name {--o|option=}');
 
-        $this->assertEquals('o', $results[2][0]->getShortcut());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertTrue($results[2][0]->acceptValue());
 
         $results = Parser::parse('command:name {--o|option=*}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('o', $results[2][0]->getShortcut());
-        $this->assertEquals('option', $results[2][0]->getName());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
 
         $results = Parser::parse('command:name {--o|option=* : The option description.}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('o', $results[2][0]->getShortcut());
-        $this->assertEquals('option', $results[2][0]->getName());
-        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description.', $results[2][0]->getDescription());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
 
         $results = Parser::parse('command:name
             {--o|option=* : The option description.}');
 
-        $this->assertEquals('command:name', $results[0]);
-        $this->assertEquals('o', $results[2][0]->getShortcut());
-        $this->assertEquals('option', $results[2][0]->getName());
-        $this->assertEquals('The option description.', $results[2][0]->getDescription());
+        $this->assertSame('command:name', $results[0]);
+        $this->assertSame('o', $results[2][0]->getShortcut());
+        $this->assertSame('option', $results[2][0]->getName());
+        $this->assertSame('The option description.', $results[2][0]->getDescription());
         $this->assertTrue($results[2][0]->acceptValue());
         $this->assertTrue($results[2][0]->isArray());
     }
@@ -114,9 +114,9 @@ class ConsoleParserTest extends TestCase
         $results = Parser::parse('command:name {argument=defaultArgumentValue} {--option=defaultOptionValue}');
 
         $this->assertFalse($results[1][0]->isRequired());
-        $this->assertEquals('defaultArgumentValue', $results[1][0]->getDefault());
+        $this->assertSame('defaultArgumentValue', $results[1][0]->getDefault());
         $this->assertTrue($results[2][0]->acceptValue());
-        $this->assertEquals('defaultOptionValue', $results[2][0]->getDefault());
+        $this->assertSame('defaultOptionValue', $results[2][0]->getDefault());
 
         $results = Parser::parse('command:name {argument=*defaultArgumentValue1,defaultArgumentValue2} {--option=*defaultOptionValue1,defaultOptionValue2}');
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -38,7 +38,7 @@ class ConsoleScheduledEventTest extends TestCase
         $app->shouldReceive('environment')->andReturn('production');
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('* * * * *', $event->getExpression());
+        $this->assertSame('* * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
         $this->assertTrue($event->skip(function () {
             return true;
@@ -48,17 +48,17 @@ class ConsoleScheduledEventTest extends TestCase
         })->filtersPass($app));
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('* * * * *', $event->getExpression());
+        $this->assertSame('* * * * *', $event->getExpression());
         $this->assertFalse($event->environments('local')->isDue($app));
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('* * * * *', $event->getExpression());
+        $this->assertSame('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(function () {
             return false;
         })->filtersPass($app));
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('* * * * *', $event->getExpression());
+        $this->assertSame('* * * * *', $event->getExpression());
         $this->assertFalse($event->when(false)->filtersPass($app));
 
         // chained rules should be commutative
@@ -83,11 +83,11 @@ class ConsoleScheduledEventTest extends TestCase
         Carbon::setTestNow(Carbon::create(2015, 1, 1, 0, 0, 0));
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('* * * * 4', $event->thursdays()->getExpression());
+        $this->assertSame('* * * * 4', $event->thursdays()->getExpression());
         $this->assertTrue($event->isDue($app));
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
-        $this->assertEquals('0 19 * * 3', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
+        $this->assertSame('0 19 * * 3', $event->wednesdays()->at('19:00')->timezone('EST')->getExpression());
         $this->assertTrue($event->isDue($app));
     }
 

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -24,100 +24,100 @@ class FrequencyTest extends TestCase
 
     public function testEveryMinute()
     {
-        $this->assertEquals('* * * * *', $this->event->getExpression());
-        $this->assertEquals('* * * * *', $this->event->everyMinute()->getExpression());
+        $this->assertSame('* * * * *', $this->event->getExpression());
+        $this->assertSame('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
     public function testEveryFiveMinutes()
     {
-        $this->assertEquals('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
+        $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
     public function testDaily()
     {
-        $this->assertEquals('0 0 * * *', $this->event->daily()->getExpression());
+        $this->assertSame('0 0 * * *', $this->event->daily()->getExpression());
     }
 
     public function testTwiceDaily()
     {
-        $this->assertEquals('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
+        $this->assertSame('0 3,15 * * *', $this->event->twiceDaily(3, 15)->getExpression());
     }
 
     public function testOverrideWithHourly()
     {
-        $this->assertEquals('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
-        $this->assertEquals('37 * * * *', $this->event->hourlyAt(37)->getExpression());
-        $this->assertEquals('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
+        $this->assertSame('0 * * * *', $this->event->everyFiveMinutes()->hourly()->getExpression());
+        $this->assertSame('37 * * * *', $this->event->hourlyAt(37)->getExpression());
+        $this->assertSame('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
     public function testMonthlyOn()
     {
-        $this->assertEquals('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
+        $this->assertSame('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());
     }
 
     public function testTwiceMonthly()
     {
-        $this->assertEquals('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
+        $this->assertSame('0 0 1,16 * *', $this->event->twiceMonthly(1, 16)->getExpression());
     }
 
     public function testMonthlyOnWithMinutes()
     {
-        $this->assertEquals('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());
+        $this->assertSame('15 15 4 * *', $this->event->monthlyOn(4, '15:15')->getExpression());
     }
 
     public function testWeekdaysDaily()
     {
-        $this->assertEquals('0 0 * * 1-5', $this->event->weekdays()->daily()->getExpression());
+        $this->assertSame('0 0 * * 1-5', $this->event->weekdays()->daily()->getExpression());
     }
 
     public function testWeekdaysHourly()
     {
-        $this->assertEquals('0 * * * 1-5', $this->event->weekdays()->hourly()->getExpression());
+        $this->assertSame('0 * * * 1-5', $this->event->weekdays()->hourly()->getExpression());
     }
 
     public function testWeekdays()
     {
-        $this->assertEquals('* * * * 1-5', $this->event->weekdays()->getExpression());
+        $this->assertSame('* * * * 1-5', $this->event->weekdays()->getExpression());
     }
 
     public function testSundays()
     {
-        $this->assertEquals('* * * * 0', $this->event->sundays()->getExpression());
+        $this->assertSame('* * * * 0', $this->event->sundays()->getExpression());
     }
 
     public function testMondays()
     {
-        $this->assertEquals('* * * * 1', $this->event->mondays()->getExpression());
+        $this->assertSame('* * * * 1', $this->event->mondays()->getExpression());
     }
 
     public function testTuesdays()
     {
-        $this->assertEquals('* * * * 2', $this->event->tuesdays()->getExpression());
+        $this->assertSame('* * * * 2', $this->event->tuesdays()->getExpression());
     }
 
     public function testWednesdays()
     {
-        $this->assertEquals('* * * * 3', $this->event->wednesdays()->getExpression());
+        $this->assertSame('* * * * 3', $this->event->wednesdays()->getExpression());
     }
 
     public function testThursdays()
     {
-        $this->assertEquals('* * * * 4', $this->event->thursdays()->getExpression());
+        $this->assertSame('* * * * 4', $this->event->thursdays()->getExpression());
     }
 
     public function testFridays()
     {
-        $this->assertEquals('* * * * 5', $this->event->fridays()->getExpression());
+        $this->assertSame('* * * * 5', $this->event->fridays()->getExpression());
     }
 
     public function testSaturdays()
     {
-        $this->assertEquals('* * * * 6', $this->event->saturdays()->getExpression());
+        $this->assertSame('* * * * 6', $this->event->saturdays()->getExpression());
     }
 
     public function testQuarterly()
     {
-        $this->assertEquals('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
+        $this->assertSame('0 0 1 1-12/3 *', $this->event->quarterly()->getExpression());
     }
 
     public function testFrequencyMacro()
@@ -126,6 +126,6 @@ class FrequencyTest extends TestCase
             return $this->spliceIntoPosition(1, "*/{$x}");
         });
 
-        $this->assertEquals('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
+        $this->assertSame('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
     }
 }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -28,12 +28,12 @@ class ContainerCallTest extends TestCase
         $container = new Container;
         $result = $container->call(ContainerTestCallStub::class.'@inject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
 
         $container = new Container;
         $result = $container->call(ContainerTestCallStub::class.'@inject', ['default' => 'foo']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('foo', $result[1]);
+        $this->assertSame('foo', $result[1]);
 
         $container = new Container;
         $result = $container->call(ContainerTestCallStub::class, ['foo', 'bar'], 'work');
@@ -53,7 +53,7 @@ class ContainerCallTest extends TestCase
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\ContainerStaticMethodStub::inject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
     }
 
     public function testCallWithGlobalMethodName()
@@ -61,7 +61,7 @@ class ContainerCallTest extends TestCase
         $container = new Container;
         $result = $container->call('Illuminate\Tests\Container\containerTestInject');
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
     }
 
     public function testCallWithBoundMethod()
@@ -83,12 +83,12 @@ class ContainerCallTest extends TestCase
         $container = new Container;
         $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo', 'default' => 'bar']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('bar', $result[1]);
+        $this->assertSame('bar', $result[1]);
 
         $container = new Container;
         $result = $container->call([new ContainerTestCallStub, 'inject'], ['_stub' => 'foo']);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
     }
 
     public function testBindMethodAcceptsAnArray()
@@ -135,7 +135,7 @@ class ContainerCallTest extends TestCase
         }, ['bar' => 'taylor']);
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
 
         $stub = new ContainerCallConcreteStub;
         $result = $container->call(function (stdClass $foo, ContainerCallConcreteStub $bar) {
@@ -156,7 +156,7 @@ class ContainerCallTest extends TestCase
         $result = $result();
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
-        $this->assertEquals('taylor', $result[1]);
+        $this->assertSame('taylor', $result[1]);
     }
 }
 

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -16,7 +16,7 @@ class ContainerExtendTest extends TestCase
             return $old.'bar';
         });
 
-        $this->assertEquals('foobar', $container->make('foo'));
+        $this->assertSame('foobar', $container->make('foo'));
 
         $container = new Container;
 
@@ -31,7 +31,7 @@ class ContainerExtendTest extends TestCase
 
         $result = $container->make('foo');
 
-        $this->assertEquals('taylor', $result->name);
+        $this->assertSame('taylor', $result->name);
         $this->assertEquals(26, $result->age);
         $this->assertSame($result, $container->make('foo'));
     }
@@ -60,9 +60,9 @@ class ContainerExtendTest extends TestCase
             return $obj;
         });
 
-        $this->assertEquals('foo', $container->make('foo')->foo);
-        $this->assertEquals('baz', $container->make('foo')->bar);
-        $this->assertEquals('foo', $container->make('foo')->baz);
+        $this->assertSame('foo', $container->make('foo')->foo);
+        $this->assertSame('baz', $container->make('foo')->bar);
+        $this->assertSame('foo', $container->make('foo')->baz);
     }
 
     public function testExtendIsLazyInitialized()
@@ -89,7 +89,7 @@ class ContainerExtendTest extends TestCase
         });
         $container['foo'] = 'foo';
 
-        $this->assertEquals('foobar', $container->make('foo'));
+        $this->assertSame('foobar', $container->make('foo'));
     }
 
     public function testExtendInstanceRebindingCallback()
@@ -145,7 +145,7 @@ class ContainerExtendTest extends TestCase
             return $value.' extended';
         });
 
-        $this->assertEquals('some value extended', $container->make('something'));
+        $this->assertSame('some value extended', $container->make('something'));
     }
 
     public function testMultipleExtends()
@@ -159,7 +159,7 @@ class ContainerExtendTest extends TestCase
             return $old.'baz';
         });
 
-        $this->assertEquals('foobarbaz', $container->make('foo'));
+        $this->assertSame('foobarbaz', $container->make('foo'));
     }
 
     public function testUnsetExtend()
@@ -185,7 +185,7 @@ class ContainerExtendTest extends TestCase
             return 'foo';
         });
 
-        $this->assertEquals('foo', $container->make('foo'));
+        $this->assertSame('foo', $container->make('foo'));
     }
 }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -36,7 +36,7 @@ class ContainerTest extends TestCase
         $container->bind('name', function () {
             return 'Taylor';
         });
-        $this->assertEquals('Taylor', $container->make('name'));
+        $this->assertSame('Taylor', $container->make('name'));
     }
 
     public function testBindIfDoesntRegisterIfServiceAlreadyRegistered()
@@ -49,7 +49,7 @@ class ContainerTest extends TestCase
             return 'Dayle';
         });
 
-        $this->assertEquals('Taylor', $container->make('name'));
+        $this->assertSame('Taylor', $container->make('name'));
     }
 
     public function testBindIfDoesRegisterIfServiceNotRegisteredYet()
@@ -62,7 +62,7 @@ class ContainerTest extends TestCase
             return 'Dayle';
         });
 
-        $this->assertEquals('Dayle', $container->make('name'));
+        $this->assertSame('Dayle', $container->make('name'));
     }
 
     public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
@@ -155,7 +155,7 @@ class ContainerTest extends TestCase
             return 'foo';
         };
         $this->assertTrue(isset($container['something']));
-        $this->assertEquals('foo', $container['something']);
+        $this->assertSame('foo', $container['something']);
         unset($container['something']);
         $this->assertFalse(isset($container['something']));
     }
@@ -166,9 +166,9 @@ class ContainerTest extends TestCase
         $container['foo'] = 'bar';
         $container->alias('foo', 'baz');
         $container->alias('baz', 'bat');
-        $this->assertEquals('bar', $container->make('foo'));
-        $this->assertEquals('bar', $container->make('baz'));
-        $this->assertEquals('bar', $container->make('bat'));
+        $this->assertSame('bar', $container->make('foo'));
+        $this->assertSame('bar', $container->make('baz'));
+        $this->assertSame('bar', $container->make('bat'));
     }
 
     public function testAliasesWithArrayOfParameters()
@@ -186,7 +186,7 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container['foo'] = 'bar';
         $container['foo'] = 'baz';
-        $this->assertEquals('baz', $container['foo']);
+        $this->assertSame('baz', $container['foo']);
     }
 
     public function testBindingAnInstanceReturnsTheInstance()
@@ -204,7 +204,7 @@ class ContainerTest extends TestCase
         $container = new Container;
         $instance = $container->make(ContainerDefaultValueStub::class);
         $this->assertInstanceOf(ContainerConcreteStub::class, $instance->stub);
-        $this->assertEquals('taylor', $instance->default);
+        $this->assertSame('taylor', $instance->default);
     }
 
     public function testUnsetRemoveBoundInstances()
@@ -424,10 +424,10 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
         $instance = $container->make(ContainerDefaultValueStub::class, ['default' => 'adam']);
-        $this->assertEquals('adam', $instance->default);
+        $this->assertSame('adam', $instance->default);
 
         $instance = $container->make(ContainerDefaultValueStub::class);
-        $this->assertEquals('taylor', $instance->default);
+        $this->assertSame('taylor', $instance->default);
 
         $container->bind('foo', function ($app, $config) {
             return $config;
@@ -441,7 +441,7 @@ class ContainerTest extends TestCase
         $container = new Container;
         $container->bind(IContainerContractStub::class, ContainerInjectVariableStubWithInterfaceImplementation::class);
         $instance = $container->make(IContainerContractStub::class, ['something' => 'laurence']);
-        $this->assertEquals('laurence', $instance->something);
+        $this->assertSame('laurence', $instance->something);
     }
 
     public function testNestedParameterOverride()

--- a/tests/Container/ResolvingCallbackTest.php
+++ b/tests/Container/ResolvingCallbackTest.php
@@ -19,7 +19,7 @@ class ResolvingCallbackTest extends TestCase
         });
         $instance = $container->make('foo');
 
-        $this->assertEquals('taylor', $instance->name);
+        $this->assertSame('taylor', $instance->name);
     }
 
     public function testResolvingCallbacksAreCalled()
@@ -33,7 +33,7 @@ class ResolvingCallbackTest extends TestCase
         });
         $instance = $container->make('foo');
 
-        $this->assertEquals('taylor', $instance->name);
+        $this->assertSame('taylor', $instance->name);
     }
 
     public function testResolvingCallbacksAreCalledForType()
@@ -47,7 +47,7 @@ class ResolvingCallbackTest extends TestCase
         });
         $instance = $container->make('foo');
 
-        $this->assertEquals('taylor', $instance->name);
+        $this->assertSame('taylor', $instance->name);
     }
 
     public function testResolvingCallbacksShouldBeFiredWhenCalledWithAliases()
@@ -62,7 +62,7 @@ class ResolvingCallbackTest extends TestCase
         });
         $instance = $container->make('foo');
 
-        $this->assertEquals('taylor', $instance->name);
+        $this->assertSame('taylor', $instance->name);
     }
 
     public function testResolvingCallbacksAreCalledOnceForImplementation()

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -19,20 +19,20 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('foo', 'bar');
         $c = $cookie->make('color', 'blue', 10, '/path', '/domain', true, false, false, 'lax');
-        $this->assertEquals('blue', $c->getValue());
+        $this->assertSame('blue', $c->getValue());
         $this->assertFalse($c->isHttpOnly());
         $this->assertTrue($c->isSecure());
-        $this->assertEquals('/domain', $c->getDomain());
-        $this->assertEquals('/path', $c->getPath());
-        $this->assertEquals('lax', $c->getSameSite());
+        $this->assertSame('/domain', $c->getDomain());
+        $this->assertSame('/path', $c->getPath());
+        $this->assertSame('lax', $c->getSameSite());
 
         $c2 = $cookie->forever('color', 'blue', '/path', '/domain', true, false, false, 'strict');
-        $this->assertEquals('blue', $c2->getValue());
+        $this->assertSame('blue', $c2->getValue());
         $this->assertFalse($c2->isHttpOnly());
         $this->assertTrue($c2->isSecure());
-        $this->assertEquals('/domain', $c2->getDomain());
-        $this->assertEquals('/path', $c2->getPath());
-        $this->assertEquals('strict', $c2->getSameSite());
+        $this->assertSame('/domain', $c2->getDomain());
+        $this->assertSame('/path', $c2->getPath());
+        $this->assertSame('strict', $c2->getSameSite());
 
         $c3 = $cookie->forget('color');
         $this->assertNull($c3->getValue());
@@ -44,11 +44,11 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
         $c = $cookie->make('color', 'blue');
-        $this->assertEquals('blue', $c->getValue());
+        $this->assertSame('blue', $c->getValue());
         $this->assertTrue($c->isSecure());
-        $this->assertEquals('/domain', $c->getDomain());
-        $this->assertEquals('/path', $c->getPath());
-        $this->assertEquals('lax', $c->getSameSite());
+        $this->assertSame('/domain', $c->getDomain());
+        $this->assertSame('/path', $c->getPath());
+        $this->assertSame('lax', $c->getSameSite());
     }
 
     public function testCookiesCanSetSecureOptionUsingDefaultPathAndDomain()
@@ -56,11 +56,11 @@ class CookieTest extends TestCase
         $cookie = $this->getCreator();
         $cookie->setDefaultPathAndDomain('/path', '/domain', true, 'lax');
         $c = $cookie->make('color', 'blue', 10, null, null, false);
-        $this->assertEquals('blue', $c->getValue());
+        $this->assertSame('blue', $c->getValue());
         $this->assertFalse($c->isSecure());
-        $this->assertEquals('/domain', $c->getDomain());
-        $this->assertEquals('/path', $c->getPath());
-        $this->assertEquals('lax', $c->getSameSite());
+        $this->assertSame('/domain', $c->getDomain());
+        $this->assertSame('/path', $c->getPath());
+        $this->assertSame('lax', $c->getSameSite());
     }
 
     public function testQueuedCookies()
@@ -151,7 +151,7 @@ class CookieTest extends TestCase
         $cookie->macro('foo', function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $cookie->foo());
+        $this->assertSame('bar', $cookie->foo());
     }
 
     public function testQueueCookie(): void

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -49,10 +49,10 @@ class EncryptCookiesTest extends TestCase
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(2, $cookies);
-        $this->assertEquals('encrypted_cookie', $cookies[0]->getName());
+        $this->assertSame('encrypted_cookie', $cookies[0]->getName());
         $this->assertNotEquals('value', $cookies[0]->getValue());
-        $this->assertEquals('unencrypted_cookie', $cookies[1]->getName());
-        $this->assertEquals('value', $cookies[1]->getValue());
+        $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
+        $this->assertSame('value', $cookies[1]->getValue());
     }
 
     public function testQueuedCookieEncryption()
@@ -66,10 +66,10 @@ class EncryptCookiesTest extends TestCase
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(2, $cookies);
-        $this->assertEquals('encrypted_cookie', $cookies[0]->getName());
+        $this->assertSame('encrypted_cookie', $cookies[0]->getName());
         $this->assertNotEquals('value', $cookies[0]->getValue());
-        $this->assertEquals('unencrypted_cookie', $cookies[1]->getName());
-        $this->assertEquals('value', $cookies[1]->getValue());
+        $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
+        $this->assertSame('value', $cookies[1]->getValue());
     }
 }
 

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -50,7 +50,7 @@ class EncryptCookiesTest extends TestCase
         $cookies = $response->headers->getCookies();
         $this->assertCount(2, $cookies);
         $this->assertSame('encrypted_cookie', $cookies[0]->getName());
-        $this->assertNotEquals('value', $cookies[0]->getValue());
+        $this->assertNotSame('value', $cookies[0]->getValue());
         $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
         $this->assertSame('value', $cookies[1]->getValue());
     }
@@ -67,7 +67,7 @@ class EncryptCookiesTest extends TestCase
         $cookies = $response->headers->getCookies();
         $this->assertCount(2, $cookies);
         $this->assertSame('encrypted_cookie', $cookies[0]->getName());
-        $this->assertNotEquals('value', $cookies[0]->getValue());
+        $this->assertNotSame('value', $cookies[0]->getValue());
         $this->assertSame('unencrypted_cookie', $cookies[1]->getName());
         $this->assertSame('value', $cookies[1]->getValue());
     }

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -135,7 +135,7 @@ class DatabaseConnectionFactoryTest extends TestCase
         $container->shouldReceive('bound')->once()->with('db.connector.foo')->andReturn(true);
         $container->shouldReceive('make')->once()->with('db.connector.foo')->andReturn('connector');
 
-        $this->assertEquals('connector', $factory->createConnector(['driver' => 'foo']));
+        $this->assertSame('connector', $factory->createConnector(['driver' => 'foo']));
     }
 
     public function testSqliteForeignKeyConstraints()

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -52,7 +52,7 @@ class DatabaseConnectionTest extends TestCase
     {
         $connection = $this->getMockConnection(['select']);
         $connection->expects($this->once())->method('select')->with('foo', ['bar' => 'baz'])->willReturn(['foo']);
-        $this->assertEquals('foo', $connection->selectOne('foo', ['bar' => 'baz']));
+        $this->assertSame('foo', $connection->selectOne('foo', ['bar' => 'baz']));
     }
 
     public function testSelectProperlyCallsPDO()
@@ -71,7 +71,7 @@ class DatabaseConnectionTest extends TestCase
         $results = $mock->select('foo', ['foo' => 'bar']);
         $this->assertEquals(['boom'], $results);
         $log = $mock->getQueryLog();
-        $this->assertEquals('foo', $log[0]['query']);
+        $this->assertSame('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
         $this->assertIsNumeric($log[0]['time']);
     }
@@ -81,7 +81,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['statement']);
         $connection->expects($this->once())->method('statement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
         $results = $connection->insert('foo', ['bar']);
-        $this->assertEquals('baz', $results);
+        $this->assertSame('baz', $results);
     }
 
     public function testUpdateCallsTheAffectingStatementMethod()
@@ -89,7 +89,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['affectingStatement']);
         $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
         $results = $connection->update('foo', ['bar']);
-        $this->assertEquals('baz', $results);
+        $this->assertSame('baz', $results);
     }
 
     public function testDeleteCallsTheAffectingStatementMethod()
@@ -97,7 +97,7 @@ class DatabaseConnectionTest extends TestCase
         $connection = $this->getMockConnection(['affectingStatement']);
         $connection->expects($this->once())->method('affectingStatement')->with($this->equalTo('foo'), $this->equalTo(['bar']))->willReturn('baz');
         $results = $connection->delete('foo', ['bar']);
-        $this->assertEquals('baz', $results);
+        $this->assertSame('baz', $results);
     }
 
     public function testStatementProperlyCallsPDO()
@@ -110,9 +110,9 @@ class DatabaseConnectionTest extends TestCase
         $mock = $this->getMockConnection(['prepareBindings'], $pdo);
         $mock->expects($this->once())->method('prepareBindings')->with($this->equalTo(['bar']))->willReturn(['bar']);
         $results = $mock->statement('foo', ['bar']);
-        $this->assertEquals('foo', $results);
+        $this->assertSame('foo', $results);
         $log = $mock->getQueryLog();
-        $this->assertEquals('foo', $log[0]['query']);
+        $this->assertSame('foo', $log[0]['query']);
         $this->assertEquals(['bar'], $log[0]['bindings']);
         $this->assertIsNumeric($log[0]['time']);
     }
@@ -130,7 +130,7 @@ class DatabaseConnectionTest extends TestCase
         $results = $mock->update('foo', ['foo' => 'bar']);
         $this->assertEquals(['boom'], $results);
         $log = $mock->getQueryLog();
-        $this->assertEquals('foo', $log[0]['query']);
+        $this->assertSame('foo', $log[0]['query']);
         $this->assertEquals(['foo' => 'bar'], $log[0]['bindings']);
         $this->assertIsNumeric($log[0]['time']);
     }
@@ -267,7 +267,7 @@ class DatabaseConnectionTest extends TestCase
                 throw new Exception('foo');
             });
         } catch (Exception $e) {
-            $this->assertEquals('foo', $e->getMessage());
+            $this->assertSame('foo', $e->getMessage());
         }
     }
 
@@ -305,7 +305,7 @@ class DatabaseConnectionTest extends TestCase
             $called = true;
         });
 
-        $this->assertEquals('result', $connection->statement('foo'));
+        $this->assertSame('result', $connection->statement('foo'));
 
         $this->assertTrue($called);
     }
@@ -350,7 +350,7 @@ class DatabaseConnectionTest extends TestCase
         $conn->setPostProcessor(m::mock(Processor::class));
         $builder = $conn->table('users');
         $this->assertInstanceOf(BaseBuilder::class, $builder);
-        $this->assertEquals('users', $builder->from);
+        $this->assertSame('users', $builder->from);
     }
 
     public function testPrepareBindings()
@@ -381,7 +381,7 @@ class DatabaseConnectionTest extends TestCase
         $queries = $connection->pretend(function ($connection) {
             $connection->select('foo bar', ['baz']);
         });
-        $this->assertEquals('foo bar', $queries[0]['query']);
+        $this->assertSame('foo bar', $queries[0]['query']);
         $this->assertEquals(['baz'], $queries[0]['bindings']);
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -36,7 +36,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
 
         $result = $builder->find('bar', ['column']);
-        $this->assertEquals('baz', $result);
+        $this->assertSame('baz', $result);
     }
 
     public function testFindManyMethod()
@@ -59,7 +59,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldNotReceive('get');
 
         $result = $builder->findMany([], ['column']);
-        $this->assertEquals('emptycollection', $result);
+        $this->assertSame('emptycollection', $result);
 
         // ids are empty collection
         $builder = m::mock(Builder::class.'[get]', [$this->getMockQueryBuilder()]);
@@ -70,7 +70,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldNotReceive('get');
 
         $result = $builder->findMany(collect(), ['column']);
-        $this->assertEquals('emptycollection', $result);
+        $this->assertSame('emptycollection', $result);
     }
 
     public function testFindOrNewMethodModelFound()
@@ -144,7 +144,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
 
         $result = $builder->find([1, 2], ['column']);
-        $this->assertEquals('baz', $result);
+        $this->assertSame('baz', $result);
     }
 
     public function testFindWithManyUsingCollection()
@@ -156,7 +156,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['column'])->andReturn('baz');
 
         $result = $builder->find($ids, ['column']);
-        $this->assertEquals('baz', $result);
+        $this->assertSame('baz', $result);
     }
 
     public function testFirstMethod()
@@ -166,7 +166,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
 
         $result = $builder->first();
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
     }
 
     public function testQualifyColumn()
@@ -176,7 +176,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->setModel(new EloquentModelStub);
 
-        $this->assertEquals('stub.column', $builder->qualifyColumn('column'));
+        $this->assertSame('stub.column', $builder->qualifyColumn('column'));
     }
 
     public function testGetMethodLoadsModelsAndHydratesEagerRelations()
@@ -212,7 +212,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $mockModel->name = 'foo';
         $builder->shouldReceive('first')->with(['name'])->andReturn($mockModel);
 
-        $this->assertEquals('foo', $builder->value('name'));
+        $this->assertSame('foo', $builder->value('name'));
     }
 
     public function testValueMethodWithModelNotFound()
@@ -583,7 +583,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         }]);
         $eagers = $builder->getEagerLoads();
 
-        $this->assertEquals('foo', $eagers['orders']());
+        $this->assertSame('foo', $eagers['orders']());
 
         $builder = $this->getBuilder();
         $builder->with(['orders.lines' => function () {
@@ -593,7 +593,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $this->assertInstanceOf(Closure::class, $eagers['orders']);
         $this->assertNull($eagers['orders']());
-        $this->assertEquals('foo', $eagers['orders.lines']());
+        $this->assertSame('foo', $eagers['orders.lines']());
     }
 
     public function testQueryPassThru()
@@ -606,22 +606,22 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insert')->once()->with(['bar'])->andReturn('foo');
 
-        $this->assertEquals('foo', $builder->insert(['bar']));
+        $this->assertSame('foo', $builder->insert(['bar']));
 
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertOrIgnore')->once()->with(['bar'])->andReturn('foo');
 
-        $this->assertEquals('foo', $builder->insertOrIgnore(['bar']));
+        $this->assertSame('foo', $builder->insertOrIgnore(['bar']));
 
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertGetId')->once()->with(['bar'])->andReturn('foo');
 
-        $this->assertEquals('foo', $builder->insertGetId(['bar']));
+        $this->assertSame('foo', $builder->insertGetId(['bar']));
 
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('insertUsing')->once()->with(['bar'], 'baz')->andReturn('foo');
 
-        $this->assertEquals('foo', $builder->insertUsing(['bar'], 'baz'));
+        $this->assertSame('foo', $builder->insertUsing(['bar'], 'baz'));
     }
 
     public function testQueryScopes()
@@ -661,7 +661,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) {
             $query->where('baz', '>', 9000);
         });
-        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
+        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
@@ -672,7 +672,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $query = $model->newQuery()->empty()->where('foo', '=', 'bar')->empty()->where(function ($query) {
             $query->empty()->where('baz', '>', 9000);
         });
-        $this->assertEquals('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
+        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 
@@ -681,7 +681,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->one()->orWhere->two();
-        $this->assertEquals('select * from "table" where "one" = ? or ("two" = ?)', $query->toSql());
+        $this->assertSame('select * from "table" where "one" = ? or ("two" = ?)', $query->toSql());
     }
 
     public function testRealQueryChainedHigherOrderOrWhereScopes()
@@ -689,7 +689,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestHigherOrderWhereScopeStub;
         $this->mockConnectionForModel($model, 'SQLite');
         $query = $model->newQuery()->one()->orWhere->two()->orWhere->three();
-        $this->assertEquals('select * from "table" where "one" = ? or ("two" = ?) or ("three" = ?)', $query->toSql());
+        $this->assertSame('select * from "table" where "one" = ? or ("two" = ?) or ("three" = ?)', $query->toSql());
     }
 
     public function testSimpleWhere()
@@ -723,7 +723,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->withCount('foo');
 
-        $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAndSelect()
@@ -732,7 +732,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->select('id')->withCount('foo');
 
-        $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAndMergedWheres()
@@ -743,7 +743,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->where('bam', '>', 'qux');
         }]);
 
-        $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ? and "active" = ?) as "active_foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
         $this->assertEquals(['qux', true], $builder->getBindings());
     }
 
@@ -761,7 +761,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             //
         });
 
-        $this->assertEquals('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "id", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountAndConstraintsAndHaving()
@@ -773,7 +773,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->where('bam', '>', 'qux');
         }])->having('foo_count', '>=', 1);
 
-        $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ?) as "foo_count" from "eloquent_builder_test_model_parent_stubs" where "bar" = ? having "foo_count" >= ?', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bam" > ?) as "foo_count" from "eloquent_builder_test_model_parent_stubs" where "bar" = ? having "foo_count" >= ?', $builder->toSql());
         $this->assertEquals(['qux', 'baz', 1], $builder->getBindings());
     }
 
@@ -783,7 +783,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->withCount('foo as foo_bar');
 
-        $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testWithCountMultipleAndPartialRename()
@@ -792,7 +792,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->withCount(['foo as foo_bar', 'foo']);
 
-        $this->assertEquals('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_bar", (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
     }
 
     public function testHasWithConstraintsAndHavingInSubquery()
@@ -804,7 +804,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
@@ -819,7 +819,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->having('street', '=', 'fooside dr');
         })->where('age', 29);
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "name" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and ("zipcode" = ? or "zipcode" = ?) having "street" = ?) and "age" = ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "name" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and ("zipcode" = ? or "zipcode" = ?) having "street" = ?) and "age" = ?', $builder->toSql());
         $this->assertEquals(['larry', '90210', '90220', 'fooside dr', 29], $builder->getBindings());
     }
 
@@ -834,7 +834,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" inner join "quuuux" on "quuuuux" = ? where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and exists (select * from "eloquent_builder_test_model_close_related_stubs" inner join "quuuux" on "quuuuux" = ? where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) and "quux" = ?', $builder->toSql());
         $this->assertEquals(['baz', 'quuuuuux', 'qux', 'quuux'], $builder->getBindings());
     }
 
@@ -847,7 +847,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $q->having('bam', '>', 'qux');
         }, '>=', 2)->where('quux', 'quuux');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) >= 2 and "quux" = ?', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? and (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" having "bam" > ?) >= 2 and "quux" = ?', $builder->toSql());
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
@@ -937,7 +937,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->doesntHave('foo');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
     }
 
     public function testDoesntHaveNested()
@@ -946,7 +946,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->doesntHave('foo.bar');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id"))', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and exists (select * from "eloquent_builder_test_model_far_related_stubs" where "eloquent_builder_test_model_close_related_stubs"."id" = "eloquent_builder_test_model_far_related_stubs"."eloquent_builder_test_model_close_related_stub_id"))', $builder->toSql());
     }
 
     public function testOrDoesntHave()
@@ -955,7 +955,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $model->where('bar', 'baz')->orDoesntHave('foo');
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id")', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -967,7 +967,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $query->where('bar', 'baz');
         });
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bar" = ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "bar" = ?)', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -979,7 +979,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             $query->where('qux', 'quux');
         });
 
-        $this->assertEquals('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "qux" = ?)', $builder->toSql());
+        $this->assertSame('select * from "eloquent_builder_test_model_parent_stubs" where "bar" = ? or not exists (select * from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id" and "qux" = ?)', $builder->toSql());
         $this->assertEquals(['baz', 'quux'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentGlobalScopesTestModel;
         $query = $model->newQuery();
-        $this->assertEquals('select * from "table" where "active" = ?', $query->toSql());
+        $this->assertSame('select * from "table" where "active" = ?', $query->toSql());
         $this->assertEquals([1], $query->getBindings());
     }
 
@@ -40,7 +40,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope(ActiveScope::class);
-        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertSame('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }
 
@@ -48,7 +48,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery();
-        $this->assertEquals('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
+        $this->assertSame('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals([1], $query->getBindings());
     }
 
@@ -56,7 +56,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScope('active_scope');
-        $this->assertEquals('select * from "table" order by "name" asc', $query->toSql());
+        $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }
 
@@ -64,11 +64,11 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery();
-        $this->assertEquals('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
+        $this->assertSame('select * from "table" where "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals([1], $query->getBindings());
 
         $query->withoutGlobalScope('active_scope');
-        $this->assertEquals('select * from "table" order by "name" asc', $query->toSql());
+        $this->assertSame('select * from "table" order by "name" asc', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }
 
@@ -76,11 +76,11 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $model = new EloquentClosureGlobalScopesTestModel;
         $query = $model->newQuery()->withoutGlobalScopes();
-        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertSame('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
 
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes();
-        $this->assertEquals('select * from "table"', $query->toSql());
+        $this->assertSame('select * from "table"', $query->toSql());
         $this->assertEquals([], $query->getBindings());
     }
 
@@ -89,11 +89,11 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
         $model = new EloquentClosureGlobalScopesWithOrTestModel;
 
         $query = $model->newQuery();
-        $this->assertEquals('select "email", "password" from "table" where ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
+        $this->assertSame('select "email", "password" from "table" where ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
 
         $query = $model->newQuery()->where('col1', 'val1')->orWhere('col2', 'val2');
-        $this->assertEquals('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
+        $this->assertSame('select "email", "password" from "table" where ("col1" = ? or "col2" = ?) and ("email" = ? or "email" = ?) and "active" = ? order by "name" asc', $query->toSql());
         $this->assertEquals(['val1', 'val2', 'taylor@gmail.com', 'someone@else.com', 1], $query->getBindings());
     }
 
@@ -101,7 +101,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes()->where('foo', 'foo')->orWhere('bar', 'bar')->approved();
 
-        $this->assertEquals('select * from "table" where ("foo" = ? or "bar" = ?) and ("approved" = ? or "should_approve" = ?)', $query->toSql());
+        $this->assertSame('select * from "table" where ("foo" = ? or "bar" = ?) and ("approved" = ? or "should_approve" = ?)', $query->toSql());
         $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
     }
 
@@ -109,7 +109,7 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         $query = EloquentClosureGlobalScopesTestModel::withoutGlobalScopes()->where('foo', 'foo')->orWhere('bar', 'bar')->orApproved();
 
-        $this->assertEquals('select * from "table" where ("foo" = ? or "bar" = ?) or ("approved" = ? or "should_approve" = ?)', $query->toSql());
+        $this->assertSame('select * from "table" where ("foo" = ? or "bar" = ?) or ("approved" = ? or "should_approve" = ?)', $query->toSql());
         $this->assertEquals(['foo', 'bar', 1, 0], $query->getBindings());
     }
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -76,7 +76,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $posts = HasManyThroughTestCountry::first()->posts;
 
-        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
     }
 
@@ -86,7 +86,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedDefaultData();
 
         $posts = HasManyThroughDefaultTestCountry::first()->posts;
-        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
 
         $this->resetDefault();
@@ -97,7 +97,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $posts = HasManyThroughIntermediateTestCountry::first()->posts;
 
-        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
     }
 
@@ -106,7 +106,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $posts = HasManyThroughIntermediateTestCountry::with('posts')->first()->posts;
 
-        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
     }
 
@@ -148,7 +148,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $post = HasManyThroughTestCountry::first()->posts()->first();
 
         $this->assertNotNull($post);
-        $this->assertEquals('A title', $post->title);
+        $this->assertSame('A title', $post->title);
     }
 
     public function testAllColumnsAreRetrievedByDefault()
@@ -266,7 +266,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 
         $posts = HasManyThroughSoftDeletesTestCountry::first()->posts;
 
-        $this->assertEquals('A title', $posts[0]->title);
+        $this->assertSame('A title', $posts[0]->title);
         $this->assertCount(2, $posts);
     }
 
@@ -275,8 +275,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->seedData();
         $country = HasManyThroughSoftDeletesTestCountry::with('posts')->first();
 
-        $this->assertEquals('us', $country->shortname);
-        $this->assertEquals('A title', $country->posts[0]->title);
+        $this->assertSame('us', $country->shortname);
+        $this->assertSame('A title', $country->posts[0]->title);
         $this->assertCount(2, $country->posts);
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -75,7 +75,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->seedData();
         $contract = HasOneThroughTestPosition::first()->contract;
 
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
     }
 
     public function testItLoadsADefaultHasOneThroughRelation()
@@ -84,7 +84,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->seedDefaultData();
 
         $contract = HasOneThroughDefaultTestPosition::first()->contract;
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
         $this->assertArrayNotHasKey('email', $contract->getAttributes());
 
         $this->resetDefault();
@@ -95,7 +95,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->seedData();
         $contract = HasOneThroughIntermediateTestPosition::first()->contract;
 
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
     }
 
     public function testEagerLoadingARelationWithCustomIntermediateAndLocalKey()
@@ -103,7 +103,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->seedData();
         $contract = HasOneThroughIntermediateTestPosition::with('contract')->first()->contract;
 
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
     }
 
     public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
@@ -143,7 +143,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $contract = HasOneThroughTestPosition::first()->contract()->first();
 
         $this->assertNotNull($contract);
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
     }
 
     public function testAllColumnsAreRetrievedByDefault()
@@ -241,7 +241,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 
         $contract = HasOneThroughSoftDeletesTestPosition::first()->contract;
 
-        $this->assertEquals('A title', $contract->title);
+        $this->assertSame('A title', $contract->title);
     }
 
     public function testEagerLoadingLoadsRelatedModelsCorrectly()
@@ -249,8 +249,8 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->seedData();
         $position = HasOneThroughSoftDeletesTestPosition::with('contract')->first();
 
-        $this->assertEquals('ps', $position->shortname);
-        $this->assertEquals('A title', $position->contract->title);
+        $this->assertSame('ps', $position->shortname);
+        $this->assertSame('A title', $position->contract->title);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -158,7 +158,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue(EloquentTestUser::where('email', 'mohamed@laravel.com')->doesntExist());
 
         $model = EloquentTestUser::where('email', 'taylorotwell@gmail.com')->first();
-        $this->assertEquals('taylorotwell@gmail.com', $model->email);
+        $this->assertSame('taylorotwell@gmail.com', $model->email);
         $this->assertTrue(isset($model->email));
         $this->assertTrue(isset($model->friends));
 
@@ -184,7 +184,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $models = EloquentTestUser::where('id', 1)->cursor();
         foreach ($models as $model) {
             $this->assertEquals(1, $model->id);
-            $this->assertEquals('default', $model->getConnectionName());
+            $this->assertSame('default', $model->getConnectionName());
         }
 
         $records = DB::table('users')->where('id', 1)->cursor();
@@ -209,8 +209,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(Collection::class, $models);
         $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
         $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
-        $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
-        $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
     }
 
     public function testPaginatedModelCollectionRetrieval()
@@ -228,8 +228,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
         $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
         $this->assertInstanceOf(EloquentTestUser::class, $models[1]);
-        $this->assertEquals('taylorotwell@gmail.com', $models[0]->email);
-        $this->assertEquals('abigailotwell@gmail.com', $models[1]->email);
+        $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
 
         Paginator::currentPageResolver(function () {
             return 2;
@@ -239,7 +239,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(1, $models);
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
         $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
-        $this->assertEquals('foo@gmail.com', $models[0]->email);
+        $this->assertSame('foo@gmail.com', $models[0]->email);
     }
 
     public function testPaginatedModelCollectionRetrievalWhenNoElements()
@@ -284,7 +284,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
     {
         $user1 = EloquentTestUser::firstOrCreate(['email' => 'taylorotwell@gmail.com']);
 
-        $this->assertEquals('taylorotwell@gmail.com', $user1->email);
+        $this->assertSame('taylorotwell@gmail.com', $user1->email);
         $this->assertNull($user1->name);
 
         $user2 = EloquentTestUser::firstOrCreate(
@@ -293,7 +293,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertEquals($user1->id, $user2->id);
-        $this->assertEquals('taylorotwell@gmail.com', $user2->email);
+        $this->assertSame('taylorotwell@gmail.com', $user2->email);
         $this->assertNull($user2->name);
 
         $user3 = EloquentTestUser::firstOrCreate(
@@ -302,8 +302,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertNotEquals($user3->id, $user1->id);
-        $this->assertEquals('abigailotwell@gmail.com', $user3->email);
-        $this->assertEquals('Abigail Otwell', $user3->name);
+        $this->assertSame('abigailotwell@gmail.com', $user3->email);
+        $this->assertSame('Abigail Otwell', $user3->name);
     }
 
     public function testUpdateOrCreate()
@@ -316,15 +316,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
         );
 
         $this->assertEquals($user1->id, $user2->id);
-        $this->assertEquals('taylorotwell@gmail.com', $user2->email);
-        $this->assertEquals('Taylor Otwell', $user2->name);
+        $this->assertSame('taylorotwell@gmail.com', $user2->email);
+        $this->assertSame('Taylor Otwell', $user2->name);
 
         $user3 = EloquentTestUser::updateOrCreate(
             ['email' => 'themsaid@gmail.com'],
             ['name' => 'Mohamed Said']
         );
 
-        $this->assertEquals('Mohamed Said', $user3->name);
+        $this->assertSame('Mohamed Said', $user3->name);
         $this->assertEquals(EloquentTestUser::count(), 2);
     }
 
@@ -357,21 +357,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user2 = EloquentTestUser::on('second_connection')->findOrNew(2);
         $this->assertFalse($user1->exists);
         $this->assertTrue($user2->exists);
-        $this->assertEquals('second_connection', $user1->getConnectionName());
-        $this->assertEquals('second_connection', $user2->getConnectionName());
+        $this->assertSame('second_connection', $user1->getConnectionName());
+        $this->assertSame('second_connection', $user2->getConnectionName());
 
         $user1 = EloquentTestUser::on('second_connection')->firstOrNew(['email' => 'taylorotwell@gmail.com']);
         $user2 = EloquentTestUser::on('second_connection')->firstOrNew(['email' => 'themsaid@gmail.com']);
         $this->assertFalse($user1->exists);
         $this->assertTrue($user2->exists);
-        $this->assertEquals('second_connection', $user1->getConnectionName());
-        $this->assertEquals('second_connection', $user2->getConnectionName());
+        $this->assertSame('second_connection', $user1->getConnectionName());
+        $this->assertSame('second_connection', $user2->getConnectionName());
 
         $this->assertEquals(1, EloquentTestUser::on('second_connection')->count());
         $user1 = EloquentTestUser::on('second_connection')->firstOrCreate(['email' => 'taylorotwell@gmail.com']);
         $user2 = EloquentTestUser::on('second_connection')->firstOrCreate(['email' => 'themsaid@gmail.com']);
-        $this->assertEquals('second_connection', $user1->getConnectionName());
-        $this->assertEquals('second_connection', $user2->getConnectionName());
+        $this->assertSame('second_connection', $user1->getConnectionName());
+        $this->assertSame('second_connection', $user2->getConnectionName());
         $this->assertEquals(2, EloquentTestUser::on('second_connection')->count());
     }
 
@@ -392,10 +392,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $i = 0;
         EloquentTestNonIncrementingSecond::query()->chunkById(2, function (Collection $users) use (&$i) {
             if (! $i) {
-                $this->assertEquals(' First', $users[0]->name);
-                $this->assertEquals(' Second', $users[1]->name);
+                $this->assertSame(' First', $users[0]->name);
+                $this->assertSame(' Second', $users[1]->name);
             } else {
-                $this->assertEquals(' Third', $users[0]->name);
+                $this->assertSame(' Third', $users[0]->name);
             }
             $i++;
         }, 'name');
@@ -452,7 +452,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $multiple = EloquentTestUser::findOrFail([1, 2]);
 
         $this->assertInstanceOf(EloquentTestUser::class, $single);
-        $this->assertEquals('taylorotwell@gmail.com', $single->email);
+        $this->assertSame('taylorotwell@gmail.com', $single->email);
         $this->assertInstanceOf(Collection::class, $multiple);
         $this->assertInstanceOf(EloquentTestUser::class, $multiple[0]);
         $this->assertInstanceOf(EloquentTestUser::class, $multiple[1]);
@@ -486,8 +486,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertTrue(isset($user->post->name));
         $this->assertInstanceOf(EloquentTestUser::class, $user);
         $this->assertInstanceOf(EloquentTestPost::class, $post);
-        $this->assertEquals('taylorotwell@gmail.com', $user->email);
-        $this->assertEquals('First Post', $post->name);
+        $this->assertSame('taylorotwell@gmail.com', $user->email);
+        $this->assertSame('First Post', $post->name);
     }
 
     public function testIssetLoadsInRelationshipIfItIsntLoadedAlready()
@@ -512,9 +512,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(EloquentTestPost::class, $posts[0]);
         $this->assertInstanceOf(EloquentTestPost::class, $posts[1]);
         $this->assertInstanceOf(EloquentTestPost::class, $post2);
-        $this->assertEquals('Second Post', $post2->name);
+        $this->assertSame('Second Post', $post2->name);
         $this->assertInstanceOf(EloquentTestUser::class, $post2->user);
-        $this->assertEquals('taylorotwell@gmail.com', $post2->user->email);
+        $this->assertSame('taylorotwell@gmail.com', $post2->user->email);
     }
 
     public function testBasicModelHydration()
@@ -531,8 +531,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $models);
         $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
-        $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
-        $this->assertEquals('second_connection', $models[0]->getConnectionName());
+        $this->assertSame('abigailotwell@gmail.com', $models[0]->email);
+        $this->assertSame('second_connection', $models[0]->getConnectionName());
         $this->assertCount(1, $models);
     }
 
@@ -546,7 +546,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestUser::has('friends')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testWhereHasOnSelfReferencingBelongsToManyRelationship()
@@ -559,7 +559,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testHasOnNestedSelfReferencingBelongsToManyRelationship()
@@ -571,7 +571,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestUser::has('friends.friends')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testWhereHasOnNestedSelfReferencingBelongsToManyRelationship()
@@ -585,7 +585,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testHasOnSelfReferencingBelongsToManyRelationshipWithWherePivot()
@@ -596,7 +596,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestUser::has('friendsOne')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testHasOnNestedSelfReferencingBelongsToManyRelationshipWithWherePivot()
@@ -608,7 +608,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestUser::has('friendsOne.friendsTwo')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('taylorotwell@gmail.com', $results->first()->email);
+        $this->assertSame('taylorotwell@gmail.com', $results->first()->email);
     }
 
     public function testHasOnSelfReferencingBelongsToRelationship()
@@ -619,7 +619,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestPost::has('parentPost')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Child Post', $results->first()->name);
+        $this->assertSame('Child Post', $results->first()->name);
     }
 
     public function testAggregatedValuesOfDatetimeField()
@@ -627,8 +627,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['id' => 1, 'email' => 'test1@test.test', 'created_at' => '2016-08-10 09:21:00', 'updated_at' => Carbon::now()]);
         EloquentTestUser::create(['id' => 2, 'email' => 'test2@test.test', 'created_at' => '2016-08-01 12:00:00', 'updated_at' => Carbon::now()]);
 
-        $this->assertEquals('2016-08-10 09:21:00', EloquentTestUser::max('created_at'));
-        $this->assertEquals('2016-08-01 12:00:00', EloquentTestUser::min('created_at'));
+        $this->assertSame('2016-08-10 09:21:00', EloquentTestUser::max('created_at'));
+        $this->assertSame('2016-08-01 12:00:00', EloquentTestUser::min('created_at'));
     }
 
     public function testWhereHasOnSelfReferencingBelongsToRelationship()
@@ -641,7 +641,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Child Post', $results->first()->name);
+        $this->assertSame('Child Post', $results->first()->name);
     }
 
     public function testHasOnNestedSelfReferencingBelongsToRelationship()
@@ -653,7 +653,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestPost::has('parentPost.parentPost')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Child Post', $results->first()->name);
+        $this->assertSame('Child Post', $results->first()->name);
     }
 
     public function testWhereHasOnNestedSelfReferencingBelongsToRelationship()
@@ -667,7 +667,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Child Post', $results->first()->name);
+        $this->assertSame('Child Post', $results->first()->name);
     }
 
     public function testHasOnSelfReferencingHasManyRelationship()
@@ -678,7 +678,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestPost::has('childPosts')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Parent Post', $results->first()->name);
+        $this->assertSame('Parent Post', $results->first()->name);
     }
 
     public function testWhereHasOnSelfReferencingHasManyRelationship()
@@ -691,7 +691,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Parent Post', $results->first()->name);
+        $this->assertSame('Parent Post', $results->first()->name);
     }
 
     public function testHasOnNestedSelfReferencingHasManyRelationship()
@@ -703,7 +703,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $results = EloquentTestPost::has('childPosts.childPosts')->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Grandparent Post', $results->first()->name);
+        $this->assertSame('Grandparent Post', $results->first()->name);
     }
 
     public function testWhereHasOnNestedSelfReferencingHasManyRelationship()
@@ -717,7 +717,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         })->get();
 
         $this->assertCount(1, $results);
-        $this->assertEquals('Grandparent Post', $results->first()->name);
+        $this->assertSame('Grandparent Post', $results->first()->name);
     }
 
     public function testHasWithNonWhereBindings()
@@ -749,7 +749,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         EloquentTestUser::first()->friends()->chunk(2, function ($friends) use ($user, $friend) {
             $this->assertCount(1, $friends);
-            $this->assertEquals('abigailotwell@gmail.com', $friends->first()->email);
+            $this->assertSame('abigailotwell@gmail.com', $friends->first()->email);
             $this->assertEquals($user->id, $friends->first()->pivot->user_id);
             $this->assertEquals($friend->id, $friends->first()->pivot->friend_id);
         });
@@ -761,7 +761,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
 
         EloquentTestUser::first()->friends()->each(function ($result) use ($user, $friend) {
-            $this->assertEquals('abigailotwell@gmail.com', $result->email);
+            $this->assertSame('abigailotwell@gmail.com', $result->email);
             $this->assertEquals($user->id, $result->pivot->user_id);
             $this->assertEquals($friend->id, $result->pivot->friend_id);
         });
@@ -773,10 +773,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user->posts()->create(['name' => 'First Post']);
         $user = EloquentTestUser::with('posts')->where('email', 'taylorotwell@gmail.com')->first();
 
-        $this->assertEquals('First Post', $user->posts->first()->name);
+        $this->assertSame('First Post', $user->posts->first()->name);
 
         $post = EloquentTestPost::with('user')->where('name', 'First Post')->get();
-        $this->assertEquals('taylorotwell@gmail.com', $post->first()->user->email);
+        $this->assertSame('taylorotwell@gmail.com', $post->first()->user->email);
     }
 
     public function testBasicNestedSelfReferencingHasManyEagerLoading()
@@ -788,15 +788,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = EloquentTestUser::with('posts.childPosts')->where('email', 'taylorotwell@gmail.com')->first();
 
         $this->assertNotNull($user->posts->first());
-        $this->assertEquals('First Post', $user->posts->first()->name);
+        $this->assertSame('First Post', $user->posts->first()->name);
 
         $this->assertNotNull($user->posts->first()->childPosts->first());
-        $this->assertEquals('Child Post', $user->posts->first()->childPosts->first()->name);
+        $this->assertSame('Child Post', $user->posts->first()->childPosts->first()->name);
 
         $post = EloquentTestPost::with('parentPost.user')->where('name', 'Child Post')->get();
         $this->assertNotNull($post->first()->parentPost);
         $this->assertNotNull($post->first()->parentPost->user);
-        $this->assertEquals('taylorotwell@gmail.com', $post->first()->parentPost->user->email);
+        $this->assertSame('taylorotwell@gmail.com', $post->first()->parentPost->user->email);
     }
 
     public function testBasicMorphManyRelationship()
@@ -814,10 +814,10 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(EloquentTestPhoto::class, $post->photos[0]);
         $this->assertCount(2, $user->photos);
         $this->assertCount(2, $post->photos);
-        $this->assertEquals('Avatar 1', $user->photos[0]->name);
-        $this->assertEquals('Avatar 2', $user->photos[1]->name);
-        $this->assertEquals('Hero 1', $post->photos[0]->name);
-        $this->assertEquals('Hero 2', $post->photos[1]->name);
+        $this->assertSame('Avatar 1', $user->photos[0]->name);
+        $this->assertSame('Avatar 2', $user->photos[1]->name);
+        $this->assertSame('Hero 1', $post->photos[0]->name);
+        $this->assertSame('Hero 2', $post->photos[1]->name);
 
         $photos = EloquentTestPhoto::orderBy('name')->get();
 
@@ -825,8 +825,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(4, $photos);
         $this->assertInstanceOf(EloquentTestUser::class, $photos[0]->imageable);
         $this->assertInstanceOf(EloquentTestPost::class, $photos[2]->imageable);
-        $this->assertEquals('taylorotwell@gmail.com', $photos[1]->imageable->email);
-        $this->assertEquals('First Post', $photos[3]->imageable->name);
+        $this->assertSame('taylorotwell@gmail.com', $photos[1]->imageable->email);
+        $this->assertSame('First Post', $photos[3]->imageable->name);
     }
 
     public function testMorphMapIsUsedForCreatingAndFetchingThroughRelation()
@@ -849,15 +849,15 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(EloquentTestPhoto::class, $post->photos[0]);
         $this->assertCount(2, $user->photos);
         $this->assertCount(2, $post->photos);
-        $this->assertEquals('Avatar 1', $user->photos[0]->name);
-        $this->assertEquals('Avatar 2', $user->photos[1]->name);
-        $this->assertEquals('Hero 1', $post->photos[0]->name);
-        $this->assertEquals('Hero 2', $post->photos[1]->name);
+        $this->assertSame('Avatar 1', $user->photos[0]->name);
+        $this->assertSame('Avatar 2', $user->photos[1]->name);
+        $this->assertSame('Hero 1', $post->photos[0]->name);
+        $this->assertSame('Hero 2', $post->photos[1]->name);
 
-        $this->assertEquals('user', $user->photos[0]->imageable_type);
-        $this->assertEquals('user', $user->photos[1]->imageable_type);
-        $this->assertEquals('post', $post->photos[0]->imageable_type);
-        $this->assertEquals('post', $post->photos[1]->imageable_type);
+        $this->assertSame('user', $user->photos[0]->imageable_type);
+        $this->assertSame('user', $user->photos[1]->imageable_type);
+        $this->assertSame('post', $post->photos[0]->imageable_type);
+        $this->assertSame('post', $post->photos[1]->imageable_type);
     }
 
     public function testMorphMapIsUsedWhenFetchingParent()
@@ -871,7 +871,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user->photos()->create(['name' => 'Avatar 1']);
 
         $photo = EloquentTestPhoto::first();
-        $this->assertEquals('user', $photo->imageable_type);
+        $this->assertSame('user', $photo->imageable_type);
         $this->assertInstanceOf(EloquentTestUser::class, $photo->imageable);
     }
 
@@ -994,7 +994,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 // ignore the exception
             }
             $user = EloquentTestUser::first();
-            $this->assertEquals('taylor@laravel.com', $user->email);
+            $this->assertSame('taylor@laravel.com', $user->email);
         });
     }
 
@@ -1010,7 +1010,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             }
 
             $user = EloquentTestUser::first();
-            $this->assertEquals('otwell@laravel.com', $user->email);
+            $this->assertSame('otwell@laravel.com', $user->email);
             $this->assertEquals(1, $user->id);
         });
     }
@@ -1028,7 +1028,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             }
 
             $user = EloquentTestUser::first();
-            $this->assertEquals('taylor@laravel.com', $user->email);
+            $this->assertSame('taylor@laravel.com', $user->email);
             $this->assertEquals(1, $user->id);
         });
     }
@@ -1044,8 +1044,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $array = $model->toArray();
 
-        $this->assertEquals('2012-12-04 00:00:00', $array['created_at']);
-        $this->assertEquals('2012-12-05 00:00:00', $array['updated_at']);
+        $this->assertSame('2012-12-04 00:00:00', $array['created_at']);
+        $this->assertSame('2012-12-05 00:00:00', $array['updated_at']);
     }
 
     public function testToArrayIncludesCustomFormattedTimestamps()
@@ -1060,8 +1060,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $array = $model->toArray();
 
-        $this->assertEquals('04-12-12', $array['created_at']);
-        $this->assertEquals('05-12-12', $array['updated_at']);
+        $this->assertSame('04-12-12', $array['created_at']);
+        $this->assertSame('05-12-12', $array['updated_at']);
     }
 
     public function testIncrementingPrimaryKeysAreCastToIntegersByDefault()
@@ -1166,8 +1166,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $johnWithFriends = EloquentTestUserWithCustomFriendPivot::with('friends')->find(1);
 
         $this->assertCount(3, $johnWithFriends->friends);
-        $this->assertEquals('friend', $johnWithFriends->friends->find(3)->pivot->level->level);
-        $this->assertEquals('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
+        $this->assertSame('friend', $johnWithFriends->friends->find(3)->pivot->level->level);
+        $this->assertSame('Jule Doe', $johnWithFriends->friends->find(4)->pivot->friend->name);
     }
 
     public function testIsAfterRetrievingTheSameModel()
@@ -1231,7 +1231,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             'created_at' => '2017-11-14 08:23:19',
         ]);
 
-        $this->assertEquals('2017-11-14 08:23:19', $model->fromDateTime($model->getAttribute('created_at')));
+        $this->assertSame('2017-11-14 08:23:19', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
     public function testTimestampsUsingDefaultSqlServerDateFormat()
@@ -1243,8 +1243,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
             'updated_at' => '2017-11-14 08:23:19.734',
         ]);
 
-        $this->assertEquals('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
-        $this->assertEquals('2017-11-14 08:23:19.734', $model->fromDateTime($model->getAttribute('updated_at')));
+        $this->assertSame('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
+        $this->assertSame('2017-11-14 08:23:19.734', $model->fromDateTime($model->getAttribute('updated_at')));
     }
 
     public function testTimestampsUsingCustomDateFormat()
@@ -1258,8 +1258,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
         ]);
 
         // Note: when storing databases would truncate the value to the given precision
-        $this->assertEquals('2017-11-14 08:23:19.000000', $model->fromDateTime($model->getAttribute('created_at')));
-        $this->assertEquals('2017-11-14 08:23:19.734800', $model->fromDateTime($model->getAttribute('updated_at')));
+        $this->assertSame('2017-11-14 08:23:19.000000', $model->fromDateTime($model->getAttribute('created_at')));
+        $this->assertSame('2017-11-14 08:23:19.734800', $model->fromDateTime($model->getAttribute('updated_at')));
     }
 
     public function testTimestampsUsingOldSqlServerDateFormat()
@@ -1270,7 +1270,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             'created_at' => '2017-11-14 08:23:19.000',
         ]);
 
-        $this->assertEquals('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
+        $this->assertSame('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
     public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases()

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -87,7 +87,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
 
         $this->assertInstanceOf(Collection::class, $models);
         $this->assertInstanceOf(EloquentTestUser::class, $models[0]);
-        $this->assertEquals('abigailotwell@gmail.com', $models[0]->email);
+        $this->assertSame('abigailotwell@gmail.com', $models[0]->email);
         $this->assertCount(1, $models);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -56,7 +56,7 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelStub;
         $model->name = 'foo';
-        $this->assertEquals('foo', $model->name);
+        $this->assertSame('foo', $model->name);
         $this->assertTrue(isset($model->name));
         unset($model->name);
         $this->assertFalse(isset($model->name));
@@ -139,7 +139,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // ensure password attribute was not set to null
         $this->assertArrayNotHasKey('password', $attributes);
-        $this->assertEquals('******', $model->password);
+        $this->assertSame('******', $model->password);
 
         $hash = 'e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4';
 
@@ -178,7 +178,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $instance = $model->newInstance(['name' => 'taylor']);
         $this->assertInstanceOf(EloquentModelStub::class, $instance);
-        $this->assertEquals('taylor', $instance->name);
+        $this->assertSame('taylor', $instance->name);
     }
 
     public function testNewInstanceReturnsNewInstanceWithTableSet()
@@ -187,7 +187,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setTable('test');
         $newInstance = $model->newInstance();
 
-        $this->assertEquals('test', $newInstance->getTable());
+        $this->assertSame('test', $newInstance->getTable());
     }
 
     public function testCreateMethodSavesNewModel()
@@ -195,7 +195,7 @@ class DatabaseEloquentModelTest extends TestCase
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::create(['name' => 'taylor']);
         $this->assertTrue($_SERVER['__eloquent.saved']);
-        $this->assertEquals('taylor', $model->name);
+        $this->assertSame('taylor', $model->name);
     }
 
     public function testMakeMethodDoesNotSaveNewModel()
@@ -203,7 +203,7 @@ class DatabaseEloquentModelTest extends TestCase
         $_SERVER['__eloquent.saved'] = false;
         $model = EloquentModelSaveStub::make(['name' => 'taylor']);
         $this->assertFalse($_SERVER['__eloquent.saved']);
-        $this->assertEquals('taylor', $model->name);
+        $this->assertSame('taylor', $model->name);
     }
 
     public function testForceCreateMethodSavesNewModelWithGuardedAttributes()
@@ -232,7 +232,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithMethodCallsQueryBuilderCorrectly()
     {
         $result = EloquentModelWithStub::with('foo', 'bar');
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 
     public function testWithoutMethodRemovesEagerLoadedRelationshipCorrectly()
@@ -258,7 +258,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testWithMethodCallsQueryBuilderCorrectlyWithArray()
     {
         $result = EloquentModelWithStub::with(['foo', 'bar']);
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 
     public function testUpdateProcess()
@@ -465,29 +465,29 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         $value = Carbon::parse('2015-04-17 22:59:01');
-        $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = new DateTime('2015-04-17 22:59:01');
         $this->assertInstanceOf(DateTime::class, $value);
         $this->assertInstanceOf(DateTimeInterface::class, $value);
-        $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = new DateTimeImmutable('2015-04-17 22:59:01');
         $this->assertInstanceOf(DateTimeImmutable::class, $value);
         $this->assertInstanceOf(DateTimeInterface::class, $value);
-        $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = '2015-04-17 22:59:01';
-        $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $value = '2015-04-17';
-        $this->assertEquals('2015-04-17 00:00:00', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 00:00:00', $model->fromDateTime($value));
 
         $value = '2015-4-17';
-        $this->assertEquals('2015-04-17 00:00:00', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 00:00:00', $model->fromDateTime($value));
 
         $value = '1429311541';
-        $this->assertEquals('2015-04-17 22:59:01', $model->fromDateTime($value));
+        $this->assertSame('2015-04-17 22:59:01', $model->fromDateTime($value));
 
         $this->assertNull($model->fromDateTime(null));
     }
@@ -505,7 +505,7 @@ class DatabaseEloquentModelTest extends TestCase
         ]);
 
         $this->assertInstanceOf(Carbon::class, $model->created_at);
-        $this->assertEquals('22:30:59.321000', $model->created_at->format('H:i:s.u'));
+        $this->assertSame('22:30:59.321000', $model->created_at->format('H:i:s.u'));
     }
 
     public function testInsertProcess()
@@ -719,9 +719,9 @@ class DatabaseEloquentModelTest extends TestCase
     public function testGetAndSetTableOperations()
     {
         $model = new EloquentModelStub;
-        $this->assertEquals('stub', $model->getTable());
+        $this->assertSame('stub', $model->getTable());
         $model->setTable('foo');
-        $this->assertEquals('foo', $model->getTable());
+        $this->assertSame('foo', $model->getTable());
     }
 
     public function testGetKeyReturnsValueOfPrimaryKey()
@@ -729,7 +729,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->id = 1;
         $this->assertEquals(1, $model->getKey());
-        $this->assertEquals('id', $model->getKeyName());
+        $this->assertSame('id', $model->getKeyName());
     }
 
     public function testConnectionManagement()
@@ -739,12 +739,12 @@ class DatabaseEloquentModelTest extends TestCase
 
         $retval = $model->setConnection('foo');
         $this->assertEquals($retval, $model);
-        $this->assertEquals('foo', $model->connection);
+        $this->assertSame('foo', $model->connection);
 
         $model->shouldReceive('getConnectionName')->once()->andReturn('somethingElse');
         $resolver->shouldReceive('connection')->once()->with('somethingElse')->andReturn('bar');
 
-        $this->assertEquals('bar', $model->getConnection());
+        $this->assertSame('bar', $model->getConnection());
     }
 
     public function testToArray()
@@ -763,17 +763,17 @@ class DatabaseEloquentModelTest extends TestCase
         $array = $model->toArray();
 
         $this->assertIsArray($array);
-        $this->assertEquals('foo', $array['name']);
-        $this->assertEquals('baz', $array['names'][0]['bar']);
-        $this->assertEquals('boom', $array['names'][1]['bam']);
-        $this->assertEquals('abby', $array['partner']['name']);
+        $this->assertSame('foo', $array['name']);
+        $this->assertSame('baz', $array['names'][0]['bar']);
+        $this->assertSame('boom', $array['names'][1]['bam']);
+        $this->assertSame('abby', $array['partner']['name']);
         $this->assertNull($array['group']);
         $this->assertEquals([], $array['multi']);
         $this->assertFalse(isset($array['password']));
 
         $model->setAppends(['appendable']);
         $array = $model->toArray();
-        $this->assertEquals('appended', $array['appendable']);
+        $this->assertSame('appended', $array['appendable']);
     }
 
     public function testVisibleCreatesArrayWhitelist()
@@ -823,8 +823,8 @@ class DatabaseEloquentModelTest extends TestCase
         ]));
         $array = $model->toArray();
 
-        $this->assertEquals('baz', $array['names_list'][0]['bar']);
-        $this->assertEquals('boom', $array['names_list'][1]['bam']);
+        $this->assertSame('baz', $array['names_list'][0]['bar']);
+        $this->assertSame('boom', $array['names_list'][1]['bam']);
 
         $model = new EloquentModelCamelStub;
         $model->setRelation('namesList', new BaseCollection([
@@ -832,8 +832,8 @@ class DatabaseEloquentModelTest extends TestCase
         ]));
         $array = $model->toArray();
 
-        $this->assertEquals('baz', $array['namesList'][0]['bar']);
-        $this->assertEquals('boom', $array['namesList'][1]['bam']);
+        $this->assertSame('baz', $array['namesList'][0]['bar']);
+        $this->assertSame('boom', $array['namesList'][1]['bam']);
     }
 
     public function testToArrayUsesMutators()
@@ -917,15 +917,15 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->fillable(['name', 'age']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
-        $this->assertEquals('foo', $model->name);
-        $this->assertEquals('bar', $model->age);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
     }
 
     public function testQualifyColumn()
     {
         $model = new EloquentModelStub;
 
-        $this->assertEquals('stub.column', $model->qualifyColumn('column'));
+        $this->assertSame('stub.column', $model->qualifyColumn('column'));
     }
 
     public function testForceFillMethodFillsGuardedAttributes()
@@ -959,8 +959,8 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelStub::unguard();
         $model->guard(['*']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
-        $this->assertEquals('foo', $model->name);
-        $this->assertEquals('bar', $model->age);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
         EloquentModelStub::unguard(false);
     }
 
@@ -978,7 +978,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->fill(['name' => 'foo', 'age' => 'bar', 'foo' => 'bar']);
         $this->assertFalse(isset($model->name));
         $this->assertFalse(isset($model->age));
-        $this->assertEquals('bar', $model->foo);
+        $this->assertSame('bar', $model->foo);
     }
 
     public function testFillableOverridesGuarded()
@@ -988,8 +988,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model->fillable(['age', 'foo']);
         $model->fill(['name' => 'foo', 'age' => 'bar', 'foo' => 'bar']);
         $this->assertFalse(isset($model->name));
-        $this->assertEquals('bar', $model->age);
-        $this->assertEquals('bar', $model->foo);
+        $this->assertSame('bar', $model->age);
+        $this->assertSame('bar', $model->foo);
     }
 
     public function testGlobalGuarded()
@@ -1007,7 +1007,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = Model::unguarded(function () {
             return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
         });
-        $this->assertEquals('Taylor', $model->name);
+        $this->assertSame('Taylor', $model->name);
         $this->assertFalse(Model::isUnguarded());
     }
 
@@ -1017,7 +1017,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = Model::unguarded(function () {
             return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
         });
-        $this->assertEquals('Taylor', $model->name);
+        $this->assertSame('Taylor', $model->name);
         $this->assertTrue(Model::isUnguarded());
         Model::reguard();
     }
@@ -1039,12 +1039,12 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentModelSaveStub::class);
-        $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentModelSaveStub::class, 'foo');
-        $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
@@ -1054,8 +1054,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphOne(EloquentModelSaveStub::class, 'morph');
-        $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
-        $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
+        $this->assertSame('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
     }
 
@@ -1076,13 +1076,13 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentModelSaveStub::class);
-        $this->assertEquals('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentModelSaveStub::class, 'foo');
 
-        $this->assertEquals('save_stub.foo', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.foo', $relation->getQualifiedForeignKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
@@ -1092,8 +1092,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->morphMany(EloquentModelSaveStub::class, 'morph');
-        $this->assertEquals('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
-        $this->assertEquals('save_stub.morph_type', $relation->getQualifiedMorphType());
+        $this->assertSame('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
     }
 
@@ -1102,14 +1102,14 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->belongsToStub();
-        $this->assertEquals('belongs_to_stub_id', $relation->getForeignKeyName());
+        $this->assertSame('belongs_to_stub_id', $relation->getForeignKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->belongsToExplicitKeyStub();
-        $this->assertEquals('foo', $relation->getForeignKeyName());
+        $this->assertSame('foo', $relation->getForeignKeyName());
     }
 
     public function testMorphToCreatesProperRelation()
@@ -1119,29 +1119,29 @@ class DatabaseEloquentModelTest extends TestCase
 
         // $this->morphTo();
         $relation = $model->morphToStub();
-        $this->assertEquals('morph_to_stub_id', $relation->getForeignKeyName());
-        $this->assertEquals('morph_to_stub_type', $relation->getMorphType());
-        $this->assertEquals('morphToStub', $relation->getRelationName());
+        $this->assertSame('morph_to_stub_id', $relation->getForeignKeyName());
+        $this->assertSame('morph_to_stub_type', $relation->getMorphType());
+        $this->assertSame('morphToStub', $relation->getRelationName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
 
         // $this->morphTo(null, 'type', 'id');
         $relation2 = $model->morphToStubWithKeys();
-        $this->assertEquals('id', $relation2->getForeignKeyName());
-        $this->assertEquals('type', $relation2->getMorphType());
-        $this->assertEquals('morphToStubWithKeys', $relation2->getRelationName());
+        $this->assertSame('id', $relation2->getForeignKeyName());
+        $this->assertSame('type', $relation2->getMorphType());
+        $this->assertSame('morphToStubWithKeys', $relation2->getRelationName());
 
         // $this->morphTo('someName');
         $relation3 = $model->morphToStubWithName();
-        $this->assertEquals('some_name_id', $relation3->getForeignKeyName());
-        $this->assertEquals('some_name_type', $relation3->getMorphType());
-        $this->assertEquals('someName', $relation3->getRelationName());
+        $this->assertSame('some_name_id', $relation3->getForeignKeyName());
+        $this->assertSame('some_name_type', $relation3->getMorphType());
+        $this->assertSame('someName', $relation3->getRelationName());
 
         // $this->morphTo('someName', 'type', 'id');
         $relation4 = $model->morphToStubWithNameAndKeys();
-        $this->assertEquals('id', $relation4->getForeignKeyName());
-        $this->assertEquals('type', $relation4->getMorphType());
-        $this->assertEquals('someName', $relation4->getRelationName());
+        $this->assertSame('id', $relation4->getForeignKeyName());
+        $this->assertSame('type', $relation4->getMorphType());
+        $this->assertSame('someName', $relation4->getRelationName());
     }
 
     public function testBelongsToManyCreatesProperRelation()
@@ -1150,8 +1150,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->addMockConnection($model);
 
         $relation = $model->belongsToMany(EloquentModelSaveStub::class);
-        $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignPivotKeyName());
-        $this->assertEquals('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());
@@ -1159,8 +1159,8 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->belongsToMany(EloquentModelSaveStub::class, 'table', 'foreign', 'other');
-        $this->assertEquals('table.foreign', $relation->getQualifiedForeignPivotKeyName());
-        $this->assertEquals('table.other', $relation->getQualifiedRelatedPivotKeyName());
+        $this->assertSame('table.foreign', $relation->getQualifiedForeignPivotKeyName());
+        $this->assertSame('table.other', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
     }
@@ -1172,78 +1172,78 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentNoConnectionModelStub::class);
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentDifferentConnectionModelStub::class);
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
 
         // Morph One
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->morphOne(EloquentNoConnectionModelStub::class, 'type');
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->morphOne(EloquentDifferentConnectionModelStub::class, 'type');
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
 
         // Belongs to
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->belongsTo(EloquentNoConnectionModelStub::class);
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->belongsTo(EloquentDifferentConnectionModelStub::class);
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentNoConnectionModelStub::class);
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentDifferentConnectionModelStub::class);
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
 
         // has many through
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasManyThrough(EloquentNoConnectionModelStub::class, EloquentModelSaveStub::class);
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->hasManyThrough(EloquentDifferentConnectionModelStub::class, EloquentModelSaveStub::class);
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
 
         // belongs to many
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->belongsToMany(EloquentNoConnectionModelStub::class);
-        $this->assertEquals('non_default', $relation->getRelated()->getConnectionName());
+        $this->assertSame('non_default', $relation->getRelated()->getConnectionName());
 
         $model = new EloquentModelStub;
         $model->setConnection('non_default');
         $this->addMockConnection($model);
         $relation = $model->belongsToMany(EloquentDifferentConnectionModelStub::class);
-        $this->assertEquals('different_connection', $relation->getRelated()->getConnectionName());
+        $this->assertSame('different_connection', $relation->getRelated()->getConnectionName());
     }
 
     public function testModelsAssumeTheirName()
@@ -1251,10 +1251,10 @@ class DatabaseEloquentModelTest extends TestCase
         require_once __DIR__.'/stubs/EloquentModelNamespacedStub.php';
 
         $model = new EloquentModelWithoutTableStub;
-        $this->assertEquals('eloquent_model_without_table_stubs', $model->getTable());
+        $this->assertSame('eloquent_model_without_table_stubs', $model->getTable());
 
         $namespacedModel = new EloquentModelNamespacedStub;
-        $this->assertEquals('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
+        $this->assertSame('eloquent_model_namespaced_stubs', $namespacedModel->getTable());
     }
 
     public function testTheMutatorCacheIsPopulated()
@@ -1274,13 +1274,13 @@ class DatabaseEloquentModelTest extends TestCase
     {
         $model = new EloquentModelNonIncrementingStub;
         $model->id = 'foo';
-        $this->assertEquals('foo', $model->getRouteKey());
+        $this->assertSame('foo', $model->getRouteKey());
     }
 
     public function testRouteNameIsPrimaryKeyName()
     {
         $model = new EloquentModelStub;
-        $this->assertEquals('id', $model->getRouteKeyName());
+        $this->assertSame('id', $model->getRouteKeyName());
     }
 
     public function testCloneModelMakesAFreshCopyOfTheModel()
@@ -1298,8 +1298,8 @@ class DatabaseEloquentModelTest extends TestCase
 
         $this->assertNull($clone->id);
         $this->assertFalse($clone->exists);
-        $this->assertEquals('taylor', $clone->first);
-        $this->assertEquals('otwell', $clone->last);
+        $this->assertSame('taylor', $clone->first);
+        $this->assertSame('otwell', $clone->last);
         $this->assertObjectNotHasAttribute('created_at', $clone);
         $this->assertObjectNotHasAttribute('updated_at', $clone);
         $this->assertEquals(['bar'], $clone->foo);
@@ -1477,9 +1477,9 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue(isset($model->camelCased));
         $this->assertTrue(isset($model->StudlyCased));
 
-        $this->assertEquals('admin', $model->is_admin);
-        $this->assertEquals('camelCased', $model->camelCased);
-        $this->assertEquals('StudlyCased', $model->StudlyCased);
+        $this->assertSame('admin', $model->is_admin);
+        $this->assertSame('camelCased', $model->camelCased);
+        $this->assertSame('StudlyCased', $model->StudlyCased);
 
         $model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
         $this->assertEquals([], $model->toArray());
@@ -1510,7 +1510,7 @@ class DatabaseEloquentModelTest extends TestCase
         $replicated = $model->replicate();
 
         $this->assertNull($replicated->id);
-        $this->assertEquals('bar', $replicated->foo);
+        $this->assertSame('bar', $replicated->foo);
         $this->assertNull($replicated->created_at);
         $this->assertNull($replicated->updated_at);
     }
@@ -1612,12 +1612,12 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($obj, $model->objectAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->arrayAttribute);
         $this->assertEquals(['foo' => 'bar'], $model->jsonAttribute);
-        $this->assertEquals('{"foo":"bar"}', $model->jsonAttributeValue());
+        $this->assertSame('{"foo":"bar"}', $model->jsonAttributeValue());
         $this->assertInstanceOf(Carbon::class, $model->dateAttribute);
         $this->assertInstanceOf(Carbon::class, $model->datetimeAttribute);
         $this->assertInstanceOf(BaseCollection::class, $model->collectionAttribute);
-        $this->assertEquals('1969-07-20', $model->dateAttribute->toDateString());
-        $this->assertEquals('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
+        $this->assertSame('1969-07-20', $model->dateAttribute->toDateString());
+        $this->assertSame('1969-07-20 22:56:00', $model->datetimeAttribute->toDateTimeString());
         $this->assertEquals(-14173440, $model->timestampAttribute);
 
         $arr = $model->toArray();
@@ -1636,8 +1636,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals($obj, $arr['objectAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['arrayAttribute']);
         $this->assertEquals(['foo' => 'bar'], $arr['jsonAttribute']);
-        $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
-        $this->assertEquals('1969-07-20 22:56:00', $arr['datetimeAttribute']);
+        $this->assertSame('1969-07-20 00:00:00', $arr['dateAttribute']);
+        $this->assertSame('1969-07-20 22:56:00', $arr['datetimeAttribute']);
         $this->assertEquals(-14173440, $arr['timestampAttribute']);
     }
 
@@ -1647,10 +1647,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->setDateFormat('Y-m-d H:i:s');
         $model->dateAttribute = '1969-07-20 22:56:00';
 
-        $this->assertEquals('1969-07-20 00:00:00', $model->dateAttribute->toDateTimeString());
+        $this->assertSame('1969-07-20 00:00:00', $model->dateAttribute->toDateTimeString());
 
         $arr = $model->toArray();
-        $this->assertEquals('1969-07-20 00:00:00', $arr['dateAttribute']);
+        $this->assertSame('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
     public function testModelAttributeCastingPreservesNull()
@@ -1780,10 +1780,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->shouldReceive('getRelationValue')->once()->with('belongsToStub')->andReturn('relation');
 
         // Can return a normal relation
-        $this->assertEquals('relation', $model->belongsToStub);
+        $this->assertSame('relation', $model->belongsToStub);
 
         // Can return a normal attribute
-        $this->assertEquals('Spark', $model->name);
+        $this->assertSame('Spark', $model->name);
 
         // Returns null for a Model.php method name
         $this->assertNull($model->delete);
@@ -1814,7 +1814,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->expects($this->once())->method('newModelQuery')->willReturn($query);
 
         $this->assertTrue($model->save());
-        $this->assertEquals('string id', $model->id);
+        $this->assertSame('string id', $model->id);
     }
 
     public function testScopesMethod()

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -23,8 +23,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar', 'created_at' => '2015-09-12'], 'table', true);
 
         $this->assertEquals(['foo' => 'bar', 'created_at' => '2015-09-12 00:00:00'], $pivot->getAttributes());
-        $this->assertEquals('connection', $pivot->getConnectionName());
-        $this->assertEquals('table', $pivot->getTable());
+        $this->assertSame('connection', $pivot->getConnectionName());
+        $this->assertSame('table', $pivot->getTable());
         $this->assertTrue($pivot->exists);
     }
 
@@ -104,8 +104,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivot = Pivot::fromAttributes($parent, ['foo' => 'bar'], 'table');
         $pivot->setPivotKeys('foreign', 'other');
 
-        $this->assertEquals('foreign', $pivot->getForeignKey());
-        $this->assertEquals('other', $pivot->getOtherKey());
+        $this->assertSame('foreign', $pivot->getForeignKey());
+        $this->assertSame('other', $pivot->getOtherKey());
     }
 
     public function testDeleteMethodDeletesModelByKeys()
@@ -127,7 +127,7 @@ class DatabaseEloquentPivotTest extends TestCase
     {
         $pivot = new Pivot;
 
-        $this->assertEquals('pivot', $pivot->getTable());
+        $this->assertSame('pivot', $pivot->getTable());
     }
 
     public function testPivotModelWithParentReturnsParentsTimestampColumns()
@@ -139,8 +139,8 @@ class DatabaseEloquentPivotTest extends TestCase
         $pivotWithParent = new Pivot;
         $pivotWithParent->pivotParent = $parent;
 
-        $this->assertEquals('parent_created_at', $pivotWithParent->getCreatedAtColumn());
-        $this->assertEquals('parent_updated_at', $pivotWithParent->getUpdatedAtColumn());
+        $this->assertSame('parent_created_at', $pivotWithParent->getCreatedAtColumn());
+        $this->assertSame('parent_updated_at', $pivotWithParent->getUpdatedAtColumn());
     }
 
     public function testPivotModelWithoutParentReturnsModelTimestampColumns()

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -244,7 +244,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $relation = new EloquentRelationStub($model->newQuery(), $model);
 
         $result = $relation->foo();
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -249,11 +249,11 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->createUsers();
 
         $result = SoftDeletesTestUser::withTrashed()->firstOrCreate(['email' => 'taylorotwell@gmail.com']);
-        $this->assertEquals('taylorotwell@gmail.com', $result->email);
+        $this->assertSame('taylorotwell@gmail.com', $result->email);
         $this->assertCount(1, SoftDeletesTestUser::all());
 
         $result = SoftDeletesTestUser::firstOrCreate(['email' => 'foo@bar.com']);
-        $this->assertEquals('foo@bar.com', $result->email);
+        $this->assertSame('foo@bar.com', $result->email);
         $this->assertCount(2, SoftDeletesTestUser::all());
         $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
     }
@@ -315,11 +315,11 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->createUsers();
 
         $result = SoftDeletesTestUser::updateOrCreate(['email' => 'foo@bar.com'], ['email' => 'bar@baz.com']);
-        $this->assertEquals('bar@baz.com', $result->email);
+        $this->assertSame('bar@baz.com', $result->email);
         $this->assertCount(2, SoftDeletesTestUser::all());
 
         $result = SoftDeletesTestUser::withTrashed()->updateOrCreate(['email' => 'taylorotwell@gmail.com'], ['email' => 'foo@bar.com']);
-        $this->assertEquals('foo@bar.com', $result->email);
+        $this->assertSame('foo@bar.com', $result->email);
         $this->assertCount(2, SoftDeletesTestUser::all());
         $this->assertCount(3, SoftDeletesTestUser::withTrashed()->get());
     }
@@ -337,14 +337,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = $abigail->fresh();
 
         $this->assertNull($abigail->address);
-        $this->assertEquals('Laravel avenue 43', $abigail->address()->withTrashed()->first()->address);
+        $this->assertSame('Laravel avenue 43', $abigail->address()->withTrashed()->first()->address);
 
         // restore
         $abigail->address()->withTrashed()->restore();
 
         $abigail = $abigail->fresh();
 
-        $this->assertEquals('Laravel avenue 43', $abigail->address->address);
+        $this->assertSame('Laravel avenue 43', $abigail->address->address);
 
         // delete on model
         $abigail->address->delete();
@@ -352,7 +352,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = $abigail->fresh();
 
         $this->assertNull($abigail->address);
-        $this->assertEquals('Laravel avenue 43', $abigail->address()->withTrashed()->first()->address);
+        $this->assertSame('Laravel avenue 43', $abigail->address()->withTrashed()->first()->address);
 
         // force delete
         $abigail->address()->withTrashed()->forceDelete();
@@ -377,14 +377,14 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = $abigail->fresh();
 
         $this->assertNull($abigail->group);
-        $this->assertEquals('admin', $abigail->group()->withTrashed()->first()->name);
+        $this->assertSame('admin', $abigail->group()->withTrashed()->first()->name);
 
         // restore
         $abigail->group()->withTrashed()->restore();
 
         $abigail = $abigail->fresh();
 
-        $this->assertEquals('admin', $abigail->group->name);
+        $this->assertSame('admin', $abigail->group->name);
 
         // delete on model
         $abigail->group->delete();
@@ -392,7 +392,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = $abigail->fresh();
 
         $this->assertNull($abigail->group);
-        $this->assertEquals('admin', $abigail->group()->withTrashed()->first()->name);
+        $this->assertSame('admin', $abigail->group()->withTrashed()->first()->name);
 
         // force delete
         $abigail->group()->withTrashed()->forceDelete();
@@ -416,7 +416,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $abigail = $abigail->fresh();
 
         $this->assertCount(1, $abigail->posts);
-        $this->assertEquals('First Title', $abigail->posts->first()->title);
+        $this->assertSame('First Title', $abigail->posts->first()->title);
         $this->assertCount(2, $abigail->posts()->withTrashed()->get());
 
         // restore

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -31,7 +31,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -43,7 +43,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key, add `email` varchar(255) not null', $statements[0]);
     }
 
     public function testEngineCreateTable()
@@ -61,7 +61,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -76,7 +76,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8 collate 'utf8_unicode_ci' engine = InnoDB", $statements[0]);
     }
 
     public function testCharsetCollationCreateTable()
@@ -94,7 +94,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci'", $statements[0]);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) default character set utf8mb4 collate 'utf8mb4_unicode_ci'", $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -109,7 +109,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
+        $this->assertSame("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
     }
 
     public function testBasicCreateTableWithPrefix()
@@ -127,7 +127,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $grammar);
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+        $this->assertSame('create table `prefix_users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
     public function testCreateTemporaryTable()
@@ -144,7 +144,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($conn, $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
+        $this->assertSame('create temporary table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -154,7 +154,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table `users`', $statements[0]);
+        $this->assertSame('drop table `users`', $statements[0]);
     }
 
     public function testDropTableIfExists()
@@ -164,7 +164,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table if exists `users`', $statements[0]);
+        $this->assertSame('drop table if exists `users`', $statements[0]);
     }
 
     public function testDropColumn()
@@ -174,21 +174,21 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop `foo`', $statements[0]);
+        $this->assertSame('alter table `users` drop `foo`', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo', 'bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop `foo`, drop `bar`', $statements[0]);
+        $this->assertSame('alter table `users` drop `foo`, drop `bar`', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -198,7 +198,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop primary key', $statements[0]);
+        $this->assertSame('alter table `users` drop primary key', $statements[0]);
     }
 
     public function testDropUnique()
@@ -208,7 +208,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
+        $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
     }
 
     public function testDropIndex()
@@ -218,7 +218,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop index `foo`', $statements[0]);
+        $this->assertSame('alter table `users` drop index `foo`', $statements[0]);
     }
 
     public function testDropSpatialIndex()
@@ -228,7 +228,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
+        $this->assertSame('alter table `geo` drop index `geo_coordinates_spatialindex`', $statements[0]);
     }
 
     public function testDropForeign()
@@ -238,7 +238,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop foreign key `foo`', $statements[0]);
+        $this->assertSame('alter table `users` drop foreign key `foo`', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -248,7 +248,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
     }
 
     public function testDropTimestampsTz()
@@ -258,7 +258,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
+        $this->assertSame('alter table `users` drop `created_at`, drop `updated_at`', $statements[0]);
     }
 
     public function testDropMorphs()
@@ -268,8 +268,8 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
-        $this->assertEquals('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
+        $this->assertSame('alter table `photos` drop index `photos_imageable_type_imageable_id_index`', $statements[0]);
+        $this->assertSame('alter table `photos` drop `imageable_type`, drop `imageable_id`', $statements[1]);
     }
 
     public function testRenameTable()
@@ -279,7 +279,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('rename table `users` to `foo`', $statements[0]);
+        $this->assertSame('rename table `users` to `foo`', $statements[0]);
     }
 
     public function testRenameIndex()
@@ -289,7 +289,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` rename index `foo` to `bar`', $statements[0]);
+        $this->assertSame('alter table `users` rename index `foo` to `bar`', $statements[0]);
     }
 
     public function testAddingPrimaryKey()
@@ -299,7 +299,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` add primary key `bar`(`foo`)', $statements[0]);
     }
 
     public function testAddingPrimaryKeyWithAlgorithm()
@@ -309,7 +309,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` add primary key `bar` using hash(`foo`)', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -319,7 +319,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add unique `bar`(`foo`)', $statements[0]);
+        $this->assertSame('alter table `users` add unique `bar`(`foo`)', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -329,7 +329,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
+        $this->assertSame('alter table `users` add index `baz`(`foo`, `bar`)', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()
@@ -339,7 +339,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
+        $this->assertSame('alter table `users` add index `baz` using hash(`foo`, `bar`)', $statements[0]);
     }
 
     public function testAddingSpatialIndex()
@@ -349,7 +349,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
@@ -359,7 +359,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
+        $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
     }
 
     public function testAddingForeignKey()
@@ -369,7 +369,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`)', $statements[0]);
     }
 
     public function testAddingIncrementingID()
@@ -379,7 +379,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `id` int unsigned not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -389,7 +389,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `id` smallint unsigned not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -399,7 +399,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `id` bigint unsigned not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingColumnInTableFirst()
@@ -409,7 +409,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `name` varchar(255) not null first', $statements[0]);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null first', $statements[0]);
     }
 
     public function testAddingColumnAfterAnotherColumn()
@@ -419,7 +419,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
+        $this->assertSame('alter table `users` add `name` varchar(255) not null after `foo`', $statements[0]);
     }
 
     public function testAddingGeneratedColumn()
@@ -431,7 +431,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
+        $this->assertSame('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
     }
 
     public function testAddingGeneratedColumnWithCharset()
@@ -443,7 +443,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
+        $this->assertSame('alter table `links` add `url` varchar(2083) character set ascii not null, add `url_hash_virtual` varchar(64) character set ascii as (sha2(url, 256)), add `url_hash_stored` varchar(64) character set ascii as (sha2(url, 256)) stored', $statements[0]);
     }
 
     public function testAddingString()
@@ -453,28 +453,28 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(255) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(100) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(100) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
     }
 
     public function testAddingText()
@@ -484,7 +484,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` text not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` text not null', $statements[0]);
     }
 
     public function testAddingBigInteger()
@@ -494,14 +494,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` bigint not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` bigint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` bigint not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -511,14 +511,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` int not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` int not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` int not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -528,14 +528,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` mediumint not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` mediumint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` mediumint not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -545,14 +545,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` smallint not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` smallint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` smallint not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -562,14 +562,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` tinyint not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` tinyint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` tinyint not null auto_increment primary key', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -579,7 +579,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` double(5, 2) not null', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -589,7 +589,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` double not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` double not null', $statements[0]);
     }
 
     public function testAddingDoubleSpecifyingPrecision()
@@ -599,7 +599,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` double(15, 8) not null', $statements[0]);
     }
 
     public function testAddingDecimal()
@@ -609,7 +609,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` decimal(5, 2) not null', $statements[0]);
     }
 
     public function testAddingBoolean()
@@ -619,7 +619,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` tinyint(1) not null', $statements[0]);
     }
 
     public function testAddingEnum()
@@ -629,7 +629,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
+        $this->assertSame('alter table `users` add `role` enum(\'member\', \'admin\') not null', $statements[0]);
     }
 
     public function testAddingSet()
@@ -639,7 +639,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
+        $this->assertSame('alter table `users` add `role` set(\'member\', \'admin\') not null', $statements[0]);
     }
 
     public function testAddingJson()
@@ -649,7 +649,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
     }
 
     public function testAddingJsonb()
@@ -659,7 +659,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` json not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` json not null', $statements[0]);
     }
 
     public function testAddingDate()
@@ -669,7 +669,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` date not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` date not null', $statements[0]);
     }
 
     public function testAddingYear()
@@ -678,7 +678,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `birth_year` year not null', $statements[0]);
+        $this->assertSame('alter table `users` add `birth_year` year not null', $statements[0]);
     }
 
     public function testAddingDateTime()
@@ -687,13 +687,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTime('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dateTime('foo', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -702,13 +702,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime(1) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` datetime not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
@@ -717,7 +717,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -726,7 +726,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->time('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -735,7 +735,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` time not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -744,7 +744,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` time(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` time(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
@@ -753,7 +753,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -762,7 +762,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimestampWithDefault()
@@ -771,7 +771,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -780,7 +780,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -789,7 +789,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp(1) not null', $statements[0]);
     }
 
     public function testAddingTimeStampTzWithDefault()
@@ -798,7 +798,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
     }
 
     public function testAddingTimestamps()
@@ -807,7 +807,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
     public function testAddingTimestampsTz()
@@ -816,7 +816,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
+        $this->assertSame('alter table `users` add `created_at` timestamp null, add `updated_at` timestamp null', $statements[0]);
     }
 
     public function testAddingRememberToken()
@@ -826,7 +826,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
+        $this->assertSame('alter table `users` add `remember_token` varchar(100) null', $statements[0]);
     }
 
     public function testAddingBinary()
@@ -836,7 +836,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` blob not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
     }
 
     public function testAddingUuid()
@@ -846,7 +846,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` char(36) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` char(36) not null', $statements[0]);
     }
 
     public function testAddingIpAddress()
@@ -856,7 +856,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(45) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(45) not null', $statements[0]);
     }
 
     public function testAddingMacAddress()
@@ -866,7 +866,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `users` add `foo` varchar(17) not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(17) not null', $statements[0]);
     }
 
     public function testAddingGeometry()
@@ -876,7 +876,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` geometry not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` geometry not null', $statements[0]);
     }
 
     public function testAddingPoint()
@@ -886,7 +886,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` point not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` point not null', $statements[0]);
     }
 
     public function testAddingLineString()
@@ -896,7 +896,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` linestring not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` linestring not null', $statements[0]);
     }
 
     public function testAddingPolygon()
@@ -906,7 +906,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` polygon not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` polygon not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
@@ -916,7 +916,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` geometrycollection not null', $statements[0]);
     }
 
     public function testAddingMultiPoint()
@@ -926,7 +926,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` multipoint not null', $statements[0]);
     }
 
     public function testAddingMultiLineString()
@@ -936,7 +936,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` multilinestring not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
@@ -946,7 +946,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
+        $this->assertSame('alter table `geo` add `coordinates` multipolygon not null', $statements[0]);
     }
 
     public function testAddingComment()
@@ -956,21 +956,21 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
+        $this->assertSame("alter table `users` add `foo` varchar(255) not null comment 'Escape \\' when using words like it\\'s'", $statements[0]);
     }
 
     public function testDropAllTables()
     {
         $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
 
-        $this->assertEquals('drop table `alpha`,`beta`,`gamma`', $statement);
+        $this->assertSame('drop table `alpha`,`beta`,`gamma`', $statement);
     }
 
     public function testDropAllViews()
     {
         $statement = $this->getGrammar()->compileDropAllViews(['alpha', 'beta', 'gamma']);
 
-        $this->assertEquals('drop view `alpha`,`beta`,`gamma`', $statement);
+        $this->assertSame('drop view `alpha`,`beta`,`gamma`', $statement);
     }
 
     public function testGrammarsAreMacroable()

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -25,7 +25,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null, "name" varchar(255) collate "nb_NO.utf8" not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -33,7 +33,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial primary key not null, add column "email" varchar(255) not null', $statements[0]);
     }
 
     public function testCreateTableAndCommentColumn()
@@ -45,8 +45,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
-        $this->assertEquals('comment on column "users"."email" is \'my first comment\'', $statements[1]);
+        $this->assertSame('create table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertSame('comment on column "users"."email" is \'my first comment\'', $statements[1]);
     }
 
     public function testCreateTemporaryTable()
@@ -59,7 +59,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
+        $this->assertSame('create temporary table "users" ("id" serial primary key not null, "email" varchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -69,7 +69,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table "users"', $statements[0]);
+        $this->assertSame('drop table "users"', $statements[0]);
     }
 
     public function testDropTableIfExists()
@@ -79,7 +79,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table if exists "users"', $statements[0]);
+        $this->assertSame('drop table if exists "users"', $statements[0]);
     }
 
     public function testDropColumn()
@@ -89,21 +89,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo', 'bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo", drop column "bar"', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -113,7 +113,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "users_pkey"', $statements[0]);
+        $this->assertSame('alter table "users" drop constraint "users_pkey"', $statements[0]);
     }
 
     public function testDropUnique()
@@ -123,7 +123,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -133,7 +133,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "foo"', $statements[0]);
+        $this->assertSame('drop index "foo"', $statements[0]);
     }
 
     public function testDropSpatialIndex()
@@ -143,7 +143,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "geo_coordinates_spatialindex"', $statements[0]);
+        $this->assertSame('drop index "geo_coordinates_spatialindex"', $statements[0]);
     }
 
     public function testDropForeign()
@@ -153,7 +153,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -163,7 +163,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
     }
 
     public function testDropTimestampsTz()
@@ -173,7 +173,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "created_at", drop column "updated_at"', $statements[0]);
     }
 
     public function testDropMorphs()
@@ -183,8 +183,8 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
+        $this->assertSame('drop index "photos_imageable_type_imageable_id_index"', $statements[0]);
+        $this->assertSame('alter table "photos" drop column "imageable_type", drop column "imageable_id"', $statements[1]);
     }
 
     public function testRenameTable()
@@ -194,7 +194,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
+        $this->assertSame('alter table "users" rename to "foo"', $statements[0]);
     }
 
     public function testRenameIndex()
@@ -204,7 +204,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter index "foo" rename to "bar"', $statements[0]);
+        $this->assertSame('alter index "foo" rename to "bar"', $statements[0]);
     }
 
     public function testAddingPrimaryKey()
@@ -214,7 +214,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add primary key ("foo")', $statements[0]);
+        $this->assertSame('alter table "users" add primary key ("foo")', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -224,7 +224,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "bar" unique ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -234,7 +234,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingIndexWithAlgorithm()
@@ -244,7 +244,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
+        $this->assertSame('create index "baz" on "users" using hash ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingSpatialIndex()
@@ -254,7 +254,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
+        $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
@@ -264,7 +264,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
+        $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
     }
 
     public function testAddingIncrementingID()
@@ -274,7 +274,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial primary key not null', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -284,7 +284,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" smallserial primary key not null', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -294,7 +294,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" serial primary key not null', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -304,7 +304,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" bigserial primary key not null', $statements[0]);
     }
 
     public function testAddingString()
@@ -314,21 +314,21 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar(255) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar(100) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar(100) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar(100) null default \'bar\'', $statements[0]);
     }
 
     public function testAddingText()
@@ -338,7 +338,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
     public function testAddingBigInteger()
@@ -348,14 +348,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" bigint not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" bigint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" bigserial primary key not null', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -365,14 +365,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" serial primary key not null', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -382,14 +382,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" serial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" serial primary key not null', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -399,14 +399,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -416,14 +416,14 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" smallint not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" smallserial primary key not null', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -433,7 +433,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" double precision not null', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -443,7 +443,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" double precision not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" double precision not null', $statements[0]);
     }
 
     public function testAddingDecimal()
@@ -453,7 +453,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" decimal(5, 2) not null', $statements[0]);
     }
 
     public function testAddingBoolean()
@@ -463,7 +463,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" boolean not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" boolean not null', $statements[0]);
     }
 
     public function testAddingEnum()
@@ -473,7 +473,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "role" varchar(255) check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
     public function testAddingDate()
@@ -483,7 +483,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
     public function testAddingYear()
@@ -492,7 +492,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
     public function testAddingJson()
@@ -502,7 +502,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" json not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" json not null', $statements[0]);
     }
 
     public function testAddingJsonb()
@@ -512,7 +512,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" jsonb not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" jsonb not null', $statements[0]);
     }
 
     public function testAddingDateTime()
@@ -521,7 +521,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -530,7 +530,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -539,7 +539,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -548,7 +548,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
     public function testAddingTime()
@@ -557,7 +557,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time(0) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -566,7 +566,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->time('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -575,7 +575,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time(0) with time zone not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -584,7 +584,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time(1) with time zone not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
@@ -593,7 +593,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -602,7 +602,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(1) without time zone not null', $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -611,7 +611,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -620,7 +620,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(1) with time zone not null', $statements[0]);
     }
 
     public function testAddingTimestamps()
@@ -629,7 +629,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) without time zone null, add column "updated_at" timestamp(0) without time zone null', $statements[0]);
     }
 
     public function testAddingTimestampsTz()
@@ -638,7 +638,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" timestamp(0) with time zone null, add column "updated_at" timestamp(0) with time zone null', $statements[0]);
     }
 
     public function testAddingBinary()
@@ -648,7 +648,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" bytea not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" bytea not null', $statements[0]);
     }
 
     public function testAddingUuid()
@@ -658,7 +658,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" uuid not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" uuid not null', $statements[0]);
     }
 
     public function testAddingGeneratedAs()
@@ -667,25 +667,25 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $blueprint->increments('foo')->generatedAs();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer generated by default as identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity primary key not null', $statements[0]);
         // With always modifier
         $blueprint = new Blueprint('users');
         $blueprint->increments('foo')->generatedAs()->always();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer generated always as identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer generated always as identity primary key not null', $statements[0]);
         // With sequence options
         $blueprint = new Blueprint('users');
         $blueprint->increments('foo')->generatedAs('increment by 10 start with 100');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer generated by default as identity (increment by 10 start with 100) primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity (increment by 10 start with 100) primary key not null', $statements[0]);
         // Not a primary key
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo')->generatedAs();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer generated by default as identity not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer generated by default as identity not null', $statements[0]);
     }
 
     public function testAddingIpAddress()
@@ -695,7 +695,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" inet not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" inet not null', $statements[0]);
     }
 
     public function testAddingMacAddress()
@@ -705,7 +705,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" macaddr not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" macaddr not null', $statements[0]);
     }
 
     public function testCompileForeign()
@@ -715,28 +715,28 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable(false)->initiallyImmediate();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade not deferrable', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade not deferrable', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->initiallyImmediate(false);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable initially deferred', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->foreign('parent_id')->references('id')->on('parents')->onDelete('cascade')->deferrable()->notValid();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "users_parent_id_foreign" foreign key ("parent_id") references "parents" ("id") on delete cascade deferrable not valid', $statements[0]);
     }
 
     public function testAddingGeometry()
@@ -746,7 +746,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(geometry, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(geometry, 4326) not null', $statements[0]);
     }
 
     public function testAddingPoint()
@@ -756,7 +756,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(point, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(point, 4326) not null', $statements[0]);
     }
 
     public function testAddingLineString()
@@ -766,7 +766,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(linestring, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(linestring, 4326) not null', $statements[0]);
     }
 
     public function testAddingPolygon()
@@ -776,7 +776,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(polygon, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(polygon, 4326) not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
@@ -786,7 +786,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(geometrycollection, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(geometrycollection, 4326) not null', $statements[0]);
     }
 
     public function testAddingMultiPoint()
@@ -796,7 +796,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(multipoint, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(multipoint, 4326) not null', $statements[0]);
     }
 
     public function testAddingMultiLineString()
@@ -806,7 +806,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(multilinestring, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(multilinestring, 4326) not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
@@ -816,28 +816,28 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geography(multipolygon, 4326) not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geography(multipolygon, 4326) not null', $statements[0]);
     }
 
     public function testDropAllTablesEscapesTableNames()
     {
         $statement = $this->getGrammar()->compileDropAllTables(['alpha', 'beta', 'gamma']);
 
-        $this->assertEquals('drop table "alpha","beta","gamma" cascade', $statement);
+        $this->assertSame('drop table "alpha","beta","gamma" cascade', $statement);
     }
 
     public function testDropAllViewsEscapesTableNames()
     {
         $statement = $this->getGrammar()->compileDropAllViews(['alpha', 'beta', 'gamma']);
 
-        $this->assertEquals('drop view "alpha","beta","gamma" cascade', $statement);
+        $this->assertSame('drop view "alpha","beta","gamma" cascade', $statement);
     }
 
     public function testDropAllTypesEscapesTableNames()
     {
         $statement = $this->getGrammar()->compileDropAllTypes(['alpha', 'beta', 'gamma']);
 
-        $this->assertEquals('drop type "alpha","beta","gamma" cascade', $statement);
+        $this->assertSame('drop type "alpha","beta","gamma" cascade', $statement);
     }
 
     protected function getConnection()

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -34,7 +34,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users');
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users"', $builder->toSql());
     }
 
     public function testBasicSelectWithGetColumns()
@@ -42,13 +42,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getProcessor()->shouldReceive('processSelect');
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
-            $this->assertEquals('select * from "users"', $sql);
+            $this->assertSame('select * from "users"', $sql);
         });
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
-            $this->assertEquals('select "foo", "bar" from "users"', $sql);
+            $this->assertSame('select "foo", "bar" from "users"', $sql);
         });
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
-            $this->assertEquals('select "baz" from "users"', $sql);
+            $this->assertSame('select "baz" from "users"', $sql);
         });
 
         $builder->from('users')->get();
@@ -60,7 +60,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->get('baz');
         $this->assertNull($builder->columns);
 
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users"', $builder->toSql());
         $this->assertNull($builder->columns);
     }
 
@@ -81,28 +81,28 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('some"table');
-        $this->assertEquals('select * from "some""table"', $builder->toSql());
+        $this->assertSame('select * from "some""table"', $builder->toSql());
     }
 
     public function testAliasWrappingAsWholeConstant()
     {
         $builder = $this->getBuilder();
         $builder->select('x.y as foo.bar')->from('baz');
-        $this->assertEquals('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
+        $this->assertSame('select "x"."y" as "foo.bar" from "baz"', $builder->toSql());
     }
 
     public function testAliasWrappingWithSpacesInDatabaseName()
     {
         $builder = $this->getBuilder();
         $builder->select('w x.y.z as foo.bar')->from('baz');
-        $this->assertEquals('select "w x"."y"."z" as "foo.bar" from "baz"', $builder->toSql());
+        $this->assertSame('select "w x"."y"."z" as "foo.bar" from "baz"', $builder->toSql());
     }
 
     public function testAddingSelects()
     {
         $builder = $this->getBuilder();
         $builder->select('foo')->addSelect('bar')->addSelect(['baz', 'boom'])->from('users');
-        $this->assertEquals('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
+        $this->assertSame('select "foo", "bar", "baz", "boom" from "users"', $builder->toSql());
     }
 
     public function testBasicSelectWithPrefix()
@@ -110,32 +110,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('users');
-        $this->assertEquals('select * from "prefix_users"', $builder->toSql());
+        $this->assertSame('select * from "prefix_users"', $builder->toSql());
     }
 
     public function testBasicSelectDistinct()
     {
         $builder = $this->getBuilder();
         $builder->distinct()->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
+        $this->assertSame('select distinct "foo", "bar" from "users"', $builder->toSql());
     }
 
     public function testBasicSelectDistinctOnColumns()
     {
         $builder = $this->getBuilder();
         $builder->distinct('foo')->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct "foo", "bar" from "users"', $builder->toSql());
+        $this->assertSame('select distinct "foo", "bar" from "users"', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
         $builder->distinct('foo')->select('foo', 'bar')->from('users');
-        $this->assertEquals('select distinct on ("foo") "foo", "bar" from "users"', $builder->toSql());
+        $this->assertSame('select distinct on ("foo") "foo", "bar" from "users"', $builder->toSql());
     }
 
     public function testBasicAlias()
     {
         $builder = $this->getBuilder();
         $builder->select('foo as bar')->from('users');
-        $this->assertEquals('select "foo" as "bar" from "users"', $builder->toSql());
+        $this->assertSame('select "foo" as "bar" from "users"', $builder->toSql());
     }
 
     public function testAliasWithPrefix()
@@ -143,7 +143,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('users as people');
-        $this->assertEquals('select * from "prefix_users" as "prefix_people"', $builder->toSql());
+        $this->assertSame('select * from "prefix_users" as "prefix_people"', $builder->toSql());
     }
 
     public function testJoinAliasesWithPrefix()
@@ -151,14 +151,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->select('*')->from('services')->join('translations AS t', 't.item_id', '=', 'services.id');
-        $this->assertEquals('select * from "prefix_services" inner join "prefix_translations" as "prefix_t" on "prefix_t"."item_id" = "prefix_services"."id"', $builder->toSql());
+        $this->assertSame('select * from "prefix_services" inner join "prefix_translations" as "prefix_t" on "prefix_t"."item_id" = "prefix_services"."id"', $builder->toSql());
     }
 
     public function testBasicTableWrapping()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('public.users');
-        $this->assertEquals('select * from "public"."users"', $builder->toSql());
+        $this->assertSame('select * from "public"."users"', $builder->toSql());
     }
 
     public function testWhenCallback()
@@ -171,11 +171,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testWhenCallbackWithReturn()
@@ -188,11 +188,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(true, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testWhenCallbackWithDefault()
@@ -211,12 +211,12 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when('truthy', $callback, $default)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when(0, $callback, $default)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -230,11 +230,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(false, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(true, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testUnlessCallbackWithReturn()
@@ -247,11 +247,11 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(false, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(true, $callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
     }
 
     public function testUnlessCallbackWithDefault()
@@ -270,12 +270,12 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless(0, $callback, $default)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->unless('truthy', $callback, $default)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -287,14 +287,14 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->tap($callback)->where('email', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
     }
 
     public function testBasicWheres()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
-        $this->assertEquals('select * from "users" where "id" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -302,45 +302,45 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->From('some`table');
-        $this->assertEquals('select * from `some``table`', $builder->toSql());
+        $this->assertSame('select * from `some``table`', $builder->toSql());
     }
 
     public function testDateBasedWheresAcceptsTwoArguments()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', 1);
-        $this->assertEquals('select * from `users` where date(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where date(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', 1);
-        $this->assertEquals('select * from `users` where day(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where day(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', 1);
-        $this->assertEquals('select * from `users` where month(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where month(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', 1);
-        $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where year(`created_at`) = ?', $builder->toSql());
     }
 
     public function testDateBasedOrWheresAcceptsTwoArguments()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhereDate('created_at', 1);
-        $this->assertEquals('select * from `users` where `id` = ? or date(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or date(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhereDay('created_at', 1);
-        $this->assertEquals('select * from `users` where `id` = ? or day(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or day(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhereMonth('created_at', 1);
-        $this->assertEquals('select * from `users` where `id` = ? or month(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or month(`created_at`) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhereYear('created_at', 1);
-        $this->assertEquals('select * from `users` where `id` = ? or year(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or year(`created_at`) = ?', $builder->toSql());
     }
 
     public function testDateBasedWheresExpressionIsNotBound()
@@ -366,19 +366,19 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-21');
-        $this->assertEquals('select * from `users` where date(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where date(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-12-21'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', new Raw('NOW()'));
-        $this->assertEquals('select * from `users` where date(`created_at`) = NOW()', $builder->toSql());
+        $this->assertSame('select * from `users` where date(`created_at`) = NOW()', $builder->toSql());
     }
 
     public function testWhereDayMySql()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-        $this->assertEquals('select * from `users` where day(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where day(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -386,7 +386,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1)->orWhereDay('created_at', '=', 2);
-        $this->assertEquals('select * from `users` where day(`created_at`) = ? or day(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where day(`created_at`) = ? or day(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -394,7 +394,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-        $this->assertEquals('select * from `users` where month(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where month(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
@@ -402,7 +402,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5)->orWhereMonth('created_at', '=', 6);
-        $this->assertEquals('select * from `users` where month(`created_at`) = ? or month(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where month(`created_at`) = ? or month(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 5, 1 => 6], $builder->getBindings());
     }
 
@@ -410,7 +410,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-        $this->assertEquals('select * from `users` where year(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where year(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
@@ -418,7 +418,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014)->orWhereYear('created_at', '=', 2015);
-        $this->assertEquals('select * from `users` where year(`created_at`) = ? or year(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where year(`created_at`) = ? or year(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => 2014, 1 => 2015], $builder->getBindings());
     }
 
@@ -426,7 +426,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
-        $this->assertEquals('select * from `users` where time(`created_at`) >= ?', $builder->toSql());
+        $this->assertSame('select * from `users` where time(`created_at`) >= ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -434,7 +434,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
-        $this->assertEquals('select * from `users` where time(`created_at`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where time(`created_at`) = ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -442,7 +442,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
-        $this->assertEquals('select * from "users" where "created_at"::time = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "created_at"::time = ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -450,12 +450,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
-        $this->assertEquals('select * from [users] where cast([created_at] as time) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where cast([created_at] as time) = ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', new Raw('NOW()'));
-        $this->assertEquals('select * from [users] where cast([created_at] as time) = NOW()', $builder->toSql());
+        $this->assertSame('select * from [users] where cast([created_at] as time) = NOW()', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -463,19 +463,19 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-21');
-        $this->assertEquals('select * from "users" where "created_at"::date = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "created_at"::date = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-12-21'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'));
-        $this->assertEquals('select * from "users" where "created_at"::date = NOW()', $builder->toSql());
+        $this->assertSame('select * from "users" where "created_at"::date = NOW()', $builder->toSql());
     }
 
     public function testWhereDayPostgres()
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-        $this->assertEquals('select * from "users" where extract(day from "created_at") = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where extract(day from "created_at") = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -483,7 +483,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-        $this->assertEquals('select * from "users" where extract(month from "created_at") = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where extract(month from "created_at") = ?', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
@@ -491,7 +491,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-        $this->assertEquals('select * from "users" where extract(year from "created_at") = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where extract(year from "created_at") = ?', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
@@ -499,7 +499,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
-        $this->assertEquals('select * from "users" where "created_at"::time >= ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "created_at"::time >= ?', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -507,27 +507,27 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', 'like', '1');
-        $this->assertEquals('select * from "users" where "id"::text like ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id"::text like ?', $builder->toSql());
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', 'LIKE', '1');
-        $this->assertEquals('select * from "users" where "id"::text LIKE ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id"::text LIKE ?', $builder->toSql());
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', 'ilike', '1');
-        $this->assertEquals('select * from "users" where "id"::text ilike ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id"::text ilike ?', $builder->toSql());
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', 'not like', '1');
-        $this->assertEquals('select * from "users" where "id"::text not like ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id"::text not like ?', $builder->toSql());
         $this->assertEquals([0 => '1'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', 'not ilike', '1');
-        $this->assertEquals('select * from "users" where "id"::text not ilike ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id"::text not ilike ?', $builder->toSql());
         $this->assertEquals([0 => '1'], $builder->getBindings());
     }
 
@@ -535,19 +535,19 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-21');
-        $this->assertEquals('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") = cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") = cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => '2015-12-21'], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'));
-        $this->assertEquals('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") = cast(NOW() as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%Y-%m-%d\', "created_at") = cast(NOW() as text)', $builder->toSql());
     }
 
     public function testWhereDaySqlite()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-        $this->assertEquals('select * from "users" where strftime(\'%d\', "created_at") = cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%d\', "created_at") = cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -555,7 +555,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-        $this->assertEquals('select * from "users" where strftime(\'%m\', "created_at") = cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%m\', "created_at") = cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
@@ -563,7 +563,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-        $this->assertEquals('select * from "users" where strftime(\'%Y\', "created_at") = cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%Y\', "created_at") = cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
@@ -571,7 +571,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '>=', '22:00');
-        $this->assertEquals('select * from "users" where strftime(\'%H:%M:%S\', "created_at") >= cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%H:%M:%S\', "created_at") >= cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -579,7 +579,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereTime('created_at', '22:00');
-        $this->assertEquals('select * from "users" where strftime(\'%H:%M:%S\', "created_at") = cast(? as text)', $builder->toSql());
+        $this->assertSame('select * from "users" where strftime(\'%H:%M:%S\', "created_at") = cast(? as text)', $builder->toSql());
         $this->assertEquals([0 => '22:00'], $builder->getBindings());
     }
 
@@ -587,19 +587,19 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-12-21');
-        $this->assertEquals('select * from [users] where cast([created_at] as date) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where cast([created_at] as date) = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-12-21'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', new Raw('NOW()'));
-        $this->assertEquals('select * from [users] where cast([created_at] as date) = NOW()', $builder->toSql());
+        $this->assertSame('select * from [users] where cast([created_at] as date) = NOW()', $builder->toSql());
     }
 
     public function testWhereDaySqlServer()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDay('created_at', '=', 1);
-        $this->assertEquals('select * from [users] where day([created_at]) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where day([created_at]) = ?', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -607,7 +607,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereMonth('created_at', '=', 5);
-        $this->assertEquals('select * from [users] where month([created_at]) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where month([created_at]) = ?', $builder->toSql());
         $this->assertEquals([0 => 5], $builder->getBindings());
     }
 
@@ -615,7 +615,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereYear('created_at', '=', 2014);
-        $this->assertEquals('select * from [users] where year([created_at]) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where year([created_at]) = ?', $builder->toSql());
         $this->assertEquals([0 => 2014], $builder->getBindings());
     }
 
@@ -623,17 +623,17 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [1, 2]);
-        $this->assertEquals('select * from "users" where "id" between ? and ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotBetween('id', [1, 2]);
-        $this->assertEquals('select * from "users" where "id" not between ? and ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" not between ? and ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereBetween('id', [new Raw(1), new Raw(2)]);
-        $this->assertEquals('select * from "users" where "id" between 1 and 2', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" between 1 and 2', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -641,7 +641,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhere('email', '=', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -649,7 +649,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereRaw('id = ? or email = ?', [1, 'foo']);
-        $this->assertEquals('select * from "users" where id = ? or email = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where id = ? or email = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -657,7 +657,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereRaw('email = ?', ['foo']);
-        $this->assertEquals('select * from "users" where "id" = ? or email = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or email = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -665,12 +665,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "id" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -678,12 +678,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', [1, 2, 3]);
-        $this->assertEquals('select * from "users" where "id" = ? or "id" not in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "id" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 1, 2 => 2, 3 => 3], $builder->getBindings());
     }
 
@@ -691,11 +691,11 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', [new Raw(1)]);
-        $this->assertEquals('select * from "users" where "id" in (1)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" in (1)', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', [new Raw(1)]);
-        $this->assertEquals('select * from "users" where "id" = ? or "id" in (1)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "id" in (1)', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -703,12 +703,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIn('id', []);
-        $this->assertEquals('select * from "users" where 0 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where 0 = 1', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereIn('id', []);
-        $this->assertEquals('select * from "users" where "id" = ? or 0 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or 0 = 1', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -716,12 +716,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', []);
-        $this->assertEquals('select * from "users" where 1 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where 1 = 1', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNotIn('id', []);
-        $this->assertEquals('select * from "users" where "id" = ? or 1 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or 1 = 1', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -729,7 +729,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', ['1a', 2]);
-        $this->assertEquals('select * from "users" where "id" in (1, 2)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" in (1, 2)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -737,7 +737,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', ['1a', 2]);
-        $this->assertEquals('select * from "users" where "id" not in (1, 2)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" not in (1, 2)', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -745,7 +745,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerInRaw('id', []);
-        $this->assertEquals('select * from "users" where 0 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where 0 = 1', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -753,7 +753,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereIntegerNotInRaw('id', []);
-        $this->assertEquals('select * from "users" where 1 = 1', $builder->toSql());
+        $this->assertSame('select * from "users" where 1 = 1', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -761,12 +761,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn('first_name', 'last_name')->orWhereColumn('first_name', 'middle_name');
-        $this->assertEquals('select * from "users" where "first_name" = "last_name" or "first_name" = "middle_name"', $builder->toSql());
+        $this->assertSame('select * from "users" where "first_name" = "last_name" or "first_name" = "middle_name"', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn('updated_at', '>', 'created_at');
-        $this->assertEquals('select * from "users" where "updated_at" > "created_at"', $builder->toSql());
+        $this->assertSame('select * from "users" where "updated_at" > "created_at"', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -779,7 +779,7 @@ class DatabaseQueryBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereColumn($conditions);
-        $this->assertEquals('select * from "users" where ("first_name" = "last_name" and "updated_at" > "created_at")', $builder->toSql());
+        $this->assertSame('select * from "users" where ("first_name" = "last_name" and "updated_at" > "created_at")', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 
@@ -788,13 +788,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)', $builder->toSql());
+        $this->assertSame('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
+        $this->assertSame('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getMysqlBuilder();
@@ -831,7 +831,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
-        $this->assertEquals('(select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)', $builder->toSql());
+        $this->assertSame('(select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $expectedSql = '(select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)';
@@ -848,7 +848,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)', $builder->toSql());
+        $this->assertSame('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?) union (select * from "users" where "id" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
@@ -858,7 +858,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->unionAll($this->getBuilder()->select('*')->from('users')->where('id', '=', 3));
-        $this->assertEquals('(select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)', $builder->toSql());
+        $this->assertSame('(select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?) union all (select * from "users" where "id" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $builder->getBindings());
     }
 
@@ -868,7 +868,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->orderBy('id', 'desc');
-        $this->assertEquals('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?) order by "id" desc', $builder->toSql());
+        $this->assertSame('(select * from "users" where "id" = ?) union (select * from "users" where "id" = ?) order by "id" desc', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -878,7 +878,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users');
         $builder->union($this->getBuilder()->select('*')->from('dogs'));
         $builder->skip(5)->take(10);
-        $this->assertEquals('(select * from "users") union (select * from "dogs") limit 10 offset 5', $builder->toSql());
+        $this->assertSame('(select * from "users") union (select * from "dogs") limit 10 offset 5', $builder->toSql());
 
         $expectedSql = '(select * from "users") union (select * from "dogs") limit 10 offset 5';
         $builder = $this->getPostgresBuilder();
@@ -903,7 +903,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $join->on('dogs.breed_id', '=', 'breeds.id')
                 ->where('breeds.is_native', '=', 1);
         }));
-        $this->assertEquals('(select * from "users") union (select * from "dogs" inner join "breeds" on "dogs"."breed_id" = "breeds"."id" and "breeds"."is_native" = ?)', $builder->toSql());
+        $this->assertSame('(select * from "users") union (select * from "dogs" inner join "breeds" on "dogs"."breed_id" = "breeds"."id" and "breeds"."is_native" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -913,7 +913,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('id', '=', 1);
         $builder->union($this->getMySqlBuilder()->select('*')->from('users')->where('id', '=', 2));
         $builder->orderBy('id', 'desc');
-        $this->assertEquals('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?) order by `id` desc', $builder->toSql());
+        $this->assertSame('(select * from `users` where `id` = ?) union (select * from `users` where `id` = ?) order by `id` desc', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -923,7 +923,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users');
         $builder->union($this->getMySqlBuilder()->select('*')->from('dogs'));
         $builder->skip(5)->take(10);
-        $this->assertEquals('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
+        $this->assertSame('(select * from `users`) union (select * from `dogs`) limit 10 offset 5', $builder->toSql());
     }
 
     public function testUnionAggregate()
@@ -965,14 +965,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->whereIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotIn('id', function ($q) {
             $q->select('id')->from('users')->where('age', '>', 25)->take(3);
         });
-        $this->assertEquals('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" not in (select "id" from "users" where "age" > ? limit 3)', $builder->toSql());
         $this->assertEquals([25], $builder->getBindings());
     }
 
@@ -980,12 +980,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull('id');
-        $this->assertEquals('select * from "users" where "id" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" is null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull('id');
-        $this->assertEquals('select * from "users" where "id" = ? or "id" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "id" is null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -993,12 +993,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNull(['id', 'expires_at']);
-        $this->assertEquals('select * from "users" where "id" is null and "expires_at" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" is null and "expires_at" is null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereNull(['id', 'expires_at']);
-        $this->assertEquals('select * from "users" where "id" = ? or "id" is null or "expires_at" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "id" is null or "expires_at" is null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -1006,12 +1006,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull('id');
-        $this->assertEquals('select * from "users" where "id" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" is not null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull('id');
-        $this->assertEquals('select * from "users" where "id" > ? or "id" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" > ? or "id" is not null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -1019,12 +1019,12 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->whereNotNull(['id', 'expires_at']);
-        $this->assertEquals('select * from "users" where "id" is not null and "expires_at" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" is not null and "expires_at" is not null', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', '>', 1)->orWhereNotNull(['id', 'expires_at']);
-        $this->assertEquals('select * from "users" where "id" > ? or "id" is not null or "expires_at" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" > ? or "id" is not null or "expires_at" is not null', $builder->toSql());
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
@@ -1032,47 +1032,47 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('email');
-        $this->assertEquals('select * from "users" group by "email"', $builder->toSql());
+        $this->assertSame('select * from "users" group by "email"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('id', 'email');
-        $this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+        $this->assertSame('select * from "users" group by "id", "email"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy(['id', 'email']);
-        $this->assertEquals('select * from "users" group by "id", "email"', $builder->toSql());
+        $this->assertSame('select * from "users" group by "id", "email"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy(new Raw('DATE(created_at)'));
-        $this->assertEquals('select * from "users" group by DATE(created_at)', $builder->toSql());
+        $this->assertSame('select * from "users" group by DATE(created_at)', $builder->toSql());
     }
 
     public function testOrderBys()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderBy('age', 'desc');
-        $this->assertEquals('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
+        $this->assertSame('select * from "users" order by "email" asc, "age" desc', $builder->toSql());
 
         $builder->orders = null;
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users"', $builder->toSql());
 
         $builder->orders = [];
-        $this->assertEquals('select * from "users"', $builder->toSql());
+        $this->assertSame('select * from "users"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderBy('email')->orderByRaw('"age" ? desc', ['foo']);
-        $this->assertEquals('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());
+        $this->assertSame('select * from "users" order by "email" asc, "age" ? desc', $builder->toSql());
         $this->assertEquals(['foo'], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->orderByDesc('name');
-        $this->assertEquals('select * from "users" order by "name" desc', $builder->toSql());
+        $this->assertSame('select * from "users" order by "name" desc', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('public', 1)
             ->unionAll($this->getBuilder()->select('*')->from('videos')->where('public', 1))
             ->orderByRaw('field(category, ?, ?) asc', ['news', 'opinion']);
-        $this->assertEquals('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
+        $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by field(category, ?, ?) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
@@ -1084,19 +1084,19 @@ class DatabaseQueryBuilderTest extends TestCase
         };
 
         $builder = $this->getBuilder()->select('*')->from('users')->orderBy($subQuery);
-        $this->assertEquals("$expected asc", $builder->toSql());
+        $this->assertSame("$expected asc", $builder->toSql());
 
         $builder = $this->getBuilder()->select('*')->from('users')->orderBy($subQuery, 'desc');
-        $this->assertEquals("$expected desc", $builder->toSql());
+        $this->assertSame("$expected desc", $builder->toSql());
 
         $builder = $this->getBuilder()->select('*')->from('users')->orderByDesc($subQuery);
-        $this->assertEquals("$expected desc", $builder->toSql());
+        $this->assertSame("$expected desc", $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('posts')->where('public', 1)
             ->unionAll($this->getBuilder()->select('*')->from('videos')->where('public', 1))
             ->orderBy($this->getBuilder()->selectRaw('field(category, ?, ?)', ['news', 'opinion']));
-        $this->assertEquals('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by (select field(category, ?, ?)) asc', $builder->toSql());
+        $this->assertSame('(select * from "posts" where "public" = ?) union all (select * from "videos" where "public" = ?) order by (select field(category, ?, ?)) asc', $builder->toSql());
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
@@ -1112,40 +1112,40 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', '>', 1);
-        $this->assertEquals('select * from "users" having "email" > ?', $builder->toSql());
+        $this->assertSame('select * from "users" having "email" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')
             ->orHaving('email', '=', 'test@example.com')
             ->orHaving('email', '=', 'test2@example.com');
-        $this->assertEquals('select * from "users" having "email" = ? or "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" having "email" = ? or "email" = ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy('email')->having('email', '>', 1);
-        $this->assertEquals('select * from "users" group by "email" having "email" > ?', $builder->toSql());
+        $this->assertSame('select * from "users" group by "email" having "email" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('email as foo_email')->from('users')->having('foo_email', '>', 1);
-        $this->assertEquals('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
+        $this->assertSame('select "email" as "foo_email" from "users" having "foo_email" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select(['category', new Raw('count(*) as "total"')])->from('item')->where('department', '=', 'popular')->groupBy('category')->having('total', '>', new Raw('3'));
-        $this->assertEquals('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > 3', $builder->toSql());
+        $this->assertSame('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > 3', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select(['category', new Raw('count(*) as "total"')])->from('item')->where('department', '=', 'popular')->groupBy('category')->having('total', '>', 3);
-        $this->assertEquals('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > ?', $builder->toSql());
+        $this->assertSame('select "category", count(*) as "total" from "item" where "department" = ? group by "category" having "total" > ?', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->havingBetween('last_login_date', ['2018-11-16', '2018-12-16']);
-        $this->assertEquals('select * from "users" having "last_login_date" between ? and ?', $builder->toSql());
+        $this->assertSame('select * from "users" having "last_login_date" between ? and ?', $builder->toSql());
     }
 
     public function testHavingShortcut()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('email', 1)->orHaving('email', 2);
-        $this->assertEquals('select * from "users" having "email" = ? or "email" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" having "email" = ? or "email" = ?', $builder->toSql());
     }
 
     public function testHavingFollowedBySelectGet()
@@ -1176,61 +1176,61 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->havingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from "users" having user_foo < user_bar', $builder->toSql());
+        $this->assertSame('select * from "users" having user_foo < user_bar', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->having('baz', '=', 1)->orHavingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
+        $this->assertSame('select * from "users" having "baz" = ? or user_foo < user_bar', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->havingBetween('last_login_date', ['2018-11-16', '2018-12-16'])->orHavingRaw('user_foo < user_bar');
-        $this->assertEquals('select * from "users" having "last_login_date" between ? and ? or user_foo < user_bar', $builder->toSql());
+        $this->assertSame('select * from "users" having "last_login_date" between ? and ? or user_foo < user_bar', $builder->toSql());
     }
 
     public function testLimitsAndOffsets()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->offset(5)->limit(10);
-        $this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+        $this->assertSame('select * from "users" limit 10 offset 5', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->skip(5)->take(10);
-        $this->assertEquals('select * from "users" limit 10 offset 5', $builder->toSql());
+        $this->assertSame('select * from "users" limit 10 offset 5', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->skip(0)->take(0);
-        $this->assertEquals('select * from "users" limit 0 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 0 offset 0', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->skip(-5)->take(-10);
-        $this->assertEquals('select * from "users" offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" offset 0', $builder->toSql());
     }
 
     public function testForPage()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(2, 15);
-        $this->assertEquals('select * from "users" limit 15 offset 15', $builder->toSql());
+        $this->assertSame('select * from "users" limit 15 offset 15', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(0, 15);
-        $this->assertEquals('select * from "users" limit 15 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 15 offset 0', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(-2, 15);
-        $this->assertEquals('select * from "users" limit 15 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 15 offset 0', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(2, 0);
-        $this->assertEquals('select * from "users" limit 0 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 0 offset 0', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(0, 0);
-        $this->assertEquals('select * from "users" limit 0 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 0 offset 0', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->forPage(-2, 0);
-        $this->assertEquals('select * from "users" limit 0 offset 0', $builder->toSql());
+        $this->assertSame('select * from "users" limit 0 offset 0', $builder->toSql());
     }
 
     public function testGetCountForPaginationWithBindings()
@@ -1283,7 +1283,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('id', 1)->orWhere('name', 'foo');
-        $this->assertEquals('select * from "users" where "id" = ? or "name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or "name" = ?', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 'foo'], $builder->getBindings());
     }
 
@@ -1291,17 +1291,17 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', 2]]);
-        $this->assertEquals('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where(['foo' => 1, 'bar' => 2]);
-        $this->assertEquals('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where ("foo" = ? and "bar" = ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where([['foo', 1], ['bar', '<', 2]]);
-        $this->assertEquals('select * from "users" where ("foo" = ? and "bar" < ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where ("foo" = ? and "bar" < ?)', $builder->toSql());
         $this->assertEquals([0 => 1, 1 => 2], $builder->getBindings());
     }
 
@@ -1311,7 +1311,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->where('email', '=', 'foo')->orWhere(function ($q) {
             $q->where('name', '=', 'bar')->where('age', '=', 25);
         });
-        $this->assertEquals('select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ? or ("name" = ? and "age" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar', 2 => 25], $builder->getBindings());
     }
 
@@ -1331,7 +1331,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $q->select(new Raw('max(id)'))->from('users')->where('email', '=', 'bar');
         });
 
-        $this->assertEquals('select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" where "email" = ? or "id" = (select max(id) from "users" where "email" = ?)', $builder->toSql());
         $this->assertEquals([0 => 'foo', 1 => 'bar'], $builder->getBindings());
     }
 
@@ -1341,40 +1341,40 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('orders')->whereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
         });
-        $this->assertEquals('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+        $this->assertSame('select * from "orders" where exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
         });
-        $this->assertEquals('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+        $this->assertSame('select * from "orders" where not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
         });
-        $this->assertEquals('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+        $this->assertSame('select * from "orders" where "id" = ? or exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('id', '=', 1)->orWhereNotExists(function ($q) {
             $q->select('*')->from('products')->where('products.id', '=', new Raw('"orders"."id"'));
         });
-        $this->assertEquals('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
+        $this->assertSame('select * from "orders" where "id" = ? or not exists (select * from "products" where "products"."id" = "orders"."id")', $builder->toSql());
     }
 
     public function testBasicJoins()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', 'users.id', 'contacts.id');
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', 'users.id', '=', 'contacts.id')->leftJoin('photos', 'users.id', '=', 'photos.id');
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" left join "photos" on "users"."id" = "photos"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->leftJoinWhere('photos', 'users.id', '=', 'bar')->joinWhere('photos', 'users.id', '=', 'foo');
-        $this->assertEquals('select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" left join "photos" on "users"."id" = ? inner join "photos" on "users"."id" = ?', $builder->toSql());
         $this->assertEquals(['bar', 'foo'], $builder->getBindings());
     }
 
@@ -1382,15 +1382,15 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('sizes')->crossJoin('colors');
-        $this->assertEquals('select * from "sizes" cross join "colors"', $builder->toSql());
+        $this->assertSame('select * from "sizes" cross join "colors"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('tableB')->join('tableA', 'tableA.column1', '=', 'tableB.column2', 'cross');
-        $this->assertEquals('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
+        $this->assertSame('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('tableB')->crossJoin('tableA', 'tableA.column1', '=', 'tableB.column2');
-        $this->assertEquals('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
+        $this->assertSame('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
     }
 
     public function testComplexJoin()
@@ -1399,17 +1399,17 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orOn('users.name', '=', 'contacts.name');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "users"."name" = "contacts"."name"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->where('users.id', '=', 'foo')->orWhere('users.name', '=', 'bar');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
 
         // Run the assertions again
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = ? or "users"."name" = ?', $builder->toSql());
         $this->assertEquals(['foo', 'bar'], $builder->getBindings());
     }
 
@@ -1419,13 +1419,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->whereNull('contacts.deleted_at');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is null', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orWhereNull('contacts.deleted_at');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is null', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is null', $builder->toSql());
     }
 
     public function testJoinWhereNotNull()
@@ -1434,13 +1434,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->whereNotNull('contacts.deleted_at');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."deleted_at" is not null', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orWhereNotNull('contacts.deleted_at');
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."deleted_at" is not null', $builder->toSql());
     }
 
     public function testJoinWhereIn()
@@ -1449,14 +1449,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->whereIn('contacts.name', [48, 'baz', null]);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orWhereIn('contacts.name', [48, 'baz', null]);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
     }
 
@@ -1468,7 +1468,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $q->select('name')->from('contacts')->where('name', 'baz');
             $j->on('users.id', '=', 'contacts.id')->whereIn('contacts.name', $q);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" in (select "name" from "contacts" where "name" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" in (select "name" from "contacts" where "name" = ?)', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -1477,7 +1477,7 @@ class DatabaseQueryBuilderTest extends TestCase
             $q->select('name')->from('contacts')->where('name', 'baz');
             $j->on('users.id', '=', 'contacts.id')->orWhereIn('contacts.name', $q);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" in (select "name" from "contacts" where "name" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" in (select "name" from "contacts" where "name" = ?)', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -1487,14 +1487,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->whereNotIn('contacts.name', [48, 'baz', null]);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" not in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" and "contacts"."name" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->join('contacts', function ($j) {
             $j->on('users.id', '=', 'contacts.id')->orWhereNotIn('contacts.name', [48, 'baz', null]);
         });
-        $this->assertEquals('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" not in (?, ?, ?)', $builder->toSql());
+        $this->assertSame('select * from "users" inner join "contacts" on "users"."id" = "contacts"."id" or "contacts"."name" not in (?, ?, ?)', $builder->toSql());
         $this->assertEquals([48, 'baz', null], $builder->getBindings());
     }
 
@@ -1506,7 +1506,7 @@ class DatabaseQueryBuilderTest extends TestCase
                 $j->where('contacts.country', '=', 'US')->orWhere('contacts.is_partner', '=', 1);
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and ("contacts"."country" = ? or "contacts"."is_partner" = ?)', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and ("contacts"."country" = ? or "contacts"."is_partner" = ?)', $builder->toSql());
         $this->assertEquals(['US', 1], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -1519,7 +1519,7 @@ class DatabaseQueryBuilderTest extends TestCase
                 });
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and "contacts"."is_active" = ? or (("contacts"."country" = ? or "contacts"."type" = "users"."type") and ("contacts"."country" = ? or "contacts"."is_partner" is null))', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and "contacts"."is_active" = ? or (("contacts"."country" = ? or "contacts"."type" = "users"."type") and ("contacts"."country" = ? or "contacts"."is_partner" is null))', $builder->toSql());
         $this->assertEquals([1, 'UK', 'US'], $builder->getBindings());
     }
 
@@ -1533,7 +1533,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->orWhereRaw('year(contacts.created_at) = 2016');
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and ("role" = ? or "contacts"."disabled" is null or year(contacts.created_at) = 2016)', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and ("role" = ? or "contacts"."disabled" is null or year(contacts.created_at) = 2016)', $builder->toSql());
         $this->assertEquals(['admin'], $builder->getBindings());
     }
 
@@ -1547,7 +1547,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->whereNull('deleted_at');
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and "contact_type_id" in (select "id" from "contact_types" where "category_id" = ? and "deleted_at" is null)', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and "contact_type_id" in (select "id" from "contact_types" where "category_id" = ? and "deleted_at" is null)', $builder->toSql());
         $this->assertEquals(['1'], $builder->getBindings());
 
         $builder = $this->getBuilder();
@@ -1559,7 +1559,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     ->whereNull('deleted_at');
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and exists (select 1 from "contact_types" where contact_types.id = contacts.contact_type_id and "category_id" = ? and "deleted_at" is null)', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and exists (select 1 from "contact_types" where contact_types.id = contacts.contact_type_id and "category_id" = ? and "deleted_at" is null)', $builder->toSql());
         $this->assertEquals(['1'], $builder->getBindings());
     }
 
@@ -1578,7 +1578,7 @@ class DatabaseQueryBuilderTest extends TestCase
                     });
             });
         });
-        $this->assertEquals('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and exists (select 1 from "contact_types" where contact_types.id = contacts.contact_type_id and "category_id" = ? and "deleted_at" is null and "level_id" in (select "id" from "levels" where "is_active" = ?))', $builder->toSql());
+        $this->assertSame('select * from "users" left join "contacts" on "users"."id" = "contacts"."id" and exists (select 1 from "contact_types" where contact_types.id = contacts.contact_type_id and "category_id" = ? and "deleted_at" is null and "level_id" in (select "id" from "levels" where "is_active" = ?))', $builder->toSql());
         $this->assertEquals(['1', true], $builder->getBindings());
     }
 
@@ -1588,7 +1588,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('users.id', 'contacts.id', 'contact_types.id')->from('users')->leftJoin('contacts', function ($j) {
             $j->on('users.id', 'contacts.id')->join('contact_types', 'contacts.contact_type_id', '=', 'contact_types.id');
         });
-        $this->assertEquals('select "users"."id", "contacts"."id", "contact_types"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id") on "users"."id" = "contacts"."id"', $builder->toSql());
+        $this->assertSame('select "users"."id", "contacts"."id", "contact_types"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id") on "users"."id" = "contacts"."id"', $builder->toSql());
     }
 
     public function testJoinsWithMultipleNestedJoins()
@@ -1606,7 +1606,7 @@ class DatabaseQueryBuilderTest extends TestCase
                         });
                 });
         });
-        $this->assertEquals('select "users"."id", "contacts"."id", "contact_types"."id", "countrys"."id", "planets"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id" left join ("countrys" inner join "planets" on "countrys"."planet_id" = "planet"."id" and "planet"."is_settled" = ? and "planet"."population" >= ?) on "contacts"."country" = "countrys"."country") on "users"."id" = "contacts"."id"', $builder->toSql());
+        $this->assertSame('select "users"."id", "contacts"."id", "contact_types"."id", "countrys"."id", "planets"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id" left join ("countrys" inner join "planets" on "countrys"."planet_id" = "planet"."id" and "planet"."is_settled" = ? and "planet"."population" >= ?) on "contacts"."country" = "countrys"."country") on "users"."id" = "contacts"."id"', $builder->toSql());
         $this->assertEquals(['1', 10000], $builder->getBindings());
     }
 
@@ -1626,7 +1626,7 @@ class DatabaseQueryBuilderTest extends TestCase
                         ->where('planet.population', '>=', 10000);
                 });
         });
-        $this->assertEquals('select "users"."id", "contacts"."id", "contact_types"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id") on "users"."id" = "contacts"."id" and exists (select * from "countrys" inner join "planets" on "countrys"."planet_id" = "planet"."id" and "planet"."is_settled" = ? where "contacts"."country" = "countrys"."country" and "planet"."population" >= ?)', $builder->toSql());
+        $this->assertSame('select "users"."id", "contacts"."id", "contact_types"."id" from "users" left join ("contacts" inner join "contact_types" on "contacts"."contact_type_id" = "contact_types"."id") on "users"."id" = "contacts"."id" and exists (select * from "countrys" inner join "planets" on "countrys"."planet_id" = "planet"."id" and "planet"."is_settled" = ? where "contacts"."country" = "countrys"."country" and "planet"."population" >= ?)', $builder->toSql());
         $this->assertEquals(['1', 10000], $builder->getBindings());
     }
 
@@ -1634,18 +1634,18 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getBuilder();
         $builder->from('users')->joinSub('select * from "contacts"', 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->from('users')->joinSub(function ($q) {
             $q->from('contacts');
         }, 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $eloquentBuilder = new EloquentBuilder($this->getBuilder()->from('contacts'));
         $builder->from('users')->joinSub($eloquentBuilder, 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" inner join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
 
         $builder = $this->getBuilder();
         $sub1 = $this->getBuilder()->from('contacts')->where('name', 'foo');
@@ -1665,28 +1665,28 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->getGrammar()->setTablePrefix('prefix_');
         $builder->from('users')->joinSub('select * from "contacts"', 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "prefix_users" inner join (select * from "contacts") as "prefix_sub" on "prefix_users"."id" = "prefix_sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "prefix_users" inner join (select * from "contacts") as "prefix_sub" on "prefix_users"."id" = "prefix_sub"."id"', $builder->toSql());
     }
 
     public function testLeftJoinSub()
     {
         $builder = $this->getBuilder();
         $builder->from('users')->leftJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "users" left join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" left join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
     }
 
     public function testRightJoinSub()
     {
         $builder = $this->getBuilder();
         $builder->from('users')->rightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
-        $this->assertEquals('select * from "users" right join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+        $this->assertSame('select * from "users" right join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
     }
 
     public function testRawExpressionsInSelect()
     {
         $builder = $this->getBuilder();
         $builder->select(new Raw('substr(foo, 6)'))->from('users');
-        $this->assertEquals('select substr(foo, 6) from "users"', $builder->toSql());
+        $this->assertSame('select substr(foo, 6) from "users"', $builder->toSql());
     }
 
     public function testFindReturnsFirstResultByID()
@@ -1739,7 +1739,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo');
-        $this->assertEquals('barbaz', $results);
+        $this->assertSame('barbaz', $results);
 
         // Test with glue.
         $builder = $this->getBuilder();
@@ -1748,7 +1748,7 @@ class DatabaseQueryBuilderTest extends TestCase
             return $results;
         });
         $results = $builder->from('users')->where('id', '=', 1)->implode('foo', ',');
-        $this->assertEquals('bar,baz', $results);
+        $this->assertSame('bar,baz', $results);
     }
 
     public function testValueMethodReturnsSingleColumn()
@@ -1757,7 +1757,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('select')->once()->with('select "foo" from "users" where "id" = ? limit 1', [1], true)->andReturn([['foo' => 'bar']]);
         $builder->getProcessor()->shouldReceive('processSelect')->once()->with($builder, [['foo' => 'bar']])->andReturn([['foo' => 'bar']]);
         $results = $builder->from('users')->where('id', '=', 1)->value('foo');
-        $this->assertEquals('bar', $results);
+        $this->assertSame('bar', $results);
     }
 
     public function testAggregateFunctions()
@@ -1873,7 +1873,7 @@ class DatabaseQueryBuilderTest extends TestCase
         }, 'post');
         $count = $builder->count();
         $this->assertEquals(1, $count);
-        $this->assertEquals('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->columns[0]->getValue());
+        $this->assertSame('(select "foo", "bar" from "posts" where "title" = ?) as "post"', $builder->columns[0]->getValue());
         $this->assertEquals(['foo'], $builder->getBindings());
     }
 
@@ -2331,7 +2331,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users');
-        $this->assertEquals('select * from `users`', $builder->toSql());
+        $this->assertSame('select * from `users`', $builder->toSql());
     }
 
     public function testMySqlUpdateWrappingJson()
@@ -2465,41 +2465,41 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar');
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."sku"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."sku"\')) = ?', $builder->toSql());
         $this->assertCount(1, $builder->getRawBindings()['where']);
-        $this->assertEquals('foo-bar', $builder->getRawBindings()['where'][0]);
+        $this->assertSame('foo-bar', $builder->getRawBindings()['where'][0]);
     }
 
     public function testMySqlWrappingJsonWithInteger()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithDouble()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1.5);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBoolean()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."available"\') = true', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where(new Raw("items->'$.available'"), '=', true);
-        $this->assertEquals("select * from `users` where items->'$.available' = true", $builder->toSql());
+        $this->assertSame("select * from `users` where items->'$.available' = true", $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBooleanAndIntegerThatLooksLikeOne()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertEquals('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
     }
 
     public function testJsonPathEscaping()
@@ -2529,109 +2529,109 @@ SQL;
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereRaw('items->\'$."price"\' = 1');
-        $this->assertEquals('select * from `users` where items->\'$."price"\' = 1', $builder->toSql());
+        $this->assertSame('select * from `users` where items->\'$."price"\' = 1', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select json_unquote(json_extract(`items`, \'$."price"\')) from `users` where json_unquote(json_extract(`users`.`items`, \'$."price"\')) = ? order by json_unquote(json_extract(`items`, \'$."price"\')) asc', $builder->toSql());
+        $this->assertSame('select json_unquote(json_extract(`items`, \'$."price"\')) from `users` where json_unquote(json_extract(`users`.`items`, \'$."price"\')) = ? order by json_unquote(json_extract(`items`, \'$."price"\')) asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ? and json_unquote(json_extract(`items`, \'$."age"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ? and json_unquote(json_extract(`items`, \'$."age"\')) = ?', $builder->toSql());
     }
 
     public function testPostgresWrappingJson()
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select "items"->>\'price\' from "users" where "users"."items"->>\'price\' = ? order by "items"->>\'price\' asc', $builder->toSql());
+        $this->assertSame('select "items"->>\'price\' from "users" where "users"."items"->>\'price\' = ? order by "items"->>\'price\' asc', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from "users" where "items"->\'price\'->>\'in_usd\' = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "items"->\'price\'->>\'in_usd\' = ?', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from "users" where "items"->\'price\'->>\'in_usd\' = ? and "items"->>\'age\' = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "items"->\'price\'->>\'in_usd\' = ? and "items"->>\'age\' = ?', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from "users" where ("items"->\'available\')::jsonb = \'true\'::jsonb', $builder->toSql());
+        $this->assertSame('select * from "users" where ("items"->\'available\')::jsonb = \'true\'::jsonb', $builder->toSql());
     }
 
     public function testSqlServerWrappingJson()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select json_value([items], \'$."price"\') from [users] where json_value([users].[items], \'$."price"\') = ? order by json_value([items], \'$."price"\') asc', $builder->toSql());
+        $this->assertSame('select json_value([items], \'$."price"\') from [users] where json_value([users].[items], \'$."price"\') = ? order by json_value([items], \'$."price"\') asc', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ?', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ? and json_value([items], \'$."age"\') = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where json_value([items], \'$."price"."in_usd"\') = ? and json_value([items], \'$."age"\') = ?', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from [users] where json_value([items], \'$."available"\') = \'true\'', $builder->toSql());
+        $this->assertSame('select * from [users] where json_value([items], \'$."available"\') = \'true\'', $builder->toSql());
     }
 
     public function testSqliteWrappingJson()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertEquals('select json_extract("items", \'$."price"\') from "users" where json_extract("users"."items", \'$."price"\') = ? order by json_extract("items", \'$."price"\') asc', $builder->toSql());
+        $this->assertSame('select json_extract("items", \'$."price"\') from "users" where json_extract("users"."items", \'$."price"\') = ? order by json_extract("items", \'$."price"\') asc', $builder->toSql());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertEquals('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ?', $builder->toSql());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertEquals('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ? and json_extract("items", \'$."age"\') = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_extract("items", \'$."price"."in_usd"\') = ? and json_extract("items", \'$."age"\') = ?', $builder->toSql());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
-        $this->assertEquals('select * from "users" where json_extract("items", \'$."available"\') = true', $builder->toSql());
+        $this->assertSame('select * from "users" where json_extract("items", \'$."available"\') = true', $builder->toSql());
     }
 
     public function testSQLiteOrderBy()
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->orderBy('email', 'desc');
-        $this->assertEquals('select * from "users" order by "email" desc', $builder->toSql());
+        $this->assertSame('select * from "users" order by "email" desc', $builder->toSql());
     }
 
     public function testSqlServerLimitsAndOffsets()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->take(10);
-        $this->assertEquals('select top 10 * from [users]', $builder->toSql());
+        $this->assertSame('select top 10 * from [users]', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10);
-        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11 order by row_num', $builder->toSql());
+        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num >= 11 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10);
-        $this->assertEquals('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $this->assertSame('select * from (select *, row_number() over (order by (select 0)) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->skip(10)->take(10)->orderBy('email', 'desc');
-        $this->assertEquals('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
+        $this->assertSame('select * from (select *, row_number() over (order by [email] desc) as row_num from [users]) as temp_table where row_num between 11 and 20 order by row_num', $builder->toSql());
     }
 
     public function testMySqlSoundsLikeOperator()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('name', 'sounds like', 'John Doe');
-        $this->assertEquals('select * from `users` where `name` sounds like ?', $builder->toSql());
+        $this->assertSame('select * from `users` where `name` sounds like ?', $builder->toSql());
         $this->assertEquals(['John Doe'], $builder->getBindings());
     }
 
@@ -2648,19 +2648,19 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', null);
-        $this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "foo" is null', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', '=', null);
-        $this->assertEquals('select * from "users" where "foo" is null', $builder->toSql());
+        $this->assertSame('select * from "users" where "foo" is null', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', '!=', null);
-        $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "foo" is not null', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('foo', '<>', null);
-        $this->assertEquals('select * from "users" where "foo" is not null', $builder->toSql());
+        $this->assertSame('select * from "users" where "foo" is not null', $builder->toSql());
     }
 
     public function testDynamicWhere()
@@ -2712,17 +2712,17 @@ SQL;
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-        $this->assertEquals('select * from `foo` where `bar` = ? for update', $builder->toSql());
+        $this->assertSame('select * from `foo` where `bar` = ? for update', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-        $this->assertEquals('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
+        $this->assertSame('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock('lock in share mode');
-        $this->assertEquals('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
+        $this->assertSame('select * from `foo` where `bar` = ? lock in share mode', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -2730,17 +2730,17 @@ SQL;
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-        $this->assertEquals('select * from "foo" where "bar" = ? for update', $builder->toSql());
+        $this->assertSame('select * from "foo" where "bar" = ? for update', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-        $this->assertEquals('select * from "foo" where "bar" = ? for share', $builder->toSql());
+        $this->assertSame('select * from "foo" where "bar" = ? for share', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock('for key share');
-        $this->assertEquals('select * from "foo" where "bar" = ? for key share', $builder->toSql());
+        $this->assertSame('select * from "foo" where "bar" = ? for key share', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -2748,17 +2748,17 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock();
-        $this->assertEquals('select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', $builder->toSql());
+        $this->assertSame('select * from [foo] with(rowlock,updlock,holdlock) where [bar] = ?', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock(false);
-        $this->assertEquals('select * from [foo] with(rowlock,holdlock) where [bar] = ?', $builder->toSql());
+        $this->assertSame('select * from [foo] with(rowlock,holdlock) where [bar] = ?', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('foo')->where('bar', '=', 'baz')->lock('with(holdlock)');
-        $this->assertEquals('select * from [foo] with(holdlock) where [bar] = ?', $builder->toSql());
+        $this->assertSame('select * from [foo] with(holdlock) where [bar] = ?', $builder->toSql());
         $this->assertEquals(['baz'], $builder->getBindings());
     }
 
@@ -2859,7 +2859,7 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereDate('created_at', '=', '2015-09-23');
-        $this->assertEquals('select * from [users] where cast([created_at] as date) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where cast([created_at] as date) = ?', $builder->toSql());
         $this->assertEquals([0 => '2015-09-23'], $builder->getBindings());
     }
 
@@ -2867,32 +2867,32 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'AND');
-        $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ?', $builder->toSql());
     }
 
     public function testLowercaseLeadingBooleansAreRemoved()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'and');
-        $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ?', $builder->toSql());
     }
 
     public function testCaseInsensitiveLeadingBooleansAreRemoved()
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->where('name', '=', 'Taylor', 'And');
-        $this->assertEquals('select * from "users" where "name" = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where "name" = ?', $builder->toSql());
     }
 
     public function testTableValuedFunctionAsTableInSqlServer()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users()');
-        $this->assertEquals('select * from [users]()', $builder->toSql());
+        $this->assertSame('select * from [users]()', $builder->toSql());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users(1,2)');
-        $this->assertEquals('select * from [users](1,2)', $builder->toSql());
+        $this->assertSame('select * from [users](1,2)', $builder->toSql());
     }
 
     public function testChunkWithLastChunkComplete()
@@ -3175,15 +3175,15 @@ SQL;
     {
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, 2]);
-        $this->assertEquals('select * from "orders" where ("last_update", "order_number") < (?, ?)', $builder->toSql());
+        $this->assertSame('select * from "orders" where ("last_update", "order_number") < (?, ?)', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->where('company_id', 1)->orWhereRowValues(['last_update', 'order_number'], '<', [1, 2]);
-        $this->assertEquals('select * from "orders" where "company_id" = ? or ("last_update", "order_number") < (?, ?)', $builder->toSql());
+        $this->assertSame('select * from "orders" where "company_id" = ? or ("last_update", "order_number") < (?, ?)', $builder->toSql());
 
         $builder = $this->getBuilder();
         $builder->select('*')->from('orders')->whereRowValues(['last_update', 'order_number'], '<', [1, new Raw('2')]);
-        $this->assertEquals('select * from "orders" where ("last_update", "order_number") < (?, 2)', $builder->toSql());
+        $this->assertSame('select * from "orders" where ("last_update", "order_number") < (?, 2)', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3200,17 +3200,17 @@ SQL;
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options', ['en']);
-        $this->assertEquals('select * from `users` where json_contains(`options`, ?)', $builder->toSql());
+        $this->assertSame('select * from `users` where json_contains(`options`, ?)', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonContains('users.options->languages', ['en']);
-        $this->assertEquals('select * from `users` where json_contains(`users`.`options`, ?, \'$."languages"\')', $builder->toSql());
+        $this->assertSame('select * from `users` where json_contains(`users`.`options`, ?, \'$."languages"\')', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from `users` where `id` = ? or json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3218,17 +3218,17 @@ SQL;
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options', ['en']);
-        $this->assertEquals('select * from "users" where ("options")::jsonb @> ?', $builder->toSql());
+        $this->assertSame('select * from "users" where ("options")::jsonb @> ?', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonContains('users.options->languages', ['en']);
-        $this->assertEquals('select * from "users" where ("users"."options"->\'languages\')::jsonb @> ?', $builder->toSql());
+        $this->assertSame('select * from "users" where ("users"."options"->\'languages\')::jsonb @> ?', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from "users" where "id" = ? or ("options"->\'languages\')::jsonb @> \'["en"]\'', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or ("options"->\'languages\')::jsonb @> \'["en"]\'', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3244,17 +3244,17 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereJsonContains('options', true);
-        $this->assertEquals('select * from [users] where ? in (select [value] from openjson([options]))', $builder->toSql());
+        $this->assertSame('select * from [users] where ? in (select [value] from openjson([options]))', $builder->toSql());
         $this->assertEquals(['true'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereJsonContains('users.options->languages', 'en');
-        $this->assertEquals('select * from [users] where ? in (select [value] from openjson([users].[options], \'$."languages"\'))', $builder->toSql());
+        $this->assertSame('select * from [users] where ? in (select [value] from openjson([users].[options], \'$."languages"\'))', $builder->toSql());
         $this->assertEquals(['en'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonContains('options->languages', new Raw("'en'"));
-        $this->assertEquals('select * from [users] where [id] = ? or \'en\' in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
+        $this->assertSame('select * from [users] where [id] = ? or \'en\' in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3262,12 +3262,12 @@ SQL;
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en']);
-        $this->assertEquals('select * from `users` where not json_contains(`options`, ?, \'$."languages"\')', $builder->toSql());
+        $this->assertSame('select * from `users` where not json_contains(`options`, ?, \'$."languages"\')', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonDoesntContain('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from `users` where `id` = ? or not json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or not json_contains(`options`, \'["en"]\', \'$."languages"\')', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3275,12 +3275,12 @@ SQL;
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', ['en']);
-        $this->assertEquals('select * from "users" where not ("options"->\'languages\')::jsonb @> ?', $builder->toSql());
+        $this->assertSame('select * from "users" where not ("options"->\'languages\')::jsonb @> ?', $builder->toSql());
         $this->assertEquals(['["en"]'], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonDoesntContain('options->languages', new Raw("'[\"en\"]'"));
-        $this->assertEquals('select * from "users" where "id" = ? or not ("options"->\'languages\')::jsonb @> \'["en"]\'', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or not ("options"->\'languages\')::jsonb @> \'["en"]\'', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3296,12 +3296,12 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereJsonDoesntContain('options->languages', 'en');
-        $this->assertEquals('select * from [users] where not ? in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
+        $this->assertSame('select * from [users] where not ? in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
         $this->assertEquals(['en'], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonDoesntContain('options->languages', new Raw("'en'"));
-        $this->assertEquals('select * from [users] where [id] = ? or not \'en\' in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
+        $this->assertSame('select * from [users] where [id] = ? or not \'en\' in (select [value] from openjson([options], \'$."languages"\'))', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3309,22 +3309,22 @@ SQL;
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonLength('options', 0);
-        $this->assertEquals('select * from `users` where json_length(`options`) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_length(`options`) = ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereJsonLength('users.options->languages', '>', 0);
-        $this->assertEquals('select * from `users` where json_length(`users`.`options`, \'$."languages"\') > ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_length(`users`.`options`, \'$."languages"\') > ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', new Raw('0'));
-        $this->assertEquals('select * from `users` where `id` = ? or json_length(`options`, \'$."languages"\') = 0', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or json_length(`options`, \'$."languages"\') = 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', '>', new Raw('0'));
-        $this->assertEquals('select * from `users` where `id` = ? or json_length(`options`, \'$."languages"\') > 0', $builder->toSql());
+        $this->assertSame('select * from `users` where `id` = ? or json_length(`options`, \'$."languages"\') > 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3332,22 +3332,22 @@ SQL;
     {
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonLength('options', 0);
-        $this->assertEquals('select * from "users" where json_array_length(("options")::json) = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_array_length(("options")::json) = ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->whereJsonLength('users.options->languages', '>', 0);
-        $this->assertEquals('select * from "users" where json_array_length(("users"."options"->\'languages\')::json) > ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_array_length(("users"."options"->\'languages\')::json) > ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', new Raw('0'));
-        $this->assertEquals('select * from "users" where "id" = ? or json_array_length(("options"->\'languages\')::json) = 0', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or json_array_length(("options"->\'languages\')::json) = 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
 
         $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', '>', new Raw('0'));
-        $this->assertEquals('select * from "users" where "id" = ? or json_array_length(("options"->\'languages\')::json) > 0', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or json_array_length(("options"->\'languages\')::json) > 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3355,22 +3355,22 @@ SQL;
     {
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereJsonLength('options', 0);
-        $this->assertEquals('select * from "users" where json_array_length("options") = ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_array_length("options") = ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->whereJsonLength('users.options->languages', '>', 0);
-        $this->assertEquals('select * from "users" where json_array_length("users"."options", \'$."languages"\') > ?', $builder->toSql());
+        $this->assertSame('select * from "users" where json_array_length("users"."options", \'$."languages"\') > ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', new Raw('0'));
-        $this->assertEquals('select * from "users" where "id" = ? or json_array_length("options", \'$."languages"\') = 0', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or json_array_length("options", \'$."languages"\') = 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
 
         $builder = $this->getSQLiteBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', '>', new Raw('0'));
-        $this->assertEquals('select * from "users" where "id" = ? or json_array_length("options", \'$."languages"\') > 0', $builder->toSql());
+        $this->assertSame('select * from "users" where "id" = ? or json_array_length("options", \'$."languages"\') > 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3378,22 +3378,22 @@ SQL;
     {
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereJsonLength('options', 0);
-        $this->assertEquals('select * from [users] where (select count(*) from openjson([options])) = ?', $builder->toSql());
+        $this->assertSame('select * from [users] where (select count(*) from openjson([options])) = ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->whereJsonLength('users.options->languages', '>', 0);
-        $this->assertEquals('select * from [users] where (select count(*) from openjson([users].[options], \'$."languages"\')) > ?', $builder->toSql());
+        $this->assertSame('select * from [users] where (select count(*) from openjson([users].[options], \'$."languages"\')) > ?', $builder->toSql());
         $this->assertEquals([0], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', new Raw('0'));
-        $this->assertEquals('select * from [users] where [id] = ? or (select count(*) from openjson([options], \'$."languages"\')) = 0', $builder->toSql());
+        $this->assertSame('select * from [users] where [id] = ? or (select count(*) from openjson([options], \'$."languages"\')) = 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
 
         $builder = $this->getSqlServerBuilder();
         $builder->select('*')->from('users')->where('id', '=', 1)->orWhereJsonLength('options->languages', '>', new Raw('0'));
-        $this->assertEquals('select * from [users] where [id] = ? or (select count(*) from openjson([options], \'$."languages"\')) > 0', $builder->toSql());
+        $this->assertSame('select * from [users] where [id] = ? or (select count(*) from openjson([options], \'$."languages"\')) > 0', $builder->toSql());
         $this->assertEquals([1], $builder->getBindings());
     }
 
@@ -3403,7 +3403,7 @@ SQL;
         $builder->fromSub(function ($query) {
             $query->select(new Raw('max(last_seen_at) as last_seen_at'))->from('user_sessions')->where('foo', '=', '1');
         }, 'sessions')->where('bar', '<', '10');
-        $this->assertEquals('select * from (select max(last_seen_at) as last_seen_at from "user_sessions" where "foo" = ?) as "sessions" where "bar" < ?', $builder->toSql());
+        $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions" where "foo" = ?) as "sessions" where "bar" < ?', $builder->toSql());
         $this->assertEquals(['1', '10'], $builder->getBindings());
     }
 
@@ -3414,7 +3414,7 @@ SQL;
         $builder->fromSub(function ($query) {
             $query->select(new Raw('max(last_seen_at) as last_seen_at'))->from('user_sessions')->where('foo', '=', '1');
         }, 'sessions')->where('bar', '<', '10');
-        $this->assertEquals('select * from (select max(last_seen_at) as last_seen_at from "prefix_user_sessions" where "foo" = ?) as "prefix_sessions" where "bar" < ?', $builder->toSql());
+        $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "prefix_user_sessions" where "foo" = ?) as "prefix_sessions" where "bar" < ?', $builder->toSql());
         $this->assertEquals(['1', '10'], $builder->getBindings());
     }
 
@@ -3424,28 +3424,28 @@ SQL;
         $builder->fromSub(function ($query) {
             $query->select(new Raw('max(last_seen_at) as last_seen_at'))->from('user_sessions');
         }, 'sessions');
-        $this->assertEquals('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
+        $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
     }
 
     public function testFromRaw()
     {
         $builder = $this->getBuilder();
         $builder->fromRaw(new Raw('(select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"'));
-        $this->assertEquals('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
+        $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
     }
 
     public function testFromRawOnSqlServer()
     {
         $builder = $this->getSqlServerBuilder();
         $builder->fromRaw('dbo.[SomeNameWithRoundBrackets (test)]');
-        $this->assertEquals('select * from dbo.[SomeNameWithRoundBrackets (test)]', $builder->toSql());
+        $this->assertSame('select * from dbo.[SomeNameWithRoundBrackets (test)]', $builder->toSql());
     }
 
     public function testFromRawWithWhereOnTheMainQuery()
     {
         $builder = $this->getBuilder();
         $builder->fromRaw(new Raw('(select max(last_seen_at) as last_seen_at from "sessions") as "last_seen_at"'))->where('last_seen_at', '>', '1520652582');
-        $this->assertEquals('select * from (select max(last_seen_at) as last_seen_at from "sessions") as "last_seen_at" where "last_seen_at" > ?', $builder->toSql());
+        $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "sessions") as "last_seen_at" where "last_seen_at" > ?', $builder->toSql());
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -27,7 +27,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -52,7 +52,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
+        $this->assertSame('create temporary table "users" ("id" integer not null primary key autoincrement, "email" varchar not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -62,7 +62,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table "users"', $statements[0]);
+        $this->assertSame('drop table "users"', $statements[0]);
     }
 
     public function testDropTableIfExists()
@@ -72,7 +72,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table if exists "users"', $statements[0]);
+        $this->assertSame('drop table if exists "users"', $statements[0]);
     }
 
     public function testDropUnique()
@@ -82,7 +82,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "foo"', $statements[0]);
+        $this->assertSame('drop index "foo"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -92,7 +92,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "foo"', $statements[0]);
+        $this->assertSame('drop index "foo"', $statements[0]);
     }
 
     public function testDropColumn()
@@ -143,7 +143,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" rename to "foo"', $statements[0]);
+        $this->assertSame('alter table "users" rename to "foo"', $statements[0]);
     }
 
     public function testRenameIndex()
@@ -195,7 +195,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("foo" varchar not null, primary key ("foo"))', $statements[0]);
+        $this->assertSame('create table "users" ("foo" varchar not null, primary key ("foo"))', $statements[0]);
     }
 
     public function testAddingForeignKey()
@@ -208,7 +208,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
+        $this->assertSame('create table "users" ("foo" varchar not null, "order_id" varchar not null, foreign key("order_id") references "orders"("id"), primary key ("foo"))', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -218,7 +218,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
+        $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -228,7 +228,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingSpatialIndex()
@@ -258,7 +258,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -268,7 +268,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -278,7 +278,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -288,7 +288,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "id" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingString()
@@ -298,21 +298,21 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar null default \'bar\'', $statements[0]);
     }
 
     public function testAddingText()
@@ -322,7 +322,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
     public function testAddingBigInteger()
@@ -332,14 +332,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -349,14 +349,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -366,14 +366,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -383,14 +383,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -400,14 +400,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" integer not null primary key autoincrement', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -417,7 +417,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" float not null', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -427,7 +427,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" float not null', $statements[0]);
     }
 
     public function testAddingDecimal()
@@ -437,7 +437,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" numeric not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" numeric not null', $statements[0]);
     }
 
     public function testAddingBoolean()
@@ -447,7 +447,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" tinyint(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" tinyint(1) not null', $statements[0]);
     }
 
     public function testAddingEnum()
@@ -457,7 +457,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "role" varchar check ("role" in (\'member\', \'admin\')) not null', $statements[0]);
     }
 
     public function testAddingJson()
@@ -467,7 +467,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
     public function testAddingJsonb()
@@ -477,7 +477,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" text not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" text not null', $statements[0]);
     }
 
     public function testAddingDate()
@@ -487,7 +487,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" date not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" date not null', $statements[0]);
     }
 
     public function testAddingYear()
@@ -496,7 +496,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "birth_year" integer not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "birth_year" integer not null', $statements[0]);
     }
 
     public function testAddingDateTime()
@@ -505,7 +505,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -514,7 +514,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -523,7 +523,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -532,7 +532,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTime()
@@ -541,7 +541,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -550,7 +550,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->time('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -559,7 +559,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -568,7 +568,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
@@ -577,7 +577,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -586,7 +586,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -595,7 +595,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -604,7 +604,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestamps()
@@ -638,7 +638,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "remember_token" varchar null', $statements[0]);
+        $this->assertSame('alter table "users" add column "remember_token" varchar null', $statements[0]);
     }
 
     public function testAddingBinary()
@@ -648,7 +648,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" blob not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" blob not null', $statements[0]);
     }
 
     public function testAddingUuid()
@@ -658,7 +658,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
     public function testAddingIpAddress()
@@ -668,7 +668,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
     public function testAddingMacAddress()
@@ -678,7 +678,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add column "foo" varchar not null', $statements[0]);
+        $this->assertSame('alter table "users" add column "foo" varchar not null', $statements[0]);
     }
 
     public function testAddingGeometry()
@@ -688,7 +688,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geometry not null', $statements[0]);
     }
 
     public function testAddingPoint()
@@ -698,7 +698,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" point not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" point not null', $statements[0]);
     }
 
     public function testAddingLineString()
@@ -708,7 +708,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" linestring not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" linestring not null', $statements[0]);
     }
 
     public function testAddingPolygon()
@@ -718,7 +718,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" polygon not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" polygon not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
@@ -728,7 +728,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" geometrycollection not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" geometrycollection not null', $statements[0]);
     }
 
     public function testAddingMultiPoint()
@@ -738,7 +738,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" multipoint not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" multipoint not null', $statements[0]);
     }
 
     public function testAddingMultiLineString()
@@ -748,7 +748,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" multilinestring not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" multilinestring not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
@@ -758,7 +758,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add column "coordinates" multipolygon not null', $statements[0]);
+        $this->assertSame('alter table "geo" add column "coordinates" multipolygon not null', $statements[0]);
     }
 
     public function testGrammarsAreMacroable()

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -35,17 +35,17 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = new Blueprint('users');
         $blueprint->unique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('users_foo_bar_unique', $commands[0]->index);
+        $this->assertSame('users_foo_bar_unique', $commands[0]->index);
 
         $blueprint = new Blueprint('users');
         $blueprint->index('foo');
         $commands = $blueprint->getCommands();
-        $this->assertEquals('users_foo_index', $commands[0]->index);
+        $this->assertSame('users_foo_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo');
         $blueprint->spatialIndex('coordinates');
         $commands = $blueprint->getCommands();
-        $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
+        $this->assertSame('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testIndexDefaultNamesWhenPrefixSupplied()
@@ -53,17 +53,17 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = new Blueprint('users', null, 'prefix_');
         $blueprint->unique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_users_foo_bar_unique', $commands[0]->index);
+        $this->assertSame('prefix_users_foo_bar_unique', $commands[0]->index);
 
         $blueprint = new Blueprint('users', null, 'prefix_');
         $blueprint->index('foo');
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_users_foo_index', $commands[0]->index);
+        $this->assertSame('prefix_users_foo_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo', null, 'prefix_');
         $blueprint->spatialIndex('coordinates');
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_geo_coordinates_spatialindex', $commands[0]->index);
+        $this->assertSame('prefix_geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testDropIndexDefaultNames()
@@ -71,17 +71,17 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = new Blueprint('users');
         $blueprint->dropUnique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('users_foo_bar_unique', $commands[0]->index);
+        $this->assertSame('users_foo_bar_unique', $commands[0]->index);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('users_foo_index', $commands[0]->index);
+        $this->assertSame('users_foo_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo');
         $blueprint->dropSpatialIndex(['coordinates']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('geo_coordinates_spatialindex', $commands[0]->index);
+        $this->assertSame('geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testDropIndexDefaultNamesWhenPrefixSupplied()
@@ -89,17 +89,17 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = new Blueprint('users', null, 'prefix_');
         $blueprint->dropUnique(['foo', 'bar']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_users_foo_bar_unique', $commands[0]->index);
+        $this->assertSame('prefix_users_foo_bar_unique', $commands[0]->index);
 
         $blueprint = new Blueprint('users', null, 'prefix_');
         $blueprint->dropIndex(['foo']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_users_foo_index', $commands[0]->index);
+        $this->assertSame('prefix_users_foo_index', $commands[0]->index);
 
         $blueprint = new Blueprint('geo', null, 'prefix_');
         $blueprint->dropSpatialIndex(['coordinates']);
         $commands = $blueprint->getCommands();
-        $this->assertEquals('prefix_geo_coordinates_spatialindex', $commands[0]->index);
+        $this->assertSame('prefix_geo_coordinates_spatialindex', $commands[0]->index);
     }
 
     public function testDefaultCurrentDateTime()

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -24,7 +24,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->increments('id');
@@ -32,7 +32,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "id" int identity primary key not null, "email" nvarchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int identity primary key not null, "email" nvarchar(255) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->create();
@@ -41,7 +41,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "prefix_users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
     public function testCreateTemporaryTable()
@@ -54,7 +54,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create table "#users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
+        $this->assertSame('create table "#users" ("id" int identity primary key not null, "email" nvarchar(255) not null)', $statements[0]);
     }
 
     public function testDropTable()
@@ -64,14 +64,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table "users"', $statements[0]);
+        $this->assertSame('drop table "users"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->drop();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop table "prefix_users"', $statements[0]);
+        $this->assertSame('drop table "prefix_users"', $statements[0]);
     }
 
     public function testDropTableIfExists()
@@ -81,14 +81,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'users\') drop table "users"', $statements[0]);
+        $this->assertSame('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'users\') drop table "users"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropIfExists();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar()->setTablePrefix('prefix_'));
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'prefix_users\') drop table "prefix_users"', $statements[0]);
+        $this->assertSame('if exists (select * from INFORMATION_SCHEMA.TABLES where TABLE_NAME = \'prefix_users\') drop table "prefix_users"', $statements[0]);
     }
 
     public function testDropColumn()
@@ -98,21 +98,21 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn(['foo', 'bar']);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo", "bar"', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->dropColumn('foo', 'bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "foo", "bar"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "foo", "bar"', $statements[0]);
     }
 
     public function testDropPrimary()
@@ -122,7 +122,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropUnique()
@@ -132,7 +132,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "foo" on "users"', $statements[0]);
+        $this->assertSame('drop index "foo" on "users"', $statements[0]);
     }
 
     public function testDropIndex()
@@ -142,7 +142,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "foo" on "users"', $statements[0]);
+        $this->assertSame('drop index "foo" on "users"', $statements[0]);
     }
 
     public function testDropSpatialIndex()
@@ -152,7 +152,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('drop index "geo_coordinates_spatialindex" on "geo"', $statements[0]);
+        $this->assertSame('drop index "geo_coordinates_spatialindex" on "geo"', $statements[0]);
     }
 
     public function testDropForeign()
@@ -162,7 +162,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop constraint "foo"', $statements[0]);
+        $this->assertSame('alter table "users" drop constraint "foo"', $statements[0]);
     }
 
     public function testDropTimestamps()
@@ -172,7 +172,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
     }
 
     public function testDropTimestampsTz()
@@ -182,7 +182,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
+        $this->assertSame('alter table "users" drop column "created_at", "updated_at"', $statements[0]);
     }
 
     public function testDropMorphs()
@@ -192,8 +192,8 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
-        $this->assertEquals('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
+        $this->assertSame('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
+        $this->assertSame('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
     }
 
     public function testRenameTable()
@@ -203,7 +203,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('sp_rename "users", "foo"', $statements[0]);
+        $this->assertSame('sp_rename "users", "foo"', $statements[0]);
     }
 
     public function testRenameIndex()
@@ -213,7 +213,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('sp_rename N\'"users"."foo"\', "bar", N\'INDEX\'', $statements[0]);
+        $this->assertSame('sp_rename N\'"users"."foo"\', "bar", N\'INDEX\'', $statements[0]);
     }
 
     public function testAddingPrimaryKey()
@@ -223,7 +223,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
+        $this->assertSame('alter table "users" add constraint "bar" primary key ("foo")', $statements[0]);
     }
 
     public function testAddingUniqueKey()
@@ -233,7 +233,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create unique index "bar" on "users" ("foo")', $statements[0]);
+        $this->assertSame('create unique index "bar" on "users" ("foo")', $statements[0]);
     }
 
     public function testAddingIndex()
@@ -243,7 +243,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create index "baz" on "users" ("foo", "bar")', $statements[0]);
+        $this->assertSame('create index "baz" on "users" ("foo", "bar")', $statements[0]);
     }
 
     public function testAddingSpatialIndex()
@@ -253,7 +253,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[0]);
+        $this->assertSame('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[0]);
     }
 
     public function testAddingFluentSpatialIndex()
@@ -263,7 +263,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
+        $this->assertSame('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
     }
 
     public function testAddingIncrementingID()
@@ -273,7 +273,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int identity primary key not null', $statements[0]);
     }
 
     public function testAddingSmallIncrementingID()
@@ -283,7 +283,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "id" smallint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" smallint identity primary key not null', $statements[0]);
     }
 
     public function testAddingMediumIncrementingID()
@@ -293,7 +293,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "id" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" int identity primary key not null', $statements[0]);
     }
 
     public function testAddingBigIncrementingID()
@@ -303,7 +303,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "id" bigint identity primary key not null', $statements[0]);
     }
 
     public function testAddingString()
@@ -313,21 +313,21 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(255) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(100) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(100) not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default('bar');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(100) null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(100) null default \'bar\'', $statements[0]);
     }
 
     public function testAddingText()
@@ -337,7 +337,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
     public function testAddingBigInteger()
@@ -347,14 +347,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" bigint not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" bigint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->bigInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" bigint identity primary key not null', $statements[0]);
     }
 
     public function testAddingInteger()
@@ -364,14 +364,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" int not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->integer('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int identity primary key not null', $statements[0]);
     }
 
     public function testAddingMediumInteger()
@@ -381,14 +381,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" int not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->mediumInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" int identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" int identity primary key not null', $statements[0]);
     }
 
     public function testAddingTinyInteger()
@@ -398,14 +398,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" tinyint not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" tinyint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->tinyInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" tinyint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" tinyint identity primary key not null', $statements[0]);
     }
 
     public function testAddingSmallInteger()
@@ -415,14 +415,14 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" smallint not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" smallint not null', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->smallInteger('foo', true);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" smallint identity primary key not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" smallint identity primary key not null', $statements[0]);
     }
 
     public function testAddingFloat()
@@ -432,7 +432,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" float not null', $statements[0]);
     }
 
     public function testAddingDouble()
@@ -442,7 +442,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" float not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" float not null', $statements[0]);
     }
 
     public function testAddingDecimal()
@@ -452,7 +452,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" decimal(5, 2) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" decimal(5, 2) not null', $statements[0]);
     }
 
     public function testAddingBoolean()
@@ -462,7 +462,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" bit not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" bit not null', $statements[0]);
     }
 
     public function testAddingEnum()
@@ -472,7 +472,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "role" nvarchar(255) check ("role" in (N\'member\', N\'admin\')) not null', $statements[0]);
     }
 
     public function testAddingJson()
@@ -482,7 +482,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
     public function testAddingJsonb()
@@ -492,7 +492,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(max) not null', $statements[0]);
     }
 
     public function testAddingDate()
@@ -502,7 +502,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" date not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" date not null', $statements[0]);
     }
 
     public function testAddingYear()
@@ -511,7 +511,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->year('birth_year');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "birth_year" int not null', $statements[0]);
+        $this->assertSame('alter table "users" add "birth_year" int not null', $statements[0]);
     }
 
     public function testAddingDateTime()
@@ -520,7 +520,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingDateTimeWithPrecision()
@@ -529,7 +529,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTime('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingDateTimeTz()
@@ -538,7 +538,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingDateTimeTzWithPrecision()
@@ -547,7 +547,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->dateTimeTz('foo', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" datetimeoffset(1) not null', $statements[0]);
     }
 
     public function testAddingTime()
@@ -556,7 +556,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->time('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeWithPrecision()
@@ -565,7 +565,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->time('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimeTz()
@@ -574,7 +574,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" time not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time not null', $statements[0]);
     }
 
     public function testAddingTimeTzWithPrecision()
@@ -583,7 +583,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timeTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" time(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" time(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamp()
@@ -592,7 +592,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime not null', $statements[0]);
     }
 
     public function testAddingTimestampWithPrecision()
@@ -601,7 +601,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime2(1) not null', $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -610,7 +610,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset not null', $statements[0]);
     }
 
     public function testAddingTimestampTzWithPrecision()
@@ -619,7 +619,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at', 1);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset(1) not null', $statements[0]);
     }
 
     public function testAddingTimestamps()
@@ -628,7 +628,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestamps();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetime null, "updated_at" datetime null', $statements[0]);
     }
 
     public function testAddingTimestampsTz()
@@ -637,7 +637,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->timestampsTz();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "created_at" datetimeoffset null, "updated_at" datetimeoffset null', $statements[0]);
+        $this->assertSame('alter table "users" add "created_at" datetimeoffset null, "updated_at" datetimeoffset null', $statements[0]);
     }
 
     public function testAddingRememberToken()
@@ -647,7 +647,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
+        $this->assertSame('alter table "users" add "remember_token" nvarchar(100) null', $statements[0]);
     }
 
     public function testAddingBinary()
@@ -657,7 +657,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" varbinary(max) not null', $statements[0]);
     }
 
     public function testAddingUuid()
@@ -667,7 +667,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" uniqueidentifier not null', $statements[0]);
     }
 
     public function testAddingIpAddress()
@@ -677,7 +677,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(45) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(45) not null', $statements[0]);
     }
 
     public function testAddingMacAddress()
@@ -687,7 +687,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);
+        $this->assertSame('alter table "users" add "foo" nvarchar(17) not null', $statements[0]);
     }
 
     public function testAddingGeometry()
@@ -697,7 +697,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingPoint()
@@ -707,7 +707,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingLineString()
@@ -717,7 +717,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingPolygon()
@@ -727,7 +727,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingGeometryCollection()
@@ -737,7 +737,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingMultiPoint()
@@ -747,7 +747,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingMultiLineString()
@@ -757,7 +757,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingMultiPolygon()
@@ -767,7 +767,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "geo" add "coordinates" geography not null', $statements[0]);
+        $this->assertSame('alter table "geo" add "coordinates" geography not null', $statements[0]);
     }
 
     public function testAddingGeneratedColumn()
@@ -778,7 +778,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $blueprint->computed('discounted_stored', 'price - 5')->persisted();
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertEquals('alter table "products" add "price" int not null, "discounted_virtual" as (price - 5), "discounted_stored" as (price - 5) persisted', $statements[0]);
+        $this->assertSame('alter table "products" add "price" int not null, "discounted_virtual" as (price - 5), "discounted_stored" as (price - 5) persisted', $statements[0]);
     }
 
     public function testGrammarsAreMacroable()

--- a/tests/Database/TableGuesserTest.php
+++ b/tests/Database/TableGuesserTest.php
@@ -10,38 +10,38 @@ class TableGuesserTest extends TestCase
     public function testMigrationIsProperlyParsed()
     {
         [$table, $create] = TableGuesser::guess('create_users_table');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertTrue($create);
 
         [$table, $create] = TableGuesser::guess('add_status_column_to_users_table');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('change_status_column_in_users_table');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users_table');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
     }
 
     public function testMigrationIsProperlyParsedWithoutTableSuffix()
     {
         [$table, $create] = TableGuesser::guess('create_users');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertTrue($create);
 
         [$table, $create] = TableGuesser::guess('add_status_column_to_users');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('change_status_column_in_users');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
 
         [$table, $create] = TableGuesser::guess('drop_status_column_from_users');
-        $this->assertEquals('users', $table);
+        $this->assertSame('users', $table);
         $this->assertFalse($create);
     }
 }

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -14,7 +14,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
+        $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
     public function testRawStringEncryption()
@@ -22,7 +22,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encryptString('foo');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decryptString($encrypted));
+        $this->assertSame('foo', $e->decryptString($encrypted));
     }
 
     public function testEncryptionUsingBase64EncodedKey()
@@ -30,7 +30,7 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(random_bytes(16));
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
+        $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
     public function testWithCustomCipher()
@@ -38,12 +38,12 @@ class EncrypterTest extends TestCase
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
         $encrypted = $e->encrypt('bar');
         $this->assertNotEquals('bar', $encrypted);
-        $this->assertEquals('bar', $e->decrypt($encrypted));
+        $this->assertSame('bar', $e->decrypt($encrypted));
 
         $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
         $encrypted = $e->encrypt('foo');
         $this->assertNotEquals('foo', $encrypted);
-        $this->assertEquals('foo', $e->decrypt($encrypted));
+        $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
     public function testDoNoAllowLongerKey()

--- a/tests/Encryption/EncrypterTest.php
+++ b/tests/Encryption/EncrypterTest.php
@@ -13,7 +13,7 @@ class EncrypterTest extends TestCase
     {
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
+        $this->assertNotSame('foo', $encrypted);
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
@@ -21,7 +21,7 @@ class EncrypterTest extends TestCase
     {
         $e = new Encrypter(str_repeat('a', 16));
         $encrypted = $e->encryptString('foo');
-        $this->assertNotEquals('foo', $encrypted);
+        $this->assertNotSame('foo', $encrypted);
         $this->assertSame('foo', $e->decryptString($encrypted));
     }
 
@@ -29,7 +29,7 @@ class EncrypterTest extends TestCase
     {
         $e = new Encrypter(random_bytes(16));
         $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
+        $this->assertNotSame('foo', $encrypted);
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 
@@ -37,12 +37,12 @@ class EncrypterTest extends TestCase
     {
         $e = new Encrypter(str_repeat('b', 32), 'AES-256-CBC');
         $encrypted = $e->encrypt('bar');
-        $this->assertNotEquals('bar', $encrypted);
+        $this->assertNotSame('bar', $encrypted);
         $this->assertSame('bar', $e->decrypt($encrypted));
 
         $e = new Encrypter(random_bytes(32), 'AES-256-CBC');
         $encrypted = $e->encrypt('foo');
-        $this->assertNotEquals('foo', $encrypted);
+        $this->assertNotSame('foo', $encrypted);
         $this->assertSame('foo', $e->decrypt($encrypted));
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -27,7 +27,7 @@ class EventsDispatcherTest extends TestCase
             $_SERVER['__event.test'] = $foo;
         });
         $d->dispatch('foo', ['bar']);
-        $this->assertEquals('bar', $_SERVER['__event.test']);
+        $this->assertSame('bar', $_SERVER['__event.test']);
     }
 
     public function testHaltingEventExecution()
@@ -74,7 +74,7 @@ class EventsDispatcherTest extends TestCase
 
         $this->assertFalse(isset($_SERVER['__event.test']));
         $d->flush('update');
-        $this->assertEquals('taylor', $_SERVER['__event.test']);
+        $this->assertSame('taylor', $_SERVER['__event.test']);
     }
 
     public function testQueuedEventsCanBeForgotten()
@@ -88,7 +88,7 @@ class EventsDispatcherTest extends TestCase
 
         $d->forgetPushed();
         $d->flush('update');
-        $this->assertEquals('unset', $_SERVER['__event.test']);
+        $this->assertSame('unset', $_SERVER['__event.test']);
     }
 
     public function testWildcardListeners()
@@ -106,7 +106,7 @@ class EventsDispatcherTest extends TestCase
         });
         $d->dispatch('foo.bar');
 
-        $this->assertEquals('wildcard', $_SERVER['__event.test']);
+        $this->assertSame('wildcard', $_SERVER['__event.test']);
     }
 
     public function testWildcardListenersCacheFlushing()
@@ -117,13 +117,13 @@ class EventsDispatcherTest extends TestCase
             $_SERVER['__event.test'] = 'cached_wildcard';
         });
         $d->dispatch('foo.bar');
-        $this->assertEquals('cached_wildcard', $_SERVER['__event.test']);
+        $this->assertSame('cached_wildcard', $_SERVER['__event.test']);
 
         $d->listen('foo.*', function () {
             $_SERVER['__event.test'] = 'new_wildcard';
         });
         $d->dispatch('foo.bar');
-        $this->assertEquals('new_wildcard', $_SERVER['__event.test']);
+        $this->assertSame('new_wildcard', $_SERVER['__event.test']);
     }
 
     public function testListenersCanBeRemoved()
@@ -178,15 +178,15 @@ class EventsDispatcherTest extends TestCase
     {
         $d = new Dispatcher;
         $d->listen('foo.*', function ($event, $data) {
-            $this->assertEquals('foo.bar', $event);
+            $this->assertSame('foo.bar', $event);
             $this->assertEquals(['first', 'second'], $data);
         });
         $d->dispatch('foo.bar', ['first', 'second']);
 
         $d = new Dispatcher;
         $d->listen('foo.bar', function ($first, $second) {
-            $this->assertEquals('first', $first);
-            $this->assertEquals('second', $second);
+            $this->assertSame('first', $first);
+            $this->assertSame('second', $second);
         });
         $d->dispatch('foo.bar', ['first', 'second']);
     }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -39,8 +39,8 @@ class FilesystemAdapterTest extends TestCase
         $content = ob_get_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals('Hello World', $content);
-        // $this->assertEquals('inline; filename="file.txt"', $response->headers->get('content-disposition'));
+        $this->assertSame('Hello World', $content);
+        // $this->assertSame('inline; filename="file.txt"', $response->headers->get('content-disposition'));
     }
 
     public function testDownload()
@@ -49,7 +49,7 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('file.txt', 'hello.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        // $this->assertEquals('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
+        // $this->assertSame('attachment; filename="hello.txt"', $response->headers->get('content-disposition'));
     }
 
     public function testDownloadNonAsciiFilename()
@@ -58,7 +58,7 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('file.txt', 'пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals("attachment; filename=pizdyuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt", $response->headers->get('content-disposition'));
+        $this->assertSame("attachment; filename=pizdyuk.txt; filename*=utf-8''%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt", $response->headers->get('content-disposition'));
     }
 
     public function testDownloadNonAsciiEmptyFilename()
@@ -67,7 +67,7 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('пиздюк.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
+        $this->assertSame('attachment; filename=pizdyuk.txt; filename*=utf-8\'\'%D0%BF%D0%B8%D0%B7%D0%B4%D1%8E%D0%BA.txt', $response->headers->get('content-disposition'));
     }
 
     public function testDownloadPercentInFilename()
@@ -76,7 +76,7 @@ class FilesystemAdapterTest extends TestCase
         $files = new FilesystemAdapter($this->filesystem);
         $response = $files->download('Hello%World.txt', 'Hello%World.txt');
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals('attachment; filename=HelloWorld.txt; filename*=utf-8\'\'Hello%25World.txt', $response->headers->get('content-disposition'));
+        $this->assertSame('attachment; filename=HelloWorld.txt; filename*=utf-8\'\'Hello%25World.txt', $response->headers->get('content-disposition'));
     }
 
     public function testExists()
@@ -97,7 +97,7 @@ class FilesystemAdapterTest extends TestCase
     {
         $this->filesystem->write('file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
-        $this->assertEquals('Hello World', $filesystemAdapter->get('file.txt'));
+        $this->assertSame('Hello World', $filesystemAdapter->get('file.txt'));
     }
 
     public function testGetFileNotFound()

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -32,7 +32,7 @@ class FilesystemTest extends TestCase
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $files = new Filesystem;
-        $this->assertEquals('Hello World', $files->get($this->tempDir.'/file.txt'));
+        $this->assertSame('Hello World', $files->get($this->tempDir.'/file.txt'));
     }
 
     public function testPutStoresFiles()
@@ -168,7 +168,7 @@ class FilesystemTest extends TestCase
         $files->macro('getFoo', function () use ($files, $tempDir) {
             return $files->get($tempDir.'/foo.txt');
         });
-        $this->assertEquals('Hello World', $files->getFoo());
+        $this->assertSame('Hello World', $files->getFoo());
     }
 
     public function testFilesMethod()
@@ -271,7 +271,7 @@ class FilesystemTest extends TestCase
     {
         file_put_contents($this->tempDir.'/file.php', '<?php return "Howdy?"; ?>');
         $files = new Filesystem;
-        $this->assertEquals('Howdy?', $files->getRequire($this->tempDir.'/file.php'));
+        $this->assertSame('Howdy?', $files->getRequire($this->tempDir.'/file.php'));
     }
 
     public function testGetRequireThrowsExceptionNonExistingFile()
@@ -305,21 +305,21 @@ class FilesystemTest extends TestCase
     {
         file_put_contents($this->tempDir.'/foobar.txt', 'foo');
         $filesystem = new Filesystem;
-        $this->assertEquals('foobar', $filesystem->name($this->tempDir.'/foobar.txt'));
+        $this->assertSame('foobar', $filesystem->name($this->tempDir.'/foobar.txt'));
     }
 
     public function testExtensionReturnsExtension()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
-        $this->assertEquals('txt', $files->extension($this->tempDir.'/foo.txt'));
+        $this->assertSame('txt', $files->extension($this->tempDir.'/foo.txt'));
     }
 
     public function testBasenameReturnsBasename()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
-        $this->assertEquals('foo.txt', $files->basename($this->tempDir.'/foo.txt'));
+        $this->assertSame('foo.txt', $files->basename($this->tempDir.'/foo.txt'));
     }
 
     public function testDirnameReturnsDirectory()
@@ -333,14 +333,14 @@ class FilesystemTest extends TestCase
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
-        $this->assertEquals('file', $files->type($this->tempDir.'/foo.txt'));
+        $this->assertSame('file', $files->type($this->tempDir.'/foo.txt'));
     }
 
     public function testTypeIdentifiesDirectory()
     {
         mkdir($this->tempDir.'/foo');
         $files = new Filesystem;
-        $this->assertEquals('dir', $files->type($this->tempDir.'/foo'));
+        $this->assertSame('dir', $files->type($this->tempDir.'/foo'));
     }
 
     public function testSizeOutputsSize()
@@ -357,7 +357,7 @@ class FilesystemTest extends TestCase
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $files = new Filesystem;
-        $this->assertEquals('text/plain', $files->mimeType($this->tempDir.'/foo.txt'));
+        $this->assertSame('text/plain', $files->mimeType($this->tempDir.'/foo.txt'));
     }
 
     public function testIsWritable()
@@ -527,15 +527,15 @@ class FilesystemTest extends TestCase
         /** @var Ftp $adapter */
         $adapter = $driver->getAdapter();
         $this->assertEquals(0700, $adapter->getPermPublic());
-        $this->assertEquals('ftp.example.com', $adapter->getHost());
-        $this->assertEquals('admin', $adapter->getUsername());
+        $this->assertSame('ftp.example.com', $adapter->getHost());
+        $this->assertSame('admin', $adapter->getUsername());
     }
 
     public function testHash()
     {
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
-        $this->assertEquals('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
+        $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -92,7 +92,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
-        $this->assertEquals('foo', $app->make('foo'));
+        $this->assertSame('foo', $app->make('foo'));
     }
 
     public function testDeferredServicesAreSharedProperly()
@@ -114,7 +114,7 @@ class FoundationApplicationTest extends TestCase
         $app->extend('foo', function ($instance, $container) {
             return $instance.'bar';
         });
-        $this->assertEquals('foobar', $app->make('foo'));
+        $this->assertSame('foobar', $app->make('foo'));
     }
 
     public function testDeferredServiceProviderIsRegisteredOnlyOnce()
@@ -147,7 +147,7 @@ class FoundationApplicationTest extends TestCase
             return $instance.'bar';
         });
         $this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
-        $this->assertEquals('foobar', $app->make('foo'));
+        $this->assertSame('foobar', $app->make('foo'));
         $this->assertTrue(ApplicationDeferredServiceProviderStub::$initialized);
     }
 
@@ -168,8 +168,8 @@ class FoundationApplicationTest extends TestCase
             'foo' => ApplicationMultiProviderStub::class,
             'bar' => ApplicationMultiProviderStub::class,
         ]);
-        $this->assertEquals('foo', $app->make('foo'));
-        $this->assertEquals('foobar', $app->make('bar'));
+        $this->assertSame('foo', $app->make('foo'));
+        $this->assertSame('foobar', $app->make('bar'));
     }
 
     public function testEnvironment()
@@ -177,7 +177,7 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
         $app['env'] = 'foo';
 
-        $this->assertEquals('foo', $app->environment());
+        $this->assertSame('foo', $app->environment());
 
         $this->assertTrue($app->environment('foo'));
         $this->assertTrue($app->environment('f*'));

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -20,7 +20,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
         $result = $env->detect(function () {
             return 'foobar';
         });
-        $this->assertEquals('foobar', $result);
+        $this->assertSame('foobar', $result);
     }
 
     public function testConsoleEnvironmentDetection()
@@ -30,7 +30,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
         $result = $env->detect(function () {
             return 'foobar';
         }, ['--env=local']);
-        $this->assertEquals('local', $result);
+        $this->assertSame('local', $result);
     }
 
     public function testConsoleEnvironmentDetectionSeparatedWithSpace()
@@ -40,7 +40,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
         $result = $env->detect(function () {
             return 'foobar';
         }, ['--env', 'local']);
-        $this->assertEquals('local', $result);
+        $this->assertSame('local', $result);
     }
 
     public function testConsoleEnvironmentDetectionWithNoValue()
@@ -50,6 +50,6 @@ class FoundationEnvironmentDetectorTest extends TestCase
         $result = $env->detect(function () {
             return 'foobar';
         }, ['--env']);
-        $this->assertEquals('foobar', $result);
+        $this->assertSame('foobar', $result);
     }
 }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -32,15 +32,15 @@ class FoundationHelpersTest extends TestCase
 
         // 3. cache('foo');
         $cache->shouldReceive('get')->once()->with('foo')->andReturn('bar');
-        $this->assertEquals('bar', cache('foo'));
+        $this->assertSame('bar', cache('foo'));
 
         // 4. cache('foo', null);
         $cache->shouldReceive('get')->once()->with('foo', null)->andReturn('bar');
-        $this->assertEquals('bar', cache('foo', null));
+        $this->assertSame('bar', cache('foo', null));
 
         // 5. cache('baz', 'default');
         $cache->shouldReceive('get')->once()->with('baz', 'default')->andReturn('default');
-        $this->assertEquals('default', cache('baz', 'default'));
+        $this->assertSame('default', cache('baz', 'default'));
     }
 
     public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
@@ -61,7 +61,7 @@ class FoundationHelpersTest extends TestCase
 
         touch(public_path($file));
 
-        $this->assertEquals('/'.$file, elixir($file));
+        $this->assertSame('/'.$file, elixir($file));
 
         unlink(public_path($file));
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -708,7 +708,7 @@ class FoundationTestResponseTest extends TestCase
 
         $response = TestResponse::fromBaseResponse(new Response);
 
-        $this->assertEquals(
+        $this->assertSame(
             'bar', $response->foo()
         );
     }
@@ -731,7 +731,7 @@ class FoundationTestResponseTest extends TestCase
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
-        $this->assertEquals('foo', $response->json('foobar.foobar_foo'));
+        $this->assertSame('foo', $response->json('foobar.foobar_foo'));
         $this->assertEquals(
             json_decode($response->getContent(), true),
             $response->json()

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -21,8 +21,8 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertEquals('12', $request->get('bar'));
-            $this->assertEquals('ab', $request->get('baz'));
+            $this->assertSame('12', $request->get('bar'));
+            $this->assertSame('ab', $request->get('baz'));
         });
     }
 
@@ -40,7 +40,7 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertEquals('Damian', $request->get('name'));
+            $this->assertSame('Damian', $request->get('name'));
             $this->assertEquals(27, $request->get('age'));
             $this->assertEquals(5, $request->get('beers'));
         });
@@ -62,7 +62,7 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertEquals('Damian', $request->get('name'));
+            $this->assertSame('Damian', $request->get('name'));
             $this->assertEquals([27, 55, 83], $request->get('age'));
             $this->assertEquals([5, 9, 13], $request->get('beers'));
         });
@@ -87,7 +87,7 @@ class TransformsRequestTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertEquals('Damian', $request->input('name'));
+            $this->assertSame('Damian', $request->input('name'));
             $this->assertEquals(27, $request->input('age'));
             $this->assertEquals(5, $request->input('beers'));
         });

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -22,10 +22,10 @@ class TrimStringsTest extends TestCase
         $request = Request::createFromBase($symfonyRequest);
 
         $middleware->handle($request, function (Request $request) {
-            $this->assertEquals('123', $request->get('abc'));
-            $this->assertEquals('456', $request->get('xyz'));
-            $this->assertEquals('  789  ', $request->get('foo'));
-            $this->assertEquals('  010  ', $request->get('bar'));
+            $this->assertSame('123', $request->get('abc'));
+            $this->assertSame('456', $request->get('xyz'));
+            $this->assertSame('  789  ', $request->get('foo'));
+            $this->assertSame('  010  ', $request->get('bar'));
         });
     }
 }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -33,21 +33,21 @@ class MakesHttpRequestsTest extends TestCase
         };
 
         $this->assertFalse($this->app->has(MyMiddleware::class));
-        $this->assertEquals(
+        $this->assertSame(
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
 
         $this->withoutMiddleware(MyMiddleware::class);
         $this->assertTrue($this->app->has(MyMiddleware::class));
-        $this->assertEquals(
+        $this->assertSame(
             'foo',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
 
         $this->withMiddleware(MyMiddleware::class);
         $this->assertFalse($this->app->has(MyMiddleware::class));
-        $this->assertEquals(
+        $this->assertSame(
             'fooWithMiddleware',
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -22,7 +22,7 @@ class HttpJsonResponseTest extends TestCase
         $response = new JsonResponse($data);
 
         $this->assertInstanceOf(stdClass::class, $response->getData());
-        $this->assertEquals('bar', $response->getData()->foo);
+        $this->assertSame('bar', $response->getData()->foo);
     }
 
     public function setAndRetrieveDataProvider(): array

--- a/tests/Http/HttpMimeTypeTest.php
+++ b/tests/Http/HttpMimeTypeTest.php
@@ -31,7 +31,7 @@ class HttpMimeTypeTest extends TestCase
     {
         $this->assertIsArray(MimeType::get());
         $this->assertArrayHasKey('jpg', MimeType::get());
-        $this->assertEquals('image/jpeg', MimeType::get()['jpg']);
+        $this->assertSame('image/jpeg', MimeType::get()['jpg']);
     }
 
     public function testSearchExtensionFromMimeType()

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -25,11 +25,11 @@ class HttpRedirectResponseTest extends TestCase
         $response = new RedirectResponse('foo.bar');
         $this->assertNull($response->headers->get('foo'));
         $response->header('foo', 'bar');
-        $this->assertEquals('bar', $response->headers->get('foo'));
+        $this->assertSame('bar', $response->headers->get('foo'));
         $response->header('foo', 'baz', false);
-        $this->assertEquals('bar', $response->headers->get('foo'));
+        $this->assertSame('bar', $response->headers->get('foo'));
         $response->header('foo', 'baz');
-        $this->assertEquals('baz', $response->headers->get('foo'));
+        $this->assertSame('baz', $response->headers->get('foo'));
     }
 
     public function testWithOnRedirect()
@@ -48,8 +48,8 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertEquals($response, $response->withCookie(new Cookie('foo', 'bar')));
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
-        $this->assertEquals('foo', $cookies[0]->getName());
-        $this->assertEquals('bar', $cookies[0]->getValue());
+        $this->assertSame('foo', $cookies[0]->getName());
+        $this->assertSame('bar', $cookies[0]->getValue());
     }
 
     public function testInputOnRedirect()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -399,7 +399,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue(isset($request['name']));
         $this->assertNull($request['name']);
 
-        $this->assertNotEquals('Taylor', $request['name']);
+        $this->assertNotSame('Taylor', $request['name']);
 
         $this->assertTrue(isset($request['foo.bar']));
         $this->assertNull($request['foo.bar']);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -52,22 +52,22 @@ class HttpRequestTest extends TestCase
     public function testRootMethod()
     {
         $request = Request::create('http://example.com/foo/bar/script.php?test');
-        $this->assertEquals('http://example.com', $request->root());
+        $this->assertSame('http://example.com', $request->root());
     }
 
     public function testPathMethod()
     {
         $request = Request::create('', 'GET');
-        $this->assertEquals('/', $request->path());
+        $this->assertSame('/', $request->path());
 
         $request = Request::create('/foo/bar', 'GET');
-        $this->assertEquals('foo/bar', $request->path());
+        $this->assertSame('foo/bar', $request->path());
     }
 
     public function testDecodedPathMethod()
     {
         $request = Request::create('/foo%20bar');
-        $this->assertEquals('foo bar', $request->decodedPath());
+        $this->assertSame('foo bar', $request->decodedPath());
     }
 
     /**
@@ -114,40 +114,40 @@ class HttpRequestTest extends TestCase
     public function testUrlMethod()
     {
         $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
-        $this->assertEquals('http://foo.com/foo/bar', $request->url());
+        $this->assertSame('http://foo.com/foo/bar', $request->url());
 
         $request = Request::create('http://foo.com/foo/bar/?', 'GET');
-        $this->assertEquals('http://foo.com/foo/bar', $request->url());
+        $this->assertSame('http://foo.com/foo/bar', $request->url());
     }
 
     public function testFullUrlMethod()
     {
         $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
-        $this->assertEquals('http://foo.com/foo/bar?name=taylor', $request->fullUrl());
+        $this->assertSame('http://foo.com/foo/bar?name=taylor', $request->fullUrl());
 
         $request = Request::create('https://foo.com', 'GET');
-        $this->assertEquals('https://foo.com', $request->fullUrl());
+        $this->assertSame('https://foo.com', $request->fullUrl());
 
         $request = Request::create('https://foo.com', 'GET');
-        $this->assertEquals('https://foo.com/?coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
+        $this->assertSame('https://foo.com/?coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
         $request = Request::create('https://foo.com?a=b', 'GET');
-        $this->assertEquals('https://foo.com/?a=b', $request->fullUrl());
+        $this->assertSame('https://foo.com/?a=b', $request->fullUrl());
 
         $request = Request::create('https://foo.com?a=b', 'GET');
-        $this->assertEquals('https://foo.com/?a=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
+        $this->assertSame('https://foo.com/?a=b&coupon=foo', $request->fullUrlWithQuery(['coupon' => 'foo']));
 
         $request = Request::create('https://foo.com?a=b', 'GET');
-        $this->assertEquals('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));
+        $this->assertSame('https://foo.com/?a=c', $request->fullUrlWithQuery(['a' => 'c']));
 
         $request = Request::create('http://foo.com/foo/bar?name=taylor', 'GET');
-        $this->assertEquals('http://foo.com/foo/bar?name=taylor', $request->fullUrlWithQuery(['name' => 'taylor']));
+        $this->assertSame('http://foo.com/foo/bar?name=taylor', $request->fullUrlWithQuery(['name' => 'taylor']));
 
         $request = Request::create('http://foo.com/foo/bar/?name=taylor', 'GET');
-        $this->assertEquals('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
+        $this->assertSame('http://foo.com/foo/bar?name=graham', $request->fullUrlWithQuery(['name' => 'graham']));
 
         $request = Request::create('https://foo.com', 'GET');
-        $this->assertEquals('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
+        $this->assertSame('https://foo.com/?key=value%20with%20spaces', $request->fullUrlWithQuery(['key' => 'value with spaces']));
     }
 
     public function testIsMethod()
@@ -205,10 +205,10 @@ class HttpRequestTest extends TestCase
             return $route;
         });
 
-        $this->assertEquals('bar', $request->route('required'));
-        $this->assertEquals('bar', $request->route('required', 'default'));
+        $this->assertSame('bar', $request->route('required'));
+        $this->assertSame('bar', $request->route('required', 'default'));
         $this->assertNull($request->route('optional'));
-        $this->assertEquals('default', $request->route('optional', 'default'));
+        $this->assertSame('default', $request->route('optional', 'default'));
     }
 
     public function testAjaxMethod()
@@ -272,7 +272,7 @@ class HttpRequestTest extends TestCase
             'HTTP_USER_AGENT' => 'Laravel',
         ]);
 
-        $this->assertEquals('Laravel', $request->userAgent());
+        $this->assertSame('Laravel', $request->userAgent());
     }
 
     public function testHasMethod()
@@ -372,9 +372,9 @@ class HttpRequestTest extends TestCase
     public function testInputMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
-        $this->assertEquals('Taylor', $request->input('name'));
-        $this->assertEquals('Taylor', $request['name']);
-        $this->assertEquals('Bob', $request->input('foo', 'Bob'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame('Taylor', $request['name']);
+        $this->assertSame('Bob', $request->input('foo', 'Bob'));
 
         $request = Request::create('/', 'GET', [], [], ['file' => new SymfonyUploadedFile(__FILE__, 'foo.php')]);
         $this->assertInstanceOf(SymfonyUploadedFile::class, $request['file']);
@@ -404,10 +404,10 @@ class HttpRequestTest extends TestCase
         $this->assertTrue(isset($request['foo.bar']));
         $this->assertNull($request['foo.bar']);
         $this->assertTrue(isset($request['foo.baz']));
-        $this->assertEquals('', $request['foo.baz']);
+        $this->assertSame('', $request['foo.baz']);
 
         $this->assertTrue(isset($request['id']));
-        $this->assertEquals('foo', $request['id']);
+        $this->assertSame('foo', $request['id']);
     }
 
     public function testAllMethod()
@@ -467,28 +467,28 @@ class HttpRequestTest extends TestCase
     public function testQueryMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
-        $this->assertEquals('Taylor', $request->query('name'));
-        $this->assertEquals('Bob', $request->query('foo', 'Bob'));
+        $this->assertSame('Taylor', $request->query('name'));
+        $this->assertSame('Bob', $request->query('foo', 'Bob'));
         $all = $request->query(null);
-        $this->assertEquals('Taylor', $all['name']);
+        $this->assertSame('Taylor', $all['name']);
     }
 
     public function testPostMethod()
     {
         $request = Request::create('/', 'POST', ['name' => 'Taylor']);
-        $this->assertEquals('Taylor', $request->post('name'));
-        $this->assertEquals('Bob', $request->post('foo', 'Bob'));
+        $this->assertSame('Taylor', $request->post('name'));
+        $this->assertSame('Bob', $request->post('foo', 'Bob'));
         $all = $request->post(null);
-        $this->assertEquals('Taylor', $all['name']);
+        $this->assertSame('Taylor', $all['name']);
     }
 
     public function testCookieMethod()
     {
         $request = Request::create('/', 'GET', [], ['name' => 'Taylor']);
-        $this->assertEquals('Taylor', $request->cookie('name'));
-        $this->assertEquals('Bob', $request->cookie('foo', 'Bob'));
+        $this->assertSame('Taylor', $request->cookie('name'));
+        $this->assertSame('Bob', $request->cookie('foo', 'Bob'));
         $all = $request->cookie(null);
-        $this->assertEquals('Taylor', $all['name']);
+        $this->assertSame('Taylor', $all['name']);
     }
 
     public function testHasCookieMethod()
@@ -534,10 +534,10 @@ class HttpRequestTest extends TestCase
     public function testServerMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], ['foo' => 'bar']);
-        $this->assertEquals('bar', $request->server('foo'));
-        $this->assertEquals('bar', $request->server('foo.doesnt.exist', 'bar'));
+        $this->assertSame('bar', $request->server('foo'));
+        $this->assertSame('bar', $request->server('foo.doesnt.exist', 'bar'));
         $all = $request->server(null);
-        $this->assertEquals('bar', $all['foo']);
+        $this->assertSame('bar', $all['foo']);
     }
 
     public function testMergeMethod()
@@ -545,8 +545,8 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['name' => 'Taylor']);
         $merge = ['buddy' => 'Dayle'];
         $request->merge($merge);
-        $this->assertEquals('Taylor', $request->input('name'));
-        $this->assertEquals('Dayle', $request->input('buddy'));
+        $this->assertSame('Taylor', $request->input('name'));
+        $this->assertSame('Dayle', $request->input('buddy'));
     }
 
     public function testReplaceMethod()
@@ -555,7 +555,7 @@ class HttpRequestTest extends TestCase
         $replace = ['buddy' => 'Dayle'];
         $request->replace($replace);
         $this->assertNull($request->input('name'));
-        $this->assertEquals('Dayle', $request->input('buddy'));
+        $this->assertSame('Dayle', $request->input('buddy'));
     }
 
     public function testOffsetUnsetMethod()
@@ -568,17 +568,17 @@ class HttpRequestTest extends TestCase
     public function testHeaderMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_DO_THIS' => 'foo']);
-        $this->assertEquals('foo', $request->header('do-this'));
+        $this->assertSame('foo', $request->header('do-this'));
         $all = $request->header(null);
-        $this->assertEquals('foo', $all['do-this'][0]);
+        $this->assertSame('foo', $all['do-this'][0]);
     }
 
     public function testJSONMethod()
     {
         $payload = ['name' => 'taylor'];
         $request = Request::create('/', 'GET', [], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($payload));
-        $this->assertEquals('taylor', $request->json('name'));
-        $this->assertEquals('taylor', $request->input('name'));
+        $this->assertSame('taylor', $request->json('name'));
+        $this->assertSame('taylor', $request->input('name'));
         $data = $request->json()->all();
         $this->assertEquals($payload, $data);
     }
@@ -598,26 +598,26 @@ class HttpRequestTest extends TestCase
 
     public function testPrefers()
     {
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['json']));
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['html', 'json']));
-        $this->assertEquals('application/foo+json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('application/foo+json'));
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('json'));
-        $this->assertEquals('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/html;q=1.0'])->prefers(['json', 'html']));
-        $this->assertEquals('txt', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/plain;q=1.0, text/html;q=1.0'])->prefers(['json', 'txt', 'html']));
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('json'));
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('json'));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['json']));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json'])->prefers(['html', 'json']));
+        $this->assertSame('application/foo+json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('application/foo+json'));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/foo+json'])->prefers('json'));
+        $this->assertSame('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/html;q=1.0'])->prefers(['json', 'html']));
+        $this->assertSame('txt', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.5, text/plain;q=1.0, text/html;q=1.0'])->prefers(['json', 'txt', 'html']));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('json'));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('json'));
         $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/xml; charset=utf-8'])->prefers(['html', 'json']));
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['html', 'json']));
-        $this->assertEquals('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['html', 'json']));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['html', 'json']));
+        $this->assertSame('html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['html', 'json']));
 
-        $this->assertEquals('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('application/json'));
-        $this->assertEquals('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['text/html', 'application/json']));
-        $this->assertEquals('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['text/html', 'application/json']));
-        $this->assertEquals('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['application/json', 'text/html']));
+        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8'])->prefers('application/json'));
+        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json, text/html'])->prefers(['text/html', 'application/json']));
+        $this->assertSame('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['text/html', 'application/json']));
+        $this->assertSame('text/html', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json;q=0.4, text/html;q=0.6'])->prefers(['application/json', 'text/html']));
 
-        $this->assertEquals('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*; charset=utf-8'])->prefers('json'));
-        $this->assertEquals('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/json'));
-        $this->assertEquals('application/xml', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/xml'));
+        $this->assertSame('json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*; charset=utf-8'])->prefers('json'));
+        $this->assertSame('application/json', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/json'));
+        $this->assertSame('application/xml', Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('application/xml'));
         $this->assertNull(Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/*'])->prefers('text/html'));
     }
 
@@ -695,7 +695,7 @@ class HttpRequestTest extends TestCase
         $session = m::mock(Store::class);
         $session->shouldReceive('getOldInput')->once()->with('foo', 'bar')->andReturn('boom');
         $request->setLaravelSession($session);
-        $this->assertEquals('boom', $request->old('foo', 'bar'));
+        $this->assertSame('boom', $request->old('foo', 'bar'));
     }
 
     public function testFlushMethodCallsSession()
@@ -737,26 +737,26 @@ class HttpRequestTest extends TestCase
     public function testFormatReturnsAcceptableFormat()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
-        $this->assertEquals('json', $request->format());
+        $this->assertSame('json', $request->format());
         $this->assertTrue($request->wantsJson());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json; charset=utf-8']);
-        $this->assertEquals('json', $request->format());
+        $this->assertSame('json', $request->format());
         $this->assertTrue($request->wantsJson());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/atom+xml']);
-        $this->assertEquals('atom', $request->format());
+        $this->assertSame('atom', $request->format());
         $this->assertFalse($request->wantsJson());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'is/not/known']);
-        $this->assertEquals('html', $request->format());
-        $this->assertEquals('foo', $request->format('foo'));
+        $this->assertSame('html', $request->format());
+        $this->assertSame('foo', $request->format('foo'));
     }
 
     public function testFormatReturnsAcceptsJson()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
-        $this->assertEquals('json', $request->format());
+        $this->assertSame('json', $request->format());
         $this->assertTrue($request->accepts('application/json'));
         $this->assertTrue($request->accepts('application/baz+json'));
         $this->assertTrue($request->acceptsJson());
@@ -775,7 +775,7 @@ class HttpRequestTest extends TestCase
     public function testFormatReturnsAcceptsHtml()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'text/html']);
-        $this->assertEquals('html', $request->format());
+        $this->assertSame('html', $request->format());
         $this->assertTrue($request->accepts('text/html'));
         $this->assertTrue($request->acceptsHtml());
         $this->assertFalse($request->acceptsJson());
@@ -788,7 +788,7 @@ class HttpRequestTest extends TestCase
     public function testFormatReturnsAcceptsAll()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*/*']);
-        $this->assertEquals('html', $request->format());
+        $this->assertSame('html', $request->format());
         $this->assertTrue($request->accepts('text/html'));
         $this->assertTrue($request->accepts('foo/bar'));
         $this->assertTrue($request->accepts('application/baz+xml'));
@@ -796,7 +796,7 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->acceptsJson());
 
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => '*']);
-        $this->assertEquals('html', $request->format());
+        $this->assertSame('html', $request->format());
         $this->assertTrue($request->accepts('text/html'));
         $this->assertTrue($request->accepts('foo/bar'));
         $this->assertTrue($request->accepts('application/baz+xml'));
@@ -860,7 +860,7 @@ class HttpRequestTest extends TestCase
         $request->setUserResolver(function () {
             return 'user';
         });
-        $this->assertEquals('user', $request->user());
+        $this->assertSame('user', $request->user());
     }
 
     public function testFingerprintMethod()
@@ -938,8 +938,8 @@ class HttpRequestTest extends TestCase
         });
 
         // Router parameter 'foo' is 'bar', then it ISSET and is NOT EMPTY.
-        $this->assertEquals('bar', $request->foo);
-        $this->assertEquals('bar', $request['foo']);
+        $this->assertSame('bar', $request->foo);
+        $this->assertSame('bar', $request['foo']);
         $this->assertEquals(isset($request->foo), true);
         $this->assertEquals(empty($request->foo), false);
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -30,33 +30,33 @@ class HttpResponseTest extends TestCase
     public function testJsonResponsesAreConvertedAndHeadersAreSet()
     {
         $response = new Response(new ArrayableStub);
-        $this->assertEquals('{"foo":"bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response = new Response(new JsonableStub);
-        $this->assertEquals('foo', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('foo', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response = new Response(new ArrayableAndJsonableStub);
-        $this->assertEquals('{"foo":"bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response = new Response;
         $response->setContent(['foo' => 'bar']);
-        $this->assertEquals('{"foo":"bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response = new Response(new JsonSerializableStub);
-        $this->assertEquals('{"foo":"bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response = new Response(new ArrayableStub);
-        $this->assertEquals('{"foo":"bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
         $response->setContent('{"foo": "bar"}');
-        $this->assertEquals('{"foo": "bar"}', $response->getContent());
-        $this->assertEquals('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('{"foo": "bar"}', $response->getContent());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
     }
 
     public function testRenderablesAreRendered()
@@ -64,7 +64,7 @@ class HttpResponseTest extends TestCase
         $mock = m::mock(Renderable::class);
         $mock->shouldReceive('render')->once()->andReturn('foo');
         $response = new Response($mock);
-        $this->assertEquals('foo', $response->getContent());
+        $this->assertSame('foo', $response->getContent());
     }
 
     public function testHeader()
@@ -72,11 +72,11 @@ class HttpResponseTest extends TestCase
         $response = new Response;
         $this->assertNull($response->headers->get('foo'));
         $response->header('foo', 'bar');
-        $this->assertEquals('bar', $response->headers->get('foo'));
+        $this->assertSame('bar', $response->headers->get('foo'));
         $response->header('foo', 'baz', false);
-        $this->assertEquals('bar', $response->headers->get('foo'));
+        $this->assertSame('bar', $response->headers->get('foo'));
         $response->header('foo', 'baz');
-        $this->assertEquals('baz', $response->headers->get('foo'));
+        $this->assertSame('baz', $response->headers->get('foo'));
     }
 
     public function testWithCookie()
@@ -86,8 +86,8 @@ class HttpResponseTest extends TestCase
         $this->assertEquals($response, $response->withCookie(new Cookie('foo', 'bar')));
         $cookies = $response->headers->getCookies();
         $this->assertCount(1, $cookies);
-        $this->assertEquals('foo', $cookies[0]->getName());
-        $this->assertEquals('bar', $cookies[0]->getValue());
+        $this->assertSame('foo', $cookies[0]->getName());
+        $this->assertSame('bar', $cookies[0]->getValue());
     }
 
     public function testGetOriginalContent()

--- a/tests/Http/HttpUploadedFileTest.php
+++ b/tests/Http/HttpUploadedFileTest.php
@@ -18,6 +18,6 @@ class HttpUploadedFileTest extends TestCase
             true
         );
 
-        $this->assertEquals('This is a story about something that happened long ago when your grandfather was a child.', trim($file->get()));
+        $this->assertSame('This is a story about something that happened long ago when your grandfather was a child.', trim($file->get()));
     }
 }

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -83,7 +83,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $response->assertStatus(200);
-        $this->assertEquals('email', $response->decodeResponseJson()['email']);
+        $this->assertSame('email', $response->decodeResponseJson()['email']);
     }
 
     public function testBasicAuthRespectsAdditionalConditions()
@@ -121,13 +121,13 @@ class AuthenticationTest extends TestCase
         $this->assertFalse($this->app['auth']->check());
         $this->assertNull($this->app['auth']->user());
         Event::assertDispatched(Attempting::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(['email' => 'wrong', 'password' => 'password'], $event->credentials);
 
             return true;
         });
         Event::assertDispatched(Failed::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(['email' => 'wrong', 'password' => 'password'], $event->credentials);
             $this->assertNull($event->user);
 
@@ -146,19 +146,19 @@ class AuthenticationTest extends TestCase
         $this->assertTrue($this->app['auth']->check());
 
         Event::assertDispatched(Attempting::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(['email' => 'email', 'password' => 'password'], $event->credentials);
 
             return true;
         });
         Event::assertDispatched(Login::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
             return true;
         });
         Event::assertDispatched(Authenticated::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
             return true;
@@ -183,7 +183,7 @@ class AuthenticationTest extends TestCase
         $this->app['auth']->logout();
         $this->assertNull($this->app['auth']->user());
         Event::assertDispatched(Logout::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
             return true;
@@ -204,7 +204,7 @@ class AuthenticationTest extends TestCase
         $this->assertEquals(1, $user->id);
 
         Event::assertDispatched(OtherDeviceLogout::class, function ($event) {
-            $this->assertEquals('web', $event->guard);
+            $this->assertSame('web', $event->guard);
             $this->assertEquals(1, $event->user->id);
 
             return true;

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -23,10 +23,10 @@ class DynamoDbStoreTest extends TestCase
     public function testItemsCanBeStoredAndRetrieved()
     {
         Cache::driver('dynamodb')->put('name', 'Taylor', 10);
-        $this->assertEquals('Taylor', Cache::driver('dynamodb')->get('name'));
+        $this->assertSame('Taylor', Cache::driver('dynamodb')->get('name'));
 
         Cache::driver('dynamodb')->put(['name' => 'Abigail', 'age' => 28], 10);
-        $this->assertEquals('Abigail', Cache::driver('dynamodb')->get('name'));
+        $this->assertSame('Abigail', Cache::driver('dynamodb')->get('name'));
         $this->assertEquals(28, Cache::driver('dynamodb')->get('age'));
 
         $this->assertEquals([

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -27,7 +27,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
         Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->forceRelease();
-        $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
             return 'taylor';
         }));
 
@@ -38,7 +38,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
     public function testLocksCanRunCallbacks()
     {
         Cache::store('memcached')->lock('foo')->forceRelease();
-        $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
             return 'taylor';
         }));
     }
@@ -51,7 +51,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
 
         Cache::store('memcached')->lock('foo')->release();
         Cache::store('memcached')->lock('foo', 5)->get();
-        $this->assertEquals('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
             return 'taylor';
         }));
     }

--- a/tests/Integration/Cache/MemcachedTaggedCacheTest.php
+++ b/tests/Integration/Cache/MemcachedTaggedCacheTest.php
@@ -16,14 +16,14 @@ class MemcachedTaggedCacheTest extends MemcachedIntegrationTest
         $store->tags(['people', 'artists'])->put('John', 'foo', 1);
         $store->tags(['people', 'authors'])->put('Anne', 'bar', 1);
 
-        $this->assertEquals('foo', $store->tags(['people', 'artists'])->get('John'));
-        $this->assertEquals('bar', $store->tags(['people', 'authors'])->get('Anne'));
+        $this->assertSame('foo', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('bar', $store->tags(['people', 'authors'])->get('Anne'));
 
         $store->tags(['people', 'artists'])->put('John', 'baz');
         $store->tags(['people', 'authors'])->put('Anne', 'qux');
 
-        $this->assertEquals('baz', $store->tags(['people', 'artists'])->get('John'));
-        $this->assertEquals('qux', $store->tags(['people', 'authors'])->get('Anne'));
+        $this->assertSame('baz', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('qux', $store->tags(['people', 'authors'])->get('Anne'));
 
         $store->tags('authors')->flush();
         $this->assertNull($store->tags(['people', 'authors'])->get('Anne'));
@@ -38,13 +38,13 @@ class MemcachedTaggedCacheTest extends MemcachedIntegrationTest
 
         $store->tags(['people', 'artists'])->putMany(['John' => 'foo', 'Jane' => 'bar'], 1);
 
-        $this->assertEquals('foo', $store->tags(['people', 'artists'])->get('John'));
-        $this->assertEquals('bar', $store->tags(['people', 'artists'])->get('Jane'));
+        $this->assertSame('foo', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('bar', $store->tags(['people', 'artists'])->get('Jane'));
 
         $store->tags(['people', 'artists'])->putMany(['John' => 'baz', 'Jane' => 'qux']);
 
-        $this->assertEquals('baz', $store->tags(['people', 'artists'])->get('John'));
-        $this->assertEquals('qux', $store->tags(['people', 'artists'])->get('Jane'));
+        $this->assertSame('baz', $store->tags(['people', 'artists'])->get('John'));
+        $this->assertSame('qux', $store->tags(['people', 'artists'])->get('Jane'));
 
         $store->tags(['people', 'artists'])->putMany(['John' => 'baz', 'Jane' => 'qux'], -1);
 

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -49,7 +49,7 @@ class RedisCacheLockTest extends TestCase
         Carbon::setTestNow();
 
         Cache::store('redis')->lock('foo')->forceRelease();
-        $this->assertEquals('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
             return 'taylor';
         }));
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -496,12 +496,12 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post->touchingTags()->attach([$tag->id]);
 
-        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
         Carbon::setTestNow('2017-10-10 10:10:10');
 
         $tag->update(['name' => $tag->name]);
-        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
         $tag->update(['name' => Str::random()]);
         $this->assertSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
@@ -513,8 +513,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post = Post::create(['title' => Str::random()]);
 
-        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
-        $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
 
         Carbon::setTestNow('2017-10-10 10:10:10');
 
@@ -530,15 +530,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $post = Post::create(['title' => Str::random()]);
 
-        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
-        $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
 
         Carbon::setTestNow('2017-10-10 10:10:10');
 
         $tag->posts()->sync([$post->id]);
 
-        $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
-        $this->assertNotEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertNotSame('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
     public function testCanRetrieveRelatedIds()
@@ -582,7 +582,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             $this->assertSame('2017-10-10 10:10:10', $date);
         }
 
-        $this->assertNotEquals('2017-10-10 10:10:10', Tag::find(300)->updated_at);
+        $this->assertNotSame('2017-10-10 10:10:10', Tag::find(300)->updated_at);
     }
 
     public function testWherePivotOnString()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -84,9 +84,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         // Testing on the pivot model
         $this->assertInstanceOf(Pivot::class, $post->tags[0]->pivot);
         $this->assertEquals($post->id, $post->tags[0]->pivot->post_id);
-        $this->assertEquals('post_id', $post->tags[0]->pivot->getForeignKey());
-        $this->assertEquals('tag_id', $post->tags[0]->pivot->getOtherKey());
-        $this->assertEquals('posts_tags', $post->tags[0]->pivot->getTable());
+        $this->assertSame('post_id', $post->tags[0]->pivot->getForeignKey());
+        $this->assertSame('tag_id', $post->tags[0]->pivot->getOtherKey());
+        $this->assertSame('posts_tags', $post->tags[0]->pivot->getTable());
         $this->assertEquals(
             [
                 'post_id' => '1', 'tag_id' => '1', 'flag' => 'taylor',
@@ -117,11 +117,11 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $loadedTag->refresh();
 
-        $this->assertEquals('newName', $loadedTag->name);
+        $this->assertSame('newName', $loadedTag->name);
 
         $post->refresh();
 
-        $this->assertEquals('newName', $post->tags[0]->name);
+        $this->assertSame('newName', $post->tags[0]->name);
     }
 
     public function testCustomPivotClass()
@@ -135,10 +135,10 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithCustomPivot()->attach($tag->id);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivot[0]->pivot);
-        $this->assertEquals('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
+        $this->assertSame('1507630210', $post->tagsWithCustomPivot[0]->pivot->getAttributes()['created_at']);
 
         $this->assertInstanceOf(PostTagPivot::class, $post->tagsWithCustomPivotClass[0]->pivot);
-        $this->assertEquals('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
+        $this->assertSame('posts_tags', $post->tagsWithCustomPivotClass()->getTable());
 
         $this->assertEquals([
             'post_id' => '1',
@@ -196,7 +196,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             $post->tagsWithCustomExtraPivot()->updateExistingPivot($tag->id, ['flag' => 'exclude'])
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
-            $this->assertEquals('exclude', $tag->pivot->flag);
+            $this->assertSame('exclude', $tag->pivot->flag);
         }
 
         // Test on non-existent pivot
@@ -226,7 +226,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->attach($tag2->id, ['flag' => 'taylor']);
         $post->load('tags');
         $this->assertEquals($tag2->name, $post->tags[1]->name);
-        $this->assertEquals('taylor', $post->tags[1]->pivot->flag);
+        $this->assertSame('taylor', $post->tags[1]->pivot->flag);
 
         $post->tags()->attach([$tag3->id, $tag4->id]);
         $post->load('tags');
@@ -236,9 +236,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->attach([$tag5->id => ['flag' => 'mohamed'], $tag6->id => ['flag' => 'adam']]);
         $post->load('tags');
         $this->assertEquals($tag5->name, $post->tags[4]->name);
-        $this->assertEquals('mohamed', $post->tags[4]->pivot->flag);
+        $this->assertSame('mohamed', $post->tags[4]->pivot->flag);
         $this->assertEquals($tag6->name, $post->tags[5]->name);
-        $this->assertEquals('adam', $post->tags[5]->pivot->flag);
+        $this->assertSame('adam', $post->tags[5]->pivot->flag);
 
         $post->tags()->attach(new Collection([$tag7, $tag8]));
         $post->load('tags');
@@ -374,7 +374,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag->id, $post->tags()->firstOrCreate(['name' => $tag->name])->id);
 
         $new = $post->tags()->firstOrCreate(['name' => 'wavez']);
-        $this->assertEquals('wavez', $new->name);
+        $this->assertSame('wavez', $new->name);
         $this->assertNotNull($new->id);
     }
 
@@ -387,7 +387,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->attach(Tag::all());
 
         $post->tags()->updateOrCreate(['id' => $tag->id], ['name' => 'wavez']);
-        $this->assertEquals('wavez', $tag->fresh()->name);
+        $this->assertSame('wavez', $tag->fresh()->name);
 
         $post->tags()->updateOrCreate(['id' => 'asd'], ['name' => 'dives']);
         $this->assertNotNull($post->tags()->whereName('dives')->first());
@@ -431,9 +431,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         ]);
         $post->load('tags');
         $this->assertEquals($tag->name, $post->tags[0]->name);
-        $this->assertEquals('taylor', $post->tags[0]->pivot->flag);
+        $this->assertSame('taylor', $post->tags[0]->pivot->flag);
         $this->assertEquals($tag2->name, $post->tags[1]->name);
-        $this->assertEquals('mohamed', $post->tags[1]->pivot->flag);
+        $this->assertSame('mohamed', $post->tags[1]->pivot->flag);
     }
 
     public function testSyncWithoutDetachingMethod()
@@ -485,7 +485,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
             Tag::whereIn('id', [$tag->id])->pluck('name'),
             $post->tags->pluck('name')
         );
-        $this->assertEquals('taylor', $post->tags[0]->pivot->flag);
+        $this->assertSame('taylor', $post->tags[0]->pivot->flag);
     }
 
     public function testTouchingParent()
@@ -504,7 +504,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertNotEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
 
         $tag->update(['name' => Str::random()]);
-        $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
     }
 
     public function testTouchingRelatedModelsOnSync()
@@ -520,8 +520,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
 
         $tag->posts()->sync([$post->id]);
 
-        $this->assertEquals('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
-        $this->assertEquals('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
+        $this->assertSame('2017-10-10 10:10:10', $post->fresh()->updated_at->toDateTimeString());
+        $this->assertSame('2017-10-10 10:10:10', $tag->fresh()->updated_at->toDateTimeString());
     }
 
     public function testNoTouchingHappensIfNotConfigured()
@@ -579,7 +579,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->touch();
 
         foreach ($post->tags()->pluck('tags.updated_at') as $date) {
-            $this->assertEquals('2017-10-10 10:10:10', $date);
+            $this->assertSame('2017-10-10 10:10:10', $date);
         }
 
         $this->assertNotEquals('2017-10-10 10:10:10', Tag::find(300)->updated_at);
@@ -642,7 +642,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithExtraPivot()->updateExistingPivot($tag->id, ['flag' => 'exclude']);
 
         foreach ($post->tagsWithExtraPivot as $tag) {
-            $this->assertEquals('exclude', $tag->pivot->flag);
+            $this->assertSame('exclude', $tag->pivot->flag);
         }
     }
 
@@ -662,7 +662,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithExtraPivot()->updateExistingPivot($tags, ['flag' => 'exclude']);
 
         foreach ($post->tagsWithExtraPivot as $tag) {
-            $this->assertEquals('exclude', $tag->pivot->flag);
+            $this->assertSame('exclude', $tag->pivot->flag);
         }
     }
 
@@ -678,7 +678,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tagsWithExtraPivot()->updateExistingPivot($tag, ['flag' => 'exclude']);
 
         foreach ($post->tagsWithExtraPivot as $tag) {
-            $this->assertEquals('exclude', $tag->pivot->flag);
+            $this->assertSame('exclude', $tag->pivot->flag);
         }
     }
 
@@ -700,7 +700,7 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($tag->name, $post->tagsWithCustomRelatedKey()->first()->pivot->tag_id);
 
         $post->tagsWithCustomRelatedKey()->updateExistingPivot($tag, ['flag' => 'exclude']);
-        $this->assertEquals('exclude', $post->tagsWithCustomRelatedKey()->first()->pivot->flag);
+        $this->assertSame('exclude', $post->tagsWithCustomRelatedKey()->first()->pivot->flag);
     }
 
     public function testGlobalScopeColumns()

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -159,7 +159,7 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         $user = factory(FactoryBuildableUser::class)->create(['name' => 'Zain']);
 
-        $this->assertEquals('Zain', $user->name);
+        $this->assertSame('Zain', $user->name);
     }
 
     public function testCreatingCollectionOfModels()
@@ -182,9 +182,9 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $callableServer = factory(FactoryBuildableServer::class)->state('callable')->create();
 
-        $this->assertEquals('active', $server->status);
+        $this->assertSame('active', $server->status);
         $this->assertEquals(['Storage', 'Data'], $server->tags);
-        $this->assertEquals('callable', $callableServer->status);
+        $this->assertSame('callable', $callableServer->status);
     }
 
     public function testCreatingModelsWithInlineState()
@@ -193,8 +193,8 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $inlineServer = factory(FactoryBuildableServer::class)->state('inline')->create();
 
-        $this->assertEquals('active', $server->status);
-        $this->assertEquals('inline', $inlineServer->status);
+        $this->assertSame('active', $server->status);
+        $this->assertSame('inline', $inlineServer->status);
     }
 
     public function testCreatingModelsWithRelationships()
@@ -217,7 +217,7 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $dbUser = FactoryBuildableUser::on('alternative-connection')->find(1);
 
-        $this->assertEquals('alternative-connection', $user->getConnectionName());
+        $this->assertSame('alternative-connection', $user->getConnectionName());
         $this->assertTrue($user->is($dbUser));
     }
 
@@ -242,7 +242,7 @@ class EloquentFactoryBuilderTest extends TestCase
             ->connection('alternative-connection')
             ->make();
 
-        $this->assertEquals('alternative-connection', $user->getConnectionName());
+        $this->assertSame('alternative-connection', $user->getConnectionName());
     }
 
     public function testMakingModelsWithAfterCallback()

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -64,16 +64,16 @@ class EloquentModelConnectionsTest extends TestCase
         $parent1 = ParentModel::create(['name' => Str::random()]);
         $parent1->children()->create(['name' => 'childOnConn1']);
         $parents1 = ParentModel::with('children')->get();
-        $this->assertEquals('childOnConn1', ChildModel::on('conn1')->first()->name);
-        $this->assertEquals('childOnConn1', $parent1->children()->first()->name);
-        $this->assertEquals('childOnConn1', $parents1[0]->children[0]->name);
+        $this->assertSame('childOnConn1', ChildModel::on('conn1')->first()->name);
+        $this->assertSame('childOnConn1', $parent1->children()->first()->name);
+        $this->assertSame('childOnConn1', $parents1[0]->children[0]->name);
 
         $parent2 = ParentModel::on('conn2')->create(['name' => Str::random()]);
         $parent2->children()->create(['name' => 'childOnConn2']);
         $parents2 = ParentModel::on('conn2')->with('children')->get();
-        $this->assertEquals('childOnConn2', ChildModel::on('conn2')->first()->name);
-        $this->assertEquals('childOnConn2', $parent2->children()->first()->name);
-        $this->assertEquals('childOnConn2', $parents2[0]->children[0]->name);
+        $this->assertSame('childOnConn2', ChildModel::on('conn2')->first()->name);
+        $this->assertSame('childOnConn2', $parent2->children()->first()->name);
+        $this->assertSame('childOnConn2', $parents2[0]->children[0]->name);
     }
 
     public function testChildUsesItsOwnConnectionIfSet()
@@ -81,10 +81,10 @@ class EloquentModelConnectionsTest extends TestCase
         $parent1 = ParentModel::create(['name' => Str::random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);
         $parents1 = ParentModel::with('childrenDefaultConn2')->get();
-        $this->assertEquals('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);
-        $this->assertEquals('childAlwaysOnConn2', $parent1->childrenDefaultConn2()->first()->name);
-        $this->assertEquals('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
-        $this->assertEquals('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
+        $this->assertSame('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);
+        $this->assertSame('childAlwaysOnConn2', $parent1->childrenDefaultConn2()->first()->name);
+        $this->assertSame('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
+        $this->assertSame('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
     }
 
     public function testChildUsesItsOwnConnectionIfSetEvenIfParentExplicitConnection()
@@ -92,9 +92,9 @@ class EloquentModelConnectionsTest extends TestCase
         $parent1 = ParentModel::on('conn1')->create(['name' => Str::random()]);
         $parent1->childrenDefaultConn2()->create(['name' => 'childAlwaysOnConn2']);
         $parents1 = ParentModel::on('conn1')->with('childrenDefaultConn2')->get();
-        $this->assertEquals('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);
-        $this->assertEquals('childAlwaysOnConn2', $parent1->childrenDefaultConn2()->first()->name);
-        $this->assertEquals('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
+        $this->assertSame('childAlwaysOnConn2', ChildModelDefaultConn2::first()->name);
+        $this->assertSame('childAlwaysOnConn2', $parent1->childrenDefaultConn2()->first()->name);
+        $this->assertSame('childAlwaysOnConn2', $parents1[0]->childrenDefaultConn2[0]->name);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -31,8 +31,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
             'datetime_field' => '2019-10-01 10:15:20',
         ]);
 
-        $this->assertEquals('2019-10', $user->toArray()['date_field']);
-        $this->assertEquals('2019-10 10:15', $user->toArray()['datetime_field']);
+        $this->assertSame('2019-10', $user->toArray()['date_field']);
+        $this->assertSame('2019-10 10:15', $user->toArray()['datetime_field']);
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
     }

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -30,14 +30,14 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
             'decimal_field_4' => '1234',
         ]);
 
-        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
-        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+        $this->assertSame('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertSame('1234.0000', $user->toArray()['decimal_field_4']);
 
         $user->decimal_field_2 = 12;
         $user->decimal_field_4 = '1234';
 
-        $this->assertEquals('12.00', $user->toArray()['decimal_field_2']);
-        $this->assertEquals('1234.0000', $user->toArray()['decimal_field_4']);
+        $this->assertSame('12.00', $user->toArray()['decimal_field_2']);
+        $this->assertSame('1234.0000', $user->toArray()['decimal_field_4']);
 
         $this->assertFalse($user->isDirty());
 

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -36,8 +36,8 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
             'json_string_as_json_field' => '{"key1":"value1"}',
         ]);
 
-        $this->assertEquals('this is a string', $object->basic_string_as_json_field);
-        $this->assertEquals('{"key1":"value1"}', $object->json_string_as_json_field);
+        $this->assertSame('this is a string', $object->basic_string_as_json_field);
+        $this->assertSame('{"key1":"value1"}', $object->json_string_as_json_field);
     }
 
     public function testArraysAreCastable()
@@ -61,7 +61,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertInstanceOf(stdClass::class, $user->object_as_json_field);
-        $this->assertEquals('value1', $user->object_as_json_field->key1);
+        $this->assertSame('value1', $user->object_as_json_field->key1);
     }
 
     public function testCollectionsAreCastable()
@@ -72,7 +72,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertInstanceOf(Collection::class, $user->collection_as_json_field);
-        $this->assertEquals('value1', $user->collection_as_json_field->get('key1'));
+        $this->assertSame('value1', $user->collection_as_json_field->get('key1'));
     }
 }
 

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -55,7 +55,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $this->assertEmpty($post->getDirty());
 
-        $this->assertEquals('patrick', $post->getOriginal('title'));
+        $this->assertSame('patrick', $post->getOriginal('title'));
     }
 }
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -41,7 +41,7 @@ class EloquentMorphManyTest extends DatabaseTestCase
 
         $post->update(['title' => 'new name']);
 
-        $this->assertEquals('new name', $post->title);
+        $this->assertSame('new name', $post->title);
     }
 }
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -42,7 +42,7 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
 
         $post->comments()->create(['title' => Str::random()]);
 
-        $this->assertNotEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
+        $this->assertNotSame('2016-10-10', $post->fresh()->updated_at->toDateString());
     }
 }
 

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -38,7 +38,7 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
     {
         $post = Post::create(['title' => Str::random(), 'updated_at' => '2016-10-10 10:10:10']);
 
-        $this->assertEquals('2016-10-10', $post->fresh()->updated_at->toDateString());
+        $this->assertSame('2016-10-10', $post->fresh()->updated_at->toDateString());
 
         $post->comments()->create(['title' => Str::random()]);
 

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -73,7 +73,7 @@ class EloquentUpdateTest extends TestCase
 
         TestUpdateModel1::latest('id')->limit(3)->update(['title'=>'Dr.']);
 
-        $this->assertEquals('Dr.', TestUpdateModel1::find(8)->title);
+        $this->assertSame('Dr.', TestUpdateModel1::find(8)->title);
         $this->assertNotEquals('Dr.', TestUpdateModel1::find(7)->title);
     }
 
@@ -95,7 +95,7 @@ class EloquentUpdateTest extends TestCase
 
         $record = TestUpdateModel2::find(1);
 
-        $this->assertEquals('Engineer: Abdul', $record->job.': '.$record->name);
+        $this->assertSame('Engineer: Abdul', $record->job.': '.$record->name);
     }
 
     public function testSoftDeleteWithJoins()

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -74,7 +74,7 @@ class EloquentUpdateTest extends TestCase
         TestUpdateModel1::latest('id')->limit(3)->update(['title'=>'Dr.']);
 
         $this->assertSame('Dr.', TestUpdateModel1::find(8)->title);
-        $this->assertNotEquals('Dr.', TestUpdateModel1::find(7)->title);
+        $this->assertNotSame('Dr.', TestUpdateModel1::find(7)->title);
     }
 
     public function testUpdatedAtWithJoins()

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -66,7 +66,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $blueprint->build($this->getConnection(), new SQLiteGrammar());
 
         $this->assertArrayHasKey(TinyInteger::NAME, Type::getTypesMap());
-        $this->assertEquals('tinyinteger', Schema::getColumnType('test', 'test_column'));
+        $this->assertSame('tinyinteger', Schema::getColumnType('test', 'test_column'));
         $this->assertEquals($expected, $statements);
     }
 }

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -123,7 +123,7 @@ class EventFakeTest extends TestCase
             $this->fail('should not be called');
         });
 
-        $this->assertEquals('two', Event::until('test'));
+        $this->assertSame('two', Event::until('test'));
 
         Event::assertNotDispatched(NonImportantEvent::class);
     }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -279,7 +279,7 @@ class ResourceTest extends TestCase
             'title' => 'Test Title',
         ]));
 
-        $this->assertEquals('http://localhost/post/5', url('/post', $post));
+        $this->assertSame('http://localhost/post/5', url('/post', $post));
     }
 
     public function testNamedRoutesAreUrlRoutable()
@@ -295,7 +295,7 @@ class ResourceTest extends TestCase
 
         $response = $this->withoutExceptionHandling()->get('/post/1');
 
-        $this->assertEquals('http://localhost/post/5', $response->original);
+        $this->assertSame('http://localhost/post/5', $response->original);
     }
 
     public function testResourcesMayBeSerializable()

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -34,12 +34,12 @@ class ThrottleRequestsTest extends TestCase
         })->middleware(ThrottleRequests::class.':2,1');
 
         $response = $this->withoutExceptionHandling()->get('/');
-        $this->assertEquals('yes', $response->getContent());
+        $this->assertSame('yes', $response->getContent());
         $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
         $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
 
         $response = $this->withoutExceptionHandling()->get('/');
-        $this->assertEquals('yes', $response->getContent());
+        $this->assertSame('yes', $response->getContent());
         $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
         $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -39,12 +39,12 @@ class ThrottleRequestsWithRedisTest extends TestCase
             })->middleware(ThrottleRequestsWithRedis::class.':2,1');
 
             $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertEquals('yes', $response->getContent());
+            $this->assertSame('yes', $response->getContent());
             $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
             $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
 
             $response = $this->withoutExceptionHandling()->get('/');
-            $this->assertEquals('yes', $response->getContent());
+            $this->assertSame('yes', $response->getContent());
             $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
             $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -18,6 +18,6 @@ class IntegrationTest extends TestCase
 
         $response = $this->get('/');
 
-        $this->assertEquals('Hello World', $response->content());
+        $this->assertSame('Hello World', $response->content());
     }
 }

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -83,7 +83,7 @@ class SendingMailWithLocaleTest extends TestCase
             app('swift.transport')->messages()[0]->getBody()
         );
 
-        $this->assertEquals('en', Carbon::getLocale());
+        $this->assertSame('en', Carbon::getLocale());
     }
 
     public function testLocaleIsSentWithModelPreferredLocale()
@@ -158,7 +158,7 @@ class SendingMailWithLocaleTest extends TestCase
         Mail::to('test@mail.com')->locale('ar')->send(new TestMail);
         Mail::to('test@mail.com')->send(new TestMail);
 
-        $this->assertEquals('en', app('translator')->getLocale());
+        $this->assertSame('en', app('translator')->getLocale());
 
         $this->assertStringContainsString('esm',
             app('swift.transport')->messages()[0]->getBody()

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -134,14 +134,14 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ]);
 
-        $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestFirstJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestFirstJob::$usedConnection);
 
-        $this->assertEquals('some_queue', JobChainingTestSecondJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestSecondJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestSecondJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestSecondJob::$usedConnection);
 
-        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestThirdJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
     public function testChainJobsUseOwnConfig()
@@ -151,14 +151,14 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ]);
 
-        $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestFirstJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestFirstJob::$usedConnection);
 
-        $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
-        $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);
+        $this->assertSame('another_queue', JobChainingTestSecondJob::$usedQueue);
+        $this->assertSame('sync2', JobChainingTestSecondJob::$usedConnection);
 
-        $this->assertEquals('some_queue', JobChainingTestThirdJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestThirdJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestThirdJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestThirdJob::$usedConnection);
     }
 
     public function testChainJobsUseDefaultConfig()
@@ -168,11 +168,11 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ]);
 
-        $this->assertEquals('some_queue', JobChainingTestFirstJob::$usedQueue);
-        $this->assertEquals('sync1', JobChainingTestFirstJob::$usedConnection);
+        $this->assertSame('some_queue', JobChainingTestFirstJob::$usedQueue);
+        $this->assertSame('sync1', JobChainingTestFirstJob::$usedConnection);
 
-        $this->assertEquals('another_queue', JobChainingTestSecondJob::$usedQueue);
-        $this->assertEquals('sync2', JobChainingTestSecondJob::$usedConnection);
+        $this->assertSame('another_queue', JobChainingTestSecondJob::$usedQueue);
+        $this->assertSame('sync2', JobChainingTestSecondJob::$usedConnection);
 
         $this->assertNull(JobChainingTestThirdJob::$usedQueue);
         $this->assertNull(JobChainingTestThirdJob::$usedConnection);

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -87,17 +87,17 @@ class ModelSerializationTest extends TestCase
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('testbench', $unSerialized->user->getConnectionName());
-        $this->assertEquals('mohamed@laravel.com', $unSerialized->user->email);
+        $this->assertSame('testbench', $unSerialized->user->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
 
         $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('testbench')->get()));
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('testbench', $unSerialized->user[0]->getConnectionName());
-        $this->assertEquals('mohamed@laravel.com', $unSerialized->user[0]->email);
-        $this->assertEquals('testbench', $unSerialized->user[1]->getConnectionName());
-        $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
+        $this->assertSame('testbench', $unSerialized->user[0]->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user[0]->email);
+        $this->assertSame('testbench', $unSerialized->user[1]->getConnectionName());
+        $this->assertSame('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 
     public function testItSerializeUserOnDifferentConnection()
@@ -114,17 +114,17 @@ class ModelSerializationTest extends TestCase
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('custom', $unSerialized->user->getConnectionName());
-        $this->assertEquals('mohamed@laravel.com', $unSerialized->user->email);
+        $this->assertSame('custom', $unSerialized->user->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
 
         $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('custom')->get()));
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertEquals('custom', $unSerialized->user[0]->getConnectionName());
-        $this->assertEquals('mohamed@laravel.com', $unSerialized->user[0]->email);
-        $this->assertEquals('custom', $unSerialized->user[1]->getConnectionName());
-        $this->assertEquals('taylor@laravel.com', $unSerialized->user[1]->email);
+        $this->assertSame('custom', $unSerialized->user[0]->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user[0]->email);
+        $this->assertSame('custom', $unSerialized->user[1]->getConnectionName());
+        $this->assertSame('taylor@laravel.com', $unSerialized->user[1]->email);
     }
 
     public function testItFailsIfModelsOnMultiConnections()

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -30,10 +30,10 @@ class FluentRoutingTest extends TestCase
             return 'Hello World';
         })->middleware([Middleware::class, Middleware2::class]);
 
-        $this->assertEquals('middleware output', $this->get('one')->content());
-        $this->assertEquals('middleware output', $this->get('two')->content());
-        $this->assertEquals('middleware output', $this->get('three')->content());
-        $this->assertEquals('middleware output', $this->get('four')->content());
+        $this->assertSame('middleware output', $this->get('one')->content());
+        $this->assertSame('middleware output', $this->get('two')->content());
+        $this->assertSame('middleware output', $this->get('three')->content());
+        $this->assertSame('middleware output', $this->get('four')->content());
     }
 }
 

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -20,8 +20,8 @@ class ResponsableTest extends TestCase
         $response = $this->get('/responsable');
 
         $this->assertEquals(201, $response->status());
-        $this->assertEquals('Taylor', $response->headers->get('X-Test-Header'));
-        $this->assertEquals('hello world', $response->getContent());
+        $this->assertSame('Taylor', $response->headers->get('X-Test-Header'));
+        $this->assertSame('hello world', $response->getContent());
     }
 }
 

--- a/tests/Integration/Routing/RouteApiResourceTest.php
+++ b/tests/Integration/Routing/RouteApiResourceTest.php
@@ -18,26 +18,26 @@ class RouteApiResourceTest extends TestCase
 
         $response = $this->get('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m index', $response->getContent());
+        $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m store', $response->getContent());
+        $this->assertSame('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m show', $response->getContent());
+        $this->assertSame('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update', $response->getContent());
+        $this->assertSame('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update', $response->getContent());
+        $this->assertSame('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m destroy', $response->getContent());
+        $this->assertSame('I`m destroy', $response->getContent());
     }
 
     public function testApiResourceWithOnly()
@@ -46,11 +46,11 @@ class RouteApiResourceTest extends TestCase
 
         $response = $this->get('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m index', $response->getContent());
+        $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m store', $response->getContent());
+        $this->assertSame('I`m store', $response->getContent());
 
         $this->assertEquals(404, $this->get('/tests/1')->getStatusCode());
         $this->assertEquals(404, $this->put('/tests/1')->getStatusCode());
@@ -67,49 +67,49 @@ class RouteApiResourceTest extends TestCase
 
         $response = $this->get('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m index', $response->getContent());
+        $this->assertSame('I`m index', $response->getContent());
 
         $response = $this->post('/tests');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m store', $response->getContent());
+        $this->assertSame('I`m store', $response->getContent());
 
         $response = $this->get('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m show', $response->getContent());
+        $this->assertSame('I`m show', $response->getContent());
 
         $response = $this->put('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update', $response->getContent());
+        $this->assertSame('I`m update', $response->getContent());
         $response = $this->patch('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update', $response->getContent());
+        $this->assertSame('I`m update', $response->getContent());
 
         $response = $this->delete('/tests/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m destroy', $response->getContent());
+        $this->assertSame('I`m destroy', $response->getContent());
 
         /////////////////////
         $response = $this->get('/tasks');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m index tasks', $response->getContent());
+        $this->assertSame('I`m index tasks', $response->getContent());
 
         $response = $this->post('/tasks');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m store tasks', $response->getContent());
+        $this->assertSame('I`m store tasks', $response->getContent());
 
         $response = $this->get('/tasks/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m show tasks', $response->getContent());
+        $this->assertSame('I`m show tasks', $response->getContent());
 
         $response = $this->put('/tasks/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update tasks', $response->getContent());
+        $this->assertSame('I`m update tasks', $response->getContent());
         $response = $this->patch('/tasks/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m update tasks', $response->getContent());
+        $this->assertSame('I`m update tasks', $response->getContent());
 
         $response = $this->delete('/tasks/1');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('I`m destroy tasks', $response->getContent());
+        $this->assertSame('I`m destroy tasks', $response->getContent());
     }
 }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -22,7 +22,7 @@ class UrlSigningTest extends TestCase
         })->name('foo');
 
         $this->assertIsString($url = URL::signedRoute('foo', ['id' => 1]));
-        $this->assertEquals('valid', $this->get($url)->original);
+        $this->assertSame('valid', $this->get($url)->original);
     }
 
     public function testTemporarySignedUrls()
@@ -33,10 +33,10 @@ class UrlSigningTest extends TestCase
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
         $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
-        $this->assertEquals('valid', $this->get($url)->original);
+        $this->assertSame('valid', $this->get($url)->original);
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1)->addMinutes(10));
-        $this->assertEquals('invalid', $this->get($url)->original);
+        $this->assertSame('invalid', $this->get($url)->original);
     }
 
     public function testSignedUrlWithUrlWithoutSignatureParameter()
@@ -45,7 +45,7 @@ class UrlSigningTest extends TestCase
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
-        $this->assertEquals('invalid', $this->get('/foo/1')->original);
+        $this->assertSame('invalid', $this->get('/foo/1')->original);
     }
 
     public function testSignedMiddleware()
@@ -56,7 +56,7 @@ class UrlSigningTest extends TestCase
 
         Carbon::setTestNow(Carbon::create(2018, 1, 1));
         $this->assertIsString($url = URL::temporarySignedRoute('foo', now()->addMinutes(5), ['id' => 1]));
-        $this->assertEquals('valid', $this->get($url)->original);
+        $this->assertSame('valid', $this->get($url)->original);
     }
 
     public function testSignedMiddlewareWithInvalidUrl()
@@ -83,7 +83,7 @@ class UrlSigningTest extends TestCase
         })->name('foo');
 
         $this->assertIsString($url = URL::signedRoute('foo', $model));
-        $this->assertEquals('routable', $this->get($url)->original);
+        $this->assertSame('routable', $this->get($url)->original);
     }
 }
 

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -39,10 +39,10 @@ class LogLoggerTest extends TestCase
 
         $writer->error('foo');
         $this->assertTrue(isset($_SERVER['__log.level']));
-        $this->assertEquals('error', $_SERVER['__log.level']);
+        $this->assertSame('error', $_SERVER['__log.level']);
         unset($_SERVER['__log.level']);
         $this->assertTrue(isset($_SERVER['__log.message']));
-        $this->assertEquals('foo', $_SERVER['__log.message']);
+        $this->assertSame('foo', $_SERVER['__log.message']);
         unset($_SERVER['__log.message']);
         $this->assertTrue(isset($_SERVER['__log.context']));
         $this->assertEquals([], $_SERVER['__log.context']);

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -93,7 +93,7 @@ class LogManagerTest extends TestCase
         $handlers = $logger->getLogger()->getHandlers();
 
         $this->assertInstanceOf(Logger::class, $logger);
-        $this->assertEquals('foobar', $logger->getName());
+        $this->assertSame('foobar', $logger->getName());
         $this->assertCount(1, $handlers);
         $this->assertInstanceOf(StreamHandler::class, $handlers[0]);
         $this->assertEquals(Monolog::NOTICE, $handlers[0]->getLevel());
@@ -101,7 +101,7 @@ class LogManagerTest extends TestCase
 
         $url = new ReflectionProperty(get_class($handlers[0]), 'url');
         $url->setAccessible(true);
-        $this->assertEquals('php://stderr', $url->getValue($handlers[0]));
+        $this->assertSame('php://stderr', $url->getValue($handlers[0]));
 
         $config->set('logging.channels.logentries', [
             'driver' => 'monolog',
@@ -119,7 +119,7 @@ class LogManagerTest extends TestCase
         $logToken->setAccessible(true);
 
         $this->assertInstanceOf(LogEntriesHandler::class, $handlers[0]);
-        $this->assertEquals('123456789', $logToken->getValue($handlers[0]));
+        $this->assertSame('123456789', $logToken->getValue($handlers[0]));
     }
 
     public function testLogManagerCreatesMonologHandlerWithConfiguredFormatter()
@@ -161,7 +161,7 @@ class LogManagerTest extends TestCase
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
 
-        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+        $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
 
     public function testLogManagerCreateSingleDriverWithConfiguredFormatter()
@@ -203,7 +203,7 @@ class LogManagerTest extends TestCase
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
 
-        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+        $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
 
     public function testLogManagerCreateDailyDriverWithConfiguredFormatter()
@@ -245,7 +245,7 @@ class LogManagerTest extends TestCase
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
 
-        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+        $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
 
     public function testLogManagerCreateSyslogDriverWithConfiguredFormatter()
@@ -285,6 +285,6 @@ class LogManagerTest extends TestCase
         $dateFormat = new ReflectionProperty(get_class($formatter), 'dateFormat');
         $dateFormat->setAccessible(true);
 
-        $this->assertEquals('Y/m/d--test', $dateFormat->getValue($formatter));
+        $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
 }

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -189,7 +189,7 @@ class MailMailerTest extends TestCase
 
         $mailer = $this->getMailer();
 
-        $this->assertEquals(
+        $this->assertSame(
             'bar', $mailer->foo()
         );
     }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -54,7 +54,7 @@ class MailMarkdownTest extends TestCase
         $viewFactory->shouldReceive('make')->with('view', [])->andReturnSelf();
         $viewFactory->shouldReceive('render')->andReturn('text');
 
-        $result = $markdown->renderText('view', []);
+        $result = $markdown->renderText('view', [])->toHtml();
 
         $this->assertSame('text', $result);
     }
@@ -64,7 +64,7 @@ class MailMarkdownTest extends TestCase
         $viewFactory = m::mock(Factory::class);
         $markdown = new Markdown($viewFactory);
 
-        $result = $markdown->parse('# Something');
+        $result = $markdown->parse('# Something')->toHtml();
 
         $this->assertSame('<h1>Something</h1>', $result);
     }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -56,7 +56,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->renderText('view', []);
 
-        $this->assertEquals('text', $result);
+        $this->assertSame('text', $result);
     }
 
     public function testParseReturnsParsedMarkdown()
@@ -66,6 +66,6 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->parse('# Something');
 
-        $this->assertEquals('<h1>Something</h1>', $result);
+        $this->assertSame('<h1>Something</h1>', $result);
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -35,7 +35,7 @@ class MailSesTransportTest extends TestCase
         /** @var SesClient $ses */
         $ses = $transport->ses();
 
-        $this->assertEquals('us-east-1', $ses->getRegion());
+        $this->assertSame('us-east-1', $ses->getRegion());
     }
 
     public function testSend()

--- a/tests/Notifications/NotificationActionTest.php
+++ b/tests/Notifications/NotificationActionTest.php
@@ -11,7 +11,7 @@ class NotificationActionTest extends TestCase
     {
         $action = new Action('Text', 'url');
 
-        $this->assertEquals('Text', $action->text);
-        $this->assertEquals('url', $action->url);
+        $this->assertSame('Text', $action->text);
+        $this->assertSame('url', $action->url);
     }
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -11,11 +11,11 @@ class NotificationMailMessageTest extends TestCase
     {
         $message = new MailMessage;
 
-        $this->assertEquals('notifications::email', $message->markdown);
+        $this->assertSame('notifications::email', $message->markdown);
 
         $message->template('notifications::foo');
 
-        $this->assertEquals('notifications::foo', $message->markdown);
+        $this->assertSame('notifications::foo', $message->markdown);
     }
 
     public function testCcIsSetCorrectly()

--- a/tests/Notifications/NotificationMessageTest.php
+++ b/tests/Notifications/NotificationMessageTest.php
@@ -10,11 +10,11 @@ class NotificationMessageTest extends TestCase
     public function testLevelCanBeRetrieved()
     {
         $message = new Message;
-        $this->assertEquals('info', $message->level);
+        $this->assertSame('info', $message->level);
 
         $message = new Message;
         $message->level('error');
-        $this->assertEquals('error', $message->level);
+        $this->assertSame('error', $message->level);
     }
 
     public function testMessageFormatsMultiLineText()
@@ -25,7 +25,7 @@ class NotificationMessageTest extends TestCase
             single line of text.
         ');
 
-        $this->assertEquals('This is a single line of text.', $message->introLines[0]);
+        $this->assertSame('This is a single line of text.', $message->introLines[0]);
 
         $message = new Message;
         $message->with([
@@ -33,6 +33,6 @@ class NotificationMessageTest extends TestCase
             'single line of text.',
         ]);
 
-        $this->assertEquals('This is a single line of text.', $message->introLines[0]);
+        $this->assertSame('This is a single line of text.', $message->introLines[0]);
     }
 }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -47,8 +47,8 @@ class NotificationRoutesNotificationsTest extends TestCase
     public function testNotificationOptionRouting()
     {
         $instance = new RoutesNotificationsTestInstance;
-        $this->assertEquals('bar', $instance->routeNotificationFor('foo'));
-        $this->assertEquals('taylor@laravel.com', $instance->routeNotificationFor('mail'));
+        $this->assertSame('bar', $instance->routeNotificationFor('foo'));
+        $this->assertSame('taylor@laravel.com', $instance->routeNotificationFor('mail'));
     }
 }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -30,10 +30,10 @@ class LengthAwarePaginatorTest extends TestCase
 
     public function testLengthAwarePaginatorGetAndSetPageName()
     {
-        $this->assertEquals('page', $this->p->getPageName());
+        $this->assertSame('page', $this->p->getPageName());
 
         $this->p->setPageName('p');
-        $this->assertEquals('p', $this->p->getPageName());
+        $this->assertSame('p', $this->p->getPageName());
     }
 
     public function testLengthAwarePaginatorCanGiveMeRelevantPageInformation()
@@ -61,16 +61,16 @@ class LengthAwarePaginatorTest extends TestCase
         $this->p->setPath('http://website.com');
         $this->p->setPageName('foo');
 
-        $this->assertEquals('http://website.com',
+        $this->assertSame('http://website.com',
                             $this->p->path());
 
-        $this->assertEquals('http://website.com?foo=2',
+        $this->assertSame('http://website.com?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertSame('http://website.com?foo=1',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com?foo=1',
+        $this->assertSame('http://website.com?foo=1',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -79,7 +79,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->p->setPath('http://website.com?sort_by=date');
         $this->p->setPageName('foo');
 
-        $this->assertEquals('http://website.com?sort_by=date&foo=2',
+        $this->assertSame('http://website.com?sort_by=date&foo=2',
                             $this->p->url($this->p->currentPage()));
     }
 
@@ -88,13 +88,13 @@ class LengthAwarePaginatorTest extends TestCase
         $this->p->setPath('http://website.com/test');
         $this->p->setPageName('foo');
 
-        $this->assertEquals('http://website.com/test?foo=2',
+        $this->assertSame('http://website.com/test?foo=2',
                             $this->p->url($this->p->currentPage()));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertSame('http://website.com/test?foo=1',
                             $this->p->url($this->p->currentPage() - 1));
 
-        $this->assertEquals('http://website.com/test?foo=1',
+        $this->assertSame('http://website.com/test?foo=1',
                             $this->p->url($this->p->currentPage() - 2));
     }
 
@@ -103,7 +103,7 @@ class LengthAwarePaginatorTest extends TestCase
         $this->p->setPath('http://website.com?key=value%20with%20spaces');
         $this->p->setPageName('foo');
 
-        $this->assertEquals('http://website.com?key=value%20with%20spaces&foo=2',
+        $this->assertSame('http://website.com?key=value%20with%20spaces&foo=2',
                             $this->p->url($this->p->currentPage()));
     }
 

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -36,7 +36,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test/']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
     public function testPaginatorGeneratesUrlsWithoutTrailingSlash()
@@ -44,7 +44,7 @@ class PaginatorTest extends TestCase
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,
                                     ['path' => 'http://website.com/test']);
 
-        $this->assertEquals('http://website.com/test?page=1', $p->previousPageUrl());
+        $this->assertSame('http://website.com/test?page=1', $p->previousPageUrl());
     }
 
     public function testItRetrievesThePaginatorOptions()

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -24,9 +24,9 @@ class PipelineTest extends TestCase
                         return $piped;
                     });
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.two']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $_SERVER['__test.pipe.two']);
 
         unset($_SERVER['__test.pipe.one']);
         unset($_SERVER['__test.pipe.two']);
@@ -41,8 +41,8 @@ class PipelineTest extends TestCase
                 return $piped;
             });
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }
@@ -58,8 +58,8 @@ class PipelineTest extends TestCase
                 }
             );
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }
@@ -81,8 +81,8 @@ class PipelineTest extends TestCase
                 }
             );
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }
@@ -98,8 +98,8 @@ class PipelineTest extends TestCase
                 }
             );
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }
@@ -115,7 +115,7 @@ class PipelineTest extends TestCase
                 return $piped;
             });
 
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
         $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
 
         unset($_SERVER['__test.pipe.parameters']);
@@ -130,7 +130,7 @@ class PipelineTest extends TestCase
             ->then(function ($piped) {
                 return $piped;
             });
-        $this->assertEquals('data', $result);
+        $this->assertSame('data', $result);
     }
 
     public function testPipelineThrowsExceptionOnResolveWithoutContainer()
@@ -152,8 +152,8 @@ class PipelineTest extends TestCase
                     ->through([PipelineTestPipeOne::class])
                     ->thenReturn();
 
-        $this->assertEquals('foo', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('foo', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -23,7 +23,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->expects($this->any())->method('currentTime')->willReturn('time');
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
-            $this->assertEquals('default', $array['queue']);
+            $this->assertSame('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'delay' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
@@ -43,7 +43,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $queue->expects($this->any())->method('currentTime')->willReturn('time');
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) {
-            $this->assertEquals('default', $array['queue']);
+            $this->assertSame('default', $array['queue']);
             $this->assertEquals(json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'delay' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -25,7 +25,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'delay' => null, 'timeout' => null, 'data' => ['data'], 'id' => 'foo', 'attempts' => 0]));
 
         $id = $queue->push('foo', ['data']);
-        $this->assertEquals('foo', $id);
+        $this->assertSame('foo', $id);
     }
 
     public function testPushProperlyPushesJobOntoRedisWithCustomPayloadHook()
@@ -40,7 +40,7 @@ class QueueRedisQueueTest extends TestCase
         });
 
         $id = $queue->push('foo', ['data']);
-        $this->assertEquals('foo', $id);
+        $this->assertSame('foo', $id);
 
         Queue::createPayloadUsing(null);
     }
@@ -61,7 +61,7 @@ class QueueRedisQueueTest extends TestCase
         });
 
         $id = $queue->push('foo', ['data']);
-        $this->assertEquals('foo', $id);
+        $this->assertSame('foo', $id);
 
         Queue::createPayloadUsing(null);
     }
@@ -80,7 +80,7 @@ class QueueRedisQueueTest extends TestCase
         );
 
         $id = $queue->later(1, 'foo', ['data']);
-        $this->assertEquals('foo', $id);
+        $this->assertSame('foo', $id);
     }
 
     public function testDelayedPushWithDateTimeProperlyPushesJobOntoRedis()

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -41,23 +41,23 @@ class RedisConnectionTest extends TestCase
     {
         foreach ($this->connections() as $redis) {
             $redis->set('one', 'mohamed', 'EX', 5, 'NX');
-            $this->assertEquals('mohamed', $redis->get('one'));
+            $this->assertSame('mohamed', $redis->get('one'));
             $this->assertNotEquals(-1, $redis->ttl('one'));
 
             // It doesn't override when NX mode
             $redis->set('one', 'taylor', 'EX', 5, 'NX');
-            $this->assertEquals('mohamed', $redis->get('one'));
+            $this->assertSame('mohamed', $redis->get('one'));
 
             // It overrides when XX mode
             $redis->set('one', 'taylor', 'EX', 5, 'XX');
-            $this->assertEquals('taylor', $redis->get('one'));
+            $this->assertSame('taylor', $redis->get('one'));
 
             // It fails if XX mode is on and key doesn't exist
             $redis->set('two', 'taylor', 'PX', 5, 'XX');
             $this->assertNull($redis->get('two'));
 
             $redis->set('three', 'mohamed', 'PX', 5000);
-            $this->assertEquals('mohamed', $redis->get('three'));
+            $this->assertSame('mohamed', $redis->get('three'));
             $this->assertNotEquals(-1, $redis->ttl('three'));
             $this->assertNotEquals(-1, $redis->pttl('three'));
 
@@ -127,17 +127,17 @@ class RedisConnectionTest extends TestCase
             $redis->set('one', 'mohamed');
             $redis->rename('one', 'two');
             $this->assertNull($redis->get('one'));
-            $this->assertEquals('mohamed', $redis->get('two'));
+            $this->assertSame('mohamed', $redis->get('two'));
 
             $redis->set('three', 'adam');
             $redis->renamenx('two', 'three');
-            $this->assertEquals('mohamed', $redis->get('two'));
-            $this->assertEquals('adam', $redis->get('three'));
+            $this->assertSame('mohamed', $redis->get('two'));
+            $this->assertSame('adam', $redis->get('three'));
 
             $redis->renamenx('two', 'four');
             $this->assertNull($redis->get('two'));
-            $this->assertEquals('mohamed', $redis->get('four'));
-            $this->assertEquals('adam', $redis->get('three'));
+            $this->assertSame('mohamed', $redis->get('four'));
+            $this->assertSame('adam', $redis->get('three'));
 
             $redis->flushall();
         }
@@ -204,10 +204,10 @@ class RedisConnectionTest extends TestCase
             $redis->set('name', 'mohamed');
 
             $this->assertSame(0, $redis->setnx('name', 'taylor'));
-            $this->assertEquals('mohamed', $redis->get('name'));
+            $this->assertSame('mohamed', $redis->get('name'));
 
             $this->assertSame(1, $redis->setnx('boss', 'taylor'));
-            $this->assertEquals('taylor', $redis->get('boss'));
+            $this->assertSame('taylor', $redis->get('boss'));
 
             $redis->flushall();
         }
@@ -219,10 +219,10 @@ class RedisConnectionTest extends TestCase
             $redis->hset('person', 'name', 'mohamed');
 
             $this->assertSame(0, $redis->hsetnx('person', 'name', 'taylor'));
-            $this->assertEquals('mohamed', $redis->hget('person', 'name'));
+            $this->assertSame('mohamed', $redis->hget('person', 'name'));
 
             $this->assertSame(1, $redis->hsetnx('person', 'boss', 'taylor'));
-            $this->assertEquals('taylor', $redis->hget('person', 'boss'));
+            $this->assertSame('taylor', $redis->hget('person', 'boss'));
 
             $redis->flushall();
         }
@@ -468,7 +468,7 @@ class RedisConnectionTest extends TestCase
     {
         foreach ($this->connections() as $redis) {
             $redis->eval('redis.call("set", KEYS[1], ARGV[1])', 1, 'name', 'mohamed');
-            $this->assertEquals('mohamed', $redis->get('name'));
+            $this->assertSame('mohamed', $redis->get('name'));
 
             $redis->flushall();
         }
@@ -529,9 +529,9 @@ class RedisConnectionTest extends TestCase
             $redis->setEventDispatcher($events = m::mock(Dispatcher::class));
 
             $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
-                $this->assertEquals('get', $event->command);
+                $this->assertSame('get', $event->command);
                 $this->assertEquals(['foobar'], $event->parameters);
-                $this->assertEquals('default', $event->connectionName);
+                $this->assertSame('default', $event->connectionName);
                 $this->assertInstanceOf(Connection::class, $event->connection);
 
                 return true;
@@ -549,7 +549,7 @@ class RedisConnectionTest extends TestCase
             $this->markTestSkipped('PhpRedis does not support persistent connections with PHP_ZTS enabled.');
         }
 
-        $this->assertEquals(
+        $this->assertSame(
             'laravel',
             $this->connections()['persistent']->getPersistentID()
         );

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -52,14 +52,14 @@ class RedisManagerExtensionTest extends TestCase
 
     public function testUsingCustomRedisConnectorWithSingleRedisInstance()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'my-redis-connection', $this->redis->resolve()
         );
     }
 
     public function testUsingCustomRedisConnectorWithRedisClusterInstance()
     {
-        $this->assertEquals(
+        $this->assertSame(
             'my-redis-cluster-connection', $this->redis->resolve('my-cluster')
         );
     }

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -157,7 +157,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index');
         });
 
-        $this->assertEquals(
+        $this->assertSame(
             'App\Http\Controllers\UsersController@index',
             $this->getRoute()->getAction()['uses']
         );
@@ -169,7 +169,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index');
         });
 
-        $this->assertEquals('api/users', $this->getRoute()->uri());
+        $this->assertSame('api/users', $this->getRoute()->uri());
     }
 
     public function testCanRegisterGroupWithPrefixAndWhere()
@@ -189,7 +189,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index')->name('users');
         });
 
-        $this->assertEquals('api.users', $this->getRoute()->getName());
+        $this->assertSame('api.users', $this->getRoute()->getName());
     }
 
     public function testCanRegisterGroupWithDomain()
@@ -198,7 +198,7 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index');
         });
 
-        $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
+        $this->assertSame('{account}.myapp.com', $this->getRoute()->getDomain());
     }
 
     public function testCanRegisterGroupWithDomainAndNamePrefix()
@@ -207,8 +207,8 @@ class RouteRegistrarTest extends TestCase
             $router->get('users', 'UsersController@index')->name('users');
         });
 
-        $this->assertEquals('{account}.myapp.com', $this->getRoute()->getDomain());
-        $this->assertEquals('api.users', $this->getRoute()->getName());
+        $this->assertSame('{account}.myapp.com', $this->getRoute()->getDomain());
+        $this->assertSame('api.users', $this->getRoute()->getName());
     }
 
     public function testRegisteringNonApprovedAttributesThrows()
@@ -498,7 +498,7 @@ class RouteRegistrarTest extends TestCase
         });
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
-        $this->assertEquals('users.index', $this->getRoute()->getName());
+        $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
     public function testCanSetRouteNameUsingNameAlias()
@@ -508,7 +508,7 @@ class RouteRegistrarTest extends TestCase
         });
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
-        $this->assertEquals('users.index', $this->getRoute()->getName());
+        $this->assertSame('users.index', $this->getRoute()->getName());
     }
 
     /**

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -55,7 +55,7 @@ class RoutingRedirectorTest extends TestCase
         $response = $this->redirect->to('bar');
 
         $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals($this->session, $response->getSession());
     }
@@ -64,7 +64,7 @@ class RoutingRedirectorTest extends TestCase
     {
         $response = $this->redirect->to('bar', 303, ['X-RateLimit-Limit' => 60, 'X-RateLimit-Remaining' => 59], true);
 
-        $this->assertEquals('https://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('https://foo.com/bar', $response->getTargetUrl());
         $this->assertEquals(303, $response->getStatusCode());
         $this->assertEquals(60, $response->headers->get('X-RateLimit-Limit'));
         $this->assertEquals(59, $response->headers->get('X-RateLimit-Remaining'));
@@ -77,7 +77,7 @@ class RoutingRedirectorTest extends TestCase
 
         $response = $this->redirect->guest('login');
 
-        $this->assertEquals('http://foo.com/login', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/login', $response->getTargetUrl());
     }
 
     public function testGuestPutPreviousUrlInSession()
@@ -88,7 +88,7 @@ class RoutingRedirectorTest extends TestCase
 
         $response = $this->redirect->guest('login');
 
-        $this->assertEquals('http://foo.com/login', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/login', $response->getTargetUrl());
     }
 
     public function testIntendedRedirectToIntendedUrlInSession()
@@ -97,7 +97,7 @@ class RoutingRedirectorTest extends TestCase
 
         $response = $this->redirect->intended();
 
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testIntendedWithoutIntendedUrlInSession()
@@ -107,19 +107,19 @@ class RoutingRedirectorTest extends TestCase
         // without fallback url
         $this->session->shouldReceive('pull')->with('url.intended', '/')->andReturn('/');
         $response = $this->redirect->intended();
-        $this->assertEquals('http://foo.com/', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/', $response->getTargetUrl());
 
         // with a fallback url
         $this->session->shouldReceive('pull')->with('url.intended', 'bar')->andReturn('bar');
         $response = $this->redirect->intended('bar');
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testRefreshRedirectToCurrentUrl()
     {
         $this->request->shouldReceive('path')->andReturn('http://foo.com/bar');
         $response = $this->redirect->refresh();
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testBackRedirectToHttpReferer()
@@ -127,26 +127,26 @@ class RoutingRedirectorTest extends TestCase
         $this->headers->shouldReceive('has')->with('referer')->andReturn(true);
         $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
         $response = $this->redirect->back();
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testAwayDoesntValidateTheUrl()
     {
         $response = $this->redirect->away('bar');
-        $this->assertEquals('bar', $response->getTargetUrl());
+        $this->assertSame('bar', $response->getTargetUrl());
     }
 
     public function testSecureRedirectToHttpsUrl()
     {
         $response = $this->redirect->secure('bar');
-        $this->assertEquals('https://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('https://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testAction()
     {
         $this->url->shouldReceive('action')->with('bar@index', [])->andReturn('http://foo.com/bar');
         $response = $this->redirect->action('bar@index');
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testRoute()
@@ -155,10 +155,10 @@ class RoutingRedirectorTest extends TestCase
         $this->url->shouldReceive('route')->with('home', [])->andReturn('http://foo.com/bar');
 
         $response = $this->redirect->route('home');
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
 
         $response = $this->redirect->home();
-        $this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+        $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
     }
 
     public function testItSetsValidIntendedUrl()

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -39,13 +39,13 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
             throw new HttpResponseException(new Response('hello'));
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', ['domain' => 'api.{name}.bar', function ($name) {
@@ -54,14 +54,14 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', ['domain' => 'api.{name}.baz', function ($name) {
             return $name;
         }]);
-        $this->assertEquals('taylor', $router->dispatch(Request::create('http://api.taylor.bar/foo/bar', 'GET'))->getContent());
-        $this->assertEquals('dayle', $router->dispatch(Request::create('http://api.dayle.baz/foo/bar', 'GET'))->getContent());
+        $this->assertSame('taylor', $router->dispatch(Request::create('http://api.taylor.bar/foo/bar', 'GET'))->getContent());
+        $this->assertSame('dayle', $router->dispatch(Request::create('http://api.dayle.baz/foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{age}', ['domain' => 'api.{name}.bar', function ($name, $age) {
             return $name.$age;
         }]);
-        $this->assertEquals('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
+        $this->assertSame('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -70,47 +70,47 @@ class RoutingRouteTest extends TestCase
         $router->post('foo/bar', function () {
             return 'post hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-        $this->assertEquals('post hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('post hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{bar}', function ($name) {
             return $name;
         });
-        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{bar}/{baz?}', function ($name, $age = 25) {
             return $name.$age;
         });
-        $this->assertEquals('taylor25', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('taylor25', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/{name}/boom/{age?}/{location?}', function ($name, $age = 25, $location = 'AR') {
             return $name.$age.$location;
         });
-        $this->assertEquals('taylor30AR', $router->dispatch(Request::create('foo/taylor/boom/30', 'GET'))->getContent());
+        $this->assertSame('taylor30AR', $router->dispatch(Request::create('foo/taylor/boom/30', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('{bar}/{baz?}', function ($name, $age = 25) {
             return $name.$age;
         });
-        $this->assertEquals('taylor25', $router->dispatch(Request::create('taylor', 'GET'))->getContent());
+        $this->assertSame('taylor25', $router->dispatch(Request::create('taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('{baz?}', function ($age = 25) {
             return $age;
         });
-        $this->assertEquals('25', $router->dispatch(Request::create('/', 'GET'))->getContent());
-        $this->assertEquals('30', $router->dispatch(Request::create('30', 'GET'))->getContent());
+        $this->assertSame('25', $router->dispatch(Request::create('/', 'GET'))->getContent());
+        $this->assertSame('30', $router->dispatch(Request::create('30', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('{foo?}/{baz?}', ['as' => 'foo', function ($name = 'taylor', $age = 25) {
             return $name.$age;
         }]);
-        $this->assertEquals('taylor25', $router->dispatch(Request::create('/', 'GET'))->getContent());
-        $this->assertEquals('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
-        $this->assertEquals('fred30', $router->dispatch(Request::create('fred/30', 'GET'))->getContent());
+        $this->assertSame('taylor25', $router->dispatch(Request::create('/', 'GET'))->getContent());
+        $this->assertSame('fred25', $router->dispatch(Request::create('fred', 'GET'))->getContent());
+        $this->assertSame('fred30', $router->dispatch(Request::create('fred/30', 'GET'))->getContent());
         $this->assertTrue($router->currentRouteNamed('foo'));
         $this->assertTrue($router->currentRouteNamed('fo*'));
         $this->assertTrue($router->is('foo'));
@@ -121,14 +121,14 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{file}', function ($file) {
             return $file;
         });
-        $this->assertEquals('oxygen%20', $router->dispatch(Request::create('http://test.com/foo/oxygen%2520', 'GET'))->getContent());
+        $this->assertSame('oxygen%20', $router->dispatch(Request::create('http://test.com/foo/oxygen%2520', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->patch('foo/bar', ['as' => 'foo', function () {
             return 'bar';
         }]);
-        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'PATCH'))->getContent());
-        $this->assertEquals('foo', $router->currentRouteName());
+        $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'PATCH'))->getContent());
+        $this->assertSame('foo', $router->currentRouteName());
 
         $router = $this->getRouter();
         $router->get('foo/bar', function () {
@@ -149,19 +149,19 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', function () {
             return 'second';
         });
-        $this->assertEquals('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar/åαф', function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->get('foo/bar', ['boom' => 'auth', function () {
             return 'closure';
         }]);
-        $this->assertEquals('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
     public function testNotModifiedResponseIsProperlyReturned()
@@ -187,7 +187,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', ['middleware' => $middleware, function () {
             return 'hello';
         }]);
-        $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
     public function testMiddlewareWorksIfControllerThrowsHttpResponseException()
@@ -201,7 +201,7 @@ class RoutingRouteTest extends TestCase
             throw new HttpResponseException(new Response('hello'));
         }]);
         $response = $router->dispatch(Request::create('foo/bar', 'GET'))->getContent();
-        $this->assertEquals('caught', $response);
+        $this->assertSame('caught', $response);
 
         // After calling controller
         $router = $this->getRouter();
@@ -218,7 +218,7 @@ class RoutingRouteTest extends TestCase
         }]);
 
         $response = $router->dispatch(Request::create('foo/bar', 'GET'))->getContent();
-        $this->assertEquals('hello caught', $response);
+        $this->assertSame('hello caught', $response);
     }
 
     public function testReturnsResponseWhenMiddlewareReturnsResponsable()
@@ -237,7 +237,7 @@ class RoutingRouteTest extends TestCase
         $router->aliasMiddleware('baz', function ($request, $next) {
             return $next($request);
         });
-        $this->assertEquals(
+        $this->assertSame(
             'bar',
             $router->dispatch(Request::create('foo/bar', 'GET'))->getContent()
         );
@@ -252,7 +252,7 @@ class RoutingRouteTest extends TestCase
         $router->aliasMiddleware('foo', function ($request, $next) {
             return 'caught';
         });
-        $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
     public function testControllerClosureMiddleware()
@@ -268,7 +268,7 @@ class RoutingRouteTest extends TestCase
             return $next($request);
         });
 
-        $this->assertEquals(
+        $this->assertSame(
             'index-foo-middleware-controller-closure',
             $router->dispatch(Request::create('foo/bar', 'GET'))->getContent()
         );
@@ -283,15 +283,15 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar')->uses(function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $router->post('foo/bar')->uses(function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
         $router->get('foo/bar')->uses(function () {
             return 'middleware';
         })->middleware(RouteTestControllerMiddleware::class);
-        $this->assertEquals('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
+        $this->assertSame('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
         $this->assertContains(RouteTestControllerMiddleware::class, $router->getCurrentRoute()->middleware());
         $router->get('foo/bar');
         $router->dispatch(Request::create('foo/bar', 'GET'));
@@ -301,14 +301,14 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
-        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
         $router->group(['namespace' => 'App'], function ($router) {
             $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
         });
         $action = $router->getRoutes()->getRoutes()[0]->getAction();
-        $this->assertEquals('App\\'.RouteTestControllerStub::class.'@index', $action['controller']);
+        $this->assertSame('App\\'.RouteTestControllerStub::class.'@index', $action['controller']);
     }
 
     public function testMiddlewareGroups()
@@ -322,7 +322,7 @@ class RoutingRouteTest extends TestCase
         $router->aliasMiddleware('two', RoutingTestMiddlewareGroupTwo::class);
         $router->middlewareGroup('web', [RoutingTestMiddlewareGroupOne::class, 'two:taylor']);
 
-        $this->assertEquals('caught taylor', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('caught taylor', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
 
         unset($_SERVER['__middleware.group']);
@@ -340,7 +340,7 @@ class RoutingRouteTest extends TestCase
         $router->middlewareGroup('first', ['two:abigail']);
         $router->middlewareGroup('web', [RoutingTestMiddlewareGroupOne::class, 'first']);
 
-        $this->assertEquals('caught abigail', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('caught abigail', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['__middleware.group']);
 
         unset($_SERVER['__middleware.group']);
@@ -354,8 +354,8 @@ class RoutingRouteTest extends TestCase
                 return 'bar';
             })->name('bar');
         });
-        $this->assertEquals('bar', $router->dispatch(Request::create('bar', 'GET'))->getContent());
-        $this->assertEquals('foo.bar', $router->currentRouteName());
+        $this->assertSame('bar', $router->dispatch(Request::create('bar', 'GET'))->getContent());
+        $this->assertSame('foo.bar', $router->currentRouteName());
     }
 
     public function testRouteGetAction()
@@ -368,7 +368,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertIsArray($route->getAction());
         $this->assertArrayHasKey('as', $route->getAction());
-        $this->assertEquals('foo', $route->getAction('as'));
+        $this->assertSame('foo', $route->getAction('as'));
         $this->assertNull($route->getAction('unknown_property'));
     }
 
@@ -381,8 +381,8 @@ class RoutingRouteTest extends TestCase
             });
         });
         $router->webhook();
-        $this->assertEquals('OK', $router->dispatch(Request::create('webhook', 'GET'))->getContent());
-        $this->assertEquals('OK', $router->dispatch(Request::create('webhook', 'POST'))->getContent());
+        $this->assertSame('OK', $router->dispatch(Request::create('webhook', 'GET'))->getContent());
+        $this->assertSame('OK', $router->dispatch(Request::create('webhook', 'POST'))->getContent());
     }
 
     public function testRouteMacro()
@@ -401,7 +401,7 @@ class RoutingRouteTest extends TestCase
 
         $router->getRoutes()->refreshNameLookups();
 
-        $this->assertEquals('fooBreadcrumb', $router->getRoutes()->getByName('foo')->getAction()['breadcrumb']);
+        $this->assertSame('fooBreadcrumb', $router->getRoutes()->getByName('foo')->getAction()['breadcrumb']);
     }
 
     public function testClassesCanBeInjectedIntoRoutes()
@@ -414,9 +414,9 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         });
 
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertInstanceOf(stdClass::class, $_SERVER['__test.route_inject'][0]);
-        $this->assertEquals('bar', $_SERVER['__test.route_inject'][1]);
+        $this->assertSame('bar', $_SERVER['__test.route_inject'][1]);
 
         unset($_SERVER['__test.route_inject']);
     }
@@ -433,7 +433,7 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch(Request::create('foo/bar', 'OPTIONS'));
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
+        $this->assertSame('GET,HEAD,POST', $response->headers->get('Allow'));
     }
 
     public function testHeadDispatcher()
@@ -445,7 +445,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('GET,HEAD,POST', $response->headers->get('Allow'));
+        $this->assertSame('GET,HEAD,POST', $response->headers->get('Allow'));
 
         $response = $router->dispatch(Request::create('foo', 'HEAD'));
         $this->assertEquals(200, $response->getStatusCode());
@@ -458,7 +458,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('GET,HEAD', $response->headers->get('Allow'));
+        $this->assertSame('GET,HEAD', $response->headers->get('Allow'));
 
         $router = $this->getRouter();
         $router->match(['POST'], 'foo', function () {
@@ -467,7 +467,7 @@ class RoutingRouteTest extends TestCase
 
         $response = $router->dispatch(Request::create('foo', 'OPTIONS'));
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('POST', $response->headers->get('Allow'));
+        $this->assertSame('POST', $response->headers->get('Allow'));
     }
 
     public function testNonGreedyMatches()
@@ -481,14 +481,14 @@ class RoutingRouteTest extends TestCase
         $route->bind($request1);
         $this->assertTrue($route->hasParameter('id'));
         $this->assertFalse($route->hasParameter('foo'));
-        $this->assertEquals('1', $route->parameter('id'));
-        $this->assertEquals('png', $route->parameter('ext'));
+        $this->assertSame('1', $route->parameter('id'));
+        $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');
         $this->assertTrue($route->matches($request2));
         $route->bind($request2);
-        $this->assertEquals('12', $route->parameter('id'));
-        $this->assertEquals('png', $route->parameter('ext'));
+        $this->assertSame('12', $route->parameter('id'));
+        $this->assertSame('png', $route->parameter('ext'));
 
         // Test parameter() default value
         $route = new Route('GET', 'foo/{foo?}', function () {
@@ -498,22 +498,22 @@ class RoutingRouteTest extends TestCase
         $request3 = Request::create('foo', 'GET');
         $this->assertTrue($route->matches($request3));
         $route->bind($request3);
-        $this->assertEquals('bar', $route->parameter('foo', 'bar'));
+        $this->assertSame('bar', $route->parameter('foo', 'bar'));
     }
 
     public function testRouteParametersDefaultValue()
     {
         $router = $this->getRouter();
         $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class.'@returnParameter'])->defaults('bar', 'foo');
-        $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+        $this->assertSame('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
 
         $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class.'@returnParameter'])->defaults('bar', 'foo');
-        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router->get('foo/{bar?}', function ($bar = '') {
             return $bar;
         })->defaults('bar', 'foo');
-        $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+        $this->assertSame('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
     public function testControllerCallActionMethodParameters()
@@ -579,13 +579,13 @@ class RoutingRouteTest extends TestCase
             'where' => ['one' => '(.+)'],
         ]);
 
-        $this->assertEquals('', $router->dispatch(Request::create(''))->getContent());
+        $this->assertSame('', $router->dispatch(Request::create(''))->getContent());
         $this->assertNull($outer_one);
         // Expects: '' ($one === null)
         // Actual: '/' ($one === '/')
 
-        $this->assertEquals('foo', $router->dispatch(Request::create('/foo', 'GET'))->getContent());
-        $this->assertEquals('foo/bar/baz', $router->dispatch(Request::create('/foo/bar/baz', 'GET'))->getContent());
+        $this->assertSame('foo', $router->dispatch(Request::create('/foo', 'GET'))->getContent());
+        $this->assertSame('foo/bar/baz', $router->dispatch(Request::create('/foo/bar/baz', 'GET'))->getContent());
     }
 
     public function testRoutesDontMatchNonMatchingPathsWithLeadingOptionals()
@@ -596,7 +596,7 @@ class RoutingRouteTest extends TestCase
         $router->get('{baz?}', function ($age = 25) {
             return $age;
         });
-        $this->assertEquals('25', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('25', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
     public function testRoutesDontMatchNonMatchingDomain()
@@ -607,7 +607,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', ['domain' => 'api.foo.bar', function () {
             return 'hello';
         }]);
-        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.baz.boom/foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('http://api.baz.boom/foo/bar', 'GET'))->getContent());
     }
 
     public function testRouteDomainRegistration()
@@ -616,7 +616,7 @@ class RoutingRouteTest extends TestCase
         $router->get('/foo/bar')->domain('api.foo.bar')->uses(function () {
             return 'hello';
         });
-        $this->assertEquals('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
     }
 
     public function testMatchesMethodAgainstRequests()
@@ -780,14 +780,14 @@ class RoutingRouteTest extends TestCase
         $request1 = Request::create('images/1.png', 'GET');
         $this->assertTrue($route->matches($request1));
         $route->bind($request1);
-        $this->assertEquals('1', $route->parameter('id'));
-        $this->assertEquals('png', $route->parameter('ext'));
+        $this->assertSame('1', $route->parameter('id'));
+        $this->assertSame('png', $route->parameter('ext'));
 
         $request2 = Request::create('images/12.png', 'GET');
         $this->assertTrue($route->matches($request2));
         $route->bind($request2);
-        $this->assertEquals('12', $route->parameter('id'));
-        $this->assertEquals('png', $route->parameter('ext'));
+        $this->assertSame('12', $route->parameter('id'));
+        $this->assertSame('png', $route->parameter('ext'));
     }
 
     public function testRouteBinding()
@@ -799,7 +799,7 @@ class RoutingRouteTest extends TestCase
         $router->bind('bar', function ($value) {
             return strtoupper($value);
         });
-        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testRouteClassBinding()
@@ -809,7 +809,7 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class);
-        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testRouteClassMethodBinding()
@@ -819,7 +819,7 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class.'@find');
-        $this->assertEquals('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
+        $this->assertSame('dragon', $router->dispatch(Request::create('foo/Dragon', 'GET'))->getContent());
     }
 
     public function testMiddlewarePrioritySorting()
@@ -856,7 +856,7 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->model('bar', RouteModelBindingStub::class);
-        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testModelBindingWithNullReturn()
@@ -881,7 +881,7 @@ class RoutingRouteTest extends TestCase
         $router->model('bar', RouteModelBindingNullStub::class, function () {
             return 'missing';
         });
-        $this->assertEquals('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testModelBindingWithBindingClosure()
@@ -893,14 +893,14 @@ class RoutingRouteTest extends TestCase
         $router->model('bar', RouteModelBindingNullStub::class, function ($value) {
             return (new RouteModelBindingClosureStub)->findAlternate($value);
         });
-        $this->assertEquals('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
+        $this->assertSame('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
     }
 
     public function testModelBindingWithCompoundParameterName()
     {
         $router = $this->getRouter();
         $router->resource('foo-bar', RouteTestResourceControllerWithModelParameter::class, ['middleware' => SubstituteBindings::class]);
-        $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
+        $this->assertSame('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
     public function testModelBindingWithCompoundParameterNameAndRouteBinding()
@@ -908,7 +908,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->model('foo_bar', RoutingTestUserModel::class);
         $router->resource('foo-bar', RouteTestResourceControllerWithModelParameter::class, ['middleware' => SubstituteBindings::class]);
-        $this->assertEquals('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
+        $this->assertSame('12345', $router->dispatch(Request::create('foo-bar/12345', 'GET'))->getContent());
     }
 
     public function testModelBindingThroughIOC()
@@ -923,7 +923,7 @@ class RoutingRouteTest extends TestCase
             return $name;
         }]);
         $router->model('bar', RouteModelInterface::class);
-        $this->assertEquals('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testGroupMerging()
@@ -961,7 +961,7 @@ class RoutingRouteTest extends TestCase
         });
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
-        $this->assertEquals('foo', $routes[0]->getPrefix());
+        $this->assertSame('foo', $routes[0]->getPrefix());
     }
 
     public function testRouteGroupingOutsideOfInheritedNamespace()
@@ -977,7 +977,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals(
+        $this->assertSame(
             'Foo\Bar\UsersController@index',
             $routes[0]->getAction()['uses']
         );
@@ -990,7 +990,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertNull($router->currentRouteAction());
 
-        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($router->uses('*RouteTestControllerStub*'));
         $this->assertTrue($router->uses('*RouteTestControllerStub@index'));
         $this->assertTrue($router->uses(['*RouteTestControllerStub*', '*FooController*']));
@@ -1011,7 +1011,7 @@ class RoutingRouteTest extends TestCase
         $request = Request::create('api/users', 'GET');
 
         $this->assertTrue($route->matches($request));
-        $this->assertEquals('all-users', $route->bind($request)->run($request));
+        $this->assertSame('all-users', $route->bind($request)->run($request));
     }
 
     public function testRouteGroupingWithAs()
@@ -1024,7 +1024,7 @@ class RoutingRouteTest extends TestCase
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::bar');
-        $this->assertEquals('foo/bar', $route->uri());
+        $this->assertSame('foo/bar', $route->uri());
     }
 
     public function testNestedRouteGroupingWithAs()
@@ -1042,7 +1042,7 @@ class RoutingRouteTest extends TestCase
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::Bar::baz');
-        $this->assertEquals('foo/bar/baz', $route->uri());
+        $this->assertSame('foo/bar/baz', $route->uri());
 
         /*
          * nested with layer skipped
@@ -1057,7 +1057,7 @@ class RoutingRouteTest extends TestCase
         });
         $routes = $router->getRoutes();
         $route = $routes->getByName('Foo::baz');
-        $this->assertEquals('foo/bar/baz', $route->uri());
+        $this->assertSame('foo/bar/baz', $route->uri());
     }
 
     public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()
@@ -1088,7 +1088,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
         $routes[0]->prefix('prefix');
-        $this->assertEquals('prefix/foo/bar', $routes[0]->uri());
+        $this->assertSame('prefix/foo/bar', $routes[0]->uri());
 
         /*
          * Use empty prefix
@@ -1100,7 +1100,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
         $routes[0]->prefix('/');
-        $this->assertEquals('foo/bar', $routes[0]->uri());
+        $this->assertSame('foo/bar', $routes[0]->uri());
 
         /*
          * Prefix homepage
@@ -1112,7 +1112,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
         $routes[0]->prefix('prefix');
-        $this->assertEquals('prefix', $routes[0]->uri());
+        $this->assertSame('prefix', $routes[0]->uri());
     }
 
     public function testRoutePreservingOriginalParametersState()
@@ -1126,8 +1126,8 @@ class RoutingRouteTest extends TestCase
             'uses' => function ($bar) use ($router) {
                 $route = $router->getCurrentRoute();
 
-                $this->assertEquals('taylor', $route->originalParameter('bar'));
-                $this->assertEquals('default', $route->originalParameter('unexisting', 'default'));
+                $this->assertSame('taylor', $route->originalParameter('bar'));
+                $this->assertSame('default', $route->originalParameter('unexisting', 'default'));
                 $this->assertEquals(['bar' => 'taylor'], $route->originalParameters());
 
                 return $bar;
@@ -1146,7 +1146,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes()->getRoutes();
         $action = $routes[0]->getAction();
 
-        $this->assertEquals('Namespace\\Controller@action', $action['controller']);
+        $this->assertSame('Namespace\\Controller@action', $action['controller']);
 
         $router = $this->getRouter();
         $router->group(['namespace' => 'Namespace'], function () use ($router) {
@@ -1157,7 +1157,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes()->getRoutes();
         $action = $routes[0]->getAction();
 
-        $this->assertEquals('Namespace\\Nested\\Controller@action', $action['controller']);
+        $this->assertSame('Namespace\\Nested\\Controller@action', $action['controller']);
 
         $router = $this->getRouter();
         $router->group(['prefix' => 'baz'], function () use ($router) {
@@ -1168,7 +1168,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes()->getRoutes();
         $action = $routes[0]->getAction();
 
-        $this->assertEquals('Namespace\\Controller@action', $action['controller']);
+        $this->assertSame('Namespace\\Controller@action', $action['controller']);
     }
 
     public function testInvalidActionException()
@@ -1212,22 +1212,22 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->uri());
+        $this->assertSame('foo-bars/{foo_bar}', $routes[0]->uri());
 
         $router = $this->getRouter();
         $router->resource('foo-bar.foo-baz', 'FooController', ['only' => ['show']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bar/{foo_bar}/foo-baz/{foo_baz}', $routes[0]->uri());
+        $this->assertSame('foo-bar/{foo_bar}/foo-baz/{foo_baz}', $routes[0]->uri());
 
         $router = $this->getRouter();
         $router->resource('foo-bars', 'FooController', ['only' => ['show'], 'as' => 'prefix']);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foo-bars/{foo_bar}', $routes[0]->uri());
-        $this->assertEquals('prefix.foo-bars.show', $routes[0]->getName());
+        $this->assertSame('foo-bars/{foo_bar}', $routes[0]->uri());
+        $this->assertSame('prefix.foo-bars.show', $routes[0]->getName());
 
         ResourceRegistrar::verbs([
             'create' => 'ajouter',
@@ -1237,8 +1237,8 @@ class RoutingRouteTest extends TestCase
         $router->resource('foo', 'FooController');
         $routes = $router->getRoutes();
 
-        $this->assertEquals('foo/ajouter', $routes->getByName('foo.create')->uri());
-        $this->assertEquals('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
+        $this->assertSame('foo/ajouter', $routes->getByName('foo.create')->uri());
+        $this->assertSame('foo/{foo}/modifier', $routes->getByName('foo.edit')->uri());
     }
 
     public function testResourceRoutingParameters()
@@ -1251,8 +1251,8 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertSame('foos/{foo}', $routes[3]->uri());
+        $this->assertSame('foos/{foo}/bars/{bar}', $routes[10]->uri());
 
         ResourceRegistrar::setParameters(['foos' => 'oof', 'bazs' => 'b']);
 
@@ -1261,7 +1261,7 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('bars/{bar}/foos/{oof}/bazs/{b}', $routes[3]->uri());
+        $this->assertSame('bars/{bar}/foos/{oof}/bazs/{b}', $routes[3]->uri());
 
         ResourceRegistrar::setParameters();
         ResourceRegistrar::singularParameters(false);
@@ -1272,22 +1272,22 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}', $routes[3]->uri());
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[10]->uri());
+        $this->assertSame('foos/{foo}', $routes[3]->uri());
+        $this->assertSame('foos/{foo}/bars/{bar}', $routes[10]->uri());
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController', ['parameters' => ['foos' => 'foo', 'bars' => 'bar']]);
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
+        $this->assertSame('foos/{foo}/bars/{bar}', $routes[3]->uri());
 
         $router = $this->getRouter();
         $router->resource('foos.bars', 'FooController')->parameter('foos', 'foo')->parameter('bars', 'bar');
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
 
-        $this->assertEquals('foos/{foo}/bars/{bar}', $routes[3]->uri());
+        $this->assertSame('foos/{foo}/bars/{bar}', $routes[3]->uri());
     }
 
     public function testResourceRouteNaming()
@@ -1404,7 +1404,7 @@ class RoutingRouteTest extends TestCase
 
         $router->get('foo/bar', RouteTestControllerStub::class.'@index');
 
-        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
@@ -1424,7 +1424,7 @@ class RoutingRouteTest extends TestCase
 
         $router->get('foo/bar', [RouteTestControllerStub::class, 'index']);
 
-        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
         $this->assertEquals(0, $_SERVER['route.test.controller.middleware.parameters.one']);
@@ -1441,8 +1441,8 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/bar', RouteTestControllerCallableStub::class.'@bar');
         $router->get('foo/baz', RouteTestControllerCallableStub::class.'@baz');
 
-        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-        $this->assertEquals('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
+        $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('baz', $router->dispatch(Request::create('foo/baz', 'GET'))->getContent());
     }
 
     public function testControllerMiddlewareGroups()
@@ -1461,7 +1461,7 @@ class RoutingRouteTest extends TestCase
 
         $router->get('foo/bar', RouteTestControllerMiddlewareGroupStub::class.'@index');
 
-        $this->assertEquals('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertTrue($_SERVER['route.test.controller.middleware']);
         $this->assertEquals(Response::class, $_SERVER['route.test.controller.middleware.class']);
     }
@@ -1477,7 +1477,7 @@ class RoutingRouteTest extends TestCase
                 return $bar->value;
             },
         ]);
-        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri()
@@ -1491,7 +1491,7 @@ class RoutingRouteTest extends TestCase
                 return $bar->value;
             },
         ]);
-        $this->assertEquals('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
+        $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
     public function testImplicitBindingsWithOptionalParameterWithNoKeyInUri()
@@ -1543,13 +1543,13 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->get('foo/bar', ActionStub::class);
 
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router->get('foo/bar2', [
             'uses' => ActionStub::class,
         ]);
 
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
     public function testResponseIsReturned()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -21,10 +21,10 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/')
         );
 
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('https://www.foo.com/foo/bar', $url->to('foo/bar', [], true));
-        $this->assertEquals('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', ['baz', 'boom'], true));
-        $this->assertEquals('https://www.foo.com/foo/bar/baz?foo=bar', $url->to('foo/bar?foo=bar', ['baz'], true));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->to('foo/bar', [], true));
+        $this->assertSame('https://www.foo.com/foo/bar/baz/boom', $url->to('foo/bar', ['baz', 'boom'], true));
+        $this->assertSame('https://www.foo.com/foo/bar/baz?foo=bar', $url->to('foo/bar?foo=bar', ['baz'], true));
 
         /*
          * Test HTTPS request URL generation...
@@ -34,7 +34,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('https://www.foo.com/')
         );
 
-        $this->assertEquals('https://www.foo.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->to('foo/bar'));
 
         /*
          * Test asset URL generation...
@@ -44,8 +44,8 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com/index.php/')
         );
 
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
-        $this->assertEquals('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
     }
 
     public function testBasicGenerationWithHostFormatting()
@@ -62,8 +62,8 @@ class RoutingUrlGeneratorTest extends TestCase
             return str_replace('foo.com', 'foo.org', $host);
         });
 
-        $this->assertEquals('http://www.foo.org/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('/named-route', $url->route('plain', [], false));
+        $this->assertSame('http://www.foo.org/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('/named-route', $url->route('plain', [], false));
     }
 
     public function testBasicGenerationWithRequestBaseUrlWithSubfolder()
@@ -81,8 +81,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
         $routes->add($route);
 
-        $this->assertEquals('/subfolder', $request->getBaseUrl());
-        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+        $this->assertSame('/subfolder', $request->getBaseUrl());
+        $this->assertSame('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 
     public function testBasicGenerationWithRequestBaseUrlWithSubfolderAndFileSuffix()
@@ -100,9 +100,9 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
         $routes->add($route);
 
-        $this->assertEquals('/subfolder', $request->getBasePath());
-        $this->assertEquals('/subfolder/index.php', $request->getBaseUrl());
-        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+        $this->assertSame('/subfolder', $request->getBasePath());
+        $this->assertSame('/subfolder/index.php', $request->getBaseUrl());
+        $this->assertSame('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 
     public function testBasicGenerationWithRequestBaseUrlWithFileSuffix()
@@ -120,9 +120,9 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/subfolder', ['as' => 'foobar']);
         $routes->add($route);
 
-        $this->assertEquals('', $request->getBasePath());
-        $this->assertEquals('/other.php', $request->getBaseUrl());
-        $this->assertEquals('/foo/bar/subfolder', $url->route('foobar', [], false));
+        $this->assertSame('', $request->getBasePath());
+        $this->assertSame('/other.php', $request->getBaseUrl());
+        $this->assertSame('/foo/bar/subfolder', $url->route('foobar', [], false));
     }
 
     public function testBasicGenerationWithPathFormatting()
@@ -139,8 +139,8 @@ class RoutingUrlGeneratorTest extends TestCase
             return '/something'.$path;
         });
 
-        $this->assertEquals('http://www.foo.com/something/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('/something/named-route', $url->route('plain', [], false));
+        $this->assertSame('http://www.foo.com/something/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('/something/named-route', $url->route('plain', [], false));
     }
 
     public function testUrlFormattersShouldReceiveTargetRoute()
@@ -161,8 +161,8 @@ class RoutingUrlGeneratorTest extends TestCase
             return $route ? '/'.$route->getAction('path') : $path;
         });
 
-        $this->assertEquals('http://abc.com/foo/bar', $url->to('foo/bar'));
-        $this->assertEquals('http://bar.com/foo', $url->route('plain'));
+        $this->assertSame('http://abc.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('http://bar.com/foo', $url->route('plain'));
     }
 
     public function testBasicRouteGeneration()
@@ -235,27 +235,27 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->assertEquals('/', $url->route('plain', [], false));
-        $this->assertEquals('/?foo=bar', $url->route('plain', ['foo' => 'bar'], false));
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
-        $this->assertEquals('/foo/bar', $url->route('foo', [], false));
-        $this->assertEquals('/foo/bar?foo=bar', $url->route('foo', ['foo' => 'bar'], false));
-        $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall']));
-        $this->assertEquals('http://www.foo.com/foo/bar/otwell/breeze/taylor?fly=wall', $url->route('bar', ['boom' => 'taylor', 'baz' => 'otwell', 'fly' => 'wall']));
-        $this->assertEquals('http://www.foo.com/foo/bar/2', $url->route('foobar', 2));
-        $this->assertEquals('http://www.foo.com/foo/bar/taylor', $url->route('foobar', 'taylor'));
-        $this->assertEquals('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall'], false));
-        $this->assertEquals('https://www.foo.com/foo/baz', $url->route('baz'));
-        $this->assertEquals('http://www.foo.com/foo/bam', $url->action('foo@bar'));
-        $this->assertEquals('http://www.foo.com/foo/bam', $url->action(['foo', 'bar']));
-        $this->assertEquals('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
-        $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
-        $this->assertEquals('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
-        $this->assertEquals('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', ['baz' => 'åαф']));
-        $this->assertEquals('/foo/bar#derp', $url->route('fragment', [], false));
-        $this->assertEquals('/foo/bar?foo=bar#derp', $url->route('fragment', ['foo' => 'bar'], false));
-        $this->assertEquals('/foo/bar?baz=%C3%A5%CE%B1%D1%84#derp', $url->route('fragment', ['baz' => 'åαф'], false));
-        $this->assertEquals('http://en.example.com/foo', $url->route('defaults'));
+        $this->assertSame('/', $url->route('plain', [], false));
+        $this->assertSame('/?foo=bar', $url->route('plain', ['foo' => 'bar'], false));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('/foo/bar', $url->route('foo', [], false));
+        $this->assertSame('/foo/bar?foo=bar', $url->route('foo', ['foo' => 'bar'], false));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall']));
+        $this->assertSame('http://www.foo.com/foo/bar/otwell/breeze/taylor?fly=wall', $url->route('bar', ['boom' => 'taylor', 'baz' => 'otwell', 'fly' => 'wall']));
+        $this->assertSame('http://www.foo.com/foo/bar/2', $url->route('foobar', 2));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('foobar', 'taylor'));
+        $this->assertSame('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall'], false));
+        $this->assertSame('https://www.foo.com/foo/baz', $url->route('baz'));
+        $this->assertSame('http://www.foo.com/foo/bam', $url->action('foo@bar'));
+        $this->assertSame('http://www.foo.com/foo/bam', $url->action(['foo', 'bar']));
+        $this->assertSame('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
+        $this->assertSame('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', ['baz' => 'åαф']));
+        $this->assertSame('/foo/bar#derp', $url->route('fragment', [], false));
+        $this->assertSame('/foo/bar?foo=bar#derp', $url->route('fragment', ['foo' => 'bar'], false));
+        $this->assertSame('/foo/bar?baz=%C3%A5%CE%B1%D1%84#derp', $url->route('fragment', ['baz' => 'åαф'], false));
+        $this->assertSame('http://en.example.com/foo', $url->route('defaults'));
     }
 
     public function testFluentRouteNameDefinitions()
@@ -273,7 +273,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
         $routes->refreshNameLookups();
 
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foo'));
     }
 
     public function testControllerRoutesWithADefaultNamespace()
@@ -297,9 +297,9 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/invoke', ['controller' => 'namespace\InvokableActionStub']);
         $routes->add($route);
 
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->action('foo@bar'));
-        $this->assertEquals('http://www.foo.com/something/else', $url->action('\something\foo@bar'));
-        $this->assertEquals('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->action('foo@bar'));
+        $this->assertSame('http://www.foo.com/something/else', $url->action('\something\foo@bar'));
+        $this->assertSame('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
     }
 
     public function testControllerRoutesOutsideOfDefaultNamespace()
@@ -317,8 +317,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'invokable/namespace', ['controller' => '\root\namespace\InvokableActionStub']);
         $routes->add($route);
 
-        $this->assertEquals('http://www.foo.com/root/namespace', $url->action('\root\namespace@foo'));
-        $this->assertEquals('http://www.foo.com/invokable/namespace', $url->action('\root\namespace\InvokableActionStub'));
+        $this->assertSame('http://www.foo.com/root/namespace', $url->action('\root\namespace@foo'));
+        $this->assertSame('http://www.foo.com/invokable/namespace', $url->action('\root\namespace\InvokableActionStub'));
     }
 
     public function testRoutableInterfaceRouting()
@@ -334,7 +334,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $model = new RoutableInterfaceStub;
         $model->key = 'routable';
 
-        $this->assertEquals('/foo/routable', $url->route('routable', [$model], false));
+        $this->assertSame('/foo/routable', $url->route('routable', [$model], false));
     }
 
     public function testRoutableInterfaceRoutingWithSingleParameter()
@@ -350,7 +350,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $model = new RoutableInterfaceStub;
         $model->key = 'routable';
 
-        $this->assertEquals('/foo/routable', $url->route('routable', $model, false));
+        $this->assertSame('/foo/routable', $url->route('routable', $model, false));
     }
 
     public function testRoutesMaintainRequestScheme()
@@ -366,7 +366,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo']);
         $routes->add($route);
 
-        $this->assertEquals('https://www.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('https://www.foo.com/foo/bar', $url->route('foo'));
     }
 
     public function testHttpOnlyRoutes()
@@ -382,7 +382,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'http']);
         $routes->add($route);
 
-        $this->assertEquals('http://www.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foo'));
     }
 
     public function testRoutesWithDomains()
@@ -401,9 +401,9 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com']);
         $routes->add($route);
 
-        $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
-        $this->assertEquals('http://sub.taylor.com/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
-        $this->assertEquals('/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell'], false));
+        $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('http://sub.taylor.com/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
+        $this->assertSame('/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell'], false));
     }
 
     public function testRoutesWithDomainsAndPorts()
@@ -422,8 +422,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar/{baz}', ['as' => 'bar', 'domain' => 'sub.{foo}.com']);
         $routes->add($route);
 
-        $this->assertEquals('http://sub.foo.com:8080/foo/bar', $url->route('foo'));
-        $this->assertEquals('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
+        $this->assertSame('http://sub.foo.com:8080/foo/bar', $url->route('foo'));
+        $this->assertSame('http://sub.taylor.com:8080/foo/bar/otwell', $url->route('bar', ['taylor', 'otwell']));
     }
 
     public function testRoutesWithDomainsStripsProtocols()
@@ -439,7 +439,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'http://sub.foo.com']);
         $routes->add($route);
 
-        $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
 
         /*
          * https:// Route
@@ -452,7 +452,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'https://sub.foo.com']);
         $routes->add($route);
 
-        $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('https://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
     public function testHttpsRoutesWithDomains()
@@ -468,7 +468,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'baz', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
-        $this->assertEquals('https://sub.foo.com/foo/bar', $url->route('baz'));
+        $this->assertSame('https://sub.foo.com/foo/bar', $url->route('baz'));
     }
 
     public function testRoutesWithDomainsThroughProxy()
@@ -483,7 +483,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], 'foo/bar', ['as' => 'foo', 'domain' => 'sub.foo.com']);
         $routes->add($route);
 
-        $this->assertEquals('http://sub.foo.com/foo/bar', $url->route('foo'));
+        $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
     public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters()
@@ -500,7 +500,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->assertEquals('http://www.foo.com:8080/foo', $url->route('foo'));
+        $this->assertSame('http://www.foo.com:8080/foo', $url->route('foo'));
     }
 
     public function testForceRootUrl()
@@ -511,11 +511,11 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         $url->forceRootUrl('https://www.bar.com');
-        $this->assertEquals('http://www.bar.com/foo/bar', $url->to('foo/bar'));
+        $this->assertSame('http://www.bar.com/foo/bar', $url->to('foo/bar'));
 
         // Ensure trailing slash is trimmed from root URL as UrlGenerator already handles this
         $url->forceRootUrl('http://www.foo.com/');
-        $this->assertEquals('http://www.foo.com/bar', $url->to('/bar'));
+        $this->assertSame('http://www.foo.com/bar', $url->to('/bar'));
 
         /*
          * Route Based...
@@ -529,10 +529,10 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], '/foo', ['as' => 'plain']);
         $routes->add($route);
 
-        $this->assertEquals('https://www.foo.com/foo', $url->route('plain'));
+        $this->assertSame('https://www.foo.com/foo', $url->route('plain'));
 
         $url->forceRootUrl('https://www.bar.com');
-        $this->assertEquals('https://www.bar.com/foo', $url->route('plain'));
+        $this->assertSame('https://www.bar.com/foo', $url->route('plain'));
     }
 
     public function testPrevious()
@@ -543,7 +543,7 @@ class RoutingUrlGeneratorTest extends TestCase
         );
 
         $url->getRequest()->headers->set('referer', 'http://www.bar.com/');
-        $this->assertEquals('http://www.bar.com/', $url->previous());
+        $this->assertSame('http://www.bar.com/', $url->previous());
 
         $url->getRequest()->headers->remove('referer');
         $this->assertEquals($url->to('/'), $url->previous());

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -25,8 +25,8 @@ class SessionStoreTest extends TestCase
         $session->getHandler()->shouldReceive('read')->once()->with($this->getSessionId())->andReturn(serialize(['foo' => 'bar', 'bagged' => ['name' => 'taylor']]));
         $session->start();
 
-        $this->assertEquals('bar', $session->get('foo'));
-        $this->assertEquals('baz', $session->get('bar', 'baz'));
+        $this->assertSame('bar', $session->get('foo'));
+        $this->assertSame('baz', $session->get('bar', 'baz'));
         $this->assertTrue($session->has('foo'));
         $this->assertFalse($session->has('bar'));
         $this->assertTrue($session->isStarted());
@@ -229,14 +229,14 @@ class SessionStoreTest extends TestCase
         $session->flashInput(['foo' => 'bar', 'bar' => 0]);
 
         $this->assertTrue($session->hasOldInput('foo'));
-        $this->assertEquals('bar', $session->getOldInput('foo'));
+        $this->assertSame('bar', $session->getOldInput('foo'));
         $this->assertEquals(0, $session->getOldInput('bar'));
         $this->assertFalse($session->hasOldInput('boom'));
 
         $session->ageFlashData();
 
         $this->assertTrue($session->hasOldInput('foo'));
-        $this->assertEquals('bar', $session->getOldInput('foo'));
+        $this->assertSame('bar', $session->getOldInput('foo'));
         $this->assertEquals(0, $session->getOldInput('bar'));
         $this->assertFalse($session->hasOldInput('boom'));
     }
@@ -249,14 +249,14 @@ class SessionStoreTest extends TestCase
         $session->flash('baz');
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(0, $session->get('bar'));
         $this->assertTrue($session->get('baz'));
 
         $session->ageFlashData();
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(0, $session->get('bar'));
 
         $session->ageFlashData();
@@ -272,7 +272,7 @@ class SessionStoreTest extends TestCase
         $session->now('bar', 0);
 
         $this->assertTrue($session->has('foo'));
-        $this->assertEquals('bar', $session->get('foo'));
+        $this->assertSame('bar', $session->get('foo'));
         $this->assertEquals(0, $session->get('bar'));
 
         $session->ageFlashData();
@@ -330,8 +330,8 @@ class SessionStoreTest extends TestCase
         $session->put('foo', 'bar');
         $session->put('qu', 'ux');
         $session->replace(['foo' => 'baz']);
-        $this->assertEquals('baz', $session->get('foo'));
-        $this->assertEquals('ux', $session->get('qu'));
+        $this->assertSame('baz', $session->get('foo'));
+        $this->assertSame('ux', $session->get('qu'));
     }
 
     public function testRemove()
@@ -340,7 +340,7 @@ class SessionStoreTest extends TestCase
         $session->put('foo', 'bar');
         $pulled = $session->remove('foo');
         $this->assertFalse($session->has('foo'));
-        $this->assertEquals('bar', $pulled);
+        $this->assertSame('bar', $pulled);
     }
 
     public function testClear()
@@ -459,8 +459,8 @@ class SessionStoreTest extends TestCase
         $result = $session->remember('foo', function () {
             return 'bar';
         });
-        $this->assertEquals('bar', $session->get('foo'));
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $session->get('foo'));
+        $this->assertSame('bar', $result);
     }
 
     public function getSession()

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -72,7 +72,7 @@ class SessionStoreTest extends TestCase
         $this->assertNotSame(['a'], $session->getId());
 
         $session->setId('wrong');
-        $this->assertNotEquals('wrong', $session->getId());
+        $this->assertNotSame('wrong', $session->getId());
     }
 
     public function testSessionInvalidate()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -294,13 +294,13 @@ class SupportArrTest extends TestCase
                 ['name' => 'chair'],
             ],
         ];
-        $this->assertEquals('desk', Arr::get($array, 'products.0.name'));
-        $this->assertEquals('chair', Arr::get($array, 'products.1.name'));
+        $this->assertSame('desk', Arr::get($array, 'products.0.name'));
+        $this->assertSame('chair', Arr::get($array, 'products.1.name'));
 
         // Test return default value for non-existing key.
         $array = ['names' => ['developer' => 'taylor']];
-        $this->assertEquals('dayle', Arr::get($array, 'names.otherDeveloper', 'dayle'));
-        $this->assertEquals('dayle', Arr::get($array, 'names.otherDeveloper', function () {
+        $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', 'dayle'));
+        $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', function () {
             return 'dayle';
         }));
     }
@@ -523,13 +523,13 @@ class SupportArrTest extends TestCase
     {
         $array = ['name' => 'Desk', 'price' => 100];
         $name = Arr::pull($array, 'name');
-        $this->assertEquals('Desk', $name);
+        $this->assertSame('Desk', $name);
         $this->assertEquals(['price' => 100], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
         $name = Arr::pull($array, 'joe@example.com');
-        $this->assertEquals('Joe', $name);
+        $this->assertSame('Joe', $name);
         $this->assertEquals(['jane@localhost' => 'Jane'], $array);
 
         // Does not work for nested keys

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -27,7 +27,7 @@ class SupportCollectionTest extends TestCase
     public function testFirstReturnsFirstItemInCollection($collection)
     {
         $c = new $collection(['foo', 'bar']);
-        $this->assertEquals('foo', $c->first());
+        $this->assertSame('foo', $c->first());
     }
 
     /**
@@ -39,7 +39,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->first(function ($value) {
             return $value === 'bar';
         });
-        $this->assertEquals('bar', $result);
+        $this->assertSame('bar', $result);
     }
 
     /**
@@ -51,7 +51,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->first(function ($value) {
             return $value === 'baz';
         }, 'default');
-        $this->assertEquals('default', $result);
+        $this->assertSame('default', $result);
     }
 
     /**
@@ -61,7 +61,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection;
         $result = $data->first(null, 'default');
-        $this->assertEquals('default', $result);
+        $this->assertSame('default', $result);
     }
 
     /**
@@ -74,8 +74,8 @@ class SupportCollectionTest extends TestCase
             ['material' => 'rubber', 'type' => 'gasket'],
         ]);
 
-        $this->assertEquals('book', $data->firstWhere('material', 'paper')['type']);
-        $this->assertEquals('gasket', $data->firstWhere('material', 'rubber')['type']);
+        $this->assertSame('book', $data->firstWhere('material', 'paper')['type']);
+        $this->assertSame('gasket', $data->firstWhere('material', 'rubber')['type']);
         $this->assertNull($data->firstWhere('material', 'nonexistant'));
         $this->assertNull($data->firstWhere('nonexistant', 'key'));
     }
@@ -86,7 +86,7 @@ class SupportCollectionTest extends TestCase
     public function testLastReturnsLastItemInCollection($collection)
     {
         $c = new $collection(['foo', 'bar']);
-        $this->assertEquals('bar', $c->last());
+        $this->assertSame('bar', $c->last());
     }
 
     /**
@@ -114,7 +114,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->last(function ($value) {
             return $value === 'baz';
         }, 'default');
-        $this->assertEquals('default', $result);
+        $this->assertSame('default', $result);
     }
 
     /**
@@ -124,24 +124,24 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection;
         $result = $data->last(null, 'default');
-        $this->assertEquals('default', $result);
+        $this->assertSame('default', $result);
     }
 
     public function testPopReturnsAndRemovesLastItemInCollection()
     {
         $c = new Collection(['foo', 'bar']);
 
-        $this->assertEquals('bar', $c->pop());
-        $this->assertEquals('foo', $c->first());
+        $this->assertSame('bar', $c->pop());
+        $this->assertSame('foo', $c->first());
     }
 
     public function testShiftReturnsAndRemovesFirstItemInCollection()
     {
         $data = new Collection(['Taylor', 'Otwell']);
 
-        $this->assertEquals('Taylor', $data->shift());
-        $this->assertEquals('Otwell', $data->first());
-        $this->assertEquals('Otwell', $data->shift());
+        $this->assertSame('Taylor', $data->shift());
+        $this->assertSame('Otwell', $data->first());
+        $this->assertSame('Otwell', $data->shift());
         $this->assertEquals(null, $data->first());
     }
 
@@ -315,14 +315,14 @@ class SupportCollectionTest extends TestCase
     public function testOffsetAccess()
     {
         $c = new Collection(['name' => 'taylor']);
-        $this->assertEquals('taylor', $c['name']);
+        $this->assertSame('taylor', $c['name']);
         $c['name'] = 'dayle';
-        $this->assertEquals('dayle', $c['name']);
+        $this->assertSame('dayle', $c['name']);
         $this->assertTrue(isset($c['name']));
         unset($c['name']);
         $this->assertFalse(isset($c['name']));
         $c[] = 'jason';
-        $this->assertEquals('jason', $c[0]);
+        $this->assertSame('jason', $c[0]);
     }
 
     public function testArrayAccessOffsetExists()
@@ -336,8 +336,8 @@ class SupportCollectionTest extends TestCase
     public function testArrayAccessOffsetGet()
     {
         $c = new Collection(['foo', 'bar']);
-        $this->assertEquals('foo', $c->offsetGet(0));
-        $this->assertEquals('bar', $c->offsetGet(1));
+        $this->assertSame('foo', $c->offsetGet(0));
+        $this->assertSame('bar', $c->offsetGet(1));
     }
 
     public function testArrayAccessOffsetSet()
@@ -345,10 +345,10 @@ class SupportCollectionTest extends TestCase
         $c = new Collection(['foo', 'foo']);
 
         $c->offsetSet(1, 'bar');
-        $this->assertEquals('bar', $c[1]);
+        $this->assertSame('bar', $c[1]);
 
         $c->offsetSet(null, 'qux');
-        $this->assertEquals('qux', $c[2]);
+        $this->assertSame('qux', $c[2]);
     }
 
     public function testArrayAccessOffsetUnset()
@@ -1286,15 +1286,15 @@ class SupportCollectionTest extends TestCase
      */
     public function testJoin($collection)
     {
-        $this->assertEquals('a, b, c', (new $collection(['a', 'b', 'c']))->join(', '));
+        $this->assertSame('a, b, c', (new $collection(['a', 'b', 'c']))->join(', '));
 
-        $this->assertEquals('a, b and c', (new $collection(['a', 'b', 'c']))->join(', ', ' and '));
+        $this->assertSame('a, b and c', (new $collection(['a', 'b', 'c']))->join(', ', ' and '));
 
-        $this->assertEquals('a and b', (new $collection(['a', 'b']))->join(', ', ' and '));
+        $this->assertSame('a and b', (new $collection(['a', 'b']))->join(', ', ' and '));
 
-        $this->assertEquals('a', (new $collection(['a']))->join(', ', ' and '));
+        $this->assertSame('a', (new $collection(['a']))->join(', ', ' and '));
 
-        $this->assertEquals('', (new $collection([]))->join(', ', ' and '));
+        $this->assertSame('', (new $collection([]))->join(', ', ' and '));
     }
 
     /**
@@ -1600,12 +1600,12 @@ class SupportCollectionTest extends TestCase
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
-        $this->assertEquals('foobar', $data->implode('email'));
-        $this->assertEquals('foo,bar', $data->implode('email', ','));
+        $this->assertSame('foobar', $data->implode('email'));
+        $this->assertSame('foo,bar', $data->implode('email', ','));
 
         $data = new $collection(['taylor', 'dayle']);
-        $this->assertEquals('taylordayle', $data->implode(''));
-        $this->assertEquals('taylor,dayle', $data->implode(','));
+        $this->assertSame('taylordayle', $data->implode(''));
+        $this->assertSame('taylor,dayle', $data->implode(','));
     }
 
     /**
@@ -1857,7 +1857,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testUnwrapCollectionWithScalar($collection)
     {
-        $this->assertEquals('foo', $collection::unwrap('foo'));
+        $this->assertSame('foo', $collection::unwrap('foo'));
     }
 
     /**
@@ -2194,8 +2194,8 @@ class SupportCollectionTest extends TestCase
 
         $data = $data->mapInto(TestCollectionMapIntoObject::class);
 
-        $this->assertEquals('first', $data->get(0)->value);
-        $this->assertEquals('second', $data->get(1)->value);
+        $this->assertSame('first', $data->get(0)->value);
+        $this->assertSame('second', $data->get(1)->value);
     }
 
     /**
@@ -2686,7 +2686,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new Collection(['foo', 'bar']);
 
-        $this->assertEquals('foo', $c->pull(0));
+        $this->assertSame('foo', $c->pull(0));
     }
 
     public function testPullRemovesItemFromCollection()
@@ -2700,7 +2700,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new Collection([]);
         $value = $c->pull(0, 'foo');
-        $this->assertEquals('foo', $value);
+        $this->assertSame('foo', $value);
     }
 
     /**
@@ -2765,11 +2765,11 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(1, $c->search(2));
         $this->assertEquals(1, $c->search('2'));
-        $this->assertEquals('foo', $c->search('bar'));
+        $this->assertSame('foo', $c->search('bar'));
         $this->assertEquals(4, $c->search(function ($value) {
             return $value > 4;
         }));
-        $this->assertEquals('foo', $c->search(function ($value) {
+        $this->assertSame('foo', $c->search(function ($value) {
             return ! is_numeric($value);
         }));
     }

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -28,7 +28,7 @@ class SupportFacadeTest extends TestCase
         $app->setAttributes(['foo' => $mock = m::mock(stdClass::class)]);
         $mock->shouldReceive('bar')->once()->andReturn('baz');
         FacadeStub::setFacadeApplication($app);
-        $this->assertEquals('baz', FacadeStub::bar());
+        $this->assertSame('baz', FacadeStub::bar());
     }
 
     public function testShouldReceiveReturnsAMockeryMock()
@@ -38,7 +38,7 @@ class SupportFacadeTest extends TestCase
         FacadeStub::setFacadeApplication($app);
 
         $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
-        $this->assertEquals('baz', $app['foo']->foo('bar'));
+        $this->assertSame('baz', $app['foo']->foo('bar'));
     }
 
     public function testSpyReturnsAMockerySpy()
@@ -61,14 +61,14 @@ class SupportFacadeTest extends TestCase
 
         $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo')->once()->with('bar')->andReturn('baz')->getMock());
         $this->assertInstanceOf(MockInterface::class, $mock = FacadeStub::shouldReceive('foo2')->once()->with('bar2')->andReturn('baz2')->getMock());
-        $this->assertEquals('baz', $app['foo']->foo('bar'));
-        $this->assertEquals('baz2', $app['foo']->foo2('bar2'));
+        $this->assertSame('baz', $app['foo']->foo('bar'));
+        $this->assertSame('baz2', $app['foo']->foo2('bar2'));
     }
 
     public function testCanBeMockedWithoutUnderlyingInstance()
     {
         FacadeStub::shouldReceive('foo')->once()->andReturn('bar');
-        $this->assertEquals('bar', FacadeStub::foo());
+        $this->assertSame('bar', FacadeStub::foo());
     }
 }
 

--- a/tests/Support/SupportFluentTest.php
+++ b/tests/Support/SupportFluentTest.php
@@ -53,9 +53,9 @@ class SupportFluentTest extends TestCase
     {
         $fluent = new Fluent(['name' => 'Taylor']);
 
-        $this->assertEquals('Taylor', $fluent->get('name'));
-        $this->assertEquals('Default', $fluent->get('foo', 'Default'));
-        $this->assertEquals('Taylor', $fluent->name);
+        $this->assertSame('Taylor', $fluent->get('name'));
+        $this->assertSame('Default', $fluent->get('foo', 'Default'));
+        $this->assertSame('Taylor', $fluent->name);
         $this->assertNull($fluent->foo);
     }
 
@@ -79,7 +79,7 @@ class SupportFluentTest extends TestCase
         $fluent->developer();
         $fluent->age(25);
 
-        $this->assertEquals('Taylor', $fluent->name);
+        $this->assertSame('Taylor', $fluent->name);
         $this->assertTrue($fluent->developer);
         $this->assertEquals(25, $fluent->age);
         $this->assertInstanceOf(Fluent::class, $fluent->programmer());

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -21,7 +21,7 @@ class SupportHelpersTest extends TestCase
     public function testE()
     {
         $str = 'A \'quote\' is <b>bold</b>';
-        $this->assertEquals('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
+        $this->assertSame('A &#039;quote&#039; is &lt;b&gt;bold&lt;/b&gt;', e($str));
         $html = m::mock(Htmlable::class);
         $html->shouldReceive('toHtml')->andReturn($str);
         $this->assertEquals($str, e($html));
@@ -29,14 +29,14 @@ class SupportHelpersTest extends TestCase
 
     public function testClassBasename()
     {
-        $this->assertEquals('Baz', class_basename('Foo\Bar\Baz'));
-        $this->assertEquals('Baz', class_basename('Baz'));
+        $this->assertSame('Baz', class_basename('Foo\Bar\Baz'));
+        $this->assertSame('Baz', class_basename('Baz'));
     }
 
     public function testValue()
     {
-        $this->assertEquals('foo', value('foo'));
-        $this->assertEquals('foo', value(function () {
+        $this->assertSame('foo', value('foo'));
+        $this->assertSame('foo', value(function () {
             return 'foo';
         }));
     }
@@ -47,7 +47,7 @@ class SupportHelpersTest extends TestCase
         $class->name = new stdClass;
         $class->name->first = 'Taylor';
 
-        $this->assertEquals('Taylor', object_get($class, 'name.first'));
+        $this->assertSame('Taylor', object_get($class, 'name.first'));
     }
 
     public function testDataGet()
@@ -57,20 +57,20 @@ class SupportHelpersTest extends TestCase
         $dottedArray = ['users' => ['first.name' => 'Taylor', 'middle.name' => null]];
         $arrayAccess = new SupportTestArrayAccess(['price' => 56, 'user' => new SupportTestArrayAccess(['name' => 'John']), 'email' => null]);
 
-        $this->assertEquals('Taylor', data_get($object, 'users.name.0'));
-        $this->assertEquals('Taylor', data_get($array, '0.users.0.name'));
+        $this->assertSame('Taylor', data_get($object, 'users.name.0'));
+        $this->assertSame('Taylor', data_get($array, '0.users.0.name'));
         $this->assertNull(data_get($array, '0.users.3'));
-        $this->assertEquals('Not found', data_get($array, '0.users.3', 'Not found'));
-        $this->assertEquals('Not found', data_get($array, '0.users.3', function () {
+        $this->assertSame('Not found', data_get($array, '0.users.3', 'Not found'));
+        $this->assertSame('Not found', data_get($array, '0.users.3', function () {
             return 'Not found';
         }));
-        $this->assertEquals('Taylor', data_get($dottedArray, ['users', 'first.name']));
+        $this->assertSame('Taylor', data_get($dottedArray, ['users', 'first.name']));
         $this->assertNull(data_get($dottedArray, ['users', 'middle.name']));
-        $this->assertEquals('Not found', data_get($dottedArray, ['users', 'last.name'], 'Not found'));
+        $this->assertSame('Not found', data_get($dottedArray, ['users', 'last.name'], 'Not found'));
         $this->assertEquals(56, data_get($arrayAccess, 'price'));
-        $this->assertEquals('John', data_get($arrayAccess, 'user.name'));
-        $this->assertEquals('void', data_get($arrayAccess, 'foo', 'void'));
-        $this->assertEquals('void', data_get($arrayAccess, 'user.foo', 'void'));
+        $this->assertSame('John', data_get($arrayAccess, 'user.name'));
+        $this->assertSame('void', data_get($arrayAccess, 'foo', 'void'));
+        $this->assertSame('void', data_get($arrayAccess, 'user.foo', 'void'));
         $this->assertNull(data_get($arrayAccess, 'foo'));
         $this->assertNull(data_get($arrayAccess, 'user.foo'));
         $this->assertNull(data_get($arrayAccess, 'email', 'Not found'));
@@ -98,7 +98,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertEquals(['taylor', 'abigail', 'dayle'], data_get($array, 'users.*.first'));
         $this->assertEquals(['taylorotwell@gmail.com', null, null], data_get($array, 'users.*.email', 'irrelevant'));
-        $this->assertEquals('not found', data_get($array, 'posts.*.date', 'not found'));
+        $this->assertSame('not found', data_get($array, 'posts.*.date', 'not found'));
         $this->assertNull(data_get($array, 'posts.*.date'));
     }
 
@@ -312,13 +312,13 @@ class SupportHelpersTest extends TestCase
     public function testHead()
     {
         $array = ['a', 'b', 'c'];
-        $this->assertEquals('a', head($array));
+        $this->assertSame('a', head($array));
     }
 
     public function testLast()
     {
         $array = ['a', 'b', 'c'];
-        $this->assertEquals('c', last($array));
+        $this->assertSame('c', last($array));
     }
 
     public function testClassUsesRecursiveShouldReturnTraitsOnParentClasses()
@@ -408,7 +408,7 @@ class SupportHelpersTest extends TestCase
 
     public function testOptionalWithArray()
     {
-        $this->assertEquals('here', optional(['present' => 'here'])['present']);
+        $this->assertSame('here', optional(['present' => 'here'])['present']);
         $this->assertNull(optional(null)['missing']);
         $this->assertNull(optional(['present' => 'here'])->missing);
     }
@@ -463,7 +463,7 @@ class SupportHelpersTest extends TestCase
 
         $this->assertNull(optional(null)->present()->something());
 
-        $this->assertEquals('$10.00', optional(new class {
+        $this->assertSame('$10.00', optional(new class {
             public function present()
             {
                 return new class {
@@ -544,11 +544,11 @@ class SupportHelpersTest extends TestCase
 
     public function testTransformDefaultWhenBlank()
     {
-        $this->assertEquals('baz', transform(null, function () {
+        $this->assertSame('baz', transform(null, function () {
             return 'bar';
         }, 'baz'));
 
-        $this->assertEquals('baz', transform('', function () {
+        $this->assertSame('baz', transform('', function () {
             return 'bar';
         }, function () {
             return 'baz';
@@ -613,16 +613,16 @@ class SupportHelpersTest extends TestCase
     public function testEnvDefault()
     {
         $_SERVER['foo'] = 'bar';
-        $this->assertEquals('bar', env('foo', 'default'));
+        $this->assertSame('bar', env('foo', 'default'));
 
         $_SERVER['foo'] = '';
-        $this->assertEquals('', env('foo', 'default'));
+        $this->assertSame('', env('foo', 'default'));
 
         unset($_SERVER['foo']);
-        $this->assertEquals('default', env('foo', 'default'));
+        $this->assertSame('default', env('foo', 'default'));
 
         $_SERVER['foo'] = null;
-        $this->assertEquals('default', env('foo', 'default'));
+        $this->assertSame('default', env('foo', 'default'));
     }
 
     public function testEnvEscapedString()

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -25,7 +25,7 @@ class SupportMacroableTest extends TestCase
         $macroable::macro(__CLASS__, function () {
             return 'Taylor';
         });
-        $this->assertEquals('Taylor', $macroable::{__CLASS__}());
+        $this->assertSame('Taylor', $macroable::{__CLASS__}());
     }
 
     public function testRegisterMacroAndCallWithoutStatic()
@@ -34,7 +34,7 @@ class SupportMacroableTest extends TestCase
         $macroable::macro(__CLASS__, function () {
             return 'Taylor';
         });
-        $this->assertEquals('Taylor', $macroable->{__CLASS__}());
+        $this->assertSame('Taylor', $macroable->{__CLASS__}());
     }
 
     public function testWhenCallingMacroClosureIsBoundToObject()
@@ -48,17 +48,17 @@ class SupportMacroableTest extends TestCase
         $instance = new TestMacroable;
 
         $result = $instance->tryInstance();
-        $this->assertEquals('instance', $result);
+        $this->assertSame('instance', $result);
 
         $result = TestMacroable::tryStatic();
-        $this->assertEquals('static', $result);
+        $this->assertSame('static', $result);
     }
 
     public function testClassBasedMacros()
     {
         TestMacroable::mixin(new TestMixin);
         $instance = new TestMacroable;
-        $this->assertEquals('instance-Adam', $instance->methodOne('Adam'));
+        $this->assertSame('instance-Adam', $instance->methodOne('Adam'));
     }
 
     public function testClassBasedMacrosNoReplace()
@@ -68,10 +68,10 @@ class SupportMacroableTest extends TestCase
         });
         TestMacroable::mixin(new TestMixin, false);
         $instance = new TestMacroable;
-        $this->assertEquals('bar', $instance->methodThree());
+        $this->assertSame('bar', $instance->methodThree());
 
         TestMacroable::mixin(new TestMixin);
-        $this->assertEquals('foo', $instance->methodThree());
+        $this->assertSame('foo', $instance->methodThree());
     }
 }
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -93,14 +93,14 @@ class SupportMessageBagTest extends TestCase
         $container->setFormat(':message');
         $container->add('foo', 'bar');
         $container->add('foo', 'baz');
-        $this->assertEquals('bar', $container->first('foo'));
+        $this->assertSame('bar', $container->first('foo'));
     }
 
     public function testFirstReturnsEmptyStringIfNoMessagesFound()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $this->assertEquals('', $container->first('foo'));
+        $this->assertSame('', $container->first('foo'));
     }
 
     public function testFirstReturnsSingleMessageFromDotKeys()
@@ -109,7 +109,7 @@ class SupportMessageBagTest extends TestCase
         $container->setFormat(':message');
         $container->add('name.first', 'jon');
         $container->add('name.last', 'snow');
-        $this->assertEquals('jon', $container->first('name.*'));
+        $this->assertSame('jon', $container->first('name.*'));
     }
 
     public function testHasIndicatesExistence()
@@ -181,15 +181,15 @@ class SupportMessageBagTest extends TestCase
         $container->setFormat('<p>:message</p>');
         $container->add('foo', 'bar');
         $container->add('boom', 'baz');
-        $this->assertEquals('<p>bar</p>', $container->first('foo'));
+        $this->assertSame('<p>bar</p>', $container->first('foo'));
         $this->assertEquals(['<p>bar</p>'], $container->get('foo'));
         $this->assertEquals(['<p>bar</p>', '<p>baz</p>'], $container->all());
-        $this->assertEquals('bar', $container->first('foo', ':message'));
+        $this->assertSame('bar', $container->first('foo', ':message'));
         $this->assertEquals(['bar'], $container->get('foo', ':message'));
         $this->assertEquals(['bar', 'baz'], $container->all(':message'));
 
         $container->setFormat(':key :message');
-        $this->assertEquals('foo bar', $container->first('foo'));
+        $this->assertSame('foo bar', $container->first('foo'));
     }
 
     public function testUnique()
@@ -219,7 +219,7 @@ class SupportMessageBagTest extends TestCase
         $container->add('foo', 'bar');
         $container->add('boom', 'baz');
 
-        $this->assertEquals('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
+        $this->assertSame('{"foo":["bar"],"boom":["baz"]}', $container->toJson());
     }
 
     public function testCountReturnsCorrectValue()
@@ -254,7 +254,7 @@ class SupportMessageBagTest extends TestCase
         $container = new MessageBag;
         $container->setFormat(':message');
         $container->add('foo.bar', 'baz');
-        $this->assertEquals('baz', $container->first('foo.*'));
+        $this->assertSame('baz', $container->first('foo.*'));
     }
 
     public function testIsEmptyTrue()
@@ -287,14 +287,14 @@ class SupportMessageBagTest extends TestCase
     {
         $container = new MessageBag;
         $container->add('foo.bar', 'baz');
-        $this->assertEquals('{"foo.bar":["baz"]}', (string) $container);
+        $this->assertSame('{"foo.bar":["baz"]}', (string) $container);
     }
 
     public function testGetFormat()
     {
         $container = new MessageBag;
         $container->setFormat(':message');
-        $this->assertEquals(':message', $container->getFormat());
+        $this->assertSame(':message', $container->getFormat());
     }
 
     public function testConstructorUniquenessConsistency()

--- a/tests/Support/SupportPluralizerTest.php
+++ b/tests/Support/SupportPluralizerTest.php
@@ -9,36 +9,36 @@ class SupportPluralizerTest extends TestCase
 {
     public function testBasicSingular()
     {
-        $this->assertEquals('child', Str::singular('children'));
+        $this->assertSame('child', Str::singular('children'));
     }
 
     public function testBasicPlural()
     {
-        $this->assertEquals('children', Str::plural('child'));
-        $this->assertEquals('cod', Str::plural('cod'));
+        $this->assertSame('children', Str::plural('child'));
+        $this->assertSame('cod', Str::plural('cod'));
     }
 
     public function testCaseSensitiveSingularUsage()
     {
-        $this->assertEquals('Child', Str::singular('Children'));
-        $this->assertEquals('CHILD', Str::singular('CHILDREN'));
-        $this->assertEquals('Test', Str::singular('Tests'));
+        $this->assertSame('Child', Str::singular('Children'));
+        $this->assertSame('CHILD', Str::singular('CHILDREN'));
+        $this->assertSame('Test', Str::singular('Tests'));
     }
 
     public function testCaseSensitiveSingularPlural()
     {
-        $this->assertEquals('Children', Str::plural('Child'));
-        $this->assertEquals('CHILDREN', Str::plural('CHILD'));
-        $this->assertEquals('Tests', Str::plural('Test'));
-        $this->assertEquals('children', Str::plural('cHiLd'));
+        $this->assertSame('Children', Str::plural('Child'));
+        $this->assertSame('CHILDREN', Str::plural('CHILD'));
+        $this->assertSame('Tests', Str::plural('Test'));
+        $this->assertSame('children', Str::plural('cHiLd'));
     }
 
     public function testIfEndOfWordPlural()
     {
-        $this->assertEquals('VortexFields', Str::plural('VortexField'));
-        $this->assertEquals('MatrixFields', Str::plural('MatrixField'));
-        $this->assertEquals('IndexFields', Str::plural('IndexField'));
-        $this->assertEquals('VertexFields', Str::plural('VertexField'));
+        $this->assertSame('VortexFields', Str::plural('VortexField'));
+        $this->assertSame('MatrixFields', Str::plural('MatrixField'));
+        $this->assertSame('IndexFields', Str::plural('IndexField'));
+        $this->assertSame('VertexFields', Str::plural('VertexField'));
 
         // This is expected behavior, use "Str::pluralStudly" instead.
         $this->assertSame('RealHumen', Str::plural('RealHuman'));
@@ -46,10 +46,10 @@ class SupportPluralizerTest extends TestCase
 
     public function testPluralWithNegativeCount()
     {
-        $this->assertEquals('test', Str::plural('test', 1));
-        $this->assertEquals('tests', Str::plural('test', 2));
-        $this->assertEquals('test', Str::plural('test', -1));
-        $this->assertEquals('tests', Str::plural('test', -2));
+        $this->assertSame('test', Str::plural('test', 1));
+        $this->assertSame('tests', Str::plural('test', 2));
+        $this->assertSame('test', Str::plural('test', -1));
+        $this->assertSame('tests', Str::plural('test', -2));
     }
 
     public function testPluralStudly()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -10,34 +10,34 @@ class SupportStrTest extends TestCase
 {
     public function testStringCanBeLimitedByWords()
     {
-        $this->assertEquals('Taylor...', Str::words('Taylor Otwell', 1));
-        $this->assertEquals('Taylor___', Str::words('Taylor Otwell', 1, '___'));
-        $this->assertEquals('Taylor Otwell', Str::words('Taylor Otwell', 3));
+        $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));
+        $this->assertSame('Taylor___', Str::words('Taylor Otwell', 1, '___'));
+        $this->assertSame('Taylor Otwell', Str::words('Taylor Otwell', 3));
     }
 
     public function testStringTrimmedOnlyWhereNecessary()
     {
-        $this->assertEquals(' Taylor Otwell ', Str::words(' Taylor Otwell ', 3));
-        $this->assertEquals(' Taylor...', Str::words(' Taylor Otwell ', 1));
+        $this->assertSame(' Taylor Otwell ', Str::words(' Taylor Otwell ', 3));
+        $this->assertSame(' Taylor...', Str::words(' Taylor Otwell ', 1));
     }
 
     public function testStringTitle()
     {
-        $this->assertEquals('Jefferson Costella', Str::title('jefferson costella'));
-        $this->assertEquals('Jefferson Costella', Str::title('jefFErson coSTella'));
+        $this->assertSame('Jefferson Costella', Str::title('jefferson costella'));
+        $this->assertSame('Jefferson Costella', Str::title('jefFErson coSTella'));
     }
 
     public function testStringWithoutWordsDoesntProduceError()
     {
         $nbsp = chr(0xC2).chr(0xA0);
-        $this->assertEquals(' ', Str::words(' '));
+        $this->assertSame(' ', Str::words(' '));
         $this->assertEquals($nbsp, Str::words($nbsp));
     }
 
     public function testStringAscii()
     {
-        $this->assertEquals('@', Str::ascii('@'));
-        $this->assertEquals('u', Str::ascii('ü'));
+        $this->assertSame('@', Str::ascii('@'));
+        $this->assertSame('u', Str::ascii('ü'));
     }
 
     public function testStringAsciiWithSpecificLocale()
@@ -96,26 +96,26 @@ class SupportStrTest extends TestCase
 
     public function testStrBefore()
     {
-        $this->assertEquals('han', Str::before('hannah', 'nah'));
-        $this->assertEquals('ha', Str::before('hannah', 'n'));
-        $this->assertEquals('ééé ', Str::before('ééé hannah', 'han'));
-        $this->assertEquals('hannah', Str::before('hannah', 'xxxx'));
-        $this->assertEquals('hannah', Str::before('hannah', ''));
-        $this->assertEquals('han', Str::before('han0nah', '0'));
-        $this->assertEquals('han', Str::before('han0nah', 0));
-        $this->assertEquals('han', Str::before('han2nah', 2));
+        $this->assertSame('han', Str::before('hannah', 'nah'));
+        $this->assertSame('ha', Str::before('hannah', 'n'));
+        $this->assertSame('ééé ', Str::before('ééé hannah', 'han'));
+        $this->assertSame('hannah', Str::before('hannah', 'xxxx'));
+        $this->assertSame('hannah', Str::before('hannah', ''));
+        $this->assertSame('han', Str::before('han0nah', '0'));
+        $this->assertSame('han', Str::before('han0nah', 0));
+        $this->assertSame('han', Str::before('han2nah', 2));
     }
 
     public function testStrAfter()
     {
-        $this->assertEquals('nah', Str::after('hannah', 'han'));
-        $this->assertEquals('nah', Str::after('hannah', 'n'));
-        $this->assertEquals('nah', Str::after('ééé hannah', 'han'));
-        $this->assertEquals('hannah', Str::after('hannah', 'xxxx'));
-        $this->assertEquals('hannah', Str::after('hannah', ''));
-        $this->assertEquals('nah', Str::after('han0nah', '0'));
-        $this->assertEquals('nah', Str::after('han0nah', 0));
-        $this->assertEquals('nah', Str::after('han2nah', 2));
+        $this->assertSame('nah', Str::after('hannah', 'han'));
+        $this->assertSame('nah', Str::after('hannah', 'n'));
+        $this->assertSame('nah', Str::after('ééé hannah', 'han'));
+        $this->assertSame('hannah', Str::after('hannah', 'xxxx'));
+        $this->assertSame('hannah', Str::after('hannah', ''));
+        $this->assertSame('nah', Str::after('han0nah', '0'));
+        $this->assertSame('nah', Str::after('han0nah', 0));
+        $this->assertSame('nah', Str::after('han2nah', 2));
     }
 
     public function testStrContains()
@@ -144,26 +144,26 @@ class SupportStrTest extends TestCase
 
     public function testSlug()
     {
-        $this->assertEquals('hello-world', Str::slug('hello world'));
-        $this->assertEquals('hello-world', Str::slug('hello-world'));
-        $this->assertEquals('hello-world', Str::slug('hello_world'));
-        $this->assertEquals('hello_world', Str::slug('hello_world', '_'));
-        $this->assertEquals('user-at-host', Str::slug('user@host'));
-        $this->assertEquals('سلام-دنیا', Str::slug('سلام دنیا', '-', null));
+        $this->assertSame('hello-world', Str::slug('hello world'));
+        $this->assertSame('hello-world', Str::slug('hello-world'));
+        $this->assertSame('hello-world', Str::slug('hello_world'));
+        $this->assertSame('hello_world', Str::slug('hello_world', '_'));
+        $this->assertSame('user-at-host', Str::slug('user@host'));
+        $this->assertSame('سلام-دنیا', Str::slug('سلام دنیا', '-', null));
     }
 
     public function testStrStart()
     {
-        $this->assertEquals('/test/string', Str::start('test/string', '/'));
-        $this->assertEquals('/test/string', Str::start('/test/string', '/'));
-        $this->assertEquals('/test/string', Str::start('//test/string', '/'));
+        $this->assertSame('/test/string', Str::start('test/string', '/'));
+        $this->assertSame('/test/string', Str::start('/test/string', '/'));
+        $this->assertSame('/test/string', Str::start('//test/string', '/'));
     }
 
     public function testFinish()
     {
-        $this->assertEquals('abbc', Str::finish('ab', 'bc'));
-        $this->assertEquals('abbc', Str::finish('abbcbc', 'bc'));
-        $this->assertEquals('abcbbc', Str::finish('abcbbcbc', 'bc'));
+        $this->assertSame('abbc', Str::finish('ab', 'bc'));
+        $this->assertSame('abbc', Str::finish('abbcbc', 'bc'));
+        $this->assertSame('abcbbc', Str::finish('abcbbcbc', 'bc'));
     }
 
     public function testIs()
@@ -205,34 +205,34 @@ class SupportStrTest extends TestCase
 
     public function testKebab()
     {
-        $this->assertEquals('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+        $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
     }
 
     public function testLower()
     {
-        $this->assertEquals('foo bar baz', Str::lower('FOO BAR BAZ'));
-        $this->assertEquals('foo bar baz', Str::lower('fOo Bar bAz'));
+        $this->assertSame('foo bar baz', Str::lower('FOO BAR BAZ'));
+        $this->assertSame('foo bar baz', Str::lower('fOo Bar bAz'));
     }
 
     public function testUpper()
     {
-        $this->assertEquals('FOO BAR BAZ', Str::upper('foo bar baz'));
-        $this->assertEquals('FOO BAR BAZ', Str::upper('foO bAr BaZ'));
+        $this->assertSame('FOO BAR BAZ', Str::upper('foo bar baz'));
+        $this->assertSame('FOO BAR BAZ', Str::upper('foO bAr BaZ'));
     }
 
     public function testLimit()
     {
-        $this->assertEquals('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
-        $this->assertEquals('这是一...', Str::limit('这是一段中文', 6));
+        $this->assertSame('Laravel is...', Str::limit('Laravel is a free, open source PHP web application framework.', 10));
+        $this->assertSame('这是一...', Str::limit('这是一段中文', 6));
 
         $string = 'The PHP framework for web artisans.';
-        $this->assertEquals('The PHP...', Str::limit($string, 7));
-        $this->assertEquals('The PHP', Str::limit($string, 7, ''));
-        $this->assertEquals('The PHP framework for web artisans.', Str::limit($string, 100));
+        $this->assertSame('The PHP...', Str::limit($string, 7));
+        $this->assertSame('The PHP', Str::limit($string, 7, ''));
+        $this->assertSame('The PHP framework for web artisans.', Str::limit($string, 100));
 
         $nonAsciiString = '这是一段中文';
-        $this->assertEquals('这是一...', Str::limit($nonAsciiString, 6));
-        $this->assertEquals('这是一', Str::limit($nonAsciiString, 6, ''));
+        $this->assertSame('这是一...', Str::limit($nonAsciiString, 6));
+        $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
     public function testLength()
@@ -251,104 +251,104 @@ class SupportStrTest extends TestCase
 
     public function testReplaceArray()
     {
-        $this->assertEquals('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
-        $this->assertEquals('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
-        $this->assertEquals('foo/bar', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?'));
-        $this->assertEquals('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertSame('foo/bar/baz', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?'));
+        $this->assertSame('foo/bar/baz/?', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?/?/?'));
+        $this->assertSame('foo/bar', Str::replaceArray('?', ['foo', 'bar', 'baz'], '?/?'));
+        $this->assertSame('?/?/?', Str::replaceArray('x', ['foo', 'bar', 'baz'], '?/?/?'));
         // Ensure recursive replacements are avoided
-        $this->assertEquals('foo?/bar/baz', Str::replaceArray('?', ['foo?', 'bar', 'baz'], '?/?/?'));
+        $this->assertSame('foo?/bar/baz', Str::replaceArray('?', ['foo?', 'bar', 'baz'], '?/?/?'));
         // Test for associative array support
-        $this->assertEquals('foo/bar', Str::replaceArray('?', [1 => 'foo', 2 => 'bar'], '?/?'));
-        $this->assertEquals('foo/bar', Str::replaceArray('?', ['x' => 'foo', 'y' => 'bar'], '?/?'));
+        $this->assertSame('foo/bar', Str::replaceArray('?', [1 => 'foo', 2 => 'bar'], '?/?'));
+        $this->assertSame('foo/bar', Str::replaceArray('?', ['x' => 'foo', 'y' => 'bar'], '?/?'));
     }
 
     public function testReplaceFirst()
     {
-        $this->assertEquals('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));
-        $this->assertEquals('foo/qux? foo/bar?', Str::replaceFirst('bar?', 'qux?', 'foo/bar? foo/bar?'));
-        $this->assertEquals('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
-        $this->assertEquals('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
-        $this->assertEquals('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
+        $this->assertSame('fooqux foobar', Str::replaceFirst('bar', 'qux', 'foobar foobar'));
+        $this->assertSame('foo/qux? foo/bar?', Str::replaceFirst('bar?', 'qux?', 'foo/bar? foo/bar?'));
+        $this->assertSame('foo foobar', Str::replaceFirst('bar', '', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceFirst('xxx', 'yyy', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceFirst('', 'yyy', 'foobar foobar'));
         // Test for multibyte string support
-        $this->assertEquals('Jxxxnköping Malmö', Str::replaceFirst('ö', 'xxx', 'Jönköping Malmö'));
-        $this->assertEquals('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
+        $this->assertSame('Jxxxnköping Malmö', Str::replaceFirst('ö', 'xxx', 'Jönköping Malmö'));
+        $this->assertSame('Jönköping Malmö', Str::replaceFirst('', 'yyy', 'Jönköping Malmö'));
     }
 
     public function testReplaceLast()
     {
-        $this->assertEquals('foobar fooqux', Str::replaceLast('bar', 'qux', 'foobar foobar'));
-        $this->assertEquals('foo/bar? foo/qux?', Str::replaceLast('bar?', 'qux?', 'foo/bar? foo/bar?'));
-        $this->assertEquals('foobar foo', Str::replaceLast('bar', '', 'foobar foobar'));
-        $this->assertEquals('foobar foobar', Str::replaceLast('xxx', 'yyy', 'foobar foobar'));
-        $this->assertEquals('foobar foobar', Str::replaceLast('', 'yyy', 'foobar foobar'));
+        $this->assertSame('foobar fooqux', Str::replaceLast('bar', 'qux', 'foobar foobar'));
+        $this->assertSame('foo/bar? foo/qux?', Str::replaceLast('bar?', 'qux?', 'foo/bar? foo/bar?'));
+        $this->assertSame('foobar foo', Str::replaceLast('bar', '', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceLast('xxx', 'yyy', 'foobar foobar'));
+        $this->assertSame('foobar foobar', Str::replaceLast('', 'yyy', 'foobar foobar'));
         // Test for multibyte string support
-        $this->assertEquals('Malmö Jönkxxxping', Str::replaceLast('ö', 'xxx', 'Malmö Jönköping'));
-        $this->assertEquals('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
+        $this->assertSame('Malmö Jönkxxxping', Str::replaceLast('ö', 'xxx', 'Malmö Jönköping'));
+        $this->assertSame('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
     public function testSnake()
     {
-        $this->assertEquals('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
-        $this->assertEquals('laravel_php_framework', Str::snake('LaravelPhpFramework'));
-        $this->assertEquals('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
-        $this->assertEquals('laravel_php_framework', Str::snake('Laravel Php Framework'));
-        $this->assertEquals('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
+        $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));
+        $this->assertSame('laravel_php_framework', Str::snake('LaravelPhpFramework'));
+        $this->assertSame('laravel php framework', Str::snake('LaravelPhpFramework', ' '));
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel Php Framework'));
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel    Php      Framework   '));
         // ensure cache keys don't overlap
-        $this->assertEquals('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
-        $this->assertEquals('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
-        $this->assertEquals('laravel_php_framework', Str::snake('laravel php Framework'));
-        $this->assertEquals('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+        $this->assertSame('laravel__php__framework', Str::snake('LaravelPhpFramework', '__'));
+        $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
+        $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
+        $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
     }
 
     public function testStudly()
     {
-        $this->assertEquals('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));
-        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel_php_framework'));
-        $this->assertEquals('LaravelPhPFramework', Str::studly('laravel-phP-framework'));
-        $this->assertEquals('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
+        $this->assertSame('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));
+        $this->assertSame('LaravelPhpFramework', Str::studly('laravel_php_framework'));
+        $this->assertSame('LaravelPhPFramework', Str::studly('laravel-phP-framework'));
+        $this->assertSame('LaravelPhpFramework', Str::studly('laravel  -_-  php   -_-   framework   '));
 
-        $this->assertEquals('FooBar', Str::studly('fooBar'));
-        $this->assertEquals('FooBar', Str::studly('foo_bar'));
-        $this->assertEquals('FooBar', Str::studly('foo_bar')); // test cache
-        $this->assertEquals('FooBarBaz', Str::studly('foo-barBaz'));
-        $this->assertEquals('FooBarBaz', Str::studly('foo-bar_baz'));
+        $this->assertSame('FooBar', Str::studly('fooBar'));
+        $this->assertSame('FooBar', Str::studly('foo_bar'));
+        $this->assertSame('FooBar', Str::studly('foo_bar')); // test cache
+        $this->assertSame('FooBarBaz', Str::studly('foo-barBaz'));
+        $this->assertSame('FooBarBaz', Str::studly('foo-bar_baz'));
     }
 
     public function testCamel()
     {
-        $this->assertEquals('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
-        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel_php_framework'));
-        $this->assertEquals('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
-        $this->assertEquals('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
+        $this->assertSame('laravelPHPFramework', Str::camel('Laravel_p_h_p_framework'));
+        $this->assertSame('laravelPhpFramework', Str::camel('Laravel_php_framework'));
+        $this->assertSame('laravelPhPFramework', Str::camel('Laravel-phP-framework'));
+        $this->assertSame('laravelPhpFramework', Str::camel('Laravel  -_-  php   -_-   framework   '));
 
-        $this->assertEquals('fooBar', Str::camel('FooBar'));
-        $this->assertEquals('fooBar', Str::camel('foo_bar'));
-        $this->assertEquals('fooBar', Str::camel('foo_bar')); // test cache
-        $this->assertEquals('fooBarBaz', Str::camel('Foo-barBaz'));
-        $this->assertEquals('fooBarBaz', Str::camel('foo-bar_baz'));
+        $this->assertSame('fooBar', Str::camel('FooBar'));
+        $this->assertSame('fooBar', Str::camel('foo_bar'));
+        $this->assertSame('fooBar', Str::camel('foo_bar')); // test cache
+        $this->assertSame('fooBarBaz', Str::camel('Foo-barBaz'));
+        $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
     public function testSubstr()
     {
-        $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1));
-        $this->assertEquals('ЛЁ', Str::substr('БГДЖИЛЁ', -2));
-        $this->assertEquals('И', Str::substr('БГДЖИЛЁ', -3, 1));
-        $this->assertEquals('ДЖИЛ', Str::substr('БГДЖИЛЁ', 2, -1));
+        $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1));
+        $this->assertSame('ЛЁ', Str::substr('БГДЖИЛЁ', -2));
+        $this->assertSame('И', Str::substr('БГДЖИЛЁ', -3, 1));
+        $this->assertSame('ДЖИЛ', Str::substr('БГДЖИЛЁ', 2, -1));
         $this->assertEmpty(Str::substr('БГДЖИЛЁ', 4, -4));
-        $this->assertEquals('ИЛ', Str::substr('БГДЖИЛЁ', -3, -1));
-        $this->assertEquals('ГДЖИЛЁ', Str::substr('БГДЖИЛЁ', 1));
-        $this->assertEquals('ГДЖ', Str::substr('БГДЖИЛЁ', 1, 3));
-        $this->assertEquals('БГДЖ', Str::substr('БГДЖИЛЁ', 0, 4));
-        $this->assertEquals('Ё', Str::substr('БГДЖИЛЁ', -1, 1));
+        $this->assertSame('ИЛ', Str::substr('БГДЖИЛЁ', -3, -1));
+        $this->assertSame('ГДЖИЛЁ', Str::substr('БГДЖИЛЁ', 1));
+        $this->assertSame('ГДЖ', Str::substr('БГДЖИЛЁ', 1, 3));
+        $this->assertSame('БГДЖ', Str::substr('БГДЖИЛЁ', 0, 4));
+        $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1, 1));
         $this->assertEmpty(Str::substr('Б', 2));
     }
 
     public function testUcfirst()
     {
-        $this->assertEquals('Laravel', Str::ucfirst('laravel'));
-        $this->assertEquals('Laravel framework', Str::ucfirst('laravel framework'));
-        $this->assertEquals('Мама', Str::ucfirst('мама'));
-        $this->assertEquals('Мама мыла раму', Str::ucfirst('мама мыла раму'));
+        $this->assertSame('Laravel', Str::ucfirst('laravel'));
+        $this->assertSame('Laravel framework', Str::ucfirst('laravel framework'));
+        $this->assertSame('Мама', Str::ucfirst('мама'));
+        $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
     public function testUuid()

--- a/tests/Support/SupportTappableTest.php
+++ b/tests/Support/SupportTappableTest.php
@@ -13,14 +13,14 @@ class SupportTappableTest extends TestCase
             $tappable->setName('MyName');
         })->getName();
 
-        $this->assertEquals('MyName', $name);
+        $this->assertSame('MyName', $name);
     }
 
     public function testTappableClassWithoutCallback()
     {
         $name = TappableClass::make()->tap()->setName('MyName')->getName();
 
-        $this->assertEquals('MyName', $name);
+        $this->assertSame('MyName', $name);
     }
 }
 

--- a/tests/Support/SupportViewErrorBagTest.php
+++ b/tests/Support/SupportViewErrorBagTest.php
@@ -123,6 +123,6 @@ class SupportViewErrorBagTest extends TestCase
     {
         $viewErrorBag = new ViewErrorBag;
         $viewErrorBag = $viewErrorBag->put('default', new MessageBag(['message' => 'content']));
-        $this->assertEquals('{"message":["content"]}', (string) $viewErrorBag);
+        $this->assertSame('{"message":["content"]}', (string) $viewErrorBag);
     }
 }

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -51,8 +51,8 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
         $this->assertEquals(['tree bar', 'breeze bar'], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodForNonExistingReturnsSameKey()
@@ -61,9 +61,9 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
-        $this->assertEquals('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('foo::unknown.bar', $t->get('foo::unknown.bar'));
+        $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
     }
 
     public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
@@ -79,8 +79,8 @@ class TranslationTranslatorTest extends TestCase
         $t = $this->getMockBuilder(Translator::class)->setMethods(null)->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :Foo :BAR']);
-        $this->assertEquals('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze Bar FOO', $t->get('foo::bar.baz', ['foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
@@ -88,9 +88,9 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
-        $this->assertEquals('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
-        $this->assertEquals('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
@@ -100,8 +100,8 @@ class TranslationTranslatorTest extends TestCase
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
-        $this->assertEquals('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
-        $this->assertEquals('foo', $t->get('foo::bar.foo'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
     }
 
     public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
@@ -109,7 +109,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
-        $this->assertEquals('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+        $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
     }
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
@@ -140,28 +140,28 @@ class TranslationTranslatorTest extends TestCase
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
-        $this->assertEquals('one', $t->get('foo'));
+        $this->assertSame('one', $t->get('foo'));
     }
 
     public function testGetJsonReplaces()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
-        $this->assertEquals('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
+        $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
     }
 
     public function testGetJsonReplacesForAssociativeInput()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
-        $this->assertEquals('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
+        $this->assertSame('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
     }
 
     public function testGetJsonPreservesOrder()
     {
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
-        $this->assertEquals('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+        $this->assertSame('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
@@ -169,7 +169,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
-        $this->assertEquals('one', $t->get('foo.bar'));
+        $this->assertSame('one', $t->get('foo.bar'));
     }
 
     public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
@@ -177,7 +177,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
-        $this->assertEquals('one two', $t->get('foo.bar', ['message' => 'two']));
+        $this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
     }
 
     public function testGetJsonForNonExistingReturnsSameKey()
@@ -185,7 +185,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
-        $this->assertEquals('Foo that bar', $t->get('Foo that bar'));
+        $this->assertSame('Foo that bar', $t->get('Foo that bar'));
     }
 
     public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
@@ -193,7 +193,7 @@ class TranslationTranslatorTest extends TestCase
         $t = new Translator($this->getLoader(), 'en');
         $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
         $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
-        $this->assertEquals('foo baz', $t->get('foo :message', ['message' => 'baz']));
+        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
     }
 
     protected function getLoader()

--- a/tests/Validation/ValidationDimensionsRuleTest.php
+++ b/tests/Validation/ValidationDimensionsRuleTest.php
@@ -12,22 +12,22 @@ class ValidationDimensionsRuleTest extends TestCase
     {
         $rule = new Dimensions(['min_width' => 100, 'min_height' => 100]);
 
-        $this->assertEquals('dimensions:min_width=100,min_height=100', (string) $rule);
+        $this->assertSame('dimensions:min_width=100,min_height=100', (string) $rule);
 
         $rule = Rule::dimensions()->width(200)->height(100);
 
-        $this->assertEquals('dimensions:width=200,height=100', (string) $rule);
+        $this->assertSame('dimensions:width=200,height=100', (string) $rule);
 
         $rule = Rule::dimensions()->maxWidth(1000)->maxHeight(500)->ratio(3 / 2);
 
-        $this->assertEquals('dimensions:max_width=1000,max_height=500,ratio=1.5', (string) $rule);
+        $this->assertSame('dimensions:max_width=1000,max_height=500,ratio=1.5', (string) $rule);
 
         $rule = new Dimensions(['ratio' => '2/3']);
 
-        $this->assertEquals('dimensions:ratio=2/3', (string) $rule);
+        $this->assertSame('dimensions:ratio=2/3', (string) $rule);
 
         $rule = Rule::dimensions()->minWidth(300)->minHeight(400);
 
-        $this->assertEquals('dimensions:min_width=300,min_height=400', (string) $rule);
+        $this->assertSame('dimensions:min_width=300,min_height=400', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -37,11 +37,11 @@ class ValidationExistsRuleTest extends TestCase
     {
         $rule = new Exists('table');
         $rule->where('foo', 'bar');
-        $this->assertEquals('exists:table,NULL,foo,"bar"', (string) $rule);
+        $this->assertSame('exists:table,NULL,foo,"bar"', (string) $rule);
 
         $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('exists:table,column,foo,"bar"', (string) $rule);
+        $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
     }
 
     public function testItChoosesValidRecordsUsingWhereInRule()

--- a/tests/Validation/ValidationInRuleTest.php
+++ b/tests/Validation/ValidationInRuleTest.php
@@ -13,30 +13,30 @@ class ValidationInRuleTest extends TestCase
     {
         $rule = new In(['Laravel', 'Framework', 'PHP']);
 
-        $this->assertEquals('in:"Laravel","Framework","PHP"', (string) $rule);
+        $this->assertSame('in:"Laravel","Framework","PHP"', (string) $rule);
 
         $rule = new In(['Life, the Universe and Everything', 'this is a "quote"']);
 
-        $this->assertEquals('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
+        $this->assertSame('in:"Life, the Universe and Everything","this is a ""quote"""', (string) $rule);
 
         $rule = new In(["a,b\nc,d"]);
 
-        $this->assertEquals("in:\"a,b\nc,d\"", (string) $rule);
+        $this->assertSame("in:\"a,b\nc,d\"", (string) $rule);
 
         $rule = Rule::in([1, 2, 3, 4]);
 
-        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::in(collect([1, 2, 3, 4]));
 
-        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::in(new Values);
 
-        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::in('1', '2', '3', '4');
 
-        $this->assertEquals('in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('in:"1","2","3","4"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationNotInRuleTest.php
+++ b/tests/Validation/ValidationNotInRuleTest.php
@@ -12,18 +12,18 @@ class ValidationNotInRuleTest extends TestCase
     {
         $rule = new NotIn(['Laravel', 'Framework', 'PHP']);
 
-        $this->assertEquals('not_in:"Laravel","Framework","PHP"', (string) $rule);
+        $this->assertSame('not_in:"Laravel","Framework","PHP"', (string) $rule);
 
         $rule = Rule::notIn([1, 2, 3, 4]);
 
-        $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::notIn(collect([1, 2, 3, 4]));
 
-        $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
 
         $rule = Rule::notIn('1', '2', '3', '4');
 
-        $this->assertEquals('not_in:"1","2","3","4"', (string) $rule);
+        $this->assertSame('not_in:"1","2","3","4"', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -13,20 +13,20 @@ class ValidationRequiredIfTest extends TestCase
             return true;
         });
 
-        $this->assertEquals('required', (string) $rule);
+        $this->assertSame('required', (string) $rule);
 
         $rule = new RequiredIf(function () {
             return false;
         });
 
-        $this->assertEquals('', (string) $rule);
+        $this->assertSame('', (string) $rule);
 
         $rule = new RequiredIf(true);
 
-        $this->assertEquals('required', (string) $rule);
+        $this->assertSame('required', (string) $rule);
 
         $rule = new RequiredIf(false);
 
-        $this->assertEquals('', (string) $rule);
+        $this->assertSame('', (string) $rule);
     }
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -12,40 +12,40 @@ class ValidationUniqueRuleTest extends TestCase
     {
         $rule = new Unique('table');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,NULL,NULL,id,foo,"bar"', (string) $rule);
+        $this->assertSame('unique:table,NULL,NULL,id,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
+        $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell"\'..-"', 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"', (string) $rule);
-        $this->assertEquals('Taylor, Otwell"\'..-"', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[2]));
-        $this->assertEquals('id_column', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[3]));
+        $this->assertSame('unique:table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"', (string) $rule);
+        $this->assertSame('Taylor, Otwell"\'..-"', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[2]));
+        $this->assertSame('id_column', stripslashes(str_getcsv('table,column,"Taylor, Otwell\"\\\'..-\"",id_column,foo,"bar"')[3]));
 
         $rule = new Unique('table', 'column');
         $rule->ignore(null, 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
+        $this->assertSame('unique:table,column,NULL,id_column,foo,"bar"', (string) $rule);
 
         $model = new EloquentModelStub(['id_column' => 1]);
 
         $rule = new Unique('table', 'column');
         $rule->ignore($model);
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
+        $this->assertSame('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table', 'column');
         $rule->ignore($model, 'id_column');
         $rule->where('foo', 'bar');
-        $this->assertEquals('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
+        $this->assertSame('unique:table,column,"1",id_column,foo,"bar"', (string) $rule);
 
         $rule = new Unique('table');
         $rule->where('foo', '"bar"');
-        $this->assertEquals('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
+        $this->assertSame('unique:table,NULL,NULL,id,foo,"""bar"""', (string) $rule);
     }
 }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -183,11 +183,11 @@ class ValidationValidatorTest extends TestCase
             'x' => 'string', 'y' => 'integer', 'z' => 'numeric', 'a' => 'array', 'b' => 'bool',
         ]);
         $this->assertTrue($v->fails());
-        $this->assertEquals('validation.string', $v->messages()->get('x')[0]);
-        $this->assertEquals('validation.integer', $v->messages()->get('y')[0]);
-        $this->assertEquals('validation.numeric', $v->messages()->get('z')[0]);
-        $this->assertEquals('validation.array', $v->messages()->get('a')[0]);
-        $this->assertEquals('validation.boolean', $v->messages()->get('b')[0]);
+        $this->assertSame('validation.string', $v->messages()->get('x')[0]);
+        $this->assertSame('validation.integer', $v->messages()->get('y')[0]);
+        $this->assertSame('validation.numeric', $v->messages()->get('z')[0]);
+        $this->assertSame('validation.array', $v->messages()->get('a')[0]);
+        $this->assertSame('validation.boolean', $v->messages()->get('b')[0]);
     }
 
     public function testNullableMakesNoDifferenceIfImplicitRuleExists()
@@ -209,7 +209,7 @@ class ValidationValidatorTest extends TestCase
             'y' => 'nullable|required_with:x|integer',
         ]);
         $this->assertTrue($v->fails());
-        $this->assertEquals('validation.integer', $v->messages()->get('x')[0]);
+        $this->assertSame('validation.integer', $v->messages()->get('x')[0]);
 
         $v = new Validator($trans, [
             'x' => 123, 'y' => null,
@@ -218,7 +218,7 @@ class ValidationValidatorTest extends TestCase
             'y' => 'nullable|required_with:x|integer',
         ]);
         $this->assertTrue($v->fails());
-        $this->assertEquals('validation.required_with', $v->messages()->get('y')[0]);
+        $this->assertSame('validation.required_with', $v->messages()->get('y')[0]);
     }
 
     public function testProperLanguageLineIsSet()
@@ -229,7 +229,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
 
-        $this->assertEquals('required!', $v->messages()->first('name'));
+        $this->assertSame('required!', $v->messages()->first('name'));
     }
 
     public function testCustomReplacersAreCalled()
@@ -242,7 +242,7 @@ class ValidationValidatorTest extends TestCase
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo taylor', $v->messages()->first('name'));
+        $this->assertSame('foo taylor', $v->messages()->first('name'));
     }
 
     public function testClassBasedCustomReplacers()
@@ -256,7 +256,7 @@ class ValidationValidatorTest extends TestCase
         $foo->shouldReceive('bar')->once()->andReturn('replaced!');
         $v->passes();
         $v->messages()->setFormat(':message');
-        $this->assertEquals('replaced!', $v->messages()->first('name'));
+        $this->assertSame('replaced!', $v->messages()->first('name'));
     }
 
     public function testNestedAttributesAreReplacedInDimensions()
@@ -269,14 +269,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_width=10,max_height=20,ratio=1']);
         $v->messages()->setFormat(':message');
         $this->assertTrue($v->fails());
-        $this->assertEquals('10 20 1', $v->messages()->first('x'));
+        $this->assertSame('10 20 1', $v->messages()->first('x'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.dimensions' => ':width :height :ratio'], 'en');
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:min_width=10,max_height=20,ratio=1']);
         $v->messages()->setFormat(':message');
         $this->assertTrue($v->fails());
-        $this->assertEquals(':width :height 1', $v->messages()->first('x'));
+        $this->assertSame(':width :height 1', $v->messages()->first('x'));
     }
 
     public function testAttributeNamesAreReplaced()
@@ -286,14 +286,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('name is required!', $v->messages()->first('name'));
+        $this->assertSame('name is required!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!', 'validation.attributes.name' => 'Name'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Name is required!', $v->messages()->first('name'));
+        $this->assertSame('Name is required!', $v->messages()->first('name'));
 
         //set customAttributes by setter
         $trans = $this->getIlluminateArrayTranslator();
@@ -303,7 +303,7 @@ class ValidationValidatorTest extends TestCase
         $v->addCustomAttributes($customAttributes);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Name is required!', $v->messages()->first('name'));
+        $this->assertSame('Name is required!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
@@ -311,21 +311,21 @@ class ValidationValidatorTest extends TestCase
         $v->setAttributeNames(['name' => 'Name']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Name is required!', $v->messages()->first('name'));
+        $this->assertSame('Name is required!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':Attribute is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Name is required!', $v->messages()->first('name'));
+        $this->assertSame('Name is required!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':ATTRIBUTE is required!'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('NAME is required!', $v->messages()->first('name'));
+        $this->assertSame('NAME is required!', $v->messages()->first('name'));
     }
 
     public function testAttributeNamesAreReplacedInArrays()
@@ -335,7 +335,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['users' => [['country_code' => 'US'], ['country_code' => null]]], ['users.*.country_code' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('users.1.country_code is required!', $v->messages()->first('users.1.country_code'));
+        $this->assertSame('users.1.country_code is required!', $v->messages()->first('users.1.country_code'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines([
@@ -345,7 +345,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['Jon', 2]], ['name.*' => 'string']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Any name must be a string!', $v->messages()->first('name.1'));
+        $this->assertSame('Any name must be a string!', $v->messages()->first('name.1'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.string' => ':attribute must be a string!'], 'en');
@@ -353,26 +353,26 @@ class ValidationValidatorTest extends TestCase
         $v->setAttributeNames(['name.*' => 'Any name']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Any name must be a string!', $v->messages()->first('name.1'));
+        $this->assertSame('Any name must be a string!', $v->messages()->first('name.1'));
 
         $v = new Validator($trans, ['users' => [['name' => 'Jon'], ['name' => 2]]], ['users.*.name' => 'string']);
         $v->setAttributeNames(['users.*.name' => 'Any name']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Any name must be a string!', $v->messages()->first('users.1.name'));
+        $this->assertSame('Any name must be a string!', $v->messages()->first('users.1.name'));
 
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $v = new Validator($trans, ['title' => ['nl' => '', 'en' => 'Hello']], ['title.*' => 'required'], [], ['title.nl' => 'Titel', 'title.en' => 'Title']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Titel is required!', $v->messages()->first('title.nl'));
+        $this->assertSame('Titel is required!', $v->messages()->first('title.nl'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
         $trans->addLines(['validation.attributes' => ['names.*' => 'names']], 'en');
         $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
         $v->messages()->setFormat(':message');
-        $this->assertEquals('names is required!', $v->messages()->first('names.0'));
+        $this->assertSame('names is required!', $v->messages()->first('names.0'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => ':attribute is required!'], 'en');
@@ -380,7 +380,7 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.attributes' => ['names.0' => 'First name']], 'en');
         $v = new Validator($trans, ['names' => [null, 'name']], ['names.*' => 'Required']);
         $v->messages()->setFormat(':message');
-        $this->assertEquals('First name is required!', $v->messages()->first('names.0'));
+        $this->assertSame('First name is required!', $v->messages()->first('names.0'));
     }
 
     public function testInputIsReplaced()
@@ -390,14 +390,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['email' => 'a@@s'], ['email' => 'email']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('a@@s is not a valid email', $v->messages()->first('email'));
+        $this->assertSame('a@@s is not a valid email', $v->messages()->first('email'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.email' => ':input is not a valid email'], 'en');
         $v = new Validator($trans, ['email' => null], ['email' => 'email']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals(' is not a valid email', $v->messages()->first('email'));
+        $this->assertSame(' is not a valid email', $v->messages()->first('email'));
     }
 
     public function testDisplayableValuesAreReplaced()
@@ -409,7 +409,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['color' => '1', 'bar' => ''], ['bar' => 'RequiredIf:color,1']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('The bar field is required when color is red.', $v->messages()->first('bar'));
+        $this->assertSame('The bar field is required when color is red.', $v->messages()->first('bar'));
 
         //required_if:foo,boolean
         $trans = $this->getIlluminateArrayTranslator();
@@ -418,7 +418,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['subscribe' => false, 'bar' => ''], ['bar' => 'RequiredIf:subscribe,false']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('The bar field is required when subscribe is false.', $v->messages()->first('bar'));
+        $this->assertSame('The bar field is required when subscribe is false.', $v->messages()->first('bar'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
@@ -426,7 +426,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['subscribe' => true, 'bar' => ''], ['bar' => 'RequiredIf:subscribe,true']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('The bar field is required when subscribe is true.', $v->messages()->first('bar'));
+        $this->assertSame('The bar field is required when subscribe is true.', $v->messages()->first('bar'));
 
         //required_unless:foo,bar
         $trans = $this->getIlluminateArrayTranslator();
@@ -435,7 +435,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['color' => '2', 'bar' => ''], ['bar' => 'RequiredUnless:color,1']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('The bar field is required unless color is in red.', $v->messages()->first('bar'));
+        $this->assertSame('The bar field is required unless color is in red.', $v->messages()->first('bar'));
 
         //in:foo,bar,...
         $trans = $this->getIlluminateArrayTranslator();
@@ -445,7 +445,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['type' => '4'], ['type' => 'in:5,300']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
 
         //date_equals:tomorrow
         $trans = $this->getIlluminateArrayTranslator();
@@ -454,7 +454,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['date' => date('Y-m-d')], ['date' => 'date_equals:tomorrow']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('The date must be a date equal to the day after today.', $v->messages()->first('date'));
+        $this->assertSame('The date must be a date equal to the day after today.', $v->messages()->first('date'));
 
         // test addCustomValues
         $trans = $this->getIlluminateArrayTranslator();
@@ -469,7 +469,7 @@ class ValidationValidatorTest extends TestCase
         $v->addCustomValues($customValues);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
 
         // set custom values by setter
         $trans = $this->getIlluminateArrayTranslator();
@@ -484,7 +484,7 @@ class ValidationValidatorTest extends TestCase
         $v->setValueNames($customValues);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('type must be included in Short, Long.', $v->messages()->first('type'));
+        $this->assertSame('type must be included in Short, Long.', $v->messages()->first('type'));
     }
 
     public function testDisplayableAttributesAreReplacedInCustomReplacers()
@@ -504,7 +504,7 @@ class ValidationValidatorTest extends TestCase
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Lastname needs to begin with the same letter as Firstname', $v->messages()->first('lastname'));
+        $this->assertSame('Lastname needs to begin with the same letter as Firstname', $v->messages()->first('lastname'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.alliteration' => ':attribute needs to begin with the same letter as :other'], 'en');
@@ -521,7 +521,7 @@ class ValidationValidatorTest extends TestCase
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('Lastname needs to begin with the same letter as Firstname', $v->messages()->first('lastname'));
+        $this->assertSame('Lastname needs to begin with the same letter as Firstname', $v->messages()->first('lastname'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.alliteration' => ':attribute needs to begin with the same letter as :other'], 'en');
@@ -542,7 +542,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('really required!', $v->messages()->first('name'));
+        $this->assertSame('really required!', $v->messages()->first('name'));
     }
 
     public function testCustomValidationLinesAreRespectedWithAsterisks()
@@ -567,9 +567,9 @@ class ValidationValidatorTest extends TestCase
 
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('all are really required!', $v->messages()->first('name.0'));
-        $this->assertEquals('all are really required!', $v->messages()->first('name.1'));
-        $this->assertEquals('english is required!', $v->messages()->first('lang.en'));
+        $this->assertSame('all are really required!', $v->messages()->first('name.0'));
+        $this->assertSame('all are really required!', $v->messages()->first('name.1'));
+        $this->assertSame('english is required!', $v->messages()->first('lang.en'));
     }
 
     public function testValidationDotCustomDotAnythingCanBeTranslated()
@@ -588,8 +588,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['validation' => ['custom' => ['string', 'string']]], ['validation.custom.*' => 'integer']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('should be integer!', $v->messages()->first('validation.custom.0'));
-        $this->assertEquals('should be integer!', $v->messages()->first('validation.custom.1'));
+        $this->assertSame('should be integer!', $v->messages()->first('validation.custom.0'));
+        $this->assertSame('should be integer!', $v->messages()->first('validation.custom.1'));
     }
 
     public function testInlineValidationMessagesAreRespected()
@@ -598,19 +598,19 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required'], ['name.required' => 'require it please!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('require it please!', $v->messages()->first('name'));
+        $this->assertSame('require it please!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required'], ['required' => 'require it please!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('require it please!', $v->messages()->first('name'));
+        $this->assertSame('require it please!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'foobarba'], ['name' => 'size:9'], ['size' => ['string' => ':attribute should be of length :size']]);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('name should be of length 9', $v->messages()->first('name'));
+        $this->assertSame('name should be of length 9', $v->messages()->first('name'));
     }
 
     public function testInlineValidationMessagesAreRespectedWithAsterisks()
@@ -619,8 +619,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => ['', '']], ['name.*' => 'required|max:255'], ['name.*.required' => 'all must be required!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('all must be required!', $v->messages()->first('name.0'));
-        $this->assertEquals('all must be required!', $v->messages()->first('name.1'));
+        $this->assertSame('all must be required!', $v->messages()->first('name.0'));
+        $this->assertSame('all must be required!', $v->messages()->first('name.1'));
     }
 
     public function testIfRulesAreSuccessfullyAdded()
@@ -941,7 +941,7 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.required_if' => 'The :attribute field is required when :other is :value.'], 'en');
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredIf:first,taylor,dayle']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The last field is required when first is dayle.', $v->messages()->first('last'));
+        $this->assertSame('The last field is required when first is dayle.', $v->messages()->first('last'));
     }
 
     public function testRequiredUnless()
@@ -971,7 +971,7 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.required_unless' => 'The :attribute field is required unless :other is in :values.'], 'en');
         $v = new Validator($trans, ['first' => 'dayle', 'last' => ''], ['last' => 'RequiredUnless:first,taylor,sven']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
+        $this->assertSame('The last field is required unless first is in taylor, sven.', $v->messages()->first('last'));
     }
 
     public function testFailedFileUploads()
@@ -1030,7 +1030,7 @@ class ValidationValidatorTest extends TestCase
 
         $trans->addLines(['validation.in_array' => 'The value of :attribute does not exist in :other.'], 'en');
         $v = new Validator($trans, ['foo' => [1, 2, 3], 'bar' => [1, 2]], ['foo.*' => 'in_array:bar.*']);
-        $this->assertEquals('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
+        $this->assertSame('The value of foo.2 does not exist in bar.*.', $v->messages()->first('foo.2'));
     }
 
     public function testValidateConfirmed()
@@ -1318,13 +1318,13 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.ends_with' => 'The :attribute must end with one of the following values :values'], 'en');
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'ends_with:http']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The url must end with one of the following values http', $v->messages()->first('url'));
+        $this->assertSame('The url must end with one of the following values http', $v->messages()->first('url'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.ends_with' => 'The :attribute must end with one of the following values :values'], 'en');
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'ends_with:http,https']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The url must end with one of the following values http, https', $v->messages()->first('url'));
+        $this->assertSame('The url must end with one of the following values http, https', $v->messages()->first('url'));
     }
 
     public function testValidateStartsWith()
@@ -1345,13 +1345,13 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.starts_with' => 'The :attribute must start with one of the following values :values'], 'en');
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:http']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The url must start with one of the following values http', $v->messages()->first('url'));
+        $this->assertSame('The url must start with one of the following values http', $v->messages()->first('url'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.starts_with' => 'The :attribute must start with one of the following values :values'], 'en');
         $v = new Validator($trans, ['url' => 'laravel.com'], ['url' => 'starts_with:http,https']);
         $this->assertFalse($v->passes());
-        $this->assertEquals('The url must start with one of the following values http, https', $v->messages()->first('url'));
+        $this->assertSame('The url must start with one of the following values http, https', $v->messages()->first('url'));
     }
 
     public function testValidateString()
@@ -1679,12 +1679,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['name' => '3'], ['name' => 'Numeric|Min:5']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('numeric', $v->messages()->first('name'));
+        $this->assertSame('numeric', $v->messages()->first('name'));
 
         $v = new Validator($trans, ['name' => 'asasdfadsfd'], ['name' => 'Size:2']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('string', $v->messages()->first('name'));
+        $this->assertSame('string', $v->messages()->first('name'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
@@ -1692,7 +1692,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Max:3']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('file', $v->messages()->first('photo'));
+        $this->assertSame('file', $v->messages()->first('photo'));
     }
 
     public function testValidateGtPlaceHolderIsReplacedProperly()
@@ -1720,7 +1720,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gt:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('minimum value', $v->messages()->first('max'));
+        $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
@@ -1762,7 +1762,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lt:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('maximum value', $v->messages()->first('min'));
+        $this->assertSame('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
@@ -1804,7 +1804,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['max' => 10], ['min' => 'numeric', 'max' => 'numeric|gte:min'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('minimum value', $v->messages()->first('max'));
+        $this->assertSame('minimum value', $v->messages()->first('max'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
@@ -1846,7 +1846,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['min' => 1], ['min' => 'numeric|lte:max', 'max' => 'numeric'], [], ['min' => 'minimum value', 'max' => 'maximum value']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('maximum value', $v->messages()->first('min'));
+        $this->assertSame('maximum value', $v->messages()->first('min'));
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['getSize', 'isValid'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(4072);
@@ -1980,8 +1980,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => ['foo', 'foo']], ['foo.*' => 'distinct'], ['foo.*.distinct' => 'There is a duplication!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('There is a duplication!', $v->messages()->first('foo.0'));
-        $this->assertEquals('There is a duplication!', $v->messages()->first('foo.1'));
+        $this->assertSame('There is a duplication!', $v->messages()->first('foo.0'));
+        $this->assertSame('There is a duplication!', $v->messages()->first('foo.1'));
     }
 
     public function testValidateDistinctForTopLevelArrays()
@@ -2003,8 +2003,8 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo', 'foo'], ['*' => 'distinct'], ['*.distinct' => 'There is a duplication!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('There is a duplication!', $v->messages()->first('0'));
-        $this->assertEquals('There is a duplication!', $v->messages()->first('1'));
+        $this->assertSame('There is a duplication!', $v->messages()->first('0'));
+        $this->assertSame('There is a duplication!', $v->messages()->first('1'));
     }
 
     public function testValidateUnique()
@@ -3375,7 +3375,7 @@ class ValidationValidatorTest extends TestCase
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo_bar' => 'foo!'], 'en');
@@ -3385,7 +3385,7 @@ class ValidationValidatorTest extends TestCase
         });
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
@@ -3395,7 +3395,7 @@ class ValidationValidatorTest extends TestCase
         $v->setFallbackMessages(['foo_bar' => 'foo!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
@@ -3405,7 +3405,7 @@ class ValidationValidatorTest extends TestCase
         $v->setFallbackMessages(['foo_bar' => 'foo!']);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
     }
 
     public function testClassBasedCustomValidators()
@@ -3419,7 +3419,7 @@ class ValidationValidatorTest extends TestCase
         $foo->shouldReceive('bar')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
     }
 
     public function testClassBasedCustomValidatorsUsingConventionalMethod()
@@ -3433,7 +3433,7 @@ class ValidationValidatorTest extends TestCase
         $foo->shouldReceive('validate')->once()->andReturn(false);
         $this->assertFalse($v->passes());
         $v->messages()->setFormat(':message');
-        $this->assertEquals('foo!', $v->messages()->first('name'));
+        $this->assertSame('foo!', $v->messages()->first('name'));
     }
 
     public function testCustomImplicitValidators()
@@ -4160,9 +4160,9 @@ class ValidationValidatorTest extends TestCase
     public function testGetLeadingExplicitAttributePath()
     {
         $this->assertNull(ValidationData::getLeadingExplicitAttributePath('*.email'));
-        $this->assertEquals('foo', ValidationData::getLeadingExplicitAttributePath('foo.*'));
-        $this->assertEquals('foo.bar', ValidationData::getLeadingExplicitAttributePath('foo.bar.*.baz'));
-        $this->assertEquals('foo.bar.1', ValidationData::getLeadingExplicitAttributePath('foo.bar.1'));
+        $this->assertSame('foo', ValidationData::getLeadingExplicitAttributePath('foo.*'));
+        $this->assertSame('foo.bar', ValidationData::getLeadingExplicitAttributePath('foo.bar.*.baz'));
+        $this->assertSame('foo.bar.1', ValidationData::getLeadingExplicitAttributePath('foo.bar.1'));
     }
 
     public function testExtractDataFromPath()
@@ -4344,7 +4344,7 @@ class ValidationValidatorTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals('name must be taylor', $v->errors()->all()[0]);
+        $this->assertSame('name must be taylor', $v->errors()->all()[0]);
 
         // Test passing case with Closure...
         $v = new Validator(
@@ -4371,7 +4371,7 @@ class ValidationValidatorTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals('name was adam instead of taylor', $v->errors()->all()[0]);
+        $this->assertSame('name was adam instead of taylor', $v->errors()->all()[0]);
 
         // Test complex failing case...
         $v = new Validator(
@@ -4407,9 +4407,9 @@ class ValidationValidatorTest extends TestCase
         );
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('states.0 must be AR or TX', $v->errors()->get('states.0')[0]);
-        $this->assertEquals('states.1 must be AR or TX', $v->errors()->get('states.1')[0]);
-        $this->assertEquals('number must be divisible by 4', $v->errors()->get('number')[0]);
+        $this->assertSame('states.0 must be AR or TX', $v->errors()->get('states.0')[0]);
+        $this->assertSame('states.1 must be AR or TX', $v->errors()->get('states.1')[0]);
+        $this->assertSame('number must be divisible by 4', $v->errors()->get('number')[0]);
 
         // Test array of messages with failing case...
         $v = new Validator(
@@ -4429,8 +4429,8 @@ class ValidationValidatorTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals('name must be taylor', $v->errors()->get('name')[0]);
-        $this->assertEquals('name must be a first name', $v->errors()->get('name')[1]);
+        $this->assertSame('name must be taylor', $v->errors()->get('name')[0]);
+        $this->assertSame('name must be a first name', $v->errors()->get('name')[1]);
 
         // Test array of messages with multiple rules for one attribute case...
         $v = new Validator(
@@ -4450,9 +4450,9 @@ class ValidationValidatorTest extends TestCase
         );
 
         $this->assertTrue($v->fails());
-        $this->assertEquals('name must be taylor', $v->errors()->get('name')[0]);
-        $this->assertEquals('name must be a first name', $v->errors()->get('name')[1]);
-        $this->assertEquals('validation.string', $v->errors()->get('name')[2]);
+        $this->assertSame('name must be taylor', $v->errors()->get('name')[0]);
+        $this->assertSame('name must be a first name', $v->errors()->get('name')[1]);
+        $this->assertSame('validation.string', $v->errors()->get('name')[2]);
     }
 
     public function testImplicitCustomValidationObjects()

--- a/tests/View/Blade/BladeAppendTest.php
+++ b/tests/View/Blade/BladeAppendTest.php
@@ -6,6 +6,6 @@ class BladeAppendTest extends AbstractBladeTestCase
 {
     public function testAppendSectionsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->appendSection(); ?>', $this->compiler->compileString('@append'));
+        $this->assertSame('<?php $__env->appendSection(); ?>', $this->compiler->compileString('@append'));
     }
 }

--- a/tests/View/Blade/BladeComponentFirstTest.php
+++ b/tests/View/Blade/BladeComponentFirstTest.php
@@ -6,7 +6,7 @@ class BladeComponentFirstTest extends AbstractBladeTestCase
 {
     public function testComponentFirstsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->startComponentFirst(["one", "two"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"])'));
-        $this->assertEquals('<?php $__env->startComponentFirst(["one", "two"], ["foo" => "bar"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"], ["foo" => "bar"])'));
+        $this->assertSame('<?php $__env->startComponentFirst(["one", "two"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"])'));
+        $this->assertSame('<?php $__env->startComponentFirst(["one", "two"], ["foo" => "bar"]); ?>', $this->compiler->compileString('@componentFirst(["one", "two"], ["foo" => "bar"])'));
     }
 }

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -6,23 +6,23 @@ class BladeComponentsTest extends AbstractBladeTestCase
 {
     public function testComponentsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->startComponent(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"])'));
-        $this->assertEquals('<?php $__env->startComponent(\'foo\'); ?>', $this->compiler->compileString('@component(\'foo\')'));
+        $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php $__env->startComponent(\'foo\'); ?>', $this->compiler->compileString('@component(\'foo\')'));
     }
 
     public function testEndComponentsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
+        $this->assertSame('<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
     }
 
     public function testSlotsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->slot(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@slot(\'foo\', ["foo" => "bar"])'));
-        $this->assertEquals('<?php $__env->slot(\'foo\'); ?>', $this->compiler->compileString('@slot(\'foo\')'));
+        $this->assertSame('<?php $__env->slot(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@slot(\'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php $__env->slot(\'foo\'); ?>', $this->compiler->compileString('@slot(\'foo\')'));
     }
 
     public function testEndSlotsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->endSlot(); ?>', $this->compiler->compileString('@endslot'));
+        $this->assertSame('<?php $__env->endSlot(); ?>', $this->compiler->compileString('@endslot'));
     }
 }

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -8,12 +8,12 @@ class BladeCustomTest extends AbstractBladeTestCase
 {
     public function testCustomPhpCodeIsCorrectlyHandled()
     {
-        $this->assertEquals('<?php if($test): ?> <?php @show(\'test\'); ?> <?php endif; ?>', $this->compiler->compileString("@if(\$test) <?php @show('test'); ?> @endif"));
+        $this->assertSame('<?php if($test): ?> <?php @show(\'test\'); ?> <?php endif; ?>', $this->compiler->compileString("@if(\$test) <?php @show('test'); ?> @endif"));
     }
 
     public function testMixingYieldAndEcho()
     {
-        $this->assertEquals('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(Config::get(\'site.title\')); ?>', $this->compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
+        $this->assertSame('<?php echo $__env->yieldContent(\'title\'); ?> - <?php echo e(Config::get(\'site.title\')); ?>', $this->compiler->compileString("@yield('title') - {{Config::get('site.title')}}"));
     }
 
     public function testCustomExtensionsAreCompiled()
@@ -21,7 +21,7 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->compiler->extend(function ($value) {
             return str_replace('foo', 'bar', $value);
         });
-        $this->assertEquals('bar', $this->compiler->compileString('foo'));
+        $this->assertSame('bar', $this->compiler->compileString('foo'));
     }
 
     public function testCustomStatements()

--- a/tests/View/Blade/BladeEchoTest.php
+++ b/tests/View/Blade/BladeEchoTest.php
@@ -6,59 +6,59 @@ class BladeEchoTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
-        $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!!$name!!}'));
-        $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!! $name !!}'));
-        $this->assertEquals('<?php echo $name; ?>', $this->compiler->compileString('{!!
+        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!!$name!!}'));
+        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!! $name !!}'));
+        $this->assertSame('<?php echo $name; ?>', $this->compiler->compileString('{!!
             $name
         !!}'));
 
-        $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{{$name}}}'));
-        $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{$name}}'));
-        $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{ $name }}'));
-        $this->assertEquals('<?php echo e($name); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{{$name}}}'));
+        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{$name}}'));
+        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{ $name }}'));
+        $this->assertSame('<?php echo e($name); ?>', $this->compiler->compileString('{{
             $name
         }}'));
-        $this->assertEquals("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
-        $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
-        $this->assertEquals("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
-        $this->assertEquals("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
+        $this->assertSame("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
+        $this->assertSame("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
+        $this->assertSame("<?php echo e(\$name); ?>\n\n", $this->compiler->compileString("{{ \$name }}\n"));
+        $this->assertSame("<?php echo e(\$name); ?>\r\n\r\n", $this->compiler->compileString("{{ \$name }}\r\n"));
 
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>',
+        $this->assertSame('<?php echo e("Hello world or foo"); ?>',
             $this->compiler->compileString('{{ "Hello world or foo" }}'));
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>',
+        $this->assertSame('<?php echo e("Hello world or foo"); ?>',
             $this->compiler->compileString('{{"Hello world or foo"}}'));
-        $this->assertEquals('<?php echo e($foo + $or + $baz); ?>', $this->compiler->compileString('{{$foo + $or + $baz}}'));
-        $this->assertEquals('<?php echo e("Hello world or foo"); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e($foo + $or + $baz); ?>', $this->compiler->compileString('{{$foo + $or + $baz}}'));
+        $this->assertSame('<?php echo e("Hello world or foo"); ?>', $this->compiler->compileString('{{
             "Hello world or foo"
         }}'));
 
-        $this->assertEquals('<?php echo e(\'Hello world or foo\'); ?>',
+        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>',
             $this->compiler->compileString('{{ \'Hello world or foo\' }}'));
-        $this->assertEquals('<?php echo e(\'Hello world or foo\'); ?>',
+        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>',
             $this->compiler->compileString('{{\'Hello world or foo\'}}'));
-        $this->assertEquals('<?php echo e(\'Hello world or foo\'); ?>', $this->compiler->compileString('{{
+        $this->assertSame('<?php echo e(\'Hello world or foo\'); ?>', $this->compiler->compileString('{{
             \'Hello world or foo\'
         }}'));
 
-        $this->assertEquals('<?php echo e(myfunc(\'foo or bar\')); ?>',
+        $this->assertSame('<?php echo e(myfunc(\'foo or bar\')); ?>',
             $this->compiler->compileString('{{ myfunc(\'foo or bar\') }}'));
-        $this->assertEquals('<?php echo e(myfunc("foo or bar")); ?>',
+        $this->assertSame('<?php echo e(myfunc("foo or bar")); ?>',
             $this->compiler->compileString('{{ myfunc("foo or bar") }}'));
-        $this->assertEquals('<?php echo e(myfunc("$name or \'foo\'")); ?>',
+        $this->assertSame('<?php echo e(myfunc("$name or \'foo\'")); ?>',
             $this->compiler->compileString('{{ myfunc("$name or \'foo\'") }}'));
     }
 
     public function testEscapedWithAtEchosAreCompiled()
     {
-        $this->assertEquals('{{$name}}', $this->compiler->compileString('@{{$name}}'));
-        $this->assertEquals('{{ $name }}', $this->compiler->compileString('@{{ $name }}'));
-        $this->assertEquals('{{
+        $this->assertSame('{{$name}}', $this->compiler->compileString('@{{$name}}'));
+        $this->assertSame('{{ $name }}', $this->compiler->compileString('@{{ $name }}'));
+        $this->assertSame('{{
             $name
         }}',
             $this->compiler->compileString('@{{
             $name
         }}'));
-        $this->assertEquals('{{ $name }}
+        $this->assertSame('{{ $name }}
             ',
             $this->compiler->compileString('@{{ $name }}
             '));

--- a/tests/View/Blade/BladeEndSectionsTest.php
+++ b/tests/View/Blade/BladeEndSectionsTest.php
@@ -6,6 +6,6 @@ class BladeEndSectionsTest extends AbstractBladeTestCase
 {
     public function testEndSectionsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@endsection'));
+        $this->assertSame('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@endsection'));
     }
 }

--- a/tests/View/Blade/BladeEscapedTest.php
+++ b/tests/View/Blade/BladeEscapedTest.php
@@ -6,11 +6,11 @@ class BladeEscapedTest extends AbstractBladeTestCase
 {
     public function testEscapedWithAtDirectivesAreCompiled()
     {
-        $this->assertEquals('@foreach', $this->compiler->compileString('@@foreach'));
-        $this->assertEquals('@verbatim @continue @endverbatim', $this->compiler->compileString('@@verbatim @@continue @@endverbatim'));
-        $this->assertEquals('@foreach($i as $x)', $this->compiler->compileString('@@foreach($i as $x)'));
-        $this->assertEquals('@continue @break', $this->compiler->compileString('@@continue @@break'));
-        $this->assertEquals('@foreach(
+        $this->assertSame('@foreach', $this->compiler->compileString('@@foreach'));
+        $this->assertSame('@verbatim @continue @endverbatim', $this->compiler->compileString('@@verbatim @@continue @@endverbatim'));
+        $this->assertSame('@foreach($i as $x)', $this->compiler->compileString('@@foreach($i as $x)'));
+        $this->assertSame('@continue @break', $this->compiler->compileString('@@continue @@break'));
+        $this->assertSame('@foreach(
             $i as $x
         )', $this->compiler->compileString('@@foreach(
             $i as $x

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -6,13 +6,13 @@ class BladeExpressionTest extends AbstractBladeTestCase
 {
     public function testExpressionsOnTheSameLine()
     {
-        $this->assertEquals('<?php echo app(\'translator\')->get(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->get(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
+        $this->assertSame('<?php echo app(\'translator\')->get(foo(bar(baz(qux(breeze()))))); ?> space () <?php echo app(\'translator\')->get(foo(bar)); ?>', $this->compiler->compileString('@lang(foo(bar(baz(qux(breeze()))))) space () @lang(foo(bar))'));
     }
 
     public function testExpressionWithinHTML()
     {
-        $this->assertEquals('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
-        $this->assertEquals('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
-        $this->assertEquals('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertSame('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
+        $this->assertSame('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
+        $this->assertSame('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeHelpersTest.php
+++ b/tests/View/Blade/BladeHelpersTest.php
@@ -6,10 +6,10 @@ class BladeHelpersTest extends AbstractBladeTestCase
 {
     public function testEchosAreCompiled()
     {
-        $this->assertEquals('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
-        $this->assertEquals('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
-        $this->assertEquals('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
-        $this->assertEquals('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
-        $this->assertEquals('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
+        $this->assertSame('<?php echo csrf_field(); ?>', $this->compiler->compileString('@csrf'));
+        $this->assertSame('<?php echo method_field(\'patch\'); ?>', $this->compiler->compileString("@method('patch')"));
+        $this->assertSame('<?php dd($var1); ?>', $this->compiler->compileString('@dd($var1)'));
+        $this->assertSame('<?php dd($var1, $var2); ?>', $this->compiler->compileString('@dd($var1, $var2)'));
+        $this->assertSame('<?php dump($var1, $var2); ?>', $this->compiler->compileString('@dump($var1, $var2)'));
     }
 }

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -6,31 +6,31 @@ class BladeIncludesTest extends AbstractBladeTestCase
 {
     public function testEachsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->renderEach(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@each(\'foo\', \'bar\')'));
-        $this->assertEquals('<?php echo $__env->renderEach(name(foo)); ?>', $this->compiler->compileString('@each(name(foo))'));
+        $this->assertSame('<?php echo $__env->renderEach(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@each(\'foo\', \'bar\')'));
+        $this->assertSame('<?php echo $__env->renderEach(name(foo)); ?>', $this->compiler->compileString('@each(name(foo))'));
     }
 
     public function testIncludesAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
-        $this->assertEquals('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
+        $this->assertSame('<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(\'foo\')'));
+        $this->assertSame('<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@include(name(foo))'));
     }
 
     public function testIncludeIfsAreCompiled()
     {
-        $this->assertEquals('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
-        $this->assertEquals('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
+        $this->assertSame('<?php if ($__env->exists(\'foo\')) echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(\'foo\')'));
+        $this->assertSame('<?php if ($__env->exists(name(foo))) echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeIf(name(foo))'));
     }
 
     public function testIncludeWhensAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
-        $this->assertEquals('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
+        $this->assertSame('<?php echo $__env->renderWhen(true, \'foo\', ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\', ["foo" => "bar"])'));
+        $this->assertSame('<?php echo $__env->renderWhen(true, \'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeWhen(true, \'foo\')'));
     }
 
     public function testIncludeFirstsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
-        $this->assertEquals('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
+        $this->assertSame('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
+        $this->assertSame('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
     }
 }

--- a/tests/View/Blade/BladeLangTest.php
+++ b/tests/View/Blade/BladeLangTest.php
@@ -13,7 +13,7 @@ class BladeLangTest extends AbstractBladeTestCase
 
     public function testLanguageAndChoicesAreCompiled()
     {
-        $this->assertEquals('<?php echo app(\'translator\')->get(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
-        $this->assertEquals('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));
+        $this->assertSame('<?php echo app(\'translator\')->get(\'foo\'); ?>', $this->compiler->compileString("@lang('foo')"));
+        $this->assertSame('<?php echo app(\'translator\')->choice(\'foo\', 1); ?>', $this->compiler->compileString("@choice('foo', 1)"));
     }
 }

--- a/tests/View/Blade/BladeOverwriteSectionTest.php
+++ b/tests/View/Blade/BladeOverwriteSectionTest.php
@@ -6,6 +6,6 @@ class BladeOverwriteSectionTest extends AbstractBladeTestCase
 {
     public function testOverwriteSectionsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->stopSection(true); ?>', $this->compiler->compileString('@overwrite'));
+        $this->assertSame('<?php $__env->stopSection(true); ?>', $this->compiler->compileString('@overwrite'));
     }
 }

--- a/tests/View/Blade/BladeSectionTest.php
+++ b/tests/View/Blade/BladeSectionTest.php
@@ -6,7 +6,7 @@ class BladeSectionTest extends AbstractBladeTestCase
 {
     public function testSectionStartsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->startSection(\'foo\'); ?>', $this->compiler->compileString('@section(\'foo\')'));
-        $this->assertEquals('<?php $__env->startSection(name(foo)); ?>', $this->compiler->compileString('@section(name(foo))'));
+        $this->assertSame('<?php $__env->startSection(\'foo\'); ?>', $this->compiler->compileString('@section(\'foo\')'));
+        $this->assertSame('<?php $__env->startSection(name(foo)); ?>', $this->compiler->compileString('@section(name(foo))'));
     }
 }

--- a/tests/View/Blade/BladeShowTest.php
+++ b/tests/View/Blade/BladeShowTest.php
@@ -6,6 +6,6 @@ class BladeShowTest extends AbstractBladeTestCase
 {
     public function testShowsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->yieldSection(); ?>', $this->compiler->compileString('@show'));
+        $this->assertSame('<?php echo $__env->yieldSection(); ?>', $this->compiler->compileString('@show'));
     }
 }

--- a/tests/View/Blade/BladeStopSectionTest.php
+++ b/tests/View/Blade/BladeStopSectionTest.php
@@ -6,6 +6,6 @@ class BladeStopSectionTest extends AbstractBladeTestCase
 {
     public function testStopSectionsAreCompiled()
     {
-        $this->assertEquals('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@stop'));
+        $this->assertSame('<?php $__env->stopSection(); ?>', $this->compiler->compileString('@stop'));
     }
 }

--- a/tests/View/Blade/BladeYieldTest.php
+++ b/tests/View/Blade/BladeYieldTest.php
@@ -6,8 +6,8 @@ class BladeYieldTest extends AbstractBladeTestCase
 {
     public function testYieldsAreCompiled()
     {
-        $this->assertEquals('<?php echo $__env->yieldContent(\'foo\'); ?>', $this->compiler->compileString('@yield(\'foo\')'));
-        $this->assertEquals('<?php echo $__env->yieldContent(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@yield(\'foo\', \'bar\')'));
-        $this->assertEquals('<?php echo $__env->yieldContent(name(foo)); ?>', $this->compiler->compileString('@yield(name(foo))'));
+        $this->assertSame('<?php echo $__env->yieldContent(\'foo\'); ?>', $this->compiler->compileString('@yield(\'foo\')'));
+        $this->assertSame('<?php echo $__env->yieldContent(\'foo\', \'bar\'); ?>', $this->compiler->compileString('@yield(\'foo\', \'bar\')'));
+        $this->assertSame('<?php echo $__env->yieldContent(name(foo)); ?>', $this->compiler->compileString('@yield(name(foo))'));
     }
 }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -59,14 +59,14 @@ class ViewBladeCompilerTest extends TestCase
         $files->shouldReceive('get')->once()->with('foo')->andReturn('Hello World');
         $files->shouldReceive('put')->once()->with(__DIR__.'/'.sha1('foo').'.php', 'Hello World<?php /**PATH foo ENDPATH**/ ?>');
         $compiler->compile('foo');
-        $this->assertEquals('foo', $compiler->getPath());
+        $this->assertSame('foo', $compiler->getPath());
     }
 
     public function testCompileSetAndGetThePath()
     {
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
         $compiler->setPath('foo');
-        $this->assertEquals('foo', $compiler->getPath());
+        $this->assertSame('foo', $compiler->getPath());
     }
 
     public function testCompileWithPathSetBefore()
@@ -78,7 +78,7 @@ class ViewBladeCompilerTest extends TestCase
         $compiler->setPath('foo');
         // trigger compilation with $path
         $compiler->compile();
-        $this->assertEquals('foo', $compiler->getPath());
+        $this->assertSame('foo', $compiler->getPath());
     }
 
     public function testRawTagsCanBeSetToLegacyValues()
@@ -86,9 +86,9 @@ class ViewBladeCompilerTest extends TestCase
         $compiler = new BladeCompiler($this->getFiles(), __DIR__);
         $compiler->setEchoFormat('%s');
 
-        $this->assertEquals('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
-        $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
-        $this->assertEquals('<?php echo $name; ?>', $compiler->compileString('{{
+        $this->assertSame('<?php echo e($name); ?>', $compiler->compileString('{{{ $name }}}'));
+        $this->assertSame('<?php echo $name; ?>', $compiler->compileString('{{ $name }}'));
+        $this->assertSame('<?php echo $name; ?>', $compiler->compileString('{{
             $name
         }}'));
     }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -22,7 +22,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('compile')->once()->with(__DIR__.'/fixtures/foo.php');
         $results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-        $this->assertEquals('Hello World
+        $this->assertSame('Hello World
 ', $results);
     }
 
@@ -34,7 +34,7 @@ class ViewCompilerEngineTest extends TestCase
         $engine->getCompiler()->shouldReceive('compile')->never();
         $results = $engine->get(__DIR__.'/fixtures/foo.php');
 
-        $this->assertEquals('Hello World
+        $this->assertSame('Hello World
 ', $results);
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -104,7 +104,7 @@ class ViewFactoryTest extends TestCase
 
         $result = $factory->renderEach('foo', ['bar' => 'baz', 'breeze' => 'boom'], 'value');
 
-        $this->assertEquals('daylerees', $result);
+        $this->assertSame('daylerees', $result);
     }
 
     public function testEmptyViewsCanBeReturnedFromRenderEach()
@@ -113,12 +113,12 @@ class ViewFactoryTest extends TestCase
         $factory->shouldReceive('make')->once()->with('foo')->andReturn($mockView = m::mock(stdClass::class));
         $mockView->shouldReceive('render')->once()->andReturn('empty');
 
-        $this->assertEquals('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
+        $this->assertSame('empty', $factory->renderEach('view', [], 'iterator', 'foo'));
     }
 
     public function testRawStringsMayBeReturnedFromRenderEach()
     {
-        $this->assertEquals('foo', $this->getFactory()->renderEach('foo', [], 'item', 'raw|foo'));
+        $this->assertSame('foo', $this->getFactory()->renderEach('foo', [], 'item', 'raw|foo'));
     }
 
     public function testEnvironmentAddsExtensionWithCustomResolver()
@@ -149,8 +149,8 @@ class ViewFactoryTest extends TestCase
         $factory->addExtension('foo', 'bar');
 
         $extensions = $factory->getExtensions();
-        $this->assertEquals('bar', reset($extensions));
-        $this->assertEquals('foo', key($extensions));
+        $this->assertSame('bar', reset($extensions));
+        $this->assertSame('foo', key($extensions));
     }
 
     public function testPrependedExtensionOverridesExistingExtensions()
@@ -163,8 +163,8 @@ class ViewFactoryTest extends TestCase
         $factory->addExtension('baz', 'bar');
 
         $extensions = $factory->getExtensions();
-        $this->assertEquals('bar', reset($extensions));
-        $this->assertEquals('baz', key($extensions));
+        $this->assertSame('bar', reset($extensions));
+        $this->assertSame('baz', key($extensions));
     }
 
     public function testComposersAreProperlyRegistered()
@@ -176,7 +176,7 @@ class ViewFactoryTest extends TestCase
         });
         $callback = $callback[0];
 
-        $this->assertEquals('bar', $callback());
+        $this->assertSame('bar', $callback());
     }
 
     public function testComposersCanBeMassRegistered()
@@ -209,7 +209,7 @@ class ViewFactoryTest extends TestCase
         $callback = $factory->composer('foo', 'FooComposer');
         $callback = $callback[0];
 
-        $this->assertEquals('composed', $callback('view'));
+        $this->assertSame('composed', $callback('view'));
     }
 
     public function testClassCallbacksWithMethods()
@@ -222,7 +222,7 @@ class ViewFactoryTest extends TestCase
         $callback = $factory->composer('foo', 'FooComposer@doComposer');
         $callback = $callback[0];
 
-        $this->assertEquals('composed', $callback('view'));
+        $this->assertSame('composed', $callback('view'));
     }
 
     public function testCallComposerCallsProperEvent()
@@ -255,13 +255,13 @@ class ViewFactoryTest extends TestCase
     public function testYieldDefault()
     {
         $factory = $this->getFactory();
-        $this->assertEquals('hi', $factory->yieldContent('foo', 'hi'));
+        $this->assertSame('hi', $factory->yieldContent('foo', 'hi'));
     }
 
     public function testYieldDefaultIsEscaped()
     {
         $factory = $this->getFactory();
-        $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo', '<p>hi</p>'));
+        $this->assertSame('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo', '<p>hi</p>'));
     }
 
     public function testYieldDefaultViewIsNotEscapedTwice()
@@ -269,7 +269,7 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $view = m::mock(View::class);
         $view->shouldReceive('__toString')->once()->andReturn('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;');
-        $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo', $view));
+        $this->assertSame('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo', $view));
     }
 
     public function testBasicSectionHandling()
@@ -278,21 +278,21 @@ class ViewFactoryTest extends TestCase
         $factory->startSection('foo');
         echo 'hi';
         $factory->stopSection();
-        $this->assertEquals('hi', $factory->yieldContent('foo'));
+        $this->assertSame('hi', $factory->yieldContent('foo'));
     }
 
     public function testBasicSectionDefault()
     {
         $factory = $this->getFactory();
         $factory->startSection('foo', 'hi');
-        $this->assertEquals('hi', $factory->yieldContent('foo'));
+        $this->assertSame('hi', $factory->yieldContent('foo'));
     }
 
     public function testBasicSectionDefaultIsEscaped()
     {
         $factory = $this->getFactory();
         $factory->startSection('foo', '<p>hi</p>');
-        $this->assertEquals('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo'));
+        $this->assertSame('&lt;p&gt;hi&lt;/p&gt;', $factory->yieldContent('foo'));
     }
 
     public function testBasicSectionDefaultViewIsNotEscapedTwice()
@@ -301,7 +301,7 @@ class ViewFactoryTest extends TestCase
         $view = m::mock(View::class);
         $view->shouldReceive('__toString')->once()->andReturn('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;');
         $factory->startSection('foo', $view);
-        $this->assertEquals('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo'));
+        $this->assertSame('<p>hi</p>&lt;p&gt;already escaped&lt;/p&gt;', $factory->yieldContent('foo'));
     }
 
     public function testSectionExtending()
@@ -314,7 +314,7 @@ class ViewFactoryTest extends TestCase
         $factory->startSection('foo');
         echo 'there';
         $factory->stopSection();
-        $this->assertEquals('hi there', $factory->yieldContent('foo'));
+        $this->assertSame('hi there', $factory->yieldContent('foo'));
     }
 
     public function testSectionMultipleExtending()
@@ -330,7 +330,7 @@ class ViewFactoryTest extends TestCase
         $factory->startSection('foo');
         echo 'friend';
         $factory->stopSection();
-        $this->assertEquals('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
+        $this->assertSame('hello my friend nice to see you my friend', $factory->yieldContent('foo'));
     }
 
     public function testComponentHandling()
@@ -346,7 +346,7 @@ class ViewFactoryTest extends TestCase
         $factory->endSlot();
         echo 'component';
         $contents = $factory->renderComponent();
-        $this->assertEquals('title<hr> component Taylor laravel.com', $contents);
+        $this->assertSame('title<hr> component Taylor laravel.com', $contents);
     }
 
     public function testTranslation()
@@ -360,7 +360,7 @@ class ViewFactoryTest extends TestCase
         echo 'Foo';
         $string = $factory->renderTranslation();
 
-        $this->assertEquals('Bar', $string);
+        $this->assertSame('Bar', $string);
     }
 
     public function testSingleStackPush()
@@ -369,7 +369,7 @@ class ViewFactoryTest extends TestCase
         $factory->startPush('foo');
         echo 'hi';
         $factory->stopPush();
-        $this->assertEquals('hi', $factory->yieldPushContent('foo'));
+        $this->assertSame('hi', $factory->yieldPushContent('foo'));
     }
 
     public function testMultipleStackPush()
@@ -381,7 +381,7 @@ class ViewFactoryTest extends TestCase
         $factory->startPush('foo');
         echo ', Hello!';
         $factory->stopPush();
-        $this->assertEquals('hi, Hello!', $factory->yieldPushContent('foo'));
+        $this->assertSame('hi, Hello!', $factory->yieldPushContent('foo'));
     }
 
     public function testSessionAppending()
@@ -393,7 +393,7 @@ class ViewFactoryTest extends TestCase
         $factory->startSection('foo');
         echo 'there';
         $factory->appendSection();
-        $this->assertEquals('hithere', $factory->yieldContent('foo'));
+        $this->assertSame('hithere', $factory->yieldContent('foo'));
     }
 
     public function testYieldSectionStopsAndYields()
@@ -401,14 +401,14 @@ class ViewFactoryTest extends TestCase
         $factory = $this->getFactory();
         $factory->startSection('foo');
         echo 'hi';
-        $this->assertEquals('hi', $factory->yieldSection());
+        $this->assertSame('hi', $factory->yieldSection());
     }
 
     public function testInjectStartsSectionWithContent()
     {
         $factory = $this->getFactory();
         $factory->inject('foo', 'hi');
-        $this->assertEquals('hi', $factory->yieldContent('foo'));
+        $this->assertSame('hi', $factory->yieldContent('foo'));
     }
 
     public function testEmptyStringIsReturnedForNonSections()
@@ -449,9 +449,9 @@ class ViewFactoryTest extends TestCase
         echo 'hi';
         $factory->stopSection();
 
-        $this->assertEquals('hi', $factory->getSection('foo'));
+        $this->assertSame('hi', $factory->getSection('foo'));
         $this->assertNull($factory->getSection('bar'));
-        $this->assertEquals('default', $factory->getSection('bar', 'default'));
+        $this->assertSame('default', $factory->getSection('bar', 'default'));
     }
 
     public function testMakeWithSlashAndDot()
@@ -669,7 +669,7 @@ class ViewFactoryTest extends TestCase
         $factory->macro('getFoo', function () {
             return 'Hello World';
         });
-        $this->assertEquals('Hello World', $factory->getFoo());
+        $this->assertSame('Hello World', $factory->getFoo());
     }
 
     protected function getFactory()

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -113,7 +113,7 @@ class ViewFileViewFinderTest extends TestCase
         $finder = $this->getFinder();
         $finder->addExtension('baz');
         $extensions = $finder->getExtensions();
-        $this->assertEquals('baz', reset($extensions));
+        $this->assertSame('baz', reset($extensions));
     }
 
     public function testAddingExtensionsReplacesOldOnes()

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -16,7 +16,7 @@ class ViewPhpEngineTest extends TestCase
     public function testViewsMayBeProperlyRendered()
     {
         $engine = new PhpEngine;
-        $this->assertEquals('Hello World
+        $this->assertSame('Hello World
 ', $engine->get(__DIR__.'/fixtures/basic.php'));
     }
 }

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -45,10 +45,10 @@ class ViewTest extends TestCase
 
         $callback = function (View $rendered, $contents) use ($view) {
             $this->assertEquals($view, $rendered);
-            $this->assertEquals('contents', $contents);
+            $this->assertSame('contents', $contents);
         };
 
-        $this->assertEquals('contents', $view->render($callback));
+        $this->assertSame('contents', $view->render($callback));
     }
 
     public function testRenderHandlingCallbackReturnValues()
@@ -61,7 +61,7 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender');
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering');
 
-        $this->assertEquals('new contents', $view->render(function () {
+        $this->assertSame('new contents', $view->render(function () {
             return 'new contents';
         }));
 
@@ -69,7 +69,7 @@ class ViewTest extends TestCase
             return '';
         }));
 
-        $this->assertEquals('contents', $view->render(function () {
+        $this->assertSame('contents', $view->render(function () {
             //
         }));
     }
@@ -99,8 +99,8 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender')->twice();
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering')->twice();
 
-        $this->assertEquals('contents', $view->render());
-        $this->assertEquals('contents', (string) $view);
+        $this->assertSame('contents', $view->render());
+        $this->assertSame('contents', (string) $view);
     }
 
     public function testViewNestBindsASubView()
@@ -119,7 +119,7 @@ class ViewTest extends TestCase
 
         $view = $this->getView($arrayable);
 
-        $this->assertEquals('bar', $view->foo);
+        $this->assertSame('bar', $view->foo);
         $this->assertEquals(['qux', 'corge'], $view->baz);
     }
 
@@ -192,7 +192,7 @@ class ViewTest extends TestCase
 
         $view->renderable = m::mock(Renderable::class);
         $view->renderable->shouldReceive('render')->once()->andReturn('text');
-        $this->assertEquals('contents', $view->render());
+        $this->assertSame('contents', $view->render());
     }
 
     public function testViewRenderSections()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Some string tests assertions use `asserEquals` while most of them use `assertSame`.
This PR ensure that all string assertions use a consistant assertion.

2 tests were adapted; see https://github.com/laravel/framework/commit/803b7b09cdb1ab37b7c1164ab7b766370cd3c708