### PR TITLE
[6.x] - Add application name after salutation

### DIFF
--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -41,7 +41,8 @@
 
 {{-- Salutation --}}
 @if (! empty($salutation))
-{{ $salutation }}
+{{ $salutation }},<br>
+{{ config('app.name') }}
 @else
 @lang('Regards'),<br>
 {{ config('app.name') }}


### PR DESCRIPTION
By default the application name is displayed after the salutation at the end of notification emails.
But when the developer customize the salutation the application name is missing.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
