### PR TITLE
[6.x] Convert Responsables to Response objects in VerifyCsrfToken

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Http\Middleware;
 use Closure;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\InteractsWithTime;
@@ -176,6 +177,10 @@ class VerifyCsrfToken
     protected function addCookieToResponse($request, $response)
     {
         $config = config('session');
+
+        if ($response instanceof Responsable) {
+            $response = $response->toResponse($request);
+        }
 
         $response->headers->setCookie(
             new Cookie(


### PR DESCRIPTION
When `VerifyCsrfToken` tries to add cookies to a `Responsable` object, it triggers an error that the `headers` property is undefined. 

The underlying problem is that if the `Responsable` hasn't been transformed to a response yet, the `$headers` doesn't necessarily exist.

This PR adds an `instanceof` check to the `$response` variable. If it's a `Responsable`, it will transform it to a `Response` object first.

Closes https://github.com/laravel/framework/issues/29845