### PR TITLE
[6.x] Add test for sorted middlewares

### DIFF
--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -44,10 +44,24 @@ class RoutingSortedMiddlewareTest extends TestCase
         $this->assertEquals([], (new SortedMiddleware(['First'], []))->all());
         $this->assertEquals(['First'], (new SortedMiddleware(['First'], ['First']))->all());
         $this->assertEquals(['First', 'Second'], (new SortedMiddleware(['First', 'Second'], ['Second', 'First']))->all());
+    }
 
+    public function testItDoesNotMoveNonStringValues()
+    {
         $closure = function () {
-            //
+            return 'foo';
         };
+
+        $closure2 = function () {
+            return 'bar';
+        };
+
+        $this->assertEquals([2, 1], (new SortedMiddleware([1, 2], [2, 1]))->all());
         $this->assertEquals(['Second', $closure], (new SortedMiddleware(['First', 'Second'], ['Second', $closure]))->all());
+        $this->assertEquals(['a', 'b', $closure], (new SortedMiddleware(['a', 'b'], ['b', $closure, 'a']))->all());
+        $this->assertEquals([$closure2, 'a', 'b', $closure, 'foo'], (new SortedMiddleware(['a', 'b'], [$closure2, 'b', $closure, 'a', 'foo']))->all());
+        $this->assertEquals([$closure, 'a', 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], [$closure, 'b', $closure2, 'foo', 'a']))->all());
+        $this->assertEquals(['a', $closure, 'b', $closure2, 'foo'], (new SortedMiddleware(['a', 'b'], ['a', $closure, 'b', $closure2, 'foo']))->all());
+        $this->assertEquals([$closure, $closure2, 'foo', 'a'], (new SortedMiddleware(['a', 'b'], [$closure, $closure2, 'foo', 'a']))->all());
     }
 }


### PR DESCRIPTION
It seems the test coverage for non string values in arrays is somewhat loosely tested so I added a few more cases.
