### PR TITLE
[6.0] Remove rackspace from suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,6 @@
         "laravel/tinker": "Required to use the tinker console command (^1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
-        "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",


### PR DESCRIPTION
Rackspace driver has been removed from v6