### PR TITLE
[6.x] Adds a pipeline() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Facades\Date;
@@ -604,6 +605,20 @@ if (! function_exists('old')) {
     function old($key = null, $default = null)
     {
         return app('request')->old($key, $default);
+    }
+}
+
+if (! function_exists('pipeline')) {
+    /**
+     * Create a new Pipeline instance.
+     *
+     * @param string|null $passable
+     * @param array $pipeline
+     * @return \Illuminate\Pipeline\Pipeline
+     */
+    function pipeline($passable = null, array $pipeline = [])
+    {
+        return app(Pipeline::class)->send($passable)->through($pipeline);
     }
 }
 


### PR DESCRIPTION
# The problem

Currently there is only one way to create a pipeline, and this is calling the `app()` helper and point out the Pipeline class.

    $pipeline = app(\Illuminate\Pipeline\Pipeline::class);
    
    $pipeline->send($passable)->through([ /* ... */ ])->thenReturn();

There is no other way to do it.

# The Fix

This PR adds a `pipeline()` helper that can take the *passable* and the *pipe stack* as an array, leaving the developer to return the result or decorate it before returning it, callable from anywhere.

    $pipeline = pipeline($passable, [ /* ... */ ])->thenReturn();

These two arguments are optional, and since it just returns a Pipeline instance, the developer can still change the handling method or replace the passable.

    $pipeline = pipeline($passable, [ /* ... */ ]);
    
    $pipeline->send($other_passable)->through([ /* other pipe stack */ ]);

# The Magic

Just some lines in the `Illuminate/Foundation/helpers.php` to add the helper.