### PR TITLE
[6.x] Sort missed stub imports

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -2,8 +2,8 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use NamespacedDummyModel;
 use Faker\Generator as Faker;
+use NamespacedDummyModel;
 
 $factory->define(DummyModel::class, function (Faker $faker) {
     return [

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use NamespacedDummyUserModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use NamespacedDummyUserModel;
 
 class DummyClass
 {

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -2,9 +2,9 @@
 
 namespace DummyNamespace;
 
-use NamespacedDummyUserModel;
-use NamespacedDummyModel;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use NamespacedDummyModel;
+use NamespacedDummyUserModel;
 
 class DummyClass
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
+use DummyRootNamespaceHttp\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class DummyClass extends Controller

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -2,8 +2,8 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
+use DummyRootNamespaceHttp\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class DummyClass extends Controller

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
-use ParentDummyFullModelClass;
+use DummyRootNamespaceHttp\Controllers\Controller;
 use Illuminate\Http\Request;
+use ParentDummyFullModelClass;
 
 class DummyClass extends Controller
 {

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -2,10 +2,10 @@
 
 namespace DummyNamespace;
 
-use DummyRootNamespaceHttp\Controllers\Controller;
 use DummyFullModelClass;
-use ParentDummyFullModelClass;
+use DummyRootNamespaceHttp\Controllers\Controller;
 use Illuminate\Http\Request;
+use ParentDummyFullModelClass;
 
 class DummyClass extends Controller
 {


### PR DESCRIPTION
Previous pull request #29954 missed some import, this pull request fixes those.

This is a cosmetic change that does not affect the output in any way as it will be sorted after stub compiling. 

This pull request was generated with the same code used after compiling and run on every `*.stub` so there shouldn't be any missed stub.