### PR TITLE
[6.x] Resolve class command via application resolution

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -245,7 +245,7 @@ class Command extends SymfonyCommand
             return $this->getApplication()->find($command);
         }
 
-        $command = new $command;
+        $command = $this->laravel->make($command);
 
         if ($command instanceof SymfonyCommand) {
             $command->setApplication($this->getApplication());

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Console;
+
+use Mockery as m;
+use Illuminate\Console\Command;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Console\Application;
+use Illuminate\Console\OutputStyle;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testCallingClassCommandResolveCommandViaApplicationResolution()
+    {
+        $command = new Command();
+
+        $application = m::mock(Application::class);
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([]);
+        $output = new NullOutput();
+        $application->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn(m::mock(OutputStyle::class));
+
+        $application->shouldReceive('call')->with([$command, 'handle'])->andReturnUsing(function () use ($command, $application) {
+            $commandCalled = m::mock(Command::class);
+
+            $application->shouldReceive('make')->once()->with(Command::class)->andReturn($commandCalled);
+
+            $commandCalled->shouldReceive('setApplication')->once()->with(null);
+            $commandCalled->shouldReceive('setLaravel')->once()->with($application);
+            $commandCalled->shouldReceive('run')->once();
+
+            $command->call(Command::class);
+        });
+
+        $command->run($input, $output);
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

From a Laravel command, we can actually invoke another command using `$this->call(Command::class);` or `$this->callSilent(Command::class);`. This allows developers to navigate through the code and identify where a command is used.

Unfortunately, application resolution is not used in those cases and it makes class injection impossible. This PR replace the `new $command` for a class resolution via the application.


