### PR TITLE
[6.x] Improved AuthServiceProvider::registerEventRebindHandler()

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -286,6 +286,16 @@ class AuthManager implements FactoryContract
     }
 
     /**
+     * Determines if any guards have already been resolved.
+     *
+     * @return bool
+     */
+    public function hasResolvedGuards()
+    {
+        return count($this->guards) > 0;
+    }
+
+    /**
      * Dynamically call the default driver instance.
      *
      * @param  string  $method

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -98,9 +98,6 @@ class AuthServiceProvider extends ServiceProvider
                 return;
             }
 
-            // If no guards have been resolved yet we don't need to call setDispatcher
-            // In case 'events' is rebound in another ServiceProvider this makes sure that no guard is initialized
-            // while registering.
             if ($app['auth']->hasResolvedGuards() === false) {
                 return;
             }

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -98,6 +98,13 @@ class AuthServiceProvider extends ServiceProvider
                 return;
             }
 
+            // If no guards have been resolved yet we don't need to call setDispatcher
+            // In case 'events' is rebound in another ServiceProvider this makes sure that no guard is initialized
+            // while registering.
+            if ($app['auth']->hasResolvedGuards() === false) {
+                return;
+            }
+
             if (method_exists($guard = $app['auth']->guard(), 'setDispatcher')) {
                 $guard->setDispatcher($dispatcher);
             }


### PR DESCRIPTION
* as Auth::guard() not only checks for an existing guard but also
initializes a new guard in case ob absence. This can lead to side-effects
when overbinding 'events' in another service provider
* this MR fixes initializing a guard while actually still being in register-phase of service providers. Please note that this only happens if you `events` if overbind with a library like https://github.com/fntneves/laravel-transactional-events. Then it leads to actually always creating a guard although it's might not needed.

Please note that this is my first MR and I'm happy to hear feedback and adjust it.

Thanks a lot!
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
