### PR TITLE
[6.x] Add new option to filter where in laravel collection.

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -506,7 +506,7 @@ trait EnumeratesValues
 
     /**
      * Filter items by the given key value pair using strpos comparison, and insensitive case if necessary.
-     * Like as Like database query compair, without "%"
+     * Like as Like database query compair, without "%".
      * @example My factory string is "Factory - ItIsMyString", $collection->whereStrpos('denomination', 'factory', false)
      * @param  string  $key
      * @param  mixed  $value
@@ -518,6 +518,7 @@ trait EnumeratesValues
         if ($sensitive === false) {
             return $this->where($key, 'stripos', strtolower($value));
         }
+
         return $this->where($key, 'strpos', $value);
     }
 
@@ -883,8 +884,8 @@ trait EnumeratesValues
                 case '>=':  return $retrieved >= $value;
                 case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
-                case 'stripos': return (stripos($retrieved, $value) !== false);
-                case 'strpos': return (strpos($retrieved, $value) !== false);
+                case 'stripos': return stripos($retrieved, $value) !== false;
+                case 'strpos': return strpos($retrieved, $value) !== false;
             }
         };
     }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -516,7 +516,7 @@ trait EnumeratesValues
     public function whereStrpos($key, $value, $sensitive = true)
     {
         if ($sensitive === false) {
-            return $this->where($key, 'strpos_insensitive', strtolower($value));
+            return $this->where($key, 'stripos', strtolower($value));
         }
         return $this->where($key, 'strpos', $value);
     }
@@ -883,7 +883,7 @@ trait EnumeratesValues
                 case '>=':  return $retrieved >= $value;
                 case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
-                case 'strpos_insensitive': return (strpos(strtolower($retrieved), $value) !== false);
+                case 'stripos': return (stripos($retrieved, $value) !== false);
                 case 'strpos': return (strpos($retrieved, $value) !== false);
             }
         };

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -505,6 +505,23 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items by the given key value pair using strpos comparison, and insensitive case if necessary.
+     * Like as Like database query compair, without "%"
+     * @example My factory string is "Factory - ItIsMyString", $collection->whereStrpos('denomination', 'factory', false)
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  bool $sensitive
+     * @return static
+     */
+    public function whereStrpos($key, $value, $sensitive = true)
+    {
+        if ($sensitive === false) {
+            return $this->where($key, 'strpos_insensitive', strtolower($value));
+        }
+        return $this->where($key, 'strpos', $value);
+    }
+
+    /**
      * Filter items by the given key value pair.
      *
      * @param  string  $key
@@ -866,6 +883,8 @@ trait EnumeratesValues
                 case '>=':  return $retrieved >= $value;
                 case '===': return $retrieved === $value;
                 case '!==': return $retrieved !== $value;
+                case 'strpos_insensitive': return (strpos(strtolower($retrieved), $value) !== false);
+                case 'strpos': return (strpos($retrieved, $value) !== false);
             }
         };
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -648,6 +648,32 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhereStrpos($collection)
+    {
+        $c = new $collection([['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']]);
+
+        $this->assertEquals(
+            [['denomination' => 'my string has factory']],
+            $c->whereStrpos('denomination', 'factory')->values()->all()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereStrposInsensitiveCase($collection)
+    {
+        $c = new $collection([['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']]);
+
+        $this->assertEquals(
+            [['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']],
+            $c->whereStrpos('denomination', 'factory', false)->values()->all()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhereInstanceOf($collection)
     {
         $c = new $collection([new stdClass, new stdClass, new $collection, new stdClass]);


### PR DESCRIPTION
Example,
I need to make some models factories with the "denomination" field, kind of  "Factory - ".$faker->name,  so... I need to filter those ids to use in the next step. But the collection has not a filter as database "like".

I decided to make a new function that filter string in the specified field and the dev may chose if is sensitive(default) or not.

Example sensitive:
  ` $c = new $collection([['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']]);

        $this->assertEquals(
            [['denomination' => 'my string has factory']],
            $c->whereStrpos('denomination', 'factory')->values()->all()
        );`
Example insensitve:
   ` $c = new $collection([['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']]);

        $this->assertEquals(
            [['denomination' => 'my string has factory'], ['denomination' => 'my Factory came back']],
            $c->whereStrpos('denomination', 'factory', false)->values()->all()
        );`

That way the devs has a new way to search data in the collection, without do loops and array filters, only using the whereStrpos passing "sensitive = false" if they want.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
