### PR TITLE
[6.x] Fixed ConcurrencyLimiter

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -48,6 +48,9 @@ trait InteractsWithRedis
         foreach ($this->redisDriverProvider() as $driver) {
             $this->redis[$driver[0]] = new RedisManager($app, $driver[0], [
                 'cluster' => false,
+                'options' => [
+                    'prefix' => 'test_',
+                ],
                 'default' => [
                     'host' => $host,
                     'port' => $port,

--- a/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
+++ b/src/Illuminate/Redis/Limiters/ConcurrencyLimiter.php
@@ -125,7 +125,7 @@ class ConcurrencyLimiter
         return <<<'LUA'
 for index, value in pairs(redis.call('mget', unpack(KEYS))) do
     if not value then
-        redis.call('set', ARGV[1]..index, ARGV[3], "EX", ARGV[2])
+        redis.call('set', KEYS[index], ARGV[3], "EX", ARGV[2])
         return ARGV[1]..index
     end
 end


### PR DESCRIPTION
Today I was using the ConcurrencyLimiter in my application and I noticed that it was not working as expected. I'm using it to ensure that there is only one worker executing a type of job at a time.
While running this locally with two queue workers I noticed that both workers were processing the same type of job even though I configured it to have a concurrency of only 1. After debugging I figured out it is related to the redis prefix. This prefix is now configured by default in https://github.com/laravel/laravel/pull/4982 so it will affect all users using Laravel 6. Any application that is using horizon will also experience this issue as horizon is adding `horizon:` as default prefix.

I've setup two queue workers while dispatching two jobs to the queue with the following script.
```php
dispatch(function () {
    Redis::funnel('foo')
        ->limit(1)
        ->then(function () {
            Log::info('[START] A');
            sleep(10);
            Log::info('[STOP] A');
        }, function () {
            Log::info('lock already obtained');
        });
});

dispatch(function () {
    Redis::funnel('foo')
        ->limit(1)
        ->then(function () {
            Log::info('[START] B');
            sleep(10);
            Log::info('[STOP] B');
        }, function () {
            Log::info('lock already obtained');
        });
});
```
My log file gives the following output:
```
[2019-09-16 09:28:16] local.INFO: [START] A
[2019-09-16 09:28:18] local.INFO: [START] B
[2019-09-16 09:28:26] local.INFO: [STOP] A
[2019-09-16 09:28:28] local.INFO: [STOP] B
```
As you can see both jobs were running at the same time. After running `redis-cli monitor` these are the redis commands that are executed (by Illuminate\Redis\Limiters\ConccurencyLimiter@lockScript`):
```
1568626342.225175 [0 lua] "mget" "laravel_database_foo1"
1568626342.225189 [0 lua] "set" "foo1" "v8E0BkXy82EAYqqrj3DX" "EX" "60"
1568626343.732566 [0 lua] "mget" "laravel_database_foo1"
1568626343.732575 [0 lua] "set" "foo1" "WPj9R8LXlLdWqygJyxqk" "EX" "60"
```
It's trying to get the lock record WITH prefix, but it's setting the lock record WITHOUT prefix.
Basically the whole concurrency check is not functioning at all at the moment when there is a redis prefix configured.

This PR makes sure the `KEYS` value is used to ensure the prefix is added when setting the lock record key.

When running the same test after this change this is the output:
```
[2019-09-16 09:36:49] local.INFO: [START] A
[2019-09-16 09:36:53] local.INFO: lock already obtained
[2019-09-16 09:36:59] local.INFO: [STOP] A
```
And `redis-cli monitor` is now showing this:
```
1568626609.462540 [0 lua] "mget" "laravel_database_foo1"
1568626609.462553 [0 lua] "set" "laravel_database_foo1" "dHVlZDemEgpncgEcxvLO" "EX" "60"
1568626610.862919 [0 lua] "mget" "laravel_database_foo1"
1568626611.114044 [0 lua] "mget" "laravel_database_foo1"
1568626611.368472 [0 lua] "mget" "laravel_database_foo1"
```