### PR TITLE
[6.x] Add bindFacadeAccessor method

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -157,6 +157,19 @@ abstract class Facade
     }
 
     /**
+     * Register a binding for the facade accessor on the container.
+     *
+     * @param  string  $concrete
+     * @return void
+     */
+    public static function bindFacadeAccessor($concrete)
+    {
+        if (static::$app) {
+            static::$app->bind(static::getFacadeAccessor(), $concrete);
+        }
+    }
+
+    /**
      * Resolve the facade root instance from the container.
      *
      * @param  object|string  $name


### PR DESCRIPTION
Laravel Facades are my good old friend, the only thing I found a little bit annoying is to track down where are the binding are happening for the facade accessor in the providers.

For example when you look at :
```php
public function register()
{
    app()->bind('productRepo', ProductRepo::class);
}
```
it does not tell you very much about which facade class has 'productRepo' as it's accessor.

And vice versa, When you look at the Facade `getFacadeAccessor` method which returns an sting, it is not very easy to track down the bindings in the providers.

I naturally prefer to do this :

![image](https://user-images.githubusercontent.com/6961695/64990486-26b4bc00-d8e5-11e9-9225-6255217432c7.png)

and now it is very clear which concrete class the facade is going to resolve as it's root object and IDE can track bindings very easily.

Also, it is much less stressful, in case you need to tweak your abstract string name, since it is now contained in a single place.

backward incompatibility :
The only incompatibility is method name collusion for `bindFacadeAccessor` in the implementations, which is very unlikely to happen.