### PR TITLE
[6.x] Let the logger be macroable

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -6,12 +6,17 @@ use Closure;
 use RuntimeException;
 use Psr\Log\LoggerInterface;
 use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Support\Arrayable;
 
 class Logger implements LoggerInterface
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The underlying logger implementation.
      *
@@ -270,6 +275,10 @@ class Logger implements LoggerInterface
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->logger->{$method}(...$parameters);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Sometimes we want to be able to handle repetitive logging operations in a more effective way: this PR allows the `Logger` to be `macroable`.

