### PR TITLE
Allow Chunk to disable preserving keys

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1029,9 +1029,10 @@ class Collection implements ArrayAccess, Enumerable
      * Chunk the collection into chunks of the given size.
      *
      * @param  int  $size
+     * @param  bool $preserve_keys
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, $preserve_keys = true)
     {
         if ($size <= 0) {
             return new static;
@@ -1039,7 +1040,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserve_keys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 


### PR DESCRIPTION
Allow Collection chunk to take a second optional parameter for preserving keys.

- There are cases where you want to chunk your collection and reset the keys instead of preserving it. The default PHP array_chunk function has this second argument.

- By default, it will break the method signature 


