### PR TITLE
[6.x] Alternative API for registering mutators and accessors

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -95,25 +95,25 @@ trait HasAttributes
     protected static $setMutators = [];
 
     /**
-     * Register a new "get" mutator on the class.
+     * Register a new "get" mutator (or accessor) on the class.
      *
-     * @param string $key
+     * @param string   $attribute
      * @param \Closure $accessor
      */
-    public static function registerAccessor($key, Closure $accessor)
+    public static function registerAccessor($attribute, Closure $accessor)
     {
-        static::$getMutators[static::class][$key] = $accessor;
+        static::$getMutators[static::class][$attribute] = $accessor;
     }
 
     /**
      * Register a new "set" mutator on the class.
      *
-     * @param string $key
+     * @param string   $attribute
      * @param \Closure $mutator
      */
-    public static function registerMutator($key, Closure $mutator)
+    public static function registerMutator($attribute, Closure $mutator)
     {
-        static::$setMutators[static::class][$key] = $mutator;
+        static::$setMutators[static::class][$attribute] = $mutator;
     }
 
     /**
@@ -662,7 +662,7 @@ trait HasAttributes
         if (method_exists($this, $method = 'set'.Str::studly($key).'Attribute')) {
             return $this->{$method}($value);
         }
-    
+
         return static::$setMutators[static::class][$key]->call($this, $value, $key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -507,7 +507,7 @@ trait HasAttributes
             ));
         }
         
-        return static::$getMutators[static::class][$key]->call($this, $value);
+        return static::$getMutators[static::class][$key]->call($this, $value, $key);
     }
 
     /**
@@ -691,7 +691,7 @@ trait HasAttributes
             ));
         }
         
-        return static::$setMutators[static::class][$key]->call($this, $value);
+        return static::$setMutators[static::class][$key]->call($this, $value, $key);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1308,26 +1308,13 @@ trait HasAttributes
      */
     public static function cacheMutatedAttributes($class)
     {
-        static::registerAllGetMutatorMethods($class);
-        
-        static::$mutatorCache[$class] = array_keys(static::$getMutators[static::class] ?? []);
-    }
-    
-    /**
-     * Register all get*Attribute methods.
-     *
-     * @param string $class
-     */
-    protected static function registerAllGetMutatorMethods($class)
-    {
-        collect(static::getMutatorMethods($class))
-            ->each(function($matches) {
-                [$method, $attribute] = $matches;
-                $key = lcfirst(static::$snakeAttributes ? Str::snake($attribute) : $attribute);
-                static::registerGetMutator($key, function($key) use ($method) {
-                    return $this->{$method}($key);
-                });
-            });
+        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))
+            ->map(function ($match) {
+                return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
+            })
+            ->merge(array_keys(static::$getMutators[static::class] ?? []))
+            ->unique()
+            ->all();
     }
 
     /**
@@ -1340,6 +1327,6 @@ trait HasAttributes
     {
         preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches);
 
-        return $matches;
+        return $matches[1];
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -476,19 +476,8 @@ trait HasAttributes
      */
     public function hasGetMutator($key)
     {
-        if (isset(static::$getMutators[static::class][$key])) {
-            return true;
-        }
-
-        if (method_exists($this, $method = 'get'.Str::studly($key).'Attribute')) {
-            static::registerAccessor($key, function ($key) use ($method) {
-                return $this->{$method}($key);
-            });
-
-            return true;
-        }
-
-        return false;
+        return isset(static::$getMutators[static::class][$key])
+            || method_exists($this, 'get'.Str::studly($key).'Attribute');
     }
 
     /**
@@ -497,15 +486,11 @@ trait HasAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @return mixed
-     *
-     * @throws \LogicException
      */
     protected function mutateAttribute($key, $value)
     {
-        if (! $this->hasGetMutator($key)) {
-            throw new LogicException(sprintf(
-                'There is no mutator registered for getting %s::$%s.', static::class, $key
-            ));
+        if (method_exists($this, $method = 'get'.Str::studly($key).'Attribute')) {
+            return $this->{$method}($value);
         }
 
         return static::$getMutators[static::class][$key]->call($this, $value, $key);
@@ -661,19 +646,8 @@ trait HasAttributes
      */
     public function hasSetMutator($key)
     {
-        if (isset(static::$setMutators[static::class][$key])) {
-            return true;
-        }
-
-        if (method_exists($this, $method = 'set'.Str::studly($key).'Attribute')) {
-            static::registerMutator($key, function ($key) use ($method) {
-                return $this->{$method}($key);
-            });
-
-            return true;
-        }
-
-        return false;
+        return isset(static::$setMutators[static::class][$key])
+            || method_exists($this, 'set'.Str::studly($key).'Attribute');
     }
 
     /**
@@ -682,17 +656,13 @@ trait HasAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @return mixed
-     *
-     * @throws \LogicException
      */
     protected function setMutatedAttributeValue($key, $value)
     {
-        if (! $this->hasSetMutator($key)) {
-            throw new LogicException(sprintf(
-                'There is no mutator registered for setting %s::$%s.', static::class, $key
-            ));
+        if (method_exists($this, $method = 'set'.Str::studly($key).'Attribute')) {
+            return $this->{$method}($value);
         }
-
+    
         return static::$setMutators[static::class][$key]->call($this, $value, $key);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -81,7 +81,7 @@ trait HasAttributes
     protected static $mutatorCache = [];
 
     /**
-     * Mutators that are applied when retrieving an attribute.
+     * "Accessors" - or mutators that are applied when retrieving an attribute.
      *
      * @var array
      */
@@ -98,11 +98,11 @@ trait HasAttributes
      * Register a new "get" mutator on the class.
      *
      * @param string $key
-     * @param \Closure $mutator
+     * @param \Closure $accessor
      */
-    public static function registerGetMutator($key, Closure $mutator)
+    public static function registerAccessor($key, Closure $accessor)
     {
-        static::$getMutators[static::class][$key] = $mutator;
+        static::$getMutators[static::class][$key] = $accessor;
     }
 
     /**
@@ -111,7 +111,7 @@ trait HasAttributes
      * @param string $key
      * @param \Closure $mutator
      */
-    public static function registerSetMutator($key, Closure $mutator)
+    public static function registerMutator($key, Closure $mutator)
     {
         static::$setMutators[static::class][$key] = $mutator;
     }
@@ -481,7 +481,7 @@ trait HasAttributes
         }
 
         if (method_exists($this, $method = 'get'.Str::studly($key).'Attribute')) {
-            static::registerGetMutator($key, function ($key) use ($method) {
+            static::registerAccessor($key, function ($key) use ($method) {
                 return $this->{$method}($key);
             });
 
@@ -666,7 +666,7 @@ trait HasAttributes
         }
 
         if (method_exists($this, $method = 'set'.Str::studly($key).'Attribute')) {
-            static::registerSetMutator($key, function ($key) use ($method) {
+            static::registerMutator($key, function ($key) use ($method) {
                 return $this->{$method}($key);
             });
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -79,21 +79,21 @@ trait HasAttributes
      * @var array
      */
     protected static $mutatorCache = [];
-    
+
     /**
      * Mutators that are applied when retrieving an attribute.
      *
      * @var array
      */
     protected static $getMutators = [];
-    
+
     /**
      * Mutators that are applied when setting an attribute.
      *
      * @var array
      */
     protected static $setMutators = [];
-    
+
     /**
      * Register a new "get" mutator on the class.
      *
@@ -104,7 +104,7 @@ trait HasAttributes
     {
         static::$getMutators[static::class][$key] = $mutator;
     }
-    
+
     /**
      * Register a new "set" mutator on the class.
      *
@@ -479,14 +479,15 @@ trait HasAttributes
         if (isset(static::$getMutators[static::class][$key])) {
             return true;
         }
-    
+
         if (method_exists($this, $method = 'get'.Str::studly($key).'Attribute')) {
-            static::registerGetMutator($key, function($key) use ($method) {
+            static::registerGetMutator($key, function ($key) use ($method) {
                 return $this->{$method}($key);
             });
+
             return true;
         }
-        
+
         return false;
     }
 
@@ -501,12 +502,12 @@ trait HasAttributes
      */
     protected function mutateAttribute($key, $value)
     {
-        if (!$this->hasGetMutator($key)) {
+        if (! $this->hasGetMutator($key)) {
             throw new LogicException(sprintf(
                 'There is no mutator registered for getting %s::$%s.', static::class, $key
             ));
         }
-        
+
         return static::$getMutators[static::class][$key]->call($this, $value, $key);
     }
 
@@ -663,14 +664,15 @@ trait HasAttributes
         if (isset(static::$setMutators[static::class][$key])) {
             return true;
         }
-    
+
         if (method_exists($this, $method = 'set'.Str::studly($key).'Attribute')) {
-            static::registerSetMutator($key, function($key) use ($method) {
+            static::registerSetMutator($key, function ($key) use ($method) {
                 return $this->{$method}($key);
             });
+
             return true;
         }
-    
+
         return false;
     }
 
@@ -685,12 +687,12 @@ trait HasAttributes
      */
     protected function setMutatedAttributeValue($key, $value)
     {
-        if (!$this->hasSetMutator($key)) {
+        if (! $this->hasSetMutator($key)) {
             throw new LogicException(sprintf(
                 'There is no mutator registered for setting %s::$%s.', static::class, $key
             ));
         }
-        
+
         return static::$setMutators[static::class][$key]->call($this, $value, $key);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -50,7 +50,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         Model::unsetEventDispatcher();
         Carbon::resetToStringFormat();
-        
+
         EloquentModelDynamicMutatorsStub::resetMutators();
     }
 
@@ -1501,37 +1501,37 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelGetMutatorsStub::$snakeAttributes = false;
         $this->assertEquals(['firstName', 'middleName', 'lastName'], $model->getMutatedAttributes());
     }
-    
+
     public function testDynamicallyDefinedMutatedAttributes()
     {
-        EloquentModelDynamicMutatorsStub::registerGetMutator('get_snake', function($value) {
+        EloquentModelDynamicMutatorsStub::registerGetMutator('get_snake', function ($value) {
             return 'snake-cased attribute';
         });
-    
-        EloquentModelDynamicMutatorsStub::registerSetMutator('set_snake', function($value) {
+
+        EloquentModelDynamicMutatorsStub::registerSetMutator('set_snake', function ($value) {
             $this->attributes['set_snake'] = 'snake-cased attribute';
         });
-    
+
         $model = new EloquentModelDynamicMutatorsStub;
         $model->set_snake = 'foo';
-        
+
         $this->assertEquals('snake-cased attribute', $model->get_snake);
         $this->assertEquals('snake-cased attribute', $model->getAttributes()['set_snake']);
-        
+
         EloquentModelDynamicMutatorsStub::resetMutators();
         EloquentModelDynamicMutatorsStub::$snakeAttributes = false;
-    
-        EloquentModelDynamicMutatorsStub::registerGetMutator('getCamel', function($value) {
+
+        EloquentModelDynamicMutatorsStub::registerGetMutator('getCamel', function ($value) {
             return 'camel-cased attribute';
         });
-    
-        EloquentModelDynamicMutatorsStub::registerSetMutator('setCamel', function($value) {
+
+        EloquentModelDynamicMutatorsStub::registerSetMutator('setCamel', function ($value) {
             $this->attributes['setCamel'] = 'camel-cased attribute';
         });
-    
+
         $model = new EloquentModelDynamicMutatorsStub;
         $model->setCamel = 'foo';
-    
+
         $this->assertEquals('camel-cased attribute', $model->getCamel);
         $this->assertEquals('camel-cased attribute', $model->getAttributes()['setCamel']);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2237,7 +2237,6 @@ class EloquentModelGetMutatorsStub extends Model
     public static function resetMutatorCache()
     {
         static::$mutatorCache = [];
-        static::$getMutators = [];
     }
 
     public function getFirstNameAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2237,6 +2237,7 @@ class EloquentModelGetMutatorsStub extends Model
     public static function resetMutatorCache()
     {
         static::$mutatorCache = [];
+        static::$getMutators = [];
     }
 
     public function getFirstNameAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1536,6 +1536,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals('camel-cased attribute', $model->getAttributes()['setCamel']);
     }
 
+    public function testClassMutatorsAndAccessorsTakePrecedence()
+    {
+        EloquentModelDynamicMutatorsStub::registerAccessor('class_accessor', function ($value) {
+            return 'via dynamic accessor';
+        });
+
+        EloquentModelDynamicMutatorsStub::registerMutator('class_mutator', function ($value) {
+            $this->attributes['class_mutator'] = 'via dynamic mutator';
+        });
+
+        $model = new EloquentModelDynamicMutatorsStub;
+        $model->class_mutator = 'foo';
+
+        $this->assertEquals('via class accessor', $model->class_accessor);
+        $this->assertEquals('via class mutator', $model->getAttributes()['class_mutator']);
+    }
+
     public function testReplicateCreatesANewModelInstanceWithSameAttributeValues()
     {
         $model = new EloquentModelStub;
@@ -2318,6 +2335,16 @@ class EloquentModelDynamicMutatorsStub extends Model
         static::$mutatorCache = [];
         static::$getMutators = [];
         static::$setMutators = [];
+    }
+
+    protected function getClassAccessorAttribute()
+    {
+        return 'via class accessor';
+    }
+
+    protected function setClassMutatorAttribute()
+    {
+        $this->attributes['class_mutator'] = 'via class mutator';
     }
 }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1504,11 +1504,11 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testDynamicallyDefinedMutatedAttributes()
     {
-        EloquentModelDynamicMutatorsStub::registerGetMutator('get_snake', function ($value) {
+        EloquentModelDynamicMutatorsStub::registerAccessor('get_snake', function ($value) {
             return 'snake-cased attribute';
         });
 
-        EloquentModelDynamicMutatorsStub::registerSetMutator('set_snake', function ($value) {
+        EloquentModelDynamicMutatorsStub::registerMutator('set_snake', function ($value) {
             $this->attributes['set_snake'] = 'snake-cased attribute';
         });
 
@@ -1521,11 +1521,11 @@ class DatabaseEloquentModelTest extends TestCase
         EloquentModelDynamicMutatorsStub::resetMutators();
         EloquentModelDynamicMutatorsStub::$snakeAttributes = false;
 
-        EloquentModelDynamicMutatorsStub::registerGetMutator('getCamel', function ($value) {
+        EloquentModelDynamicMutatorsStub::registerAccessor('getCamel', function ($value) {
             return 'camel-cased attribute';
         });
 
-        EloquentModelDynamicMutatorsStub::registerSetMutator('setCamel', function ($value) {
+        EloquentModelDynamicMutatorsStub::registerMutator('setCamel', function ($value) {
             $this->attributes['setCamel'] = 'camel-cased attribute';
         });
 


### PR DESCRIPTION
Currently, the only way to define mutators and accessors is via the `getFooAttribute()` and `setFooAttribute()` naming convention. This means that it's impossible to dynamically register a mutator and it makes it more cumbersome to re-use logic. There are often times when it would be helpful to use the same mutation logic in different classes—for example, when working with UUIDs that are stored as binary in the database, or monetary values.

### A concrete example of the problem this solves:

We always store monetary values in the database as the currency’s smallest unit. For example, an event may have a registration fee stored as `registration_fee_cents`. We re-use this pattern in many places—a `cents` column on our billing plan, or on a billing transaction record.

Because of this, we **nearly always** have to do `$cents / 100` and `$dollars * 100` calculations, as most people want to see dollars. This results in `getRegistrationFeeDollars()` and `getPlanDollars()` and `getTransactionAmountDollars()` methods peppered throughout the code base that all do exactly the same thing.

### How this addresses the problem:

This PR introduces two new `Model` methods:

 - `public static function registerAccessor($attribute, Closure $accessor)`
 - `public static function registerMutator($attribute, Closure $mutator)`

This allows for dynamically defining mutators and accessors, and reusing mutation code. For example:

```php
trait MutatesCents
{
    protected static function registerCentMutator($cent_attribute, $dollar_attribute)
    {
        static::registerAccessor($dollar_attribute, function() use ($cent_attribute) {
            return $this->getAttribute($cent_attribute) / 100;
        });

        static::registerMutator($dollar_attribute, function($value) use ($cent_attribute) {
            $this->attributes[$cent_attribute] = $value * 100;
        });
    }
}

class MeetupEvent extends Model
{
    use MutatesCents;
    
    protected static function boot()
    {
        parent::boot();
        
        static::registerCentMutator('registration_fee_cents', 'registration_fee_dollars');
        static::registerCentMutator('admin_fee_cents', 'admin_fee_dollars');
    }
}

$event = new MeetupEvent([
    'registration_fee_cents' => 10000,
]);

assert($event->registration_fee_dollars === 100.00);

$event->registration_fee_dollars = 99.99;
assert($event->registration_fee_cents === 9999);
```