### PR TITLE
[7.x] Ensure the destination directory exists when copying a file.

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -236,8 +236,10 @@ class Filesystem
      */
     public function copy($path, $target)
     {
-        if (! $this->exists(dirname($target))) {
-            $this->makeDirectory(dirname($target), 0755, true, true);
+        $targetDirectory = dirname($target);
+        
+        if (! $this->exists($targetDirectory)) {
+            $this->makeDirectory($targetDirectory, 0755, true, true);
         }
 
         return copy($path, $target);

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -236,6 +236,10 @@ class Filesystem
      */
     public function copy($path, $target)
     {
+        if (! $this->exists(dirname($target))) {
+            $this->makeDirectory(dirname($target), 0755, true, true);
+        }
+
         return copy($path, $target);
     }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -237,7 +237,7 @@ class Filesystem
     public function copy($path, $target)
     {
         $targetDirectory = dirname($target);
-        
+
         if (! $this->exists($targetDirectory)) {
             $this->makeDirectory($targetDirectory, 0755, true, true);
         }


### PR DESCRIPTION
When you copy a file "/dir1/a.txt" to "/dir2/b.txt" while "/dir2" doesn't exist, you'll get an error "failed to open stream: No such file or directory".

Instead, I suggest we make the copy function behave the same way as `copyDirectory()` and create all the destination folders if needed.

Since there's a slight chance that someone relies on this function throwing an exception, I'm submitting this to master, however, this chance sounds ridiculous to me.