### PR TITLE
[6.x] Add whereHas()/whereDoesntHave() to Collection

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -589,6 +589,32 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where the given key exists.
+     *
+     * @param  string|array  $key
+     * @return static
+     */
+    public function whereHas($key)
+    {
+        return $this->filter(function ($item) use ($key) {
+            return (new static($item))->has($key);
+        });
+    }
+
+    /**
+     * Filter items where the given key does not exist.
+     *
+     * @param  string|array  $key
+     * @return static
+     */
+    public function whereDoesntHave($key)
+    {
+        return $this->reject(function ($item) use ($key) {
+            return (new static($item))->has($key);
+        });
+    }
+
+    /**
      * Filter the items, removing any items that don't match the given type.
      *
      * @param  string  $type

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -729,6 +729,26 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhereHas($collection)
+    {
+        $c = new $collection([['x' => 1], ['y' => 2], ['x' => 3, 'y' => 4]]);
+        $this->assertEquals([['x' => 1], ['x' => 3, 'y' => 4]], $c->whereHas('x')->values()->all());
+        $this->assertEquals([['x' => 3, 'y' => 4]], $c->whereHas(['x', 'y'])->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereDoesntHave($collection)
+    {
+        $c = new $collection([['x' => 1], ['y' => 2], ['x' => 3, 'y' => 4]]);
+        $this->assertEquals([['y' => 2]], $c->whereDoesntHave('x')->values()->all());
+        $this->assertEquals([['x' => 1], ['y' => 2]], $c->whereDoesntHave(['x', 'y'])->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testFlatten($collection)
     {
         // Flat arrays are unaffected


### PR DESCRIPTION
This adds two new methods to the `Collection` class.

`Collection::whereHas($key)` filters the items of the collection where the given key exists.
`Collection::whereDoesntHave($key)` filters the items of the collection where the given key does not exist.

`$key` can be an array and will filter the items of the collection where all given keys do or do not exist.