### PR TITLE
added an artisan command to clear logs

### DIFF
--- a/src/Illuminate/Foundation/Console/LogsClearCommand.php
+++ b/src/Illuminate/Foundation/Console/LogsClearCommand.php
@@ -27,7 +27,7 @@ class LogsClearCommand extends Command
      */
     public function handle()
     {
-        exec('rm ' . storage_path('logs/*.log'));
+        exec('rm '.storage_path('logs/*.log'));
         $this->info('Logs have been cleared!');
     }
 }

--- a/src/Illuminate/Foundation/Console/LogsClearCommand.php
+++ b/src/Illuminate/Foundation/Console/LogsClearCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+
+class LogsClearCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'logs:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear log files';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        exec('rm ' . storage_path('logs/*.log'));
+        $this->info('Logs have been cleared!');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -29,6 +29,7 @@ use Illuminate\Foundation\Console\ExceptionMakeCommand;
 use Illuminate\Foundation\Console\JobMakeCommand;
 use Illuminate\Foundation\Console\KeyGenerateCommand;
 use Illuminate\Foundation\Console\ListenerMakeCommand;
+use Illuminate\Foundation\Console\LogsClearCommand;
 use Illuminate\Foundation\Console\MailMakeCommand;
 use Illuminate\Foundation\Console\ModelMakeCommand;
 use Illuminate\Foundation\Console\NotificationMakeCommand;
@@ -88,6 +89,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'EventClear' => 'command.event.clear',
         'EventList' => 'command.event.list',
         'KeyGenerate' => 'command.key.generate',
+        'LogsClear' => 'command.logs.clear',
         'Optimize' => 'command.optimize',
         'OptimizeClear' => 'command.optimize.clear',
         'PackageDiscover' => 'command.package.discover',
@@ -447,6 +449,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.listener.make', function ($app) {
             return new ListenerMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerLogsClearCommand()
+    {
+        $this->app->singleton('command.logs.clear', function ($app) {
+            return new LogsClearCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
This PR adds a `logs:clear` command to prune log files and clean up the
logs directory, it's a bit painful to manually delete the files via editor, CLI or IDE

Signed-off-by: Salim Djerbouh <caddydz4@gmail.com>
