### PR TITLE
[6.x] Add an `eager()` method to the lazy collection class

### DIFF
--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -100,12 +100,11 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Cache all values by enumerating the collection
-     * into a new lazy collection backed by an array.
+     * Eager load all items into a new lazy collection backed by an array.
      *
      * @return static
      */
-    public function cache()
+    public function eager()
     {
         return new static($this->all());
     }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -100,6 +100,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Cache all values by enumerating the collection
+     * into a new lazy collection backed by an array.
+     *
+     * @return static
+     */
+    public function cache()
+    {
+        return new static($this->all());
+    }
+
+    /**
      * Get the average value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -8,10 +8,10 @@ use Illuminate\Support\LazyCollection;
 
 class SupportLazyCollectionIsLazyTest extends TestCase
 {
-    public function testCacheEnumeratesOnce()
+    public function testEagerEnumeratesOnce()
     {
         $this->assertEnumeratesOnce(function ($collection) {
-            $collection = $collection->cache();
+            $collection = $collection->eager();
 
             $collection->count();
             $collection->all();

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -8,6 +8,16 @@ use Illuminate\Support\LazyCollection;
 
 class SupportLazyCollectionIsLazyTest extends TestCase
 {
+    public function testCacheEnumeratesOnce()
+    {
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection = $collection->cache();
+
+            $collection->count();
+            $collection->all();
+        });
+    }
+
     public function testChunkIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -67,6 +67,19 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testCache()
+    {
+        $source = [1, 2, 3, 4, 5];
+
+        $data = LazyCollection::make(function () use (&$source) {
+            yield from $source;
+        })->cache();
+
+        $source[] = 6;
+
+        $this->assertSame([1, 2, 3, 4, 5], $data->all());
+    }
+
     public function testTapEach()
     {
         $data = LazyCollection::times(10);

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -67,13 +67,13 @@ class SupportLazyCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testCache()
+    public function testEager()
     {
         $source = [1, 2, 3, 4, 5];
 
         $data = LazyCollection::make(function () use (&$source) {
             yield from $source;
-        })->cache();
+        })->eager();
 
         $source[] = 6;
 


### PR DESCRIPTION
The `eager()` method enumerates all of the lazy collection's values, and constructs a new `LazyCollection` instance, which will now be backed by an array:

```php
$users = User::cursor();

$users = $users->eager();

$count = $users->count();

$users->each(function ($user) {
    //
});
```

The above will only fetch the users once. Without calling `eager` in between, the query would execute (and fetch all results) twice.

This is a pretty useless example, but is a clear illustration of what the `eager` method does.