### PR TITLE
[7.x] Services and discovery cache files are exclusive to Laravel

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -184,13 +184,6 @@ interface Application extends Container
     public function environmentFilePath();
 
     /**
-     * Get the path to the cached packages.php file.
-     *
-     * @return string
-     */
-    public function getCachedPackagesPath();
-
-    /**
      * Get the current application locale.
      *
      * @return string


### PR DESCRIPTION
Based on laravel/ideas#1772 

`getCachedServicesPath()` and `getCachedPackagesPath()` only being used
in `Illuminate\Foundation\ComposerScripts` and
`Illuminate\Foundation\Console\ClearCompiledCommand`.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
