### PR TITLE
[6.x] Add collection method to modify a single item

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1224,7 +1224,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         return new static(array_pad($this->items, $size, $value));
     }
-    
+
     /**
      * Change an item specified by key.
      *

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1224,6 +1224,22 @@ class Collection implements ArrayAccess, Enumerable
     {
         return new static(array_pad($this->items, $size, $value));
     }
+    
+    /**
+     * Change an item specified by key.
+     *
+     * @param  mixed $key
+     * @param  callable $callback
+     * @return void
+     */
+    public function change($key, callable $callback)
+    {
+        Arr::set(
+            $this->items,
+            $key,
+            $callback(Arr::get($this->items, $key))
+        );
+    }
 
     /**
      * Get an iterator for the items.

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2894,6 +2894,7 @@ class SupportCollectionTest extends TestCase
         $c = new Collection(['b' => ['c1']]);
         $c->change('b', function ($item) {
             $item[] = 'c2';
+
             return $item;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c1', 'c2']], $c->all());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2889,24 +2889,21 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
 
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testChange($collection)
+    public function testChange()
     {
-        $c = new $collection(['b' => ['c1']]);
+        $c = new Collection(['b' => ['c1']]);
         $c->change('b', function ($item) {
             $item[] = 'c2';
             return $item;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c1', 'c2']], $c->all());
-    
-        $c = new $collection(['b' => []]);
+
+        $c = new Collection(['b' => []]);
         $c->change('b.c.d', function ($item) {
             return 3;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c' => ['d' => 3]]], $c->all());
-	
+
         $c->change('b.c.d', function ($item) {
             return 2 + $item;
         });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2888,26 +2888,26 @@ class SupportCollectionTest extends TestCase
         $c = $c->pad(-4, 0);
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
-    
+
     /**
      * @dataProvider collectionClassProvider
      */
     public function testChange($collection)
     {
         $c = new $collection(['b' => ['c1']]);
-        $c->change('b', function($item) {
+        $c->change('b', function ($item) {
             $item[] = 'c2';
             return $item;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c1', 'c2']], $c->all());
     
         $c = new $collection(['b' => []]);
-        $c->change('b.c.d', function($item) {
+        $c->change('b.c.d', function ($item) {
             return 3;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c' => ['d' => 3]]], $c->all());
 	
-        $c->change('b.c.d', function($item) {
+        $c->change('b.c.d', function ($item) {
             return 2 + $item;
         });
         $this->assertEqualsCanonicalizing(['b' => ['c' => ['d' => 5]]], $c->all());

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2888,6 +2888,30 @@ class SupportCollectionTest extends TestCase
         $c = $c->pad(-4, 0);
         $this->assertEquals([1, 2, 3, 4, 5], $c->all());
     }
+    
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChange($collection)
+    {
+        $c = new $collection(['b' => ['c1']]);
+        $c->change('b', function($item) {
+            $item[] = 'c2';
+            return $item;
+        });
+        $this->assertEqualsCanonicalizing(['b' => ['c1', 'c2']], $c->all());
+    
+        $c = new $collection(['b' => []]);
+        $c->change('b.c.d', function($item) {
+            return 3;
+        });
+        $this->assertEqualsCanonicalizing(['b' => ['c' => ['d' => 3]]], $c->all());
+	
+        $c->change('b.c.d', function($item) {
+            return 2 + $item;
+        });
+        $this->assertEqualsCanonicalizing(['b' => ['c' => ['d' => 5]]], $c->all());
+    }
 
     /**
      * @dataProvider collectionClassProvider


### PR DESCRIPTION
This adds a method to change a single item in collection in a map/transform-like syntax.

```php
$c = collect(['b' => ['c1']])
$c->change('b', function($item) {
	$item[] = 'c2';
	return $item;
});
// $c->all() is  ['b' => ['c1', 'c2']]
```

Allows dot notation as well.
```php
$c = new $collection(['b' => []]);
$c->change('b.c.d', function($item) {
	return 3;
});
// $c is ['b' => ['c' => ['d' => 3]]]

$c->change('b.c.d', function($item) {
	return 2 + $item;
});
// $c is ['b' => ['c' => ['d' => 5]]]
```

Sorry, I oversold this a little in #30021 forgetting to include the return statement.