### PR TITLE
[6.x] Allow setting locale in Mailable

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -422,7 +422,9 @@ class Mailable implements MailableContract, Renderable
      */
     public function locale($locale)
     {
-        $this->locale = $locale;
+        // Prevent PendingMail from erasing locale
+        if(!empty($locale))
+            $this->locale = $locale;
 
         return $this;
     }

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -69,6 +69,18 @@ class SendingMailWithLocaleTest extends TestCase
         );
     }
 
+    public function testMailIsSentWithLocaleFromMailable()
+    {
+        $mailable = new TestMail();
+        $mailable->locale('ar');
+
+        Mail::to('test@mail.com')->send($mailable);
+
+        $this->assertStringContainsString('esm',
+            app('swift.transport')->messages()[0]->getBody()
+        );
+    }
+
     public function testMailIsSentWithLocaleUpdatedListenersCalled()
     {
         Carbon::setTestNow('2018-04-01');


### PR DESCRIPTION
Purpose
--

Its currently only possible to set the locale of a mail through the `\Mail` Facade:
    
    $mailable = new \App\Mail\Confirm($user);
    \Mail::to('test@mail.de')->locale('en')->send($mailable);

The purpose of this commit is to allow setting the locale in a `Mailable` object.

Benefits
--

It may happen, that the locale is already determined in the constructor of a `Mailable` object

    class Confirm extends Mailable implements ShouldQueue
    {
        public function __construct($user)
        {
           $this->locale = $user->getLocale();
           //...

Or that one finds it convenient to set the locale on the `Mailable` before using the `Facade`:

     $mailable = new \App\Mail\Confirm($user);
     $mailable->locale('en);
     \Mail::to('test@mail.de')->send($mailable);

This is currently not possible, because the `locale` property of the `Mailable` object will be erased by the `fill` method of the `PendingMail`.

The proposed commit prevents `PendingMail` from erasing the `locale` attribute from the `Mailable` object.

Possible downsides
--

If this commit is accepted then this may break code that set and erased the `locale` attribute:   

    \Mail::to('test@mail.de')->locale('en')->locale('')->send(..);

but this does not seem very reasonable code, since one could achieve the same by not using locale at all

    \Mail::to('test@mail.de')->send(..);

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
