### PR TITLE
[6.x] Allow to use scoped macro in nested queries

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -223,7 +223,7 @@ class Builder
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure) {
-            $column($query = $this->model->newQuery());
+            $column($query = $this->model->newQueryWithoutRelationships());
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -223,7 +223,7 @@ class Builder
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column instanceof Closure) {
-            $column($query = $this->model->newModelQuery());
+            $column($query = $this->model->newQuery());
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
         } else {

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -643,7 +643,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $model = $this->getMockModel()->makePartial();
-        $model->shouldReceive('newQuery')->once()->andReturn($nestedQuery);
+        $model->shouldReceive('newQueryWithoutRelationships')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('from');
         $builder->setModel($model);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -643,7 +643,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $nestedRawQuery = $this->getMockQueryBuilder();
         $nestedQuery->shouldReceive('getQuery')->once()->andReturn($nestedRawQuery);
         $model = $this->getMockModel()->makePartial();
-        $model->shouldReceive('newModelQuery')->once()->andReturn($nestedQuery);
+        $model->shouldReceive('newQuery')->once()->andReturn($nestedQuery);
         $builder = $this->getBuilder();
         $builder->getQuery()->shouldReceive('from');
         $builder->setModel($model);
@@ -664,6 +664,17 @@ class DatabaseEloquentBuilderTest extends TestCase
             $query->where('baz', '>', 9000);
         });
         $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
+        $this->assertEquals(['bar', 9000], $query->getBindings());
+    }
+
+    public function testRealNestedWhereWithScopesMacro()
+    {
+        $model = new EloquentBuilderTestNestedStub;
+        $this->mockConnectionForModel($model, 'SQLite');
+        $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) {
+            $query->where('baz', '>', 9000)->onlyTrashed();
+        })->withTrashed();
+        $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ? and "table"."deleted_at" is not null)', $query->toSql());
         $this->assertEquals(['bar', 9000], $query->getBindings());
     }
 


### PR DESCRIPTION
Sometimes need to use scope macro in nested queries:
```php
Model::query()->where(function (Builder $query) {
    $query->withoutTrashed()
        ->orWhereDate('created_at', '>', Carbon::now()->subMonth());
})->withTrashed();

//Real example:
Access::query()
    ->where('type', 'free')
    ->orWhere(function (Builder $query) {
        $query
            ->where('type', 'protected')
            ->forUser(Auth::user()); //scoped macro with nested logic
    })
```

Scopes are applying only when you call `get()` or `cursor()`. But In nested queries this not happening.

I believe this is bug what scope macro does not work in nested queries.