### PR TITLE
[6.x] Adds the ability to validate artisan command arguments/options

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -229,7 +229,7 @@ class Command extends SymfonyCommand
             $this->attributes()
         );
 
-        return !$this->validator->fails();
+        return ! $this->validator->fails();
     }
 
     /**

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -217,19 +217,19 @@ class Command extends SymfonyCommand
         }
 
         try {
-            $this->validator = $this->validator ?? $this->makeValidator();
+            $factory = $this->getValidationFactory();
         } catch (BindingResolutionException $e) {
             return true;
         }
 
-        $this->validator->make(
+        $this->validator = $factory->make(
             array_merge($this->arguments(), $this->options()),
             $rules,
             $this->messages(),
             $this->attributes()
         );
 
-        return ! $this->validator->fails();
+        return !$this->validator->fails();
     }
 
     /**
@@ -237,7 +237,7 @@ class Command extends SymfonyCommand
      *
      * @return \Illuminate\Contracts\Validation\Factory
      */
-    protected function makeValidator()
+    protected function getValidationFactory()
     {
         return $this->laravel->make(ValidatorFactory::class);
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Support\Str;
@@ -79,7 +80,7 @@ class Command extends SymfonyCommand
     /**
      * The command input validator.
      *
-     * @var Illuminate\Contracts\Validation\Factory|null
+     * @var Illuminate\Contracts\Validation\Validator|null
      */
     protected $validator;
 
@@ -215,12 +216,16 @@ class Command extends SymfonyCommand
             return true;
         }
 
-        $this->validator = $this->validator ?? $this->makeValidator()->make(
-            array_merge($this->arguments(), $this->options()),
-            $rules,
-            $this->messages(),
-            $this->attributes()
-        );
+        try {
+            $this->validator = $this->validator ?? $this->makeValidator()->make(
+                array_merge($this->arguments(), $this->options()),
+                $rules,
+                $this->messages(),
+                $this->attributes()
+            );
+        } catch (BindingResolutionException $e) {
+            return true;
+        }
 
         return ! $this->validator->fails();
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -217,15 +217,17 @@ class Command extends SymfonyCommand
         }
 
         try {
-            $this->validator = $this->validator ?? $this->makeValidator()->make(
-                array_merge($this->arguments(), $this->options()),
-                $rules,
-                $this->messages(),
-                $this->attributes()
-            );
+            $this->validator = $this->validator ?? $this->makeValidator();
         } catch (BindingResolutionException $e) {
             return true;
         }
+
+        $this->validator->make(
+            array_merge($this->arguments(), $this->options()),
+            $rules,
+            $this->messages(),
+            $this->attributes()
+        );
 
         return ! $this->validator->fails();
     }

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
@@ -78,7 +79,7 @@ class Command extends SymfonyCommand
     /**
      * The command input validator.
      *
-     * @var \Illuminate\Contracts\Validation\Validator|null
+     * @var Illuminate\Contracts\Validation\Factory|null
      */
     protected $validator;
 
@@ -193,8 +194,6 @@ class Command extends SymfonyCommand
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return mixed
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -209,8 +208,6 @@ class Command extends SymfonyCommand
      * Check if the argument and option values are valid.
      *
      * @return bool
-     *
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function hasValidInput()
     {
@@ -218,7 +215,7 @@ class Command extends SymfonyCommand
             return true;
         }
 
-        $this->validator = $this->validator ?? $this->laravel->make('validator')->make(
+        $this->validator = $this->validator ?? $this->makeValidator()->make(
             array_merge($this->arguments(), $this->options()),
             $rules,
             $this->messages(),
@@ -226,6 +223,16 @@ class Command extends SymfonyCommand
         );
 
         return ! $this->validator->fails();
+    }
+
+    /**
+     * Resolve the command input validator.
+     *
+     * @return \Illuminate\Contracts\Validation\Factory
+     */
+    protected function makeValidator()
+    {
+        return $this->laravel->make(ValidatorFactory::class);
     }
 
     /**


### PR DESCRIPTION
This is a second attempt at introducing the ability to define validation rules, attributes, and messages on artisan command classes to allow artisan command argument/option validation as I suggested in the ideas repo:

https://github.com/laravel/ideas/issues/1773

There was a first attempt put up about 2 weeks ago but it doesn't seem like the author is interested in following up in the changes required or must be busy:

https://github.com/laravel/framework/pull/29798

I've addressed the changes suggested there.