### PR TITLE
[6.x] Add optional connection name to DatabaseUserProvider

### DIFF
--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -66,7 +66,7 @@ trait CreatesUserProviders
      */
     protected function createDatabaseProvider($config)
     {
-        $connection = $this->app['db']->connection();
+        $connection = $this->app['db']->connection($config['connection'] ?? null);
 
         return new DatabaseUserProvider($connection, $this->app['hash'], $config['table']);
     }


### PR DESCRIPTION
Usage:

```php
// config/auth.php
'providers' => [
    'users' => [
        'driver' => 'database',
        'table' => 'users',
        'connection' => 'my_custom_connection',
    ],
],
```
There are no existing tests for this function AFAIK.