### PR TITLE
[7.x] Configure Schema on migration instantiation

### DIFF
--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -2,8 +2,17 @@
 
 namespace Illuminate\Database\Migrations;
 
+use Illuminate\Support\Facades\Schema;
+
 abstract class Migration
 {
+    /**
+     * The database schema.
+     *
+     * @var \Illuminate\Support\Facades\Schema
+     */
+    protected $schema;
+
     /**
      * The name of the database connection to use.
      *
@@ -17,6 +26,16 @@ abstract class Migration
      * @var bool
      */
     public $withinTransaction = true;
+
+    /**
+     * Create a new migration instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->schema = Schema::connection($this->getConnection());
+    }
 
     /**
      * Get the migration connection name.

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -9,7 +9,7 @@ abstract class Migration
     /**
      * The database schema.
      *
-     * @var \Illuminate\Support\Facades\Schema
+     * @var \Illuminate\Database\Schema\Builder
      */
     protected $schema;
 


### PR DESCRIPTION
This PR adds to abstract Migration class `$schema` property with configured connection from Migration's `getConnection()` method.

### Motivation

Migration has `getConnection()` method which used inside of the Migrator class to determine if schema transactions are supported:
```php
protected function runMigration($migration, $method)
{
    $connection = $this->resolveConnection(
        $migration->getConnection()
    );

    $callback = function () use ($migration, $method) {
        if (method_exists($migration, $method)) {
            $this->fireMigrationEvent(new MigrationStarted($migration, $method));

            $migration->{$method}();

            $this->fireMigrationEvent(new MigrationEnded($migration, $method));
        }
    };

    $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
        && $migration->withinTransaction
                ? $connection->transaction($callback)
                : $callback();
}
```

But when migration is running Schema facade is being used and it doesn't care about `getConnection()` method of the migration. Migrator checks connection and enables transactions, but in fact migrations could be executed on another connection.

To respect database connection, instead of this:
```php
Schema::create('users', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->timestamps();
});

Schema::dropIfExists('users');
```

We should write this:
```php
Schema::connection($this->getConnection())->create('users', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->timestamps();
});

Schema::connection($this->getConnection())->dropIfExists('users');
```

### New Implementation

```php
$this->schema->create('users', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->timestamps();
});

$this->schema->dropIfExists('users');
```

[Similar approach implemented in Laravel Telescope](https://github.com/laravel/telescope/blob/ad74ce0499f5facb73f85ea0a0263b0d8cc0838c/src/Storage/migrations/2018_08_08_100000_create_telescope_entries_table.php#L9-L26), but there it doesn't get connection name from `getConnection()` method, what means that Migrator wouldn't determine correctly if schema transactions are supported.