### PR TITLE
[5.8] Mailer user-provided callbacks wrong timings

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -239,8 +239,6 @@ class Mailer implements MailerContract, MailQueueContract
         // Once we have retrieved the view content for the e-mail we will set the body
         // of this message using the HTML type, which will provide a simple wrapper
         // to creating view based emails that are able to receive arrays of data.
-        call_user_func($callback, $message);
-
         $this->addContent($message, $view, $plain, $raw, $data);
 
         // If a global "to" address has been set, we will set that address on the mail
@@ -249,6 +247,10 @@ class Mailer implements MailerContract, MailQueueContract
         if (isset($this->to['address'])) {
             $this->setGlobalToAndRemoveCcAndBcc($message);
         }
+
+        // Execute any user-defined callbacks in order to allow the user to
+        // make any custom changes to the message object
+        call_user_func($callback, $message);
 
         // Next we will determine if the message should be sent. We give the developer
         // one final chance to stop this message and then we will send it to all of


### PR DESCRIPTION
The documentation states that `withSwiftMessage()` allows us to change the SwiftMailer message object right before it is sent. That method registers a callback in the Mailer that should be executed right before sending the message. However since Laravel 5.6 that is not the case. The problem is that the user makes some changes to the message object and then Laravel overwrites them.

This PR will give more freedom to the user and allow them to modify the message object right before it is sent in a way that suits them.
