### PR TITLE
[5.8] Fix MorphTo::associate() with custom owner key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -197,9 +197,11 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
-        $this->parent->setAttribute(
-            $this->foreignKey, $model instanceof Model ? $model->getKey() : null
-        );
+        $key = $model instanceof Model
+                ? ($this->ownerKey ? $model->{$this->ownerKey} : $model->getKey())
+                : null;
+
+        $this->parent->setAttribute($this->foreignKey, $key);
 
         $this->parent->setAttribute(
             $this->morphType, $model instanceof Model ? $model->getMorphClass() : null

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -112,7 +112,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation = $this->getRelationAssociate($parent);
 
         $associate = m::mock(Model::class);
-        $associate->shouldReceive('getKey')->once()->andReturn(1);
+        $associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
         $associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);


### PR DESCRIPTION
`MorphTo::associate()` doesn't consider a custom owner key and always uses the primary key:

```php
class Comment extends Model
{
    public function commentable()
    {
        return $this->morphTo(null, null, null, 'slug');
    }
}

$post = Post::create(['slug' => 'foo']);

$comment = (new Comment)->commentable()->associate($post);

dump($comment->commentable_id);

// expected: "foo"
// actual:   1
```