### PR TITLE
[6.x] Fix bug caused by localisation refactoring

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -909,7 +909,7 @@ if (! function_exists('__')) {
         if (is_null($key)) {
             return $key;
         }
-        
+
         return trans($key, $replace, $locale);
     }
 }

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -906,6 +906,10 @@ if (! function_exists('__')) {
      */
     function __($key = null, $replace = [], $locale = null)
     {
+        if (is_null($key)) {
+            return $key;
+        }
+        
         return trans($key, $replace, $locale);
     }
 }


### PR DESCRIPTION
In Laravel 5.8 calling `__(null)` would return `null`. This is no longer the case in Laravel 6.

Calling `__(null)` now returns a Translator object due to the Translator code refactoring; `$this->getFromJson(...)` is no longer calling `$this->makeReplacements(...)`. 

As this is not mentioned in the Upgrade Guide and the documentation at https://laravel.com/docs/5.7/localization#retrieving-translation-strings states:
> If the specified translation string does not exist, the __ function will return the translation string key. So, using the example above, the __ function would return  messages.welcome if the translation string does not exist.

I presume this is an unintended bug. This pull request resolves the issue.

Details:
In Laravel 5.8 you could run the following code in a blade:
````
    @dump(trans(null))  // Returns Translator object in 5.8 and 6.
    @dump(__(null))  // Returns null in 5.8 and Translator object in 6.

    {{ __(null) }} // Runs successfully on 5.8 fails on 6.0 as it expects a string not an object, see full error below.
````

````
Facade\Ignition\Exceptions\ViewException
htmlspecialchars() expects parameter 1 to be string, object given (View: resources\views\welcome.blade.php)
````
If it is intentional the upgrade guide should be updated to put an if statement checking for null for any variables that are translated that could contain null.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
