### PR TITLE
[6.x] Support for serializers in PhpRedis connection

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -91,6 +91,28 @@ class PhpRedisConnector implements Connector
             if (! empty($config['read_timeout'])) {
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
+            if (! empty($config['serializer'])) {
+                $serializers = [
+                    //Redis::SERIALIZER_NONE
+                    'none' => 0,
+                    //Redis::SERIALIZER_PHP
+                    'php' => 1,
+                    //Redis::SERIALIZER_IGBINARY
+                    'igbinary' => 2,
+                    //Redis::SERIALIZER_MSGPACK
+                    'msgpack' => 3,
+                    //Redis::SERIALIZER_JSON
+                    'json' => 4,
+                ];
+
+                if (in_array($config['serializer'], $serializers)) {
+                    $client->setOption(Redis::OPT_SERIALIZER, $config['serializer'], true);
+                } elseif (in_array($config['serializer'], array_keys($serializers))) {
+                    $client->setOption(Redis::OPT_SERIALIZER, $serializers[$config['serializer']], true);
+                } else {
+                    throw new \InvalidArgumentException('Wrong serializer configuration for Redis connection');
+                }
+            }
         });
     }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -74,6 +74,8 @@ class PhpRedisConnector implements Connector
                 );
             }
 
+            /* @var Redis $client */
+
             $this->establishConnection($client, $config);
 
             if (! empty($config['password'])) {
@@ -92,23 +94,32 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
             if (! empty($config['serializer'])) {
-                $serializers = [
-                    //Redis::SERIALIZER_NONE
-                    'none' => 0,
-                    //Redis::SERIALIZER_PHP
-                    'php' => 1,
-                    //Redis::SERIALIZER_IGBINARY
-                    'igbinary' => 2,
-                    //Redis::SERIALIZER_MSGPACK
-                    'msgpack' => 3,
-                    //Redis::SERIALIZER_JSON
-                    'json' => 4,
-                ];
+                $serializers = [];
 
-                if (in_array($config['serializer'], $serializers)) {
-                    $client->setOption(Redis::OPT_SERIALIZER, $config['serializer'], true);
-                } elseif (in_array($config['serializer'], array_keys($serializers))) {
-                    $client->setOption(Redis::OPT_SERIALIZER, $serializers[$config['serializer']], true);
+                if (defined('Redis::SERIALIZER_NONE')) {
+                    $serializers['none'] = Redis::SERIALIZER_NONE;
+                }
+
+                if (defined('Redis::SERIALIZER_PHP')) {
+                    $serializers['php'] = Redis::SERIALIZER_PHP;
+                }
+
+                if (defined('Redis::SERIALIZER_IGBINARY')) {
+                    $serializers['igbinary'] = Redis::SERIALIZER_IGBINARY;
+                }
+
+                if (defined('Redis::SERIALIZER_MSGPACK')) {
+                    $serializers['msgpack'] = Redis::SERIALIZER_MSGPACK;
+                }
+
+                if (defined('Redis::SERIALIZER_JSON')) {
+                    $serializers['json'] = Redis::SERIALIZER_JSON;
+                }
+
+                if (in_array($config['serializer'], $serializers, true)) {
+                    $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+                } elseif (in_array($config['serializer'], array_keys($serializers), true)) {
+                    $client->setOption(Redis::OPT_SERIALIZER, $serializers[$config['serializer']]);
                 } else {
                     throw new \InvalidArgumentException('Wrong serializer configuration for Redis connection');
                 }


### PR DESCRIPTION
Added support for "none", "php", "igbinary", "msgpack", "json" serializers configuration for PhpRedis connection.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
