### PR TITLE
[6.0] Return object instead of undefined constant

### DIFF
--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -204,7 +204,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
             } elseif (isset($config['table'])) {
                 return $this->databaseFailedJobProvider($config);
             } else {
-                return NullFailedJobProvider;
+                return new NullFailedJobProvider;
             }
         });
     }


### PR DESCRIPTION
Bug was introduced here: https://github.com/laravel/framework/pull/29748/files#diff-2d0eb4713c33f8d4045f517245def58eL201 in #29748 