### PR TITLE
[6.x] Add hasMacro methods to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1264,6 +1264,39 @@ class Builder
     }
 
     /**
+     * Checks if a macro is registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasMacro($name)
+    {
+        return isset($this->localMacros[$name]);
+    }
+
+    /**
+     * Get the given global macro by name.
+     *
+     * @param  string  $name
+     * @return \Closure
+     */
+    public static function getGlobalMacro($name)
+    {
+        return Arr::get(static::$macros, $name);
+    }
+
+    /**
+     * Checks if a global macro is registered.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public static function hasGlobalMacro($name)
+    {
+        return isset(static::$macros[$name]);
+    }
+
+    /**
      * Dynamically access builder proxies.
      *
      * @param  string  $key
@@ -1295,13 +1328,13 @@ class Builder
             return;
         }
 
-        if (isset($this->localMacros[$method])) {
+        if ($this->hasMacro($method)) {
             array_unshift($parameters, $this);
 
             return $this->localMacros[$method](...$parameters);
         }
 
-        if (isset(static::$macros[$method])) {
+        if (static::hasGlobalMacro($method)) {
             if (static::$macros[$method] instanceof Closure) {
                 return call_user_func_array(static::$macros[$method]->bindTo($this, static::class), $parameters);
             }
@@ -1339,7 +1372,7 @@ class Builder
             return;
         }
 
-        if (! isset(static::$macros[$method])) {
+        if (! static::hasGlobalMacro($method)) {
             static::throwBadMethodCallException($method);
         }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -431,6 +431,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         });
         $result = $builder->fooBar();
 
+        $this->assertTrue($builder->hasMacro('fooBar'));
         $this->assertEquals($builder, $result);
         $this->assertEquals($builder, $_SERVER['__test.builder']);
         unset($_SERVER['__test.builder']);
@@ -446,6 +447,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder = $this->getBuilder();
 
+        $this->assertTrue(Builder::hasGlobalMacro('foo'));
         $this->assertEquals($builder->foo('bar'), 'bar');
         $this->assertEquals($builder->bam(), $builder->getQuery());
     }


### PR DESCRIPTION
Adding 3 new public methods to the Eloquent Builder for convenience to allow tests to assert on whether or not the Builder class has global macros - or an instance of it, local macros - registered to it.

This will allow for tests where the assertion is looking to see if a macro method is registered _without_ having to be concerned about the macro's specific implementation, as demonstrated.

It also allows for a more defensive style of coding against Builder macros, if you're that way inclined. For those times when you prefer to check that a macro is registered rather than handling the exception thrown when it isn't.