### PR TITLE
[6.x] Removed static return type PHPDoc from first()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -136,7 +136,7 @@ trait BuildsQueries
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     * @return \Illuminate\Database\Eloquent\Model|object|null
      */
     public function first($columns = ['*'])
     {


### PR DESCRIPTION
`first()` can never return static, so it shouldn't be listed as a possible return type.

For example, Model::where('id', 1)->first() is only going to return Model or null.

Per #22854 it can return a generic object.

`static` was added in #20254, when the PHPDoc for the function was changed from `mixed` to union return types, though there isn't any reason given why `static` was included. I can't see in documentation anywhere where it should be returning a `Builder` object either. If there in fact is a way that this could occur then this is moot, but I don't think there is.

Including `static` generates incorrect suggestions in IDEs and implies from reading PHPDoc return types that we don't have to worry about.