### PR TITLE
[6.x] Add custom deleted_at column name for assertSoftDeleted

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Testing\Constraints\HasInDatabase;
 use Illuminate\Foundation\Testing\Constraints\SoftDeletedInDatabase;
 use Illuminate\Support\Arr;
@@ -52,19 +53,32 @@ trait InteractsWithDatabase
      * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
+     * @param  string|null  $deletedAtColumn
      * @return $this
      */
-    protected function assertSoftDeleted($table, array $data = [], $connection = null)
+    protected function assertSoftDeleted($table, array $data = [], $connection = null, $deletedAtColumn = 'deleted_at')
     {
-        if ($table instanceof Model) {
-            return $this->assertSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        if ($this->isSoftDeletableModel($table)) {
+            return $this->assertSoftDeleted($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName(), $table->getDeletedAtColumn());
         }
 
         $this->assertThat(
-            $table, new SoftDeletedInDatabase($this->getConnection($connection), $data)
+            $table, new SoftDeletedInDatabase($this->getConnection($connection), $data, $deletedAtColumn)
         );
 
         return $this;
+    }
+
+    /**
+     * Determine if the argument is a soft deletable model.
+     *
+     * @param  mixed  $model
+     * @return bool
+     */
+    protected function isSoftDeletableModel($model)
+    {
+        return $model instanceof Model
+            && in_array(SoftDeletes::class, class_uses_recursive($model));
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -29,6 +29,13 @@ class SoftDeletedInDatabase extends Constraint
     protected $data;
 
     /**
+     * The name of the column that indicates soft deletion has occurred.
+     *
+     * @var string
+     */
+    protected $deletedAtColumn;
+
+    /**
      * Create a new constraint instance.
      *
      * @param  \Illuminate\Database\Connection  $database

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -33,13 +33,16 @@ class SoftDeletedInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  array  $data
+     * @param  string  $deletedAtColumn
      * @return void
      */
-    public function __construct(Connection $database, array $data)
+    public function __construct(Connection $database, array $data, string $deletedAtColumn)
     {
         $this->data = $data;
 
         $this->database = $database;
+
+        $this->deletedAtColumn = $deletedAtColumn;
     }
 
     /**
@@ -51,7 +54,9 @@ class SoftDeletedInDatabase extends Constraint
     public function matches($table): bool
     {
         return $this->database->table($table)
-                ->where($this->data)->whereNotNull('deleted_at')->count() > 0;
+                ->where($this->data)
+                ->whereNotNull($this->deletedAtColumn)
+                ->count() > 0;
     }
 
     /**

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Foundation;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Mockery as m;
@@ -131,13 +132,27 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertSoftDeleted(new ProductStub($this->data));
     }
 
-    protected function mockCountBuilder($countResult)
+    public function testAssertSoftDeletedInDatabaseDoesNotFindModelWithCustomColumnResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0, 'trashed_at');
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertSoftDeleted(new CustomProductStub($this->data));
+    }
+
+    protected function mockCountBuilder($countResult, $deletedAtColumn = 'deleted_at')
     {
         $builder = m::mock(Builder::class);
 
         $builder->shouldReceive('where')->with($this->data)->andReturnSelf();
 
-        $builder->shouldReceive('whereNotNull')->with('deleted_at')->andReturnSelf();
+        $builder->shouldReceive('whereNotNull')->with($deletedAtColumn)->andReturnSelf();
 
         $builder->shouldReceive('count')->andReturn($countResult);
 
@@ -156,7 +171,14 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
 class ProductStub extends Model
 {
+    use SoftDeletes;
+
     protected $table = 'products';
 
     protected $guarded = [];
+}
+
+class CustomProductStub extends ProductStub
+{
+    const DELETED_AT = 'trashed_at';
 }


### PR DESCRIPTION
This fixes issue #30110 where it isn't possible to use `assertSoftDeleted` if you're using a column name other than `deleted_at`. This allows the custom column name to be passed into the assertion, and it also adds support if you pass in a model instance.

A few things to note:

* I updated the model check to also include that it uses the `SoftDeletes` trait. It wasn't required previously but now that we call `getDeletedAtColumn()` we want to be sure that the method will be there. This would be backwards incompatible if you were using this assertion but not using the `SoftDeletes` trait, but I don't think that would be expected behaviour.

* I've popped `$deletedAtColumn` on as the last argument to the method so as not to break anything. However I have a gut feeling it should rather be between the `$data` and `$connection` arguments. Curious as to your thoughts in regard to this.