### PR TITLE
[6.x] Fix Monolog v2 handler instantiation

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\FormattableHandlerInterface;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Handler\SlackWebhookHandler;
@@ -372,9 +373,17 @@ class LogManager implements LoggerInterface
      */
     protected function prepareHandler(HandlerInterface $handler, array $config = [])
     {
-        if (! isset($config['formatter'])) {
+        $isHandlerFormattable = false;
+
+        if (Monolog::API === 1) {
+            $isHandlerFormattable = true;
+        } elseif (Monolog::API === 2 && $handler instanceof FormattableHandlerInterface) {
+            $isHandlerFormattable = true;
+        }
+
+        if ($isHandlerFormattable && ! isset($config['formatter'])) {
             $handler->setFormatter($this->formatter());
-        } elseif ($config['formatter'] !== 'default') {
+        } elseif ($isHandlerFormattable && $config['formatter'] !== 'default') {
             $handler->setFormatter($this->app->make($config['formatter'], $config['formatter_with'] ?? []));
         }
 

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -9,6 +9,7 @@ use Monolog\Formatter\LineFormatter;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Handler\LogEntriesHandler;
 use Monolog\Handler\NewRelicHandler;
+use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Logger as Monolog;
@@ -162,6 +163,44 @@ class LogManagerTest extends TestCase
         $dateFormat->setAccessible(true);
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
+    }
+
+    public function testLogManagerCreatesMonologHandlerWithProperFormatter()
+    {
+        $config = $this->app->make('config');
+        $config->set('logging.channels.null', [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+            'formatter' => HtmlFormatter::class,
+        ]);
+
+        $manager = new LogManager($this->app);
+
+        // create logger with handler specified from configuration
+        $logger = $manager->channel('null');
+        $handler = $logger->getLogger()->getHandlers()[0];
+
+        if (Monolog::API === 1) {
+            $this->assertInstanceOf(NullHandler::class, $handler);
+            $this->assertInstanceOf(HtmlFormatter::class, $handler->getFormatter());
+        } else {
+            $this->assertInstanceOf(NullHandler::class, $handler);
+        }
+
+        $config->set('logging.channels.null2', [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ]);
+
+        $logger = $manager->channel('null2');
+        $handler = $logger->getLogger()->getHandlers()[0];
+
+        if (Monolog::API === 1) {
+            $this->assertInstanceOf(NullHandler::class, $handler);
+            $this->assertInstanceOf(LineFormatter::class, $handler->getFormatter());
+        } else {
+            $this->assertInstanceOf(NullHandler::class, $handler);
+        }
     }
 
     public function testLogManagerCreateSingleDriverWithConfiguredFormatter()


### PR DESCRIPTION
Monolog 1 has the `setFormatter` method on the [HandlerInterface](https://github.com/Seldaek/monolog/blob/1.x/src/Monolog/Handler/HandlerInterface.php#L82) while Monolog 2 extracted that method from the `HandlerInterface` to a [FormattableHandlerInterface](https://github.com/Seldaek/monolog/blob/2.0.0/src/Monolog/Handler/FormattableHandlerInterface.php). This now means that a bunch of handlers in Monolog 2 don't have that method aka they are not formattable. The problem is that Laravel is calling the `setFormatter` method without checking if it actually exists on the handler when using Monolog 2 which causes an exception to be thrown.

This PR fixes the problem by checking for the `FormattableHandlerInterface` if Monolog 2 is being used. A test has also been added which tests the instantiation of a logger which has the `NullHandler` handler which is no longer formattable in Monolog 2. This test will be run with Monolog 1 in the CI with the low deps option and with Monolog 2 in the newest deps pipeline so it confirms that the instantiation now works with both Monolog versions. This test of course doesn't pass without the fix in this PR.

Fixes #30026 
