### PR TITLE
[6.x] Allow Pipeline to receive Pipe with any-type of arguments

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -190,7 +190,7 @@ class Pipeline implements PipelineContract
     protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
-            return [$pipe[0],  array_slice($pipe, 1 - count($pipe))];
+            return [$pipe[0], array_slice($pipe, 1 - count($pipe))];
         }
 
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -190,7 +190,7 @@ class Pipeline implements PipelineContract
     protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
-            $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));
+            return [$pipe[0],  array_slice($pipe, 1 - count($pipe))];
         }
 
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -184,11 +184,15 @@ class Pipeline implements PipelineContract
     /**
      * Parse full pipe string to get name and parameters.
      *
-     * @param  string $pipe
+     * @param  string|array $pipe
      * @return array
      */
     protected function parsePipeString($pipe)
     {
+        if (is_array($pipe)) {
+            $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));
+        }
+
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);
 
         if (is_string($parameters)) {

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -152,7 +152,7 @@ class Pipeline implements PipelineContract
                         // the appropriate method and arguments, returning the results back out.
                         return $pipe($passable, $stack);
                     } elseif (! is_object($pipe)) {
-                        [$name, $parameters] = $this->parsePipeString($pipe);
+                        [$name, $parameters] = $this->parsePipe($pipe);
 
                         // If the pipe is a string we will parse the string and resolve the class out
                         // of the dependency injection container. We can then build a callable and
@@ -187,7 +187,7 @@ class Pipeline implements PipelineContract
      * @param  string|array $pipe
      * @return array
      */
-    protected function parsePipeString($pipe)
+    protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
             $pipe = $pipe[0] . ':' . implode(',', array_slice($pipe, 1));

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -190,7 +190,7 @@ class Pipeline implements PipelineContract
     protected function parsePipe($pipe)
     {
         if (is_array($pipe)) {
-            return [$pipe[0], array_slice($pipe, 1 - count($pipe))];
+            return [$pipe[0], array_slice(array_pad($pipe, 2, null), 1)];
         }
 
         [$name, $parameters] = array_pad(explode(':', $pipe, 2), 2, []);

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -133,8 +133,6 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithArrayAsPipe()
     {
-        $parameters = ['one', 'two'];
-
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
@@ -174,6 +172,23 @@ class PipelineTest extends TestCase
 
         $this->assertSame('foo', $result);
         $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
+
+    public function testPipelineWithPipeWithoutArgumentsReturnPipeName()
+    {
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                [PipelineTestParameterPipe::class],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals([PipelineTestParameterPipe::class, null], $_SERVER['__test.pipe.parameters']);
 
         unset($_SERVER['__test.pipe.parameters']);
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -152,7 +152,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                array_merge([PipelineTestParameterPipe::class], $parameters)
+                array_merge([PipelineTestParameterPipe::class], $parameters),
             ])
             ->then(function ($piped) {
                 return $piped;
@@ -166,7 +166,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                array_merge([PipelineTestParameterPipe::class], $parameters)
+                array_merge([PipelineTestParameterPipe::class], $parameters),
             ])
             ->then(function ($piped) {
                 return $piped;

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -133,6 +133,8 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithArrayAsPipe()
     {
+        $parameters = ['one', 'two'];
+
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
@@ -188,7 +190,7 @@ class PipelineTest extends TestCase
             });
 
         $this->assertSame('foo', $result);
-        $this->assertEquals([PipelineTestParameterPipe::class, null], $_SERVER['__test.pipe.parameters']);
+        $this->assertEquals([null, null], $_SERVER['__test.pipe.parameters']);
 
         unset($_SERVER['__test.pipe.parameters']);
     }

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -131,6 +131,39 @@ class PipelineTest extends TestCase
         unset($_SERVER['__test.pipe.parameters']);
     }
 
+    public function testPipelineUsageWithArrayAsPipe()
+    {
+        $parameters = ['one', 'two'];
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                [PipelineTestParameterPipe::class, implode(',', $parameters)],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                array_merge([PipelineTestParameterPipe::class], $parameters)
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals($parameters, $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+    }
+
     public function testPipelineViaChangesTheMethodBeingCalledOnThePipes()
     {
         $pipelineInstance = new Pipeline(new Container);

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -138,7 +138,21 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([
-                [PipelineTestParameterPipe::class, implode(',', $parameters)],
+                [PipelineTestParameterPipe::class, 'not,exploded'],
+            ])
+            ->then(function ($piped) {
+                return $piped;
+            });
+
+        $this->assertSame('foo', $result);
+        $this->assertEquals(['not,exploded', null], $_SERVER['__test.pipe.parameters']);
+
+        unset($_SERVER['__test.pipe.parameters']);
+
+        $result = (new Pipeline(new Container))
+            ->send('foo')
+            ->through([
+                array_merge([PipelineTestParameterPipe::class], $parameters)
             ])
             ->then(function ($piped) {
                 return $piped;


### PR DESCRIPTION
Let's start declaring the problem, the fix and the magic.

# The Problem

Currently, when using the Pipeline, there are only **ONE** way to add parameters to a Pipe handling method, which is to append the string ':param_one,param_two' to the Pipe declaration. Only strings are allowed.

    $result = app(\Illuminate\Pipeline\Pipeline::class)
                ->send('foo')
                ->through([
                    PipeOne::class  . ':argument_one,argument_two',
                    'servicename:argument_one,argument_two'
                ])
                ->thenReturn();

So:
* You must duct tape a string to a class name or service name, which is inelegant and counterintuitive.
* Only strings are allowed. No arrays, objects or whatever.

# The Magic

This PR allows to declare a Pipe with arguments when using the Pipeline through an array, whichever they may be, at run time.

    $result = app(\Illuminate\Pipeline\Pipeline::class)
                ->send('foo')
                ->through([
                    [PipeOne::class, 'parameter_one', 'parameter_two'],
                    [PipeTwo::class, ['array', 'of, 'things'] ],
                    [PipeThree::class, $any_object],
                    ['servicefour', 'foo', $bar]
                ])
                ->thenReturn();

For example, we can push a Route with a middleware by class, and push some arguments in a clean way:

    Route::get('/', 'HomeController')
        ->middleware([
            [ MyMiddleware::class, 'foo', 'bar']
        ]);

Or a Job Middleware when is being declared, inside the job.

    /**
     * Get the middleware the job should pass through.
     *
     * @return array
     */
    public function middleware()
    {
        return [
            [ Ratelimiter::class, config('rate_imiter') ]
        ];
   }

Or even at runtime:

    SomeJob::dispatch()->through([
        [ Ratelimiter::class, $user->rate_limits, $user->preferred_rate_api ]
    ]);

This allows a more clean implementation of arguments at runtime (when you create the Pipeline) instead of just duct taping a class name with arguments, and imploding parameters outside the Pipe.

# How its fixed

This is possible in one additional check when parsing the Pipe: If pipe is an array, it will separate the class name from the rest of parameters, and add the additional parameter to the stack of arguments the handling expects.

# Limitations

It only works for **service names** or **Class names**, not for callables (like closures), invokables or object instances - since these already don't receive arguments, this PR doesn't change that behaviour. In these cases, it should be assumed the developer has control over them before pushing them through the Pipeline.

# Can this be its own package?

Nope, it's a core change.