### PR TITLE
Refactor assertions on empty/non-empty objects

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -57,8 +57,8 @@ class BusFake implements Dispatcher
             return $this->assertDispatchedTimes($command, $callback);
         }
 
-        PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->dispatched($command, $callback),
             "The expected [{$command}] job was not dispatched."
         );
     }
@@ -72,8 +72,8 @@ class BusFake implements Dispatcher
      */
     public function assertDispatchedTimes($command, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->dispatched($command)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->dispatched($command)->count(),
             "The expected [{$command}] job was pushed {$count} times instead of {$times} times."
         );
     }
@@ -87,8 +87,8 @@ class BusFake implements Dispatcher
      */
     public function assertNotDispatched($command, $callback = null)
     {
-        PHPUnit::assertTrue(
-            $this->dispatched($command, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->dispatched($command, $callback),
             "The unexpected [{$command}] job was dispatched."
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -57,8 +57,8 @@ class EventFake implements Dispatcher
             return $this->assertDispatchedTimes($event, $callback);
         }
 
-        PHPUnit::assertTrue(
-            $this->dispatched($event, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->dispatched($event, $callback),
             "The expected [{$event}] event was not dispatched."
         );
     }
@@ -72,8 +72,8 @@ class EventFake implements Dispatcher
      */
     public function assertDispatchedTimes($event, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->dispatched($event)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->dispatched($event)->count(),
             "The expected [{$event}] event was dispatched {$count} times instead of {$times} times."
         );
     }
@@ -88,7 +88,8 @@ class EventFake implements Dispatcher
     public function assertNotDispatched($event, $callback = null)
     {
         PHPUnit::assertTrue(
-            $this->dispatched($event, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->dispatched($event, $callback),
             "The unexpected [{$event}] event was dispatched."
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -43,8 +43,8 @@ class MailFake implements Mailer, MailQueue
             $message .= ' Did you mean to use assertQueued() instead?';
         }
 
-        PHPUnit::assertTrue(
-            $this->sent($mailable, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->sent($mailable, $callback),
             $message
         );
     }
@@ -58,8 +58,8 @@ class MailFake implements Mailer, MailQueue
      */
     protected function assertSentTimes($mailable, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->sent($mailable)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->sent($mailable)->count(),
             "The expected [{$mailable}] mailable was sent {$count} times instead of {$times} times."
         );
     }
@@ -73,8 +73,8 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNotSent($mailable, $callback = null)
     {
-        PHPUnit::assertTrue(
-            $this->sent($mailable, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->sent($mailable, $callback),
             "The unexpected [{$mailable}] mailable was sent."
         );
     }
@@ -102,8 +102,8 @@ class MailFake implements Mailer, MailQueue
             return $this->assertQueuedTimes($mailable, $callback);
         }
 
-        PHPUnit::assertTrue(
-            $this->queued($mailable, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->queued($mailable, $callback),
             "The expected [{$mailable}] mailable was not queued."
         );
     }
@@ -117,8 +117,8 @@ class MailFake implements Mailer, MailQueue
      */
     protected function assertQueuedTimes($mailable, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->queued($mailable)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->queued($mailable)->count(),
             "The expected [{$mailable}] mailable was queued {$count} times instead of {$times} times."
         );
     }
@@ -132,8 +132,8 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNotQueued($mailable, $callback = null)
     {
-        PHPUnit::assertTrue(
-            $this->queued($mailable, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->queued($mailable, $callback),
             "The unexpected [{$mailable}] mailable was queued."
         );
     }
@@ -178,7 +178,7 @@ class MailFake implements Mailer, MailQueue
      */
     public function hasSent($mailable)
     {
-        return $this->mailablesOf($mailable)->count() > 0;
+        return $this->mailablesOf($mailable)->isNotEmpty();
     }
 
     /**
@@ -211,7 +211,7 @@ class MailFake implements Mailer, MailQueue
      */
     public function hasQueued($mailable)
     {
-        return $this->queuedMailablesOf($mailable)->count() > 0;
+        return $this->queuedMailablesOf($mailable)->isNotEmpty();
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -50,8 +50,8 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             return $this->assertSentToTimes($notifiable, $notification, $callback);
         }
 
-        PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->sent($notifiable, $notification, $callback),
             "The expected [{$notification}] notification was not sent."
         );
     }
@@ -66,8 +66,8 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      */
     public function assertSentToTimes($notifiable, $notification, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->sent($notifiable, $notification)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->sent($notifiable, $notification)->count(),
             "Expected [{$notification}] to be sent {$times} times, but was sent {$count} times."
         );
     }
@@ -90,8 +90,8 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             return;
         }
 
-        PHPUnit::assertTrue(
-            $this->sent($notifiable, $notification, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->sent($notifiable, $notification, $callback),
             "The unexpected [{$notification}] notification was sent."
         );
     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -29,8 +29,8 @@ class QueueFake extends QueueManager implements Queue
             return $this->assertPushedTimes($job, $callback);
         }
 
-        PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->count() > 0,
+        PHPUnit::assertNotEmpty(
+            $this->pushed($job, $callback),
             "The expected [{$job}] job was not pushed."
         );
     }
@@ -44,8 +44,8 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function assertPushedTimes($job, $times = 1)
     {
-        PHPUnit::assertTrue(
-            ($count = $this->pushed($job)->count()) === $times,
+        PHPUnit::assertSame(
+            $times, $count = $this->pushed($job)->count(),
             "The expected [{$job}] job was pushed {$count} times instead of {$times} times."
         );
     }
@@ -79,13 +79,13 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertPushedWithChain($job, $expectedChain = [], $callback = null)
     {
-        PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->isNotEmpty(),
+        PHPUnit::assertNotEmpty(
+            $this->pushed($job, $callback),
             "The expected [{$job}] job was not pushed."
         );
 
-        PHPUnit::assertTrue(
-            collect($expectedChain)->isNotEmpty(),
+        PHPUnit::assertNotEmpty(
+            $expectedChain,
             'The expected chain can not be empty.'
         );
 
@@ -108,10 +108,10 @@ class QueueFake extends QueueManager implements Queue
             return serialize($job);
         })->all();
 
-        PHPUnit::assertTrue(
+        PHPUnit::assertNotEmpty(
             $this->pushed($job, $callback)->filter(function ($job) use ($chain) {
                 return $job->chained == $chain;
-            })->isNotEmpty(),
+            }),
             'The expected chain was not pushed.'
         );
     }
@@ -134,8 +134,8 @@ class QueueFake extends QueueManager implements Queue
             return $chain->all() === $expectedChain;
         });
 
-        PHPUnit::assertTrue(
-            $matching->isNotEmpty(), 'The expected chain was not pushed.'
+        PHPUnit::assertNotEmpty(
+            $matching, 'The expected chain was not pushed.'
         );
     }
 
@@ -147,8 +147,8 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return ! collect($chain)->contains(function ($job) {
-            return ! is_object($job);
+        return collect($chain)->every(function ($job) {
+            return is_object($job);
         });
     }
 
@@ -161,8 +161,8 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertNotPushed($job, $callback = null)
     {
-        PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->count() === 0,
+        PHPUnit::assertEmpty(
+            $this->pushed($job, $callback),
             "The unexpected [{$job}] job was pushed."
         );
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -152,6 +152,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection;
 
+        $this->assertEmpty($c);
         $this->assertTrue($c->isEmpty());
     }
 
@@ -162,6 +163,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection(['foo', 'bar']);
 
+        $this->assertNotEmpty($c);
         $this->assertFalse($c->isEmpty());
         $this->assertTrue($c->isNotEmpty());
     }
@@ -1880,8 +1882,8 @@ class SupportCollectionTest extends TestCase
         $range = $collection::times(5);
 
         $this->assertEquals(['slug-1', 'slug-2'], $two->all());
-        $this->assertTrue($zero->isEmpty());
-        $this->assertTrue($negative->isEmpty());
+        $this->assertEmpty($zero);
+        $this->assertEmpty($negative);
         $this->assertEquals(range(1, 5), $range->all());
     }
 
@@ -2751,8 +2753,8 @@ class SupportCollectionTest extends TestCase
             'b' => true,
             'c' => true,
         ]);
-        $this->assertTrue(
-            $data2->reject()->isEmpty()
+        $this->assertEmpty(
+            $data2->reject()
         );
     }
 
@@ -3681,7 +3683,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($collection) {
+        $data = $data->whenEmpty(function ($data) {
             return $data->concat(['adam']);
         });
 


### PR DESCRIPTION
…True for checking empty/non-empty collections, or for counting collection items, we can use more appropriate PHPUnit assertions.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
