### PR TITLE
[6.x] Normalize cache file paths

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -894,7 +894,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedServicesPath()
     {
-        return Env::get('APP_SERVICES_CACHE', $this->bootstrapPath().'/cache/services.php');
+        return $this->normalizeCachePath('cache/services.php', 'APP_SERVICES_CACHE');
     }
 
     /**
@@ -904,7 +904,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedPackagesPath()
     {
-        return Env::get('APP_PACKAGES_CACHE', $this->bootstrapPath().'/cache/packages.php');
+        return $this->normalizeCachePath('cache/packages.php', 'APP_PACKAGES_CACHE');
     }
 
     /**
@@ -924,7 +924,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedConfigPath()
     {
-        return Env::get('APP_CONFIG_CACHE', $this->bootstrapPath().'/cache/config.php');
+        return $this->normalizeCachePath('cache/config.php', 'APP_CONFIG_CACHE');
     }
 
     /**
@@ -944,7 +944,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedRoutesPath()
     {
-        return Env::get('APP_ROUTES_CACHE', $this->bootstrapPath().'/cache/routes.php');
+        return $this->normalizeCachePath('cache/routes.php', 'APP_ROUTES_CACHE');
     }
 
     /**
@@ -964,7 +964,29 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getCachedEventsPath()
     {
-        return Env::get('APP_EVENTS_CACHE', $this->bootstrapPath().'/cache/events.php');
+        return $this->normalizeCachePath('cache/events.php', 'APP_EVENTS_CACHE');
+    }
+
+    /**
+     * Normalize a relative or absolute path to a cache file.
+     *
+     * @param  string  $path
+     * @param  string  $key
+     * @return string
+     */
+    protected function normalizeCachePath($path, $key)
+    {
+        $env = Env::get($key);
+
+        if ($env === null) {
+            return $this->bootstrapPath($path);
+        }
+
+        if (Str::startsWith($env, '/')) {
+            return $env;
+        }
+
+        return $this->basePath($env);
     }
 
     /**

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -343,6 +343,89 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame('Laravel\\One\\', $app1->getNamespace());
         $this->assertSame('Laravel\\Two\\', $app2->getNamespace());
     }
+
+    public function testCachePathsResolveToBootstrapCacheDirectory()
+    {
+        $app = new Application('/base/path');
+
+        $this->assertSame('/base/path/bootstrap/cache/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path/bootstrap/cache/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path/bootstrap/cache/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path/bootstrap/cache/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path/bootstrap/cache/events.php', $app->getCachedEventsPath());
+    }
+
+    public function testEnvPathsAreUsedForCachePathsWhenSpecified()
+    {
+        $app = new Application('/base/path');
+        $_SERVER['APP_SERVICES_CACHE'] = '/absolute/path/services.php';
+        $_SERVER['APP_PACKAGES_CACHE'] = '/absolute/path/packages.php';
+        $_SERVER['APP_CONFIG_CACHE'] = '/absolute/path/config.php';
+        $_SERVER['APP_ROUTES_CACHE'] = '/absolute/path/routes.php';
+        $_SERVER['APP_EVENTS_CACHE'] = '/absolute/path/events.php';
+
+        $this->assertSame('/absolute/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/absolute/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/absolute/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/absolute/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/absolute/path/events.php', $app->getCachedEventsPath());
+
+        unset(
+            $_SERVER['APP_SERVICES_CACHE'],
+            $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CONFIG_CACHE'],
+            $_SERVER['APP_ROUTES_CACHE'],
+            $_SERVER['APP_EVENTS_CACHE']
+        );
+    }
+
+    public function testEnvPathsAreUsedAndMadeAbsoluteForCachePathsWhenSpecifiedAsRelative()
+    {
+        $app = new Application('/base/path');
+        $_SERVER['APP_SERVICES_CACHE'] = 'relative/path/services.php';
+        $_SERVER['APP_PACKAGES_CACHE'] = 'relative/path/packages.php';
+        $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
+        $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
+        $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
+
+        $this->assertSame('/base/path/relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path/relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path/relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path/relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path/relative/path/events.php', $app->getCachedEventsPath());
+
+        unset(
+            $_SERVER['APP_SERVICES_CACHE'],
+            $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CONFIG_CACHE'],
+            $_SERVER['APP_ROUTES_CACHE'],
+            $_SERVER['APP_EVENTS_CACHE']
+        );
+    }
+
+    public function testEnvPathsAreUsedAndMadeAbsoluteForCachePathsWhenSpecifiedAsRelativeWithNullBasePath()
+    {
+        $app = new Application();
+        $_SERVER['APP_SERVICES_CACHE'] = 'relative/path/services.php';
+        $_SERVER['APP_PACKAGES_CACHE'] = 'relative/path/packages.php';
+        $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
+        $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
+        $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
+
+        $this->assertSame('/relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/relative/path/events.php', $app->getCachedEventsPath());
+
+        unset(
+            $_SERVER['APP_SERVICES_CACHE'],
+            $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CONFIG_CACHE'],
+            $_SERVER['APP_ROUTES_CACHE'],
+            $_SERVER['APP_EVENTS_CACHE']
+        );
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/29862

Note: I believe this is an issue in need of fixing with and without the new bootstrap file but has become apparent due to the new file.

## Scenario

You have set a **relative** path for the cache files using its environment variable, i.e. `APP_CONFIG_CACHE`.

Assume we have the environment variable set:

```
APP_CONFIG_CACHE=relative/path.php
```

## Problem

### In PHPStorm

From their docs:

**Custom working directory**
_... By default, the field is empty and the working directory is the root of the project._
_Source: https://www.jetbrains.com/help/phpstorm/run-debug-configuration-phpunit.html_

Unfortunately it seems that this is not always the case and people are hitting errors as it is not using the project root as the "base path".  I believe PHPStorm is now looking for the config cache file relative to where you run the test, so if you are in the `tests/Unit` file it is looking for `tests/Unit/relative/path.php`


There is a manual fix where in PHPStorm's settings you can specify a "Custom working directory" when running tests, but I'm sure everyone would prefer it "just work".

### When running tests on the command line from a sub directory.

If you are in a project's root directory and you `cd app` and then run PHPUnit from this directory with...

```
$ ../vendor/bin/phpunit -c ../phpunit.xml
```

it will look for the cache directory in `app/relative/path.php`. 

---

I believe these are both the same issue just being hit with different tools, i.e. PHPStorm vs PHPUnit.

## Solution

1. If no environment variable is set, this PR does **not change functionality**, i.e.

```
# no value set, no change in functionality
APP_CONFIG_CACHE=
```
resolves to `BASE_PATH/bootstrap/cache/config.php`

2. If the environment variable is set using an absolute path, this PR does **not change functionality**, i.e.

```
# absolute path set, no change in functionality
APP_CONFIG_CACHE=/absolute/path/to/file.php
```
resolves to `/absolute/path/to/file.php`


3. If the environment variable is set using a relative path, this PR **does change functionality**, i.e.

```
# relative path set, changes functionality
APP_CONFIG_CACHE=relative/path/to/file.php
```
resolves to `BASE_PATH/relative/path/to/file.php`

Essentially this PR just enforces a consistent path when specifying a relative path and has the added bonus of fixing the bug I introduced to Laravel 👀