### PR TITLE
[6.x] Null type check consistency

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -190,7 +190,7 @@ class Gate implements GateContract
                 $policy, $user, $ability, $arguments
             );
 
-            if (! is_null($result)) {
+            if (null !== $result) {
                 return $result;
             }
 
@@ -362,7 +362,7 @@ class Gate implements GateContract
             $user, $ability, $arguments
         );
 
-        if (is_null($result)) {
+        if (null === $result) {
             $result = $this->callAuthCallback($user, $ability, $arguments);
         }
 
@@ -384,11 +384,11 @@ class Gate implements GateContract
      */
     protected function canBeCalledWithUser($user, $class, $method = null)
     {
-        if (! is_null($user)) {
+        if (null !== $user) {
             return true;
         }
 
-        if (! is_null($method)) {
+        if (null !== $method) {
             return $this->methodAllowsGuests($class, $method);
         }
 
@@ -451,7 +451,7 @@ class Gate implements GateContract
     protected function parameterAllowsGuests($parameter)
     {
         return ($parameter->getClass() && $parameter->allowsNull()) ||
-               ($parameter->isDefaultValueAvailable() && is_null($parameter->getDefaultValue()));
+               ($parameter->isDefaultValueAvailable() && null === $parameter->getDefaultValue());
     }
 
     /**
@@ -484,7 +484,7 @@ class Gate implements GateContract
                 continue;
             }
 
-            if (! is_null($result = $before($user, $ability, $arguments))) {
+            if (null !== ($result = $before($user, $ability, $arguments))) {
                 return $result;
             }
         }
@@ -525,7 +525,7 @@ class Gate implements GateContract
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
         if (isset($arguments[0]) &&
-            ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
+            null !== ($policy = $this->getPolicyFor($arguments[0])) &&
             $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
             return $callback;
         }
@@ -650,7 +650,7 @@ class Gate implements GateContract
             // When we receive a non-null result from this before method, we will return it
             // as the "final" results. This will allow developers to override the checks
             // in this policy to return the result for all rules defined in the class.
-            if (! is_null($result)) {
+            if (null !== $result) {
                 return $result;
             }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -190,7 +190,7 @@ class Gate implements GateContract
                 $policy, $user, $ability, $arguments
             );
 
-            if (null !== $result) {
+            if ($result !== null) {
                 return $result;
             }
 
@@ -362,7 +362,7 @@ class Gate implements GateContract
             $user, $ability, $arguments
         );
 
-        if (null === $result) {
+        if ($result === null) {
             $result = $this->callAuthCallback($user, $ability, $arguments);
         }
 
@@ -384,11 +384,11 @@ class Gate implements GateContract
      */
     protected function canBeCalledWithUser($user, $class, $method = null)
     {
-        if (null !== $user) {
+        if ($user !== null) {
             return true;
         }
 
-        if (null !== $method) {
+        if ($method !== null) {
             return $this->methodAllowsGuests($class, $method);
         }
 
@@ -451,7 +451,7 @@ class Gate implements GateContract
     protected function parameterAllowsGuests($parameter)
     {
         return ($parameter->getClass() && $parameter->allowsNull()) ||
-               ($parameter->isDefaultValueAvailable() && null === $parameter->getDefaultValue());
+               ($parameter->isDefaultValueAvailable() && $parameter->getDefaultValue() === null);
     }
 
     /**
@@ -484,7 +484,7 @@ class Gate implements GateContract
                 continue;
             }
 
-            if (null !== ($result = $before($user, $ability, $arguments))) {
+            if (($result = $before($user, $ability, $arguments)) !== null) {
                 return $result;
             }
         }
@@ -525,7 +525,7 @@ class Gate implements GateContract
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
         if (isset($arguments[0]) &&
-            null !== ($policy = $this->getPolicyFor($arguments[0])) &&
+            ($policy = $this->getPolicyFor($arguments[0])) !== null &&
             $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
             return $callback;
         }
@@ -650,7 +650,7 @@ class Gate implements GateContract
             // When we receive a non-null result from this before method, we will return it
             // as the "final" results. This will allow developers to override the checks
             // in this policy to return the result for all rules defined in the class.
-            if (null !== $result) {
+            if ($result !== null) {
                 return $result;
             }
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -80,7 +80,7 @@ class AuthManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (null === $config) {
+        if ($config === null) {
             throw new InvalidArgumentException("Auth guard [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -80,7 +80,7 @@ class AuthManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if (null === $config) {
             throw new InvalidArgumentException("Auth guard [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -23,7 +23,7 @@ trait CreatesUserProviders
      */
     public function createUserProvider($provider = null)
     {
-        if (is_null($config = $this->getProviderConfiguration($provider))) {
+        if (null === ($config = $this->getProviderConfiguration($provider))) {
             return;
         }
 

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -23,7 +23,7 @@ trait CreatesUserProviders
      */
     public function createUserProvider($provider = null)
     {
-        if (null === ($config = $this->getProviderConfiguration($provider))) {
+        if (($config = $this->getProviderConfiguration($provider)) === null) {
             return;
         }
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -138,7 +138,7 @@ class DatabaseUserProvider implements UserProvider
      */
     protected function getGenericUser($user)
     {
-        if (null !== $user) {
+        if ($user !== null) {
             return new GenericUser((array) $user);
         }
     }

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -138,7 +138,7 @@ class DatabaseUserProvider implements UserProvider
      */
     protected function getGenericUser($user)
     {
-        if (! is_null($user)) {
+        if (null !== $user) {
             return new GenericUser((array) $user);
         }
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -153,7 +153,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function newModelQuery($model = null)
     {
-        return is_null($model)
+        return null === $model
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -153,7 +153,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function newModelQuery($model = null)
     {
-        return null === $model
+        return $model === null
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
     }

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -33,7 +33,7 @@ trait GuardHelpers
      */
     public function authenticate()
     {
-        if (! is_null($user = $this->user())) {
+        if (null !== ($user = $this->user())) {
             return $user;
         }
 
@@ -47,7 +47,7 @@ trait GuardHelpers
      */
     public function hasUser()
     {
-        return ! is_null($this->user);
+        return null !== $this->user;
     }
 
     /**
@@ -57,7 +57,7 @@ trait GuardHelpers
      */
     public function check()
     {
-        return ! is_null($this->user());
+        return null !== $this->user();
     }
 
     /**

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -33,7 +33,7 @@ trait GuardHelpers
      */
     public function authenticate()
     {
-        if (null !== ($user = $this->user())) {
+        if (($user = $this->user()) !== null) {
             return $user;
         }
 
@@ -47,7 +47,7 @@ trait GuardHelpers
      */
     public function hasUser()
     {
-        return null !== $this->user;
+        return $this->user !== null;
     }
 
     /**
@@ -57,7 +57,7 @@ trait GuardHelpers
      */
     public function check()
     {
-        return null !== $this->user();
+        return $this->user() !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -54,7 +54,7 @@ class Authorize
      */
     protected function getGateArguments($request, $models)
     {
-        if (null === $models) {
+        if ($models === null) {
             return [];
         }
 

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -54,7 +54,7 @@ class Authorize
      */
     protected function getGateArguments($request, $models)
     {
-        if (is_null($models)) {
+        if (null === $models) {
             return [];
         }
 

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -11,7 +11,7 @@ trait MustVerifyEmail
      */
     public function hasVerifiedEmail()
     {
-        return null !== $this->email_verified_at;
+        return $this->email_verified_at !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -11,7 +11,7 @@ trait MustVerifyEmail
      */
     public function hasVerifiedEmail()
     {
-        return ! is_null($this->email_verified_at);
+        return null !== $this->email_verified_at;
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -51,7 +51,7 @@ class PasswordBroker implements PasswordBrokerContract
         // "flash" data in the session to indicate to the developers the errors.
         $user = $this->getUser($credentials);
 
-        if (null === $user) {
+        if ($user === null) {
             return static::INVALID_USER;
         }
 
@@ -103,7 +103,7 @@ class PasswordBroker implements PasswordBrokerContract
      */
     protected function validateReset(array $credentials)
     {
-        if (null === ($user = $this->getUser($credentials))) {
+        if (($user = $this->getUser($credentials)) === null) {
             return static::INVALID_USER;
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -51,7 +51,7 @@ class PasswordBroker implements PasswordBrokerContract
         // "flash" data in the session to indicate to the developers the errors.
         $user = $this->getUser($credentials);
 
-        if (is_null($user)) {
+        if (null === $user) {
             return static::INVALID_USER;
         }
 
@@ -103,7 +103,7 @@ class PasswordBroker implements PasswordBrokerContract
      */
     protected function validateReset(array $credentials)
     {
-        if (is_null($user = $this->getUser($credentials))) {
+        if (null === ($user = $this->getUser($credentials))) {
             return static::INVALID_USER;
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -61,7 +61,7 @@ class PasswordBrokerManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (null === $config) {
+        if ($config === null) {
             throw new InvalidArgumentException("Password resetter [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -61,7 +61,7 @@ class PasswordBrokerManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if (null === $config) {
             throw new InvalidArgumentException("Password resetter [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -50,7 +50,7 @@ class RequestGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (null !== $this->user) {
+        if ($this->user !== null) {
             return $this->user;
         }
 
@@ -67,9 +67,9 @@ class RequestGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        return null !== (new static(
+        return (new static(
             $this->callback, $credentials['request'], $this->getProvider()
-        ))->user();
+        ))->user() !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -50,7 +50,7 @@ class RequestGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if (null !== $this->user) {
             return $this->user;
         }
 
@@ -67,9 +67,9 @@ class RequestGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        return ! is_null((new static(
+        return null !== (new static(
             $this->callback, $credentials['request'], $this->getProvider()
-        ))->user());
+        ))->user();
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -119,7 +119,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if (null !== $this->user) {
             return $this->user;
         }
 
@@ -128,14 +128,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // First we will try to load the user using the identifier in the session if
         // one exists. Otherwise we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
-        if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
+        if (null !== $id && $this->user = $this->provider->retrieveById($id)) {
             $this->fireAuthenticatedEvent($this->user);
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to
         // pull the user data on that cookie which serves as a remember cookie on
         // the application. Once we have a user we can return it to the caller.
-        if (is_null($this->user) && ! is_null($recaller = $this->recaller())) {
+        if (null === $this->user && null !== ($recaller = $this->recaller())) {
             $this->user = $this->userFromRecaller($recaller);
 
             if ($this->user) {
@@ -165,7 +165,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // the application. Once we have a user we can return it to the caller.
         $this->recallAttempted = true;
 
-        $this->viaRemember = ! is_null($user = $this->provider->retrieveByToken(
+        $this->viaRemember = null !== ($user = $this->provider->retrieveByToken(
             $recaller->id(), $recaller->token()
         ));
 
@@ -179,7 +179,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function recaller()
     {
-        if (is_null($this->request)) {
+        if (null === $this->request) {
             return;
         }
 
@@ -231,7 +231,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function onceUsingId($id)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        if (null !== ($user = $this->provider->retrieveById($id))) {
             $this->setUser($user);
 
             return $user;
@@ -374,7 +374,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function hasValidCredentials($user, $credentials)
     {
-        return ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
+        return null !== $user && $this->provider->validateCredentials($user, $credentials);
     }
 
     /**
@@ -386,7 +386,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function loginUsingId($id, $remember = false)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        if (null !== ($user = $this->provider->retrieveById($id))) {
             $this->login($user, $remember);
 
             return $user;
@@ -487,7 +487,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
+        if (null !== $this->user && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 
@@ -512,7 +512,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $this->session->remove($this->getName());
 
-        if (! is_null($this->recaller())) {
+        if (null !== $this->recaller()) {
             $this->getCookieJar()->queue($this->getCookieJar()
                     ->forget($this->getRecallerName()));
         }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -119,7 +119,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (null !== $this->user) {
+        if ($this->user !== null) {
             return $this->user;
         }
 
@@ -128,14 +128,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // First we will try to load the user using the identifier in the session if
         // one exists. Otherwise we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
-        if (null !== $id && $this->user = $this->provider->retrieveById($id)) {
+        if ($id !== null && $this->user = $this->provider->retrieveById($id)) {
             $this->fireAuthenticatedEvent($this->user);
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to
         // pull the user data on that cookie which serves as a remember cookie on
         // the application. Once we have a user we can return it to the caller.
-        if (null === $this->user && null !== ($recaller = $this->recaller())) {
+        if ($this->user === null && ($recaller = $this->recaller()) !== null) {
             $this->user = $this->userFromRecaller($recaller);
 
             if ($this->user) {
@@ -165,9 +165,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // the application. Once we have a user we can return it to the caller.
         $this->recallAttempted = true;
 
-        $this->viaRemember = null !== ($user = $this->provider->retrieveByToken(
+        $this->viaRemember = ($user = $this->provider->retrieveByToken(
             $recaller->id(), $recaller->token()
-        ));
+        )) !== null;
 
         return $user;
     }
@@ -179,7 +179,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function recaller()
     {
-        if (null === $this->request) {
+        if ($this->request === null) {
             return;
         }
 
@@ -231,7 +231,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function onceUsingId($id)
     {
-        if (null !== ($user = $this->provider->retrieveById($id))) {
+        if (($user = $this->provider->retrieveById($id)) !== null) {
             $this->setUser($user);
 
             return $user;
@@ -374,7 +374,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function hasValidCredentials($user, $credentials)
     {
-        return null !== $user && $this->provider->validateCredentials($user, $credentials);
+        return $user !== null && $this->provider->validateCredentials($user, $credentials);
     }
 
     /**
@@ -386,7 +386,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function loginUsingId($id, $remember = false)
     {
-        if (null !== ($user = $this->provider->retrieveById($id))) {
+        if (($user = $this->provider->retrieveById($id)) !== null) {
             $this->login($user, $remember);
 
             return $user;
@@ -487,7 +487,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
-        if (null !== $this->user && ! empty($user->getRememberToken())) {
+        if ($this->user !== null && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 
@@ -512,7 +512,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $this->session->remove($this->getName());
 
-        if (null !== $this->recaller()) {
+        if ($this->recaller() !== null) {
             $this->getCookieJar()->queue($this->getCookieJar()
                     ->forget($this->getRecallerName()));
         }

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -72,7 +72,7 @@ class TokenGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (null !== $this->user) {
+        if ($this->user !== null) {
             return $this->user;
         }
 

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -72,7 +72,7 @@ class TokenGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if (null !== $this->user) {
             return $this->user;
         }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -110,7 +110,7 @@ class BroadcastManager implements FactoryContract
     {
         $connection = $event instanceof ShouldBroadcastNow ? 'sync' : null;
 
-        if (null === $connection && isset($event->connection)) {
+        if ($connection === null && isset($event->connection)) {
             $connection = $event->connection;
         }
 
@@ -265,7 +265,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        if (null !== $name && $name !== 'null') {
+        if ($name !== null && $name !== 'null') {
             return $this->app['config']["broadcasting.connections.{$name}"];
         }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -110,7 +110,7 @@ class BroadcastManager implements FactoryContract
     {
         $connection = $event instanceof ShouldBroadcastNow ? 'sync' : null;
 
-        if (is_null($connection) && isset($event->connection)) {
+        if (null === $connection && isset($event->connection)) {
             $connection = $event->connection;
         }
 
@@ -265,7 +265,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if (null !== $name && $name !== 'null') {
             return $this->app['config']["broadcasting.connections.{$name}"];
         }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -147,7 +147,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function extractChannelKeys($pattern, $channel)
     {
-        preg_match('/^'.preg_replace('/{(.*?)}/', '(?<$1>[^\.]+)', $pattern).'/', $channel, $keys);
+        preg_match('/^'.preg_replace('/\{(.*?)\}/', '(?<$1>[^\.]+)', $pattern).'/', $channel, $keys);
 
         return $keys;
     }
@@ -285,7 +285,7 @@ abstract class Broadcaster implements BroadcasterContract
 
         $guards = $options['guards'] ?? null;
 
-        if (null === $guards) {
+        if ($guards === null) {
             return $request->user();
         }
 
@@ -324,6 +324,6 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function channelNameMatchesPattern($channel, $pattern)
     {
-        return Str::is(preg_replace('/{(.*?)}/', '*', $pattern), $channel);
+        return Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel);
     }
 }

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -147,7 +147,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function extractChannelKeys($pattern, $channel)
     {
-        preg_match('/^'.preg_replace('/\{(.*?)\}/', '(?<$1>[^\.]+)', $pattern).'/', $channel, $keys);
+        preg_match('/^'.preg_replace('/{(.*?)}/', '(?<$1>[^\.]+)', $pattern).'/', $channel, $keys);
 
         return $keys;
     }
@@ -285,7 +285,7 @@ abstract class Broadcaster implements BroadcasterContract
 
         $guards = $options['guards'] ?? null;
 
-        if (is_null($guards)) {
+        if (null === $guards) {
             return $request->user();
         }
 
@@ -324,6 +324,6 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function channelNameMatchesPattern($channel, $pattern)
     {
-        return Str::is(preg_replace('/\{(.*?)\}/', '*', $pattern), $channel);
+        return Str::is(preg_replace('/{(.*?)}/', '*', $pattern), $channel);
     }
 }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -94,7 +94,7 @@ class CacheManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (null === $config) {
+        if ($config === null) {
             throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -94,7 +94,7 @@ class CacheManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if (null === $config) {
             throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -65,7 +65,7 @@ class DatabaseStore implements Store
         // If we have a cache record we will check the expiration time against current
         // time on the system and see if the record has expired. If it has, we will
         // remove the records from the database table so it isn't returned again.
-        if (null === $cache) {
+        if ($cache === null) {
             return;
         }
 
@@ -155,7 +155,7 @@ class DatabaseStore implements Store
             // If there is no value in the cache, we will return false here. Otherwise the
             // value will be decrypted and we will proceed with this function to either
             // increment or decrement this value based on the given action callbacks.
-            if (null === $cache) {
+            if ($cache === null) {
                 return false;
             }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -65,7 +65,7 @@ class DatabaseStore implements Store
         // If we have a cache record we will check the expiration time against current
         // time on the system and see if the record has expired. If it has, we will
         // remove the records from the database table so it isn't returned again.
-        if (is_null($cache)) {
+        if (null === $cache) {
             return;
         }
 
@@ -155,7 +155,7 @@ class DatabaseStore implements Store
             // If there is no value in the cache, we will return false here. Otherwise the
             // value will be decrypted and we will proceed with this function to either
             // increment or decrement this value based on the given action callbacks.
-            if (is_null($cache)) {
+            if (null === $cache) {
                 return false;
             }
 

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -42,7 +42,7 @@ abstract class Lock implements LockContract
      */
     public function __construct($name, $seconds, $owner = null)
     {
-        if (is_null($owner)) {
+        if (null === $owner) {
             $owner = Str::random();
         }
 

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -42,7 +42,7 @@ abstract class Lock implements LockContract
      */
     public function __construct($name, $seconds, $owner = null)
     {
-        if (null === $owner) {
+        if ($owner === null) {
             $owner = Str::random();
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -53,7 +53,7 @@ class RedisStore extends TaggableStore implements LockProvider
     {
         $value = $this->connection()->get($this->prefix.$key);
 
-        return ! is_null($value) ? $this->unserialize($value) : null;
+        return null !== $value ? $this->unserialize($value) : null;
     }
 
     /**
@@ -73,7 +73,7 @@ class RedisStore extends TaggableStore implements LockProvider
         }, $keys));
 
         foreach ($values as $index => $value) {
-            $results[$keys[$index]] = ! is_null($value) ? $this->unserialize($value) : null;
+            $results[$keys[$index]] = null !== $value ? $this->unserialize($value) : null;
         }
 
         return $results;
@@ -110,7 +110,7 @@ class RedisStore extends TaggableStore implements LockProvider
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
+            $manyResult = null === $manyResult ? $result : $result && $manyResult;
         }
 
         $this->connection()->exec();

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -53,7 +53,7 @@ class RedisStore extends TaggableStore implements LockProvider
     {
         $value = $this->connection()->get($this->prefix.$key);
 
-        return null !== $value ? $this->unserialize($value) : null;
+        return $value !== null ? $this->unserialize($value) : null;
     }
 
     /**
@@ -73,7 +73,7 @@ class RedisStore extends TaggableStore implements LockProvider
         }, $keys));
 
         foreach ($values as $index => $value) {
-            $results[$keys[$index]] = null !== $value ? $this->unserialize($value) : null;
+            $results[$keys[$index]] = $value !== null ? $this->unserialize($value) : null;
         }
 
         return $results;
@@ -110,7 +110,7 @@ class RedisStore extends TaggableStore implements LockProvider
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = null === $manyResult ? $result : $result && $manyResult;
+            $manyResult = $manyResult === null ? $result : $result && $manyResult;
         }
 
         $this->connection()->exec();

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -411,7 +411,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately
         // and if not we will execute the given Closure and cache the result
         // of that forever so it is available for all subsequent requests.
-        if ($value !== null) {
+        if (null !== $value) {
             return $value;
         }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -67,7 +67,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function has($key)
     {
-        return ! is_null($this->get($key));
+        return null !== $this->get($key);
     }
 
     /**
@@ -99,7 +99,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (is_null($value)) {
+        if (null === $value) {
             $this->event(new CacheMissed($key));
 
             $value = value($default);
@@ -156,7 +156,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (is_null($value)) {
+        if (null === $value) {
             $this->event(new CacheMissed($key));
 
             return isset($keys[$key]) ? value($keys[$key]) : null;
@@ -312,7 +312,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the value did not exist in the cache, we will put the value in the cache
         // so it exists for subsequent requests. Then, we will return true so it is
         // easy to know if the value gets added. Otherwise, we will return false.
-        if (is_null($this->get($key))) {
+        if (null === $this->get($key)) {
             return $this->put($key, $value, $ttl);
         }
 
@@ -376,7 +376,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
-        if (! is_null($value)) {
+        if (null !== $value) {
             return $value;
         }
 
@@ -411,7 +411,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately
         // and if not we will execute the given Closure and cache the result
         // of that forever so it is available for all subsequent requests.
-        if (! is_null($value)) {
+        if ($value !== null) {
             return $value;
         }
 
@@ -483,7 +483,7 @@ class Repository implements ArrayAccess, CacheContract
 
         $cache = $this->store->tags(is_array($names) ? $names : func_get_args());
 
-        if (! is_null($this->events)) {
+        if (null !== $this->events) {
             $cache->setEventDispatcher($this->events);
         }
 

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -67,7 +67,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function has($key)
     {
-        return null !== $this->get($key);
+        return $this->get($key) !== null;
     }
 
     /**
@@ -99,7 +99,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (null === $value) {
+        if ($value === null) {
             $this->event(new CacheMissed($key));
 
             $value = value($default);
@@ -156,7 +156,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (null === $value) {
+        if ($value === null) {
             $this->event(new CacheMissed($key));
 
             return isset($keys[$key]) ? value($keys[$key]) : null;
@@ -312,7 +312,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the value did not exist in the cache, we will put the value in the cache
         // so it exists for subsequent requests. Then, we will return true so it is
         // easy to know if the value gets added. Otherwise, we will return false.
-        if (null === $this->get($key)) {
+        if ($this->get($key) === null) {
             return $this->put($key, $value, $ttl);
         }
 
@@ -376,7 +376,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
-        if (null !== $value) {
+        if ($value !== null) {
             return $value;
         }
 
@@ -411,7 +411,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately
         // and if not we will execute the given Closure and cache the result
         // of that forever so it is available for all subsequent requests.
-        if (null !== $value) {
+        if ($value !== null) {
             return $value;
         }
 
@@ -483,7 +483,7 @@ class Repository implements ArrayAccess, CacheContract
 
         $cache = $this->store->tags(is_array($names) ? $names : func_get_args());
 
-        if (null !== $this->events) {
+        if ($this->events !== null) {
             $cache->setEventDispatcher($this->events);
         }
 

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -37,7 +37,7 @@ trait RetrievesMultipleKeys
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
+            $manyResult = null === $manyResult ? $result : $result && $manyResult;
         }
 
         return $manyResult ?: false;

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -37,7 +37,7 @@ trait RetrievesMultipleKeys
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = null === $manyResult ? $result : $result && $manyResult;
+            $manyResult = $manyResult === null ? $result : $result && $manyResult;
         }
 
         return $manyResult ?: false;

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -310,7 +310,7 @@ class Command extends SymfonyCommand
      */
     public function argument($key = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $this->input->getArguments();
         }
 
@@ -346,7 +346,7 @@ class Command extends SymfonyCommand
      */
     public function option($key = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $this->input->getOptions();
         }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -310,7 +310,7 @@ class Command extends SymfonyCommand
      */
     public function argument($key = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $this->input->getArguments();
         }
 
@@ -346,7 +346,7 @@ class Command extends SymfonyCommand
      */
     public function option($key = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $this->input->getOptions();
         }
 

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -17,7 +17,7 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
-        $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
+        $callback = null === $callback ? $this->getDefaultConfirmCallback() : $callback;
 
         $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;
 

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -17,7 +17,7 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
-        $callback = null === $callback ? $this->getDefaultConfirmCallback() : $callback;
+        $callback = $callback ?? $this->getDefaultConfirmCallback();
 
         $shouldConfirm = $callback instanceof Closure ? call_user_func($callback) : $callback;
 

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -21,7 +21,7 @@ class Parser
     {
         $name = static::name($expression);
 
-        if (preg_match_all('/{\s*(.*?)\s*}/', $expression, $matches)) {
+        if (preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches)) {
             if (count($matches[1])) {
                 return array_merge([$name], static::parameters($matches[1]));
             }
@@ -40,7 +40,7 @@ class Parser
      */
     protected static function name($expression)
     {
-        if (! preg_match('/[\S]+/', $expression, $matches)) {
+        if (! preg_match('/[^\s]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }
 
@@ -87,9 +87,9 @@ class Parser
                 return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
             case Str::endsWith($token, '?'):
                 return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
-            case preg_match('/(.+)=\*(.+)/', $token, $matches):
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)=(.+)/', $token, $matches):
+            case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
             default:
                 return new InputArgument($token, InputArgument::REQUIRED, $description);
@@ -120,9 +120,9 @@ class Parser
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case Str::endsWith($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
-            case preg_match('/(.+)=\*(.+)/', $token, $matches):
+            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)=(.+)/', $token, $matches):
+            case preg_match('/(.+)\=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
             default:
                 return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -21,7 +21,7 @@ class Parser
     {
         $name = static::name($expression);
 
-        if (preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches)) {
+        if (preg_match_all('/{\s*(.*?)\s*}/', $expression, $matches)) {
             if (count($matches[1])) {
                 return array_merge([$name], static::parameters($matches[1]));
             }
@@ -40,7 +40,7 @@ class Parser
      */
     protected static function name($expression)
     {
-        if (! preg_match('/[^\s]+/', $expression, $matches)) {
+        if (! preg_match('/[\S]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }
 
@@ -87,9 +87,9 @@ class Parser
                 return new InputArgument(trim($token, '*'), InputArgument::IS_ARRAY | InputArgument::REQUIRED, $description);
             case Str::endsWith($token, '?'):
                 return new InputArgument(trim($token, '?'), InputArgument::OPTIONAL, $description);
-            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
+            case preg_match('/(.+)=\*(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)\=(.+)/', $token, $matches):
+            case preg_match('/(.+)=(.+)/', $token, $matches):
                 return new InputArgument($matches[1], InputArgument::OPTIONAL, $description, $matches[2]);
             default:
                 return new InputArgument($token, InputArgument::REQUIRED, $description);
@@ -120,9 +120,9 @@ class Parser
                 return new InputOption(trim($token, '='), $shortcut, InputOption::VALUE_OPTIONAL, $description);
             case Str::endsWith($token, '=*'):
                 return new InputOption(trim($token, '=*'), $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description);
-            case preg_match('/(.+)\=\*(.+)/', $token, $matches):
+            case preg_match('/(.+)=\*(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, $description, preg_split('/,\s?/', $matches[2]));
-            case preg_match('/(.+)\=(.+)/', $token, $matches):
+            case preg_match('/(.+)=(.+)/', $token, $matches):
                 return new InputOption($matches[1], $shortcut, InputOption::VALUE_OPTIONAL, $description, $matches[2]);
             default:
                 return new InputOption($token, $shortcut, InputOption::VALUE_NONE, $description);

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -443,7 +443,7 @@ class Event
      */
     protected function ensureOutputIsBeingCaptured()
     {
-        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
+        if (null === $this->output || $this->output == $this->getDefaultOutput()) {
             $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));
         }
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -443,7 +443,7 @@ class Event
      */
     protected function ensureOutputIsBeingCaptured()
     {
-        if (null === $this->output || $this->output == $this->getDefaultOutput()) {
+        if ($this->output === null || $this->output == $this->getDefaultOutput()) {
             $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));
         }
     }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -55,7 +55,7 @@ class BoundMethod
         $method = count($segments) === 2
                         ? $segments[1] : $defaultMethod;
 
-        if (null === $method) {
+        if ($method === null) {
             throw new InvalidArgumentException('Method not provided.');
         }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -55,7 +55,7 @@ class BoundMethod
         $method = count($segments) === 2
                         ? $segments[1] : $defaultMethod;
 
-        if (is_null($method)) {
+        if (null === $method) {
             throw new InvalidArgumentException('Method not provided.');
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -919,7 +919,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolvePrimitive(ReflectionParameter $parameter)
     {
-        if (null !== ($concrete = $this->getContextualConcrete('$' . $parameter->name))) {
+        if (null !== ($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -227,7 +227,7 @@ class Container implements ArrayAccess, ContainerContract
         // If no concrete type was given, we will simply set the concrete type to the
         // abstract type. After that, the concrete type to be registered as shared
         // without being forced to state their classes in both of the parameters.
-        if (null === $concrete) {
+        if ($concrete === null) {
             $concrete = $abstract;
         }
 
@@ -660,7 +660,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $abstract = $this->getAlias($abstract);
 
-        $needsContextualBuild = ! empty($parameters) || null !== $this->getContextualConcrete($abstract);
+        $needsContextualBuild = ! empty($parameters) || $this->getContextualConcrete($abstract) !== null;
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -718,7 +718,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getConcrete($abstract)
     {
-        if (null !== ($concrete = $this->getContextualConcrete($abstract))) {
+        if (($concrete = $this->getContextualConcrete($abstract)) !== null) {
             return $concrete;
         }
 
@@ -740,7 +740,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getContextualConcrete($abstract)
     {
-        if (null !== ($binding = $this->findInContextualBindings($abstract))) {
+        if (($binding = $this->findInContextualBindings($abstract)) !== null) {
             return $binding;
         }
 
@@ -752,7 +752,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         foreach ($this->abstractAliases[$abstract] as $alias) {
-            if (null !== ($binding = $this->findInContextualBindings($alias))) {
+            if (($binding = $this->findInContextualBindings($alias)) !== null) {
                 return $binding;
             }
         }
@@ -818,7 +818,7 @@ class Container implements ArrayAccess, ContainerContract
         // If there are no constructors, that means there are no dependencies then
         // we can just resolve the instances of the objects right away, without
         // resolving any other types or dependencies out of these containers.
-        if (null === $constructor) {
+        if ($constructor === null) {
             array_pop($this->buildStack);
 
             return new $concrete;
@@ -867,7 +867,7 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $results[] = null === $dependency->getClass()
+            $results[] = $dependency->getClass() === null
                             ? $this->resolvePrimitive($dependency)
                             : $this->resolveClass($dependency);
         }
@@ -919,7 +919,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolvePrimitive(ReflectionParameter $parameter)
     {
-        if (null !== ($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
+        if (($concrete = $this->getContextualConcrete('$'.$parameter->name)) !== null) {
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
         }
 
@@ -1005,7 +1005,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if (null === $callback && $abstract instanceof Closure) {
+        if ($callback === null && $abstract instanceof Closure) {
             $this->globalResolvingCallbacks[] = $abstract;
         } else {
             $this->resolvingCallbacks[$abstract][] = $callback;
@@ -1025,7 +1025,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if ($abstract instanceof Closure && null === $callback) {
+        if ($abstract instanceof Closure && $callback === null) {
             $this->globalAfterResolvingCallbacks[] = $abstract;
         } else {
             $this->afterResolvingCallbacks[$abstract][] = $callback;
@@ -1204,7 +1204,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (null === static::$instance) {
+        if (static::$instance === null) {
             static::$instance = new static;
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -227,7 +227,7 @@ class Container implements ArrayAccess, ContainerContract
         // If no concrete type was given, we will simply set the concrete type to the
         // abstract type. After that, the concrete type to be registered as shared
         // without being forced to state their classes in both of the parameters.
-        if (is_null($concrete)) {
+        if (null === $concrete) {
             $concrete = $abstract;
         }
 
@@ -660,9 +660,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $abstract = $this->getAlias($abstract);
 
-        $needsContextualBuild = ! empty($parameters) || ! is_null(
-            $this->getContextualConcrete($abstract)
-        );
+        $needsContextualBuild = ! empty($parameters) || null !== $this->getContextualConcrete($abstract);
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -720,7 +718,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getConcrete($abstract)
     {
-        if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
+        if (null !== ($concrete = $this->getContextualConcrete($abstract))) {
             return $concrete;
         }
 
@@ -742,7 +740,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getContextualConcrete($abstract)
     {
-        if (! is_null($binding = $this->findInContextualBindings($abstract))) {
+        if (null !== ($binding = $this->findInContextualBindings($abstract))) {
             return $binding;
         }
 
@@ -754,7 +752,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         foreach ($this->abstractAliases[$abstract] as $alias) {
-            if (! is_null($binding = $this->findInContextualBindings($alias))) {
+            if (null !== ($binding = $this->findInContextualBindings($alias))) {
                 return $binding;
             }
         }
@@ -820,7 +818,7 @@ class Container implements ArrayAccess, ContainerContract
         // If there are no constructors, that means there are no dependencies then
         // we can just resolve the instances of the objects right away, without
         // resolving any other types or dependencies out of these containers.
-        if (is_null($constructor)) {
+        if (null === $constructor) {
             array_pop($this->buildStack);
 
             return new $concrete;
@@ -869,7 +867,7 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $results[] = is_null($dependency->getClass())
+            $results[] = null === $dependency->getClass()
                             ? $this->resolvePrimitive($dependency)
                             : $this->resolveClass($dependency);
         }
@@ -921,7 +919,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolvePrimitive(ReflectionParameter $parameter)
     {
-        if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
+        if (null !== ($concrete = $this->getContextualConcrete('$' . $parameter->name))) {
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
         }
 
@@ -1007,7 +1005,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if (is_null($callback) && $abstract instanceof Closure) {
+        if (null === $callback && $abstract instanceof Closure) {
             $this->globalResolvingCallbacks[] = $abstract;
         } else {
             $this->resolvingCallbacks[$abstract][] = $callback;
@@ -1027,7 +1025,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if ($abstract instanceof Closure && is_null($callback)) {
+        if ($abstract instanceof Closure && null === $callback) {
             $this->globalAfterResolvingCallbacks[] = $abstract;
         } else {
             $this->afterResolvingCallbacks[$abstract][] = $callback;
@@ -1206,7 +1204,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (is_null(static::$instance)) {
+        if (null === static::$instance) {
             static::$instance = new static;
         }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -110,7 +110,7 @@ class CookieJar implements JarContract
      */
     public function hasQueued($key, $path = null)
     {
-        return ! is_null($this->queued($key, null, $path));
+        return null !== $this->queued($key, null, $path);
     }
 
     /**

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -110,7 +110,7 @@ class CookieJar implements JarContract
      */
     public function hasQueued($key, $path = null)
     {
-        return null !== $this->queued($key, null, $path);
+        return $this->queued($key, null, $path) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -211,9 +211,7 @@ trait ManagesTransactions
         // We allow developers to rollback to a certain transaction level. We will verify
         // that this given transaction level is valid before attempting to rollback to
         // that level. If it's not we will just return out and not attempt anything.
-        $toLevel = null === $toLevel
-                    ? $this->transactions - 1
-                    : $toLevel;
+        $toLevel = $toLevel ?? ($this->transactions - 1);
 
         if ($toLevel < 0 || $toLevel >= $this->transactions) {
             return;

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -211,7 +211,7 @@ trait ManagesTransactions
         // We allow developers to rollback to a certain transaction level. We will verify
         // that this given transaction level is valid before attempting to rollback to
         // that level. If it's not we will just return out and not attempt anything.
-        $toLevel = is_null($toLevel)
+        $toLevel = null === $toLevel
                     ? $this->transactions - 1
                     : $toLevel;
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -247,7 +247,7 @@ class Connection implements ConnectionInterface
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if (null === $this->schemaGrammar) {
             $this->useDefaultSchemaGrammar();
         }
 
@@ -767,7 +767,7 @@ class Connection implements ConnectionInterface
      */
     protected function reconnectIfMissingConnection()
     {
-        if (is_null($this->pdo)) {
+        if (null === $this->pdo) {
             $this->reconnect();
         }
     }
@@ -895,7 +895,7 @@ class Connection implements ConnectionInterface
      */
     public function getDoctrineConnection()
     {
-        if (is_null($this->doctrineConnection)) {
+        if (null === $this->doctrineConnection) {
             $driver = $this->getDoctrineDriver();
 
             $this->doctrineConnection = new DoctrineConnection(array_filter([

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -247,7 +247,7 @@ class Connection implements ConnectionInterface
      */
     public function getSchemaBuilder()
     {
-        if (null === $this->schemaGrammar) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 
@@ -767,7 +767,7 @@ class Connection implements ConnectionInterface
      */
     protected function reconnectIfMissingConnection()
     {
-        if (null === $this->pdo) {
+        if ($this->pdo === null) {
             $this->reconnect();
         }
     }
@@ -895,7 +895,7 @@ class Connection implements ConnectionInterface
      */
     public function getDoctrineConnection()
     {
-        if (null === $this->doctrineConnection) {
+        if ($this->doctrineConnection === null) {
             $driver = $this->getDoctrineDriver();
 
             $this->doctrineConnection = new DoctrineConnection(array_filter([

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -39,7 +39,7 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        if (is_null($name)) {
+        if (null === $name) {
             $name = $this->getDefaultConnection();
         }
 

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -39,7 +39,7 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        if (null === $name) {
+        if ($name === null) {
             $name = $this->getDefaultConnection();
         }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -124,7 +124,7 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function getMigrationPath()
     {
-        if (null !== ($targetPath = $this->input->getOption('path'))) {
+        if (($targetPath = $this->input->getOption('path')) !== null) {
             return ! $this->usingRealPath()
                             ? $this->laravel->basePath().'/'.$targetPath
                             : $targetPath;

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -124,7 +124,7 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function getMigrationPath()
     {
-        if (! is_null($targetPath = $this->input->getOption('path'))) {
+        if (null !== ($targetPath = $this->input->getOption('path'))) {
             return ! $this->usingRealPath()
                             ? $this->laravel->basePath().'/'.$targetPath
                             : $targetPath;

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -148,7 +148,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // If the configuration doesn't exist, we'll throw an exception and bail.
         $connections = $this->app['config']['database.connections'];
 
-        if (null === ($config = Arr::get($connections, $name))) {
+        if (($config = Arr::get($connections, $name)) === null) {
             throw new InvalidArgumentException("Database [{$name}] not configured.");
         }
 

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -148,7 +148,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // If the configuration doesn't exist, we'll throw an exception and bail.
         $connections = $this->app['config']['database.connections'];
 
-        if (is_null($config = Arr::get($connections, $name))) {
+        if (null === ($config = Arr::get($connections, $name))) {
             throw new InvalidArgumentException("Database [{$name}] not configured.");
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -258,7 +258,7 @@ class Builder
      */
     public function latest($column = null)
     {
-        if (is_null($column)) {
+        if (null === $column) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -275,7 +275,7 @@ class Builder
      */
     public function oldest($column = null)
     {
-        if (is_null($column)) {
+        if (null === $column) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -364,7 +364,7 @@ class Builder
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif (null !== $result) {
             return $result;
         }
 
@@ -382,7 +382,7 @@ class Builder
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (! is_null($model = $this->find($id, $columns))) {
+        if (null !== ($model = $this->find($id, $columns))) {
             return $model;
         }
 
@@ -398,7 +398,7 @@ class Builder
      */
     public function firstOrNew(array $attributes, array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (null !== ($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
@@ -414,7 +414,7 @@ class Builder
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (null !== ($instance = $this->where($attributes)->first())) {
             return $instance;
         }
 
@@ -447,7 +447,7 @@ class Builder
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (null !== ($model = $this->first($columns))) {
             return $model;
         }
 
@@ -469,7 +469,7 @@ class Builder
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->first($columns))) {
+        if (null !== ($model = $this->first($columns))) {
             return $model;
         }
 
@@ -813,7 +813,7 @@ class Builder
     protected function addUpdatedAtColumn(array $values)
     {
         if (! $this->model->usesTimestamps() ||
-            is_null($this->model->getUpdatedAtColumn())) {
+            null === $this->model->getUpdatedAtColumn()) {
             return $values;
         }
 
@@ -956,7 +956,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = is_null($query->wheres)
+        $originalWhereCount = null === $query->wheres
                     ? 0 : count($query->wheres);
 
         $result = $scope(...array_values($parameters)) ?? $this;

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -258,7 +258,7 @@ class Builder
      */
     public function latest($column = null)
     {
-        if (null === $column) {
+        if ($column === null) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -275,7 +275,7 @@ class Builder
      */
     public function oldest($column = null)
     {
-        if (null === $column) {
+        if ($column === null) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -364,7 +364,7 @@ class Builder
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (null !== $result) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -382,7 +382,7 @@ class Builder
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (null !== ($model = $this->find($id, $columns))) {
+        if (($model = $this->find($id, $columns)) !== null) {
             return $model;
         }
 
@@ -398,7 +398,7 @@ class Builder
      */
     public function firstOrNew(array $attributes, array $values = [])
     {
-        if (null !== ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) !== null) {
             return $instance;
         }
 
@@ -414,7 +414,7 @@ class Builder
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (null !== ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) !== null) {
             return $instance;
         }
 
@@ -447,7 +447,7 @@ class Builder
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (null !== ($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -469,7 +469,7 @@ class Builder
             $columns = ['*'];
         }
 
-        if (null !== ($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -813,7 +813,7 @@ class Builder
     protected function addUpdatedAtColumn(array $values)
     {
         if (! $this->model->usesTimestamps() ||
-            null === $this->model->getUpdatedAtColumn()) {
+            $this->model->getUpdatedAtColumn() === null) {
             return $values;
         }
 
@@ -956,7 +956,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = null === $query->wheres
+        $originalWhereCount = $query->wheres === null
                     ? 0 : count($query->wheres);
 
         $result = $scope(...array_values($parameters)) ?? $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -152,7 +152,7 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         $models->filter(function ($model) use ($name) {
-            return null !== $model && ! $model->relationLoaded($name);
+            return $model !== null && ! $model->relationLoaded($name);
         })->load($relation);
 
         if (empty($path)) {
@@ -335,7 +335,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function unique($key = null, $strict = false)
     {
-        if (null !== $key) {
+        if ($key !== null) {
             return parent::unique($key, $strict);
         }
 
@@ -350,7 +350,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function only($keys)
     {
-        if (null === $keys) {
+        if ($keys === null) {
             return new static($this->items);
         }
 
@@ -402,7 +402,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getDictionary($items = null)
     {
-        $items = null === $items ? $this->items : $items;
+        $items = $items ?? $this->items;
 
         $dictionary = [];
 

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -152,7 +152,7 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         $models->filter(function ($model) use ($name) {
-            return ! is_null($model) && ! $model->relationLoaded($name);
+            return null !== $model && ! $model->relationLoaded($name);
         })->load($relation);
 
         if (empty($path)) {
@@ -335,7 +335,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function unique($key = null, $strict = false)
     {
-        if (! is_null($key)) {
+        if (null !== $key) {
             return parent::unique($key, $strict);
         }
 
@@ -350,7 +350,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function only($keys)
     {
-        if (is_null($keys)) {
+        if (null === $keys) {
             return new static($this->items);
         }
 
@@ -402,7 +402,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getDictionary($items = null)
     {
-        $items = is_null($items) ? $this->items : $items;
+        $items = null === $items ? $this->items : $items;
 
         $dictionary = [];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,7 +250,7 @@ trait HasAttributes
             // If the value is null, we'll still go ahead and set it in this list of
             // attributes since null is used to represent empty relationships if
             // if it a has one or belongs to type relationships on the models.
-            elseif (is_null($value)) {
+            elseif (null === $value) {
                 $relation = $value;
             }
 
@@ -264,7 +264,7 @@ trait HasAttributes
             // If the relation value has been set, we will set it on this attributes
             // list for returning. If it was not arrayable or null, we'll not set
             // the value on the array because it is some type of invalid value.
-            if (isset($relation) || is_null($value)) {
+            if (isset($relation) || null === $value) {
                 $attributes[$key] = $relation;
             }
 
@@ -360,8 +360,7 @@ trait HasAttributes
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
+        if (null !== $value && in_array($key, $this->getDates())) {
             return $this->asDateTime($value);
         }
 
@@ -415,7 +414,7 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            if (is_null($relation)) {
+            if ($relation === null) {
                 throw new LogicException(sprintf(
                     '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));
@@ -477,7 +476,7 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        if (null === $value) {
             return $value;
         }
 
@@ -580,7 +579,7 @@ trait HasAttributes
             $value = $this->fromDateTime($value);
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if (null !== $value && $this->isJsonCastable($key)) {
             $value = $this->castAttributeAsJson($key, $value);
         }
 
@@ -1167,7 +1166,7 @@ trait HasAttributes
 
         if ($current === $original) {
             return true;
-        } elseif (is_null($current)) {
+        } elseif (null === $current) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -414,7 +414,7 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            if ($relation === null) {
+            if (null === $relation) {
                 throw new LogicException(sprintf(
                     '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -250,7 +250,7 @@ trait HasAttributes
             // If the value is null, we'll still go ahead and set it in this list of
             // attributes since null is used to represent empty relationships if
             // if it a has one or belongs to type relationships on the models.
-            elseif (null === $value) {
+            elseif ($value === null) {
                 $relation = $value;
             }
 
@@ -264,7 +264,7 @@ trait HasAttributes
             // If the relation value has been set, we will set it on this attributes
             // list for returning. If it was not arrayable or null, we'll not set
             // the value on the array because it is some type of invalid value.
-            if (isset($relation) || null === $value) {
+            if (isset($relation) || $value === null) {
                 $attributes[$key] = $relation;
             }
 
@@ -360,7 +360,7 @@ trait HasAttributes
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (null !== $value && in_array($key, $this->getDates())) {
+        if ($value !== null && in_array($key, $this->getDates())) {
             return $this->asDateTime($value);
         }
 
@@ -414,7 +414,7 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            if (null === $relation) {
+            if ($relation === null) {
                 throw new LogicException(sprintf(
                     '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));
@@ -476,7 +476,7 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        if (null === $value) {
+        if ($value === null) {
             return $value;
         }
 
@@ -579,7 +579,7 @@ trait HasAttributes
             $value = $this->fromDateTime($value);
         }
 
-        if (null !== $value && $this->isJsonCastable($key)) {
+        if ($value !== null && $this->isJsonCastable($key)) {
             $value = $this->castAttributeAsJson($key, $value);
         }
 
@@ -1166,7 +1166,7 @@ trait HasAttributes
 
         if ($current === $original) {
             return true;
-        } elseif (null === $current) {
+        } elseif ($current === null) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -204,7 +204,7 @@ trait HasEvents
 
         $result = static::$dispatcher->$method(new $this->dispatchesEvents[$event]($this));
 
-        if (null !== $result) {
+        if ($result !== null) {
             return $result;
         }
     }
@@ -219,7 +219,7 @@ trait HasEvents
     {
         if (is_array($result)) {
             $result = array_filter($result, function ($response) {
-                return null !== $response;
+                return $response !== null;
             });
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -204,7 +204,7 @@ trait HasEvents
 
         $result = static::$dispatcher->$method(new $this->dispatchesEvents[$event]($this));
 
-        if (! is_null($result)) {
+        if (null !== $result) {
             return $result;
         }
     }
@@ -219,7 +219,7 @@ trait HasEvents
     {
         if (is_array($result)) {
             $result = array_filter($result, function ($response) {
-                return ! is_null($response);
+                return null !== $response;
             });
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -20,7 +20,7 @@ trait HasGlobalScopes
      */
     public static function addGlobalScope($scope, Closure $implementation = null)
     {
-        if (is_string($scope) && ! is_null($implementation)) {
+        if (is_string($scope) && null !== $implementation) {
             return static::$globalScopes[static::class][$scope] = $implementation;
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
@@ -39,7 +39,7 @@ trait HasGlobalScopes
      */
     public static function hasGlobalScope($scope)
     {
-        return ! is_null(static::getGlobalScope($scope));
+        return null !== static::getGlobalScope($scope);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -20,7 +20,7 @@ trait HasGlobalScopes
      */
     public static function addGlobalScope($scope, Closure $implementation = null)
     {
-        if (is_string($scope) && null !== $implementation) {
+        if (is_string($scope) && $implementation !== null) {
             return static::$globalScopes[static::class][$scope] = $implementation;
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
@@ -39,7 +39,7 @@ trait HasGlobalScopes
      */
     public static function hasGlobalScope($scope)
     {
-        return null !== static::getGlobalScope($scope);
+        return static::getGlobalScope($scope) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -172,7 +172,7 @@ trait HasRelationships
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relationships.
-        if (null === $relation) {
+        if ($relation === null) {
             $relation = $this->guessBelongsToRelation();
         }
 
@@ -181,7 +181,7 @@ trait HasRelationships
         // If no foreign key was supplied, we can use a backtrace to guess the proper
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
-        if (null === $foreignKey) {
+        if ($foreignKey === null) {
             $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
         }
 
@@ -451,7 +451,7 @@ trait HasRelationships
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
-        if (null === $relation) {
+        if ($relation === null) {
             $relation = $this->guessBelongsToManyRelation();
         }
 
@@ -467,7 +467,7 @@ trait HasRelationships
         // If no table name was provided, we can guess it by concatenating the two
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.
-        if (null === $table) {
+        if ($table === null) {
             $table = $this->joiningTable($related, $instance);
         }
 
@@ -608,7 +608,7 @@ trait HasRelationships
             );
         });
 
-        return null !== $caller ? $caller['function'] : null;
+        return $caller !== null ? $caller['function'] : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -172,7 +172,7 @@ trait HasRelationships
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relationships.
-        if (is_null($relation)) {
+        if (null === $relation) {
             $relation = $this->guessBelongsToRelation();
         }
 
@@ -181,7 +181,7 @@ trait HasRelationships
         // If no foreign key was supplied, we can use a backtrace to guess the proper
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
-        if (is_null($foreignKey)) {
+        if (null === $foreignKey) {
             $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
         }
 
@@ -451,7 +451,7 @@ trait HasRelationships
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
-        if (is_null($relation)) {
+        if (null === $relation) {
             $relation = $this->guessBelongsToManyRelation();
         }
 
@@ -467,7 +467,7 @@ trait HasRelationships
         // If no table name was provided, we can guess it by concatenating the two
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.
-        if (is_null($table)) {
+        if (null === $table) {
             $table = $this->joiningTable($related, $instance);
         }
 
@@ -608,7 +608,7 @@ trait HasRelationships
             );
         });
 
-        return ! is_null($caller) ? $caller['function'] : null;
+        return null !== $caller ? $caller['function'] : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -38,11 +38,11 @@ trait HasTimestamps
     {
         $time = $this->freshTimestamp();
 
-        if (! is_null(static::UPDATED_AT) && ! $this->isDirty(static::UPDATED_AT)) {
+        if (null !== static::UPDATED_AT && ! $this->isDirty(static::UPDATED_AT)) {
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! is_null(static::CREATED_AT) &&
+        if (! $this->exists && null !== static::CREATED_AT &&
             ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -38,11 +38,11 @@ trait HasTimestamps
     {
         $time = $this->freshTimestamp();
 
-        if (null !== static::UPDATED_AT && ! $this->isDirty(static::UPDATED_AT)) {
+        if (static::UPDATED_AT !== null && ! $this->isDirty(static::UPDATED_AT)) {
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && null !== static::CREATED_AT &&
+        if (! $this->exists && static::CREATED_AT !== null &&
             ! $this->isDirty(static::CREATED_AT)) {
             $this->setCreatedAt($time);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -357,7 +357,7 @@ trait QueriesRelationships
             return $this;
         }
 
-        if (is_null($this->query->columns)) {
+        if (null === $this->query->columns) {
             $this->query->select([$this->query->from.'.*']);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -357,7 +357,7 @@ trait QueriesRelationships
             return $this;
         }
 
-        if (null === $this->query->columns) {
+        if ($this->query->columns === null) {
             $this->query->select([$this->query->from.'.*']);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -883,7 +883,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function delete()
     {
-        if (is_null($this->getKeyName())) {
+        if (null === $this->getKeyName()) {
             throw new Exception('No primary key defined on model.');
         }
 
@@ -1192,7 +1192,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function is($model)
     {
-        return ! is_null($model) &&
+        return null !== $model &&
                $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();
@@ -1543,7 +1543,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        return null !== $this->getAttribute($offset);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -883,7 +883,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function delete()
     {
-        if (null === $this->getKeyName()) {
+        if ($this->getKeyName() === null) {
             throw new Exception('No primary key defined on model.');
         }
 
@@ -1192,7 +1192,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function is($model)
     {
-        return null !== $model &&
+        return $model !== null &&
                $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();
@@ -1543,7 +1543,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return null !== $this->getAttribute($offset);
+        return $this->getAttribute($offset) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -76,7 +76,7 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
-        if (null === $this->child->{$this->foreignKey}) {
+        if ($this->child->{$this->foreignKey} === null) {
             return $this->getDefaultFor($this->parent);
         }
 
@@ -132,7 +132,7 @@ class BelongsTo extends Relation
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
-            if (null !== ($value = $model->{$this->foreignKey})) {
+            if (($value = $model->{$this->foreignKey}) !== null) {
                 $keys[] = $value;
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -76,7 +76,7 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
-        if (is_null($this->child->{$this->foreignKey})) {
+        if (null === $this->child->{$this->foreignKey}) {
             return $this->getDefaultFor($this->parent);
         }
 
@@ -132,7 +132,7 @@ class BelongsTo extends Relation
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
-            if (! is_null($value = $model->{$this->foreignKey})) {
+            if (null !== ($value = $model->{$this->foreignKey})) {
                 $keys[] = $value;
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -404,7 +404,7 @@ class BelongsToMany extends Relation
             return $this;
         }
 
-        if (null === $value) {
+        if ($value === null) {
             throw new InvalidArgumentException('The provided value may not be null.');
         }
 
@@ -434,7 +434,7 @@ class BelongsToMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (null === ($instance = $this->find($id, $columns))) {
+        if (($instance = $this->find($id, $columns)) === null) {
             $instance = $this->related->newInstance();
         }
 
@@ -449,7 +449,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -466,7 +466,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->create($attributes, $joining, $touch);
         }
 
@@ -484,7 +484,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             return $this->create($values, $joining, $touch);
         }
 
@@ -540,7 +540,7 @@ class BelongsToMany extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (null !== $result) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -570,7 +570,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (null !== ($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -584,7 +584,7 @@ class BelongsToMany extends Relation
      */
     public function getResults()
     {
-        return null !== $this->parent->{$this->parentKey}
+        return $this->parent->{$this->parentKey} !== null
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -404,7 +404,7 @@ class BelongsToMany extends Relation
             return $this;
         }
 
-        if (is_null($value)) {
+        if (null === $value) {
             throw new InvalidArgumentException('The provided value may not be null.');
         }
 
@@ -434,7 +434,7 @@ class BelongsToMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (is_null($instance = $this->find($id, $columns))) {
+        if (null === ($instance = $this->find($id, $columns))) {
             $instance = $this->related->newInstance();
         }
 
@@ -449,7 +449,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -466,7 +466,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             $instance = $this->create($attributes, $joining, $touch);
         }
 
@@ -484,7 +484,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             return $this->create($values, $joining, $touch);
         }
 
@@ -540,7 +540,7 @@ class BelongsToMany extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif (null !== $result) {
             return $result;
         }
 
@@ -570,7 +570,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (null !== ($model = $this->first($columns))) {
             return $model;
         }
 
@@ -584,7 +584,7 @@ class BelongsToMany extends Relation
      */
     public function getResults()
     {
-        return ! is_null($this->parent->{$this->parentKey})
+        return null !== $this->parent->{$this->parentKey}
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -425,7 +425,7 @@ trait InteractsWithPivotTable
             // If associated IDs were passed to the method we will only delete those
             // associations, otherwise all of the association ties will be broken.
             // We'll return the numbers of affected rows when we do the deletes.
-            if (! is_null($ids)) {
+            if (null !== $ids) {
                 $ids = $this->parseIds($ids);
 
                 if (empty($ids)) {

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -425,7 +425,7 @@ trait InteractsWithPivotTable
             // If associated IDs were passed to the method we will only delete those
             // associations, otherwise all of the association ties will be broken.
             // We'll return the numbers of affected rows when we do the deletes.
-            if (null !== $ids) {
+            if ($ids !== null) {
                 $ids = $this->parseIds($ids);
 
                 if (empty($ids)) {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,7 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return ! is_null($this->getParentKey())
+        return null !== $this->getParentKey()
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,7 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return null !== $this->getParentKey()
+        return $this->getParentKey() !== null
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -223,7 +223,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -269,7 +269,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (null !== ($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -329,7 +329,7 @@ class HasManyThrough extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (null !== $result) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -343,7 +343,7 @@ class HasManyThrough extends Relation
      */
     public function getResults()
     {
-        return null !== $this->farParent->{$this->localKey}
+        return $this->farParent->{$this->localKey} !== null
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -223,7 +223,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -269,7 +269,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (null !== ($model = $this->first($columns))) {
             return $model;
         }
 
@@ -329,7 +329,7 @@ class HasManyThrough extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif (null !== $result) {
             return $result;
         }
 
@@ -343,7 +343,7 @@ class HasManyThrough extends Relation
      */
     public function getResults()
     {
-        return ! is_null($this->farParent->{$this->localKey})
+        return null !== $this->farParent->{$this->localKey}
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,7 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        if (is_null($this->getParentKey())) {
+        if (null === $this->getParentKey()) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,7 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        if (null === $this->getParentKey()) {
+        if ($this->getParentKey() === null) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -180,7 +180,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (null === ($instance = $this->find($id, $columns))) {
+        if (($instance = $this->find($id, $columns)) === null) {
             $instance = $this->related->newInstance();
 
             $this->setForeignAttributesForCreate($instance);
@@ -198,7 +198,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrNew(array $attributes, array $values = [])
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes + $values);
 
             $this->setForeignAttributesForCreate($instance);
@@ -216,7 +216,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (null === ($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->create($attributes + $values);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -180,7 +180,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (is_null($instance = $this->find($id, $columns))) {
+        if (null === ($instance = $this->find($id, $columns))) {
             $instance = $this->related->newInstance();
 
             $this->setForeignAttributesForCreate($instance);
@@ -198,7 +198,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrNew(array $attributes, array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes + $values);
 
             $this->setForeignAttributesForCreate($instance);
@@ -216,7 +216,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (null === ($instance = $this->where($attributes)->first())) {
             $instance = $this->create($attributes + $values);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,7 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return null !== $this->getParentKey()
+        return $this->getParentKey() !== null
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,7 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return ! is_null($this->getParentKey())
+        return null !== $this->getParentKey()
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -17,7 +17,7 @@ class MorphOne extends MorphOneOrMany
      */
     public function getResults()
     {
-        if (is_null($this->getParentKey())) {
+        if (null === $this->getParentKey()) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -17,7 +17,7 @@ class MorphOne extends MorphOneOrMany
      */
     public function getResults()
     {
-        if (null === $this->getParentKey()) {
+        if ($this->getParentKey() === null) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -179,7 +179,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, Collection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = null !== $this->ownerKey ? $result->{$this->ownerKey} : $result->getKey();
+            $ownerKey = $this->ownerKey !== null ? $result->{$this->ownerKey} : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
@@ -229,7 +229,7 @@ class MorphTo extends BelongsTo
      */
     public function touch()
     {
-        if (null !== $this->child->{$this->foreignKey}) {
+        if ($this->child->{$this->foreignKey} !== null) {
             parent::touch();
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -179,7 +179,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, Collection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey();
+            $ownerKey = null !== $this->ownerKey ? $result->{$this->ownerKey} : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
@@ -229,7 +229,7 @@ class MorphTo extends BelongsTo
      */
     public function touch()
     {
-        if (! is_null($this->child->{$this->foreignKey})) {
+        if (null !== $this->child->{$this->foreignKey}) {
             parent::touch();
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -349,7 +349,7 @@ abstract class Relation
      */
     protected static function buildMorphMapFromModels(array $models = null)
     {
-        if (null === $models || Arr::isAssoc($models)) {
+        if ($models === null || Arr::isAssoc($models)) {
             return $models;
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -349,7 +349,7 @@ abstract class Relation
      */
     protected static function buildMorphMapFromModels(array $models = null)
     {
-        if (is_null($models) || Arr::isAssoc($models)) {
+        if (null === $models || Arr::isAssoc($models)) {
             return $models;
         }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -85,7 +85,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps && null !== $this->getUpdatedAtColumn()) {
+        if ($this->timestamps && $this->getUpdatedAtColumn() !== null) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
@@ -129,7 +129,7 @@ trait SoftDeletes
      */
     public function trashed()
     {
-        return null !== $this->{$this->getDeletedAtColumn()};
+        return $this->{$this->getDeletedAtColumn()} !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -85,7 +85,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
+        if ($this->timestamps && null !== $this->getUpdatedAtColumn()) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
@@ -129,7 +129,7 @@ trait SoftDeletes
      */
     public function trashed()
     {
-        return ! is_null($this->{$this->getDeletedAtColumn()});
+        return null !== $this->{$this->getDeletedAtColumn()};
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -91,7 +91,7 @@ class MigrationCreator
      */
     protected function getStub($table, $create)
     {
-        if (is_null($table)) {
+        if (null === $table) {
             return $this->files->get($this->stubPath().'/blank.stub');
         }
 
@@ -118,7 +118,7 @@ class MigrationCreator
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
-        if (! is_null($table)) {
+        if (null !== $table) {
             $stub = str_replace('DummyTable', $table, $stub);
         }
 

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -91,7 +91,7 @@ class MigrationCreator
      */
     protected function getStub($table, $create)
     {
-        if (null === $table) {
+        if ($table === null) {
             return $this->files->get($this->stubPath().'/blank.stub');
         }
 
@@ -118,7 +118,7 @@ class MigrationCreator
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
-        if (null !== $table) {
+        if ($table !== null) {
             $stub = str_replace('DummyTable', $table, $stub);
         }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -528,7 +528,7 @@ class Migrator
      */
     public function setConnection($name)
     {
-        if (! is_null($name)) {
+        if (null !== $name) {
             $this->resolver->setDefaultConnection($name);
         }
 
@@ -556,7 +556,7 @@ class Migrator
      */
     protected function getSchemaGrammar($connection)
     {
-        if (is_null($grammar = $connection->getSchemaGrammar())) {
+        if (null === ($grammar = $connection->getSchemaGrammar())) {
             $connection->useDefaultSchemaGrammar();
 
             $grammar = $connection->getSchemaGrammar();

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -528,7 +528,7 @@ class Migrator
      */
     public function setConnection($name)
     {
-        if (null !== $name) {
+        if ($name !== null) {
             $this->resolver->setDefaultConnection($name);
         }
 
@@ -556,7 +556,7 @@ class Migrator
      */
     protected function getSchemaGrammar($connection)
     {
-        if (null === ($grammar = $connection->getSchemaGrammar())) {
+        if (($grammar = $connection->getSchemaGrammar()) === null) {
             $connection->useDefaultSchemaGrammar();
 
             $grammar = $connection->getSchemaGrammar();

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -28,7 +28,7 @@ class MySqlConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if (null === $this->schemaGrammar) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -28,7 +28,7 @@ class MySqlConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (null === $this->schemaGrammar) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -27,7 +27,7 @@ class PostgresConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if (null === $this->schemaGrammar) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -27,7 +27,7 @@ class PostgresConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (null === $this->schemaGrammar) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -363,7 +363,7 @@ class Builder
                 $column instanceof EloquentBuilder ||
                 $column instanceof Closure
             )) {
-                if (is_null($this->columns)) {
+                if (null === $this->columns) {
                     $this->select($this->from.'.*');
                 }
 
@@ -678,7 +678,7 @@ class Builder
         // If the value is "null", we will just assume the developer wants to add a
         // where null clause to the query. So, we will allow a short-cut here to
         // that method for convenience so the developer doesn't have to check.
-        if (is_null($value)) {
+        if (null === $value) {
             return $this->whereNull($column, $boolean, $operator !== '=');
         }
 
@@ -762,7 +762,7 @@ class Builder
      */
     protected function invalidOperatorAndValue($operator, $value)
     {
-        return is_null($value) && in_array($operator, $this->operators) &&
+        return null === $value && in_array($operator, $this->operators) &&
              ! in_array($operator, ['=', '<>', '!=']);
     }
 
@@ -974,6 +974,7 @@ class Builder
         foreach ($values as &$value) {
             $value = (int) $value;
         }
+        unset($value);
 
         $this->wheres[] = compact('type', 'column', 'values', 'boolean');
 
@@ -1970,7 +1971,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if (null !== $lastId) {
             $this->where($column, '<', $lastId);
         }
 
@@ -1990,7 +1991,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if (null !== $lastId) {
             $this->where($column, '>', $lastId);
         }
 
@@ -2054,7 +2055,7 @@ class Builder
     {
         $this->lock = $value;
 
-        if (! is_null($this->lock)) {
+        if (null !== $this->lock) {
             $this->useWritePdo();
         }
 
@@ -2248,7 +2249,7 @@ class Builder
      */
     public function cursor()
     {
-        if (is_null($this->columns)) {
+        if (null === $this->columns) {
             $this->columns = ['*'];
         }
 
@@ -2286,7 +2287,7 @@ class Builder
         // given columns / key. Once we have the results, we will be able to take
         // the results and get the exact data that was requested for the query.
         $queryResult = $this->onceWithColumns(
-            is_null($key) ? [$column] : [$column, $key],
+            null === $key ? [$column] : [$column, $key],
             function () {
                 return $this->processor->processSelect(
                     $this, $this->runSelect()
@@ -2318,7 +2319,7 @@ class Builder
      */
     protected function stripTableForPluck($column)
     {
-        return is_null($column) ? $column : last(preg_split('~\.| ~', $column));
+        return null === $column ? $column : last(preg_split('~[. ]~', $column));
     }
 
     /**
@@ -2333,7 +2334,7 @@ class Builder
     {
         $results = [];
 
-        if (is_null($key)) {
+        if (null === $key) {
             foreach ($queryResult as $row) {
                 $results[] = $row->$column;
             }
@@ -2358,7 +2359,7 @@ class Builder
     {
         $results = [];
 
-        if (is_null($key)) {
+        if (null === $key) {
             foreach ($queryResult as $row) {
                 $results[] = $row[$column];
             }
@@ -2565,7 +2566,7 @@ class Builder
     {
         $original = $this->columns;
 
-        if (is_null($original)) {
+        if (null === $original) {
             $this->columns = $columns;
         }
 
@@ -2763,7 +2764,7 @@ class Builder
         // If an ID is passed to the method, we will set the where clause to check the
         // ID to let developers to simply and quickly remove a single row from this
         // database without manually specifying the "where" clauses on the query.
-        if (! is_null($id)) {
+        if (null !== $id) {
             $this->where($this->from.'.id', '=', $id);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -363,7 +363,7 @@ class Builder
                 $column instanceof EloquentBuilder ||
                 $column instanceof Closure
             )) {
-                if (null === $this->columns) {
+                if ($this->columns === null) {
                     $this->select($this->from.'.*');
                 }
 
@@ -678,7 +678,7 @@ class Builder
         // If the value is "null", we will just assume the developer wants to add a
         // where null clause to the query. So, we will allow a short-cut here to
         // that method for convenience so the developer doesn't have to check.
-        if (null === $value) {
+        if ($value === null) {
             return $this->whereNull($column, $boolean, $operator !== '=');
         }
 
@@ -762,7 +762,7 @@ class Builder
      */
     protected function invalidOperatorAndValue($operator, $value)
     {
-        return null === $value && in_array($operator, $this->operators) &&
+        return $value === null && in_array($operator, $this->operators) &&
              ! in_array($operator, ['=', '<>', '!=']);
     }
 
@@ -1971,7 +1971,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (null !== $lastId) {
+        if ($lastId !== null) {
             $this->where($column, '<', $lastId);
         }
 
@@ -1991,7 +1991,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (null !== $lastId) {
+        if ($lastId !== null) {
             $this->where($column, '>', $lastId);
         }
 
@@ -2055,7 +2055,7 @@ class Builder
     {
         $this->lock = $value;
 
-        if (null !== $this->lock) {
+        if ($this->lock !== null) {
             $this->useWritePdo();
         }
 
@@ -2249,7 +2249,7 @@ class Builder
      */
     public function cursor()
     {
-        if (null === $this->columns) {
+        if ($this->columns === null) {
             $this->columns = ['*'];
         }
 
@@ -2287,7 +2287,7 @@ class Builder
         // given columns / key. Once we have the results, we will be able to take
         // the results and get the exact data that was requested for the query.
         $queryResult = $this->onceWithColumns(
-            null === $key ? [$column] : [$column, $key],
+            $key === null ? [$column] : [$column, $key],
             function () {
                 return $this->processor->processSelect(
                     $this, $this->runSelect()
@@ -2319,7 +2319,7 @@ class Builder
      */
     protected function stripTableForPluck($column)
     {
-        return null === $column ? $column : last(preg_split('~[. ]~', $column));
+        return $column === null ? $column : last(preg_split('~\.| ~', $column));
     }
 
     /**
@@ -2334,7 +2334,7 @@ class Builder
     {
         $results = [];
 
-        if (null === $key) {
+        if ($key === null) {
             foreach ($queryResult as $row) {
                 $results[] = $row->$column;
             }
@@ -2359,7 +2359,7 @@ class Builder
     {
         $results = [];
 
-        if (null === $key) {
+        if ($key === null) {
             foreach ($queryResult as $row) {
                 $results[] = $row[$column];
             }
@@ -2566,7 +2566,7 @@ class Builder
     {
         $original = $this->columns;
 
-        if (null === $original) {
+        if ($original === null) {
             $this->columns = $columns;
         }
 
@@ -2764,7 +2764,7 @@ class Builder
         // If an ID is passed to the method, we will set the where clause to check the
         // ID to let developers to simply and quickly remove a single row from this
         // database without manually specifying the "where" clauses on the query.
-        if (null !== $id) {
+        if ($id !== null) {
             $this->where($this->from.'.id', '=', $id);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -54,7 +54,7 @@ class Grammar extends BaseGrammar
         // can build the query and concatenate all the pieces together as one.
         $original = $query->columns;
 
-        if (is_null($query->columns)) {
+        if (null === $query->columns) {
             $query->columns = ['*'];
         }
 
@@ -88,7 +88,7 @@ class Grammar extends BaseGrammar
             // To compile the query, we'll spin through each component of the query and
             // see if that component exists. If it does we'll just call the compiler
             // function for the component which is responsible for making the SQL.
-            if (isset($query->$component) && ! is_null($query->$component)) {
+            if (isset($query->$component) && null !== $query->$component) {
                 $method = 'compile'.ucfirst($component);
 
                 $sql[$component] = $this->$method($query, $query->$component);
@@ -133,7 +133,7 @@ class Grammar extends BaseGrammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (! is_null($query->aggregate)) {
+        if (null !== $query->aggregate) {
             return;
         }
 
@@ -170,9 +170,9 @@ class Grammar extends BaseGrammar
         return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
 
-            $nestedJoins = is_null($join->joins) ? '' : ' '.$this->compileJoins($query, $join->joins);
+            $nestedJoins = null === $join->joins ? '' : ' '.$this->compileJoins($query, $join->joins);
 
-            $tableAndNestedJoins = is_null($join->joins) ? $table : '('.$table.$nestedJoins.')';
+            $tableAndNestedJoins = null === $join->joins ? $table : '('.$table.$nestedJoins.')';
 
             return trim("{$join->type} join {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
@@ -189,7 +189,7 @@ class Grammar extends BaseGrammar
         // Each type of where clauses has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice
         // and maintainable since each clause has a very small method that it uses.
-        if (is_null($query->wheres)) {
+        if (null === $query->wheres) {
             return '';
         }
 
@@ -1198,7 +1198,7 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonPath($value, $delimiter = '->')
     {
-        $value = preg_replace("/([\\\\]+)?\\'/", "\\'", $value);
+        $value = preg_replace("/([\\\\]+)?'/", "\\'", $value);
 
         return '\'$."'.str_replace($delimiter, '"."', $value).'"\'';
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -54,7 +54,7 @@ class Grammar extends BaseGrammar
         // can build the query and concatenate all the pieces together as one.
         $original = $query->columns;
 
-        if (null === $query->columns) {
+        if ($query->columns === null) {
             $query->columns = ['*'];
         }
 
@@ -88,7 +88,7 @@ class Grammar extends BaseGrammar
             // To compile the query, we'll spin through each component of the query and
             // see if that component exists. If it does we'll just call the compiler
             // function for the component which is responsible for making the SQL.
-            if (isset($query->$component) && null !== $query->$component) {
+            if (isset($query->$component) && $query->$component !== null) {
                 $method = 'compile'.ucfirst($component);
 
                 $sql[$component] = $this->$method($query, $query->$component);
@@ -133,7 +133,7 @@ class Grammar extends BaseGrammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (null !== $query->aggregate) {
+        if ($query->aggregate !== null) {
             return;
         }
 
@@ -170,9 +170,9 @@ class Grammar extends BaseGrammar
         return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
 
-            $nestedJoins = null === $join->joins ? '' : ' '.$this->compileJoins($query, $join->joins);
+            $nestedJoins = $join->joins === null ? '' : ' '.$this->compileJoins($query, $join->joins);
 
-            $tableAndNestedJoins = null === $join->joins ? $table : '('.$table.$nestedJoins.')';
+            $tableAndNestedJoins = $join->joins === null ? $table : '('.$table.$nestedJoins.')';
 
             return trim("{$join->type} join {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
@@ -189,7 +189,7 @@ class Grammar extends BaseGrammar
         // Each type of where clauses has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice
         // and maintainable since each clause has a very small method that it uses.
-        if (null === $query->wheres) {
+        if ($query->wheres === null) {
             return '';
         }
 
@@ -1198,7 +1198,7 @@ class Grammar extends BaseGrammar
      */
     protected function wrapJsonPath($value, $delimiter = '->')
     {
-        $value = preg_replace("/([\\\\]+)?'/", "\\'", $value);
+        $value = preg_replace("/([\\\\]+)?\\'/", "\\'", $value);
 
         return '\'$."'.str_replace($delimiter, '"."', $value).'"\'';
     }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -97,7 +97,7 @@ class PostgresGrammar extends Grammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (! is_null($query->aggregate)) {
+        if (null !== $query->aggregate) {
             return;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -97,7 +97,7 @@ class PostgresGrammar extends Grammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (null !== $query->aggregate) {
+        if ($query->aggregate !== null) {
             return;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -33,7 +33,7 @@ class SqlServerGrammar extends Grammar
         // If an offset is present on the query, we will need to wrap the query in
         // a big "ANSI" offset syntax block. This is very nasty compared to the
         // other database systems but is necessary for implementing features.
-        if (is_null($query->columns)) {
+        if (null === $query->columns) {
             $query->columns = ['*'];
         }
 
@@ -51,7 +51,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileColumns(Builder $query, $columns)
     {
-        if (! is_null($query->aggregate)) {
+        if (null !== $query->aggregate) {
             return;
         }
 
@@ -82,7 +82,7 @@ class SqlServerGrammar extends Grammar
             return $from.' '.$query->lock;
         }
 
-        if (! is_null($query->lock)) {
+        if (null !== $query->lock) {
             return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -33,7 +33,7 @@ class SqlServerGrammar extends Grammar
         // If an offset is present on the query, we will need to wrap the query in
         // a big "ANSI" offset syntax block. This is very nasty compared to the
         // other database systems but is necessary for implementing features.
-        if (null === $query->columns) {
+        if ($query->columns === null) {
             $query->columns = ['*'];
         }
 
@@ -51,7 +51,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileColumns(Builder $query, $columns)
     {
-        if (null !== $query->aggregate) {
+        if ($query->aggregate !== null) {
             return;
         }
 
@@ -82,7 +82,7 @@ class SqlServerGrammar extends Grammar
             return $from.' '.$query->lock;
         }
 
-        if (null !== $query->lock) {
+        if ($query->lock !== null) {
             return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -51,7 +51,7 @@ class SQLiteConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if (null === $this->schemaGrammar) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -51,7 +51,7 @@ class SQLiteConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (null === $this->schemaGrammar) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,7 +79,7 @@ class Blueprint
         $this->table = $table;
         $this->prefix = $prefix;
 
-        if (null !== $callback) {
+        if ($callback !== null) {
             $callback($this);
         }
     }
@@ -120,7 +120,7 @@ class Blueprint
             $method = 'compile'.ucfirst($command->name);
 
             if (method_exists($grammar, $method)) {
-                if (null !== ($sql = $grammar->$method($this, $command, $connection))) {
+                if (($sql = $grammar->$method($this, $command, $connection)) !== null) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,7 +79,7 @@ class Blueprint
         $this->table = $table;
         $this->prefix = $prefix;
 
-        if (! is_null($callback)) {
+        if (null !== $callback) {
             $callback($this);
         }
     }
@@ -120,7 +120,7 @@ class Blueprint
             $method = 'compile'.ucfirst($command->name);
 
             if (method_exists($grammar, $method)) {
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (null !== ($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -79,7 +79,7 @@ class ChangeColumn
             // Doctrine column definitions - which is necessary because Laravel and Doctrine
             // use some different terminology for various column attributes on the tables.
             foreach ($fluent->getAttributes() as $key => $value) {
-                if (null !== ($option = static::mapFluentOptionToDoctrine($key))) {
+                if (($option = static::mapFluentOptionToDoctrine($key)) !== null) {
                     if (method_exists($column, $method = 'set'.ucfirst($option))) {
                         $column->{$method}(static::mapFluentValueToDoctrine($option, $value));
                         continue;

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -79,7 +79,7 @@ class ChangeColumn
             // Doctrine column definitions - which is necessary because Laravel and Doctrine
             // use some different terminology for various column attributes on the tables.
             foreach ($fluent->getAttributes() as $key => $value) {
-                if (! is_null($option = static::mapFluentOptionToDoctrine($key))) {
+                if (null !== ($option = static::mapFluentOptionToDoctrine($key))) {
                     if (method_exists($column, $method = 'set'.ucfirst($option))) {
                         $column->{$method}(static::mapFluentValueToDoctrine($option, $value));
                         continue;

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -84,11 +84,11 @@ abstract class Grammar extends BaseGrammar
         // Once we have the basic foreign key creation statement constructed we can
         // build out the syntax for what should happen on an update or delete of
         // the affected columns, which will get something like "cascade", etc.
-        if (null !== $command->onDelete) {
+        if ($command->onDelete !== null) {
             $sql .= " on delete {$command->onDelete}";
         }
 
-        if (null !== $command->onUpdate) {
+        if ($command->onUpdate !== null) {
             $sql .= " on update {$command->onUpdate}";
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -84,11 +84,11 @@ abstract class Grammar extends BaseGrammar
         // Once we have the basic foreign key creation statement constructed we can
         // build out the syntax for what should happen on an update or delete of
         // the affected columns, which will get something like "cascade", etc.
-        if (! is_null($command->onDelete)) {
+        if (null !== $command->onDelete) {
             $sql .= " on delete {$command->onDelete}";
         }
 
-        if (! is_null($command->onUpdate)) {
+        if (null !== $command->onUpdate) {
             $sql .= " on update {$command->onUpdate}";
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -107,7 +107,7 @@ class MySqlGrammar extends Grammar
         // table is being created on. We will add these to the create table query.
         if (isset($blueprint->charset)) {
             $sql .= ' default character set '.$blueprint->charset;
-        } elseif (null !== ($charset = $connection->getConfig('charset'))) {
+        } elseif (($charset = $connection->getConfig('charset')) !== null) {
             $sql .= ' default character set '.$charset;
         }
 
@@ -116,7 +116,7 @@ class MySqlGrammar extends Grammar
         // connection that the query is targeting. We'll add it to this SQL query.
         if (isset($blueprint->collation)) {
             $sql .= " collate '{$blueprint->collation}'";
-        } elseif (null !== ($collation = $connection->getConfig('collation'))) {
+        } elseif (($collation = $connection->getConfig('collation')) !== null) {
             $sql .= " collate '{$collation}'";
         }
 
@@ -135,7 +135,7 @@ class MySqlGrammar extends Grammar
     {
         if (isset($blueprint->engine)) {
             return $sql.' engine = '.$blueprint->engine;
-        } elseif (null !== ($engine = $connection->getConfig('engine'))) {
+        } elseif (($engine = $connection->getConfig('engine')) !== null) {
             return $sql.' engine = '.$engine;
         }
 
@@ -869,7 +869,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->virtualAs) {
+        if ($column->virtualAs !== null) {
             return " as ({$column->virtualAs})";
         }
     }
@@ -883,7 +883,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->storedAs) {
+        if ($column->storedAs !== null) {
             return " as ({$column->storedAs}) stored";
         }
     }
@@ -911,7 +911,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCharset(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->charset) {
+        if ($column->charset !== null) {
             return ' character set '.$column->charset;
         }
     }
@@ -925,7 +925,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->collation) {
+        if ($column->collation !== null) {
             return " collate '{$column->collation}'";
         }
     }
@@ -939,7 +939,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        if (null === $column->virtualAs && null === $column->storedAs) {
+        if ($column->virtualAs === null && $column->storedAs === null) {
             return $column->nullable ? ' null' : ' not null';
         }
     }
@@ -953,7 +953,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->default) {
+        if ($column->default !== null) {
             return ' default ('.$this->getDefaultValue($column->default).')';
         }
     }
@@ -981,7 +981,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyFirst(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->first) {
+        if ($column->first !== null) {
             return ' first';
         }
     }
@@ -995,7 +995,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyAfter(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->after) {
+        if ($column->after !== null) {
             return ' after '.$this->wrap($column->after);
         }
     }
@@ -1009,7 +1009,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyComment(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->comment) {
+        if ($column->comment !== null) {
             return " comment '".addslashes($column->comment)."'";
         }
     }
@@ -1023,7 +1023,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifySrid(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->srid && is_int($column->srid) && $column->srid > 0) {
+        if ($column->srid !== null && is_int($column->srid) && $column->srid > 0) {
             return ' srid '.$column->srid;
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -107,7 +107,7 @@ class MySqlGrammar extends Grammar
         // table is being created on. We will add these to the create table query.
         if (isset($blueprint->charset)) {
             $sql .= ' default character set '.$blueprint->charset;
-        } elseif (! is_null($charset = $connection->getConfig('charset'))) {
+        } elseif (null !== ($charset = $connection->getConfig('charset'))) {
             $sql .= ' default character set '.$charset;
         }
 
@@ -116,7 +116,7 @@ class MySqlGrammar extends Grammar
         // connection that the query is targeting. We'll add it to this SQL query.
         if (isset($blueprint->collation)) {
             $sql .= " collate '{$blueprint->collation}'";
-        } elseif (! is_null($collation = $connection->getConfig('collation'))) {
+        } elseif (null !== ($collation = $connection->getConfig('collation'))) {
             $sql .= " collate '{$collation}'";
         }
 
@@ -135,7 +135,7 @@ class MySqlGrammar extends Grammar
     {
         if (isset($blueprint->engine)) {
             return $sql.' engine = '.$blueprint->engine;
-        } elseif (! is_null($engine = $connection->getConfig('engine'))) {
+        } elseif (null !== ($engine = $connection->getConfig('engine'))) {
             return $sql.' engine = '.$engine;
         }
 
@@ -869,7 +869,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->virtualAs)) {
+        if (null !== $column->virtualAs) {
             return " as ({$column->virtualAs})";
         }
     }
@@ -883,7 +883,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->storedAs)) {
+        if (null !== $column->storedAs) {
             return " as ({$column->storedAs}) stored";
         }
     }
@@ -911,7 +911,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCharset(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->charset)) {
+        if (null !== $column->charset) {
             return ' character set '.$column->charset;
         }
     }
@@ -925,7 +925,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if (null !== $column->collation) {
             return " collate '{$column->collation}'";
         }
     }
@@ -939,7 +939,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        if (is_null($column->virtualAs) && is_null($column->storedAs)) {
+        if (null === $column->virtualAs && null === $column->storedAs) {
             return $column->nullable ? ' null' : ' not null';
         }
     }
@@ -953,7 +953,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (null !== $column->default) {
             return ' default ('.$this->getDefaultValue($column->default).')';
         }
     }
@@ -981,7 +981,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyFirst(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->first)) {
+        if (null !== $column->first) {
             return ' first';
         }
     }
@@ -995,7 +995,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyAfter(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->after)) {
+        if (null !== $column->after) {
             return ' after '.$this->wrap($column->after);
         }
     }
@@ -1009,7 +1009,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyComment(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->comment)) {
+        if (null !== $column->comment) {
             return " comment '".addslashes($column->comment)."'";
         }
     }
@@ -1023,7 +1023,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifySrid(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->srid) && is_int($column->srid) && $column->srid > 0) {
+        if (null !== $column->srid && is_int($column->srid) && $column->srid > 0) {
             return ' srid '.$column->srid;
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -158,15 +158,15 @@ class PostgresGrammar extends Grammar
     {
         $sql = parent::compileForeign($blueprint, $command);
 
-        if (null !== $command->deferrable) {
+        if ($command->deferrable !== null) {
             $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
         }
 
-        if ($command->deferrable && null !== $command->initiallyImmediate) {
+        if ($command->deferrable && $command->initiallyImmediate !== null) {
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
         }
 
-        if (null !== $command->notValid) {
+        if ($command->notValid !== null) {
             $sql .= ' not valid';
         }
 
@@ -526,11 +526,11 @@ class PostgresGrammar extends Grammar
      */
     protected function generatableColumn($type, Fluent $column)
     {
-        if (! $column->autoIncrement && null === $column->generatedAs) {
+        if (! $column->autoIncrement && $column->generatedAs === null) {
             return $type;
         }
 
-        if ($column->autoIncrement && null === $column->generatedAs) {
+        if ($column->autoIncrement && $column->generatedAs === null) {
             return with([
                 'integer' => 'serial',
                 'bigint' => 'bigserial',
@@ -888,7 +888,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->collation) {
+        if ($column->collation !== null) {
             return ' collate '.$this->wrapValue($column->collation);
         }
     }
@@ -914,7 +914,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->default) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -158,15 +158,15 @@ class PostgresGrammar extends Grammar
     {
         $sql = parent::compileForeign($blueprint, $command);
 
-        if (! is_null($command->deferrable)) {
+        if (null !== $command->deferrable) {
             $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
         }
 
-        if ($command->deferrable && ! is_null($command->initiallyImmediate)) {
+        if ($command->deferrable && null !== $command->initiallyImmediate) {
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
         }
 
-        if (! is_null($command->notValid)) {
+        if (null !== $command->notValid) {
             $sql .= ' not valid';
         }
 
@@ -526,11 +526,11 @@ class PostgresGrammar extends Grammar
      */
     protected function generatableColumn($type, Fluent $column)
     {
-        if (! $column->autoIncrement && is_null($column->generatedAs)) {
+        if (! $column->autoIncrement && null === $column->generatedAs) {
             return $type;
         }
 
-        if ($column->autoIncrement && is_null($column->generatedAs)) {
+        if ($column->autoIncrement && null === $column->generatedAs) {
             return with([
                 'integer' => 'serial',
                 'bigint' => 'bigserial',
@@ -888,7 +888,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if (null !== $column->collation) {
             return ' collate '.$this->wrapValue($column->collation);
         }
     }
@@ -914,7 +914,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (null !== $column->default) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -80,14 +80,14 @@ class SQLiteGrammar extends Grammar
             // are building, since SQLite needs foreign keys on the tables creation.
             $sql .= $this->getForeignKey($foreign);
 
-            if (null !== $foreign->onDelete) {
+            if ($foreign->onDelete !== null) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
 
             // If this foreign key specifies the action to be taken on update we will add
             // that to the statement here. We'll append it to this SQL and then return
             // the SQL so we can keep adding any other foreign constraints onto this.
-            if (null !== $foreign->onUpdate) {
+            if ($foreign->onUpdate !== null) {
                 $sql .= " on update {$foreign->onUpdate}";
             }
 
@@ -121,7 +121,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function addPrimaryKeys(Blueprint $blueprint)
     {
-        if (null !== ($primary = $this->getCommandByName($blueprint, 'primary'))) {
+        if (($primary = $this->getCommandByName($blueprint, 'primary')) !== null) {
             return ", primary key ({$this->columnize($primary->columns)})";
         }
     }
@@ -839,7 +839,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->default) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -80,14 +80,14 @@ class SQLiteGrammar extends Grammar
             // are building, since SQLite needs foreign keys on the tables creation.
             $sql .= $this->getForeignKey($foreign);
 
-            if (! is_null($foreign->onDelete)) {
+            if (null !== $foreign->onDelete) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
 
             // If this foreign key specifies the action to be taken on update we will add
             // that to the statement here. We'll append it to this SQL and then return
             // the SQL so we can keep adding any other foreign constraints onto this.
-            if (! is_null($foreign->onUpdate)) {
+            if (null !== $foreign->onUpdate) {
                 $sql .= " on update {$foreign->onUpdate}";
             }
 
@@ -121,7 +121,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function addPrimaryKeys(Blueprint $blueprint)
     {
-        if (! is_null($primary = $this->getCommandByName($blueprint, 'primary'))) {
+        if (null !== ($primary = $this->getCommandByName($blueprint, 'primary'))) {
             return ", primary key ({$this->columnize($primary->columns)})";
         }
     }
@@ -839,7 +839,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (null !== $column->default) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -764,7 +764,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if (null !== $column->collation) {
             return ' collate '.$column->collation;
         }
     }
@@ -792,7 +792,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (null !== $column->default) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -764,7 +764,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->collation) {
+        if ($column->collation !== null) {
             return ' collate '.$column->collation;
         }
     }
@@ -792,7 +792,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (null !== $column->default) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -74,7 +74,7 @@ class SqlServerConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (null === $this->schemaGrammar) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -74,7 +74,7 @@ class SqlServerConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if (null === $this->schemaGrammar) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -198,7 +198,7 @@ class Dispatcher implements DispatcherContract
             // If a response is returned from the listener and event halting is enabled
             // we will just return this response, and not call the rest of the event
             // listeners. Otherwise we will add the response on the response list.
-            if ($halt && null !== $response) {
+            if ($halt && $response !== null) {
                 return $response;
             }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -198,7 +198,7 @@ class Dispatcher implements DispatcherContract
             // If a response is returned from the listener and event halting is enabled
             // we will just return this response, and not call the rest of the event
             // listeners. Otherwise we will add the response on the response list.
-            if ($halt && ! is_null($response)) {
+            if ($halt && null !== $response) {
                 return $response;
             }
 

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -51,7 +51,7 @@ class Cache extends AbstractCache
     {
         $contents = $this->repository->get($this->key);
 
-        if (! is_null($contents)) {
+        if (null !== $contents) {
             $this->setFromStorage($contents);
         }
     }

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -51,7 +51,7 @@ class Cache extends AbstractCache
     {
         $contents = $this->repository->get($this->key);
 
-        if (null !== $contents) {
+        if ($contents !== null) {
             $this->setFromStorage($contents);
         }
     }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -456,7 +456,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (null !== ($url = $this->driver->getConfig()->get('url'))) {
+        if (($url = $this->driver->getConfig()->get('url')) !== null) {
             return $this->concatPathToUrl($url, $adapter->getPathPrefix().$path);
         }
 
@@ -678,7 +678,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function parseVisibility($visibility)
     {
-        if (null === $visibility) {
+        if ($visibility === null) {
             return;
         }
 

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -456,7 +456,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (! is_null($url = $this->driver->getConfig()->get('url'))) {
+        if (null !== ($url = $this->driver->getConfig()->get('url'))) {
             return $this->concatPathToUrl($url, $adapter->getPathPrefix().$path);
         }
 
@@ -678,7 +678,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function parseVisibility($visibility)
     {
-        if (is_null($visibility)) {
+        if (null === $visibility) {
             return;
         }
 

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -51,7 +51,7 @@ class AliasLoader
      */
     public static function getInstance(array $aliases = [])
     {
-        if (null === static::$instance) {
+        if (static::$instance === null) {
             return static::$instance = new static($aliases);
         }
 

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -51,7 +51,7 @@ class AliasLoader
      */
     public static function getInstance(array $aliases = [])
     {
-        if (is_null(static::$instance)) {
+        if (null === static::$instance) {
             return static::$instance = new static($aliases);
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -976,7 +976,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function normalizeCachePath($key, $default)
     {
-        if (is_null($env = Env::get($key))) {
+        if (null === ($env = Env::get($key))) {
             return $this->bootstrapPath($default);
         }
 
@@ -1220,7 +1220,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getNamespace()
     {
-        if (! is_null($this->namespace)) {
+        if (null !== $this->namespace) {
             return $this->namespace;
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -976,7 +976,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     protected function normalizeCachePath($key, $default)
     {
-        if (null === ($env = Env::get($key))) {
+        if (($env = Env::get($key)) === null) {
             return $this->bootstrapPath($default);
         }
 
@@ -1220,7 +1220,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function getNamespace()
     {
-        if (null !== $this->namespace) {
+        if ($this->namespace !== null) {
             return $this->namespace;
         }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -130,7 +130,7 @@ class HandleExceptions
      */
     public function handleShutdown()
     {
-        if (null !== ($error = error_get_last()) && $this->isFatal($error['type'])) {
+        if (($error = error_get_last()) !== null && $this->isFatal($error['type'])) {
             $this->handleException($this->fatalExceptionFromError($error, 0));
         }
     }

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -130,7 +130,7 @@ class HandleExceptions
      */
     public function handleShutdown()
     {
-        if (! is_null($error = error_get_last()) && $this->isFatal($error['type'])) {
+        if (null !== ($error = error_get_last()) && $this->isFatal($error['type'])) {
             $this->handleException($this->fatalExceptionFromError($error, 0));
         }
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -336,7 +336,7 @@ class Kernel implements KernelContract
      */
     protected function getArtisan()
     {
-        if (is_null($this->artisan)) {
+        if (null === $this->artisan) {
             return $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
                                 ->resolveCommands($this->commands);
         }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -336,7 +336,7 @@ class Kernel implements KernelContract
      */
     protected function getArtisan()
     {
-        if (null === $this->artisan) {
+        if ($this->artisan === null) {
             return $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
                                 ->resolveCommands($this->commands);
         }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -99,7 +99,7 @@ class ServeCommand extends Command
      */
     protected function canTryAnotherPort()
     {
-        return is_null($this->input->getOption('port')) &&
+        return null === $this->input->getOption('port') &&
                ($this->input->getOption('tries') > $this->portOffset);
     }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -99,7 +99,7 @@ class ServeCommand extends Command
      */
     protected function canTryAnotherPort()
     {
-        return null === $this->input->getOption('port') &&
+        return $this->input->getOption('port') === null &&
                ($this->input->getOption('tries') > $this->portOffset);
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -111,7 +111,7 @@ class VendorPublishCommand extends Command
             $choices = $this->publishableChoices()
         );
 
-        if ($choice == $choices[0] || null === $choice) {
+        if ($choice === null || $choice == $choices[0]) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -111,7 +111,7 @@ class VendorPublishCommand extends Command
             $choices = $this->publishableChoices()
         );
 
-        if ($choice == $choices[0] || is_null($choice)) {
+        if ($choice == $choices[0] || null === $choice) {
             return;
         }
 

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -46,7 +46,7 @@ class EnvironmentDetector
         // First we will check if an environment argument was passed via console arguments
         // and if it was that automatically overrides as the environment. Otherwise, we
         // will check the environment as a "web" request like a typical HTTP request.
-        if (! is_null($value = $this->getEnvironmentArgument($args))) {
+        if (null !== ($value = $this->getEnvironmentArgument($args))) {
             return $value;
         }
 

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -46,7 +46,7 @@ class EnvironmentDetector
         // First we will check if an environment argument was passed via console arguments
         // and if it was that automatically overrides as the environment. Otherwise, we
         // will check the environment as a "web" request like a typical HTTP request.
-        if (null !== ($value = $this->getEnvironmentArgument($args))) {
+        if (($value = $this->getEnvironmentArgument($args)) !== null) {
             return $value;
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -140,9 +140,9 @@ class Handler implements ExceptionHandlerContract
     {
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
+        return null !== Arr::first($dontReport, function ($type) use ($e) {
             return $e instanceof $type;
-        }));
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -140,9 +140,9 @@ class Handler implements ExceptionHandlerContract
     {
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return null !== Arr::first($dontReport, function ($type) use ($e) {
+        return Arr::first($dontReport, function ($type) use ($e) {
             return $e instanceof $type;
-        });
+        }) !== null;
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -89,7 +89,7 @@ class PackageManifest
      */
     protected function getManifest()
     {
-        if (! is_null($this->manifest)) {
+        if (null !== $this->manifest) {
             return $this->manifest;
         }
 

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -89,7 +89,7 @@ class PackageManifest
      */
     protected function getManifest()
     {
-        if (null !== $this->manifest) {
+        if ($this->manifest !== null) {
             return $this->manifest;
         }
 

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -106,7 +106,7 @@ class ProviderRepository
      */
     public function shouldRecompile($manifest, $providers)
     {
-        return null === $manifest || $manifest['providers'] != $providers;
+        return $manifest === null || $manifest['providers'] != $providers;
     }
 
     /**

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -106,7 +106,7 @@ class ProviderRepository
      */
     public function shouldRecompile($manifest, $providers)
     {
-        return is_null($manifest) || $manifest['providers'] != $providers;
+        return null === $manifest || $manifest['providers'] != $providers;
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -49,7 +49,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function setRootControllerNamespace()
     {
-        if (! is_null($this->namespace)) {
+        if (null !== $this->namespace) {
             $this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
         }
     }

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -49,7 +49,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function setRootControllerNamespace()
     {
-        if (null !== $this->namespace) {
+        if ($this->namespace !== null) {
             $this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
         }
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -92,7 +92,7 @@ trait MakesHttpRequests
      */
     public function withoutMiddleware($middleware = null)
     {
-        if (null === $middleware) {
+        if ($middleware === null) {
             $this->app->instance('middleware.disable', true);
 
             return $this;
@@ -118,7 +118,7 @@ trait MakesHttpRequests
      */
     public function withMiddleware($middleware = null)
     {
-        if (null === $middleware) {
+        if ($middleware === null) {
             unset($this->app['middleware.disable']);
 
             return $this;

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -92,7 +92,7 @@ trait MakesHttpRequests
      */
     public function withoutMiddleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if (null === $middleware) {
             $this->app->instance('middleware.disable', true);
 
             return $this;
@@ -118,7 +118,7 @@ trait MakesHttpRequests
      */
     public function withMiddleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if (null === $middleware) {
             unset($this->app['middleware.disable']);
 
             return $this;

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -166,7 +166,7 @@ class TestResponse
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        if (! is_null($uri)) {
+        if (null !== $uri) {
             $this->assertLocation($uri);
         }
 
@@ -188,7 +188,7 @@ class TestResponse
 
         $actual = $this->headers->get($headerName);
 
-        if (! is_null($value)) {
+        if (null !== $value) {
             PHPUnit::assertEquals(
                 $value, $this->headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
@@ -258,7 +258,7 @@ class TestResponse
             "Cookie [{$cookieName}] not present on response."
         );
 
-        if (! $cookie || is_null($value)) {
+        if (! $cookie || null === $value) {
             return $this;
         }
 
@@ -595,11 +595,11 @@ class TestResponse
      */
     public function assertJsonStructure(array $structure = null, $responseData = null)
     {
-        if (is_null($structure)) {
+        if (null === $structure) {
             return $this->assertExactJson($this->json());
         }
 
-        if (is_null($responseData)) {
+        if (null === $responseData) {
             $responseData = $this->decodeResponseJson();
         }
 
@@ -722,7 +722,7 @@ class TestResponse
 
         $errors = $json[$responseKey];
 
-        if (is_null($keys) && count($errors) > 0) {
+        if (null === $keys && count($errors) > 0) {
             PHPUnit::fail(
                 'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
@@ -749,7 +749,7 @@ class TestResponse
     {
         $decodedResponse = json_decode($this->getContent(), true);
 
-        if (is_null($decodedResponse) || $decodedResponse === false) {
+        if (null === $decodedResponse || $decodedResponse === false) {
             if ($this->exception) {
                 throw $this->exception;
             } else {
@@ -801,7 +801,7 @@ class TestResponse
 
         $this->ensureResponseHasView();
 
-        if (is_null($value)) {
+        if (null === $value) {
             PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value($this->original->gatherData()[$key]));
@@ -888,7 +888,7 @@ class TestResponse
             return $this->assertSessionHasAll($key);
         }
 
-        if (is_null($value)) {
+        if (null === $value) {
             PHPUnit::assertTrue(
                 $this->session()->has($key),
                 "Session is missing expected key [{$key}]."
@@ -942,7 +942,7 @@ class TestResponse
             return $this;
         }
 
-        if (is_null($value)) {
+        if (null === $value) {
             PHPUnit::assertTrue(
                 $this->session()->getOldInput($key),
                 "Session is missing expected key [{$key}]."
@@ -999,7 +999,7 @@ class TestResponse
             return $this->assertSessionHasNoErrors();
         }
 
-        if (is_null($this->session()->get('errors'))) {
+        if (null === $this->session()->get('errors')) {
             PHPUnit::assertTrue(true);
 
             return $this;
@@ -1122,7 +1122,7 @@ class TestResponse
      */
     public function streamedContent()
     {
-        if (! is_null($this->streamedContent)) {
+        if (null !== $this->streamedContent) {
             return $this->streamedContent;
         }
 

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -166,7 +166,7 @@ class TestResponse
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        if (null !== $uri) {
+        if ($uri !== null) {
             $this->assertLocation($uri);
         }
 
@@ -188,7 +188,7 @@ class TestResponse
 
         $actual = $this->headers->get($headerName);
 
-        if (null !== $value) {
+        if ($value !== null) {
             PHPUnit::assertEquals(
                 $value, $this->headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
@@ -258,7 +258,7 @@ class TestResponse
             "Cookie [{$cookieName}] not present on response."
         );
 
-        if (! $cookie || null === $value) {
+        if (! $cookie || $value === null) {
             return $this;
         }
 
@@ -595,11 +595,11 @@ class TestResponse
      */
     public function assertJsonStructure(array $structure = null, $responseData = null)
     {
-        if (null === $structure) {
+        if ($structure === null) {
             return $this->assertExactJson($this->json());
         }
 
-        if (null === $responseData) {
+        if ($responseData === null) {
             $responseData = $this->decodeResponseJson();
         }
 
@@ -722,7 +722,7 @@ class TestResponse
 
         $errors = $json[$responseKey];
 
-        if (null === $keys && count($errors) > 0) {
+        if ($keys === null && count($errors) > 0) {
             PHPUnit::fail(
                 'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
@@ -749,7 +749,7 @@ class TestResponse
     {
         $decodedResponse = json_decode($this->getContent(), true);
 
-        if (null === $decodedResponse || $decodedResponse === false) {
+        if ($decodedResponse === null || $decodedResponse === false) {
             if ($this->exception) {
                 throw $this->exception;
             } else {
@@ -801,7 +801,7 @@ class TestResponse
 
         $this->ensureResponseHasView();
 
-        if (null === $value) {
+        if ($value === null) {
             PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value($this->original->gatherData()[$key]));
@@ -888,7 +888,7 @@ class TestResponse
             return $this->assertSessionHasAll($key);
         }
 
-        if (null === $value) {
+        if ($value === null) {
             PHPUnit::assertTrue(
                 $this->session()->has($key),
                 "Session is missing expected key [{$key}]."
@@ -942,7 +942,7 @@ class TestResponse
             return $this;
         }
 
-        if (null === $value) {
+        if ($value === null) {
             PHPUnit::assertTrue(
                 $this->session()->getOldInput($key),
                 "Session is missing expected key [{$key}]."
@@ -999,7 +999,7 @@ class TestResponse
             return $this->assertSessionHasNoErrors();
         }
 
-        if (null === $this->session()->get('errors')) {
+        if ($this->session()->get('errors') === null) {
             PHPUnit::assertTrue(true);
 
             return $this;
@@ -1122,7 +1122,7 @@ class TestResponse
      */
     public function streamedContent()
     {
-        if (null !== $this->streamedContent) {
+        if ($this->streamedContent !== null) {
             return $this->streamedContent;
         }
 

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -31,7 +31,7 @@ trait WithFaker
      */
     protected function faker($locale = null)
     {
-        return null === $locale ? $this->faker : $this->makeFaker($locale);
+        return $locale === null ? $this->faker : $this->makeFaker($locale);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -31,7 +31,7 @@ trait WithFaker
      */
     protected function faker($locale = null)
     {
-        return is_null($locale) ? $this->faker : $this->makeFaker($locale);
+        return null === $locale ? $this->faker : $this->makeFaker($locale);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -114,7 +114,7 @@ if (! function_exists('app')) {
      */
     function app($abstract = null, array $parameters = [])
     {
-        if (is_null($abstract)) {
+        if (null === $abstract) {
             return Container::getInstance();
         }
 
@@ -158,7 +158,7 @@ if (! function_exists('auth')) {
      */
     function auth($guard = null)
     {
-        if (is_null($guard)) {
+        if (null === $guard) {
             return app(AuthFactory::class);
         }
 
@@ -272,7 +272,7 @@ if (! function_exists('config')) {
      */
     function config($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return app('config');
         }
 
@@ -316,7 +316,7 @@ if (! function_exists('cookie')) {
     {
         $cookie = app(CookieFactory::class);
 
-        if (is_null($name)) {
+        if (null === $name) {
             return $cookie;
         }
 
@@ -530,7 +530,7 @@ if (! function_exists('logger')) {
      */
     function logger($message = null, array $context = [])
     {
-        if (is_null($message)) {
+        if (null === $message) {
             return app('log');
         }
 
@@ -647,7 +647,7 @@ if (! function_exists('redirect')) {
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {
-        if (is_null($to)) {
+        if (null === $to) {
             return app('redirect');
         }
 
@@ -683,7 +683,7 @@ if (! function_exists('request')) {
      */
     function request($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return app('request');
         }
 
@@ -693,7 +693,7 @@ if (! function_exists('request')) {
 
         $value = app('request')->__get($key);
 
-        return is_null($value) ? value($default) : $value;
+        return $value ?? value($default);
     }
 }
 
@@ -822,7 +822,7 @@ if (! function_exists('session')) {
      */
     function session($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return app('session');
         }
 
@@ -871,7 +871,7 @@ if (! function_exists('trans')) {
      */
     function trans($key = null, $replace = [], $locale = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return app('translator');
         }
 
@@ -921,7 +921,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        if (is_null($path)) {
+        if (null === $path) {
             return app(UrlGenerator::class);
         }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -114,7 +114,7 @@ if (! function_exists('app')) {
      */
     function app($abstract = null, array $parameters = [])
     {
-        if (null === $abstract) {
+        if ($abstract === null) {
             return Container::getInstance();
         }
 
@@ -158,7 +158,7 @@ if (! function_exists('auth')) {
      */
     function auth($guard = null)
     {
-        if (null === $guard) {
+        if ($guard === null) {
             return app(AuthFactory::class);
         }
 
@@ -272,7 +272,7 @@ if (! function_exists('config')) {
      */
     function config($key = null, $default = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return app('config');
         }
 
@@ -316,7 +316,7 @@ if (! function_exists('cookie')) {
     {
         $cookie = app(CookieFactory::class);
 
-        if (null === $name) {
+        if ($name === null) {
             return $cookie;
         }
 
@@ -530,7 +530,7 @@ if (! function_exists('logger')) {
      */
     function logger($message = null, array $context = [])
     {
-        if (null === $message) {
+        if ($message === null) {
             return app('log');
         }
 
@@ -647,7 +647,7 @@ if (! function_exists('redirect')) {
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {
-        if (null === $to) {
+        if ($to === null) {
             return app('redirect');
         }
 
@@ -683,7 +683,7 @@ if (! function_exists('request')) {
      */
     function request($key = null, $default = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return app('request');
         }
 
@@ -822,7 +822,7 @@ if (! function_exists('session')) {
      */
     function session($key = null, $default = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return app('session');
         }
 
@@ -871,7 +871,7 @@ if (! function_exists('trans')) {
      */
     function trans($key = null, $replace = [], $locale = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return app('translator');
         }
 
@@ -921,7 +921,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        if (null === $path) {
+        if ($path === null) {
             return app(UrlGenerator::class);
         }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -107,7 +107,7 @@ trait InteractsWithContentTypes
             foreach ($contentTypes as $contentType) {
                 $type = $contentType;
 
-                if (! is_null($mimeType = $this->getMimeType($contentType))) {
+                if (null !== ($mimeType = $this->getMimeType($contentType))) {
                     $type = $mimeType;
                 }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -107,7 +107,7 @@ trait InteractsWithContentTypes
             foreach ($contentTypes as $contentType) {
                 $type = $contentType;
 
-                if (null !== ($mimeType = $this->getMimeType($contentType))) {
+                if (($mimeType = $this->getMimeType($contentType)) !== null) {
                     $type = $mimeType;
                 }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -30,7 +30,7 @@ trait InteractsWithInput
      */
     public function hasHeader($key)
     {
-        return null !== $this->header($key);
+        return $this->header($key) !== null;
     }
 
     /**
@@ -284,7 +284,7 @@ trait InteractsWithInput
      */
     public function hasCookie($key)
     {
-        return null !== $this->cookie($key);
+        return $this->cookie($key) !== null;
     }
 
     /**
@@ -320,7 +320,7 @@ trait InteractsWithInput
     protected function convertUploadedFiles(array $files)
     {
         return array_map(function ($file) {
-            if (null === $file || (is_array($file) && empty(array_filter($file)))) {
+            if ($file === null || (is_array($file) && empty(array_filter($file)))) {
                 return $file;
             }
 
@@ -384,7 +384,7 @@ trait InteractsWithInput
      */
     protected function retrieveItem($source, $key, $default)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $this->$source->all();
         }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -30,7 +30,7 @@ trait InteractsWithInput
      */
     public function hasHeader($key)
     {
-        return ! is_null($this->header($key));
+        return null !== $this->header($key);
     }
 
     /**
@@ -284,7 +284,7 @@ trait InteractsWithInput
      */
     public function hasCookie($key)
     {
-        return ! is_null($this->cookie($key));
+        return null !== $this->cookie($key);
     }
 
     /**
@@ -320,7 +320,7 @@ trait InteractsWithInput
     protected function convertUploadedFiles(array $files)
     {
         return array_map(function ($file) {
-            if (is_null($file) || (is_array($file) && empty(array_filter($file)))) {
+            if (null === $file || (is_array($file) && empty(array_filter($file)))) {
                 return $file;
             }
 
@@ -384,7 +384,7 @@ trait InteractsWithInput
      */
     protected function retrieveItem($source, $key, $default)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $this->$source->all();
         }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -74,7 +74,7 @@ class RedirectResponse extends BaseRedirectResponse
     public function withInput(array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
-            ! is_null($input) ? $input : $this->request->input()
+            $input ?? $this->request->input()
         ));
 
         return $this;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -349,7 +349,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
         }
 
-        if (is_null($key)) {
+        if (null === $key) {
             return $this->json;
         }
 
@@ -528,7 +528,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $route = call_user_func($this->getRouteResolver());
 
-        if (is_null($route) || is_null($param)) {
+        if (null === $route || null === $param) {
             return $route;
         }
 
@@ -683,7 +683,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __isset($key)
     {
-        return ! is_null($this->__get($key));
+        return null !== $this->__get($key);
     }
 
     /**

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -349,7 +349,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
         }
 
-        if (null === $key) {
+        if ($key === null) {
             return $this->json;
         }
 
@@ -528,7 +528,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $route = call_user_func($this->getRouteResolver());
 
-        if (null === $route || null === $param) {
+        if ($route === null || $param === null) {
             return $route;
         }
 
@@ -683,7 +683,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __isset($key)
     {
-        return null !== $this->__get($key);
+        return $this->__get($key) !== null;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -32,7 +32,7 @@ trait ConditionallyLoadsAttributes
                 );
             }
 
-            if ($value instanceof self && null === $value->resource) {
+            if ($value instanceof self && $value->resource === null) {
                 $data[$key] = null;
             }
         }

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -32,7 +32,7 @@ trait ConditionallyLoadsAttributes
                 );
             }
 
-            if ($value instanceof self && is_null($value->resource)) {
+            if ($value instanceof self && null === $value->resource) {
                 $data[$key] = null;
             }
         }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -111,7 +111,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
-        if (null === $this->resource) {
+        if ($this->resource === null) {
             return [];
         }
 

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -111,7 +111,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
-        if (is_null($this->resource)) {
+        if (null === $this->resource) {
             return [];
         }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -171,7 +171,7 @@ class LogManager implements LoggerInterface
     {
         $config = $this->configurationFor($name);
 
-        if (null === $config) {
+        if ($config === null) {
             throw new InvalidArgumentException("Log [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -171,7 +171,7 @@ class LogManager implements LoggerInterface
     {
         $config = $this->configurationFor($name);
 
-        if (is_null($config)) {
+        if (null === $config) {
             throw new InvalidArgumentException("Log [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -430,7 +430,7 @@ class Mailer implements MailerContract, MailQueueContract
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        return $view->later($delay, is_null($queue) ? $this->queue : $queue);
+        return $view->later($delay, null === $queue ? $this->queue : $queue);
     }
 
     /**

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -430,7 +430,7 @@ class Mailer implements MailerContract, MailQueueContract
             throw new InvalidArgumentException('Only mailables may be queued.');
         }
 
-        return $view->later($delay, null === $queue ? $this->queue : $queue);
+        return $view->later($delay, $queue ?? $this->queue);
     }
 
     /**

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -56,7 +56,7 @@ abstract class Transport implements Swift_Transport
      */
     public function registerPlugin(Swift_Events_EventListener $plugin)
     {
-        array_push($this->plugins, $plugin);
+        $this->plugins[] = $plugin;
     }
 
     /**

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -93,7 +93,7 @@ class MailChannel
             return $message->view;
         }
 
-        if (property_exists($message, 'theme') && ! is_null($message->theme)) {
+        if (property_exists($message, 'theme') && null !== $message->theme) {
             $this->markdown->theme($message->theme);
         }
 
@@ -138,7 +138,7 @@ class MailChannel
 
         $this->addAttachments($mailMessage, $message);
 
-        if (! is_null($message->priority)) {
+        if (null !== $message->priority) {
             $mailMessage->setPriority($message->priority);
         }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -93,7 +93,7 @@ class MailChannel
             return $message->view;
         }
 
-        if (property_exists($message, 'theme') && null !== $message->theme) {
+        if (property_exists($message, 'theme') && $message->theme !== null) {
             $this->markdown->theme($message->theme);
         }
 
@@ -138,7 +138,7 @@ class MailChannel
 
         $this->addAttachments($mailMessage, $message);
 
-        if (null !== $message->priority) {
+        if ($message->priority !== null) {
             $mailMessage->setPriority($message->priority);
         }
 

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -52,7 +52,7 @@ class DatabaseNotification extends Model
      */
     public function markAsRead()
     {
-        if (null === $this->read_at) {
+        if ($this->read_at === null) {
             $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
         }
     }
@@ -64,7 +64,7 @@ class DatabaseNotification extends Model
      */
     public function markAsUnread()
     {
-        if (null !== $this->read_at) {
+        if ($this->read_at !== null) {
             $this->forceFill(['read_at' => null])->save();
         }
     }

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -52,7 +52,7 @@ class DatabaseNotification extends Model
      */
     public function markAsRead()
     {
-        if (is_null($this->read_at)) {
+        if (null === $this->read_at) {
             $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
         }
     }
@@ -64,7 +64,7 @@ class DatabaseNotification extends Model
      */
     public function markAsUnread()
     {
-        if (! is_null($this->read_at)) {
+        if (null !== $this->read_at) {
             $this->forceFill(['read_at' => null])->save();
         }
     }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -184,7 +184,7 @@ class NotificationSender
 
                 $notification->id = $notificationId;
 
-                if (! is_null($this->locale)) {
+                if (null !== $this->locale) {
                     $notification->locale = $this->locale;
                 }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -184,7 +184,7 @@ class NotificationSender
 
                 $notification->id = $notificationId;
 
-                if (null !== $this->locale) {
+                if ($this->locale !== null) {
                     $notification->locale = $this->locale;
                 }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -186,7 +186,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function fragment($fragment = null)
     {
-        if (is_null($fragment)) {
+        if (null === $fragment) {
             return $this->fragment;
         }
 
@@ -204,7 +204,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function appends($key, $value = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $this;
         }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -186,7 +186,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function fragment($fragment = null)
     {
-        if (null === $fragment) {
+        if ($fragment === null) {
             return $this->fragment;
         }
 
@@ -204,7 +204,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function appends($key, $value = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $this;
         }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -31,7 +31,7 @@ class RetryCommand extends Command
         foreach ($this->getJobIds() as $id) {
             $job = $this->laravel['queue.failer']->find($id);
 
-            if (is_null($job)) {
+            if (null === $job) {
                 $this->error("Unable to find failed job with ID [{$id}].");
             } else {
                 $this->retryJob($job);

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -31,7 +31,7 @@ class RetryCommand extends Command
         foreach ($this->getJobIds() as $id) {
             $job = $this->laravel['queue.failer']->find($id);
 
-            if (null === $job) {
+            if ($job === null) {
                 $this->error("Unable to find failed job with ID [{$id}].");
             } else {
                 $this->retryJob($job);

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -157,7 +157,7 @@ class Listener
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
         ], function ($value) {
-            return null !== $value;
+            return $value !== null;
         });
     }
 

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -157,7 +157,7 @@ class Listener
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
         ], function ($value) {
-            return ! is_null($value);
+            return null !== $value;
         });
     }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -217,7 +217,7 @@ abstract class Queue
      */
     public static function createPayloadUsing($callback)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             static::$createPayloadCallbacks = [];
         } else {
             static::$createPayloadCallbacks[] = $callback;

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -217,7 +217,7 @@ abstract class Queue
      */
     public static function createPayloadUsing($callback)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             static::$createPayloadCallbacks = [];
         } else {
             static::$createPayloadCallbacks[] = $callback;

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -207,7 +207,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if (null !== $name && $name !== 'null') {
             return $this->app['config']["queue.connections.{$name}"];
         }
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -207,7 +207,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        if (null !== $name && $name !== 'null') {
+        if ($name !== null && $name !== 'null') {
             return $this->app['config']["queue.connections.{$name}"];
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -190,7 +190,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->migrateExpiredJobs($queue.':delayed', $queue);
 
-        if (! is_null($this->retryAfter)) {
+        if (null !== $this->retryAfter) {
             $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
     }
@@ -229,7 +229,7 @@ class RedisQueue extends Queue implements QueueContract
 
         [$job, $reserved] = $nextJob;
 
-        if (! $job && ! is_null($this->blockFor) && $block &&
+        if (! $job && null !== $this->blockFor && $block &&
             $this->getConnection()->blpop([$queue.':notify'], $this->blockFor)) {
             return $this->retrieveNextJob($queue, false);
         }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -190,7 +190,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->migrateExpiredJobs($queue.':delayed', $queue);
 
-        if (null !== $this->retryAfter) {
+        if ($this->retryAfter !== null) {
             $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
     }
@@ -229,7 +229,7 @@ class RedisQueue extends Queue implements QueueContract
 
         [$job, $reserved] = $nextJob;
 
-        if (! $job && null !== $this->blockFor && $block &&
+        if (! $job && $this->blockFor !== null && $block &&
             $this->getConnection()->blpop([$queue.':notify'], $this->blockFor)) {
             return $this->retrieveNextJob($queue, false);
         }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -121,7 +121,7 @@ class SqsQueue extends Queue implements QueueContract
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
-        if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
+        if (null !== $response['Messages'] && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
                 $this->connectionName, $queue

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -121,7 +121,7 @@ class SqsQueue extends Queue implements QueueContract
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
-        if (null !== $response['Messages'] && count($response['Messages']) > 0) {
+        if ($response['Messages'] !== null && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
                 $this->connectionName, $queue

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -174,7 +174,7 @@ class Worker
      */
     protected function timeoutForJob($job, WorkerOptions $options)
     {
-        return $job && null !== $job->timeout() ? $job->timeout() : $options->timeout;
+        return $job && $job->timeout() !== null ? $job->timeout() : $options->timeout;
     }
 
     /**
@@ -221,7 +221,7 @@ class Worker
             $this->stop(12);
         } elseif ($this->queueShouldRestart($lastRestart)) {
             $this->stop();
-        } elseif ($options->stopWhenEmpty && null === $job) {
+        } elseif ($options->stopWhenEmpty && $job === null) {
             $this->stop();
         }
     }
@@ -261,7 +261,7 @@ class Worker
     {
         try {
             foreach (explode(',', $queue) as $queue) {
-                if (null !== ($job = $connection->pop($queue))) {
+                if (($job = $connection->pop($queue)) !== null) {
                     return $job;
                 }
             }
@@ -389,7 +389,7 @@ class Worker
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                 $job->release(
-                    method_exists($job, 'delaySeconds') && null !== $job->delaySeconds()
+                    method_exists($job, 'delaySeconds') && $job->delaySeconds() !== null
                                 ? $job->delaySeconds()
                                 : $options->delay
                 );

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -174,7 +174,7 @@ class Worker
      */
     protected function timeoutForJob($job, WorkerOptions $options)
     {
-        return $job && ! is_null($job->timeout()) ? $job->timeout() : $options->timeout;
+        return $job && null !== $job->timeout() ? $job->timeout() : $options->timeout;
     }
 
     /**
@@ -221,7 +221,7 @@ class Worker
             $this->stop(12);
         } elseif ($this->queueShouldRestart($lastRestart)) {
             $this->stop();
-        } elseif ($options->stopWhenEmpty && is_null($job)) {
+        } elseif ($options->stopWhenEmpty && null === $job) {
             $this->stop();
         }
     }
@@ -261,7 +261,7 @@ class Worker
     {
         try {
             foreach (explode(',', $queue) as $queue) {
-                if (! is_null($job = $connection->pop($queue))) {
+                if (null !== ($job = $connection->pop($queue))) {
                     return $job;
                 }
             }
@@ -389,7 +389,7 @@ class Worker
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                 $job->release(
-                    method_exists($job, 'delaySeconds') && ! is_null($job->delaySeconds())
+                    method_exists($job, 'delaySeconds') && null !== $job->delaySeconds()
                                 ? $job->delaySeconds()
                                 : $options->delay
                 );
@@ -411,7 +411,7 @@ class Worker
      */
     protected function markJobAsFailedIfAlreadyExceedsMaxAttempts($connectionName, $job, $maxTries)
     {
-        $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
+        $maxTries = $job->maxTries() ?? $maxTries;
 
         $timeoutAt = $job->timeoutAt();
 
@@ -439,7 +439,7 @@ class Worker
      */
     protected function markJobAsFailedIfWillExceedMaxAttempts($connectionName, $job, $maxTries, $e)
     {
-        $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
+        $maxTries = $job->maxTries() ?? $maxTries;
 
         if ($job->timeoutAt() && $job->timeoutAt() <= Carbon::now()->getTimestamp()) {
             $this->failJob($job, $e);

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -300,7 +300,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $pipeline = $this->client()->pipeline();
 
-        return is_null($callback)
+        return null === $callback
             ? $pipeline
             : tap($pipeline, $callback)->exec();
     }
@@ -315,7 +315,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $transaction = $this->client()->multi();
 
-        return is_null($callback)
+        return null === $callback
             ? $transaction
             : tap($transaction, $callback)->exec();
     }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -300,7 +300,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $pipeline = $this->client()->pipeline();
 
-        return null === $callback
+        return $callback === null
             ? $pipeline
             : tap($pipeline, $callback)->exec();
     }
@@ -315,7 +315,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $transaction = $this->client()->multi();
 
-        return null === $callback
+        return $callback === null
             ? $transaction
             : tap($transaction, $callback)->exec();
     }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -49,9 +49,9 @@ class ControllerMakeCommand extends GeneratorCommand
             $stub = '/stubs/controller.stub';
         }
 
-        if ($this->option('api') && null === $stub) {
+        if ($this->option('api') && $stub === null) {
             $stub = '/stubs/controller.api.stub';
-        } elseif ($this->option('api') && null !== $stub && ! $this->option('invokable')) {
+        } elseif ($this->option('api') && $stub !== null && ! $this->option('invokable')) {
             $stub = str_replace('.stub', '.api.stub', $stub);
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -49,9 +49,9 @@ class ControllerMakeCommand extends GeneratorCommand
             $stub = '/stubs/controller.stub';
         }
 
-        if ($this->option('api') && is_null($stub)) {
+        if ($this->option('api') && null === $stub) {
             $stub = '/stubs/controller.api.stub';
-        } elseif ($this->option('api') && ! is_null($stub) && ! $this->option('invokable')) {
+        } elseif ($this->option('api') && null !== $stub && ! $this->option('invokable')) {
             $stub = str_replace('.stub', '.api.stub', $stub);
         }
 

--- a/src/Illuminate/Routing/Matching/HostValidator.php
+++ b/src/Illuminate/Routing/Matching/HostValidator.php
@@ -16,7 +16,7 @@ class HostValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        if (is_null($route->getCompiled()->getHostRegex())) {
+        if (null === $route->getCompiled()->getHostRegex()) {
             return true;
         }
 

--- a/src/Illuminate/Routing/Matching/HostValidator.php
+++ b/src/Illuminate/Routing/Matching/HostValidator.php
@@ -16,7 +16,7 @@ class HostValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        if (null === $route->getCompiled()->getHostRegex()) {
+        if ($route->getCompiled()->getHostRegex() === null) {
             return true;
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -171,7 +171,7 @@ class ThrottleRequests
             'X-RateLimit-Remaining' => $remainingAttempts,
         ];
 
-        if (null !== $retryAfter) {
+        if ($retryAfter !== null) {
             $headers['Retry-After'] = $retryAfter;
             $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
         }
@@ -189,7 +189,7 @@ class ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (null === $retryAfter) {
+        if ($retryAfter === null) {
             return $this->limiter->retriesLeft($key, $maxAttempts);
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -171,7 +171,7 @@ class ThrottleRequests
             'X-RateLimit-Remaining' => $remainingAttempts,
         ];
 
-        if (! is_null($retryAfter)) {
+        if (null !== $retryAfter) {
             $headers['Retry-After'] = $retryAfter;
             $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
         }
@@ -189,7 +189,7 @@ class ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (is_null($retryAfter)) {
+        if (null === $retryAfter) {
             return $this->limiter->retriesLeft($key, $maxAttempts);
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -101,7 +101,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (is_null($retryAfter)) {
+        if (null === $retryAfter) {
             return $this->remaining;
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -101,7 +101,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (null === $retryAfter) {
+        if ($retryAfter === null) {
             return $this->remaining;
         }
 

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -39,7 +39,7 @@ class MiddlewareNameResolver
         // which may be run using the Pipeline which accepts this string format.
         [$name, $parameters] = array_pad(explode(':', $name, 2), 2, null);
 
-        return ($map[$name] ?? $name).(! is_null($parameters) ? ':'.$parameters : '');
+        return ($map[$name] ?? $name).(null !== $parameters ? ':'.$parameters : '');
     }
 
     /**

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -39,7 +39,7 @@ class MiddlewareNameResolver
         // which may be run using the Pipeline which accepts this string format.
         [$name, $parameters] = array_pad(explode(':', $name, 2), 2, null);
 
-        return ($map[$name] ?? $name).(null !== $parameters ? ':'.$parameters : '');
+        return ($map[$name] ?? $name).($parameters !== null ? ':'.$parameters : '');
     }
 
     /**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -136,7 +136,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new StreamedResponse($callback, 200, $headers);
 
-        if (null !== $name) {
+        if ($name !== null) {
             $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
                 $disposition,
                 $name,
@@ -160,7 +160,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
-        if (null !== $name) {
+        if ($name !== null) {
             return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
         }
 

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -136,7 +136,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new StreamedResponse($callback, 200, $headers);
 
-        if (! is_null($name)) {
+        if (null !== $name) {
             $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
                 $disposition,
                 $name,
@@ -160,7 +160,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
-        if (! is_null($name)) {
+        if (null !== $name) {
             return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -428,7 +428,7 @@ class Route
     public function parametersWithoutNulls()
     {
         return array_filter($this->parameters(), function ($p) {
-            return ! is_null($p);
+            return null !== $p;
         });
     }
 
@@ -453,7 +453,7 @@ class Route
      */
     protected function compileParameterNames()
     {
-        preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
+        preg_match_all('/{(.*?)}/', $this->getDomain().$this->uri, $matches);
 
         return array_map(function ($m) {
             return trim($m, '?');
@@ -588,7 +588,7 @@ class Route
      */
     public function domain($domain = null)
     {
-        if (is_null($domain)) {
+        if (null === $domain) {
             return $this->getDomain();
         }
 
@@ -687,7 +687,7 @@ class Route
      */
     public function named(...$patterns)
     {
-        if (is_null($routeName = $this->getName())) {
+        if (null === ($routeName = $this->getName())) {
             return false;
         }
 
@@ -784,7 +784,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        if (! is_null($this->computedMiddleware)) {
+        if (null !== $this->computedMiddleware) {
             return $this->computedMiddleware;
         }
 
@@ -803,7 +803,7 @@ class Route
      */
     public function middleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if (null === $middleware) {
             return (array) ($this->action['middleware'] ?? []);
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -428,7 +428,7 @@ class Route
     public function parametersWithoutNulls()
     {
         return array_filter($this->parameters(), function ($p) {
-            return null !== $p;
+            return $p !== null;
         });
     }
 
@@ -453,7 +453,7 @@ class Route
      */
     protected function compileParameterNames()
     {
-        preg_match_all('/{(.*?)}/', $this->getDomain().$this->uri, $matches);
+        preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
 
         return array_map(function ($m) {
             return trim($m, '?');
@@ -588,7 +588,7 @@ class Route
      */
     public function domain($domain = null)
     {
-        if (null === $domain) {
+        if ($domain === null) {
             return $this->getDomain();
         }
 
@@ -687,7 +687,7 @@ class Route
      */
     public function named(...$patterns)
     {
-        if (null === ($routeName = $this->getName())) {
+        if (($routeName = $this->getName()) === null) {
             return false;
         }
 
@@ -784,7 +784,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        if (null !== $this->computedMiddleware) {
+        if ($this->computedMiddleware !== null) {
             return $this->computedMiddleware;
         }
 
@@ -803,7 +803,7 @@ class Route
      */
     public function middleware($middleware = null)
     {
-        if (null === $middleware) {
+        if ($middleware === null) {
             return (array) ($this->action['middleware'] ?? []);
         }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -21,7 +21,7 @@ class RouteAction
         // If no action is passed in right away, we assume the user will make use of
         // fluent routing. In that case, we set a default closure, to be executed
         // if the user never explicitly sets an action to handle the given uri.
-        if (is_null($action)) {
+        if (null === $action) {
             return static::missingAction($uri);
         }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -21,7 +21,7 @@ class RouteAction
         // If no action is passed in right away, we assume the user will make use of
         // fluent routing. In that case, we set a default closure, to be executed
         // if the user never explicitly sets an action to handle the given uri.
-        if (null === $action) {
+        if ($action === null) {
             return static::missingAction($uri);
         }
 

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -56,7 +56,7 @@ class RouteBinding
     public static function forModel($container, $class, $callback = null)
     {
         return function ($value) use ($container, $class, $callback) {
-            if (is_null($value)) {
+            if (null === $value) {
                 return;
             }
 

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -56,7 +56,7 @@ class RouteBinding
     public static function forModel($container, $class, $callback = null)
     {
         return function ($value) use ($container, $class, $callback) {
-            if (null === $value) {
+            if ($value === null) {
                 return;
             }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -163,7 +163,7 @@ class RouteCollection implements Countable, IteratorAggregate
         // by the consumer. Otherwise we will check for routes with another verb.
         $route = $this->matchAgainstRoutes($routes, $request);
 
-        if (null !== $route) {
+        if ($route !== null) {
             return $route->bind($request);
         }
 
@@ -214,7 +214,7 @@ class RouteCollection implements Countable, IteratorAggregate
         $others = [];
 
         foreach ($methods as $method) {
-            if (null !== $this->matchAgainstRoutes($this->get($method), $request, false)) {
+            if ($this->matchAgainstRoutes($this->get($method), $request, false) !== null) {
                 $others[] = $method;
             }
         }
@@ -271,7 +271,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function get($method = null)
     {
-        return null === $method ? $this->getRoutes() : Arr::get($this->routes, $method, []);
+        return $method === null ? $this->getRoutes() : Arr::get($this->routes, $method, []);
     }
 
     /**
@@ -282,7 +282,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function hasNamedRoute($name)
     {
-        return null !== $this->getByName($name);
+        return $this->getByName($name) !== null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -163,7 +163,7 @@ class RouteCollection implements Countable, IteratorAggregate
         // by the consumer. Otherwise we will check for routes with another verb.
         $route = $this->matchAgainstRoutes($routes, $request);
 
-        if (! is_null($route)) {
+        if (null !== $route) {
             return $route->bind($request);
         }
 
@@ -214,7 +214,7 @@ class RouteCollection implements Countable, IteratorAggregate
         $others = [];
 
         foreach ($methods as $method) {
-            if (! is_null($this->matchAgainstRoutes($this->get($method), $request, false))) {
+            if (null !== $this->matchAgainstRoutes($this->get($method), $request, false)) {
                 $others[] = $method;
             }
         }
@@ -271,7 +271,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function get($method = null)
     {
-        return is_null($method) ? $this->getRoutes() : Arr::get($this->routes, $method, []);
+        return null === $method ? $this->getRoutes() : Arr::get($this->routes, $method, []);
     }
 
     /**
@@ -282,7 +282,7 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     public function hasNamedRoute($name)
     {
-        return ! is_null($this->getByName($name));
+        return null !== $this->getByName($name);
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCompiler.php
+++ b/src/Illuminate/Routing/RouteCompiler.php
@@ -33,7 +33,7 @@ class RouteCompiler
     {
         $optionals = $this->getOptionalParameters();
 
-        $uri = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->route->uri());
+        $uri = preg_replace('/{(\w+?)\?}/', '{$1}', $this->route->uri());
 
         return (
             new SymfonyRoute($uri, $optionals, $this->route->wheres, ['utf8' => true], $this->route->getDomain() ?: '')
@@ -47,7 +47,7 @@ class RouteCompiler
      */
     protected function getOptionalParameters()
     {
-        preg_match_all('/\{(\w+?)\?\}/', $this->route->uri(), $matches);
+        preg_match_all('/{(\w+?)\?}/', $this->route->uri(), $matches);
 
         return isset($matches[1]) ? array_fill_keys($matches[1], null) : [];
     }

--- a/src/Illuminate/Routing/RouteCompiler.php
+++ b/src/Illuminate/Routing/RouteCompiler.php
@@ -33,7 +33,7 @@ class RouteCompiler
     {
         $optionals = $this->getOptionalParameters();
 
-        $uri = preg_replace('/{(\w+?)\?}/', '{$1}', $this->route->uri());
+        $uri = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->route->uri());
 
         return (
             new SymfonyRoute($uri, $optionals, $this->route->wheres, ['utf8' => true], $this->route->getDomain() ?: '')

--- a/src/Illuminate/Routing/RouteCompiler.php
+++ b/src/Illuminate/Routing/RouteCompiler.php
@@ -47,7 +47,7 @@ class RouteCompiler
      */
     protected function getOptionalParameters()
     {
-        preg_match_all('/{(\w+?)\?}/', $this->route->uri(), $matches);
+        preg_match_all('/\{(\w+?)\?\}/', $this->route->uri(), $matches);
 
         return isset($matches[1]) ? array_fill_keys($matches[1], null) : [];
     }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -46,7 +46,7 @@ trait RouteDependencyResolverTrait
                 $parameter, $parameters
             );
 
-            if (! is_null($instance)) {
+            if (null !== $instance) {
                 $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
@@ -89,9 +89,9 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
+        return null !== Arr::first($parameters, function ($value) use ($class) {
             return $value instanceof $class;
-        }));
+        });
     }
 
     /**

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -46,7 +46,7 @@ trait RouteDependencyResolverTrait
                 $parameter, $parameters
             );
 
-            if (null !== $instance) {
+            if ($instance !== null) {
                 $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
@@ -89,9 +89,9 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return null !== Arr::first($parameters, function ($value) use ($class) {
+        return Arr::first($parameters, function ($value) use ($class) {
             return $value instanceof $class;
-        });
+        }) !== null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -40,7 +40,7 @@ class RouteParameterBinder
         // If the route has a regular expression for the host part of the URI, we will
         // compile that and get the parameter matches for this domain. We will then
         // merge them into this parameters array so that this array is completed.
-        if (! is_null($this->route->compiled->getHostRegex())) {
+        if (null !== $this->route->compiled->getHostRegex()) {
             $parameters = $this->bindHostParameters(
                 $request, $parameters
             );

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -40,7 +40,7 @@ class RouteParameterBinder
         // If the route has a regular expression for the host part of the URI, we will
         // compile that and get the parameter matches for this domain. We will then
         // merge them into this parameters array so that this array is completed.
-        if (null !== $this->route->compiled->getHostRegex()) {
+        if ($this->route->compiled->getHostRegex() !== null) {
             $parameters = $this->bindHostParameters(
                 $request, $parameters
             );

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -159,7 +159,7 @@ class RouteRegistrar
      */
     protected function compileAction($action)
     {
-        if (is_null($action)) {
+        if (null === $action) {
             return $this->attributes;
         }
 

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -159,7 +159,7 @@ class RouteRegistrar
      */
     protected function compileAction($action)
     {
-        if (null === $action) {
+        if ($action === null) {
             return $this->attributes;
         }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -21,7 +21,7 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($action['uses'])
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
-        return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
+        return null === $subClass ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
             return $p->getClass() && $p->getClass()->isSubclassOf($subClass);
         });
     }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -21,7 +21,7 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($action['uses'])
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
-        return null === $subClass ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
+        return $subClass === null ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
             return $p->getClass() && $p->getClass()->isSubclassOf($subClass);
         });
     }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -87,7 +87,7 @@ class RouteUrlGenerator
             $route
         ), $parameters);
 
-        if (preg_match('/{.*?}/', $uri)) {
+        if (preg_match('/\{.*?\}/', $uri)) {
             throw UrlGenerationException::forMissingParameters($route);
         }
 
@@ -196,7 +196,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/{.*?}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
@@ -205,7 +205,7 @@ class RouteUrlGenerator
                         : Arr::pull($parameters, 0);
         }, $path);
 
-        return trim(preg_replace('/{.*?\?}/', '', $path), '/');
+        return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
     }
 
     /**
@@ -217,7 +217,7 @@ class RouteUrlGenerator
      */
     protected function replaceNamedParameters($path, &$parameters)
     {
-        return preg_replace_callback('/{(.*?)\??}/', function ($m) use (&$parameters) {
+        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
             if (isset($parameters[$m[1]])) {
                 return Arr::pull($parameters, $m[1]);
             } elseif (isset($this->defaultParameters[$m[1]])) {
@@ -240,13 +240,13 @@ class RouteUrlGenerator
         // If the URI has a fragment we will move it to the end of this URI since it will
         // need to come after any query string that may be added to the URL else it is
         // not going to be available. We will remove it then append it back on here.
-        if (null !== ($fragment = parse_url($uri, PHP_URL_FRAGMENT))) {
+        if (($fragment = parse_url($uri, PHP_URL_FRAGMENT)) !== null) {
             $uri = preg_replace('/#.*/', '', $uri);
         }
 
         $uri .= $this->getRouteQueryString($parameters);
 
-        return null === $fragment ? $uri : $uri."#{$fragment}";
+        return $fragment === null ? $uri : $uri."#{$fragment}";
     }
 
     /**

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -87,7 +87,7 @@ class RouteUrlGenerator
             $route
         ), $parameters);
 
-        if (preg_match('/\{.*?\}/', $uri)) {
+        if (preg_match('/{.*?}/', $uri)) {
             throw UrlGenerationException::forMissingParameters($route);
         }
 
@@ -196,7 +196,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/{.*?}/', function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
@@ -205,7 +205,7 @@ class RouteUrlGenerator
                         : Arr::pull($parameters, 0);
         }, $path);
 
-        return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
+        return trim(preg_replace('/{.*?\?}/', '', $path), '/');
     }
 
     /**
@@ -217,7 +217,7 @@ class RouteUrlGenerator
      */
     protected function replaceNamedParameters($path, &$parameters)
     {
-        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
+        return preg_replace_callback('/{(.*?)\??}/', function ($m) use (&$parameters) {
             if (isset($parameters[$m[1]])) {
                 return Arr::pull($parameters, $m[1]);
             } elseif (isset($this->defaultParameters[$m[1]])) {
@@ -240,13 +240,13 @@ class RouteUrlGenerator
         // If the URI has a fragment we will move it to the end of this URI since it will
         // need to come after any query string that may be added to the URL else it is
         // not going to be available. We will remove it then append it back on here.
-        if (! is_null($fragment = parse_url($uri, PHP_URL_FRAGMENT))) {
+        if (null !== ($fragment = parse_url($uri, PHP_URL_FRAGMENT))) {
             $uri = preg_replace('/#.*/', '', $uri);
         }
 
         $uri .= $this->getRouteQueryString($parameters);
 
-        return is_null($fragment) ? $uri : $uri."#{$fragment}";
+        return null === $fragment ? $uri : $uri."#{$fragment}";
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -296,11 +296,11 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatScheme($secure = null)
     {
-        if (null !== $secure) {
+        if ($secure !== null) {
             return $secure ? 'https://' : 'http://';
         }
 
-        if (null === $this->cachedScheme) {
+        if ($this->cachedScheme === null) {
             $this->cachedScheme = $this->forceScheme ?: $this->request->getScheme().'://';
         }
 
@@ -382,7 +382,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        if (null !== ($route = $this->routes->getByName($name))) {
+        if (($route = $this->routes->getByName($name)) !== null) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -418,7 +418,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function action($action, $parameters = [], $absolute = true)
     {
-        if (null === ($route = $this->routes->getByAction($action = $this->formatAction($action)))) {
+        if (($route = $this->routes->getByAction($action = $this->formatAction($action))) === null) {
             throw new InvalidArgumentException("Action {$action} not defined.");
         }
 
@@ -490,8 +490,8 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatRoot($scheme, $root = null)
     {
-        if (null === $root) {
-            if (null === $this->cachedRoot) {
+        if ($root === null) {
+            if ($this->cachedRoot === null) {
                 $this->cachedRoot = $this->forcedRoot ?: $this->request->root();
             }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -296,11 +296,11 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatScheme($secure = null)
     {
-        if (! is_null($secure)) {
+        if (null !== $secure) {
             return $secure ? 'https://' : 'http://';
         }
 
-        if (is_null($this->cachedScheme)) {
+        if (null === $this->cachedScheme) {
             $this->cachedScheme = $this->forceScheme ?: $this->request->getScheme().'://';
         }
 
@@ -382,7 +382,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        if (! is_null($route = $this->routes->getByName($name))) {
+        if (null !== ($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -418,7 +418,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function action($action, $parameters = [], $absolute = true)
     {
-        if (is_null($route = $this->routes->getByAction($action = $this->formatAction($action)))) {
+        if (null === ($route = $this->routes->getByAction($action = $this->formatAction($action)))) {
             throw new InvalidArgumentException("Action {$action} not defined.");
         }
 
@@ -490,8 +490,8 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatRoot($scheme, $root = null)
     {
-        if (is_null($root)) {
-            if (is_null($this->cachedRoot)) {
+        if (null === $root) {
+            if (null === $this->cachedRoot) {
                 $this->cachedRoot = $this->forcedRoot ?: $this->request->root();
             }
 

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -68,7 +68,7 @@ class CookieSessionHandler implements SessionHandlerInterface
     {
         $value = $this->request->cookies->get($sessionId) ?: '';
 
-        if (null !== ($decoded = json_decode($value, true)) && is_array($decoded)) {
+        if (($decoded = json_decode($value, true)) !== null && is_array($decoded)) {
             if (isset($decoded['expires']) && $this->currentTime() <= $decoded['expires']) {
                 return $decoded['data'];
             }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -68,7 +68,7 @@ class CookieSessionHandler implements SessionHandlerInterface
     {
         $value = $this->request->cookies->get($sessionId) ?: '';
 
-        if (! is_null($decoded = json_decode($value, true)) && is_array($decoded)) {
+        if (null !== ($decoded = json_decode($value, true)) && is_array($decoded)) {
             if (isset($decoded['expires']) && $this->currentTime() <= $decoded['expires']) {
                 return $decoded['data'];
             }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -201,7 +201,7 @@ class StartSession
      */
     protected function sessionConfigured()
     {
-        return ! is_null($this->manager->getSessionConfig()['driver'] ?? null);
+        return null !== ($this->manager->getSessionConfig()['driver'] ?? null);
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -201,7 +201,7 @@ class StartSession
      */
     protected function sessionConfigured()
     {
-        return null !== ($this->manager->getSessionConfig()['driver'] ?? null);
+        return ($this->manager->getSessionConfig()['driver'] ?? null) !== null;
     }
 
     /**

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -97,7 +97,7 @@ class Store implements Session
         if ($data = $this->handler->read($this->getId())) {
             $data = @unserialize($this->prepareForUnserialize($data));
 
-            if ($data !== false && ! is_null($data) && is_array($data)) {
+            if ($data !== false && null !== $data && is_array($data)) {
                 return $data;
             }
         }
@@ -202,7 +202,7 @@ class Store implements Session
     public function has($key)
     {
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
-            return is_null($this->get($key));
+            return null === $this->get($key);
         });
     }
 
@@ -240,7 +240,7 @@ class Store implements Session
     {
         $old = $this->getOldInput($key);
 
-        return is_null($key) ? count($old) > 0 : ! is_null($old);
+        return null === $key ? count($old) > 0 : null !== $old;
     }
 
     /**
@@ -293,7 +293,7 @@ class Store implements Session
      */
     public function remember($key, Closure $callback)
     {
-        if (! is_null($value = $this->get($key))) {
+        if (null !== ($value = $this->get($key))) {
             return $value;
         }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -97,7 +97,7 @@ class Store implements Session
         if ($data = $this->handler->read($this->getId())) {
             $data = @unserialize($this->prepareForUnserialize($data));
 
-            if ($data !== false && null !== $data && is_array($data)) {
+            if ($data !== false && $data !== null && is_array($data)) {
                 return $data;
             }
         }
@@ -202,7 +202,7 @@ class Store implements Session
     public function has($key)
     {
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
-            return null === $this->get($key);
+            return $this->get($key) === null;
         });
     }
 
@@ -240,7 +240,7 @@ class Store implements Session
     {
         $old = $this->getOldInput($key);
 
-        return null === $key ? count($old) > 0 : null !== $old;
+        return $key === null ? count($old) > 0 : $old !== null;
     }
 
     /**
@@ -293,7 +293,7 @@ class Store implements Session
      */
     public function remember($key, Closure $callback)
     {
-        if (null !== ($value = $this->get($key))) {
+        if (($value = $this->get($key)) !== null) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -31,7 +31,7 @@ class Arr
      */
     public static function add($array, $key, $value)
     {
-        if (is_null(static::get($array, $key))) {
+        if (null === static::get($array, $key)) {
             static::set($array, $key, $value);
         }
 
@@ -161,7 +161,7 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             if (empty($array)) {
                 return value($default);
             }
@@ -190,7 +190,7 @@ class Arr
      */
     public static function last($array, callable $callback = null, $default = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             return empty($array) ? value($default) : end($array);
         }
 
@@ -285,7 +285,7 @@ class Arr
             return value($default);
         }
 
-        if (is_null($key)) {
+        if (null === $key) {
             return $array;
         }
 
@@ -389,7 +389,7 @@ class Arr
             // If the key is "null", we will just append the value to the array and keep
             // looping. Otherwise we will key the array using the value of the key we
             // received from the developer. Then we'll return the final array form.
-            if (is_null($key)) {
+            if (null === $key) {
                 $results[] = $itemValue;
             } else {
                 $itemKey = data_get($item, $key);
@@ -416,7 +416,7 @@ class Arr
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        $key = null === $key || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }
@@ -431,7 +431,7 @@ class Arr
      */
     public static function prepend($array, $value, $key = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             array_unshift($array, $value);
         } else {
             $array = [$key => $value] + $array;
@@ -468,7 +468,7 @@ class Arr
      */
     public static function random($array, $number = null)
     {
-        $requested = is_null($number) ? 1 : $number;
+        $requested = $number ?? 1;
 
         $count = count($array);
 
@@ -478,7 +478,7 @@ class Arr
             );
         }
 
-        if (is_null($number)) {
+        if (null === $number) {
             return $array[array_rand($array)];
         }
 
@@ -509,7 +509,7 @@ class Arr
      */
     public static function set(&$array, $key, $value)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $array = $value;
         }
 
@@ -542,7 +542,7 @@ class Arr
      */
     public static function shuffle($array, $seed = null)
     {
-        if (is_null($seed)) {
+        if (null === $seed) {
             shuffle($array);
         } else {
             mt_srand($seed);
@@ -578,6 +578,7 @@ class Arr
                 $value = static::sortRecursive($value);
             }
         }
+        unset($value);
 
         if (static::isAssoc($array)) {
             ksort($array);
@@ -619,7 +620,7 @@ class Arr
      */
     public static function wrap($value)
     {
-        if (is_null($value)) {
+        if (null === $value) {
             return [];
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -31,7 +31,7 @@ class Arr
      */
     public static function add($array, $key, $value)
     {
-        if (null === static::get($array, $key)) {
+        if (static::get($array, $key) === null) {
             static::set($array, $key, $value);
         }
 
@@ -161,7 +161,7 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             if (empty($array)) {
                 return value($default);
             }
@@ -190,7 +190,7 @@ class Arr
      */
     public static function last($array, callable $callback = null, $default = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             return empty($array) ? value($default) : end($array);
         }
 
@@ -285,7 +285,7 @@ class Arr
             return value($default);
         }
 
-        if (null === $key) {
+        if ($key === null) {
             return $array;
         }
 
@@ -389,7 +389,7 @@ class Arr
             // If the key is "null", we will just append the value to the array and keep
             // looping. Otherwise we will key the array using the value of the key we
             // received from the developer. Then we'll return the final array form.
-            if (null === $key) {
+            if ($key === null) {
                 $results[] = $itemValue;
             } else {
                 $itemKey = data_get($item, $key);
@@ -416,7 +416,7 @@ class Arr
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = null === $key || is_array($key) ? $key : explode('.', $key);
+        $key = $key === null || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }
@@ -431,7 +431,7 @@ class Arr
      */
     public static function prepend($array, $value, $key = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             array_unshift($array, $value);
         } else {
             $array = [$key => $value] + $array;
@@ -478,7 +478,7 @@ class Arr
             );
         }
 
-        if (null === $number) {
+        if ($number === null) {
             return $array[array_rand($array)];
         }
 
@@ -509,7 +509,7 @@ class Arr
      */
     public static function set(&$array, $key, $value)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $array = $value;
         }
 
@@ -542,7 +542,7 @@ class Arr
      */
     public static function shuffle($array, $seed = null)
     {
-        if (null === $seed) {
+        if ($seed === null) {
             shuffle($array);
         } else {
             mt_srand($seed);
@@ -620,7 +620,7 @@ class Arr
      */
     public static function wrap($value)
     {
-        if (null === $value) {
+        if ($value === null) {
             return [];
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -43,7 +43,7 @@ class Collection implements ArrayAccess, Enumerable
             return new static;
         }
 
-        if (is_null($callback)) {
+        if (null === $callback) {
             return new static(range(1, $number));
         }
 
@@ -83,7 +83,7 @@ class Collection implements ArrayAccess, Enumerable
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return null !== $value;
         });
 
         if ($count = $items->count()) {
@@ -101,7 +101,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
             ->filter(function ($item) {
-                return ! is_null($item);
+                return null !== $item;
             })->sort()->values();
 
         $count = $values->count();
@@ -768,7 +768,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function only($keys)
     {
-        if (is_null($keys)) {
+        if (null === $keys) {
             return new static($this->items);
         }
 
@@ -871,7 +871,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function random($number = null)
     {
-        if (is_null($number)) {
+        if (null === $number) {
             return Arr::random($this->items);
         }
 
@@ -1299,7 +1299,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function offsetSet($key, $value)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             $this->items[] = $value;
         } else {
             $this->items[$key] = $value;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -43,7 +43,7 @@ class Collection implements ArrayAccess, Enumerable
             return new static;
         }
 
-        if (null === $callback) {
+        if ($callback === null) {
             return new static(range(1, $number));
         }
 
@@ -83,7 +83,7 @@ class Collection implements ArrayAccess, Enumerable
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return null !== $value;
+            return $value !== null;
         });
 
         if ($count = $items->count()) {
@@ -101,7 +101,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
             ->filter(function ($item) {
-                return null !== $item;
+                return $item !== null;
             })->sort()->values();
 
         $count = $values->count();
@@ -768,7 +768,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function only($keys)
     {
-        if (null === $keys) {
+        if ($keys === null) {
             return new static($this->items);
         }
 
@@ -871,7 +871,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function random($number = null)
     {
-        if (null === $number) {
+        if ($number === null) {
             return Arr::random($this->items);
         }
 
@@ -1299,7 +1299,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function offsetSet($key, $value)
     {
-        if (null === $key) {
+        if ($key === null) {
             $this->items[] = $value;
         } else {
             $this->items[$key] = $value;

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -64,7 +64,7 @@ class ConfigurationUrlParser
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
         ], function ($value) {
-            return ! is_null($value);
+            return null !== $value;
         });
     }
 

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -64,7 +64,7 @@ class ConfigurationUrlParser
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
         ], function ($value) {
-            return null !== $value;
+            return $value !== null;
         });
     }
 

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -19,7 +19,7 @@ class Cookie extends Facade
      */
     public static function has($key)
     {
-        return null !== static::$app['request']->cookie($key, null);
+        return static::$app['request']->cookie($key, null) !== null;
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -19,7 +19,7 @@ class Cookie extends Facade
      */
     public static function has($key)
     {
-        return ! is_null(static::$app['request']->cookie($key, null));
+        return null !== static::$app['request']->cookie($key, null);
     }
 
     /**

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -30,7 +30,7 @@ class LazyCollection implements Enumerable
     {
         if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
-        } elseif (is_null($source)) {
+        } elseif (null === $source) {
             $this->source = static::empty();
         } else {
             $this->source = $this->getArrayableItems($source);
@@ -66,7 +66,7 @@ class LazyCollection implements Enumerable
             }
         });
 
-        return is_null($callback) ? $instance : $instance->map($callback);
+        return $callback === null ? $instance : $instance->map($callback);
     }
 
     /**
@@ -303,7 +303,7 @@ class LazyCollection implements Enumerable
      */
     public function filter(callable $callback = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             $callback = function ($value) {
                 return (bool) $value;
             };
@@ -329,7 +329,7 @@ class LazyCollection implements Enumerable
     {
         $iterator = $this->getIterator();
 
-        if (is_null($callback)) {
+        if (null === $callback) {
             if (! $iterator->valid()) {
                 return value($default);
             }
@@ -392,7 +392,7 @@ class LazyCollection implements Enumerable
      */
     public function get($key, $default = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return;
         }
 
@@ -542,7 +542,7 @@ class LazyCollection implements Enumerable
         $needle = $placeholder = new stdClass;
 
         foreach ($this as $key => $value) {
-            if (is_null($callback) || $callback($value, $key)) {
+            if (null === $callback || $callback($value, $key)) {
                 $needle = $value;
             }
         }
@@ -565,7 +565,7 @@ class LazyCollection implements Enumerable
             foreach ($this as $item) {
                 $itemValue = data_get($item, $value);
 
-                if (is_null($key)) {
+                if (null === $key) {
                     yield $itemValue;
                 } else {
                     $itemKey = data_get($item, $key);
@@ -721,12 +721,12 @@ class LazyCollection implements Enumerable
     {
         if ($keys instanceof Enumerable) {
             $keys = $keys->all();
-        } elseif (! is_null($keys)) {
+        } elseif (null !== $keys) {
             $keys = is_array($keys) ? $keys : func_get_args();
         }
 
         return new static(function () use ($keys) {
-            if (is_null($keys)) {
+            if (null === $keys) {
                 yield from $this;
             } else {
                 $keys = array_flip($keys);
@@ -772,7 +772,7 @@ class LazyCollection implements Enumerable
     {
         $result = $this->collect()->random(...func_get_args());
 
-        return is_null($number) ? $result : new static($result);
+        return null === $number ? $result : new static($result);
     }
 
     /**
@@ -914,7 +914,7 @@ class LazyCollection implements Enumerable
 
         $instance = $this->skip($offset);
 
-        return is_null($length) ? $instance : $instance->take($length);
+        return null === $length ? $instance : $instance->take($length);
     }
 
     /**
@@ -1194,7 +1194,7 @@ class LazyCollection implements Enumerable
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        $key = null === $key || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -30,7 +30,7 @@ class LazyCollection implements Enumerable
     {
         if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
-        } elseif (null === $source) {
+        } elseif ($source === null) {
             $this->source = static::empty();
         } else {
             $this->source = $this->getArrayableItems($source);
@@ -66,7 +66,7 @@ class LazyCollection implements Enumerable
             }
         });
 
-        return null === $callback ? $instance : $instance->map($callback);
+        return $callback === null ? $instance : $instance->map($callback);
     }
 
     /**
@@ -303,7 +303,7 @@ class LazyCollection implements Enumerable
      */
     public function filter(callable $callback = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return (bool) $value;
             };
@@ -329,7 +329,7 @@ class LazyCollection implements Enumerable
     {
         $iterator = $this->getIterator();
 
-        if (null === $callback) {
+        if ($callback === null) {
             if (! $iterator->valid()) {
                 return value($default);
             }
@@ -392,7 +392,7 @@ class LazyCollection implements Enumerable
      */
     public function get($key, $default = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return;
         }
 
@@ -542,7 +542,7 @@ class LazyCollection implements Enumerable
         $needle = $placeholder = new stdClass;
 
         foreach ($this as $key => $value) {
-            if (null === $callback || $callback($value, $key)) {
+            if ($callback === null || $callback($value, $key)) {
                 $needle = $value;
             }
         }
@@ -565,7 +565,7 @@ class LazyCollection implements Enumerable
             foreach ($this as $item) {
                 $itemValue = data_get($item, $value);
 
-                if (null === $key) {
+                if ($key === null) {
                     yield $itemValue;
                 } else {
                     $itemKey = data_get($item, $key);
@@ -721,12 +721,12 @@ class LazyCollection implements Enumerable
     {
         if ($keys instanceof Enumerable) {
             $keys = $keys->all();
-        } elseif (null !== $keys) {
+        } elseif ($keys !== null) {
             $keys = is_array($keys) ? $keys : func_get_args();
         }
 
         return new static(function () use ($keys) {
-            if (null === $keys) {
+            if ($keys === null) {
                 yield from $this;
             } else {
                 $keys = array_flip($keys);
@@ -772,7 +772,7 @@ class LazyCollection implements Enumerable
     {
         $result = $this->collect()->random(...func_get_args());
 
-        return null === $number ? $result : new static($result);
+        return $number === null ? $result : new static($result);
     }
 
     /**
@@ -914,7 +914,7 @@ class LazyCollection implements Enumerable
 
         $instance = $this->skip($offset);
 
-        return null === $length ? $instance : $instance->take($length);
+        return $length === null ? $instance : $instance->take($length);
     }
 
     /**
@@ -1194,7 +1194,7 @@ class LazyCollection implements Enumerable
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = null === $key || is_array($key) ? $key : explode('.', $key);
+        $key = $key === null || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -66,7 +66,7 @@ class LazyCollection implements Enumerable
             }
         });
 
-        return $callback === null ? $instance : $instance->map($callback);
+        return null === $callback ? $instance : $instance->map($callback);
     }
 
     /**

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -77,7 +77,7 @@ abstract class Manager
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
-        if (is_null($driver)) {
+        if (null === $driver) {
             throw new InvalidArgumentException(sprintf(
                 'Unable to resolve NULL driver for [%s].', static::class
             ));

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -77,7 +77,7 @@ abstract class Manager
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
-        if (null === $driver) {
+        if ($driver === null) {
             throw new InvalidArgumentException(sprintf(
                 'Unable to resolve NULL driver for [%s].', static::class
             ));

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -109,7 +109,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
             return false;
         }
 
-        if (is_null($key)) {
+        if (null === $key) {
             return $this->any();
         }
 
@@ -156,7 +156,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function first($key = null, $format = null)
     {
-        $messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
+        $messages = null === $key ? $this->all($format) : $this->get($key, $format);
 
         $firstMessage = Arr::first($messages, null, '');
 

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -109,7 +109,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
             return false;
         }
 
-        if (null === $key) {
+        if ($key === null) {
             return $this->any();
         }
 
@@ -156,7 +156,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function first($key = null, $format = null)
     {
-        $messages = null === $key ? $this->all($format) : $this->get($key, $format);
+        $messages = $key === null ? $this->all($format) : $this->get($key, $format);
 
         $firstMessage = Arr::first($messages, null, '');
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -194,7 +194,7 @@ abstract class ServiceProvider
      */
     public static function pathsToPublish($provider = null, $group = null)
     {
-        if (! is_null($paths = static::pathsForProviderOrGroup($provider, $group))) {
+        if (null !== ($paths = static::pathsForProviderOrGroup($provider, $group))) {
             return $paths;
         }
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -194,7 +194,7 @@ abstract class ServiceProvider
      */
     public static function pathsToPublish($provider = null, $group = null)
     {
-        if (null !== ($paths = static::pathsForProviderOrGroup($provider, $group))) {
+        if (($paths = static::pathsForProviderOrGroup($provider, $group)) !== null) {
             return $paths;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -63,7 +63,7 @@ class Str
     {
         $languageSpecific = static::languageSpecificCharsArray($language);
 
-        if (! is_null($languageSpecific)) {
+        if (null !== $languageSpecific) {
             $value = str_replace($languageSpecific[0], $languageSpecific[1], $value);
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -63,7 +63,7 @@ class Str
     {
         $languageSpecific = static::languageSpecificCharsArray($language);
 
-        if (null !== $languageSpecific) {
+        if ($languageSpecific !== null) {
             $value = str_replace($languageSpecific[0], $languageSpecific[1], $value);
         }
 

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -123,7 +123,7 @@ trait EnumeratesValues
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            return null !== $this->first($key);
         }
 
         foreach ($this as $item) {
@@ -311,9 +311,9 @@ trait EnumeratesValues
         return $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return null !== $value;
         })->reduce(function ($result, $value) {
-            return is_null($result) || $value < $result ? $value : $result;
+            return null === $result || $value < $result ? $value : $result;
         });
     }
 
@@ -328,11 +328,11 @@ trait EnumeratesValues
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return ! is_null($value);
+            return null !== $value;
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
-            return is_null($result) || $value > $result ? $value : $result;
+            return null === $result || $value > $result ? $value : $result;
         });
     }
 
@@ -386,7 +386,7 @@ trait EnumeratesValues
      */
     public function sum($callback = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             $callback = function ($value) {
                 return $value;
             };
@@ -747,7 +747,7 @@ trait EnumeratesValues
      */
     public function countBy($callback = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             $callback = function ($value) {
                 return $value;
             };

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -123,7 +123,7 @@ trait EnumeratesValues
         }
 
         if ($this->useAsCallable($key)) {
-            return null !== $this->first($key);
+            return $this->first($key) !== null;
         }
 
         foreach ($this as $item) {
@@ -311,9 +311,9 @@ trait EnumeratesValues
         return $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return null !== $value;
+            return $value !== null;
         })->reduce(function ($result, $value) {
-            return null === $result || $value < $result ? $value : $result;
+            return $result === null || $value < $result ? $value : $result;
         });
     }
 
@@ -328,11 +328,11 @@ trait EnumeratesValues
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return null !== $value;
+            return $value !== null;
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
-            return null === $result || $value > $result ? $value : $result;
+            return $result === null || $value > $result ? $value : $result;
         });
     }
 
@@ -386,7 +386,7 @@ trait EnumeratesValues
      */
     public function sum($callback = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return $value;
             };
@@ -747,7 +747,7 @@ trait EnumeratesValues
      */
     public function countBy($callback = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return $value;
             };

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -39,7 +39,7 @@ if (! function_exists('blank')) {
      */
     function blank($value)
     {
-        if (null === $value) {
+        if ($value === null) {
             return true;
         }
 
@@ -136,13 +136,13 @@ if (! function_exists('data_get')) {
      */
     function data_get($target, $key, $default = null)
     {
-        if (null === $key) {
+        if ($key === null) {
             return $target;
         }
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        while (null !== ($segment = array_shift($key))) {
+        while (($segment = array_shift($key)) !== null) {
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();
@@ -316,7 +316,7 @@ if (! function_exists('object_get')) {
      */
     function object_get($object, $key, $default = null)
     {
-        if (null === $key || trim($key) === '') {
+        if ($key === null || trim($key) === '') {
             return $object;
         }
 
@@ -342,9 +342,9 @@ if (! function_exists('optional')) {
      */
     function optional($value = null, callable $callback = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             return new Optional($value);
-        } elseif (null !== $value) {
+        } elseif ($value !== null) {
             return $callback($value);
         }
     }
@@ -417,7 +417,7 @@ if (! function_exists('tap')) {
      */
     function tap($value, $callback = null)
     {
-        if (null === $callback) {
+        if ($callback === null) {
             return new HigherOrderTapProxy($value);
         }
 
@@ -545,6 +545,6 @@ if (! function_exists('with')) {
      */
     function with($value, callable $callback = null)
     {
-        return null === $callback ? $value : $callback($value);
+        return $callback === null ? $value : $callback($value);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -39,7 +39,7 @@ if (! function_exists('blank')) {
      */
     function blank($value)
     {
-        if (is_null($value)) {
+        if (null === $value) {
             return true;
         }
 
@@ -136,13 +136,13 @@ if (! function_exists('data_get')) {
      */
     function data_get($target, $key, $default = null)
     {
-        if (is_null($key)) {
+        if (null === $key) {
             return $target;
         }
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        while (! is_null($segment = array_shift($key))) {
+        while (null !== ($segment = array_shift($key))) {
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();
@@ -316,7 +316,7 @@ if (! function_exists('object_get')) {
      */
     function object_get($object, $key, $default = null)
     {
-        if (is_null($key) || trim($key) == '') {
+        if (null === $key || trim($key) === '') {
             return $object;
         }
 
@@ -342,9 +342,9 @@ if (! function_exists('optional')) {
      */
     function optional($value = null, callable $callback = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             return new Optional($value);
-        } elseif (! is_null($value)) {
+        } elseif (null !== $value) {
             return $callback($value);
         }
     }
@@ -417,7 +417,7 @@ if (! function_exists('tap')) {
      */
     function tap($value, $callback = null)
     {
-        if (is_null($callback)) {
+        if (null === $callback) {
             return new HigherOrderTapProxy($value);
         }
 
@@ -545,6 +545,6 @@ if (! function_exists('with')) {
      */
     function with($value, callable $callback = null)
     {
-        return is_null($callback) ? $value : $callback($value);
+        return null === $callback ? $value : $callback($value);
     }
 }

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -63,7 +63,7 @@ class FileLoader implements Loader
             return $this->loadJsonPaths($locale);
         }
 
-        if (null === $namespace || $namespace === '*') {
+        if ($namespace === null || $namespace === '*') {
             return $this->loadPath($this->path, $locale, $group);
         }
 
@@ -141,7 +141,7 @@ class FileLoader implements Loader
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $decoded = json_decode($this->files->get($full), true);
 
-                    if (null === $decoded || json_last_error() !== JSON_ERROR_NONE) {
+                    if ($decoded === null || json_last_error() !== JSON_ERROR_NONE) {
                         throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
                     }
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -63,7 +63,7 @@ class FileLoader implements Loader
             return $this->loadJsonPaths($locale);
         }
 
-        if (is_null($namespace) || $namespace === '*') {
+        if (null === $namespace || $namespace === '*') {
             return $this->loadPath($this->path, $locale, $group);
         }
 
@@ -141,7 +141,7 @@ class FileLoader implements Loader
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $decoded = json_decode($this->files->get($full), true);
 
-                    if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
+                    if (null === $decoded || json_last_error() !== JSON_ERROR_NONE) {
                         throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
                     }
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -43,7 +43,7 @@ class MessageSelector
     private function extract($segments, $number)
     {
         foreach ($segments as $part) {
-            if (! is_null($line = $this->extractFromString($part, $number))) {
+            if (null !== ($line = $this->extractFromString($part, $number))) {
                 return $line;
             }
         }
@@ -58,7 +58,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        preg_match('/^[\{\[]([^\[\]\{\}]*)[\}\]](.*)/s', $part, $matches);
+        preg_match('/^[{\[]([^\[\]{}]*)[}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
             return;

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -43,7 +43,7 @@ class MessageSelector
     private function extract($segments, $number)
     {
         foreach ($segments as $part) {
-            if (null !== ($line = $this->extractFromString($part, $number))) {
+            if (($line = $this->extractFromString($part, $number)) !== null) {
                 return $line;
             }
         }
@@ -58,7 +58,7 @@ class MessageSelector
      */
     private function extractFromString($part, $number)
     {
-        preg_match('/^[{\[]([^\[\]{}]*)[}\]](.*)/s', $part, $matches);
+        preg_match('/^[\{\[]([^\[\]\{\}]*)[\}\]](.*)/s', $part, $matches);
 
         if (count($matches) !== 3) {
             return;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -120,9 +120,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
             foreach ($locales as $locale) {
-                if (! is_null($line = $this->getLine(
-                    $namespace, $group, $locale, $item, $replace
-                ))) {
+                if (null !== ($line = $this->getLine($namespace, $group, $locale, $item, $replace))) {
                     return $line ?? $key;
                 }
             }
@@ -325,7 +323,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $segments = parent::parseKey($key);
 
-        if (is_null($segments[0])) {
+        if (null === $segments[0]) {
             $segments[0] = '*';
         }
 

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -120,7 +120,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
             foreach ($locales as $locale) {
-                if (null !== ($line = $this->getLine($namespace, $group, $locale, $item, $replace))) {
+                if (($line = $this->getLine($namespace, $group, $locale, $item, $replace)) !== null) {
                     return $line ?? $key;
                 }
             }
@@ -323,7 +323,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $segments = parent::parseKey($key);
 
-        if (null === $segments[0]) {
+        if ($segments[0] === null) {
             $segments[0] = '*';
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -25,7 +25,7 @@ trait FormatsMessages
         // First we will retrieve the custom message for the validation rule if one
         // exists. If a custom validation message is being used we'll return the
         // custom message, otherwise we'll keep searching for a valid message.
-        if (! is_null($inlineMessage)) {
+        if (null !== $inlineMessage) {
             return $inlineMessage;
         }
 
@@ -294,7 +294,7 @@ trait FormatsMessages
     {
         $actualValue = $this->getValue($attribute);
 
-        if (is_scalar($actualValue) || is_null($actualValue)) {
+        if (is_scalar($actualValue) || null === $actualValue) {
             $message = str_replace(':input', $actualValue, $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -25,7 +25,7 @@ trait FormatsMessages
         // First we will retrieve the custom message for the validation rule if one
         // exists. If a custom validation message is being used we'll return the
         // custom message, otherwise we'll keep searching for a valid message.
-        if (null !== $inlineMessage) {
+        if ($inlineMessage !== null) {
             return $inlineMessage;
         }
 
@@ -294,7 +294,7 @@ trait FormatsMessages
     {
         $actualValue = $this->getValue($attribute);
 
-        if (is_scalar($actualValue) || null === $actualValue) {
+        if (is_scalar($actualValue) || $actualValue === null) {
             $message = str_replace(':input', $actualValue, $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,7 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (null === ($value = $this->getValue($parameters[0]))) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -277,7 +277,7 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (null === ($value = $this->getValue($parameters[0]))) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -295,7 +295,7 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (null === ($value = $this->getValue($parameters[0]))) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -313,7 +313,7 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (null === ($value = $this->getValue($parameters[0]))) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,7 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        if (null === ($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -277,7 +277,7 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (null === ($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -295,7 +295,7 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        if (null === ($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -313,7 +313,7 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (null === ($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -193,7 +193,7 @@ trait ValidatesAttributes
         if ($this->isTestingRelativeDateTime($value)) {
             $date = $this->getDateTime($value);
 
-            if (! is_null($date)) {
+            if (null !== $date) {
                 return $date->getTimestamp();
             }
         }
@@ -735,7 +735,7 @@ trait ValidatesAttributes
         if (isset($parameters[2])) {
             [$idColumn, $id] = $this->getUniqueIds($parameters);
 
-            if (! is_null($id)) {
+            if (null !== $id) {
                 $id = stripslashes($id);
             }
         }
@@ -910,7 +910,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
@@ -941,7 +941,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
@@ -972,7 +972,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
@@ -1003,7 +1003,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
@@ -1338,7 +1338,7 @@ trait ValidatesAttributes
      */
     public function validateRequired($attribute, $value)
     {
-        if (is_null($value)) {
+        if (null === $value) {
             return false;
         } elseif (is_string($value) && trim($value) === '') {
             return false;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -193,7 +193,7 @@ trait ValidatesAttributes
         if ($this->isTestingRelativeDateTime($value)) {
             $date = $this->getDateTime($value);
 
-            if (null !== $date) {
+            if ($date !== null) {
                 return $date->getTimestamp();
             }
         }
@@ -735,7 +735,7 @@ trait ValidatesAttributes
         if (isset($parameters[2])) {
             [$idColumn, $id] = $this->getUniqueIds($parameters);
 
-            if (null !== $id) {
+            if ($id !== null) {
                 $id = stripslashes($id);
             }
         }
@@ -910,7 +910,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
@@ -941,7 +941,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
@@ -972,7 +972,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
@@ -1003,7 +1003,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (null === $comparedToValue && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
@@ -1338,7 +1338,7 @@ trait ValidatesAttributes
      */
     public function validateRequired($attribute, $value)
     {
-        if (null === $value) {
+        if ($value === null) {
             return false;
         } elseif (is_string($value) && trim($value) === '') {
             return false;

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -48,7 +48,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
     {
         $query = $this->table($collection)->where($column, '=', $value);
 
-        if (! is_null($excludeId) && $excludeId !== 'NULL') {
+        if (null !== $excludeId && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
         }
 

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -48,7 +48,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
     {
         $query = $this->table($collection)->where($column, '=', $value);
 
-        if (null !== $excludeId && $excludeId !== 'NULL') {
+        if ($excludeId !== null && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
         }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -104,14 +104,14 @@ class Factory implements FactoryContract
         // The presence verifier is responsible for checking the unique and exists data
         // for the validator. It is behind an interface so that multiple versions of
         // it may be written besides database. We'll inject it into the validator.
-        if (! is_null($this->verifier)) {
+        if (null !== $this->verifier) {
             $validator->setPresenceVerifier($this->verifier);
         }
 
         // Next we'll set the IoC container instance of the validator, which is used to
         // resolve out class based validator extensions. If it is not set then these
         // types of extensions will not be possible on these validation instances.
-        if (! is_null($this->container)) {
+        if (null !== $this->container) {
             $validator->setContainer($this->container);
         }
 
@@ -147,7 +147,7 @@ class Factory implements FactoryContract
      */
     protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
     {
-        if (is_null($this->resolver)) {
+        if (null === $this->resolver) {
             return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
         }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -104,14 +104,14 @@ class Factory implements FactoryContract
         // The presence verifier is responsible for checking the unique and exists data
         // for the validator. It is behind an interface so that multiple versions of
         // it may be written besides database. We'll inject it into the validator.
-        if (null !== $this->verifier) {
+        if ($this->verifier !== null) {
             $validator->setPresenceVerifier($this->verifier);
         }
 
         // Next we'll set the IoC container instance of the validator, which is used to
         // resolve out class based validator extensions. If it is not set then these
         // types of extensions will not be possible on these validation instances.
-        if (null !== $this->container) {
+        if ($this->container !== null) {
             $validator->setContainer($this->container);
         }
 
@@ -147,7 +147,7 @@ class Factory implements FactoryContract
      */
     protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
     {
-        if (null === $this->resolver) {
+        if ($this->resolver === null) {
             return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -542,7 +542,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return ! is_null(Arr::get($this->data, $attribute, 0));
+        return null !== Arr::get($this->data, $attribute, 0);
     }
 
     /**
@@ -735,7 +735,7 @@ class Validator implements ValidatorContract
      */
     public function hasRule($attribute, $rules)
     {
-        return ! is_null($this->getRule($attribute, $rules));
+        return null !== $this->getRule($attribute, $rules);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -542,7 +542,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return null !== Arr::get($this->data, $attribute, 0);
+        return Arr::get($this->data, $attribute, 0) !== null;
     }
 
     /**
@@ -735,7 +735,7 @@ class Validator implements ValidatorContract
      */
     public function hasRule($attribute, $rules)
     {
-        return null !== $this->getRule($attribute, $rules);
+        return $this->getRule($attribute, $rules) !== null;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,7 +118,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $this->setPath($path);
         }
 
-        if (! is_null($this->cachePath)) {
+        if (null !== $this->cachePath) {
             $contents = $this->compileString(
                 $this->files->get($this->getPath())
             );

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -118,7 +118,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $this->setPath($path);
         }
 
-        if (null !== $this->cachePath) {
+        if ($this->cachePath !== null) {
             $contents = $this->compileString(
                 $this->files->get($this->getPath())
             );

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -19,7 +19,7 @@ trait CompilesConditionals
      */
     protected function compileAuth($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard ?? '()';
 
         return "<?php if(auth()->guard{$guard}->check()): ?>";
     }
@@ -32,7 +32,7 @@ trait CompilesConditionals
      */
     protected function compileElseAuth($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard ?? '()';
 
         return "<?php elseif(auth()->guard{$guard}->check()): ?>";
     }
@@ -55,7 +55,7 @@ trait CompilesConditionals
      */
     protected function compileGuest($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard ?? '()';
 
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
@@ -68,7 +68,7 @@ trait CompilesConditionals
      */
     protected function compileElseGuest($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard ?? '()';
 
         return "<?php elseif(auth()->guard{$guard}->guest()): ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -12,7 +12,7 @@ trait CompilesInjections
      */
     protected function compileInject($expression)
     {
-        $segments = explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression));
+        $segments = explode(',', preg_replace("/[()\"']/", '', $expression));
 
         $variable = trim($segments[0]);
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesInjections.php
@@ -12,7 +12,7 @@ trait CompilesInjections
      */
     protected function compileInject($expression)
     {
-        $segments = explode(',', preg_replace("/[()\"']/", '', $expression));
+        $segments = explode(',', preg_replace("/[\(\)\\\"\']/", '', $expression));
 
         $variable = trim($segments[0]);
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -12,7 +12,7 @@ trait CompilesTranslations
      */
     protected function compileLang($expression)
     {
-        if (is_null($expression)) {
+        if (null === $expression) {
             return '<?php $__env->startTranslation(); ?>';
         } elseif ($expression[1] === '[') {
             return "<?php \$__env->startTranslation{$expression}; ?>";

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -12,7 +12,7 @@ trait CompilesTranslations
      */
     protected function compileLang($expression)
     {
-        if (null === $expression) {
+        if ($expression === null) {
             return '<?php $__env->startTranslation(); ?>';
         } elseif ($expression[1] === '[') {
             return "<?php \$__env->startTranslation{$expression}; ?>";

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -97,7 +97,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
             // another view gets rendered in the future by the application developer.
             $this->factory->flushStateIfDoneRendering();
 
-            return ! is_null($response) ? $response : $contents;
+            return $response ?? $contents;
         } catch (Exception $e) {
             $this->factory->flushState();
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -29,7 +29,7 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function setUp(): void
     {
-        if (is_null($this->files)) {
+        if (null === $this->files) {
             $this->files = new Filesystem;
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2531,7 +2531,7 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertTrue($c->contains(function ($value) {
-            return is_null($value);
+            return null === $value;
         }));
     }
 
@@ -2572,7 +2572,7 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertTrue($c->some(function ($value) {
-            return is_null($value);
+            return null === $value;
         }));
     }
 
@@ -3981,7 +3981,7 @@ class TestAccessorEloquentTestStub
         $accessor = 'get'.lcfirst($attribute).'Attribute';
 
         if (method_exists($this, $accessor)) {
-            return ! is_null($this->$accessor());
+            return null !== $this->$accessor();
         }
 
         return isset($this->$attribute);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3360,7 +3360,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['name' => 'first', 'title' => null]]], []);
         $v->sometimes('foo.*.name', 'Required|String', function ($i) {
-            return is_null($i['foo'][0]['title']);
+            return null === $i['foo'][0]['title'];
         });
         $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
     }


### PR DESCRIPTION
This PR aligns `null` checks with comparable type checks like `true` and `false`. Though this might not improve performance by any means, it makes a lot more sense to me than using the `is_null` function (opinions will differ).

My other motivation was the amount of calls to the `is_null` function in our call graph. Using the primitive check should reduce the amount of calls (went from 2600+ to not even showing up). Whether this interests anybody I don't know, but it reduced the amount of clutter on our call graph so we're happy.

PR also contains removal of redundant regex escapes and minor step count optimisations.