### PR TITLE
[6.0] Use new UUID Factory

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidFactory;
 use Illuminate\Support\Traits\Macroable;
 use Ramsey\Uuid\Generator\CombGenerator;
 use Ramsey\Uuid\Codec\TimestampFirstCombCodec;
@@ -588,7 +589,7 @@ class Str
             return call_user_func(static::$uuidFactory);
         }
 
-        $factory = Uuid::getFactory();
+        $factory = new UuidFactory();
 
         $factory->setRandomGenerator(new CombGenerator(
             $factory->getRandomGenerator(),


### PR DESCRIPTION
The Uuid::getFactory() always returns the same factory instance, so when you modify that instance, it applies for all future UUID factory (also the non-ordered) (see https://github.com/ramsey/uuid/blob/f30bc1af81b1fdf5dec5ae085eb3ac2c59c32fe7/src/Uuid.php#L604-L611). I think it is probably better to create a new instance each time (or cache your own time-based factory separately in performance might be a concern).

I think this change is introduced here, but don't know the exact context/requirements: https://github.com/laravel/framework/commit/2e9db3129b78ef961b183d7b8453975f243c76b7#diff-d19e1b0b8c742f268aabdbf1595bcfbd

I'm not sure WHY, but that commit does seem to cause issues with at least the Telescope tests, see https://github.com/laravel/telescope/pull/712#issuecomment-526533257
This PR fixes the tests in my local setup (just clone laravel/telescope, require laravel 6.0, run tests)