### PR TITLE
[6.x] Change email verification key to route key

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -62,7 +62,7 @@ class VerifyEmail extends Notification
             'verification.verify',
             Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
             [
-                'id' => $notifiable->getKey(),
+                'id' => $notifiable->getRouteKey(),
                 'hash' => sha1($notifiable->getEmailForVerification()),
             ]
         );

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -32,7 +32,8 @@ trait VerifiesEmails
      */
     public function verify(Request $request)
     {
-        if (! hash_equals((string) $request->route('id'), (string) $request->user()->getKey())) {
+        if (! hash_equals((string) $request->route('id'), (string) $request->user()->getKey()) ||
+            ! hash_equals((string) $request->route('id'), (string) $request->user()->getRouteKey())) {
             throw new AuthorizationException;
         }
 


### PR DESCRIPTION
This pull request is a follow up to #29884.

#### Shamelessly copied description:
Currently, the verify process exposes the database id the user record when a user attempts to confirm their email. If the application has changed the field used for routing via `getRouteKeyName()`, there will be no change to the verification link. By changing `getKey()` to `getRouteKey()`, the app can define the field to be used. If no route key name is specified, then the default id will be used.

#### This pull request:
 - Changes the id sent in the notification mail to the route key
 - Updates the id check to accept the route key while keeping the compatibility with the model key. In the next major version this can be dropped as it gives long enough time to expire all already sent link.
