### PR TITLE
[6.x] Tweak symfony suggest blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,8 +130,8 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^3.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^4.3).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.1).",
+        "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },
     "config": {

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -33,7 +33,7 @@
         "illuminate/database": "Required to use the database cache driver (^6.0).",
         "illuminate/filesystem": "Required to use the file cache driver (^6.0).",
         "illuminate/redis": "Required to use the redis cache driver (^6.0).",
-        "symfony/cache": "Required to PSR-6 cache bridge (^4.3)."
+        "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -39,7 +39,7 @@
     },
     "suggest": {
         "illuminate/console": "Required to use the make commands (^6.0).",
-        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.1)."
+        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.2)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Some of the existing suggests were `^4.3.4`, but some `^4.3`. We should probably unify them all.