### PR TITLE
[6.x] Prevent event autodiscovery from crashing when trying to instantiate files without classes

### DIFF
--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Events;
 
+use ReflectionException;
 use SplFileInfo;
 use ReflectionClass;
 use ReflectionMethod;
@@ -38,9 +39,13 @@ class DiscoverEvents
         $listenerEvents = [];
 
         foreach ($listeners as $listener) {
-            $listener = new ReflectionClass(
-                static::classFromFile($listener, $basePath)
-            );
+            try {
+                $listener = new ReflectionClass(
+                    static::classFromFile($listener, $basePath)
+                );
+            } catch (ReflectionException $e) {
+                continue;
+            }
 
             if (! $listener->isInstantiable()) {
                 continue;

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Events;
 
-use ReflectionException;
 use SplFileInfo;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionException;
 use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently if you store other files than php classes in a folder where the autodiscovery mechanism looks for listeners, it will crash because of a reflection error when trying to instantiate the reflection class. I think that these exceptions should be caught and ignored, just like the code ignores classes which are not instantiatable.

The exception can be seen by running the current autodiscovery test (without the try-catch block present) when a non-php class file is present in the fixture folder. I've added a empty js file as an example to the test fixture to make sure the test passes when other files are present in the discovery directory.