### PR TITLE
Add collection method to modify a single item

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1226,6 +1226,18 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Change an item specified by key.
+     *
+     * @param  mixed $key
+     * @param  callable $callback
+     * @return void
+     */
+    public function change($key, callable $callback)
+    {
+        $this->items[$key] = $callback($this->items[$key]);
+    }
+
+    /**
      * Get an iterator for the items.
      *
      * @return \ArrayIterator

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1234,7 +1234,11 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function change($key, callable $callback)
     {
-        $this->items[$key] = $callback($this->items[$key]);
+        Arr::set(
+            $this->items,
+            $key, 
+            $callback(Arr::get($this->items, $key))
+        );
     }
 
     /**


### PR DESCRIPTION
Working with keyed collections I have had the need to edit a particular item and found it cumbersome.

Let's set up a collection containing an array
```php
$collection = collect(['myBag' => [] ]);
```
Currently a modification requires multiple steps and a temporary variable. It feels like one shouldn't be pulling out an item and then reassign it to modify it.

```php
// this doesn't work:
// $collection['myBag'][] = 'lipstick';

// this does
$myBag = $collection['myBag'];
$myBag[] = 'lipstick';
$collection['myBag'] = $myBag;
```

With the PR it could be done like this:
```php
$collection->change('myBag', function($bag) {
    $bag[] = 'lipstick';
});
```

This would feel a bit more natural and improve readibility of code - it explicitly states I am changing an item instead of doing some assignments that may or may not be related. This should also decrease verbosity once PHP 7.4 comes with the arrow functions.

No idea if `change` is the right name. `modify` would work just as well. Or maybe `transform` should be upgraded with an optional parameter - `transform($callback, $key)`?