### PR TITLE
[5.8] Added warning when not renaming the Redis facade

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -66,7 +66,7 @@ class PhpRedisConnector implements Connector
     protected function createClient(array $config)
     {
         return tap(new Redis, function ($client) use ($config) {
-            
+
             if ($client instanceof RedisFacade) {
                 throw new LogicException(
                     'Rename or delete the "Redis" Facade to avoid collision with the underlaying Redis client class.'

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -7,8 +7,8 @@ use RedisCluster;
 use LogicException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Redis\Connector;
-use Illuminate\Support\Facades\Redis as RedisFacade;
 use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Support\Facades\Redis as RedisFacade;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 
 class PhpRedisConnector implements Connector
@@ -72,7 +72,7 @@ class PhpRedisConnector implements Connector
                     'Rename or delete the "Redis" Facade to avoid collision with the underlaying Redis client class.'
                 );
             }
-            
+
             $this->establishConnection($client, $config);
 
             if (! empty($config['password'])) {

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -66,7 +66,6 @@ class PhpRedisConnector implements Connector
     protected function createClient(array $config)
     {
         return tap(new Redis, function ($client) use ($config) {
-
             if ($client instanceof RedisFacade) {
                 throw new LogicException(
                     'Rename or delete the "Redis" Facade to avoid collision with the underlaying Redis client class.'

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -4,8 +4,10 @@ namespace Illuminate\Redis\Connectors;
 
 use Redis;
 use RedisCluster;
+use LogicException;
 use Illuminate\Support\Arr;
 use Illuminate\Contracts\Redis\Connector;
+use Illuminate\Support\Facades\Redis as RedisFacade;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 
@@ -64,6 +66,13 @@ class PhpRedisConnector implements Connector
     protected function createClient(array $config)
     {
         return tap(new Redis, function ($client) use ($config) {
+            
+            if ($client instanceof RedisFacade) {
+                throw new LogicException(
+                    'Rename or delete the "Redis" Facade to avoid collision with the underlaying Redis client class.'
+                );
+            }
+            
             $this->establishConnection($client, $config);
 
             if (! empty($config['password'])) {


### PR DESCRIPTION
When using `phpredis` as the driver, and the Redis Facade is aliased, the connector will create a new Facade instance instead of the expected Redis Client instance.

With this patch, if the Facade is detected, a more friendly exception will be thrown telling the developer to rename the Facade to avoid collisions with the expected class.

Doesn't fix #29806, but a workaround to avoid breaking changes.