### PR TITLE
[6.x] Add runtime for seeders

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -36,12 +36,21 @@ abstract class Seeder
 
         foreach ($classes as $class) {
             $seeder = $this->resolve($class);
+            $name = get_class($seeder);
 
             if ($silent === false && isset($this->command)) {
-                $this->command->getOutput()->writeln('<info>Seeding:</info> '.get_class($seeder));
+                $this->command->getOutput()->writeln("<comment>Seeding:</comment> {$name}");
             }
 
+            $startTime = microtime(true);
+
             $seeder->__invoke();
+
+            $runTime = round(microtime(true) - $startTime, 2);
+
+            if ($silent === false && isset($this->command)) {
+                $this->command->getOutput()->writeln("<info>Seeded:</info>  {$name} ({$runTime} seconds)");
+            }
         }
 
         return $this;

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -38,7 +38,7 @@ class DatabaseSeederTest extends TestCase
         $seeder = new TestSeeder;
         $seeder->setContainer($container = m::mock(Container::class));
         $output = m::mock(OutputInterface::class);
-        $output->shouldReceive('writeln')->once()->andReturn('foo');
+        $output->shouldReceive('writeln')->once();
         $command = m::mock(Command::class);
         $command->shouldReceive('getOutput')->once()->andReturn($output);
         $seeder->setCommand($command);
@@ -46,6 +46,8 @@ class DatabaseSeederTest extends TestCase
         $child->shouldReceive('setContainer')->once()->with($container)->andReturn($child);
         $child->shouldReceive('setCommand')->once()->with($command)->andReturn($child);
         $child->shouldReceive('__invoke')->once();
+        $command->shouldReceive('getOutput')->once()->andReturn($output);
+        $output->shouldReceive('writeln')->once();
 
         $seeder->call('ClassName');
     }


### PR DESCRIPTION
This PR is based on #29193. It adds "runtime" information to `db:seed` command.

The implementation closely follows "runtime" information provided in the `migrate` command.

It does not attempt to introduce the `Stopwatch` class, this is left to a possible future PR (if actually needed).

Thanks