### PR TITLE
[6.x] Hub enhancement to use internal Pipelines

### DIFF
--- a/src/Illuminate/Pipeline/Hub.php
+++ b/src/Illuminate/Pipeline/Hub.php
@@ -5,6 +5,7 @@ namespace Illuminate\Pipeline;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Pipeline\Hub as HubContract;
+use Illuminate\Support\Str;
 use LogicException;
 
 class Hub implements HubContract
@@ -74,7 +75,7 @@ class Hub implements HubContract
             );
         }
 
-        if (method_exists($this, $method = 'pipeline'.ucfirst($pipeline))) {
+        if (method_exists($this, $method = Str::studly('pipeline'.ucfirst($pipeline)))) {
             return $this->$method(new Pipeline($this->container), $object);
         }
 

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -45,7 +45,7 @@ class HubTest extends TestCase
     public function testHubUsesNamedMethod()
     {
         $hub = new class(new Container) extends Hub {
-            protected function pipelineNamed($pipeline, $passable)
+            protected function pipelineFooBar($pipeline, $passable)
             {
                 return $pipeline->send($passable)->through(PipelineEmpty::class)->thenReturn();
             }
@@ -65,7 +65,10 @@ class HubTest extends TestCase
 
         $this->assertEquals('foo', $hub->pipe('foo', 'test-pipeline'));
         $this->assertEquals('foo', $hub->pipe('bar'));
-        $this->assertEquals('baz', $hub->pipe('baz', 'named'));
+        $this->assertEquals('baz', $hub->pipe('baz', 'foo-bar'));
+        $this->assertEquals('baz', $hub->pipe('baz', 'foo_bar'));
+        $this->assertEquals('baz', $hub->pipe('baz', 'fooBar'));
+        $this->assertEquals('baz', $hub->pipe('baz', 'FooBar'));
     }
 
     public function testHubFailsIfPipelineDoesntExists()

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Pipeline;
+
+use Illuminate\Container\Container;
+use Illuminate\Pipeline\Hub;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class HubTest extends TestCase
+{
+    public function testHubReceivesDefault()
+    {
+        $hub = new Hub(new Container);
+
+        $hub->defaults(function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineEmpty::class)
+                ->thenReturn();
+        });
+
+        $this->assertTrue($hub->pipe(true));
+    }
+
+    public function testHubReceivesNamedPipe()
+    {
+        $hub = new Hub(new Container);
+
+        $hub->pipeline('test-pipeline', function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineEmpty::class)
+                ->thenReturn();
+        });
+
+        $hub->defaults(function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineFoo::class)
+                ->thenReturn();
+        });
+
+        $this->assertEquals('foo', $hub->pipe('foo', 'test-pipeline'));
+        $this->assertEquals('foo', $hub->pipe('bar'));
+    }
+
+    public function testHubUsesNamedMethod()
+    {
+        $hub = new class(new Container) extends Hub
+        {
+            protected function pipelineNamed($pipeline, $passable)
+            {
+                return $pipeline->send($passable)->through(PipelineEmpty::class)->thenReturn();
+            }
+        };
+
+        $hub->pipeline('test-pipeline', function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineEmpty::class)
+                ->thenReturn();
+        });
+
+        $hub->defaults(function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineFoo::class)
+                ->thenReturn();
+        });
+
+        $this->assertEquals('foo', $hub->pipe('foo', 'test-pipeline'));
+        $this->assertEquals('foo', $hub->pipe('bar'));
+        $this->assertEquals('baz', $hub->pipe('baz', 'named'));
+    }
+
+    public function testHubFailsIfPipelineDoesntExists()
+    {
+        $this->expectException(LogicException::class);
+
+        $hub = new class(new Container) extends Hub
+        {
+            protected function pipelineNamed($pipeline, $passable)
+            {
+                return $pipeline->send($passable)->through(PipelineEmpty::class)->thenReturn();
+            }
+        };
+
+        $hub->pipeline('test-pipeline', function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineEmpty::class)
+                ->thenReturn();
+        });
+
+        $hub->defaults(function ($pipeline, $passable) {
+            return $pipeline->send($passable)
+                ->through(PipelineFoo::class)
+                ->thenReturn();
+        });
+
+        $hub->pipe('foo', 'no-pipe');
+    }
+}
+
+class PipelineEmpty
+{
+    public function handle($piped, $next)
+    {
+        return $next($piped);
+    }
+}
+
+class PipelineFoo
+{
+    public function handle($piped, $next)
+    {
+        return $next('foo');
+    }
+}

--- a/tests/Pipeline/HubTest.php
+++ b/tests/Pipeline/HubTest.php
@@ -44,8 +44,7 @@ class HubTest extends TestCase
 
     public function testHubUsesNamedMethod()
     {
-        $hub = new class(new Container) extends Hub
-        {
+        $hub = new class(new Container) extends Hub {
             protected function pipelineNamed($pipeline, $passable)
             {
                 return $pipeline->send($passable)->through(PipelineEmpty::class)->thenReturn();
@@ -73,8 +72,7 @@ class HubTest extends TestCase
     {
         $this->expectException(LogicException::class);
 
-        $hub = new class(new Container) extends Hub
-        {
+        $hub = new class(new Container) extends Hub {
             protected function pipelineNamed($pipeline, $passable)
             {
                 return $pipeline->send($passable)->through(PipelineEmpty::class)->thenReturn();


### PR DESCRIPTION
# The problem

The Hub class allows to register custom Pipelines inside it, so the developer can call the Hub afterwards and call one of the named Pipelines from it. No problem with that. 

You can even have multiple Hubs holding multiple pipelines, separated by concerns, like a "PlaneHub" with Pipelines related to take off, fyling, landing, and other called "CarHub" for starting, driving and parking.

The problem with the actual Hub implementation is that there are no way to pre-define Pipelines inside the class. Meaning, you MUST register each pipeline in an AppServiceProvider (or any provider of sorts) to inject the pipelines:

    public function boot()
    {
        app(CustomHub::class)->pipeline('my-named-pipeline', function ($pipeline, $passable) {
            return $pipeline->send($passable)->through([ /* ... */ ])->thenReturn();
        });
       
        // Rinse and repeat for all your named pipeline
    }

# The Fix

This PR allows any class that extends the Hub class to declare their own pipelines inside, instead of having them to be registered afterwards.

    `<?php
    
    namespace App\Hubs;
    
    use Illuminate\Pipeline\Hub;
    
    class PlaneHub extends Hub
    {
        protected function pipelineTakeOff($pipeline, $passable)
        {
            return $pipeline->send($passable)->through([
                // ...
            ])->thenReturn();
        }
    
        protected function pipelineLand($pipeline, $passable)
        {
            return $pipeline->send($passable)->through([
                // ...
            ])->thenReturn();
        }
    }

Then, the developer can call the Hub from anywhere and use the pipelines declared inside the Hub without resorting register each one after the Hub has been instanced.

    $hub = app(\App\Hubs\PlaneHub::class);
    
    $hub->pipe($plane, 'take-off');
    $hub->pipe($plane, 'land');

# The Magic

This doesn't break the actual Hub behaviour, but only adds one line that checks if there any method called "pipeline{studly_case}" if there is not a pipeline already registered by that name in the custom Hub class.

That means, if there is a `pipelineTakeOff()` method, and the developer registers the `take-off` pipeline, **the registered pipeline will take precedence over the method**.

If the pipeline is not found, a `LogicException` will be thrown.