### PR TITLE
[6.x] Revert "[6.x] Removed static return type PHPDoc from first()"

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -136,7 +136,7 @@ trait BuildsQueries
      * Execute the query and get the first result.
      *
      * @param  array  $columns
-     * @return \Illuminate\Database\Eloquent\Model|object|null
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
      */
     public function first($columns = ['*'])
     {


### PR DESCRIPTION
Reverts laravel/framework#29877

Removing the static typehint will prevent the detection by IDE's of custom methods on the implementing model.

As noted by @sisve here: https://github.com/laravel/framework/pull/29877#issuecomment-528817486