### PR TITLE
[6.x] Make it possible to disable to disable encryption via 0/false

### DIFF
--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -32,7 +32,7 @@ class TransportManager extends Manager
         // a developer has available. We will just pass this configured host.
         $transport = new SmtpTransport($config['host'], $config['port']);
 
-        if (!empty($config['encryption'])) {
+        if (! empty($config['encryption'])) {
             $transport->setEncryption($config['encryption']);
         }
 

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -32,7 +32,7 @@ class TransportManager extends Manager
         // a developer has available. We will just pass this configured host.
         $transport = new SmtpTransport($config['host'], $config['port']);
 
-        if (isset($config['encryption'])) {
+        if (!empty($config['encryption'])) {
             $transport->setEncryption($config['encryption']);
         }
 


### PR DESCRIPTION
it is not possible to set an env var to `null`, so its otherwise impossible to disable encryption via an env variable

this will for example make it possible to provide out of the box support for Laravel emailing on platform.sh via their bridge:
https://github.com/platformsh/laravel-bridge/blob/master/platformsh-laravel-env.php#L155