### PR TITLE
[6.x] Adds `assertJsonPath` to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -466,7 +466,7 @@ class TestResponse
 
     /**
      * Assert that the expected value exists at the given path in the response.
-     * 
+     *
      * @param  string  $path
      * @param  mixed  $expect
      * @return $this

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -465,6 +465,20 @@ class TestResponse
     }
 
     /**
+     * Assert that the expected value exists at the given path in the response.
+     * 
+     * @param  string  $path
+     * @param  mixed  $expect
+     * @return $this
+     */
+    public function assertJsonPath($path, $expect)
+    {
+        PHPUnit::assertEquals($expect, $this->json($path));
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -285,6 +285,8 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonPath('foobar.foobar_foo', 'foo');
         $response->assertJsonPath('foobar.foobar_bar', 'bar');
 
+        $response->assertJsonPath('foobar.foobar_foo', 'foo')->assertJsonPath('foobar.foobar_bar', 'bar');
+
         $response->assertJsonPath('bars', [
             ['foo' => 'bar 0', 'bar' => 'foo 0'],
             ['foo' => 'bar 1', 'bar' => 'foo 1'],

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -268,6 +268,37 @@ class FoundationTestResponseTest extends TestCase
         $response->assertExactJson($resource->jsonSerialize());
     }
 
+    public function testAssertJsonPath()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
+
+        $response->assertJsonPath('0.foo', 'foo 0');
+
+        $response->assertJsonPath('0.foo', 'foo 0');
+        $response->assertJsonPath('0.bar', 'bar 0');
+        $response->assertJsonPath('0.foobar', 'foobar 0');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonPath('foo', 'bar');
+
+        $response->assertJsonPath('foobar.foobar_foo', 'foo');
+        $response->assertJsonPath('foobar.foobar_bar', 'bar');
+
+        $response->assertJsonPath('bars', [
+            ['foo' => 'bar 0', 'bar' => 'foo 0'],
+            ['foo' => 'bar 1', 'bar' => 'foo 1'],
+            ['foo' => 'bar 2', 'bar' => 'foo 2'],
+        ]);
+        $response->assertJsonPath('bars.0', ['foo' => 'bar 0', 'bar' => 'foo 0']);
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPath('0.id', 10);
+        $response->assertJsonPath('1.id', 20);
+        $response->assertJsonPath('2.id', 30);
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
**In our test we want to assert the following:**
- The post has no tags
- The first comment belongs to the user `ecrmnn`
- The body of the first comment is `First!` and the body of the second comment is `This is my comment`

Given the following response from our `Post` API:
```json
{
  "title": "My blog post",
  "body": "Lorem ipsum ...",
  "tags": [],
  "comments": [{
  	"body": "First!",
  	"user_id": 42,
  	"user": {
  		"id": 42,
  		"username": "ecrmnn"
  	}
  }, {
  	"body": "This is my comment",
  	"user_id": 731,
  	"user": {
  		"id": 731,
  		"username": "ventrec"
  	}
  }]
}
```

## The problem

#### Using `assertEquals`
`-` Forces us to create a temporary variable
`-` Assertions are not chainable
```php
$response = $this->getJson(route('api.post.show', [$post->id]));

$this->assertEmpty($response->json('tags'));
$this->assertEquals('ecrmnn', $response->json('comments.0.user.username'));
$this->assertEquals([
    'First!',
    'This is my comment',
], $response->json('comments.*.body'));
```

#### Using `assertExactJson`
`-` Can not ignore irrelevant data
`-` Forces us to provide the entire response to make three simple assertions
```php
$this->getJson(route('api.post.show', [$post->id]))
	->assertExactJson([
	    'title' => 'My blog post',
	    'body' => 'Lorem ipsum ...',
	    'tags' => [],
	    'comments' => [
	        [
	            'body' => 'First!',
	            'user_id' => 42,
	            'user' => [
	                'id' => 42,
	                'username' => 'ecrmnn',
	            ],
	        ],
	        [
	            'body' => 'This is my comment',
	            'user_id' => 731,
	            'user' => [
	                'id' => 731,
	                'username' => 'ventrec',
	            ],
	        ],
	    ],
	]);
```

#### Using `assertJsonFragment`
`-` We don't know if the first or the second user is the one named `ecrmnn`
`-` Unable to assert on the body of the first and second comment
```php
$this->getJson(route('api.post.show', [$post->id]))
	->assertJsonFragment([
	    'tags' => [],
	    'username' => 'ecrmnn',
	]);
```

## The solution

This PR introduces `assertJsonPath` in the `TestResponse` class. It makes it possible to assert that a given value exists at the specified path.

#### Using `assertJsonPath`
`+` No need for a temporary variable
`+` Lets us assert on a specific user
`+` No need to include irrelevant data in the assertion
```php
$this->getJson(route('api.post.show', [$post->id]))
    ->assertJsonPath('tags', [])
    ->assertJsonPath('comments.0.user.username', 'ecrmnn')
    ->assertJsonPath('comments.*.body', [
        'First!',
        'This is my comment',
    ]);
```


