### PR TITLE
[6.x] Throw exception on commit without transaction

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -162,11 +162,16 @@ trait ManagesTransactions
      * Commit the active database transaction.
      *
      * @return void
+     * @throws TransactionException
      */
     public function commit()
     {
         if ($this->transactions == 1) {
             $this->getPdo()->commit();
+        }
+
+        if ($this->transactions == 0) {
+            throw new TransactionException('Cannot commit. No transaction active.');
         }
 
         $this->transactions = max(0, $this->transactions - 1);

--- a/src/Illuminate/Database/Concerns/TransactionException.php
+++ b/src/Illuminate/Database/Concerns/TransactionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database\Concerns;
+
+use Exception;
+
+class TransactionException extends Exception
+{
+}

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -201,10 +201,13 @@ class DatabaseConnectionTest extends TestCase
     public function testCommittedFiresEventsIfSet()
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+        $pdo->expects($this->once())->method('beginTransaction');
         $connection = $this->getMockConnection(['getName'], $pdo);
         $connection->expects($this->any())->method('getName')->willReturn('name');
         $connection->setEventDispatcher($events = m::mock(Dispatcher::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(TransactionCommitted::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(TransactionBeginning::class));
+        $connection->beginTransaction();
         $connection->commit();
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adresses issue [#29505](https://github.com/laravel/framework/issues/29505).

At the current state a database commit will not commit if no transaction is active. However due to a missing notification this might go unnoticed and lead to some confusion.
With this PR an exception will be thrown in the specified case to notify the developer of a missing transaction.

Due to the change in behaviour of the commit-method this change is considered breaking.