### PR TITLE
[6.x] Update and rename CHANGELOG-6.0.md to CHANGELOG-6.x.md

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,4 +1,4 @@
-# Release Notes for 6.0.x
+# Release Notes for 6.x
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v6.0.0...6.x)
 


### PR DESCRIPTION
I think it makes more sense to maintain a Laravel "6" changelog. I guess we could name the file `CHANGELOG-6.md` or `CHANGELOG-6.x.md`. Not sure.