### PR TITLE
[6.x] Fix belongsTo relation when using multiple database connections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -719,7 +719,8 @@ trait HasRelationships
     {
         return tap(new $class, function ($instance) {
             if (! $instance->getConnectionName()) {
-                $instance->setConnection($this->connection);
+                $connection = config('database.default');
+                $instance->setConnection($connection);
             }
         });
     }


### PR DESCRIPTION
**The problem**
Could previously cause errors where the owner belonged to another database and the child to the default one.

**Fix**
This PR tries to fix that by using the correct relational connection.
Feel free to provide feedback or tweak whenever needed.
Possibly related to https://github.com/laravel/framework/issues/29935.

This pull request was built together with @jordyvanderhaegen.

**Update**
I see the tests fail on the use of config.
Two possible options:
1. Removing the `setConnection`, as getConnection will fall back to the right one when a model has no custom connection. Might cause elsewhere though
2. Get the config another way.

Anyone who could point me in the right direction would be a great help!