### PR TITLE
[5.8] Support 'NOT RLIKE' SQL operator

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -182,7 +182,7 @@ class Builder
         '=', '<', '>', '<=', '>=', '<>', '!=', '<=>',
         'like', 'like binary', 'not like', 'ilike',
         '&', '|', '^', '<<', '>>',
-        'rlike', 'regexp', 'not regexp',
+        'rlike', 'not rlike', 'regexp', 'not regexp',
         '~', '~*', '!~', '!~*', 'similar to',
         'not similar to', 'not ilike', '~~*', '!~~*',
     ];


### PR DESCRIPTION
Currently, `RLIKE` is a supported operator. This PR adds the `NOT RLIKE` operator to the collection similar to `NOT LIKE` and `NOT REGEXP`.

This operator, like `RLIKE`, is not supported by PostgreSQL but MySQL, MariaDB etc.