### PR TITLE
[6.x] Strict parameter added to assertJsonPath

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -484,11 +484,16 @@ class TestResponse
      *
      * @param  string  $path
      * @param  mixed  $expect
+     * @param  bool  $strict
      * @return $this
      */
-    public function assertJsonPath($path, $expect)
+    public function assertJsonPath($path, $expect, $strict = false)
     {
-        PHPUnit::assertEquals($expect, $this->json($path));
+        if ($strict) {
+            PHPUnit::assertSame($expect, $this->json($path));
+        } else {
+            PHPUnit::assertEquals($expect, $this->json($path));
+        }
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -349,6 +349,25 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonPath('2.id', 30);
     }
 
+    public function testAssertJsonPathStrict()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPath('0.id', 10, true);
+        $response->assertJsonPath('1.id', 20, true);
+        $response->assertJsonPath('2.id', 30, true);
+    }
+
+    public function testAssertJsonPathStrictCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that 10 is identical to \'10\'.');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
+
+        $response->assertJsonPath('0.id', '10', true);
+    }
+
     public function testAssertJsonFragment()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));


### PR DESCRIPTION
Allows strict comparison when using `assertJsonPath`.

Example response data:
```json
{
    "foo": false
}
```

**The problem**
```php
$response->assertJsonPath('foo', 0); // pass
$response->assertJsonPath('foo', null); // pass
```

**The solution**
```php
$response->assertJsonPath('foo', 0, true); // fail
$response->assertJsonPath('foo', null, true); // fail
$response->assertJsonPath('foo', false, true); // pass
```
