### PR TITLE
[6.x] Fix getQueue method signature

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -155,7 +155,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return $queue ?: $this->default;
     }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -308,7 +308,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return $queue ?: $this->default;
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -283,7 +283,7 @@ class RedisQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return 'queues:'.($queue ?: $this->default);
     }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -135,7 +135,7 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         $queue = $queue ?: $this->default;
 


### PR DESCRIPTION
DocBlock says that `null` is allowed, but it requires to pass `null` value explicitly. This PR adds default `null` value to `$queue` variable, because all other public methods in queue classes which allows `null` value has nullable type.