### PR TITLE
[6.x] Better readability in auth.throttle translation

### DIFF
--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -55,7 +55,7 @@ trait ThrottlesLogins
         throw ValidationException::withMessages([
             $this->username() => [Lang::get('auth.throttle', [
                 'seconds' => $seconds,
-                'minutes' => ceil($seconds * 60)
+                'minutes' => ceil($seconds * 60),
             ])],
         ])->status(Response::HTTP_TOO_MANY_REQUESTS);
     }

--- a/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
+++ b/src/Illuminate/Foundation/Auth/ThrottlesLogins.php
@@ -53,7 +53,10 @@ trait ThrottlesLogins
         );
 
         throw ValidationException::withMessages([
-            $this->username() => [Lang::get('auth.throttle', ['seconds' => $seconds])],
+            $this->username() => [Lang::get('auth.throttle', [
+                'seconds' => $seconds,
+                'minutes' => ceil($seconds * 60)
+            ])],
         ])->status(Response::HTTP_TOO_MANY_REQUESTS);
     }
 


### PR DESCRIPTION
When actively implementing authentication throttling, we noticed that end users now get messages like "please try again in 878 seconds" when we configured the throttle to be 15 minutes. This is not very user friendly.

With this adjustment, we make minutes available in the in auth.throttle translation message for better readability.