### PR TITLE
Changing User class on make:policy stub

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -43,7 +43,7 @@ class PolicyMakeCommand extends GeneratorCommand
 
         return $model ? $this->replaceModel($stub, $model) : $stub;
     }
-    
+
     /**
      * Replace the model for the given stub.
      *

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -37,36 +37,13 @@ class PolicyMakeCommand extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $stub = $this->replaceUserNamespace(
-            parent::buildClass($name)
-        );
+        $stub = parent::buildClass($name);
 
         $model = $this->option('model');
 
         return $model ? $this->replaceModel($stub, $model) : $stub;
     }
-
-    /**
-     * Replace the User model namespace.
-     *
-     * @param  string  $stub
-     * @return string
-     */
-    protected function replaceUserNamespace($stub)
-    {
-        $model = $this->userProviderModel();
-
-        if (! $model) {
-            return $stub;
-        }
-
-        return str_replace(
-            $this->rootNamespace().'User',
-            $model,
-            $stub
-        );
-    }
-
+    
     /**
      * Replace the model for the given stub.
      *
@@ -92,8 +69,6 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $model = class_basename(trim($model, '\\'));
 
-        $dummyUser = class_basename($this->userProviderModel());
-
         $dummyModel = Str::camel($model) === 'user' ? 'model' : $model;
 
         $stub = str_replace('DocDummyModel', Str::snake($dummyModel, ' '), $stub);
@@ -101,8 +76,6 @@ class PolicyMakeCommand extends GeneratorCommand
         $stub = str_replace('DummyModel', $model, $stub);
 
         $stub = str_replace('dummyModel', Str::camel($dummyModel), $stub);
-
-        $stub = str_replace('DummyUser', $dummyUser, $stub);
 
         return str_replace('DocDummyPluralModel', Str::snake(Str::pluralStudly($dummyModel), ' '), $stub);
     }

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -4,7 +4,7 @@ namespace DummyNamespace;
 
 use Illuminate\Auth\Access\HandlesAuthorization;
 use NamespacedDummyModel;
-use NamespacedDummyUserModel;
+use Illuminate\Foundation\Auth\User;
 
 class DummyClass
 {
@@ -13,10 +13,10 @@ class DummyClass
     /**
      * Determine whether the user can view any DocDummyPluralModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @return mixed
      */
-    public function viewAny(DummyUser $user)
+    public function viewAny(User $user)
     {
         //
     }
@@ -24,11 +24,11 @@ class DummyClass
     /**
      * Determine whether the user can view the DocDummyModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function view(DummyUser $user, DummyModel $dummyModel)
+    public function view(User $user, DummyModel $dummyModel)
     {
         //
     }
@@ -36,10 +36,10 @@ class DummyClass
     /**
      * Determine whether the user can create DocDummyPluralModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @return mixed
      */
-    public function create(DummyUser $user)
+    public function create(User $user)
     {
         //
     }
@@ -47,11 +47,11 @@ class DummyClass
     /**
      * Determine whether the user can update the DocDummyModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function update(DummyUser $user, DummyModel $dummyModel)
+    public function update(User $user, DummyModel $dummyModel)
     {
         //
     }
@@ -59,11 +59,11 @@ class DummyClass
     /**
      * Determine whether the user can delete the DocDummyModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function delete(DummyUser $user, DummyModel $dummyModel)
+    public function delete(User $user, DummyModel $dummyModel)
     {
         //
     }
@@ -71,11 +71,11 @@ class DummyClass
     /**
      * Determine whether the user can restore the DocDummyModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function restore(DummyUser $user, DummyModel $dummyModel)
+    public function restore(User $user, DummyModel $dummyModel)
     {
         //
     }
@@ -83,11 +83,11 @@ class DummyClass
     /**
      * Determine whether the user can permanently delete the DocDummyModel.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \Illuminate\Foundation\Auth\User  $user
      * @param  \NamespacedDummyModel  $dummyModel
      * @return mixed
      */
-    public function forceDelete(DummyUser $user, DummyModel $dummyModel)
+    public function forceDelete(User $user, DummyModel $dummyModel)
     {
         //
     }


### PR DESCRIPTION
Instead of stubbing out the  (typically) \App\User-model for typehints on the make:policy command, this PR changes this to be using the \Illuminate\Foundation\Auth\User-class.

Not a breaking change as it only applies to *new* policies being created from the console command.

Reason:
a) the default app's User-model extends from \Illuminate\Foundation\Auth\User anyhow
b) [main reason for the PR] :  when different "authenticatable" models are used (*) methods of the new policy will match the type of the $user parameter.

(*) for example a Staff or an Admin-model used from their resp. Guards