### PR TITLE
[6.x] Add additional param to Arr::has helper method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -328,7 +328,7 @@ class Arr
             $subKeyArray = $array;
 
             if (static::exists($array, $key)) {
-                if($matchAll) {
+                if ($matchAll) {
 					continue;
                 } else {
                     break;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -329,7 +329,7 @@ class Arr
 
             if (static::exists($array, $key)) {
                 if ($matchAll) {
-					continue;
+                    continue;
                 } else {
                     break;
                 }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -313,9 +313,10 @@ class Arr
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|array  $keys
+     * @param  bool $matchAll
      * @return bool
      */
-    public static function has($array, $keys)
+    public static function has($array, $keys, $matchAll = true)
     {
         $keys = (array) $keys;
 
@@ -327,7 +328,11 @@ class Arr
             $subKeyArray = $array;
 
             if (static::exists($array, $key)) {
-                continue;
+                if($matchAll) {
+					continue;
+                } else {
+                    break;
+                }
             }
 
             foreach (explode('.', $key) as $segment) {


### PR DESCRIPTION
This modification adds the option to the `Arr::has()` helper method to search for multiple keys inside an array and return true if only one key has been found. The default behaviour of the method will stay the same.

```php
$array = [
    'key1' => 'value1',
    'key2' => 'value2
];

$searchKeys = [
    'key1',
    'key2',
    'non_existing_key1',
    'non_existing_key2'
];

Arr::has($array, $searchKeys); // returns false
Arr::has($array, $searchKeys, true); // returns false
Arr::has($array, $searchKeys, false); // returns true
```