### PR TITLE
Fix issue with spaces in createSelectWithConstraint in Builder.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1119,7 +1119,7 @@ class Builder
     protected function createSelectWithConstraint($name)
     {
         return [explode(':', $name)[0], function ($query) use ($name) {
-            $query->select(explode(',', explode(':', $name)[1]));
+            $query->select(array_map('trim', explode(',', explode(':', $name)[1])));
         }];
     }
 


### PR DESCRIPTION
When specifying fields in a with if the user has spaces it will error.
`->with('table:id, name')`

Adding a trim fixes that from happening. Had a friend who spent a long time trying to figure out why his query wasn't working.
