### PR TITLE
[6.x] Postgresql column precision declaration fix

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -685,7 +685,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return "time($column->precision) without time zone";
+        return 'time' . (is_null($column->precision) ? '' : "($column->precision)") . ' without time zone';
     }
 
     /**
@@ -696,7 +696,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return "time($column->precision) with time zone";
+        return 'time' . (is_null($column->precision) ? '' : "($column->precision)") . ' with time zone';
     }
 
     /**
@@ -707,7 +707,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = "timestamp($column->precision) without time zone";
+        $columnType = 'timestamp' . (is_null($column->precision) ? '' : "($column->precision)") . ' without time zone';
 
         return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
@@ -720,7 +720,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        $columnType = "timestamp($column->precision) with time zone";
+        $columnType = 'timestamp' . (is_null($column->precision) ? '' : "($column->precision)") . ' with time zone';
 
         return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!

Briefly:
Allows you to create columns without optional precision:
`    "column1" timestamp WITHOUT TIME zone NOT NULL,`

In detail:

Now there is no way to create Date/Time column with undefined precision as described 
https://www.postgresql.org/docs/11/datatype-datetime.html#DATATYPE-DATETIME-INPUT

> type [ (p) ] 'value'
> where p is an optional precision specification giving the number of fractional digits in the seconds field. Precision can be specified for time, timestamp, and interval types, and can range from 0 to 6. If no precision is specified in a constant specification, it defaults to the precision of the literal value (but not more than 6 digits).

For example this code:
```
        Schema::create('test', function (Blueprint $table) {
            $table->timestamp('column1');
            $table->timestampsTz('column2');
            $table->time('column3');
            $table->timeTz('column4');
        });
```
will create this sql request:
```
CREATE TABLE "test"
(
    "column1" timestamp(0) WITHOUT TIME zone NOT NULL,
    "column2" timestamp(0) WITH TIME zone NOT NULL,
    "column3" time(0) WITHOUT TIME zone NOT NULL,
    "column4" time(0) WITH TIME zone NOT NULL
)
```
There is no way to get rid of (0) in a SQL query. Because of 0 as a default value:
`public function timestamp($column, $precision = 0)`

In this patch, null precision can be specified.

```
        Schema::create('test2', function (Blueprint $table) {
            $table->timestamp('column1', null);
            $table->timestampTz('column2', null);
            $table->time('column3', null);
            $table->timeTz('column4', null);
        });
```
in result:
```
CREATE TABLE "test2"
(
    "column1" timestamp WITHOUT TIME zone NOT NULL,
    "column2" timestamp WITH TIME zone NOT NULL,
    "column3" time WITHOUT TIME zone NOT NULL,
    "column4" time WITH TIME zone NOT NULL
)

```

Full backward compatibility. Since the previous behavior generated an invalid SQL query in this case.

Thank you!

P.S. This is my first pull request. Please correct me if I made a mistake. Thanks.