### PR TITLE
Apply limit to database rather than collection

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -75,13 +75,13 @@ class HasInDatabase extends Constraint
      */
     protected function getAdditionalInfo($table)
     {
-        $results = $this->database->table($table)->get();
+        $results = $this->database->table($table)->limit($this->show)->get();
 
         if ($results->isEmpty()) {
             return 'The table is empty';
         }
 
-        $description = 'Found: '.json_encode($results->take($this->show), JSON_PRETTY_PRINT);
+        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
 
         if ($results->count() > $this->show) {
             $description .= sprintf(' and %s others', $results->count() - $this->show);


### PR DESCRIPTION
If the following conditions are true:

* The test is using `DatabaseTransactions` rather than `RefreshDatabase`;
* There is a large dataset for the table under test;
* The `assertDatabaseHas` assertion is being used; and
* The assertion fails

The entire table is put into memory causing allowed memory fatal errors. 

This is because the `limit` is applied on a `Collection` after putting all the records in memory.

This change puts the `limit` on the database query so only the limited amount of records go into memory.

This avoids errors in tests for users and does not break any existing features.