### PR TITLE
[5.8] Fix self-referencing MorphOneOrMany existence queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -91,7 +91,7 @@ abstract class MorphOneOrMany extends HasOneOrMany
     public function getRelationExistenceQuery(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
         return parent::getRelationExistenceQuery($query, $parentQuery, $columns)->where(
-            $this->morphType, $this->morphClass
+            $query->qualifyColumn($this->getMorphType()), $this->morphClass
         );
     }
 

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -43,6 +43,19 @@ class EloquentMorphManyTest extends DatabaseTestCase
 
         $this->assertEquals('new name', $post->title);
     }
+
+    public function test_self_referencing_existence_query()
+    {
+        $post = Post::create(['title' => 'foo']);
+
+        $comment = tap((new Comment(['name' => 'foo']))->commentable()->associate($post))->save();
+
+        (new Comment(['name' => 'bar']))->commentable()->associate($comment)->save();
+
+        $comments = Comment::has('replies')->get();
+
+        $this->assertEquals([1], $comments->pluck('id')->all());
+    }
 }
 
 class Post extends Model
@@ -67,5 +80,10 @@ class Comment extends Model
     public function commentable()
     {
         return $this->morphTo();
+    }
+
+    public function replies()
+    {
+        return $this->morphMany(self::class, 'commentable');
     }
 }


### PR DESCRIPTION
Self-referencing existence queries of `MorphOneOrMany` relationships are incorrect:

```php
class Comment extends Model
{
    public function replies()
    {
        return $this->morphMany(self::class, 'commentable');
    }
}

Comment::has('replies')->get();
```

```sql
# expected
select * from `comments` where exists (
  select * from `comments` as `laravel_reserved_0`
  where `comments`.`id` = `laravel_reserved_0`.`commentable_id`
  and `laravel_reserved_0`.`commentable_type` = ?
)

# actual
select * from `comments` where exists (
  select * from `comments` as `laravel_reserved_0`
  where `comments`.`id` = `laravel_reserved_0`.`commentable_id`
  and `comments`.`commentable_type` = ?
)      ^^^^^^^^
```
