### PR TITLE
[6.x] Allow a symfony file instance in validate dimensions

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -499,7 +499,7 @@ trait ValidatesAttributes
      */
     public function validateDimensions($attribute, $value, $parameters)
     {
-        if ($this->isValidFileInstance($value) && $value->getClientMimeType() === 'image/svg+xml') {
+        if ($this->isValidFileInstance($value) && $value->getMimeType() === 'image/svg+xml') {
             return true;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2656,6 +2656,12 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_width=1,max_height=1']);
         $this->assertTrue($v->passes());
+
+        $file = new File(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => $file], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $this->assertTrue($v->passes());
     }
 
     /**

--- a/tests/Validation/fixtures/image.svg
+++ b/tests/Validation/fixtures/image.svg
@@ -1,2 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 400 600">
 </svg>


### PR DESCRIPTION
### The Problem

When a user validates the dimensions of a `Symfony\Component\HttpFoundation\File\File` via the `Illuminate/Validation/Concerns/ValidatesAttributes` trait the request throws an error within `validateDimensions` because the `getClientMimeType()` method does not exist on the instance.

Only `UploadedFile` has the currently used `getClientMimeType()` method.


### The Solution

This PR fixes that issue by using the `getMimeType()`method that exists on both valid file instances.

### Additional

According to Symfony documentation:

> The client mime type is extracted from the request from which the file
> was uploaded, so it should not be considered as a safe value.
>
> For a trusted mime type, use getMimeType() instead (which guesses the mime
> type based on the file content).

### What does this break?
The mime type will not be extracted from the request but guessed from the files content. So the uploaded files must be valid. In case of a .svg the file must contain the opening `<xml>` tag otherwise it will be interpreted as `plain/text` and the validation will fail.

I think that is **not a breaking change**, because uploaded files should – in the past also – always be valid.  

---

Resolves #29962