### PR TITLE
[7.x] Use UrlGenerator interface instead of concrete implementation

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -76,4 +76,18 @@ interface UrlGenerator
      * @return $this
      */
     public function setRootControllerNamespace($rootNamespace);
+
+    /**
+     * Get the request instance.
+     *
+     * @return \Illuminate\Http\Request
+     */
+    public function getRequest();
+
+    /**
+     * Get the full URL for the current request.
+     *
+     * @return string
+     */
+    public function full();
 }

--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -12,6 +12,13 @@ interface UrlGenerator
     public function current();
 
     /**
+     * Get the full URL for the current request.
+     *
+     * @return string
+     */
+    public function full();
+
+    /**
      * Get the URL for the previous request.
      *
      * @param  mixed  $fallback
@@ -83,11 +90,4 @@ interface UrlGenerator
      * @return \Illuminate\Http\Request
      */
     public function getRequest();
-
-    /**
-     * Get the full URL for the current request.
-     *
-     * @return string
-     */
-    public function full();
 }

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -13,7 +13,7 @@ class Redirector
     /**
      * The URL generator instance.
      *
-     * @var \Illuminate\Routing\UrlGenerator
+     * @var \Illuminate\Contracts\Routing\UrlGenerator
      */
     protected $generator;
 
@@ -27,7 +27,7 @@ class Redirector
     /**
      * Create a new Redirector instance.
      *
-     * @param  \Illuminate\Routing\UrlGenerator  $generator
+     * @param  \Illuminate\Contracts\Routing\UrlGenerator  $generator
      * @return void
      */
     public function __construct(UrlGenerator $generator)
@@ -85,8 +85,8 @@ class Redirector
         $request = $this->generator->getRequest();
 
         $intended = $request->method() === 'GET' && $request->route() && ! $request->expectsJson()
-                        ? $this->generator->full()
-                        : $this->generator->previous();
+            ? $this->generator->full()
+            : $this->generator->previous();
 
         if ($intended) {
             $this->setIntendedUrl($intended);
@@ -212,7 +212,7 @@ class Redirector
     /**
      * Get the URL generator instance.
      *
-     * @return \Illuminate\Routing\UrlGenerator
+     * @return \Illuminate\Contracts\Routing\UrlGenerator
      */
     public function getUrlGenerator()
     {


### PR DESCRIPTION
This PR is related to https://github.com/laravel/framework/pull/19894 and makes the Redirector class use the UrlGenerator interface instead of the concrete implementation. This enables to change the implementation of the UrlGenerator the DI container provides.

As additional methods were added to Illuminate\Contracts\Routing\UrlGenerator interface, current classes using this interface would break after update, therefore I have created this PR against the master branch to be hopefully merged into a future release.


