### PR TITLE
[6.x] verify() accepts key defined in getRouteKeyName()

### DIFF
--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,7 +32,7 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if (! hash_equals((string) $request->route('id'), (string) $request->user()->getKey())) {
+        if (! hash_equals((string) $request->route('id'), (string) $request->user()->getRouteKey())) {
             throw new AuthorizationException;
         }
 


### PR DESCRIPTION
**Title:**

`verify()` accepts key defined in `getRouteKeyName()`

**Description:**

Currently, the verify process exposes the database id the user record when a user attempts to confirm their email. If the application has changed the field used for routing via `getRouteKeyName()`, there will be no change to the verification link. By changing `getKey()` to `getRouteKey()`, the app can define the field to be used. If no route key name is specified, then the default id will be used.

**The benefit to end-users:**

This change allows the email verification to use other fields beyond the standard id. This enables the application to mask its id and utilize a different unique identifier such as a UID.

The reasons it does not break any existing features: `getRouteKey()` will always return an accurate value whether `getRouteKeyName()` is defined or not.

**How it makes building web applications easier:**

There is no need to override the `verify()` method in the `VerificationController` if a custom field has been defined to identify a model.