### PR TITLE
[5.8] Fix: FormRequest: Call to a member function validated() on null

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -185,7 +185,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      */
     public function validated()
     {
-        return $this->validator->validated();
+        return $this->getValidatorInstance()->validated();
     }
 
     /**


### PR DESCRIPTION
In normal case app will call `FormRequest::validateResolved()` and this method will create a new instance of validator. **But** when you create/mock `FormRequest` by hand (in our case we need a mock for tests) the `validateResolved()` will not be called -> `FormRequest::$validator` will be `null` => `$request->validated()` will fail: "Call to a member function validated() on null". 

This PR fixes this.