### PR TITLE
[6.x] Fix query builder multiple orwhere not work as expected

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -722,7 +722,7 @@ class Builder
         return $this->whereNested(function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
-                    $query->{$method}(...array_values($value));
+                    $query->{$method}(...array_values($value) + ['', null, null, $boolean]);
                 } else {
                     $query->$method($key, '=', $value, $boolean);
                 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3449,6 +3449,16 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
+    public function testOrWhere()
+    {
+        $builder = $this->getBuilder();
+        $conditions = [
+            ['a', '=', 1],
+            ['b', '=', 2],
+        ];
+        $this->assertEquals('select * where ("a" = ? or "b" = ?)', $builder->orWhere($conditions)->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Grammar;


### PR DESCRIPTION
This pull request is to make `orWhere` works like `where` when multiple columns input.

For example:

```php
$conditions = [
            ['a', '=', 1],
            ['b', '=', 2],
        ];

echo Users::orWhere($conditions)->toSql();
```
output:  ```select * from `Users` where (`a` = ? or `b` = ?)```