### PR TITLE
[6.x] Simplify gatherKeysByType method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -138,9 +138,7 @@ class MorphTo extends BelongsTo
      */
     protected function gatherKeysByType($type)
     {
-        return collect($this->dictionary[$type])->map(function ($models) {
-            return head($models)->{$this->foreignKey};
-        })->values()->unique()->all();
+        return array_keys($this->dictionary[$type]);
     }
 
     /**


### PR DESCRIPTION
This PR doesn't fix any bug nor it does introduce any new feature. It does simplify a method's code.
`gatherKeysByType` method receives a morph type and returns all model keys linked with that type. Those model keys can easily be retrieved from the `$this->dictionary` property since they are used as array keys under the `$this->dictionary[$type]` namespace
