### PR TITLE
[6.x] Remove brackets arround URL php artisan serve

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -42,7 +42,7 @@ class ServeCommand extends Command
     {
         chdir(public_path());
 
-        $this->line("<info>Laravel development server started:</info> <http://{$this->host()}:{$this->port()}>");
+        $this->line("<info>Laravel development server started:</info> http://{$this->host()}:{$this->port()}");
 
         passthru($this->serverCommand(), $status);
 


### PR DESCRIPTION
To allow opening the development URL in Visual Studio Code with ctrl + click the bracket after the URL needs to be removed.
This patch wil remove the brackets around the url for allowing the link to work in the terminal.