### PR TITLE
[6.x] Default value for optionals

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -19,14 +19,24 @@ class Optional implements ArrayAccess
     protected $value;
 
     /**
+     * Default value to be returned in case
+     * the object doesn't exist.
+     *
+     * @var mixed
+     */
+    protected $default = null;
+
+    /**
      * Create a new optional instance.
      *
      * @param  mixed  $value
+     * @param  mixed  $default
      * @return void
      */
-    public function __construct($value)
+    public function __construct($value, $default = null)
     {
         $this->value = $value;
+        $this->default = $default;
     }
 
     /**
@@ -38,8 +48,10 @@ class Optional implements ArrayAccess
     public function __get($key)
     {
         if (is_object($this->value)) {
-            return $this->value->{$key} ?? null;
+            return $this->value->{$key} ?? $this->default;
         }
+
+        return $this->default;
     }
 
     /**
@@ -126,5 +138,7 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+
+        return $this->default;
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -337,15 +337,15 @@ if (! function_exists('optional')) {
      * Provide access to optional objects.
      *
      * @param  mixed  $value
-     * @param  callable|null  $callback
+     * @param  mixed  $second
      * @return mixed
      */
-    function optional($value = null, callable $callback = null)
+    function optional($value = null, $second = null)
     {
-        if (is_null($callback)) {
-            return new Optional($value);
+        if (! is_callable($second)) {
+            return new Optional($value, $second);
         } elseif (! is_null($value)) {
-            return $callback($value);
+            return $second($value);
         }
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -393,6 +393,24 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
+    public function testOptionalDefaultReturnValue()
+    {
+        $this->assertEquals([], optional(null, [])->something());
+
+        $this->assertEquals(10, optional(new class {
+            public function something()
+            {
+                return 10;
+            }
+        }, 5)->something());
+
+        $existingObject = new stdClass;
+        $existingObject->foo = 'bar';
+
+        $this->assertEquals('bar', optional($existingObject, 'defaultValue')->foo);
+        $this->assertEquals('defaultValue', optional(null, 'defaultValue')->foo);
+    }
+
     public function testOptionalWithCallback()
     {
         $this->assertNull(optional(null, function () {


### PR DESCRIPTION
This will allow default return values to be defined for `optional()` objects' methods or properties. Such as:

```php
optional(null, [])->posts() // return []
optional(null, 5)->count // return 5
```

instead of `null` which is the existing behavior.

Second argument can still be a callback that can be called over the existing object.

This is an additional feature rather than a breaking change so will probably be able to go to 6.x