### PR TITLE
[6.x] Apply limit to database rather than collection

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -75,7 +75,8 @@ class HasInDatabase extends Constraint
      */
     protected function getAdditionalInfo($table)
     {
-        $results = $this->database->table($table)->limit($this->show)->get();
+        $query = $this->database->table($table);
+        $results = $query->limit($this->show)->get();
 
         if ($results->isEmpty()) {
             return 'The table is empty';
@@ -83,8 +84,8 @@ class HasInDatabase extends Constraint
 
         $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
 
-        if ($results->count() > $this->show) {
-            $description .= sprintf(' and %s others', $results->count() - $this->show);
+        if ($query->count() > $this->show) {
+            $description .= sprintf(' and %s others', $query->count() - $this->show);
         }
 
         return $description;

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -76,6 +76,7 @@ class HasInDatabase extends Constraint
     protected function getAdditionalInfo($table)
     {
         $query = $this->database->table($table);
+
         $results = $query->limit($this->show)->get();
 
         if ($results->isEmpty()) {

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -75,13 +75,13 @@ class HasInDatabase extends Constraint
      */
     protected function getAdditionalInfo($table)
     {
-        $results = $this->database->table($table)->get();
+        $results = $this->database->table($table)->limit($this->show)->get();
 
         if ($results->isEmpty()) {
             return 'The table is empty';
         }
 
-        $description = 'Found: '.json_encode($results->take($this->show), JSON_PRETTY_PRINT);
+        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
 
         if ($results->count() > $this->show) {
             $description .= sprintf(' and %s others', $results->count() - $this->show);

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -89,6 +89,7 @@ class SoftDeletedInDatabase extends Constraint
     protected function getAdditionalInfo($table)
     {
         $query = $this->database->table($table);
+
         $results = $query->limit($this->show)->get();
 
         if ($results->isEmpty()) {

--- a/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/SoftDeletedInDatabase.php
@@ -88,16 +88,17 @@ class SoftDeletedInDatabase extends Constraint
      */
     protected function getAdditionalInfo($table)
     {
-        $results = $this->database->table($table)->get();
+        $query = $this->database->table($table);
+        $results = $query->limit($this->show)->get();
 
         if ($results->isEmpty()) {
             return 'The table is empty';
         }
 
-        $description = 'Found: '.json_encode($results->take($this->show), JSON_PRETTY_PRINT);
+        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
 
-        if ($results->count() > $this->show) {
-            $description .= sprintf(' and %s others', $results->count() - $this->show);
+        if ($query->count() > $this->show) {
+            $description .= sprintf(' and %s others', $query->count() - $this->show);
         }
 
         return $description;

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -71,10 +71,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->expectExceptionMessage('Found: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
         $builder = $this->mockCountBuilder(0);
+        $builder->shouldReceive('count')->andReturn(0, 5);
 
         $builder->shouldReceive('take')->andReturnSelf();
         $builder->shouldReceive('get')->andReturn(
-            collect(array_fill(0, 5, 'data'))
+            collect(array_fill(0, 3, 'data'))
         );
 
         $this->assertDatabaseHas($this->table, $this->data);
@@ -150,11 +151,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         $builder = m::mock(Builder::class);
 
+        $builder->shouldReceive('limit')->andReturnSelf();
+
         $builder->shouldReceive('where')->with($this->data)->andReturnSelf();
 
         $builder->shouldReceive('whereNotNull')->with($deletedAtColumn)->andReturnSelf();
 
-        $builder->shouldReceive('count')->andReturn($countResult);
+        $builder->shouldReceive('count')->andReturn($countResult)->byDefault();
 
         $this->connection->shouldReceive('table')
             ->with($this->table)


### PR DESCRIPTION
From #30144 with fixed tests

---

If the following conditions are true:

* The test is using `DatabaseTransactions` rather than `RefreshDatabase`;
* There is a large dataset for the table under test;
* The `assertDatabaseHas` assertion is being used; and
* The assertion fails

The entire table is put into memory causing allowed memory fatal errors. 

This is because the `limit` is applied on a `Collection` after putting all the records in memory.

This change puts the `limit` on the database query so only the limited amount of records go into memory.

This avoids errors in tests for users and does not break any existing features.