### PR TITLE
[6.x] Allow a symfony file instance in validate dimensions

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -499,7 +499,7 @@ trait ValidatesAttributes
      */
     public function validateDimensions($attribute, $value, $parameters)
     {
-        if ($this->isValidFileInstance($value) && $value->getClientMimeType() === 'image/svg+xml') {
+        if ($this->isValidFileInstance($value) && $value->getMimeType() === 'image/svg+xml') {
             return true;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2656,6 +2656,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_width=1,max_height=1']);
         $this->assertTrue($v->passes());
+
+        $file = new File(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => $file], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $this->assertTrue($v->passes());
     }
 
     /**

--- a/tests/Validation/fixtures/image.svg
+++ b/tests/Validation/fixtures/image.svg
@@ -1,2 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 400 600">
 </svg>


### PR DESCRIPTION
`Illuminate/Validation/Concerns/ValidatesAttributes::isValidFileInstance` allows an instance of `Symfony\Component\HttpFoundation\File\UploadedFile` as well as `Symfony\Component\HttpFoundation\File\File`. But the method `getClientMimeType` – that is called by validating dimensions – only exists on UploadedFile.

This PR fixes this issue by using the `getMimeType` method that exists on both objects.

---

Refs #29994. Closes #29962.