### PR TITLE
[7.x] Remove unnecessary sorting on withCount

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -393,6 +393,8 @@ trait QueriesRelationships
             // not influence the count either, so we can safely remove those too
             $query->orders = null;
 
+            $query->setBindings([], 'order');
+
             if (count($query->columns) > 1) {
                 $query->columns = [$query->columns[0]];
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -388,9 +388,6 @@ trait QueriesRelationships
 
             $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
 
-            // Because the ordering of the subresult does not influence the total count, we can
-            // safely remove it from the final result. Furthermore, the selected columns do
-            // not influence the count either, so we can safely remove those too
             $query->orders = null;
 
             $query->setBindings([], 'order');

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -388,6 +388,11 @@ trait QueriesRelationships
 
             $query = $query->mergeConstraintsFrom($relation->getQuery())->toBase();
 
+            // Because the ordering of the subresult does not influence the total count, we can
+            // safely remove it from the final result. Furthermore, the selected columns do
+            // not influence the count either, so we can safely remove those too
+            $query->orders = null;
+
             if (count($query->columns) > 1) {
                 $query->columns = [$query->columns[0]];
             }

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -64,6 +64,16 @@ class EloquentWithCountTest extends DatabaseTestCase
         $result = Model1::withCount('allFours')->first();
         $this->assertEquals(1, $result->all_fours_count);
     }
+
+    public function testSortingScopes()
+    {
+        $one = Model1::create();
+        $one->twos()->create();
+
+        $result = Model1::withCount('twos')->toSql();
+
+        $this->assertEquals('select "one".*, (select count(*) from "two" where "one"."id" = "two"."one_id") as "twos_count" from "one"', $result);
+    }
 }
 
 class Model1 extends Model
@@ -94,6 +104,15 @@ class Model2 extends Model
     public $timestamps = false;
     protected $guarded = ['id'];
     protected $withCount = ['threes'];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::addGlobalScope('app', function ($builder) {
+            $builder->latest();
+        });
+    }
 
     public function threes()
     {


### PR DESCRIPTION
When adding a `withCount` to an Eloquent query for a relationship that has sorting baked into the model by (global) scope or directly in the relationship, ordering does not actually influence the final result, but could have a (potentially massive) impact on query time. This PR seeks to solve [issue 29865](https://github.com/laravel/framework/issues/29865)

Maybe I'm thinking too straightforward here, but it seems to do the trick. Modifying `getRelationExistenceCountQuery()` would also work, but would break the rather clean immediate return in that method, because as far as I know there is no way to unset ordering on a query by method. Any feedback would be appreciated.

Unrelated, the comment I added seeks to also clarify the statement below my change. Let me know if I misunderstood the reason that it's there.