### PR TITLE
[7.x] Make $queue null by default in getQueue method

### DIFF
--- a/src/Illuminate/Queue/BeanstalkdQueue.php
+++ b/src/Illuminate/Queue/BeanstalkdQueue.php
@@ -155,7 +155,7 @@ class BeanstalkdQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return $queue ?: $this->default;
     }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -308,7 +308,7 @@ class DatabaseQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return $queue ?: $this->default;
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -283,7 +283,7 @@ class RedisQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         return 'queues:'.($queue ?: $this->default);
     }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -135,7 +135,7 @@ class SqsQueue extends Queue implements QueueContract
      * @param  string|null  $queue
      * @return string
      */
-    public function getQueue($queue)
+    public function getQueue($queue = null)
     {
         $queue = $queue ?: $this->default;
 


### PR DESCRIPTION
Resubmittion of #29946

DocBlock says that `null` is allowed in public `getQueue` method, but it requires to pass `null` value explicitly. I'm making this PR because all other public methods which allows `null` value has default `null` value.

For example here is another one method in one of the Queue classes:

```php
/**
 * Get the size of the queue.
 *
 * @param  string|null  $queue
 * @return int
 */
public function size($queue = null)
{
    $queue = $this->getQueue($queue);

    return $this->getConnection()->eval(
        LuaScripts::size(), 3, $queue, $queue.':delayed', $queue.':reserved'
    );
}
```