### PR TITLE
[6.x] Make consistent null type order in DocBlocks

### DIFF
--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -19,7 +19,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool viaRemember()
  * @method static void logout()
  * @method static \Symfony\Component\HttpFoundation\Response|null onceBasic(string $field = 'email',array $extraConditions = [])
- * @method static null|bool logoutOtherDevices(string $password, string $attribute = 'password')
+ * @method static bool|null logoutOtherDevices(string $password, string $attribute = 'password')
  * @method static \Illuminate\Contracts\Auth\UserProvider|null createUserProvider(string $provider = null)
  * @method static \Illuminate\Auth\AuthManager extend(string $driver, \Closure $callback)
  * @method static \Illuminate\Auth\AuthManager provider(string $name, \Closure $callback)


### PR DESCRIPTION
This is trivial change. Just to keep all the DocBlocks style consistent. This is only one place where `null` type defined as first one.