### PR TITLE
[5.8] support for array callables as pipes

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -66,11 +66,12 @@ class Pipeline implements PipelineContract
     /**
      * Set the array of pipes.
      *
-     * @param  array|mixed  $pipes
+     * @param  callable|array|string  $pipes
      * @return $this
      */
     public function through($pipes)
     {
+        $pipes = is_callable($pipes) ? [$pipes] : $pipes;
         $this->pipes = is_array($pipes) ? $pipes : func_get_args();
 
         return $this;


### PR DESCRIPTION
This bring support for all the php callables to be accepted as pipes.
Previous PRs to add tests for pipe are made to make sure that this change is not going to break the current functionality and is fully additive.

This makes the pipeline component sweeter specially when used outside of laravel or when used within the application code.