### PR TITLE
[6.x] Ability to use firstOrNew without passing the $attributes parameter

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -396,7 +396,7 @@ class Builder
      * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function firstOrNew(array $attributes, array $values = [])
+    public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;


### PR DESCRIPTION
This pull request is to make `firstOrNew` easy to read and works as `first` do, e.g.

```php
$post = Post::where('something', 1)->firstOrNew();
$post->user()->associate(auth()->user());
$post->save();
```