### PR TITLE
[6.x] Dispatch PendingChain on destruction

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -17,6 +17,13 @@ class PendingChain
      * @var array
      */
     public $chain;
+    
+    /**
+     * Indicates if the chain has already been dispatched.
+     *
+     * @var bool
+     */
+    public $dispatched;
 
     /**
      * Create a new PendingChain instance.
@@ -38,6 +45,8 @@ class PendingChain
      */
     public function dispatch()
     {
+        $this->dispatched = true;
+
         return (new PendingDispatch(
             new $this->class(...func_get_args())
         ))->chain($this->chain);
@@ -50,6 +59,8 @@ class PendingChain
      */
     public function __destruct()
     {
-        $this->dispatch();
+        if (! $this->dispatched) {
+            $this->dispatch();
+        };
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -17,7 +17,7 @@ class PendingChain
      * @var array
      */
     public $chain;
-    
+
     /**
      * Indicates if the chain has already been dispatched.
      *
@@ -61,6 +61,6 @@ class PendingChain
     {
         if (! $this->dispatched) {
             $this->dispatch();
-        };
+        }
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -42,4 +42,14 @@ class PendingChain
             new $this->class(...func_get_args())
         ))->chain($this->chain);
     }
+    
+    /**
+     * Handle the object's destruction.
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->dispatch();
+    }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -23,7 +23,7 @@ class PendingChain
      *
      * @var bool
      */
-    public $dispatched;
+    public $dispatched = false;
 
     /**
      * Create a new PendingChain instance.

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -42,7 +42,7 @@ class PendingChain
             new $this->class(...func_get_args())
         ))->chain($this->chain);
     }
-    
+
     /**
      * Handle the object's destruction.
      *


### PR DESCRIPTION
This PR allows you to dispatch job chains without chaining the dispatch method at the end, similar to how you can with the PendingDispatch.

This allows you to refactor this code:

```php
ProcessPodcast::withChain([
    new OptimizePodcast,
    new ReleasePodcast
])->dispatch();
```

Into this:

```php
ProcessPodcast::withChain([
    new OptimizePodcast,
    new ReleasePodcast
]);
```

Docs PR to update code example: https://github.com/laravel/docs/pull/5455