### PR TITLE
[6.x] Add retryUntil to SendQueueNotifications

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -111,6 +111,20 @@ class SendQueuedNotifications implements ShouldQueue
     }
 
     /**
+     * Get the expiration for the notification.
+     *
+     * @return mixed
+     */
+    public function retryUntil()
+    {
+        if (! method_exists($this->notification, 'retryUntil') && ! isset($this->notification->timeoutAt)) {
+            return;
+        }
+
+        return $this->notification->timeoutAt ?? $this->notification->retryUntil();
+    }
+
+    /**
      * Prepare the instance for cloning.
      *
      * @return void


### PR DESCRIPTION
This PR adds ability to define the `retryUntil` or `timeoutAt` in Notification and to be passed to `SendQueueNotifications`.

I think this feature is useful if we want to control how long we try to send the notification without thinking about how many times we will try to send it, for example when the notification is sent through `RateLimited` and we want it to be sent no matter how much times we tried to.