### PR TITLE
[6.x] Move creating the migration after the controller in `make:model`

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -93,6 +93,8 @@ class MigrateMakeCommand extends BaseCommand
         // make sure that the migrations are registered by the class loaders.
         $this->writeMigration($name, $table, $create);
 
+        $this->line('<info>Dumping Composer autoload</info>');
+
         $this->composer->dumpAutoloads();
     }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -51,12 +51,12 @@ class ModelMakeCommand extends GeneratorCommand
             $this->createFactory();
         }
 
-        if ($this->option('migration')) {
-            $this->createMigration();
-        }
-
         if ($this->option('controller') || $this->option('resource')) {
             $this->createController();
+        }
+
+        if ($this->option('migration')) {
+            $this->createMigration();
         }
     }
 


### PR DESCRIPTION
This pull request relates to the issue I made #30174

**Changes:**
- moves creating migration in `make:model` artisan command to last as dumping autoload takes forever and holds up creating controller if that option was selected.
- adds info console log stating that composer autoload is being dumped after the migration was created.

**Benefits:**
- The developer won't have to wait for a lengthy composer autoload dump to start modifying and playing around with the controller. The current status quo is that it waits until the migration is created to create a controller and that will be delayed by composer autoload. Even tho other files appear immeately it will take while for Controller to appear.
- It notifies the developer that at the end of `make:migration` composer autoload is dumped so the developer won't have to wonder if everything has been generated why is command still running and not freeing up the command line.
- For the developers whose dump-autoload does not take ages nothing will change except for the tiny line of extra log. If it is reason enough to disapprove this change then that can be omitted. Other than that is a small change that nobody will ever notice besides people who have a situation where their development setup has pretty slow composer dump-autoload.
- If dumping-the autoloader fails for some unforeseen reason the files will be still generated, currently, it will have generated all except controller, forcing the user to re-run create the controller. 