### PR TITLE
[6.x] Add InteractsWithQueue to SendQueueNotifications

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -4,11 +4,12 @@ namespace Illuminate\Notifications;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
 class SendQueuedNotifications implements ShouldQueue
 {
-    use Queueable, SerializesModels;
+    use InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * The notifiable entities that should receive the notification.


### PR DESCRIPTION
This PR adds InteractsWithQueue to SendQueueNotifications.

Indeed, #30070 add ability to send notification through job middleware and classic example [`RateLimited`](https://laravel.com/docs/6.x/queues#job-middleware) cannot be used because the job cannot be released to the queue as it does not have `InteractsWithQueue`.

This could be very useful because some email providers can have rate limitation on sending email.
