### PR TITLE
[6.x] Make Optional class jsonSerializable

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -4,8 +4,9 @@ namespace Illuminate\Support;
 
 use ArrayAccess;
 use ArrayObject;
+use JsonSerializable;
 
-class Optional implements ArrayAccess
+class Optional implements ArrayAccess, JsonSerializable
 {
     use Traits\Macroable {
         __call as macroCall;
@@ -126,5 +127,15 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+    }
+
+    /**
+     * Convert the object into something JSON serializable.
+     *
+     * @return mixed
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
I believe that the optional class should implement the `jsonSerializable` interface to allow calls to `json_encode` on an optional object to use the underlying value to be used for the serialization instead of the optional object itself:

## Problem
Calling `json_encode` on an optional object will always return an empty json string object:

![image](https://user-images.githubusercontent.com/12025002/64902375-e995c300-d673-11e9-8742-bfb320b2b1d0.png)

## Proposed
Make the class implement the interface and return the value for serialization:

```php 

public function jsonSerialize()
{
    return $this->value;
}
```

That way the underlying value is what gets serialized: 

![image](https://user-images.githubusercontent.com/12025002/64902385-1fd34280-d674-11e9-8897-dc4a382f1900.png)
