### PR TITLE
[6.0] Fix replaceRouteParameters() for query-string parameters

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -197,9 +197,16 @@ class RouteUrlGenerator
         $path = $this->replaceNamedParameters($path, $parameters);
 
         $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+            // Reset numeric keys on $parameters so we can
+            // get the first non-associative element
+            // using Arr::pull($parameters, 0)
+            $parameters = array_merge($parameters);
+
             return (empty($parameters) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
-                        : array_shift($parameters);
+                        // Use only non-associative elements, so we don't
+                        // replace parameters that were meant for query string.
+                        : Arr::pull($parameters, 0);
         }, $path);
 
         return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -197,6 +197,12 @@ class RoutingUrlGeneratorTest extends TestCase
         $routes->add($route);
 
         /*
+         * Optional parameter
+         */
+        $route = new Route(['GET'], 'foo/bar/{baz?}', ['as' => 'optional']);
+        $routes->add($route);
+
+        /*
          * HTTPS...
          */
         $route = new Route(['GET'], 'foo/baz', ['as' => 'baz', 'https']);
@@ -251,6 +257,13 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/invoke', $url->action('InvokableActionStub'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor?wall=woz', $url->route('optional', ['wall' => 'woz', 'taylor']));
+        $this->assertSame('http://www.foo.com/foo/bar/taylor?wall=woz&breeze', $url->route('optional', ['wall' => 'woz', 'breeze', 'baz' => 'taylor']));
+        $this->assertSame('http://www.foo.com/foo/bar?wall=woz', $url->route('optional', ['wall' => 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar/%C3%A5%CE%B1%D1%84/%C3%A5%CE%B1%D1%84', $url->route('foobarbaz', ['baz' => 'åαф']));
         $this->assertSame('/foo/bar#derp', $url->route('fragment', [], false));
         $this->assertSame('/foo/bar?foo=bar#derp', $url->route('fragment', ['foo' => 'bar'], false));


### PR DESCRIPTION
I am working on a search-engine application. It has routes that use optional route-parameters in combination with query-string parameters.

One of my routes looks like this

    Route::get('/profiles/{location?}', 'ProfileController@index')->name('profiles.index');

The URL-strings for search-results pages may look something like these:

- `http://homestead.local/profiles/London?age=30`
- `http://homestead.local/profiles?status[0]=single&status[1]=married`

The last one searches for profiles in any location whose statuses are either 'single' or 'married'.

In my controller, I wanted to redirect to a route using given query-string parameters. For example, if I wanted to redirect to the 2nd example from above, I might have attempted something like this:

    return redirect()->route('profiles.index', ['status' => ['single', 'married']]);

Doing so resulted in an _"Array to string conversion"_ ErrorException.

I noticed `replaceRouteParameters()` in `Illuminate/Routing/RouteUrlGenerator` uses `array_shift($parameters)` to pull the first element from the `$parameters` array and put it in place of the optional `location` route parameter. This breaks when the first element is an array.

In the example above, the intention was not to use the `location` parameter at all. The given parameters were meant to be used as the query-string.

A workaround was to explicitly specify an empty `location` like this:

    return redirect()->route('profiles.index', ['status' => ['single', 'married'], 'location' => '']);

In the pull-request I've made changes to `replaceRouteParameters()` such that it better accommodates query-string parameters.

It should work with combinations of query-string and route parameters. It assumes that any associative elements in `$parameters` that haven't already been filtered in `replaceNamedParameters()` are referring to query-string parameters and should not be used for route-parameter replacement.

I've used `Arr::pull($parameters, 0)` instead of `array_shift($parameters)` to pull the first non-associative element. Arr::pull does not reset the array keys, so I've used `$parameters = array_merge($parameters)` to reset the numeric keys before each replacement.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
