### PR TITLE
[6.x] Wrap MySQL default values in parentheses

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -954,7 +954,7 @@ class MySqlGrammar extends Grammar
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
         if (! is_null($column->default)) {
-            return ' default '.$this->getDefaultValue($column->default);
+            return ' default ('.$this->getDefaultValue($column->default).')';
         }
     }
 

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -467,14 +467,14 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` varchar(100) null default \'bar\'', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default (\'bar\')', $statements[0]);
 
         $blueprint = new Blueprint('users');
         $blueprint->string('foo', 100)->nullable()->default(new Expression('CURRENT TIMESTAMP'));
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` varchar(100) null default CURRENT TIMESTAMP', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` varchar(100) null default (CURRENT TIMESTAMP)', $statements[0]);
     }
 
     public function testAddingText()
@@ -771,7 +771,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestamp('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default ('2015-07-22 11:43:17')", $statements[0]);
     }
 
     public function testAddingTimestampTz()
@@ -798,7 +798,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $blueprint->timestampTz('created_at')->default('2015-07-22 11:43:17');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
         $this->assertCount(1, $statements);
-        $this->assertSame("alter table `users` add `created_at` timestamp not null default '2015-07-22 11:43:17'", $statements[0]);
+        $this->assertSame("alter table `users` add `created_at` timestamp not null default ('2015-07-22 11:43:17')", $statements[0]);
     }
 
     public function testAddingTimestamps()


### PR DESCRIPTION
Prior to MySQL 8.0.13, types of `Blob`, `Text`, `Geometry`, and `JSON` could not be assigned default values.

This made JSON fields cast as Collections annoying to handle when the value was `null`.

As of MySQL 8.0.13, we can now add default values to these fields, but a minor change needs to be made in the grammar.  These fields can be assigned a default value only if the value is written as an expression, even if the expression value is a literal.

This **will not** work:

```mysql
CREATE TABLE t2 (b BLOB DEFAULT 'abc');
```

but this **will**:

```mysql
CREATE TABLE t2 (b BLOB DEFAULT ('abc'));
```

Originally I was going to conditionally check for the field type and only apply the parentheses for the required types, but that seemed like overkill.  Only if there were performance or other implications for making **every** default value an expression would I think we would need to do that.

I won't presume to know how the other DB engines handle this, but there's a decent chance these changes will need to be made to them as well.

On a side note, now that we've switched to SemVer, do we need to indicate in our PRs if we think they are minor or patch commits?