### PR TITLE
[5.8] Revert "Fix MorphTo::associate() with custom owner key"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -197,11 +197,9 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
-        $key = $model instanceof Model
-                ? ($this->ownerKey ? $model->{$this->ownerKey} : $model->getKey())
-                : null;
-
-        $this->parent->setAttribute($this->foreignKey, $key);
+        $this->parent->setAttribute(
+            $this->foreignKey, $model instanceof Model ? $model->getKey() : null
+        );
 
         $this->parent->setAttribute(
             $this->morphType, $model instanceof Model ? $model->getMorphClass() : null

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -112,7 +112,7 @@ class DatabaseEloquentMorphToTest extends TestCase
         $relation = $this->getRelationAssociate($parent);
 
         $associate = m::mock(Model::class);
-        $associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $associate->shouldReceive('getKey')->once()->andReturn(1);
         $associate->shouldReceive('getMorphClass')->once()->andReturn('Model');
 
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);


### PR DESCRIPTION
We have to revert #29767, it breaks certain use cases (https://github.com/laravel/framework/pull/29767#issuecomment-526570107).

There's apparently no other way to fix the bug.