### PR TITLE
[6.x] Add extra JSON assertion methods for expected value at given key

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -678,7 +678,6 @@ class TestResponse
      */
     public function assertJsonNotContains($expected, $key)
     {
-
         PHPUnit::assertNotEquals(
             $expected,
             data_get($this->json(), $key),

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -673,7 +673,7 @@ class TestResponse
      * Assert that the response JSON does not contain given value at the given key.
      *
      * @param  mixed  $expected
-     * @param  string $key
+     * @param  string  $key
      * @return $this
      */
     public function assertJsonNotContains($expected, $key)

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -655,7 +655,7 @@ class TestResponse
      * Assert that the response JSON contains the expected value at the given key.
      *
      * @param  mixed  $expected
-     * @param  string $key
+     * @param  string  $key
      * @return $this
      */
     public function assertJsonContains($expected, $key)

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -652,6 +652,43 @@ class TestResponse
     }
 
     /**
+     * Assert that the response JSON contains the expected value at the given key.
+     *
+     * @param  mixed  $expected
+     * @param  string $key
+     * @return $this
+     */
+    public function assertJsonContains($expected, $key)
+    {
+        PHPUnit::assertEquals(
+            $expected,
+            data_get($this->json(), $key),
+            "Failed to assert that the response contained the expected value at key: {$key}"
+        );
+
+        return $this;
+    }
+
+    /**
+     * Assert that the response JSON does not contain given value at the given key.
+     *
+     * @param  mixed  $expected
+     * @param  string $key
+     * @return $this
+     */
+    public function assertJsonNotContains($expected, $key)
+    {
+
+        PHPUnit::assertNotEquals(
+            $expected,
+            data_get($this->json(), $key),
+            "Failed to assert that the response does not contain the expected value at key: {$key}"
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response JSON has the expected count of items at the given key.
      *
      * @param  int  $count

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -409,6 +409,52 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonStructure(['*' => ['foo', 'bar', 'foobar']]);
     }
 
+    public function testAssertJsonContains()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonContains('bar', 'foo');
+
+        $response->assertJsonContains('foo', 'foobar.foobar_foo');
+
+        $response->assertJsonContains('foo 0', 'bars.0.bar');
+
+        $response->assertJsonContains([
+            'foobar_foo' => 'foo',
+            'foobar_bar' => 'bar',
+        ], 'foobar');
+    }
+
+    public function testAssertJsonContainsCanFail()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertJsonContains('baz', 'foo');
+    }
+
+    public function testAssertJsonNotContains()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonNotContains('baz', 'foo');
+
+        $response->assertJsonNotContains('baz', 'foobar.foobar_foo');
+
+        $response->assertJsonNotContains('baz', 'bars.0.bar');
+    }
+
+
+    public function testAssertJsonNotContainsCanFail()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $this->expectException(AssertionFailedError::class);
+
+        $response->assertJsonNotContains('bar', 'foo');
+    }
+
     public function testAssertJsonCount()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -445,7 +445,6 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonNotContains('baz', 'bars.0.bar');
     }
 
-
     public function testAssertJsonNotContainsCanFail()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
This PR adds two assertions on the `TestResponse` class: `assertJsonContains` and its inverse `assertJsonNotContains`.

These methods make it more convenient to test the value for a single key somewhere in the JSON response using dot-notation. 

Previously this required two steps, but can now be rewritten as one method call directly on the `TestResponse`:

```php
// before:
$response = $this->getJson('/api/orders')->decodeResponseJson();
$this->assertEquals('expected value', $response['payment']['provider']);

// after:
$this->getJson('/api/orders')->assertJsonContains('expected value', 'payment.provider');
```

The method names `assertJsonContains` and `assertJsonNotContains` are based on `assertStringContains`, `assertStringNotContains` and the `contains` collection helper. Any thoughts on more coherent/evident names are welcome.