### PR TITLE
[7.x] Automate $casts property for models from property types in PHP 7.4

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2278,19 +2278,20 @@ class EloquentModelGetMutatorsStub extends Model
 class EloquentModelCastingStub extends Model
 {
     protected $casts = [
-        'intAttribute' => 'int',
-        'floatAttribute' => 'float',
-        'stringAttribute' => 'string',
-        'boolAttribute' => 'bool',
-        'booleanAttribute' => 'boolean',
-        'objectAttribute' => 'object',
-        'arrayAttribute' => 'array',
         'jsonAttribute' => 'json',
         'collectionAttribute' => 'collection',
         'dateAttribute' => 'date',
-        'datetimeAttribute' => 'datetime',
         'timestampAttribute' => 'timestamp',
     ];
+
+    protected ?int $intAttribute;
+    protected ?float $floatAttribute;
+    protected ?string $stringAttribute;
+    protected ?bool $boolAttribute;
+    protected ?bool $booleanAttribute;
+    protected ?object $objectAttribute;
+    protected ?array $arrayAttribute;
+    protected ?DateTime $datetimeAttribute;
 
     public function jsonAttributeValue()
     {


### PR DESCRIPTION
With the introduction of PHP 7.4, typed properties for classes are now available. This presents an opportunity to add properties to our model classes, so instead of:

```php
class User extends Authenticatable
{
    protected $casts = [
        'email_verified_at' => 'datetime',
    ];
}
```

we can do:

```php
class User extends Authenticatable
{
    protected DateTime $email_verified_at;
}
```

This has the following benefits:

* Better code for understanding the properties of models
* Better possibilities for intellisense without the need for docblocks and third party packages
* Better structure for other attribute flags such as hidden, fillable via docblock decorators

This change is completely opt in as any property specified in the `$casts` array will take priority over the class property type. 

Challenges:

* Currently if you set a public property on a class, the `__set` and `__get` magic methods are broken so fields are saved and retrieved as `null`

As PHP 7.4 has not been released, this RFC is a discussion point for this approach.