### PR TITLE
[6.x] Add setAssetRoot()

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -728,4 +728,17 @@ class UrlGenerator implements UrlGeneratorContract
 
         return $this;
     }
+
+    /**
+     * Set the asset root.
+     *
+     * @param  string  $rootNamespace
+     * @return $this
+     */
+    public function setAssetRoot($root)
+    {
+        $this->assetRoot = $root;
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -730,14 +730,14 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
-     * Set the asset root.
+     * Set the asset root URL.
      *
-     * @param  string  $rootNamespace
+     * @param  string  $assetRoot
      * @return $this
      */
-    public function setAssetRoot($root)
+    public function setAssetRoot($assetRoot)
     {
-        $this->assetRoot = $root;
+        $this->assetRoot = $assetRoot;
 
         return $this;
     }


### PR DESCRIPTION
I have some logic that scopes the filesystem paths to the current tenant. This setter would let me set the asset root, so that `asset()` can return a URL to a controller that serves tenant-specific assets.