### PR TITLE
[6.x] Add loadFactoriesFrom method

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -140,9 +140,8 @@ abstract class ServiceProvider
     /**
      * Register factories.
      *
-     * @param string $path
+     * @param  string  $path
      * @return void
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     protected function loadFactoriesFrom($path)
     {

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Database\Eloquent\Factory;
 
 abstract class ServiceProvider
 {
@@ -134,6 +135,18 @@ abstract class ServiceProvider
                 $migrator->path($path);
             }
         });
+    }
+
+    /**
+     * Register factories.
+     *
+     * @param string $path
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected function loadFactoriesFrom($path)
+    {
+        $this->app->make(Factory::class)->load($path);
     }
 
     /**


### PR DESCRIPTION
This PR introduces a `loadFactoriesFrom` method which can be used by Package developers to support development with Models or Migrations that are provided by the package. We've already got several supporting methods like `loadRoutesFrom`, `loadTranslationsFrom` and `loadMigrationsFrom`. I feel this would also be a good functionality to add to that list.

Let's say a package provides you a User model along with a user migration. This method would allow package developers to also provide a factory for this model from within their package. Developers using this package could easily seed the Users table or test their application without having to write a factory themselves.