### PR TITLE
[6.x] Remove trailing spaces from policy.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -9,7 +9,7 @@ use Illuminate\Auth\Access\HandlesAuthorization;
 class DummyClass
 {
     use HandlesAuthorization;
-    
+
     /**
      * Determine whether the user can view any DocDummyPluralModel.
      *


### PR DESCRIPTION
The `policy.stub` contained some trailing spaces on an empty line.