### PR TITLE
[6.x] allow adding NotFoundHttpException to "allowed" exceptions in tests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithExceptionHandling.php
@@ -114,16 +114,16 @@ trait InteractsWithExceptionHandling
              */
             public function render($request, Exception $e)
             {
-                if ($e instanceof NotFoundHttpException) {
-                    throw new NotFoundHttpException(
-                        "{$request->method()} {$request->url()}", null, $e->getCode()
-                    );
-                }
-
                 foreach ($this->except as $class) {
                     if ($e instanceof $class) {
                         return $this->originalHandler->render($request, $e);
                     }
+                }
+
+                if ($e instanceof NotFoundHttpException) {
+                    throw new NotFoundHttpException(
+                        "{$request->method()} {$request->url()}", null, $e->getCode()
+                    );
                 }
 
                 throw $e;


### PR DESCRIPTION
Currently, it is not possible to have:

```php
/**
 * @test
 */
public function my_test()
{
    $this->handleExceptions([
        NotFoundHttpException::class,
    ]);

    // ...
}
```

This is because the checking for `NotFoundHttpException` happens before checking the "excepts" in `InteractsWithExceptionHandling`. This PR ensures checking for "excepts" happens first.
