### PR TITLE
[6.x] Add methods for sending cookies with test requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -12,6 +12,13 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 trait MakesHttpRequests
 {
     /**
+     * Additional cookies for the request.
+     *
+     * @var array
+     */
+    protected $defaultCookies = [];
+
+    /**
      * Additional headers for the request.
      *
      * @var array
@@ -31,6 +38,13 @@ trait MakesHttpRequests
      * @var bool
      */
     protected $followRedirects = false;
+
+    /**
+     * Indicates whether cookies should be encrypted.
+     *
+     * @var bool
+     */
+    protected $encryptCookies = true;
 
     /**
      * Define additional headers to be sent with the request.
@@ -132,6 +146,33 @@ trait MakesHttpRequests
     }
 
     /**
+     * Define additional cookies to be sent with the request.
+     *
+     * @param  array $cookies
+     * @return $this
+     */
+    public function withCookies(array $cookies)
+    {
+        $this->defaultCookies = array_merge($this->defaultCookies, $cookies);
+
+        return $this;
+    }
+
+    /**
+     * Add a cookie to be sent with the request.
+     *
+     * @param  string $name
+     * @param  string $value
+     * @return $this
+     */
+    public function withCookie(string $name, string $value)
+    {
+        $this->defaultCookies[$name] = $value;
+
+        return $this;
+    }
+
+    /**
      * Automatically follow any redirects returned from the response.
      *
      * @return $this
@@ -139,6 +180,18 @@ trait MakesHttpRequests
     public function followingRedirects()
     {
         $this->followRedirects = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable automatic encryption of cookie values.
+     *
+     * @return $this
+     */
+    public function disableCookieEncryption()
+    {
+        $this->encryptCookies = false;
 
         return $this;
     }
@@ -166,8 +219,9 @@ trait MakesHttpRequests
     public function get($uri, array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], [], [], $server);
+        return $this->call('GET', $uri, [], $cookies, [], $server);
     }
 
     /**
@@ -193,8 +247,9 @@ trait MakesHttpRequests
     public function post($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('POST', $uri, $data, [], [], $server);
+        return $this->call('POST', $uri, $data, $cookies, [], $server);
     }
 
     /**
@@ -221,8 +276,9 @@ trait MakesHttpRequests
     public function put($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PUT', $uri, $data, [], [], $server);
+        return $this->call('PUT', $uri, $data, $cookies, [], $server);
     }
 
     /**
@@ -249,8 +305,9 @@ trait MakesHttpRequests
     public function patch($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('PATCH', $uri, $data, [], [], $server);
+        return $this->call('PATCH', $uri, $data, $cookies, [], $server);
     }
 
     /**
@@ -277,8 +334,9 @@ trait MakesHttpRequests
     public function delete($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('DELETE', $uri, $data, [], [], $server);
+        return $this->call('DELETE', $uri, $data, $cookies, [], $server);
     }
 
     /**
@@ -305,8 +363,9 @@ trait MakesHttpRequests
     public function options($uri, array $data = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
+        $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('OPTIONS', $uri, $data, [], [], $server);
+        return $this->call('OPTIONS', $uri, $data, $cookies, [], $server);
     }
 
     /**
@@ -458,6 +517,22 @@ trait MakesHttpRequests
         }
 
         return $files;
+    }
+
+    /**
+     * If enabled, encrypt cookie values for request.
+     *
+     * @return array
+     */
+    protected function prepareCookiesForRequest()
+    {
+        if (! $this->encryptCookies) {
+            return $this->defaultCookies;
+        }
+
+        return collect($this->defaultCookies)->map(function ($value) {
+            return encrypt($value, false);
+        })->all();
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -52,6 +52,27 @@ class MakesHttpRequestsTest extends TestCase
             $this->app->make(MyMiddleware::class)->handle('foo', $next)
         );
     }
+
+    public function testWithCookieSetCookie()
+    {
+        $this->withCookie('foo', 'bar');
+
+        $this->assertCount(1, $this->defaultCookies);
+        $this->assertSame('bar', $this->defaultCookies['foo']);
+    }
+
+    public function testWithCookiesSetsCookiesAndOverwritesPreviousValues()
+    {
+        $this->withCookie('foo', 'bar');
+        $this->withCookies([
+            'foo' => 'baz',
+            'new-cookie' => 'new-value',
+        ]);
+
+        $this->assertCount(2, $this->defaultCookies);
+        $this->assertSame('baz', $this->defaultCookies['foo']);
+        $this->assertSame('new-value', $this->defaultCookies['new-cookie']);
+    }
 }
 
 class MyMiddleware


### PR DESCRIPTION
This introduces methods for making it easier to send cookies in HTTP Tests. Previously, sending cookies restricted developers to using the low-level `call` method and required manually encrypting the cookie values ([#12032](https://github.com/laravel/framework/issues/12032#issuecomment-175203805)).

**Before**
```php
$cookies = [
    'name1' => encrypt('value1'),
    'name2' => encrypt('value2')
];
$response = $this->call('get', 'test', [], $cookies);
```

**After**
```php
$response = $this->withCookies([
    'name1' => 'value1',
    'name2' => 'value2'
])->get('test');
```

Similar to the header methods, the following methods were added:

- `withCookie()` for setting a single cookie with a value.
- `withCookies()` for setting multiple cookies with name/value pairs.
- `disableCookieEncryption()` for disabling the automatic encryption of cookie values.

Cookies are prepared before sending the HTTP request and encrypted using the `encrypter`.

This implementation implies a few design decisions:

- To remain backwards compatible, the `call` method does not honor cookies set by these new methods. In a future version, all logic could be moved to the `call` method and merge its `$cookie` argument with cookies set by these methods. 
- Since the `EncryptCookies` middleware is only enabled for `web` requests by default, the `json*` HTTP methods do not honor cookies set by these new methods. This could be amended by passing the unencrypted cookie values in these methods. 
- Since cookies values are not serialized by default starting in Laravel 5.5, these methods do not serialize cookie values. This could be amended by adding a `enableCookieSerialize` method or leveraging the static property of `EncryptCookies`.

In the end, these methods improve the  out-of-the-box developer experience by making it easier to test requests using cookies. For more complex scenarios, developers can continue using `call` as they have been all along.
