### PR TITLE
[6.x] Add the ability to delete a resolved log driver/channel

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -98,6 +98,27 @@ class LogManager implements LoggerInterface
     }
 
     /**
+     * @param string|null $driver
+     * @return void
+     */
+    public function purge($driver = null)
+    {
+        $driver = $driver ?? $this->getDefaultDriver();
+
+        if (isset($this->channels[$driver])) {
+            unset($this->channels[$driver]);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getChannels()
+    {
+        return $this->channels;
+    }
+
+    /**
      * Attempt to get the log from the local cache.
      *
      * @param  string  $name

--- a/tests/Log/LogManagerTest.php
+++ b/tests/Log/LogManagerTest.php
@@ -287,4 +287,19 @@ class LogManagerTest extends TestCase
 
         $this->assertSame('Y/m/d--test', $dateFormat->getValue($formatter));
     }
+
+    public function testLogMnagerPurgeResolvedChannels()
+    {
+        $manager = new LogManager($this->app);
+
+        $this->assertEmpty($manager->getChannels());
+
+        $manager->channel('single')->getLogger();
+
+        $this->assertCount(1, $manager->getChannels());
+
+        $manager->purge('single');
+
+        $this->assertEmpty($manager->getChannels());
+    }
 }


### PR DESCRIPTION
Backstory:

I am currently working on a little multi-tenancy project. In order for me to ease the development i did a little research and found the tenancy/tenancy origanisation was building a new package(s). Specifically tailored to my needs. It is not released yet. So I thought i might help them out with the development of it.

Motivation:

By doing some digging into their implementation of their log affect, I discovered that they are trying to delete the resolved channel/driver at runtime in order for the logging to be recreated for the same driver/channel but with different configuration keys/values.

But they currently have to recreate the entire LogManager instance as the LogManager currently does not have the ability to delete a resolved channel. I found that we have a purge method (aliased to disconnect) on the DatabaseManager. So i figured why not make it possible here as well?

This is what this pr is all about, the ability to delete a resolved log channel/driver.