### PR TITLE
str_is(): Make wildcards match newlines

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -199,7 +199,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#su', $value) === 1) {
                 return true;
             }
         }


### PR DESCRIPTION
`str_is()` does not behave as I would expect it to based on [the documentation](https://laravel.com/docs/6.0/helpers#method-str-is).

For example, I would expect `str_is('foo*bar', "foo\nbar");` to return `true` -- but it does not. Because `str_is()` internally translates wildcards (`*`) to regex `.*`, this flag is necessary to allow wildcards in the `$pattern` param to match newlines.