### PR TITLE
Allow pluck to keep the original keys

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -374,7 +374,7 @@ class Arr
      *
      * @param  array  $array
      * @param  string|array  $value
-     * @param  string|array|boolean|null  $key
+     * @param  string|array|bool|null  $key
      * @return array
      */
     public static function pluck($array, $value, $key = null)
@@ -387,8 +387,8 @@ class Arr
             $itemValue = data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
-            // looping. If the key is "true" we will keep the original keys. Otherwise 
-            // we will key the array using the value of the key we received from the 
+            // looping. If the key is "true" we will keep the original keys. Otherwise
+            // we will key the array using the value of the key we received from the
             // developer. Then we'll return the final array form.
             if (is_null($key)) {
                 $results[] = $itemValue;
@@ -412,14 +412,14 @@ class Arr
      * Explode the "value" and "key" arguments passed to "pluck".
      *
      * @param  string|array  $value
-     * @param  string|array|boolean|null  $key
+     * @param  string|array|bool|null  $key
      * @return array
      */
     protected static function explodePluckParameters($value, $key)
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        if (!is_null($key) && true !== $key && !is_array($key)) {
+        if (! is_null($key) && true !== $key && ! is_array($key)) {
             $key = explode('.', $key);
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -374,7 +374,7 @@ class Arr
      *
      * @param  array  $array
      * @param  string|array  $value
-     * @param  string|array|null  $key
+     * @param  string|array|boolean|null  $key
      * @return array
      */
     public static function pluck($array, $value, $key = null)
@@ -383,14 +383,17 @@ class Arr
 
         [$value, $key] = static::explodePluckParameters($value, $key);
 
-        foreach ($array as $item) {
+        foreach ($array as $oldKey => $item) {
             $itemValue = data_get($item, $value);
 
             // If the key is "null", we will just append the value to the array and keep
-            // looping. Otherwise we will key the array using the value of the key we
-            // received from the developer. Then we'll return the final array form.
+            // looping. If the key is "true" we will keep the original keys. Otherwise 
+            // we will key the array using the value of the key we received from the 
+            // developer. Then we'll return the final array form.
             if (is_null($key)) {
                 $results[] = $itemValue;
+            } elseif (true === $key) {
+                $results[$oldKey] = $itemValue;
             } else {
                 $itemKey = data_get($item, $key);
 
@@ -409,14 +412,16 @@ class Arr
      * Explode the "value" and "key" arguments passed to "pluck".
      *
      * @param  string|array  $value
-     * @param  string|array|null  $key
+     * @param  string|array|boolean|null  $key
      * @return array
      */
     protected static function explodePluckParameters($value, $key)
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        if (!is_null($key) && true !== $key && !is_array($key)) {
+            $key = explode('.', $key);
+        }
 
         return [$value, $key];
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -487,6 +487,39 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, ['user', 1], ['user', 0]));
     }
 
+    public function testArrayPluckWithOriginalKeys()
+    {
+        $data = [
+            'post-1' => [
+                'comments' => [
+                    'tags' => [
+                        '#foo', '#bar',
+                    ],
+                ],
+            ],
+            'post-2' => [
+                'comments' => [
+                    'tags' => [
+                        '#baz',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals([
+            'post-1' => [
+                'tags' => [
+                    '#foo', '#bar',
+                ],
+            ],
+            'post-2' => [
+                'tags' => [
+                    '#baz',
+                ],
+            ],
+        ], Arr::pluck($data, 'comments', true));
+    }
+
     public function testArrayPluckWithNestedArrays()
     {
         $array = [


### PR DESCRIPTION
It seems that you can key a plucked array however you want except with the original keys.

I propose an optional key keeping that one could enable by specifying a boolean `true` in the `$key` parameter.