### PR TITLE
[6.x] Changed Contract to Class

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Mail;
 
-use Illuminate\Contracts\Mail\Mailable as MailableContract;
-use Illuminate\Contracts\Mail\Mailer as MailerContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 
@@ -12,7 +10,7 @@ class PendingMail
     /**
      * The mailer instance.
      *
-     * @var \Illuminate\Contracts\Mail\Mailer
+     * @var \Illuminate\Mail\Mailer
      */
     protected $mailer;
 
@@ -47,10 +45,10 @@ class PendingMail
     /**
      * Create a new mailable mailer instance.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailer  $mailer
+     * @param  \Illuminate\Mail\Mailer  $mailer
      * @return void
      */
-    public function __construct(MailerContract $mailer)
+    public function __construct(Mailer $mailer)
     {
         $this->mailer = $mailer;
     }
@@ -114,11 +112,11 @@ class PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
+     * @param  \Illuminate\Mail\Mailable  $mailable
      *
      * @return mixed
      */
-    public function send(MailableContract $mailable)
+    public function send(Mailable $mailable)
     {
         if ($mailable instanceof ShouldQueue) {
             return $this->queue($mailable);
@@ -130,10 +128,10 @@ class PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
-    public function sendNow(MailableContract $mailable)
+    public function sendNow(Mailable $mailable)
     {
         return $this->mailer->send($this->fill($mailable));
     }
@@ -141,10 +139,10 @@ class PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
-    public function queue(MailableContract $mailable)
+    public function queue(Mailable $mailable)
     {
         $mailable = $this->fill($mailable);
 
@@ -159,10 +157,10 @@ class PendingMail
      * Deliver the queued message after the given delay.
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
-    public function later($delay, MailableContract $mailable)
+    public function later($delay, Mailable $mailable)
     {
         return $this->mailer->later($delay, $this->fill($mailable));
     }
@@ -170,14 +168,14 @@ class PendingMail
     /**
      * Populate the mailable with the addresses.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return \Illuminate\Mail\Mailable
      */
-    protected function fill(MailableContract $mailable)
+    protected function fill(Mailable $mailable)
     {
         return tap($mailable->to($this->to)
             ->cc($this->cc)
-            ->bcc($this->bcc), function ($mailable) {
+            ->bcc($this->bcc), function (Mailable $mailable) {
                 if ($this->locale) {
                     $mailable->locale($this->locale);
                 }

--- a/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/PendingMailFake.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
-use Illuminate\Contracts\Mail\Mailable;
+use Illuminate\Mail\Mailable;
 use Illuminate\Mail\PendingMail;
 
 class PendingMailFake extends PendingMail
@@ -21,7 +21,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a new mailable message instance.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
     public function send(Mailable $mailable)
@@ -32,7 +32,7 @@ class PendingMailFake extends PendingMail
     /**
      * Send a mailable message immediately.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
     public function sendNow(Mailable $mailable)
@@ -43,7 +43,7 @@ class PendingMailFake extends PendingMail
     /**
      * Push the given mailable onto the queue.
      *
-     * @param  \Illuminate\Contracts\Mail\Mailable $mailable;
+     * @param  \Illuminate\Mail\Mailable $mailable
      * @return mixed
      */
     public function queue(Mailable $mailable)


### PR DESCRIPTION
 - I have changed `\Illuminate\Contracts\Mail\Mailable` to `\Illuminate\Mail\Mailable`, since contract does not contains `cc` / `to` / `bcc` / `locale` methods, and in case if you call method only with contract, then we will get fatall error, since method is not present in the contract

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
