### PR TITLE
[6.x] Update make:model to apply the model prefix for controller

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -101,12 +101,15 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function createController()
     {
-        $controller = Str::studly(class_basename($this->argument('name')));
+        $name = $this->argument('name');
+        $classBaseName = class_basename($name);
+        $classPath = str_replace($classBaseName, '', $name);
+        $controller = Str::studly($classBaseName);
 
         $modelName = $this->qualifyClass($this->getNameInput());
 
         $this->call('make:controller', [
-            'name' => "{$controller}Controller",
+            'name' => "{$classPath}{$controller}Controller",
             '--model' => $this->option('resource') ? $modelName : null,
         ]);
     }


### PR DESCRIPTION
When creating a model with a prefix (in a folder rather than default) using `make:model` command along with the `--all` or `--controller` or `--resource`, it is a best practice to apply the above prefix to the controller.
E.g.  after executing the below command
`php artisan make:model Products/Product -c`
we should have the `Product` Model in `App\Products` namespace and `ProductController` in `App\Http\Controllers\Products`.

Currently, users should manually:

1. Create the `Products`  folder in `Controllers` directory
2. Move the `ProductController` to that directory
3. Correct the namespace