### PR TITLE
[6.x] Add support of asserting pushed and flushed events

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -158,7 +158,9 @@ class EventFake implements Dispatcher
      */
     public function push($event, $payload = [])
     {
-        //
+        $this->dispatcher->listen($event.'_pushed', function () use ($event, $payload) {
+            $this->dispatch($event, $payload);
+        });
     }
 
     /**
@@ -180,7 +182,7 @@ class EventFake implements Dispatcher
      */
     public function flush($event)
     {
-        //
+        $this->dispatch($event.'_pushed');
     }
 
     /**

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -95,6 +95,19 @@ class SupportTestingEventFakeTest extends TestCase
         $fake->assertDispatched('Bar');
         $fake->assertNotDispatched('Baz');
     }
+
+    public function testAssertDispatchedWithFlushed()
+    {
+        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher->shouldReceive('listen')->once();
+
+        $fake = new EventFake($dispatcher);
+
+        $fake->push(EventStub::class);
+        $fake->flush(EventStub::class);
+
+        $fake->assertDispatched('Illuminate\Tests\Support\EventStub_pushed');
+    }
 }
 
 class EventStub


### PR DESCRIPTION
Currently the implementation of `push` and `flush` methods of `EventFake` are empty, which is not able to test pushed listener and flushed events. This PR implemented those two methods.