### PR TITLE
Fixed hasMorph bug when field is nullableMorph and at least 1 row (co…

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -202,7 +202,8 @@ trait QueriesRelationships
         $types = (array) $types;
 
         if ($types === ['*']) {
-            $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->all();
+            $morphKey = $relation->getMorphType();
+            $types = $this->model->newModelQuery()->whereNotNull($morphKey)->distinct()->pluck($morphKey)->all();
 
             foreach ($types as &$type) {
                 $type = Relation::getMorphedModel($type) ?? $type;


### PR DESCRIPTION
Fixed `hasMorph` bug when field is `nullableMorph` and at least 1 row (column: [morph_key]) is null in database.

Fatal error: **Class name must be a valid object or a string**