### PR TITLE
[6.x] Add "unauthenticated" method in auth middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -68,7 +68,7 @@ class Authenticate
     }
 
     /**
-     * Handle unauthenticated user.
+     * Handle an unauthenticated user.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  array  $guards

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -71,12 +71,12 @@ class Authenticate
      * Handle unauthenticated user.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  array  $gaurds
+     * @param  array  $guards
      * @return void
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */
-    protected function unauthenticated($request, array $gaurds)
+    protected function unauthenticated($request, array $guards)
     {
         throw new AuthenticationException(
             'Unauthenticated.', $guards, $this->redirectTo($request)

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -64,6 +64,20 @@ class Authenticate
             }
         }
 
+        $this->unauthenticated($request, $guards);
+    }
+
+    /**
+     * Handle unauthenticated user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  array  $gaurds
+     * @return void
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    protected function unauthenticated($request, array $gaurds)
+    {
         throw new AuthenticationException(
             'Unauthenticated.', $guards, $this->redirectTo($request)
         );


### PR DESCRIPTION
It would be nice to have an easy way to customise the "unauthenticated" behaviour in Authenticate middleware.

For example, I'd like to display a `404` page when the user is unauthenticated.

Of course, one solution might be to catch `AuthenticationException` in the exception handler and adjust the behaviour accordingly but I find it much cleaner to do it in the middleware.

With this PR I could simply override the `unauthenticated` method in the Authenticate middleware that ships with Laravel.

```php
class Authenticate extends Middleware
{
    /**
     * Handle unauthenticated user.
     *
     * @return void
     *
     * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
     */
    protected function unauthenticated()
    {
        throw new NotFoundHttpException;
    }
}
```