### PR TITLE
[6.x] Override (static) password key name

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -117,7 +117,7 @@ class EloquentUserProvider implements UserProvider
         $query = $this->newModelQuery();
 
         foreach ($credentials as $key => $value) {
-            if (Str::contains($key, 'password')) {
+            if (Str::contains($key, $query->getModel()->getPasswordKeyName())) {
                 continue;
             }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -56,7 +56,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     protected $passwordKey = 'password';
 
-
     /**
      * The "type" of the primary key ID.
      *

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -50,6 +50,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected $primaryKey = 'id';
 
     /**
+     * The password key for the model.
+     *
+     * @var string
+     */
+    protected $passwordKey = 'password';
+
+
+    /**
      * The "type" of the primary key ID.
      *
      * @var string
@@ -1326,6 +1334,29 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function setKeyName($key)
     {
         $this->primaryKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Get the password key for the model.
+     *
+     * @return string
+     */
+    public function getPasswordKeyName()
+    {
+        return $this->passwordKey;
+    }
+
+    /**
+     * Set the password key for the model.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function setPasswordKeyName($key)
+    {
+        $this->passwordKey = $key;
 
         return $this;
     }

--- a/tests/Auth/AuthEloquentUserProviderTest.php
+++ b/tests/Auth/AuthEloquentUserProviderTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Auth;
 use Illuminate\Auth\EloquentUserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Hashing\Hasher;
+use Illuminate\Database\Eloquent\Model;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -83,6 +84,9 @@ class AuthEloquentUserProviderTest extends TestCase
         $provider = $this->getProviderMock();
         $mock = m::mock(stdClass::class);
         $mock->shouldReceive('newQuery')->once()->andReturn($mock);
+        $model = m::mock(Model::class);
+        $mock->shouldReceive('getModel')->andReturn($model);
+        $model->shouldReceive('getPasswordKeyName')->andReturn('password');
         $mock->shouldReceive('where')->once()->with('username', 'dayle');
         $mock->shouldReceive('whereIn')->once()->with('group', ['one', 'two']);
         $mock->shouldReceive('first')->once()->andReturn('bar');


### PR DESCRIPTION
There was a case when I needed to make the User model store the password in a different column rather than "password", unfortunately, this column can't be changed, so to make it more dynamic, I've added a method that can be overridden, where we can specify the name of the column that stores the password, and an attribute in the User model that has a default value for that column with a value = "password"

old: `if (Str::contains($key, 'password'))`

new: `if (Str::contains($key, $query->getModel()->getPasswordKeyName()))`

the new attribute: `protected $passwordKey = 'password';`