### PR TITLE
[7.x] Consistent console commands signature definition

### DIFF
--- a/src/Illuminate/Auth/Console/ClearResetsCommand.php
+++ b/src/Illuminate/Auth/Console/ClearResetsCommand.php
@@ -3,15 +3,16 @@
 namespace Illuminate\Auth\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class ClearResetsCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'auth:clear-resets {name? : The name of the password broker}';
+    protected $name = 'auth:clear-resets';
 
     /**
      * The console command description.
@@ -30,5 +31,17 @@ class ClearResetsCommand extends Command
         $this->laravel['auth.password']->broker($this->argument('name'))->getRepository()->deleteExpired();
 
         $this->info('Expired reset tokens cleared!');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::OPTIONAL, 'The name of the password broker'],
+        ];
     }
 }

--- a/src/Illuminate/Cache/Console/ForgetCommand.php
+++ b/src/Illuminate/Cache/Console/ForgetCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Cache\Console;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class ForgetCommand extends Command
 {
@@ -12,7 +13,7 @@ class ForgetCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'cache:forget {key : The key to remove} {store? : The store to remove the key from}';
+    protected $name = 'cache:forget';
 
     /**
      * The console command description.
@@ -53,5 +54,18 @@ class ForgetCommand extends Command
         );
 
         $this->info('The ['.$this->argument('key').'] key has been removed from the cache.');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['key', InputArgument::REQUIRED, 'The key to remove'],
+            ['store', InputArgument::OPTIONAL, 'The store to remove the key from'],
+        ];
     }
 }

--- a/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleFinishCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class ScheduleFinishCommand extends Command
 {
@@ -11,7 +12,7 @@ class ScheduleFinishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'schedule:finish {id}';
+    protected $name = 'schedule:finish';
 
     /**
      * The console command description.
@@ -38,5 +39,17 @@ class ScheduleFinishCommand extends Command
         collect($schedule->events())->filter(function ($value) {
             return $value->mutexName() == $this->argument('id');
         })->each->callAfterCallbacks($this->laravel);
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['id', InputArgument::REQUIRED, ''],
+        ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -4,23 +4,18 @@ namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
 
 class MigrateCommand extends BaseCommand
 {
     use ConfirmableTrait;
 
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'migrate {--database= : The database connection to use}
-                {--force : Force the operation to run when in production}
-                {--path=* : The path(s) to the migrations files to be executed}
-                {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
-                {--pretend : Dump the SQL queries that would be run}
-                {--seed : Indicates if the seed task should be re-run}
-                {--step : Force the migrations to be run so they can be rolled back individually}';
+    protected $name = 'migrate';
 
     /**
      * The console command description.
@@ -93,5 +88,23 @@ class MigrateCommand extends BaseCommand
                 '--database' => $this->option('database'),
             ]));
         }
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['path', null, InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
+            ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
+            ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],
+        ];
     }
 }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -99,7 +99,7 @@ class MigrateCommand extends BaseCommand
     {
         return [
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
-            ['path', null, InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
+            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
             ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -5,20 +5,17 @@ namespace Illuminate\Database\Console\Migrations;
 use Illuminate\Database\Migrations\MigrationCreator;
 use Illuminate\Support\Composer;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class MigrateMakeCommand extends BaseCommand
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'make:migration {name : The name of the migration}
-        {--create= : The table to be created}
-        {--table= : The table to migrate}
-        {--path= : The location where the migration file should be created}
-        {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
-        {--fullpath : Output the full path of the migration}';
+    protected $name = 'make:migration';
 
     /**
      * The console command description.
@@ -141,5 +138,33 @@ class MigrateMakeCommand extends BaseCommand
     protected function usingRealPath()
     {
         return $this->input->hasOption('realpath') && $this->option('realpath');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the migration'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['create', null, InputOption::VALUE_OPTIONAL, 'The table to be created'],
+            ['table', null, InputOption::VALUE_OPTIONAL, 'The table to migrate'],
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The location where the migration file should be created'],
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+            ['fullpath', null, InputOption::VALUE_NONE, 'Output the full path of the migration'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -5,19 +5,18 @@ namespace Illuminate\Foundation\Console;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\InteractsWithTime;
+use Symfony\Component\Console\Input\InputOption;
 
 class DownCommand extends Command
 {
     use InteractsWithTime;
 
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'down {--message= : The message for the maintenance mode}
-                                 {--retry= : The number of seconds after which the request may be retried}
-                                 {--allow=* : IP or networks allowed to access the application while in maintenance mode}';
+    protected $name = 'down';
 
     /**
      * The console command description.
@@ -73,5 +72,19 @@ class DownCommand extends Command
         $retry = $this->option('retry');
 
         return is_numeric($retry) && $retry > 0 ? (int) $retry : null;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['message', null, InputOption::VALUE_OPTIONAL, 'The message for the maintenance mode'],
+            ['retry', null, InputOption::VALUE_OPTIONAL, 'The number of seconds after which the request may be retried'],
+            ['allow', null, InputOption::VALUE_IS_ARRAY, 'IP or networks allowed to access the application while in maintenance mode'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -84,7 +84,7 @@ class DownCommand extends Command
         return [
             ['message', null, InputOption::VALUE_OPTIONAL, 'The message for the maintenance mode'],
             ['retry', null, InputOption::VALUE_OPTIONAL, 'The number of seconds after which the request may be retried'],
-            ['allow', null, InputOption::VALUE_IS_ARRAY, 'IP or networks allowed to access the application while in maintenance mode'],
+            ['allow', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'IP or networks allowed to access the application while in maintenance mode'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/EventCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/EventCacheCommand.php
@@ -8,11 +8,11 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 class EventCacheCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'event:cache';
+    protected $name = 'event:cache';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -5,15 +5,16 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 class EventListCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'event:list {--event= : Filter the events by name}';
+    protected $name = 'event:list';
 
     /**
      * The console command description.
@@ -87,5 +88,17 @@ class EventListCommand extends Command
     protected function filteringByEvent()
     {
         return ! empty($this->option('event'));
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['event', null, InputOption::VALUE_OPTIONAL, 'Filter the events by name'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -5,19 +5,18 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Encryption\Encrypter;
+use Symfony\Component\Console\Input\InputOption;
 
 class KeyGenerateCommand extends Command
 {
     use ConfirmableTrait;
 
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'key:generate
-                    {--show : Display the key instead of modifying files}
-                    {--force : Force the operation to run when in production}';
+    protected $name = 'key:generate';
 
     /**
      * The console command description.
@@ -107,5 +106,18 @@ class KeyGenerateCommand extends Command
         $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
 
         return "/^APP_KEY{$escaped}/m";
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['show', null, InputOption::VALUE_NONE, 'Display the key instead of modifying files'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
+++ b/src/Illuminate/Foundation/Console/PackageDiscoverCommand.php
@@ -8,11 +8,11 @@ use Illuminate\Foundation\PackageManifest;
 class PackageDiscoverCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'package:discover';
+    protected $name = 'package:discover';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -114,7 +114,7 @@ class PresetCommand extends Command
     protected function getOptions()
     {
         return [
-            ['option', null, InputOption::VALUE_IS_ARRAY, 'Pass an option to the preset command'],
+            ['option', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Pass an option to the preset command'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/PresetCommand.php
+++ b/src/Illuminate/Foundation/Console/PresetCommand.php
@@ -4,17 +4,17 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class PresetCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'preset
-                            { type : The preset type (none, bootstrap, vue, react) }
-                            { --option=* : Pass an option to the preset command }';
+    protected $name = 'preset';
 
     /**
      * The console command description.
@@ -92,5 +92,29 @@ class PresetCommand extends Command
 
         $this->info('React scaffolding installed successfully.');
         $this->comment('Please run "npm install && npm run dev" to compile your fresh scaffolding.');
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['type', InputArgument::REQUIRED, 'The preset type (none, bootstrap, vue, react)'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['option', null, InputOption::VALUE_IS_ARRAY, 'Pass an option to the preset command'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -7,11 +7,11 @@ use Illuminate\Console\Command;
 class StorageLinkCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'storage:link';
+    protected $name = 'storage:link';
 
     /**
      * The console command description.

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -4,6 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class TestMakeCommand extends GeneratorCommand
 {
@@ -12,7 +14,7 @@ class TestMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:test {name : The name of the class} {--unit : Create a unit test}';
+    protected $name = 'make:test';
 
     /**
      * The console command description.
@@ -78,5 +80,29 @@ class TestMakeCommand extends GeneratorCommand
     protected function rootNamespace()
     {
         return 'Tests';
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['unit', null, InputOption::VALUE_NONE, 'Create a unit test'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -280,7 +280,7 @@ class VendorPublishCommand extends Command
     {
         return [
             ['provider', null, InputOption::VALUE_OPTIONAL, 'The service provider that has assets you want to publish'],
-            ['tag', null, InputOption::VALUE_IS_ARRAY, 'One or many tags that have assets you want to publish'],
+            ['tag', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'One or many tags that have assets you want to publish'],
             ['force', null, InputOption::VALUE_NONE, 'Overwrite any existing files'],
             ['all', null, InputOption::VALUE_NONE, 'Publish assets for all service providers without prompt'],
         ];

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\MountManager;
+use Symfony\Component\Console\Input\InputOption;
 
 class VendorPublishCommand extends Command
 {
@@ -34,14 +35,11 @@ class VendorPublishCommand extends Command
     protected $tags = [];
 
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'vendor:publish {--force : Overwrite any existing files}
-                    {--all : Publish assets for all service providers without prompt}
-                    {--provider= : The service provider that has assets you want to publish}
-                    {--tag=* : One or many tags that have assets you want to publish}';
+    protected $name = 'vendor:publish';
 
     /**
      * The console command description.
@@ -271,5 +269,20 @@ class VendorPublishCommand extends Command
         $to = str_replace(base_path(), '', realpath($to));
 
         $this->line('<info>Copied '.$type.'</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['provider', null, InputOption::VALUE_OPTIONAL, 'The service provider that has assets you want to publish'],
+            ['tag', null, InputOption::VALUE_IS_ARRAY, 'One or many tags that have assets you want to publish'],
+            ['force', null, InputOption::VALUE_NONE, 'Overwrite any existing files'],
+            ['all', null, InputOption::VALUE_NONE, 'Publish assets for all service providers without prompt'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -10,11 +10,11 @@ use Symfony\Component\Finder\SplFileInfo;
 class ViewCacheCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'view:cache';
+    protected $name = 'view:cache';
 
     /**
      * The console command description.

--- a/src/Illuminate/Queue/Console/ForgetFailedCommand.php
+++ b/src/Illuminate/Queue/Console/ForgetFailedCommand.php
@@ -3,15 +3,16 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 
 class ForgetFailedCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'queue:forget {id : The ID of the failed job}';
+    protected $name = 'queue:forget';
 
     /**
      * The console command description.
@@ -32,5 +33,17 @@ class ForgetFailedCommand extends Command
         } else {
             $this->error('No failed job matches the given ID.');
         }
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['id', InputArgument::REQUIRED, 'The ID of the failed job'],
+        ];
     }
 }

--- a/src/Illuminate/Queue/Console/ListenCommand.php
+++ b/src/Illuminate/Queue/Console/ListenCommand.php
@@ -5,6 +5,8 @@ namespace Illuminate\Queue\Console;
 use Illuminate\Console\Command;
 use Illuminate\Queue\Listener;
 use Illuminate\Queue\ListenerOptions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class ListenCommand extends Command
 {
@@ -13,15 +15,7 @@ class ListenCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:listen
-                            {connection? : The name of connection}
-                            {--delay=0 : The number of seconds to delay failed jobs}
-                            {--force : Force the worker to run even in maintenance mode}
-                            {--memory=128 : The memory limit in megabytes}
-                            {--queue= : The queue to listen on}
-                            {--sleep=3 : Number of seconds to sleep when no job is available}
-                            {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}';
+    protected $name = 'queue:listen';
 
     /**
      * The console command description.
@@ -110,5 +104,35 @@ class ListenCommand extends Command
         $listener->setOutputHandler(function ($type, $line) {
             $this->output->write($line);
         });
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['connection', InputArgument::OPTIONAL, 'The name of connection'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['delay', null, InputOption::VALUE_OPTIONAL, 'The number of seconds to delay failed jobs', 0],
+            ['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
+            ['sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3],
+            ['timeout', null, InputOption::VALUE_OPTIONAL, 'The number of seconds a child process can run', 60],
+            ['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 1],
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The queue to listen on'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the worker to run even in maintenance mode'],
+        ];
     }
 }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -4,15 +4,16 @@ namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Symfony\Component\Console\Input\InputArgument;
 
 class RetryCommand extends Command
 {
     /**
-     * The console command signature.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'queue:retry {id* : The ID of the failed job or "all" to retry all jobs}';
+    protected $name = 'queue:retry';
 
     /**
      * The console command description.
@@ -89,5 +90,17 @@ class RetryCommand extends Command
         }
 
         return json_encode($payload);
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['id', InputArgument::IS_ARRAY, 'The ID of the failed job or "all" to retry all jobs'],
+        ];
     }
 }

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -100,7 +100,7 @@ class RetryCommand extends Command
     protected function getArguments()
     {
         return [
-            ['id', InputArgument::IS_ARRAY, 'The ID of the failed job or "all" to retry all jobs'],
+            ['id', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The ID of the failed job or "all" to retry all jobs'],
         ];
     }
 }

--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -11,6 +11,8 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Worker;
 use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Carbon;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class WorkCommand extends Command
 {
@@ -19,17 +21,7 @@ class WorkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:work
-                            {connection? : The name of the queue connection to work}
-                            {--queue= : The names of the queues to work}
-                            {--once : Only process the next job on the queue}
-                            {--stop-when-empty : Stop when the queue is empty}
-                            {--delay=0 : The number of seconds to delay failed jobs}
-                            {--force : Force the worker to run even in maintenance mode}
-                            {--memory=128 : The memory limit in megabytes}
-                            {--sleep=3 : Number of seconds to sleep when no job is available}
-                            {--timeout=60 : The number of seconds a child process can run}
-                            {--tries=1 : Number of times to attempt a job before logging it failed}';
+    protected $name = 'queue:work';
 
     /**
      * The console command description.
@@ -221,5 +213,37 @@ class WorkCommand extends Command
     protected function downForMaintenance()
     {
         return $this->option('force') ? false : $this->laravel->isDownForMaintenance();
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['connection', InputArgument::OPTIONAL, 'The name of the queue connection to work'],
+        ];
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['queue', null, InputOption::VALUE_OPTIONAL, 'The names of the queues to work'],
+            ['memory', null, InputOption::VALUE_OPTIONAL, 'The memory limit in megabytes', 128],
+            ['delay', null, InputOption::VALUE_OPTIONAL, 'The number of seconds to delay failed jobs', 0],
+            ['sleep', null, InputOption::VALUE_OPTIONAL, 'Number of seconds to sleep when no job is available', 3],
+            ['timeout', null, InputOption::VALUE_OPTIONAL, 'The number of seconds a child process can run', 60],
+            ['tries', null, InputOption::VALUE_OPTIONAL, 'Number of times to attempt a job before logging it failed', 1],
+            ['once', null, InputOption::VALUE_NONE, 'Only process the next job on the queue'],
+            ['stop-when-empty', null, InputOption::VALUE_NONE, 'Stop when the queue is empty'],
+            ['force', null, InputOption::VALUE_NONE, 'Force the worker to run even in maintenance mode'],
+        ];
     }
 }


### PR DESCRIPTION
This PR makes console commands signature definition style consistent.

Right now some of the commands uses `$signature` property, other ones uses `$name`.
I propose to follow same code style and define arguments in `getArguments` method and define options in `getOptions` method.

*// Generated command stub left untouched. New commands will be generated with `$signature` property.*

### Motivation

This becomes important when you are trying to extend default commands.

I've started to extend `migrate` command:
```php
public function __construct(Migrator $migrator)
{
    parent::__construct($migrator);

    $this->signature .= "{--tenant= : Run migrations for given tenant}";
}
```
And then I found that `migrate:rollback` has different signature definition style, and it should be extened in other way:
```php
protected function getOptions()
{
    $options = parent::getOptions();

    array_push($options,
        ['tenant', null, InputOption::VALUE_OPTIONAL, 'Run migrations for given tenant']
    );

    return $options;
}
```