### PR TITLE
[6.x] Pipeline - Allows Pipes to use any parameter

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -190,7 +190,7 @@ class Pipeline implements PipelineContract
     protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
-            $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));
+            return [$pipe[0],  array_slice($pipe, 1 - count($pipe))];
         }
 
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -184,11 +184,15 @@ class Pipeline implements PipelineContract
     /**
      * Parse full pipe string to get name and parameters.
      *
-     * @param  string $pipe
+     * @param  string|array $pipe
      * @return array
      */
     protected function parsePipeString($pipe)
     {
+        if (is_array($pipe)) {
+            $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));
+        }
+
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);
 
         if (is_string($parameters)) {

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -152,7 +152,7 @@ class Pipeline implements PipelineContract
                         // the appropriate method and arguments, returning the results back out.
                         return $pipe($passable, $stack);
                     } elseif (! is_object($pipe)) {
-                        [$name, $parameters] = $this->parsePipeString($pipe);
+                        [$name, $parameters] = $this->parsePipe($pipe);
 
                         // If the pipe is a string we will parse the string and resolve the class out
                         // of the dependency injection container. We can then build a callable and
@@ -187,7 +187,7 @@ class Pipeline implements PipelineContract
      * @param  string|array $pipe
      * @return array
      */
-    protected function parsePipeString($pipe)
+    protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
             $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -152,7 +152,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                array_merge([PipelineTestParameterPipe::class], $parameters)
+                array_merge([PipelineTestParameterPipe::class], $parameters),
             ])
             ->then(function ($piped) {
                 return $piped;
@@ -166,7 +166,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                array_merge([PipelineTestParameterPipe::class], $parameters)
+                array_merge([PipelineTestParameterPipe::class], $parameters),
             ])
             ->then(function ($piped) {
                 return $piped;

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -131,6 +131,39 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.parameters']);
     }
 
+    public function testPipelineUsageWithArrayAsPipe()
+    {
+        $parameters = ['one', 'two'];
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                [PipelineTestParameterPipe::class, implode(',', $parameters)],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                array_merge([PipelineTestParameterPipe::class], $parameters)
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
+
     public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
     {
         $pipelineInstance = new Pipeline(new Container);

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -138,7 +138,21 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                [PipelineTestParameterPipe::class, implode(',', $parameters)],
+                [PipelineTestParameterPipe::class, 'not,exploded'],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals(['not,exploded', null], $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                array_merge([PipelineTestParameterPipe::class], $parameters)
             ])
             ->then(function ($piped) {
                 return $piped;


### PR DESCRIPTION
# The Magic

This PR allows to declare a Pipe with arguments when using the Pipeline through an array, whichever they may be:

    $result = app(\Illuminate\Pipeline\Pipeline::class)
                ->send('foo')
                ->through([
                    [PipeOne::class, 'parameter_one', 'parameter_two'],
                    [PipeTwo::class, ['array', 'of',' 'arguments'] ],
                    [PipeThree::class, $anObject],
                ])
                ->thenReturn();

# The Problem

Currently, when using the Pipeline, there are only one way to add parameters to a Pipe handling method, which is to append ':param_one,param_two' to the Pipe declaration. Only strings are allowed.

    $result = app(\Illuminate\Pipeline\Pipeline::class)
                ->send('foo')
                ->through([
                    PipeOne::class  . ':argument_one,argument_two',
                ])
                ->thenReturn();

This is the same for Middlewares, which use the Pipelines underneath:

    Route::get('/', 'HomeController')
        ->middleware(MyMiddleware::class . ':' . 'foo,bar');

This allows a more clean implementation of arguments at runtime (when you create the Pipeline) instead of just duct taping a class name with arguments, and imploding parameters outside the Pipe.

# How its fixed

This is possible when parsing the pipe. If will check if the pipe is an array. If that's the case, it will separate the class name from the rest of parameters and that's it.