### PR TITLE
[6.x] Update stub import order

### DIFF
--- a/src/Illuminate/Cache/Console/stubs/cache.stub
+++ b/src/Illuminate/Cache/Console/stubs/cache.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateCacheTable extends Migration
 {

--- a/src/Illuminate/Database/Migrations/stubs/blank.stub
+++ b/src/Illuminate/Database/Migrations/stubs/blank.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {

--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class DummyClass extends Migration
 {

--- a/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler-queued.stub
@@ -3,8 +3,8 @@
 namespace DummyNamespace;
 
 use DummyFullEvent;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass implements ShouldQueue
 {

--- a/src/Illuminate/Foundation/Console/stubs/event-handler.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event-handler.stub
@@ -3,8 +3,8 @@
 namespace DummyNamespace;
 
 use DummyFullEvent;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass
 {

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -3,12 +3,12 @@
 namespace DummyNamespace;
 
 use Illuminate\Broadcasting\Channel;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
-use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
 
 class DummyClass
 {

--- a/src/Illuminate/Foundation/Console/stubs/job-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job-queued.stub
@@ -3,10 +3,10 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
 class DummyClass implements ShouldQueue
 {

--- a/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass
 {

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
@@ -2,13 +2,13 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass implements ShouldQueue
 {
     use InteractsWithQueue;
-    
+
     /**
      * Create the event listener.
      *

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
@@ -3,8 +3,8 @@
 namespace DummyNamespace;
 
 use DummyFullEvent;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass implements ShouldQueue
 {

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -3,8 +3,8 @@
 namespace DummyNamespace;
 
 use DummyFullEvent;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 
 class DummyClass
 {

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -3,9 +3,9 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class DummyClass extends Mailable
 {

--- a/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
@@ -3,9 +3,9 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
 class DummyClass extends Mailable
 {

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -3,9 +3,9 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
 
 class DummyClass extends Notification
 {

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -3,9 +3,9 @@
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
 
 class DummyClass extends Notification
 {

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use NamespacedDummyUserModel;
 use NamespacedDummyModel;
+use NamespacedDummyUserModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class DummyClass

--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class DummyClass extends TestCase
 {

--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
 
 class DummyClass extends TestCase
 {

--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateNotificationsTable extends Migration
 {

--- a/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/failed_jobs.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class Create{{tableClassName}}Table extends Migration
 {

--- a/src/Illuminate/Queue/Console/stubs/jobs.stub
+++ b/src/Illuminate/Queue/Console/stubs/jobs.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class Create{{tableClassName}}Table extends Migration
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Http\Request;
 use DummyRootNamespaceHttp\Controllers\Controller;
+use Illuminate\Http\Request;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Http\Request;
 use DummyRootNamespaceHttp\Controllers\Controller;
+use Illuminate\Http\Request;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
+use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
+use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
+use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
 use ParentDummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
+use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
 use ParentDummyFullModelClass;
 use Illuminate\Http\Request;
-use DummyRootNamespaceHttp\Controllers\Controller;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Http\Request;
 use DummyRootNamespaceHttp\Controllers\Controller;
+use Illuminate\Http\Request;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use Illuminate\Http\Request;
 use DummyRootNamespaceHttp\Controllers\Controller;
+use Illuminate\Http\Request;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateSessionsTable extends Migration
 {


### PR DESCRIPTION
This pull request updates the stubs to conform the new alpha ordered import style policy.

Assumptions made while ordering:

 - The default namespace (App) is used
 - Models have higher chance to be before the default user class in policies
 - Models have higher chance to be after the Http namespace part in classes