### PR TITLE
[7.x] @pushonce and @prependonce blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesStacks.php
@@ -37,6 +37,27 @@ trait CompilesStacks
     }
 
     /**
+     * Compile the pushonce statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePushonce($expression)
+    {
+        return "<?php \$__env->startPushOnce{$expression}; ?>";
+    }
+
+    /**
+     * Compile the end-pushonce statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndpushonce()
+    {
+        return '<?php $__env->stopPushOnce(); ?>';
+    }
+
+    /**
      * Compile the prepend statements into valid PHP.
      *
      * @param  string  $expression
@@ -55,5 +76,26 @@ trait CompilesStacks
     protected function compileEndprepend()
     {
         return '<?php $__env->stopPrepend(); ?>';
+    }
+
+    /**
+     * Compile the prependonce statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compilePrependonce($expression)
+    {
+        return "<?php \$__env->startPrependOnce{$expression}; ?>";
+    }
+
+    /**
+     * Compile the end-prependonce statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndprependonce()
+    {
+        return '<?php $__env->stopPrependOnce(); ?>';
     }
 }

--- a/src/Illuminate/View/Concerns/ManagesStacks.php
+++ b/src/Illuminate/View/Concerns/ManagesStacks.php
@@ -223,7 +223,6 @@ trait ManagesStacks
         }
     }
 
-
     /**
      * Check if content exists in stack section. Remember if not added before.
      *

--- a/tests/View/Blade/BladePrependonceTest.php
+++ b/tests/View/Blade/BladePrependonceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladePrependonceTest extends AbstractBladeTestCase
+{
+    public function testPrependonceIsCompiled()
+    {
+        $string = '@prependonce(\'foo\')
+bar
+@endprependonce';
+        $expected = '<?php $__env->startPrependOnce(\'foo\'); ?>
+bar
+<?php $__env->stopPrependOnce(); ?>';
+
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/Blade/BladePushonceTest.php
+++ b/tests/View/Blade/BladePushonceTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladePushonceTest extends AbstractBladeTestCase
+{
+    public function testPushonceIsCompiled()
+    {
+        $string = '@pushonce(\'foo\')
+test
+@endpushonce';
+        $expected = '<?php $__env->startPushOnce(\'foo\'); ?>
+test
+<?php $__env->stopPushOnce(); ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
In addition to ```@push``` and ```@prepend``` these new blade directives allow to fill a ```@stack``` section, but in these cases only when their contents are unique among other ```@pushonce``` or ```@prependonce``` calls for the same stack. This is useful when, for instance, a partial view is rendered multiple times while also pushing identical contents to the stack.

```
<!-- resources\views\layout.blade.php -->
<html>
	<body>
		@yield('content')

		@stack('scripts')
	</body>
</html>


<!-- resources\views\page.blade.php -->
@extends('layout')

@section('content')

<p>Components:</p>
@each('partials.some-component', ['data', 'otherdata', 'moredata'], 'data')

@endsection


<!-- resources\views\partials\some-component.blade.php -->
<div>
	{{ $data }}
</div>

@pushonce('scripts')
<script type="text/javascript" src="script-that-every-component-uses.js"></script>
@endpushonce
```