### PR TITLE
[6.x]  Create storage fakes with custom configuration

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -16,8 +16,7 @@ class Storage extends Facade
      *
      * @param  string|null  $disk
      * @param  array  $config
-     *
-     * @return \Illuminate\Filesystem\Filesystem
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function fake($disk = null, array $config = [])
     {
@@ -39,7 +38,7 @@ class Storage extends Facade
      *
      * @param  string|null  $disk
      * @param  array  $config
-     * @return \Illuminate\Filesystem\Filesystem
+     * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
     public static function persistentFake($disk = null, array $config = [])
     {

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -15,10 +15,11 @@ class Storage extends Facade
      * Replace the given disk with a local testing disk.
      *
      * @param  string|null  $disk
+     * @param  array  $config
      *
      * @return \Illuminate\Filesystem\Filesystem
      */
-    public static function fake($disk = null)
+    public static function fake($disk = null, array $config = [])
     {
         $disk = $disk ?: self::$app['config']->get('filesystems.default');
 
@@ -26,7 +27,9 @@ class Storage extends Facade
             $root = storage_path('framework/testing/disks/'.$disk)
         );
 
-        static::set($disk, $fake = self::createLocalDriver(['root' => $root]));
+        static::set($disk, $fake = self::createLocalDriver(array_merge($config, [
+            'root' => $root,
+        ])));
 
         return $fake;
     }
@@ -35,15 +38,16 @@ class Storage extends Facade
      * Replace the given disk with a persistent local testing disk.
      *
      * @param  string|null  $disk
+     * @param  array  $config
      * @return \Illuminate\Filesystem\Filesystem
      */
-    public static function persistentFake($disk = null)
+    public static function persistentFake($disk = null, array $config = [])
     {
         $disk = $disk ?: self::$app['config']->get('filesystems.default');
 
-        static::set($disk, $fake = self::createLocalDriver([
+        static::set($disk, $fake = self::createLocalDriver(array_merge($config, [
             'root' => storage_path('framework/testing/disks/'.$disk),
-        ]));
+        ])));
 
         return $fake;
     }

--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -20,13 +20,13 @@ class Storage extends Facade
      */
     public static function fake($disk = null, array $config = [])
     {
-        $disk = $disk ?: self::$app['config']->get('filesystems.default');
+        $disk = $disk ?: static::$app['config']->get('filesystems.default');
 
         (new Filesystem)->cleanDirectory(
             $root = storage_path('framework/testing/disks/'.$disk)
         );
 
-        static::set($disk, $fake = self::createLocalDriver(array_merge($config, [
+        static::set($disk, $fake = static::createLocalDriver(array_merge($config, [
             'root' => $root,
         ])));
 
@@ -42,9 +42,9 @@ class Storage extends Facade
      */
     public static function persistentFake($disk = null, array $config = [])
     {
-        $disk = $disk ?: self::$app['config']->get('filesystems.default');
+        $disk = $disk ?: static::$app['config']->get('filesystems.default');
 
-        static::set($disk, $fake = self::createLocalDriver(array_merge($config, [
+        static::set($disk, $fake = static::createLocalDriver(array_merge($config, [
             'root' => storage_path('framework/testing/disks/'.$disk),
         ])));
 


### PR DESCRIPTION
Currently when a storage disk is faked, we are creating a local disk with the default configuration.

If the developers want to use a custom configuration or reuse the configuration they have in their `filesystems.php` file, there is no easy way to achieve this.

This commit allows us to pass optional configuration as a second parameter:

```php
Storage::fake('documents', ['visibility' => 'private']);
```

This change is totally backwars-compatible, but in the future it would be convenient to fetch the actual configuration of the given disk (maybe in Laravel 7.x?).