### PR TITLE
[6.x] Fix return types for mock and spy test helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -38,7 +38,7 @@ trait InteractsWithContainer
      *
      * @param  string  $abstract
      * @param  \Closure|null  $mock
-     * @return Mockery\MockInterface
+     * @return \Mockery\MockInterface
      */
     protected function mock($abstract, Closure $mock = null)
     {
@@ -50,7 +50,7 @@ trait InteractsWithContainer
      *
      * @param  string  $abstract
      * @param  \Closure|null  $mock
-     * @return Mockery\MockInterface
+     * @return \Mockery\MockInterface
      */
     protected function spy($abstract, Closure $mock = null)
     {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -38,7 +38,7 @@ trait InteractsWithContainer
      *
      * @param  string  $abstract
      * @param  \Closure|null  $mock
-     * @return object
+     * @return Mockery\MockInterface
      */
     protected function mock($abstract, Closure $mock = null)
     {
@@ -50,7 +50,7 @@ trait InteractsWithContainer
      *
      * @param  string  $abstract
      * @param  \Closure|null  $mock
-     * @return object
+     * @return Mockery\MockInterface
      */
     protected function spy($abstract, Closure $mock = null)
     {


### PR DESCRIPTION
Both `$this->mock()` and `$this->spy()` return an instance of `Mockery\MockInterface`.


Currently, without this return type:
![image](https://user-images.githubusercontent.com/7202674/64536370-46624800-d319-11e9-947f-565ddfe18ca1.png)

With this PR:
![image](https://user-images.githubusercontent.com/7202674/64536408-5bd77200-d319-11e9-9d06-9474b8a39701.png)

