### PR TITLE
[6.x] Add push method to Arr

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -441,6 +441,25 @@ class Arr
     }
 
     /**
+     * Push an item onto the end of an array.
+     *
+     * @param  array  $array
+     * @param  mixed  $value
+     * @param  mixed  $key
+     * @return array
+     */
+    public static function push($array, $value, $key = null)
+    {
+        if (is_null($key)) {
+            array_push($array, $value);
+        } else {
+            $array = $array + [$key => $value];
+        }
+
+        return $array;
+    }
+
+    /**
      * Get a value from the array, and remove it.
      *
      * @param  array   $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -519,6 +519,15 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $array);
     }
 
+    public function testPush()
+    {
+        $array = Arr::push(['one', 'two', 'three', 'four'], 'five');
+        $this->assertEquals(['one', 'two', 'three', 'four', 'five'], $array);
+
+        $array = Arr::push(['one' => 1, 'two' => 2], 3, 'three');
+        $this->assertEquals(['one' => 1, 'two' => 2, 'three' => 3], $array);
+    }
+
     public function testPull()
     {
         $array = ['name' => 'Desk', 'price' => 100];


### PR DESCRIPTION
Just a little bit of sugar so we could get the extended array using a single statement.

Few examples, first is the actually useful, rest are fun:

```php
function addMe($array) {
    return Arr::push($array, 'me');
}

$goodAnimals = ['dog'];
$allAnimals = Arr::push($goodAnimals, 'homo sapiens');
// $goodAnimals still correct

$badum = Arr::push([], 'tss');
```

As useful as the prepend method, I know.