### PR TITLE
[6.x] Use qualifyColumn method when build where query on BelongsTo instead of join table name and column string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -94,9 +94,7 @@ class BelongsTo extends Relation
             // For belongs to relationships, which are essentially the inverse of has one
             // or has many relationships, we need to actually query on the primary key
             // of the related models matching on the foreign key that's on a parent.
-            $table = $this->related->getTable();
-
-            $this->query->where($table.'.'.$this->ownerKey, '=', $this->child->{$this->foreignKey});
+            $this->query->where($this->related->qualifyColumn($this->ownerKey), '=', $this->child->{$this->foreignKey});
         }
     }
 
@@ -111,7 +109,7 @@ class BelongsTo extends Relation
         // We'll grab the primary key name of the related models since it could be set to
         // a non-standard name and not "id". We will then construct the constraint for
         // our eagerly loading query so it returns the proper models from execution.
-        $key = $this->related->getTable().'.'.$this->ownerKey;
+        $key = $this->related->qualifyColumn($this->ownerKey);
 
         $whereIn = $this->whereInMethod($this->related, $this->ownerKey);
 
@@ -262,7 +260,7 @@ class BelongsTo extends Relation
         $query->getModel()->setTable($hash);
 
         return $query->whereColumn(
-            $hash.'.'.$this->ownerKey, '=', $this->getQualifiedForeignKeyName()
+            $query->qualifyColumn($this->ownerKey), '=', $this->getQualifiedForeignKeyName()
         );
     }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -182,6 +182,8 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->related->shouldReceive('getKeyType')->andReturn($keyType);
         $this->related->shouldReceive('getKeyName')->andReturn('id');
         $this->related->shouldReceive('getTable')->andReturn('relation');
+        $this->related->shouldReceive('qualifyColumn')->with('id')->andReturn('relation.id');
+        $this->related->shouldReceive('qualifyColumn')->with('foreign_key')->andReturn('relation.foreign_key');
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentBelongsToModelStub;
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -157,6 +157,8 @@ class DatabaseEloquentMorphToTest extends TestCase
         $related = m::mock(Model::class);
         $related->shouldReceive('getKey')->andReturn(1);
         $related->shouldReceive('getTable')->andReturn('relation');
+        $related->shouldReceive('qualifyColumn')->with('id')->andReturn('relation.id');
+        $related->shouldReceive('qualifyColumn')->with('foreign_key')->andReturn('relation.foreign_key');
         $builder->shouldReceive('getModel')->andReturn($related);
 
         return new MorphTo($builder, $parent, 'foreign_key', 'id', 'morph_type', 'relation');
@@ -169,6 +171,8 @@ class DatabaseEloquentMorphToTest extends TestCase
         $this->related = m::mock(Model::class);
         $this->related->shouldReceive('getKeyName')->andReturn('id');
         $this->related->shouldReceive('getTable')->andReturn('relation');
+        $this->related->shouldReceive('qualifyColumn')->with('id')->andReturn('relation.id');
+        $this->related->shouldReceive('qualifyColumn')->with('foreign_key')->andReturn('relation.foreign_key');
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $parent = $parent ?: new EloquentMorphToModelStub;
 


### PR DESCRIPTION
Hello!

I'm fan of Eloquent and fan of `qualifyColumn` method. It's awesome.
In many project I always override qualifyColumn method, and sometimes override BelongTo class too. Here is a simple example.
I want to get an Event where Transaction is happen. Transaction only have timestamp column `transaction_at`, and Event have `event_date` date column.
_*Note: This is for example only, Event happen once a day._

```php
...
use App\Database\Eloquent\Relations\BelongsTo;

class Transaction extends Model
{
    public function event()
    {
        return $this->belongsTo(Event::class, 'transaction_date', 'event_date');
    }

    public function qualifyColumn($column)
    {
        if ($column == 'transaction_date') return DB::raw("DATE({$this->qualifyColumn('transaction_at')})");
        return parent::qualifyColumn($column)
    }

    /** Need to override this */
    protected function newBelongsTo(Builder $query, Model $child, $foreignKey, $ownerKey, $relation)
    {
        return new BelongsTo($query, $child, $foreignKey, $ownerKey, $relation);
    }
}
```

The benefit of this changes is that you can use raw statement on foreign key or owner key. You can do eager load as well.

```php
Transaction::select([
    (new Transaction)->qualifyColumn('*'),
    DB::raw((new Transaction)->qualifyColumn('transaction_date')." as transaction_date"),
])->with('event')->get();
```

For real implementation sometimes I add global scope to update select statement, and override qualifyColumn, and then you can simply `Transaction::with('event')->get();`

Happy Hacktoberfest! 😄 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
