### PR TITLE
[6.x] Interfaces for test helpers

### DIFF
--- a/src/Illuminate/Contracts/Foundation/Testing/DatabaseMigratable.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/DatabaseMigratable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface DatabaseMigratable
+{
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @return void
+     */
+    public function runDatabaseMigrations();
+}

--- a/src/Illuminate/Contracts/Foundation/Testing/DatabaseRefreshable.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/DatabaseRefreshable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface DatabaseRefreshable
+{
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @return void
+     */
+    public function refreshDatabase();
+}

--- a/src/Illuminate/Contracts/Foundation/Testing/DatabaseTransactable.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/DatabaseTransactable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface DatabaseTransactable
+{
+    /**
+     * Handle database transactions on the specified connections.
+     *
+     * @return void
+     */
+    public function beginDatabaseTransaction();
+}

--- a/src/Illuminate/Contracts/Foundation/Testing/Fakeable.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/Fakeable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface Fakeable
+{
+    /**
+     * Setup up the Faker instance.
+     *
+     * @return void
+     */
+    public function doSetUpFaker();
+}

--- a/src/Illuminate/Contracts/Foundation/Testing/WithoutEvents.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/WithoutEvents.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface WithoutEvents
+{
+    /**
+     * Prevent all event handles from being executed.
+     *
+     * @throws \Exception
+     */
+    public function disableEventsForAllTests();
+}

--- a/src/Illuminate/Contracts/Foundation/Testing/WithoutMiddleware.php
+++ b/src/Illuminate/Contracts/Foundation/Testing/WithoutMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Foundation\Testing;
+
+interface WithoutMiddleware
+{
+    /**
+     * Prevent all middleware from being executed for this test class.
+     *
+     * @throws \Exception
+     */
+    public function disableMiddlewareForAllTests();
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -5,6 +5,12 @@ namespace Illuminate\Foundation\Testing;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Contracts\Foundation\Testing\DatabaseMigratable;
+use Illuminate\Contracts\Foundation\Testing\DatabaseRefreshable;
+use Illuminate\Contracts\Foundation\Testing\DatabaseTransactable;
+use Illuminate\Contracts\Foundation\Testing\Fakeable;
+use Illuminate\Contracts\Foundation\Testing\WithoutEvents as WithoutEventsContract;
+use Illuminate\Contracts\Foundation\Testing\WithoutMiddleware as WithoutMiddlewareContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Str;
@@ -111,28 +117,28 @@ abstract class TestCase extends BaseTestCase
     {
         $uses = array_flip(class_uses_recursive(static::class));
 
-        if (isset($uses[RefreshDatabase::class])) {
+        if ($this instanceof DatabaseRefreshable || isset($uses[RefreshDatabase::class])) {
             $this->refreshDatabase();
         }
 
-        if (isset($uses[DatabaseMigrations::class])) {
+        if ($this instanceof DatabaseMigratable || isset($uses[DatabaseMigrations::class])) {
             $this->runDatabaseMigrations();
         }
 
-        if (isset($uses[DatabaseTransactions::class])) {
+        if ($this instanceof DatabaseTransactable || isset($uses[DatabaseTransactions::class])) {
             $this->beginDatabaseTransaction();
         }
 
-        if (isset($uses[WithoutMiddleware::class])) {
+        if ($this instanceof WithoutMiddlewareContract || isset($uses[WithoutMiddleware::class])) {
             $this->disableMiddlewareForAllTests();
         }
 
-        if (isset($uses[WithoutEvents::class])) {
+        if ($this instanceof WithoutEventsContract || isset($uses[WithoutEvents::class])) {
             $this->disableEventsForAllTests();
         }
 
-        if (isset($uses[WithFaker::class])) {
-            $this->setUpFaker();
+        if ($this instanceof Fakeable || isset($uses[WithFaker::class])) {
+            $this->doSetUpFaker();
         }
 
         return $uses;

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -16,6 +16,18 @@ trait WithFaker
     /**
      * Setup up the Faker instance.
      *
+     * @return $this
+     */
+    public function doSetUpFaker()
+    {
+        $this->faker = $this->makeFaker();
+
+        return $this;
+    }
+
+    /**
+     * Setup up the Faker instance.
+     *
      * @return void
      */
     protected function setUpFaker()

--- a/tests/Foundation/Testing/TestCaseTest.php
+++ b/tests/Foundation/Testing/TestCaseTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Contracts\Foundation\Testing\DatabaseMigratable;
+use Illuminate\Contracts\Foundation\Testing\DatabaseRefreshable;
+use Illuminate\Contracts\Foundation\Testing\DatabaseTransactable;
+use Illuminate\Contracts\Foundation\Testing\Fakeable;
+use Illuminate\Contracts\Foundation\Testing\WithoutEvents as WithoutEventsContract;
+use Illuminate\Contracts\Foundation\Testing\WithoutMiddleware as WithoutMiddlewareContract;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Mockery as m;
+use Mockery\Exception\InvalidCountException;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+class TestCaseTest extends PHPUnitTestCase
+{
+    /**
+     * @return TestCaseWithInterfacesAndTraits|MockInterface
+     */
+    private function setUpTestCaseWithInterfaceAndTraits()
+    {
+        return m::mock(TestCaseWithInterfacesAndTraits::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('refreshDatabase')
+            ->getMock()
+            ->shouldReceive('runDatabaseMigrations')
+            ->getMock()
+            ->shouldReceive('disableMiddlewareForAllTests')
+            ->getMock()
+            ->shouldReceive('disableEventsForAllTests')
+            ->getMock()
+            ->shouldReceive('doSetUpFaker')
+            ->getMock();
+    }
+
+    /**
+     * @return TestCaseWithDatabaseTransactionsInterfaceAndTrait|MockInterface
+     */
+    private function setUpTestCaseWithDatabaseTransactionsInterfaceAndTrait()
+    {
+        return m::mock(TestCaseWithDatabaseTransactionsInterfaceAndTrait::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('beginDatabaseTransaction')
+            ->getMock();
+    }
+
+    /**
+     * @return TestCaseWithoutHelpers|MockInterface
+     */
+    private function setUpTestCaseWithoutHelpers()
+    {
+        return m::mock(TestCaseWithoutHelpers::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods();
+    }
+
+    /**
+     * @return TestCaseWithImplementedMethods|MockInterface
+     */
+    private function setUpTestCaseWithImplementedMethods()
+    {
+        return m::mock(TestCaseWithImplementedMethods::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('refreshDatabase')
+            ->getMock()
+            ->shouldReceive('beginDatabaseTransaction')
+            ->getMock()
+            ->shouldReceive('runDatabaseMigrations')
+            ->getMock()
+            ->shouldReceive('disableMiddlewareForAllTests')
+            ->getMock()
+            ->shouldReceive('disableEventsForAllTests')
+            ->getMock()
+            ->shouldReceive('doSetUpFaker')
+            ->getMock();
+    }
+
+    /**
+     * @return TestCaseWithTraits|MockInterface
+     */
+    private function setUpTestCaseWithTraits()
+    {
+        return m::mock(TestCaseWithTraits::class)
+            ->makePartial()
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('refreshDatabase')
+            ->getMock()
+            ->shouldReceive('runDatabaseMigrations')
+            ->getMock()
+            ->shouldReceive('disableMiddlewareForAllTests')
+            ->getMock()
+            ->shouldReceive('disableEventsForAllTests')
+            ->getMock()
+            ->shouldReceive('doSetUpFaker')
+            ->getMock();
+    }
+
+    public function testSetUpTraitsWithClassUsingTraits()
+    {
+        $testCase = $this->setUpTestCaseWithInterfaceAndTraits();
+
+        $testCase->runSetUpTraits();
+
+        $this
+            ->assertShouldHaveReceived($testCase, 'refreshDatabase')
+            ->assertShouldHaveReceived($testCase, 'runDatabaseMigrations')
+            ->assertShouldHaveReceived($testCase, 'disableMiddlewareForAllTests')
+            ->assertShouldHaveReceived($testCase, 'disableEventsForAllTests')
+            ->assertShouldHaveReceived($testCase, 'doSetUpFaker');
+    }
+
+    public function testSetUpTraitsWithClassUsingDatabaseTransactionTrait()
+    {
+        $testCase = $this->setUpTestCaseWithDatabaseTransactionsInterfaceAndTrait();
+
+        $testCase->runSetUpTraits();
+
+        $this->assertShouldHaveReceived($testCase, 'beginDatabaseTransaction');
+    }
+
+    public function testSetUpTraitsWithClassUsingNoTraits()
+    {
+        $testCase = $this->setUpTestCaseWithoutHelpers();
+
+        $testCase->runSetUpTraits();
+
+        $this
+            ->assertShouldNotHaveReceived($testCase, 'refreshDatabase')
+            ->assertShouldNotHaveReceived($testCase, 'runDatabaseMigrations')
+            ->assertShouldNotHaveReceived($testCase, 'disableMiddlewareForAllTests')
+            ->assertShouldNotHaveReceived($testCase, 'disableEventsForAllTests')
+            ->assertShouldNotHaveReceived($testCase, 'doSetUpFaker')
+            ->assertShouldNotHaveReceived($testCase, 'beginDatabaseTransaction');
+    }
+
+    public function testSetUpTraitsWithImplementedMethods()
+    {
+        $testCase = $this->setUpTestCaseWithImplementedMethods();
+
+        $testCase->runSetUpTraits();
+
+        $this
+            ->assertShouldHaveReceived($testCase, 'refreshDatabase')
+            ->assertShouldHaveReceived($testCase, 'runDatabaseMigrations')
+            ->assertShouldHaveReceived($testCase, 'disableMiddlewareForAllTests')
+            ->assertShouldHaveReceived($testCase, 'disableEventsForAllTests')
+            ->assertShouldHaveReceived($testCase, 'doSetUpFaker')
+            ->assertShouldHaveReceived($testCase, 'beginDatabaseTransaction');
+    }
+
+    public function testSetUpTraitsWithTraits()
+    {
+        $testCase = $this->setUpTestCaseWithTraits();
+
+        $testCase->runSetUpTraits();
+
+        $this
+            ->assertShouldHaveReceived($testCase, 'refreshDatabase')
+            ->assertShouldHaveReceived($testCase, 'runDatabaseMigrations')
+            ->assertShouldHaveReceived($testCase, 'disableMiddlewareForAllTests')
+            ->assertShouldHaveReceived($testCase, 'disableEventsForAllTests')
+            ->assertShouldHaveReceived($testCase, 'doSetUpFaker');
+    }
+
+    private function assertShouldHaveReceived(MockInterface $testCase, $method)
+    {
+        try {
+            $testCase->shouldHaveReceived($method)->once();
+
+            $this->assertTrue(true);
+        } catch (InvalidCountException $e) {
+            $this->assertTrue(false);
+        }
+
+        return $this;
+    }
+
+    private function assertShouldNotHaveReceived(MockInterface $testCase, $method)
+    {
+        try {
+            $testCase->shouldNotHaveReceived($method);
+
+            $this->assertTrue(true);
+        } catch (InvalidCountException $e) {
+            $this->assertTrue(false);
+        }
+
+        return $this;
+    }
+}
+
+class TestCaseWithInterfacesAndTraits extends TestCase implements
+    DatabaseMigratable,
+    DatabaseRefreshable,
+    Fakeable,
+    WithoutEventsContract,
+    WithoutMiddlewareContract
+{
+    use RefreshDatabase;
+    use DatabaseMigrations;
+    use WithoutMiddleware;
+    use WithoutEvents;
+    use WithFaker;
+
+    public function runSetUpTraits()
+    {
+        $this->setUpTraits();
+    }
+
+    public function createApplication()
+    {
+    }
+}
+
+class TestCaseWithDatabaseTransactionsInterfaceAndTrait extends TestCase implements DatabaseTransactable
+{
+    use DatabaseTransactions;
+
+    public function runSetUpTraits()
+    {
+        $this->setUpTraits();
+    }
+
+    public function createApplication()
+    {
+    }
+}
+
+class TestCaseWithoutHelpers extends TestCase
+{
+    public function runSetUpTraits()
+    {
+        $this->setUpTraits();
+    }
+
+    public function createApplication()
+    {
+    }
+}
+
+class TestCaseWithImplementedMethods extends TestCase implements
+    DatabaseMigratable,
+    DatabaseRefreshable,
+    DatabaseTransactable,
+    Fakeable,
+    WithoutEventsContract,
+    WithoutMiddlewareContract
+{
+    public function runSetUpTraits()
+    {
+        $this->setUpTraits();
+    }
+
+    public function createApplication()
+    {
+    }
+
+    public function runDatabaseMigrations()
+    {
+    }
+
+    public function refreshDatabase()
+    {
+    }
+
+    public function doSetUpFaker()
+    {
+    }
+
+    public function disableEventsForAllTests()
+    {
+    }
+
+    public function disableMiddlewareForAllTests()
+    {
+    }
+
+    public function beginDatabaseTransaction()
+    {
+    }
+}
+
+class TestCaseWithTraits extends TestCase
+{
+    use RefreshDatabase;
+    use DatabaseMigrations;
+    use WithoutMiddleware;
+    use WithoutEvents;
+    use WithFaker;
+
+    public function runSetUpTraits()
+    {
+        $this->setUpTraits();
+    }
+
+    public function createApplication()
+    {
+    }
+}


### PR DESCRIPTION
I added interfaces for the test helper traits and changed the TestCase::setUpTraits method to not be dependent on the specific Laravel traits.
This is the reopened PR #30188 but this time for the current release branch because I made the changes backwards compatible.
