### PR TITLE
[6.0] Fix incorrect HTTP OPTION verb

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -295,31 +295,31 @@ trait MakesHttpRequests
     }
 
     /**
-     * Visit the given URI with a OPTION request.
+     * Visit the given URI with a OPTIONS request.
      *
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function option($uri, array $data = [], array $headers = [])
+    public function options($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
 
-        return $this->call('OPTION', $uri, $data, [], [], $server);
+        return $this->call('OPTIONS', $uri, $data, [], [], $server);
     }
 
     /**
-     * Visit the given URI with a OPTION request, expecting a JSON response.
+     * Visit the given URI with a OPTIONS request, expecting a JSON response.
      *
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function optionJson($uri, array $data = [], array $headers = [])
+    public function optionsJson($uri, array $data = [], array $headers = [])
     {
-        return $this->json('OPTION', $uri, $data, $headers);
+        return $this->json('OPTIONS', $uri, $data, $headers);
     }
 
     /**


### PR DESCRIPTION
Hey there,

As I was testing a new app I'm working on, I stumbled across the `option` and `optionJson` methods in `Illuminate\Foundation\Testing\Concerns\MakesHttpRequests`. I had weird exceptions so I decided to dig a little.

I believe a mistake was introduced in #29258 because the HTTP `OPTION` method does not exist but the `OPTIONS` one does.

For reference : https://tools.ietf.org/html/rfc7231#section-4