### PR TITLE
[7.x] Add a way to throw custom exception when running "findOrFail" and "firstOrFail" eloquent method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -350,13 +350,14 @@ class Builder
     /**
      * Find a model by its primary key or throw an exception.
      *
-     * @param  mixed  $id
-     * @param  array  $columns
+     * @param  mixed   $id
+     * @param  array   $columns
+     * @param  string  $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection|static|static[]
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail($id, $columns = ['*'])
+    public function findOrFail($id, $columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         $result = $this->find($id, $columns);
 
@@ -368,7 +369,7 @@ class Builder
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(
+        throw (new $exceptionClass)->setModel(
             get_class($this->model), $id
         );
     }
@@ -441,17 +442,18 @@ class Builder
      * Execute the query and get the first result or throw an exception.
      *
      * @param  array  $columns
+     * @param  string $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function firstOrFail($columns = ['*'])
+    public function firstOrFail($columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         if (! is_null($model = $this->first($columns))) {
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->model));
+        throw (new $exceptionClass)->setModel(get_class($this->model));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -526,13 +526,14 @@ class BelongsToMany extends Relation
     /**
      * Find a related model by its primary key or throw an exception.
      *
-     * @param  mixed  $id
-     * @param  array  $columns
+     * @param  mixed   $id
+     * @param  array   $columns
+     * @param  string  $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail($id, $columns = ['*'])
+    public function findOrFail($id, $columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         $result = $this->find($id, $columns);
 
@@ -544,7 +545,7 @@ class BelongsToMany extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new $exceptionClass)->setModel(get_class($this->related), $id);
     }
 
     /**
@@ -563,18 +564,19 @@ class BelongsToMany extends Relation
     /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array  $columns
+     * @param  array   $columns
+     * @param  string  $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function firstOrFail($columns = ['*'])
+    public function firstOrFail($columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         if (! is_null($model = $this->first($columns))) {
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new $exceptionClass)->setModel(get_class($this->related));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -262,18 +262,19 @@ class HasManyThrough extends Relation
     /**
      * Execute the query and get the first result or throw an exception.
      *
-     * @param  array  $columns
+     * @param  array   $columns
+     * @param  string  $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|static
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function firstOrFail($columns = ['*'])
+    public function firstOrFail($columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         if (! is_null($model = $this->first($columns))) {
             return $model;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related));
+        throw (new $exceptionClass)->setModel(get_class($this->related));
     }
 
     /**
@@ -315,13 +316,14 @@ class HasManyThrough extends Relation
     /**
      * Find a related model by its primary key or throw an exception.
      *
-     * @param  mixed  $id
-     * @param  array  $columns
+     * @param  mixed   $id
+     * @param  array   $columns
+     * @param  string  $exceptionClass
      * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Database\Eloquent\Collection
      *
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function findOrFail($id, $columns = ['*'])
+    public function findOrFail($id, $columns = ['*'], $exceptionClass = ModelNotFoundException::class)
     {
         $result = $this->find($id, $columns);
 
@@ -333,7 +335,7 @@ class HasManyThrough extends Relation
             return $result;
         }
 
-        throw (new ModelNotFoundException)->setModel(get_class($this->related), $id);
+        throw (new $exceptionClass)->setModel(get_class($this->related), $id);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -126,6 +126,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->findOrFail([1, 2], ['column']);
     }
 
+    public function testFindOrFailMethodThrowsCustomModelNotFoundException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->findOrFail('bar', ['column'], CustomModelNotFoundException::class);
+    }
+
     public function testFirstOrFailMethodThrowsModelNotFoundException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -134,6 +145,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->setModel($this->getMockModel());
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->firstOrFail(['column']);
+    }
+
+    public function testFirstOrFailMethodThrowsCustomModelNotFoundException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+
+        $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
+        $builder->setModel($this->getMockModel());
+        $builder->shouldReceive('first')->with(['column'])->andReturn(null);
+        $builder->firstOrFail(['column'], CustomModelNotFoundException::class);
     }
 
     public function testFindWithMany()
@@ -1387,4 +1408,9 @@ class EloquentBuilderTestStubWithoutTimestamp extends Model
     const UPDATED_AT = null;
 
     protected $table = 'table';
+}
+
+class CustomModelNotFoundException extends ModelNotFoundException
+{
+    //
 }

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -131,6 +131,17 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
 
+    public function testFirstOrFailThrowsACustomException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost].');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->firstOrFail(['*'], CustomModelNotFoundException::class);
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -140,6 +151,17 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 
         HasManyThroughTestCountry::first()->posts()->findOrFail(1);
+    }
+
+    public function testFindOrFailThrowsAnCustomException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasManyThroughTestPost] 1');
+
+        HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
+                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+
+        HasManyThroughTestCountry::first()->posts()->findOrFail(1, ['*'], CustomModelNotFoundException::class);
     }
 
     public function testFirstRetrievesFirstRecord()

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -127,6 +127,17 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         HasOneThroughTestPosition::first()->contract()->firstOrFail();
     }
 
+    public function testFirstOrFailThrowsACustomException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+        $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Database\HasOneThroughTestContract].');
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->firstOrFail(['*'], CustomModelNotFoundException::class);
+    }
+
     public function testFindOrFailThrowsAnException()
     {
         $this->expectException(ModelNotFoundException::class);
@@ -135,6 +146,16 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
 
         HasOneThroughTestPosition::first()->contract()->findOrFail(1);
+    }
+
+    public function testFindOrFailThrowsACustomException()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+
+        HasOneThroughTestPosition::create(['id' => 1, 'name' => 'President', 'shortname' => 'ps'])
+            ->user()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'position_short' => 'ps']);
+
+        HasOneThroughTestPosition::first()->contract()->findOrFail(1, ['*'], CustomModelNotFoundException::class);
     }
 
     public function testFirstRetrievesFirstRecord()

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -309,6 +309,15 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->firstOrFail(['id' => 10]);
     }
 
+    public function testFirstOrFailCustomMethod()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+
+        $post = Post::create(['title' => Str::random()]);
+
+        $post->tags()->firstOrFail(['id' => 10], CustomModelNotFoundException::class);
+    }
+
     public function testFindMethod()
     {
         $post = Post::create(['title' => Str::random()]);
@@ -333,6 +342,19 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $post->tags()->attach(Tag::all());
 
         $post->tags()->findOrFail(10);
+    }
+
+    public function testFindOrFailCustomExceptionMethod()
+    {
+        $this->expectException(CustomModelNotFoundException::class);
+
+        $post = Post::create(['title' => Str::random()]);
+
+        Tag::create(['name' => Str::random()]);
+
+        $post->tags()->attach(Tag::all());
+
+        $post->tags()->findOrFail(10, ['*'], CustomModelNotFoundException::class);
     }
 
     public function testFindOrNewMethod()
@@ -897,4 +919,9 @@ class TagWithGlobalScope extends Model
             $query->select('tags.id');
         });
     }
+}
+
+class CustomModelNotFoundException extends ModelNotFoundException
+{
+    //
 }


### PR DESCRIPTION
### Problem:

Laravel added the reportable & renderable exceptions in version 5.5 where it add a `report` and `render` methods directly as a custom response for the exception. Right now I want to maximize that feature by creating more custom exception and throw it when needed. 

https://laravel.com/docs/6.0/errors#renderable-exceptions

So right now my problem is I want to use a custom exception when model not found is fired, this is available when you run `findOrFail` or `firstOrFail`.

### Example implication:

Let say I have this custom exception where it throws when no post is found
```php
class PostNotFoundException extends ModelNotFoundException
{
    /**
     * Render the exception into an HTTP response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @return \Illuminate\Http\Response
     */
    public function render($request)
    {
        return response()->json([
            'message' => 'Sorry, post not found.',
        ], , Response::HTTP_NOT_FOUND);
    }
}
```

Right now when we implement that on the current version of laravel we do it like this

```php
public function show($id)
{
    try {
        return Post::findOrFail($id);
    } catch (ModelNotFoundException $e) {
        throw new PostNotFoundException;
    }
}
```
**or we do it like this**
```php
public function show($id)
{
    try {
        return Post::findOrFail($id);
    } catch (ModelNotFoundException $e) {
        return response()->json([
            'message' => 'Sorry, post not found.',
        ], Response::HTTP_NOT_FOUND);
    }
}
```

Now, I want write it like this.

```php
public function show($id)
{
    return Post::findOrFail($id, ['*'], PostNotFoundException::class);
}
```

### Conclusion

I think this will benefit all and would maximize the potential of this renderable exception feature.