### PR TITLE
[6.x] Allow adding command arguments and options with objects

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -9,7 +9,9 @@ use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
@@ -154,11 +156,19 @@ class Command extends SymfonyCommand
         // set them all on the base command instance. This specifies what can get
         // passed into these commands as "parameters" to control the execution.
         foreach ($this->getArguments() as $arguments) {
-            call_user_func_array([$this, 'addArgument'], $arguments);
+            if ($arguments instanceof InputArgument) {
+                $this->getDefinition()->addArgument($arguments);
+            } else {
+                call_user_func_array([$this, 'addArgument'], $arguments);
+            }
         }
 
         foreach ($this->getOptions() as $options) {
-            call_user_func_array([$this, 'addOption'], $options);
+            if ($options instanceof InputOption) {
+                $this->getDefinition()->addOption($options);
+            } else {
+                call_user_func_array([$this, 'addOption'], $options);
+            }
         }
     }
 

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -48,7 +48,9 @@ class CommandTest extends TestCase
     public function testGettingCommandArgumentsAndOptionsByClass()
     {
         $command = new class extends Command {
-            public function handle() {}
+            public function handle()
+            {
+            }
 
             protected function getArguments()
             {
@@ -74,7 +76,7 @@ class CommandTest extends TestCase
             'argument-one' => 'test-first-argument',
             'argument-two' => 'test-second-argument',
             '--option-one' => 'test-first-option',
-            '--option-two' => 'test-second-option'
+            '--option-two' => 'test-second-option',
         ]);
         $output = new NullOutput();
 

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -8,6 +8,8 @@ use Illuminate\Console\OutputStyle;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 
 class CommandTest extends TestCase
@@ -41,5 +43,46 @@ class CommandTest extends TestCase
         });
 
         $command->run($input, $output);
+    }
+
+    public function testGettingCommandArgumentsAndOptionsByClass()
+    {
+        $command = new class extends Command {
+            public function handle() {}
+
+            protected function getArguments()
+            {
+                return [
+                    new InputArgument('argument-one', InputArgument::REQUIRED, 'first test argument'),
+                    ['argument-two', InputArgument::OPTIONAL, 'a second test argument'],
+                ];
+            }
+
+            protected function getOptions()
+            {
+                return [
+                    new InputOption('option-one', 'o', InputOption::VALUE_OPTIONAL, 'first test option'),
+                    ['option-two', 't', InputOption::VALUE_REQUIRED, 'second test option'],
+                ];
+            }
+        };
+
+        $application = app();
+        $command->setLaravel($application);
+
+        $input = new ArrayInput([
+            'argument-one' => 'test-first-argument',
+            'argument-two' => 'test-second-argument',
+            '--option-one' => 'test-first-option',
+            '--option-two' => 'test-second-option'
+        ]);
+        $output = new NullOutput();
+
+        $command->run($input, $output);
+
+        $this->assertEquals('test-first-argument', $command->argument('argument-one'));
+        $this->assertequals('test-second-argument', $command->argument('argument-two'));
+        $this->assertEquals('test-first-option', $command->option('option-one'));
+        $this->assertEquals('test-second-option', $command->option('option-two'));
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR will allow the end user to define arguments and options in artisan commands by instantiating objects (more specifically, `InputArgument` and `InputOption` objects) instead of using "plain" arrays. The benefit of this is that you won't have to refer back to the documentation to see the order in which the array should be constructed. Instead, you can look at the constructor of the `InputArgument`/`InputOption` class. 

Before:
```php
protected function getArguments() 
{
    return [
        ['name', InputArgument::REQUIRED, 'the argument\'s description', 'default value'],
    ];
}
```

After:
```php
protected function getArguments() 
{
    return [
        new InputArgument('name', InputArgument::REQUIRED, 'the argument\'s description', 'default value'),
    ];
}
```

It should be noted that the "old" way still works, this is simply an extra way of doing it.

I've also added a (hopefully useful) test, though I couldn't figure out how to properly "mock" the `$application` that should be given to the command via `->setLaravel()`. I'd appreciate some pointers about how I should go about doing this without whipping up a full `Application` object.