### PR TITLE
[6.x] Add assertJsonPathStrict method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -499,6 +499,18 @@ class TestResponse
     }
 
     /**
+     * Assert that the expected value exists at the given path in the response.
+     *
+     * @param  string  $path
+     * @param  mixed  $expect
+     * @return $this
+     */
+    public function assertJsonPathStrict($path, $expect)
+    {
+        return $this->assertJsonPath($path, $expect, true);
+    }
+
+    /**
      * Assert that the response has the exact given JSON.
      *
      * @param  array  $data


### PR DESCRIPTION
Implements the suggestion of @BrandonSurowiec and @ttrig  at https://github.com/laravel/framework/pull/30142

This function is an alias of **assertJsonPath**. The tests are just the same