### PR TITLE
[6.x] Use the policies() method instead of the property policies

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/AuthServiceProvider.php
@@ -21,7 +21,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function registerPolicies()
     {
-        foreach ($this->policies as $key => $value) {
+        foreach ($this->policies() as $key => $value) {
             Gate::policy($key, $value);
         }
     }


### PR DESCRIPTION
This change allows to use the *unused* `policies()` method and also to do something dynamic like this:

```php
// App\Providers\AuthServiceProvider

   /**
     * Get the policies defined on the provider.
     *
     * @return array
     */
    public function policies()
    {
        return config('policies', []);
    }
```

**Related:** #26810