### PR TITLE
[6.x] Add events to signal when scheduled task runs

### DIFF
--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -24,11 +24,12 @@ class ScheduledTaskFinished
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @param  float  $runtime
      * @return void
      */
-    public function __construct(Event $task)
+    public function __construct(Event $task, $runtime)
     {
         $this->task = $task;
-        $this->runtime = microtime(true) - LARAVEL_START;
+        $this->runtime = $runtime;
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -18,6 +18,7 @@ class ScheduledTaskFinished
      *
      * @var float
      */
+    public $runtime;
 
     /**
      * Create a new event instance.

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+
+class ScheduledTaskFinished
+{
+    /**
+     * The scheduled event that ran.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $event;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return void
+     */
+    public function __construct(Event $event)
+    {
+        $this->event = $event;
+    }
+}

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -14,6 +14,12 @@ class ScheduledTaskFinished
     public $task;
 
     /**
+     * The runtime of the scheduled event.
+     *
+     * @var float
+     */
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\Event  $task
@@ -22,5 +28,6 @@ class ScheduledTaskFinished
     public function __construct(Event $task)
     {
         $this->task = $task;
+        $this->runtime = microtime(true) - LARAVEL_START;
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskFinished.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFinished.php
@@ -11,16 +11,16 @@ class ScheduledTaskFinished
      *
      * @var \Illuminate\Console\Scheduling\Event
      */
-    public $event;
+    public $task;
 
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Console\Scheduling\Event  $task
      * @return void
      */
-    public function __construct(Event $event)
+    public function __construct(Event $task)
     {
-        $this->event = $event;
+        $this->task = $task;
     }
 }

--- a/src/Illuminate/Console/Events/ScheduledTaskStarting.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskStarting.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+
+class ScheduledTaskStarting
+{
+    /**
+     * The scheduled event being run.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $event;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @return void
+     */
+    public function __construct(Event $event)
+    {
+        $this->event = $event;
+    }
+}

--- a/src/Illuminate/Console/Events/ScheduledTaskStarting.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskStarting.php
@@ -11,16 +11,16 @@ class ScheduledTaskStarting
      *
      * @var \Illuminate\Console\Scheduling\Event
      */
-    public $event;
+    public $task;
 
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Console\Scheduling\Event  $event
+     * @param  \Illuminate\Console\Scheduling\Event  $task
      * @return void
      */
-    public function __construct(Event $event)
+    public function __construct(Event $task)
     {
-        $this->event = $event;
+        $this->task = $task;
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -46,6 +46,13 @@ class ScheduleRunCommand extends Command
     protected $eventsRan = false;
 
     /**
+     * The runtime of the scheduled task.
+     *
+     * @var float
+     */
+    protected $runtime;
+
+    /**
      * Create a new command instance.
      *
      * @return void
@@ -81,7 +88,7 @@ class ScheduleRunCommand extends Command
                 $this->runEvent($event);
             }
 
-            $dispatcher->dispatch(new ScheduledTaskFinished($event));
+            $dispatcher->dispatch(new ScheduledTaskFinished($event, $this->runtime));
 
             $this->eventsRan = true;
         }
@@ -116,7 +123,11 @@ class ScheduleRunCommand extends Command
     {
         $this->line('<info>Running scheduled command:</info> '.$event->getSummaryForDisplay());
 
-        $event->run($this->laravel);
+        tap(Date::now(), function ($start) use ($event) {
+            $event->run($this->laravel);
+
+            $this->runtime = Date::now()->floatDiffInSeconds($start);
+        });
 
         $this->eventsRan = true;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -4,6 +4,9 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskStarting;
 
 class ScheduleRunCommand extends Command
 {
@@ -58,9 +61,10 @@ class ScheduleRunCommand extends Command
      * Execute the console command.
      *
      * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
      * @return void
      */
-    public function handle(Schedule $schedule)
+    public function handle(Schedule $schedule, Dispatcher $dispatcher)
     {
         $this->schedule = $schedule;
 
@@ -69,11 +73,15 @@ class ScheduleRunCommand extends Command
                 continue;
             }
 
+            $dispatcher->dispatch(new ScheduledTaskStarting($event));
+
             if ($event->onOneServer) {
                 $this->runSingleServerEvent($event);
             } else {
                 $this->runEvent($event);
             }
+
+            $dispatcher->dispatch(new ScheduledTaskFinished($event));
 
             $this->eventsRan = true;
         }


### PR DESCRIPTION
We already have the `Illuminate\Console\Events\CommandStarting` and `Illuminate\Console\Events\CommandFinished` events, but these are fired for _any_ command that is run, be it via the CLI directly, or via `schedule:run`.

Having the scheduled-task specific events makes it much easier to identify when a _scheduled_ task runs, allowing better monitoring of these tasks in a more dynamic manner.