### PR TITLE
[6.x] Add partialMock shorthand

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -46,6 +46,18 @@ trait InteractsWithContainer
     }
 
     /**
+     * Mock a partial instance of an object in the container.
+     *
+     * @param  string  $abstract
+     * @param  \Closure|null  $mock
+     * @return \Mockery\MockInterface
+     */
+    protected function partialMock($abstract, Closure $mock = null)
+    {
+        return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
+    }
+
+    /**
      * Spy an instance of an object in the container.
      *
      * @param  string  $abstract


### PR DESCRIPTION
This is similar to `mock()` but it makes a partial mock. Method name could also be changed to `mockPartial()`

So instead of
```PHP
$this->instance(Abstract::class, Mockery::mock(Abstract::class, function ($mock) {
    $mock->shouldReceive('call')->once();
})->makePartial());
```

You can write
```PHP
$this->partialMock(Abstract::class, function ($mock) {
    $mock->shouldReceive('call')->once();
});
```