### PR TITLE
[6.x] Add ability to change notification type

### DIFF
--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -55,7 +55,7 @@ class DatabaseChannel
     {
         return [
             'id' => $notification->id,
-            'type' => get_class($notification),
+            'type' => $notification->type ?? get_class($notification),
             'data' => $this->getData($notifiable, $notification),
             'read_at' => null,
         ];

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -23,6 +23,11 @@ class Notification
     public $locale;
 
     /**
+     * @var string
+     */
+    public $type;
+
+    /**
      * Get the channels the event should broadcast on.
      *
      * @return array

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -23,7 +23,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification->type ?? get_class($notification),
             'data' => ['invoice_id' => 1],
             'read_at' => null,
         ]);
@@ -40,7 +40,7 @@ class NotificationDatabaseChannelTest extends TestCase
 
         $notifiable->shouldReceive('routeNotificationFor->create')->with([
             'id' => 1,
-            'type' => get_class($notification),
+            'type' => $notification->type ?? get_class($notification),
             'data' => ['invoice_id' => 1],
             'read_at' => null,
             'something' => 'else',
@@ -53,6 +53,8 @@ class NotificationDatabaseChannelTest extends TestCase
 
 class NotificationDatabaseChannelTestNotification extends Notification
 {
+    public $type = 'invoice_received';
+
     public function toDatabase($notifiable)
     {
         return new DatabaseMessage(['invoice_id' => 1]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## This allows you to set your own type in the type column.

**Why is it better?**

Namespaces can change, for example, when moving files, and then working with these types in database, may not work properly, and with their own types - there will be no problems.

It is motivating to looks like [custom-polymorphic-types](https://laravel.com/docs/6.0/eloquent-relationships#custom-polymorphic-types)

Note: This is my first pull-request, thanks for any review or reply.