### PR TITLE
[6.0] Universal `collect()`

### DIFF
--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -887,6 +887,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function countBy($callback = null);
 
     /**
+     * Collect the values into a collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect();
+
+    /**
      * Convert the collection to its string representation.
      *
      * @return string

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -100,16 +100,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Collect the values into a collection.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function collect()
-    {
-        return new Collection($this->all());
-    }
-
-    /**
      * Get the average value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -7,6 +7,7 @@ use Traversable;
 use CachingIterator;
 use JsonSerializable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Contracts\Support\Jsonable;
 use Symfony\Component\VarDumper\VarDumper;
@@ -672,6 +673,16 @@ trait EnumeratesValues
     public function uniqueStrict($key = null)
     {
         return $this->unique($key, true);
+    }
+
+    /**
+     * Collect the values into a collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function collect()
+    {
+        return new Collection($this->all());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3909,6 +3909,26 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCollect($collection)
+    {
+        $data = $collection::make([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ])->collect();
+
+        $this->assertInstanceOf(Collection::class, $data);
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ], $data->all());
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -67,23 +67,6 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testCollect()
-    {
-        $data = LazyCollection::make(function () {
-            yield 'a' => 1;
-            yield 'b' => 2;
-            yield 'c' => 3;
-        })->collect();
-
-        $this->assertInstanceOf(Collection::class, $data);
-
-        $this->assertSame([
-            'a' => 1,
-            'b' => 2,
-            'c' => 3,
-        ], $data->all());
-    }
-
     public function testTapEach()
     {
         $data = LazyCollection::times(10);


### PR DESCRIPTION
Add a `collect()` method to the standard collection, the same way we have it on the `LazyCollection`.

On its own, it doesn't really look that useful, but it's necessary for when all you have is an `Enumerable`, and you want to ascertain that you;re working with a collection (similar to .net's [`.ToList()`](https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tolist?view=netframework-4.8)).

```php
function foo(Enumerable $collection)
{
    $collection = $collection->collect();

    // Now you can be sure you're dealing with an eager collection
}

foo(collect(1, 2, 3));
```