### PR TITLE
[6.x] Add phpDoc for validate macros method

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,6 +12,9 @@ use Illuminate\Contracts\Support\Arrayable;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+/**
+ * @method array validate(array $rules)
+ */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
     use Concerns\InteractsWithContentTypes,


### PR DESCRIPTION
Request class officially provide method validate for validating request parameters. But this method created via macros mechanism, and IDE can't highlight or autocomplete this. With phpDoc for Request class this small problem is solved.
