### PR TITLE
[5.8] Create MySQL Table with Comment

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -67,10 +67,14 @@ class MySqlGrammar extends Grammar
             $sql, $connection, $blueprint
         );
 
-        // Finally, we will append the engine configuration onto this SQL statement as
-        // the final thing we do before returning this finished SQL. Once this gets
-        // added the query will be ready to execute against the real connections.
-        return $this->compileCreateEngine(
+        // Next, we will append the engine configuration onto this SQL statement. Once this
+        // gets added the query will be ready to execute against the real connections.
+        $sql = $this->compileCreateEngine(
+            $sql, $connection, $blueprint
+        );
+
+        // Lastly, we check to see if a the blueprint has a comment and append it.
+        return $this->compileCreateComment(
             $sql, $connection, $blueprint
         );
     }
@@ -137,6 +141,23 @@ class MySqlGrammar extends Grammar
             return $sql.' engine = '.$blueprint->engine;
         } elseif (! is_null($engine = $connection->getConfig('engine'))) {
             return $sql.' engine = '.$engine;
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Append a table comment to the command.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @return string
+     */
+    protected function compileCreateComment($sql, Connection $connection, Blueprint $blueprint)
+    {
+        if (isset($blueprint->comment)) {
+            return $sql.' comment \''.addslashes($blueprint->comment).'\'';
         }
 
         return $sql;

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -112,6 +112,24 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) character set utf8mb4 collate 'utf8mb4_unicode_ci' not null) default character set utf8 collate 'utf8_unicode_ci'", $statements[0]);
     }
 
+    public function testCommentCreateTable()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->create();
+        $blueprint->increments('id');
+        $blueprint->string('email');
+        $blueprint->comment = 'Stores users\' emails';
+
+        $conn = $this->getConnection();
+        $conn->shouldReceive('getConfig')->once()->with('charset')->andReturnNull();
+        $conn->shouldReceive('getConfig')->once()->with('collation')->andReturnNull();
+        $conn->shouldReceive('getConfig')->once()->with('engine')->andReturnNull();
+        $statements = $blueprint->toSql($conn, $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertEquals("create table `users` (`id` int unsigned not null auto_increment primary key, `email` varchar(255) not null) comment 'Stores users\\' emails'", $statements[0]);
+    }
+
     public function testBasicCreateTableWithPrefix()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
The MySQL Schema Grammar appends the charset, collation, and engine. I would like to propose the ability to also append a Table comment. 

The benefit of this is that it allows developers to provide some type of documentation on new tables. Traditionally for larger teams, database administration was managed by a DBA's and both developer and DBA would collaborate on the schema changes so there was a transfer of knowledge in that discussion. With Laravel's migrations, developers are able rapidly develop applications however, this can leave the Database team in the dark on the purpose. With the ability to add a comment to a table, we're able to better document our systems for developers and others alike.
