### PR TITLE
[6.x] Use value helper where possible

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Console;
 
-use Closure;
-
 trait ConfirmableTrait
 {
     /**
@@ -19,7 +17,7 @@ trait ConfirmableTrait
     {
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
 
-        $shouldConfirm = $callback instanceof Closure ? $callback() : $callback;
+        $shouldConfirm = value($callback);
 
         if ($shouldConfirm) {
             if ($this->hasOption('force') && $this->option('force')) {

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -75,7 +75,7 @@ class BoundMethod
     protected static function callBoundMethod($container, $callback, $default)
     {
         if (! is_array($callback)) {
-            return $default instanceof Closure ? $default() : $default;
+            return value($default);
         }
 
         // Here we need to turn the array callable into a Class@method string we can use to
@@ -87,7 +87,7 @@ class BoundMethod
             return $container->callMethodBinding($method, $callback[0]);
         }
 
-        return $default instanceof Closure ? $default() : $default;
+        return value($default);
     }
 
     /**


### PR DESCRIPTION
The framework already uses the value helper many places, this pull request updates the remaining three occurrences for consistency.

Both the Console and the Container package already depends on the Support package so this does not introduce new dependency.