### PR TITLE
[6.x] Remove confusing identation

### DIFF
--- a/src/Illuminate/Database/Grammar.php
+++ b/src/Illuminate/Database/Grammar.php
@@ -83,9 +83,7 @@ abstract class Grammar
             $segments[1] = $this->tablePrefix.$segments[1];
         }
 
-        return $this->wrap(
-            $segments[0]).' as '.$this->wrapValue($segments[1]
-        );
+        return $this->wrap($segments[0]).' as '.$this->wrapValue($segments[1]);
     }
 
     /**


### PR DESCRIPTION
The indentation makes it seem like we're only calling 1 method, and have 2 mismatched parenthesis.