### PR TITLE
[6.x] Adds support for Container::call($callableObject)

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -136,6 +136,8 @@ class BoundMethod
     {
         if (is_string($callback) && strpos($callback, '::') !== false) {
             $callback = explode('::', $callback);
+        } elseif (is_object($callback) && !$callback instanceof Closure) {
+            $callback = [$callback, '__invoke'];
         }
 
         return is_array($callback)

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -136,7 +136,7 @@ class BoundMethod
     {
         if (is_string($callback) && strpos($callback, '::') !== false) {
             $callback = explode('::', $callback);
-        } elseif (is_object($callback) && !$callback instanceof Closure) {
+        } elseif (is_object($callback) && ! $callback instanceof Closure) {
             $callback = [$callback, '__invoke'];
         }
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -158,6 +158,15 @@ class ContainerCallTest extends TestCase
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertSame('taylor', $result[1]);
     }
+
+    public function testCallWithCallableObject()
+    {
+        $container = new Container;
+        $callable = new ContainerCallCallableStub;
+        $result = $container->call($callable);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+        $this->assertSame('jeffrey', $result[1]);
+    }
 }
 
 class ContainerTestCallStub
@@ -191,6 +200,14 @@ function containerTestInject(ContainerCallConcreteStub $stub, $default = 'taylor
 class ContainerStaticMethodStub
 {
     public static function inject(ContainerCallConcreteStub $stub, $default = 'taylor')
+    {
+        return func_get_args();
+    }
+}
+
+class ContainerCallCallableStub
+{
+    public function __invoke(ContainerCallConcreteStub $stub, $default = 'jeffrey')
     {
         return func_get_args();
     }


### PR DESCRIPTION
Adds support for callable objects in `Container::call`:

```php
class CallMe {
  public function __invoke(stdClass $dependency) {
    return $dependency;
  }
}

app()->call(new CallMe); // currently would fail
```