### PR TITLE
[6.0] Always call parent::setUp and parent::tearDown in tests.

### DIFF
--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -17,12 +17,18 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         Carbon::setTestNow(Carbon::now());
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
 
         m::close();
         Carbon::setTestNow(null);

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -15,6 +15,9 @@ class AuthDatabaseUserProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -13,6 +13,9 @@ class AuthEloquentUserProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Auth/AuthGuardTest.php
+++ b/tests/Auth/AuthGuardTest.php
@@ -26,6 +26,9 @@ class AuthGuardTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -17,6 +17,9 @@ class AuthPasswordBrokerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -12,6 +12,9 @@ class AuthTokenGuardTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -20,6 +20,9 @@ class AuthenticateMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $container = Container::setInstance(new Container);
 
         $this->auth = new AuthManager($container);
@@ -31,6 +34,9 @@ class AuthenticateMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
         Container::setInstance(null);

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -27,6 +27,9 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->user = new stdClass;
 
         Container::setInstance($this->container = new Container);
@@ -46,6 +49,9 @@ class AuthorizeMiddlewareTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
         Container::setInstance(null);

--- a/tests/Broadcasting/BroadcastEventTest.php
+++ b/tests/Broadcasting/BroadcastEventTest.php
@@ -11,6 +11,9 @@ class BroadcastEventTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -23,11 +23,17 @@ class BroadcasterTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $this->broadcaster = new FakeBroadcaster;
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
 
         Container::setInstance(null);

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -21,6 +21,9 @@ class PusherBroadcasterTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->pusher = m::mock('Pusher\Pusher');
         $this->broadcaster = m::mock(PusherBroadcaster::class, [$this->pusher])->makePartial();
     }

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -19,11 +19,17 @@ class RedisBroadcasterTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -18,11 +18,17 @@ class UsePusherChannelConventionsTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -17,6 +17,9 @@ class BusDispatcherTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -15,6 +15,9 @@ class CacheDatabaseStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -17,6 +17,9 @@ class CacheEventsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -14,12 +14,18 @@ class CacheFileStoreTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Carbon::setTestNow(Carbon::now());
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
 
         Carbon::setTestNow(null);
     }

--- a/tests/Cache/CacheManagerTest.php
+++ b/tests/Cache/CacheManagerTest.php
@@ -11,6 +11,9 @@ class CacheManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cache/CacheMemcachedConnectorTest.php
+++ b/tests/Cache/CacheMemcachedConnectorTest.php
@@ -11,6 +11,9 @@ class CacheMemcachedConnectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cache/CacheRateLimiterTest.php
+++ b/tests/Cache/CacheRateLimiterTest.php
@@ -11,6 +11,9 @@ class CacheRateLimiterTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Cache/CacheRedisStoreTest.php
+++ b/tests/Cache/CacheRedisStoreTest.php
@@ -11,6 +11,9 @@ class CacheRedisStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -20,6 +20,9 @@ class CacheRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
         Carbon::setTestNow();
     }

--- a/tests/Cache/CacheTableCommandTest.php
+++ b/tests/Cache/CacheTableCommandTest.php
@@ -16,6 +16,9 @@ class CacheTableCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Cache/CacheTaggedCacheTest.php
+++ b/tests/Cache/CacheTaggedCacheTest.php
@@ -16,6 +16,9 @@ class CacheTaggedCacheTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Cache/ClearCommandTest.php
+++ b/tests/Cache/ClearCommandTest.php
@@ -42,6 +42,9 @@ class ClearCommandTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->cacheManager = m::mock(CacheManager::class);
         $this->files = m::mock(Filesystem::class);
         $this->cacheRepository = m::mock(Repository::class);
@@ -54,6 +57,9 @@ class ClearCommandTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -15,12 +15,18 @@ class RedisCacheIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
         $this->tearDownRedis();
         m::close();
     }

--- a/tests/Config/RepositoryTest.php
+++ b/tests/Config/RepositoryTest.php
@@ -19,6 +19,9 @@ class RepositoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->repository = new Repository($this->config = [
             'foo' => 'bar',
             'bar' => 'baz',
@@ -37,7 +40,7 @@ class RepositoryTest extends TestCase
             ],
         ]);
 
-        parent::setUp();
+
     }
 
     public function testConstruct()

--- a/tests/Console/ConsoleApplicationTest.php
+++ b/tests/Console/ConsoleApplicationTest.php
@@ -14,6 +14,9 @@ class ConsoleApplicationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -23,6 +23,9 @@ class ConsoleEventSchedulerTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $container = Container::getInstance();
 
         $container->instance(EventMutex::class, m::mock(CacheEventMutex::class));
@@ -34,6 +37,9 @@ class ConsoleEventSchedulerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -20,12 +20,18 @@ class ConsoleScheduledEventTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $this->defaultTimezone = date_default_timezone_get();
         date_default_timezone_set('UTC');
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         date_default_timezone_set($this->defaultTimezone);
         Carbon::setTestNow(null);
         m::close();

--- a/tests/Console/Scheduling/CacheEventMutexTest.php
+++ b/tests/Console/Scheduling/CacheEventMutexTest.php
@@ -35,6 +35,9 @@ class CacheEventMutexTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $this->cacheFactory = m::mock(Factory::class);
         $this->cacheRepository = m::mock(Repository::class);
         $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);

--- a/tests/Console/Scheduling/CacheSchedulingMutexTest.php
+++ b/tests/Console/Scheduling/CacheSchedulingMutexTest.php
@@ -42,6 +42,9 @@ class CacheSchedulingMutexTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->cacheFactory = m::mock(Factory::class);
         $this->cacheRepository = m::mock(Repository::class);
         $this->cacheFactory->shouldReceive('store')->andReturn($this->cacheRepository);

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -11,6 +11,9 @@ class EventTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -16,6 +16,9 @@ class FrequencyTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->event = new Event(
             m::mock(EventMutex::class),
             'php foo'

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -13,6 +13,9 @@ class ContainerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         Container::setInstance(null);
     }
 

--- a/tests/Cookie/CookieTest.php
+++ b/tests/Cookie/CookieTest.php
@@ -11,6 +11,9 @@ class CookieTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -30,6 +30,9 @@ class EncryptCookiesTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $container = new Container;
         $container->singleton(EncrypterContract::class, function () {
             return new Encrypter(str_repeat('a', 16));

--- a/tests/Database/DatabaseConnectionFactoryTest.php
+++ b/tests/Database/DatabaseConnectionFactoryTest.php
@@ -17,6 +17,9 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->db = new DB;
 
         $this->db->addConnection([
@@ -43,6 +46,9 @@ class DatabaseConnectionFactoryTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -27,6 +27,9 @@ class DatabaseConnectionTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -15,6 +15,9 @@ class DatabaseConnectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -11,6 +11,9 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -71,6 +74,9 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -10,6 +10,9 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -57,6 +60,9 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $this->schema()->drop('users');
         $this->schema()->drop('articles');
         $this->schema()->drop('article_user');

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -12,6 +12,9 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -17,6 +17,9 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -25,6 +25,9 @@ class DatabaseEloquentBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentCollectionQueueableTest.php
+++ b/tests/Database/DatabaseEloquentCollectionQueueableTest.php
@@ -12,6 +12,9 @@ class DatabaseEloquentCollectionQueueableTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Mockery::close();
     }
 

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -13,6 +13,9 @@ class DatabaseEloquentCollectionTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -15,6 +15,9 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         tap(new DB)->addConnection([
             'driver'    => 'sqlite',
             'database'  => ':memory:',
@@ -23,6 +26,9 @@ class DatabaseEloquentGlobalScopesTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
         Model::unsetConnectionResolver();

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -14,6 +14,9 @@ class DatabaseEloquentHasManyTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -13,6 +13,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -66,6 +69,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('countries');

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -21,6 +21,9 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -12,6 +12,9 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -65,6 +68,9 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema()->drop('users');
         $this->schema()->drop('contracts');
         $this->schema()->drop('positions');

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -32,6 +32,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -132,6 +135,9 @@ class DatabaseEloquentIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->drop('users');
             $this->schema($connection)->drop('friends');

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -17,6 +17,9 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -68,6 +71,9 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('users');
             $this->schema($connection)->drop('friends');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -11,6 +11,9 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -55,6 +58,9 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema()->drop('irregular_plural_tokens');
         $this->schema()->drop('irregular_plural_humans');
         $this->schema()->drop('irregular_plural_human_irregular_plural_token');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -38,12 +38,18 @@ class DatabaseEloquentModelTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         Carbon::setTestNow(Carbon::now());
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
 
         m::close();
         Carbon::setTestNow(null);

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -15,6 +15,9 @@ class DatabaseEloquentMorphTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Relation::morphMap([], false);
 
         m::close();

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -12,6 +12,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -16,6 +16,9 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -11,6 +11,9 @@ class DatabaseEloquentPivotTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -10,6 +10,9 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -68,6 +71,9 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $this->schema()->drop('users');
         $this->schema()->drop('posts');
         $this->schema()->drop('comments');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -16,6 +16,9 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -60,6 +63,9 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         foreach (['default'] as $connection) {
             $this->schema($connection)->drop('posts');
             $this->schema($connection)->drop('images');

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -16,6 +16,9 @@ class DatabaseEloquentRelationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -16,6 +16,9 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         Carbon::setTestNow(Carbon::now());
 
         $db = new DB;
@@ -87,6 +90,9 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         Carbon::setTestNow(null);
 
         $this->schema()->drop('users');

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -11,6 +11,9 @@ class DatabaseEloquentTimestampsTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -58,6 +61,9 @@ class DatabaseEloquentTimestampsTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema()->drop('users');
         $this->schema()->drop('users_created_at');
         $this->schema()->drop('users_updated_at');

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -12,6 +12,9 @@ class DatabaseMigrationCreatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -14,6 +14,9 @@ class DatabaseMigrationInstallCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationMakeCommandTest.php
+++ b/tests/Database/DatabaseMigrationMakeCommandTest.php
@@ -15,6 +15,9 @@ class DatabaseMigrationMakeCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -14,6 +14,9 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -17,6 +17,9 @@ class DatabaseMigrationRefreshCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRepositoryTest.php
+++ b/tests/Database/DatabaseMigrationRepositoryTest.php
@@ -15,6 +15,9 @@ class DatabaseMigrationRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -14,6 +14,9 @@ class DatabaseMigrationResetCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -14,6 +14,9 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -25,6 +25,9 @@ class DatabaseMigratorIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->db = $db = new DB;
 
         $db->addConnection([
@@ -57,6 +60,9 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -13,6 +13,9 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -12,6 +12,9 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseProcessorTest.php
+++ b/tests/Database/DatabaseProcessorTest.php
@@ -13,6 +13,9 @@ class DatabaseProcessorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -27,6 +27,9 @@ class DatabaseQueryBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -15,6 +15,9 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -23,6 +23,9 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->db = $db = new DB;
 
         $db->addConnection([
@@ -39,6 +42,9 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -15,6 +15,9 @@ class DatabaseSchemaBlueprintTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -18,6 +18,9 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->db = $db = new DB;
 
         $db->addConnection([
@@ -34,6 +37,9 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
     }

--- a/tests/Database/DatabaseSchemaBuilderTest.php
+++ b/tests/Database/DatabaseSchemaBuilderTest.php
@@ -12,6 +12,9 @@ class DatabaseSchemaBuilderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -30,6 +30,9 @@ class DatabaseSeederTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSoftDeletingScopeTest.php
+++ b/tests/Database/DatabaseSoftDeletingScopeTest.php
@@ -17,6 +17,9 @@ class DatabaseSoftDeletingScopeTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -11,6 +11,9 @@ class DatabaseSoftDeletingTraitTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -12,6 +12,9 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -47,6 +47,9 @@ class SeedCommandTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 }

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -16,6 +16,9 @@ class EventsDispatcherTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -18,12 +18,18 @@ class FilesystemAdapterTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->tempDir = __DIR__.'/tmp';
         $this->filesystem = new Filesystem(new Local($this->tempDir));
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $filesystem = new Filesystem(new Local(dirname($this->tempDir)));
         $filesystem->deleteDir(basename($this->tempDir));
     }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -16,12 +16,18 @@ class FilesystemTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $this->tempDir = __DIR__.'/tmp';
         mkdir($this->tempDir);
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
 
         $files = new Filesystem;

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -11,6 +11,9 @@ class LoadEnvironmentVariablesTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -15,6 +15,9 @@ class FoundationApplicationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationAuthenticationTest.php
+++ b/tests/Foundation/FoundationAuthenticationTest.php
@@ -51,6 +51,9 @@ class FoundationAuthenticationTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -14,6 +14,9 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Container::setInstance(null);
     }
 

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -10,6 +10,9 @@ class FoundationEnvironmentDetectorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -38,6 +38,9 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->config = m::mock(Config::class);
 
         $this->request = m::mock(stdClass::class);
@@ -60,6 +63,9 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
         Container::setInstance(null);

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -23,6 +23,9 @@ class FoundationFormRequestTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
         $this->mocks = [];

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -15,6 +15,9 @@ class FoundationHelpersTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -22,11 +22,17 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->connection = m::mock(Connection::class);
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -15,6 +15,9 @@ class FoundationProviderRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -29,6 +29,9 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         if (is_null($this->files)) {
             $this->files = new Filesystem;
         }
@@ -41,6 +44,9 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $this->files->deleteDirectory($this->storagePath);
 
         m::close();

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -17,6 +17,9 @@ class HttpRedirectResponseTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -16,6 +16,9 @@ class HttpRequestTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Http/HttpResponseTest.php
+++ b/tests/Http/HttpResponseTest.php
@@ -24,6 +24,9 @@ class HttpResponseTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -44,6 +44,9 @@ class AuthenticationTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -15,6 +15,9 @@ class DynamoDbStoreTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         if (! isset($_ENV['DYNAMODB_CACHE_TABLE'])) {
             $this->markTestSkipped('DynamoDB not configured.');
         }

--- a/tests/Integration/Cache/MemcachedIntegrationTest.php
+++ b/tests/Integration/Cache/MemcachedIntegrationTest.php
@@ -14,6 +14,9 @@ abstract class MemcachedIntegrationTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         if (! extension_loaded('memcached')) {
             $this->markTestSkipped('Memcached module not installed');
         }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -19,12 +19,18 @@ class RedisCacheLockTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
 
         $this->tearDownRedis();
     }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -13,6 +13,9 @@ class ConsoleApplicationTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->app[Kernel::class]->registerCommand(new FooCommandStub);
     }
 

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -23,6 +23,9 @@ class EventPingTest extends TestCase
     {
         parent::tearDown();
 
+       
+
+
         m::close();
     }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -22,6 +22,9 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('uuid');

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -17,6 +17,9 @@ class EloquentBelongsToTest extends DatabaseTestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('slug')->nullable();

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -15,6 +15,9 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -19,6 +19,9 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('some_default_value');

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -17,6 +17,9 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -16,6 +16,9 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -31,6 +31,9 @@ class EloquentDeleteTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -108,6 +108,9 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -18,6 +18,9 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('slug')->nullable();

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -17,6 +17,9 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('one', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -36,6 +36,9 @@ class EloquentModelConnectionsTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('parent', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -17,6 +17,9 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -17,6 +17,9 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
             $table->date('date_field')->nullable();

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -16,6 +16,9 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
             $table->decimal('decimal_field_2', 8, 2)->nullable();

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -18,6 +18,9 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('json_casts', function (Blueprint $table) {
             $table->increments('id');
             $table->json('basic_string_as_json_field')->nullable();

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -17,6 +17,9 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('base_models', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -17,6 +17,9 @@ class EloquentModelLoadMissingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -17,6 +17,9 @@ class EloquentModelRefreshTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -15,6 +15,9 @@ class EloquentModelStringCastingTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -51,6 +54,9 @@ class EloquentModelStringCastingTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $this->schema()->drop('casting_table');
     }
 

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -17,6 +17,9 @@ class EloquentModelTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
             $table->timestamp('nullable_date')->nullable();

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -17,6 +17,9 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -18,6 +18,9 @@ class EloquentMorphManyTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -18,6 +18,9 @@ class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->softDeletes();

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -17,6 +17,9 @@ class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -16,6 +16,9 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -17,6 +17,9 @@ class EloquentMorphToTouchesTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -16,6 +16,9 @@ class EloquentPaginateTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -16,6 +16,9 @@ class EloquentPivotEventsTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -19,6 +19,9 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -15,6 +15,9 @@ class EloquentPushTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -18,6 +18,9 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -31,6 +31,9 @@ class EloquentUpdateTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('test_model1', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->nullable();

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -19,6 +19,9 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -16,6 +16,9 @@ class EloquentWhereHasTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -15,6 +15,9 @@ class EloquentWhereTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -16,6 +16,9 @@ class EloquentWithCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('one', function (Blueprint $table) {
             $table->increments('id');
         });

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -15,6 +15,9 @@ class MigrateWithRealpathTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         $options = [
             '--path' => realpath(__DIR__.'/stubs/'),
             '--realpath' => true,

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -18,6 +18,9 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -40,6 +40,9 @@ class EventFakeTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
@@ -55,9 +58,12 @@ class EventFakeTest extends TestCase
      */
     protected function tearDown(): void
     {
+
+
         Schema::dropIfExists('posts');
 
         parent::tearDown();
+
     }
 
     public function testNonFakedEventGetsProperlyDispatched()

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -28,6 +28,9 @@ class InteractsWithAuthenticationTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
+++ b/tests/Integration/Http/Middleware/VerifyCsrfTokenExceptTest.php
@@ -15,6 +15,9 @@ class VerifyCsrfTokenExceptTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->stub = new VerifyCsrfTokenExceptStub(app(), new Encrypter(Encrypter::generateKey('AES-128-CBC')));
         $this->request = Request::create('http://example.com/foo/bar', 'POST');
     }

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -17,6 +17,9 @@ class ThrottleRequestsTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
         Carbon::setTestNow(null);
     }
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -19,6 +19,9 @@ class ThrottleRequestsWithRedisTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
         Carbon::setTestNow(null);
     }
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -22,6 +22,9 @@ class SendingMailWithLocaleTest extends TestCase
     {
         parent::tearDown();
 
+
+
+
         m::close();
     }
 
@@ -49,6 +52,9 @@ class SendingMailWithLocaleTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+
+
     }
 
     public function testMailIsSentWithDefaultLocale()

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -28,6 +28,9 @@ class SendingMailNotificationsTest extends TestCase
     {
         parent::tearDown();
 
+       
+
+
         m::close();
     }
 
@@ -58,6 +61,9 @@ class SendingMailNotificationsTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
 
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -58,6 +58,9 @@ class SendingNotificationsWithLocaleTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -22,6 +22,9 @@ class CallQueuedHandlerTest extends TestCase
     {
         parent::tearDown();
 
+       
+
+
         m::close();
     }
 

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -31,6 +31,9 @@ class JobChainingTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -39,6 +39,9 @@ class ModelSerializationTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -17,6 +17,9 @@ class ValidatorTest extends DatabaseTestCase
     {
         parent::setUp();
 
+       
+
+
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
             $table->string('first_name');

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -15,6 +15,9 @@ class LogLoggerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -20,6 +20,9 @@ class MailMailerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -11,6 +11,9 @@ class MailMarkdownTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -24,12 +24,18 @@ class MailMessageTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->swift = m::mock(Swift_Mime_Message::class);
         $this->message = new Message($this->swift);
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -21,6 +21,9 @@ class MailableQueuedTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -15,6 +15,9 @@ class NotificationBroadcastChannelTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationChannelManagerTest.php
+++ b/tests/Notifications/NotificationChannelManagerTest.php
@@ -20,6 +20,9 @@ class NotificationChannelManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
 
         Container::setInstance(null);

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -12,6 +12,9 @@ class NotificationDatabaseChannelTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -13,6 +13,9 @@ class NotificationRoutesNotificationsTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
 
         Container::setInstance(null);

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -11,6 +11,9 @@ class NotificationSendQueuedNotificationTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -19,6 +19,9 @@ class NotificationSenderTest extends TestCase
     {
         parent::tearDown();
 
+       
+
+
         m::close();
     }
 

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -19,12 +19,18 @@ class LengthAwarePaginatorTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->options = ['onEachSide' => 5];
         $this->p = new LengthAwarePaginator($array = ['item1', 'item2', 'item3', 'item4'], 4, 2, 2, $this->options);
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         unset($this->p);
     }
 

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -16,6 +16,9 @@ class DynamoDbFailedJobProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Queue/QueueBeanstalkdJobTest.php
+++ b/tests/Queue/QueueBeanstalkdJobTest.php
@@ -17,6 +17,9 @@ class QueueBeanstalkdJobTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -14,6 +14,9 @@ class QueueBeanstalkdQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -29,6 +29,9 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $db = new DB;
 
         $db->addConnection([
@@ -97,6 +100,9 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         $this->schema()->drop('jobs');
     }
 

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -14,6 +14,9 @@ class QueueDatabaseQueueUnitTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Queue/QueueListenerTest.php
+++ b/tests/Queue/QueueListenerTest.php
@@ -12,6 +12,9 @@ class QueueListenerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -12,6 +12,9 @@ class QueueManagerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -13,6 +13,9 @@ class QueueRedisJobTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -14,6 +14,9 @@ class QueueRedisQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueSqsJobTest.php
+++ b/tests/Queue/QueueSqsJobTest.php
@@ -14,6 +14,9 @@ class QueueSqsJobTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->key = 'AMAZONSQSKEY';
         $this->secret = 'AmAz0n+SqSsEcReT+aLpHaNuM3R1CsTr1nG';
         $this->service = 'sqs';
@@ -52,6 +55,9 @@ class QueueSqsJobTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -15,11 +15,17 @@ class QueueSqsQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         // Use Mockery to mock the SqsClient
         $this->sqs = m::mock(SqsClient::class);
 

--- a/tests/Queue/QueueSyncQueueTest.php
+++ b/tests/Queue/QueueSyncQueueTest.php
@@ -15,6 +15,9 @@ class QueueSyncQueueTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
 
         Container::setInstance(null);

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -25,6 +25,9 @@ class QueueWorkerTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->events = m::spy(Dispatcher::class);
         $this->exceptionHandler = m::spy(ExceptionHandler::class);
 
@@ -36,6 +39,9 @@ class QueueWorkerTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         Container::setInstance(null);
     }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -22,15 +22,21 @@ class RedisQueueIntegrationTest extends TestCase
 
     protected function setUp(): void
     {
-        Carbon::setTestNow(Carbon::now());
         parent::setUp();
+
+       
+        Carbon::setTestNow(Carbon::now());
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
-        Carbon::setTestNow(null);
         parent::tearDown();
+
+       
+        Carbon::setTestNow(null);
+
         $this->tearDownRedis();
         m::close();
     }

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -19,12 +19,18 @@ class ConcurrentLimiterTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
 
         $this->tearDownRedis();
     }

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -19,12 +19,18 @@ class DurationLimiterTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $this->setUpRedis();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+
+
 
         $this->tearDownRedis();
     }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -17,6 +17,9 @@ class RedisConnectionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
         $this->setUpRedis();
 
         if (! isset($this->redis['phpredis'])) {
@@ -31,6 +34,9 @@ class RedisConnectionTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
 
         $this->tearDownRedis();
 

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -21,6 +21,9 @@ class RedisManagerExtensionTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->redis = new RedisManager(new Application(), 'my_custom_driver', [
             'default' => [
                 'host' => 'some-host',
@@ -47,6 +50,9 @@ class RedisManagerExtensionTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -18,6 +18,9 @@ class RouteCollectionTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->routeCollection = new RouteCollection;
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -21,11 +21,17 @@ class RouteRegistrarTest extends TestCase
     {
         parent::setUp();
 
+       
+
+
         $this->router = new Router(m::mock(Dispatcher::class), Container::getInstance());
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -21,6 +21,9 @@ class RoutingRedirectorTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $this->headers = m::mock(HeaderBag::class);
 
         $this->request = m::mock(Request::class);
@@ -47,6 +50,9 @@ class RoutingRedirectorTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Session/EncryptedSessionStoreTest.php
+++ b/tests/Session/EncryptedSessionStoreTest.php
@@ -13,6 +13,9 @@ class EncryptedSessionStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -16,6 +16,9 @@ class SessionStoreTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Session/SessionTableCommandTest.php
+++ b/tests/Session/SessionTableCommandTest.php
@@ -16,6 +16,9 @@ class SessionTableCommandTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -17,6 +17,9 @@ class DateFacadeTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
         DateFactory::use(Carbon::class);
     }
 

--- a/tests/Support/SupportCapsuleManagerTraitTest.php
+++ b/tests/Support/SupportCapsuleManagerTraitTest.php
@@ -15,6 +15,9 @@ class SupportCapsuleManagerTraitTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -20,15 +20,21 @@ class SupportCarbonTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         Carbon::setTestNow($this->now = Carbon::create(2017, 6, 27, 13, 14, 15, 'UTC'));
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         Carbon::setTestNow();
         Carbon::serializeUsing(null);
 
-        parent::tearDown();
+
     }
 
     public function testInstance()

--- a/tests/Support/SupportComposerTest.php
+++ b/tests/Support/SupportComposerTest.php
@@ -12,6 +12,9 @@ class SupportComposerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/SupportFacadeTest.php
+++ b/tests/Support/SupportFacadeTest.php
@@ -13,12 +13,18 @@ class SupportFacadeTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         Facade::clearResolvedInstances();
         FacadeStub::setFacadeApplication(null);
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -19,6 +19,9 @@ class SupportFacadesEventTest extends TestCase
     {
         parent::setUp();
 
+
+
+
         $this->events = m::spy(Dispatcher::class);
 
         $container = new Container;
@@ -29,6 +32,9 @@ class SupportFacadesEventTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         Event::clearResolvedInstances();
 
         m::close();

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -15,6 +15,9 @@ class SupportHelpersTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -11,6 +11,9 @@ class SupportMacroableTest extends TestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         $this->macroable = $this->createObjectForTrait();
     }
 

--- a/tests/Support/SupportMessageBagTest.php
+++ b/tests/Support/SupportMessageBagTest.php
@@ -11,6 +11,9 @@ class SupportMessageBagTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/SupportServiceProviderTest.php
+++ b/tests/Support/SupportServiceProviderTest.php
@@ -11,6 +11,9 @@ class SupportServiceProviderTest extends TestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
+
+       
         ServiceProvider::$publishes = [];
         ServiceProvider::$publishGroups = [];
 
@@ -23,6 +26,9 @@ class SupportServiceProviderTest extends TestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -17,12 +17,18 @@ class SupportTestingBusFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
         $this->fake = new BusFake(m::mock(Dispatcher::class));
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
+
+       
+
         m::close();
     }
 

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -14,6 +14,9 @@ class SupportTestingEventFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
         $this->fake = new EventFake(m::mock(Dispatcher::class));
     }
 

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -26,6 +26,9 @@ class SupportTestingMailFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
         $this->fake = new MailFake;
         $this->mailable = new MailableStub;
     }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -30,6 +30,9 @@ class SupportTestingNotificationFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+
+
         $this->fake = new NotificationFake;
         $this->notification = new NotificationStub;
         $this->user = new UserStub;

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -25,6 +25,9 @@ class SupportTestingQueueFakeTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+       
+
         $this->fake = new QueueFake(new Application);
         $this->job = new JobStub;
     }

--- a/tests/Translation/TranslationFileLoaderTest.php
+++ b/tests/Translation/TranslationFileLoaderTest.php
@@ -11,6 +11,9 @@ class TranslationFileLoaderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Translation/TranslationTranslatorTest.php
+++ b/tests/Translation/TranslationTranslatorTest.php
@@ -13,6 +13,9 @@ class TranslationTranslatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -13,6 +13,9 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -20,6 +20,9 @@ class ValidationExistsRuleTest extends TestCase
      */
     protected function setUp(): void
     {
+        parent::setUp();
+
+
         $db = new DB;
 
         $db->addConnection([
@@ -161,6 +164,9 @@ class ValidationExistsRuleTest extends TestCase
      */
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         $this->schema('default')->drop('users');
     }
 

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -13,6 +13,9 @@ class ValidationFactoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -28,6 +28,9 @@ class ValidationValidatorTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         Carbon::setTestNow();
         m::close();
     }

--- a/tests/View/Blade/AbstractBladeTestCase.php
+++ b/tests/View/Blade/AbstractBladeTestCase.php
@@ -16,15 +16,21 @@ abstract class AbstractBladeTestCase extends TestCase
 
     protected function setUp(): void
     {
-        $this->compiler = new BladeCompiler($this->getFiles(), __DIR__);
         parent::setUp();
+
+       
+        $this->compiler = new BladeCompiler($this->getFiles(), __DIR__);
+
     }
 
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
 
-        parent::tearDown();
+
     }
 
     protected function getFiles()

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -12,6 +12,9 @@ class ViewBladeCompilerTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -11,6 +11,9 @@ class ViewCompilerEngineTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -25,6 +25,9 @@ class ViewFactoryTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -12,6 +12,9 @@ class ViewFileViewFinderTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -10,6 +10,9 @@ class ViewPhpEngineTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+
         m::close();
     }
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -18,6 +18,9 @@ class ViewTest extends TestCase
 {
     protected function tearDown(): void
     {
+        parent::tearDown();
+
+       
         m::close();
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Always call `parent::setUp` and `parent::tearDown` in tests.
This is a best practice and particularly useful if the framework tests classes want to extend a different TestCase.