### PR TITLE
[7.x] Drop support for Monolog v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
-        "monolog/monolog": "^1.12|^2.0",
+        "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "illuminate/contracts": "^7.0",
         "illuminate/support": "^7.0",
-        "monolog/monolog": "^1.12|^2.0"
+        "monolog/monolog": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since Monolog v2 is out and we support both v1 and v2 in Laravel 6.x let's drop support for it in 7.0. Monolog v1 probably won't get much support anymore so we should refrain ourselves from supporting it further.