### PR TITLE
[6.x] Remove the middleware() function from Queueable

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -121,16 +121,6 @@ trait Queueable
     }
 
     /**
-     * Get the middleware the job should be dispatched through.
-     *
-     * @return array
-     */
-    public function middleware()
-    {
-        return $this->middleware ?: [];
-    }
-
-    /**
      * Specify the middleware the job should be dispatched through.
      *
      * @param  array|object  $middleware

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -141,17 +141,10 @@ class CallQueuedHandlerTestJob
     }
 }
 
-class CallQueuedHandlerTestJobWithMiddleware
+/** This exists to test that middleware can also be defined in base classes */
+abstract class AbstractCallQueuedHandlerTestJobWithMiddleware
 {
-    use InteractsWithQueue, Queueable;
-
-    public static $handled = false;
     public static $middlewareCommand;
-
-    public function handle()
-    {
-        static::$handled = true;
-    }
 
     public function middleware()
     {
@@ -159,12 +152,24 @@ class CallQueuedHandlerTestJobWithMiddleware
             new class {
                 public function handle($command, $next)
                 {
-                    CallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = $command;
+                    AbstractCallQueuedHandlerTestJobWithMiddleware::$middlewareCommand = $command;
 
                     return $next($command);
                 }
             },
         ];
+    }
+}
+
+class CallQueuedHandlerTestJobWithMiddleware extends AbstractCallQueuedHandlerTestJobWithMiddleware
+{
+    use InteractsWithQueue, Queueable;
+
+    public static $handled = false;
+
+    public function handle()
+    {
+        static::$handled = true;
     }
 }
 


### PR DESCRIPTION
This removes the middleware() function from the `Queueable` trait.

The motivation for this change is that the implementation of the method in the trait overwrites a potential `middleware()` function of a parent class.
Given that `CallQueuedHandler::dispatchThroughMiddleware()` checks for the existence of the method before calling it, this change is made to avoid a potential regression which is extremely hard to track down.

Example:
```php
abstract class AbstractJob
{
    public function middleware()
    {
        // This function will never be executed if the child class uses the Queueable trait
        return [new MiddlewareForAllMyJobs];
    }
}

class MyJob extends AbstractJob
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    //...
}
```