### PR TITLE
[6.0] Allow to use custom response when using Route Model Binding

### DIFF
--- a/src/Illuminate/Contracts/Routing/Registrar.php
+++ b/src/Illuminate/Contracts/Routing/Registrar.php
@@ -102,4 +102,11 @@ interface Registrar
      * @return void
      */
     public function substituteImplicitBindings($route);
+
+    /**
+     * Get response from route model binding.
+     *
+     * @return \Symfony\Component\HttpFoundation\Response|null
+     */
+    public function bindingsResponse();
 }

--- a/src/Illuminate/Routing/Middleware/SubstituteBindings.php
+++ b/src/Illuminate/Routing/Middleware/SubstituteBindings.php
@@ -36,6 +36,10 @@ class SubstituteBindings
     {
         $this->router->substituteBindings($route = $request->route());
 
+        if ($response = $this->router->bindingsResponse()) {
+            return $response;
+        }
+
         $this->router->substituteImplicitBindings($route);
 
         return $next($request);

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -119,6 +119,13 @@ class Router implements BindingRegistrar, RegistrarContract
     public static $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 
     /**
+     * Response from route model binding.
+     *
+     * @var \Symfony\Component\HttpFoundation\Response|null
+     */
+    protected $bindingsResponse = null;
+
+    /**
      * Create a new Router instance.
      *
      * @param  \Illuminate\Contracts\Events\Dispatcher  $events
@@ -767,11 +774,38 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         foreach ($route->parameters() as $key => $value) {
             if (isset($this->binders[$key])) {
-                $route->setParameter($key, $this->performBinding($key, $value, $route));
+                $bound = $this->performBinding($key, $value, $route);
+
+                if ($bound instanceof SymfonyResponse) {
+                    $this->setBindingsResponse($bound);
+                    break;
+                }
+
+                $route->setParameter($key, $bound);
             }
         }
 
         return $route;
+    }
+
+    /**
+     * Set response from route model binding.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     */
+    protected function setBindingsResponse(SymfonyResponse $response)
+    {
+        $this->bindingsResponse = $response;
+    }
+
+    /**
+     * Get response from route model binding.
+     *
+     * @return \Symfony\Component\HttpFoundation\Response|null
+     */
+    public function bindingsResponse()
+    {
+        return $this->bindingsResponse;
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -802,6 +802,24 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
     }
 
+    public function testRouteBindingWithCustomResponse()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+            return $name;
+        }]);
+
+        $router->bind('bar', function ($value) {
+            return new JsonResponse(['name' => strtolower($value)], 201);
+        });
+
+        $response = $router->dispatch(Request::create('foo/TAYLOR', 'GET'));
+
+        $this->assertSame('{"name":"taylor"}', $response->getContent());
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
At the moment when using route model binding you can basically return model or use helper like `abort` in case model is not found. However sometimes it's useful to use other response (especially redirection) when you want to redirect user to some other part of app (useful when moving old app to Laravel and want to use urls scheme).

In current Laravel app as far as I know it's much more complicated than this but doable if you return fake model and then create custom middleware that verifies whether model exists and then handle response. However in this way it would be much easier to achieve and it would be much easier to understand what is going on.