### PR TITLE
[6.0] Added support for console command argument and option validation

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Validation\Factory;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -201,6 +201,8 @@ class Command extends SymfonyCommand
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -209,6 +211,8 @@ class Command extends SymfonyCommand
         }
 
         $this->displayValidationErrors();
+
+        return 1;
     }
 
     /**
@@ -266,8 +270,6 @@ class Command extends SymfonyCommand
         foreach ($this->validator->errors()->all() as $error) {
             $this->error($error);
         }
-
-        exit(1);
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -72,14 +72,14 @@ class Command extends SymfonyCommand
     /**
      * The rules used to validate console command input.
      *
-     * @var array
+     * @var array|null
      */
     protected $rules;
 
     /**
      * The command input validator.
      *
-     * @var Validator
+     * @var \Illuminate\Contracts\Validation\Validator|null
      */
     protected $validator;
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -215,16 +215,17 @@ class Command extends SymfonyCommand
     /**
      * Check the argument and option values are valid.
      *
-     * @param  \Illuminate\Contracts\Validation\Factory  $factory
      * @return bool
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function hasValidInput(Factory $factory = null)
+    protected function hasValidInput()
     {
         if (! isset($this->rules)) {
             return true;
         }
 
-        $this->validator = $this->validator ?? $factory->make(
+        $this->validator = $this->validator ?? $this->laravel->make(Validator::class)->make(
             array_merge($this->arguments(), $this->options()),
             $this->rules,
             $this->messages(),


### PR DESCRIPTION
This PR is in reference to https://github.com/laravel/ideas/issues/1773, requesting argument and option validation for console commands.

## Problem
Currently there is no way to validate command argument / option input. For example, if one of your arguments is supposed to be an email but is in fact a plain string, you will need to manually create a Validator and check it.

This results in messy logic inside of the command `handle()` method, but can be replaced with some cleaner validation behind the scenes.

## Solution
Instead of manually creating a Validator and checking if it fails, I have decided to wrap the call in the `execute()` method with a condition, only allowing the command to run if the validation passes.

If the validation does not pass, it will automatically report the error messages and terminate the process. This rules can be defined through a protected `$rules` property on the class, custom errors messages and attributes can also be defined through a protected `messages()` and `attributes()` method which should return an array.

There are no breaking changes involved, as the `execute()` method still calls the `handle()` method, even if no rules have been set.