### PR TITLE
[6.x] Correctly modify updated_at on custom pivot model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -227,10 +227,14 @@ trait InteractsWithPivotTable
 
         $updated = $pivot ? $pivot->fill($attributes)->isDirty() : false;
 
-        $this->newPivot([
+        $pivot = $this->newPivot([
             $this->foreignPivotKey => $this->parent->{$this->parentKey},
             $this->relatedPivotKey => $this->parseId($id),
-        ], true)->fill($attributes)->save();
+        ], true);
+
+        $pivot->timestamps = in_array($this->updatedAt(), $this->pivotColumns);
+
+        $pivot->fill($attributes)->save();
 
         if ($touch) {
             $this->touchIfTouching();


### PR DESCRIPTION
Resubmit of #29370 

- [[5.8] Correctly modify updated_at on custom pivot model by mpyw · Pull Request #29370 · laravel/framework](https://github.com/laravel/framework/pull/29370)

This PR fixes #29321.