### PR TITLE
[6.0] Restore the exception's messages

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/401.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/401.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Unauthorized'))
 @section('code', '401')
-@section('message', __('Unauthorized'))
+@section('message', __($exception->getMessage() ?: 'Unauthorized'))

--- a/src/Illuminate/Foundation/Exceptions/views/404.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/404.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Not Found'))
 @section('code', '404')
-@section('message', __('Not Found'))
+@section('message', __($exception->getMessage() ?: 'Not Found'))

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Page Expired'))
 @section('code', '419')
-@section('message', __('Page Expired'))
+@section('message', __($exception->getMessage() ?: 'Page Expired'))

--- a/src/Illuminate/Foundation/Exceptions/views/429.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/429.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Too Many Requests'))
 @section('code', '429')
-@section('message', __('Too Many Requests'))
+@section('message', __($exception->getMessage() ?: 'Too Many Requests'))

--- a/src/Illuminate/Foundation/Exceptions/views/500.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/500.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Server Error'))
 @section('code', '500')
-@section('message', __('Server Error'))
+@section('message', __($exception->getMessage() ?: 'Server Error'))


### PR DESCRIPTION
This PR resolves #29774 

By adding the same behavior as the `403.blade.php` and the `503.blade.php` in the following files : 

- `401.blade.php`
- `404.blade.php`
- `419.blade.php`
- `429.blade.php`
- `500.blade.php`

The goal is to have the same behavior for the `abort()` method
