### PR TITLE
[7.x] Add optional exception message parameter to assertStatus method on TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -139,16 +139,17 @@ class TestResponse
     /**
      * Assert that the response has the given status code.
      *
-     * @param  int  $status
+     * @param int $status
+     * @param string|null $message
      * @return $this
      */
-    public function assertStatus($status)
+    public function assertStatus($status, $message = null)
     {
         $actual = $this->getStatusCode();
 
         PHPUnit::assertTrue(
             $actual === $status,
-            "Expected status code {$status} but received {$actual}."
+            $message ?? "Expected status code {$status} but received {$actual}."
         );
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -211,6 +211,23 @@ class FoundationTestResponseTest extends TestCase
         $response->assertStatus($expectedStatusCode);
     }
 
+    public function testAssertStatusWithCustomMessage()
+    {
+        $statusCode = 500;
+        $expectedStatusCode = 401;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage($msg = "Some custom exception message");
+
+        $baseResponse = tap(new Response, function (Response $response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertStatus($expectedStatusCode, $msg);
+    }
+
     public function testAssertHeader()
     {
         $this->expectException(AssertionFailedError::class);

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -218,7 +218,7 @@ class FoundationTestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage($msg = "Some custom exception message");
+        $this->expectExceptionMessage($msg = 'Some custom exception message');
 
         $baseResponse = tap(new Response, function (Response $response) use ($statusCode) {
             $response->setStatusCode($statusCode);


### PR DESCRIPTION
Non-breaking change.

Adding an optional parameter to the assertStatus method on TestResponse Class.