### PR TITLE
[5.8] adding pipe each method on collection

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3194,6 +3194,41 @@ class SupportCollectionTest extends TestCase
         $collection = new Collection([1, 2, 3]);
         $this->assertNull($collection->get(null));
     }
+
+    public function testPipeEach()
+    {
+        $collection = new Collection([1,2]);
+        $numbers = $collection->pipeEach([
+            function ($i) {
+                return $i + 1;
+            },
+            function ($i) {
+                return $i * 3;
+            }
+        ]);
+        $this->assertInstanceOf(Collection::class, $numbers);
+        $this->assertEquals(6, $numbers[0]);
+        $this->assertEquals(9, $numbers[1]);
+    }
+
+    public function testPipeEachWithExceptionHandling()
+    {
+        $collection = new Collection([1,2]);
+        $numbers = $collection->pipeEach([
+            function ($i) {
+                return $i + 1;
+            },
+            function ($i) {
+                throw new \Exception('test');
+            }
+        ], function ($exception, $originalElement) {
+            $this->assertEquals('test', $exception->getMessage());
+            $this->assertTrue($originalElement == 1 || $originalElement == 2);
+        });
+        $this->assertInstanceOf(Collection::class, $numbers);
+        $this->assertEquals(2, $numbers[0]);
+        $this->assertEquals(3, $numbers[1]);
+    }
 }
 
 class TestSupportCollectionHigherOrderItem


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adding the pipeEach method on the Collection, a versatile way to pass a collection of elements through a pipeline of callables.

It accepts as a second optional argument, an exception handler applied to each collection element.

The third argument, breakOnError, defines if the pipeline will stop on the first error for each collection element.

Each callable can return the modified received element. If a callable does not return anything, the element received is passed to the next callable as is.