### PR TITLE
[6.x] Remove unnecessary param passed to updatePackageArray method

### DIFF
--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -37,8 +37,7 @@ class Preset
         $packages = json_decode(file_get_contents(base_path('package.json')), true);
 
         $packages[$configurationKey] = static::updatePackageArray(
-            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [],
-            $configurationKey
+            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : []
         );
 
         ksort($packages[$configurationKey]);


### PR DESCRIPTION
The `updatePackageArray` function has only one param in all classes tha use it, but the function `updatePackages` from the `Preset` class are passing two params to the parent function.