### PR TITLE
[6.x] Add new data_unset helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -234,7 +234,7 @@ if (! function_exists('data_set')) {
     }
 }
 
-if (!function_exists('data_unset')) {
+if (! function_exists('data_unset')) {
     /**
      * Unset an item on an array or object using dot notation.
      *
@@ -247,7 +247,7 @@ if (!function_exists('data_unset')) {
         $segments = is_array($key) ? $key : explode('.', $key);
 
         if (($segment = array_shift($segments)) === '*') {
-            if (!Arr::accessible($target)) {
+            if (! Arr::accessible($target)) {
                 $target = [];
             }
 
@@ -262,7 +262,7 @@ if (!function_exists('data_unset')) {
             }
         } elseif (Arr::accessible($target)) {
             if ($segments) {
-                if (!Arr::exists($target, $segment)) {
+                if (! Arr::exists($target, $segment)) {
                     $target[$segment] = [];
                 }
 
@@ -272,7 +272,7 @@ if (!function_exists('data_unset')) {
             }
         } elseif (is_object($target)) {
             if ($segments) {
-                if (!isset($target->{$segment})) {
+                if (! isset($target->{$segment})) {
                     $target->{$segment} = [];
                 }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -234,6 +234,66 @@ if (! function_exists('data_set')) {
     }
 }
 
+if (!function_exists('data_unset')) {
+    /**
+     * Unset an item on an array or object using dot notation.
+     *
+     * @param mixed $target
+     * @param string|array $key
+     * @return mixed
+     */
+    function data_unset(&$target, $key)
+    {
+        $segments = is_array($key) ? $key : explode('.', $key);
+
+        if (($segment = array_shift($segments)) === '*') {
+            if (!Arr::accessible($target)) {
+                $target = [];
+            }
+
+            if ($segments) {
+                foreach ($target as &$inner) {
+                    data_unset($inner, $segments);
+                }
+            } else {
+                foreach ($target as $key => $_) {
+                    unset($target[$key]);
+                }
+            }
+        } elseif (Arr::accessible($target)) {
+            if ($segments) {
+                if (!Arr::exists($target, $segment)) {
+                    $target[$segment] = [];
+                }
+
+                data_unset($target[$segment], $segments);
+            } else {
+                unset($target[$segment]);
+            }
+        } elseif (is_object($target)) {
+            if ($segments) {
+                if (!isset($target->{$segment})) {
+                    $target->{$segment} = [];
+                }
+
+                data_unset($target->{$segment}, $segments);
+            } else {
+                unset($target->{$segment});
+            }
+        } else {
+            $target = [];
+
+            if ($segments) {
+                data_unset($target[$segment], $segments);
+            } else {
+                unset($target[$segment]);
+            }
+        }
+
+        return $target;
+    }
+}
+
 if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -309,6 +309,191 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
+    public function dataUnsetTestDataProvider() {
+        return [
+            // dataset 0
+            [
+                'baz',
+                [
+                    'foo' => [
+                        'bar' => 'boom',
+                        'baz' => 'noop',
+                    ]
+                ],
+            ],
+            // dataset 1
+            [
+                'baz.bar',
+                [
+                    'foo' => [
+                        'bar' => 'boom',
+                        'baz' => 'noop',
+                    ],
+                    'baz' => []
+                ],
+            ],
+            // dataset 2
+            [
+                'foo.*',
+                [
+                    'foo' => [
+                    ],
+                    'baz' => [
+                        'bar' => [
+                            'boom' => ['kaboom' => 'boom'],
+                            'buz' => ['kaboom' => 'noop']
+                        ]
+                    ]
+                ],
+            ],
+            // dataset 3
+            [
+                'foo.bar',
+                [
+                    'foo' => [
+                        'baz' => 'noop',
+                    ],
+                    'baz' => [
+                        'bar' => [
+                            'boom' => ['kaboom' => 'boom'],
+                            'buz' => ['kaboom' => 'noop']
+                        ]
+                    ]
+                ],
+            ],
+            // dataset 4
+            [
+                'baz.bar',
+                [
+                    'foo' => [
+                        'bar' => 'boom',
+                        'baz' => 'noop',
+                    ],
+                    'baz' => [
+                    ]
+                ],
+            ],
+            // dataset 5
+            [
+                'baz.bar.boom.kaboom',
+                [
+                    'foo' => [
+                        'bar' => 'boom',
+                        'baz' => 'noop',
+                    ],
+                    'baz' => [
+                        'bar' => [
+                            'boom' => [],
+                            'buz' => ['kaboom' => 'noop']
+                        ]
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataUnsetTestDataProvider
+     * @param string $expression
+     * @param array $expected
+     */
+    public function testDataUnset($expression, array $expected)
+    {
+        $data = [
+            'foo' => [
+                'bar' => 'boom',
+                'baz' => 'noop',
+            ],
+            'baz' => [
+                'bar' => [
+                    'boom' => ['kaboom' => 'boom'],
+                    'buz' => ['kaboom' => 'noop']
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            data_unset($data, $expression)
+        );
+    }
+
+    public function testDataUnsetWithStar()
+    {
+        $data = [
+            'foo' => [
+                'bar' => [
+                    'baz' => ['kaboom' => 'boom'],
+                    'buz' => ['kaboom' => 'boom']
+                ],
+                'baz' => [
+                    'baz' => ['kaboom' => 'boom'],
+                    'buz' => ['kaboom' => 'boom']
+                ]
+            ],
+        ];
+
+        $this->assertEquals(
+            [
+                'foo' => [
+                    'bar' => [
+                        'buz' => ['kaboom' => 'boom']
+                    ],
+                    'baz' => [
+                        'buz' => ['kaboom' => 'boom']
+                    ]
+                ],
+            ],
+            data_unset($data, 'foo.*.baz')
+        );
+
+        $this->assertEquals(
+            [
+                'foo' => [],
+            ],
+            data_unset($data, 'foo.*')
+        );
+    }
+
+    public function testDataUnsetWithDoubleStar()
+    {
+        $data = [
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'First', 'text' => 'Hi'],
+                        (object) ['name' => 'Second', 'text' => 'Hello'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['name' => 'Third', 'text' => 'Nice to meet you'],
+                        (object) ['name' => 'Fourth', 'text' => 'Wag1'],
+                    ],
+                ],
+            ],
+        ];
+
+        data_unset($data, 'posts.*.comments.*.name');
+
+        $this->assertEquals([
+            'posts' => [
+                (object) [
+                    'comments' => [
+                        (object) ['text' => 'Hi'],
+                        (object) ['text' => 'Hello'],
+                    ],
+                ],
+                (object) [
+                    'comments' => [
+                        (object) ['text' => 'Nice to meet you'],
+                        (object) ['text' => 'Wag1'],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+
     public function testHead()
     {
         $array = ['a', 'b', 'c'];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -309,7 +309,8 @@ class SupportHelpersTest extends TestCase
         ], $data);
     }
 
-    public function dataUnsetTestDataProvider() {
+    public function dataUnsetTestDataProvider()
+    {
         return [
             // dataset 0
             [
@@ -318,7 +319,7 @@ class SupportHelpersTest extends TestCase
                     'foo' => [
                         'bar' => 'boom',
                         'baz' => 'noop',
-                    ]
+                    ],
                 ],
             ],
             // dataset 1
@@ -329,7 +330,7 @@ class SupportHelpersTest extends TestCase
                         'bar' => 'boom',
                         'baz' => 'noop',
                     ],
-                    'baz' => []
+                    'baz' => [],
                 ],
             ],
             // dataset 2
@@ -341,9 +342,9 @@ class SupportHelpersTest extends TestCase
                     'baz' => [
                         'bar' => [
                             'boom' => ['kaboom' => 'boom'],
-                            'buz' => ['kaboom' => 'noop']
-                        ]
-                    ]
+                            'buz' => ['kaboom' => 'noop'],
+                        ],
+                    ],
                 ],
             ],
             // dataset 3
@@ -356,9 +357,9 @@ class SupportHelpersTest extends TestCase
                     'baz' => [
                         'bar' => [
                             'boom' => ['kaboom' => 'boom'],
-                            'buz' => ['kaboom' => 'noop']
-                        ]
-                    ]
+                            'buz' => ['kaboom' => 'noop'],
+                        ],
+                    ],
                 ],
             ],
             // dataset 4
@@ -370,7 +371,7 @@ class SupportHelpersTest extends TestCase
                         'baz' => 'noop',
                     ],
                     'baz' => [
-                    ]
+                    ],
                 ],
             ],
             // dataset 5
@@ -384,9 +385,9 @@ class SupportHelpersTest extends TestCase
                     'baz' => [
                         'bar' => [
                             'boom' => [],
-                            'buz' => ['kaboom' => 'noop']
-                        ]
-                    ]
+                            'buz' => ['kaboom' => 'noop'],
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -407,9 +408,9 @@ class SupportHelpersTest extends TestCase
             'baz' => [
                 'bar' => [
                     'boom' => ['kaboom' => 'boom'],
-                    'buz' => ['kaboom' => 'noop']
-                ]
-            ]
+                    'buz' => ['kaboom' => 'noop'],
+                ],
+            ],
         ];
 
         $this->assertEquals(
@@ -424,12 +425,12 @@ class SupportHelpersTest extends TestCase
             'foo' => [
                 'bar' => [
                     'baz' => ['kaboom' => 'boom'],
-                    'buz' => ['kaboom' => 'boom']
+                    'buz' => ['kaboom' => 'boom'],
                 ],
                 'baz' => [
                     'baz' => ['kaboom' => 'boom'],
-                    'buz' => ['kaboom' => 'boom']
-                ]
+                    'buz' => ['kaboom' => 'boom'],
+                ],
             ],
         ];
 
@@ -437,11 +438,11 @@ class SupportHelpersTest extends TestCase
             [
                 'foo' => [
                     'bar' => [
-                        'buz' => ['kaboom' => 'boom']
+                        'buz' => ['kaboom' => 'boom'],
                     ],
                     'baz' => [
-                        'buz' => ['kaboom' => 'boom']
-                    ]
+                        'buz' => ['kaboom' => 'boom'],
+                    ],
                 ],
             ],
             data_unset($data, 'foo.*.baz')


### PR DESCRIPTION
This is the modification of the data_set function.

At the moment we have 3 data_* helpers:
`data_fill(&$target, $key, $value)`
`data_get($target, $key, $default = null)`
`data_set(&$target, $key, $value, $overwrite = true)`

We can create, update and receive items of array or objects using dot notation, but we still can't remove items with that style. I want to introduce new `data_unset(&$target, $key)` helper, which will cover this disadvantage. 

It was needed in one of my projects and i'm sure that it will be useful for many people.


