### PR TITLE
[7.x] Expand Mailable interface

### DIFF
--- a/src/Illuminate/Contracts/Mail/Mailable.php
+++ b/src/Illuminate/Contracts/Mail/Mailable.php
@@ -30,4 +30,39 @@ interface Mailable
      * @return mixed
      */
     public function later($delay, Queue $queue);
+
+    /**
+     * Set the recipients of the message.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return self
+     */
+    public function cc($address, $name = null);
+
+    /**
+     * Set the recipients of the message.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return $this
+     */
+    public function bcc($address, $name = null);
+
+    /**
+     * Set the recipients of the message.
+     *
+     * @param  object|array|string  $address
+     * @param  string|null  $name
+     * @return $this
+     */
+    public function to($address, $name = null);
+
+    /**
+     * Set the locale of the message.
+     *
+     * @param  string  $locale
+     * @return $this
+     */
+    public function locale($locale);
 }

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -177,7 +177,7 @@ class PendingMail
     {
         return tap($mailable->to($this->to)
             ->cc($this->cc)
-            ->bcc($this->bcc), function ($mailable) {
+            ->bcc($this->bcc), function (MailableContract $mailable) {
                 if ($this->locale) {
                     $mailable->locale($this->locale);
                 }


### PR DESCRIPTION
 - expand Mailable interface since `PendingMail::fill()` used some not existed method from the Mailable interface now. And it will caused an fatal error.
 Base PR: https://github.com/laravel/framework/pull/30088

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
