### PR TITLE
[6.x] Default value for optional

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -19,6 +19,14 @@ class Optional implements ArrayAccess
     protected $value;
 
     /**
+     * Default value to be returned in case
+     * the object doesn't exist.
+     *
+     * @var mixed
+     */
+    protected $default = null;
+
+    /**
      * Create a new optional instance.
      *
      * @param  mixed  $value
@@ -38,8 +46,10 @@ class Optional implements ArrayAccess
     public function __get($key)
     {
         if (is_object($this->value)) {
-            return $this->value->{$key} ?? null;
+            return $this->value->{$key} ?? $this->default;
         }
+
+        return $this->default;
     }
 
     /**
@@ -111,6 +121,20 @@ class Optional implements ArrayAccess
     }
 
     /**
+     * Sets the default return value for nonexisting object.
+     *
+     * @param $value
+     *
+     * @return mixed
+     */
+    public function default($value)
+    {
+        $this->default = $value;
+
+        return $this;
+    }
+
+    /**
      * Dynamically pass a method to the underlying object.
      *
      * @param  string  $method
@@ -126,5 +150,7 @@ class Optional implements ArrayAccess
         if (is_object($this->value)) {
             return $this->value->{$method}(...$parameters);
         }
+
+        return $this->default;
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -393,6 +393,24 @@ class SupportHelpersTest extends TestCase
         })->something());
     }
 
+    public function testOptionalDefaultReturnValue()
+    {
+        $this->assertEquals([], optional(null)->default([])->something());
+
+        $this->assertEquals(10, optional(new class {
+            public function something()
+            {
+                return 10;
+            }
+        })->default(5)->something());
+
+        $existingObject = new stdClass;
+        $existingObject->foo = 'bar';
+
+        $this->assertEquals('bar', optional($existingObject)->default('defaultValue')->foo);
+        $this->assertEquals('defaultValue', optional(null)->default('defaultValue')->foo);
+    }
+
     public function testOptionalWithCallback()
     {
         $this->assertNull(optional(null, function () {


### PR DESCRIPTION
This will allow default values to be defined for `optional()` objects' methods or properties. Such as:

```php
optional(null)->default([])->posts() // return []
optional(null)->default(5)->count // return 5
```

instead of `null` which is the existing behavior.