### PR TITLE
[5.8] Verify a user when successfully reset his password

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -106,6 +106,10 @@ trait ResetsPasswords
 
         $user->setRememberToken(Str::random(60));
 
+        if (is_null($user->email_verified_at)) {
+            $user->email_verified_at = now();
+        }
+
         $user->save();
 
         event(new PasswordReset($user));

--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
@@ -108,6 +109,8 @@ trait ResetsPasswords
 
         if (is_null($user->email_verified_at)) {
             $user->email_verified_at = now();
+
+            event(new Verified($user));
         }
 
         $user->save();


### PR DESCRIPTION
> Many web applications require users to verify their email addresses before using the application. Rather than forcing you to re-implement this on each application, Laravel provides convenient methods for sending and verifying email verification requests.

### To problem
When a new user with an **unverified email address** reset his password and get to a route with `verified` middleware, he should not be asked again to verify his email. We already verified he is who he is by a **password reset email**, asking to verify his email again is a bummer.

### To reproduce
1. Create a new Laravel project and setup database and email
2. Generate the auth scaffolding and setup email verification
3. Apply `verified` middleware to the `home` route
4. Signup an account don't verify the email for now
5. Reset the password for the account
6. After you provide the new password visit the `home` route

You will see you will be asked to verify the email address even though you have just reset your password through email.

What do you think guys? @taylorotwell @driesvints @themsaid 

