### PR TITLE
[6.x] Revert #27807 "Extract registered event and login to registered method"

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -30,7 +30,9 @@ trait RegistersUsers
     {
         $this->validator($request->all())->validate();
 
-        $user = $this->create($request->all());
+        event(new Registered($user = $this->create($request->all())));
+
+        $this->guard()->login($user);
 
         return $this->registered($request, $user)
                         ?: redirect($this->redirectPath());
@@ -55,8 +57,6 @@ trait RegistersUsers
      */
     protected function registered(Request $request, $user)
     {
-        event(new Registered($user));
-
-        $this->guard()->login($user);
+        //
     }
 }


### PR DESCRIPTION
This PR fixes #29874 by reverting the changes to the `RegistersUsers` trait introduced in #27807.

Because `RegistersUsers` is a trait, classes `use`ing it directly can't extend its functionality with the `parent` keyword [as suggested in the upgrade guide](https://laravel.com/docs/6.0/upgrade#the-register-controller), which means that to 'extend' a method we would have to override it completely and copy in any of the trait's functionality that we wanted to keep (or use something weird like `use RegistersUsers { registered as afterRegistered; }`).

It worked great before, and let people hook into the registration process or [return a different response](https://github.com/laravel/framework/pull/27807#issuecomment-524627328) from the registration controller.

If we don't want to provide that functionality at all, we should take out the `registered` method completely, since splitting it in two doesn't accomplish anything if we can't extend either of them anyway.

If this is merged I'll submit a PR to update the docs. We should probably still mention this somewhere though, since people following the letter of the upgrade guide would have broken their apps by using the `parent` keyword.