### PR TITLE
[7.x] Switch timezone implementation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1613,15 +1613,7 @@ trait ValidatesAttributes
      */
     public function validateTimezone($attribute, $value)
     {
-        try {
-            new DateTimeZone($value);
-        } catch (Exception $e) {
-            return false;
-        } catch (Throwable $e) {
-            return false;
-        }
-
-        return true;
+        return in_array($value, timezone_identifiers_list(), true);
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -5,8 +5,6 @@ namespace Illuminate\Validation\Concerns;
 use DateTime;
 use Countable;
 use Exception;
-use Throwable;
-use DateTimeZone;
 use DateTimeInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2838,8 +2838,14 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => 'Africa/Windhoek'], ['foo' => 'Timezone']);
         $this->assertTrue($v->passes());
 
+        $v = new Validator($trans, ['foo' => 'africa/windhoek'], ['foo' => 'Timezone']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['foo' => 'GMT'], ['foo' => 'Timezone']);
-        $this->assertTrue($v->passes());
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'GB'], ['foo' => 'Timezone']);
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => ['this_is_not_a_timezone']], ['foo' => 'Timezone']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
The current implementation of timezone validation uses `DateTimeZone()` which accepts additional timezones that aren't included in the array returned from `timezone_identifiers_list()`. The documentation on timezone validation implies that only values from `timezone_identifiers_list()` will be considered valid (see https://laravel.com/docs/5.8/validation#rule-timezone).

To make timezone validation only accept values from `timezone_identifiers_list` i've changed the implementation to use just that.

See issue https://github.com/laravel/framework/issues/29867