### PR TITLE
[6.x] Fix callback return for DurationLimiter

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiter.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiter.php
@@ -87,7 +87,7 @@ class DurationLimiter
         }
 
         if (is_callable($callback)) {
-            $callback();
+            return $callback();
         }
 
         return true;

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -83,6 +83,17 @@ class DurationLimiterTest extends TestCase
         $this->assertEquals([1, 3], $store);
     }
 
+    public function testItReturnsTheCallbackResult()
+    {
+        $limiter = new DurationLimiter($this->redis(), 'key', 1, 1);
+
+        $result = $limiter->block(1, function () {
+            return 'foo';
+        });
+
+        $this->assertEquals('foo', $result);
+    }
+
     private function redis()
     {
         return $this->redis['phpredis']->connection();


### PR DESCRIPTION
The callback return value wasn't properly cascaded back as a result.

Fixes https://github.com/laravel/framework/issues/28729
