### PR TITLE
[6.x] Improve messages for failed artisan tests which expect output

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -59,9 +59,9 @@ trait InteractsWithConsole
             if ($assertedOutput->values()->toArray() !== $this->expectedOutput) {
                 $missingOutput = collect($this->expectedOutput)->diff($this->actualOutput)->unique();
                 $missingString = $missingOutput->isEmpty()
-                    ? "Output given in wrong order:\n" . collect($this->expectedOutput)->join("\n")
-                    : "Expected output missing:\n" . $missingOutput->join("\n");
-                $actualString = count($this->actualOutput) === 0 ? 'No output was given.' : "Actual output was:\n" . join("\n", $this->actualOutput);
+                    ? "Output printed in wrong order:\n" . collect($this->expectedOutput)->join("\n")
+                    : "Expected output was not printed:\n" . $missingOutput->join("\n");
+                $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n" . join("\n", $this->actualOutput);
 
                 $this->fail("{$missingString}\n\n{$actualString}");
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -61,7 +61,7 @@ trait InteractsWithConsole
                 $missingString = $missingOutput->isEmpty()
                     ? "Output printed in wrong order:\n".collect($this->expectedOutput)->join("\n")
                     : "Expected output was not printed:\n".$missingOutput->join("\n");
-                $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n" . join("\n", $this->actualOutput);
+                $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n".join("\n", $this->actualOutput);
 
                 $this->fail("{$missingString}\n\n{$actualString}");
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -59,8 +59,8 @@ trait InteractsWithConsole
             if ($assertedOutput->values()->toArray() !== $this->expectedOutput) {
                 $missingOutput = collect($this->expectedOutput)->diff($this->actualOutput)->unique();
                 $missingString = $missingOutput->isEmpty()
-                    ? "Output printed in wrong order:\n" . collect($this->expectedOutput)->join("\n")
-                    : "Expected output was not printed:\n" . $missingOutput->join("\n");
+                    ? "Output printed in wrong order:\n".collect($this->expectedOutput)->join("\n")
+                    : "Expected output was not printed:\n".$missingOutput->join("\n");
                 $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n" . join("\n", $this->actualOutput);
 
                 $this->fail("{$missingString}\n\n{$actualString}");

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -61,7 +61,7 @@ trait InteractsWithConsole
                 $missingString = $missingOutput->isEmpty()
                     ? "Output printed in wrong order:\n".collect($this->expectedOutput)->join("\n")
                     : "Expected output was not printed:\n".$missingOutput->join("\n");
-                $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n".join("\n", $this->actualOutput);
+                $actualString = count($this->actualOutput) === 0 ? 'No output was printed.' : "Actual output was:\n".implode("\n", $this->actualOutput);
 
                 $this->fail("{$missingString}\n\n{$actualString}");
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -24,6 +24,13 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
+     * All of the actual output lines.
+     *
+     * @var array
+     */
+    public $actualOutput = [];
+
+    /**
      * All of the expected questions.
      *
      * @var array
@@ -48,8 +55,15 @@ trait InteractsWithConsole
                 $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
             }
 
-            if (count($this->expectedOutput)) {
-                $this->fail('Output "'.Arr::first($this->expectedOutput).'" was not printed.');
+            $assertedOutput = collect($this->actualOutput)->diff(collect($this->actualOutput)->diff($this->expectedOutput));
+            if ($assertedOutput->values()->toArray() !== $this->expectedOutput) {
+                $missingOutput = collect($this->expectedOutput)->diff($this->actualOutput)->unique();
+                $missingString = $missingOutput->isEmpty()
+                    ? "Output given in wrong order:\n" . collect($this->expectedOutput)->join("\n")
+                    : "Expected output missing:\n" . $missingOutput->join("\n");
+                $actualString = count($this->actualOutput) === 0 ? 'No output was given.' : "Actual output was:\n" . join("\n", $this->actualOutput);
+
+                $this->fail("{$missingString}\n\n{$actualString}");
             }
         });
 

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -193,15 +193,9 @@ class PendingCommand
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
 
-        foreach ($this->test->expectedOutput as $i => $output) {
-            $mock->shouldReceive('doWrite')
-                ->once()
-                ->ordered()
-                ->with($output, Mockery::any())
-                ->andReturnUsing(function () use ($i) {
-                    unset($this->test->expectedOutput[$i]);
-                });
-        }
+        $mock->shouldReceive('doWrite')->andReturnUsing(function ($output) {
+            $this->test->actualOutput[] = $output;
+        });
 
         return $mock;
     }


### PR DESCRIPTION
## Background
Messages printed by artisan-commands may be asserted using  `expectsOutput($message)`. When this fails, the actual message is not as helpful as it could be as it doesn't show the actual output at all. This PR intends to present both the expected output as well as the given output, allowing for the user to spot the difference much more easily.

Also, if several expected outputs were not printed, the previous implementation only informed about the first one. Now, all missing expected outputs are shown.

## Examples

![image](https://user-images.githubusercontent.com/25909128/66272265-ad671400-e867-11e9-8083-86725ae8b0cb.png)

Previously, only `Output "4 models affected." was not printed.` is printed.

If nothing is printed, the following is now printed:
![image](https://user-images.githubusercontent.com/25909128/66272291-06cf4300-e868-11e9-82f9-74824b8810ad.png)

If the only problem is the order of the output, this is mentioned.
![image](https://user-images.githubusercontent.com/25909128/66272313-7b09e680-e868-11e9-9025-5ae1d287d9e1.png)

Previously, this resulted in mockery exceptions since ordered expectations were used.

## Implementation details
Instead of using mockery for each expected output, all given output is recorded and compared in the `beforeApplicationDestroyed`-callback. 


This is my first PR and all help is appreciated. I was unable to find tests (and the changes only affects messages for failing tests), but I may have been looking in the wrong place.





