### PR TITLE
[6.x] validateDimensions() handle image/svg MIME

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -499,7 +499,7 @@ trait ValidatesAttributes
      */
     public function validateDimensions($attribute, $value, $parameters)
     {
-        if ($this->isValidFileInstance($value) && $value->getMimeType() === 'image/svg+xml') {
+        if ($this->isValidFileInstance($value) && in_array($value->getMimeType(), ['image/svg+xml', 'image/svg'])) {
             return true;
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2650,17 +2650,30 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:ratio=2/3']);
         $this->assertTrue($v->passes());
 
-        // Ensure svg images always pass as size is irreleveant
-        $uploadedFile = new UploadedFile(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
+        // Ensure svg images always pass as size is irreleveant (image/svg+xml)
+        $svgXmlUploadedFile = new UploadedFile(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans, ['x' => $uploadedFile], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $v = new Validator($trans, ['x' => $svgXmlUploadedFile], ['x' => 'dimensions:max_width=1,max_height=1']);
         $this->assertTrue($v->passes());
 
-        $file = new File(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
+        $svgXmlFile = new File(__DIR__.'/fixtures/image.svg', '', 'image/svg+xml', null, null, true);
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans, ['x' => $file], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $v = new Validator($trans, ['x' => $svgXmlFile], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $this->assertTrue($v->passes());
+
+        // Ensure svg images always pass as size is irreleveant (image/svg)
+        $svgUploadedFile = new UploadedFile(__DIR__.'/fixtures/image2.svg', '', 'image/svg', null, null, true);
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => $svgUploadedFile], ['x' => 'dimensions:max_width=1,max_height=1']);
+        $this->assertTrue($v->passes());
+
+        $svgFile = new File(__DIR__.'/fixtures/image2.svg', '', 'image/svg', null, null, true);
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, ['x' => $svgFile], ['x' => 'dimensions:max_width=1,max_height=1']);
         $this->assertTrue($v->passes());
     }
 

--- a/tests/Validation/fixtures/image2.svg
+++ b/tests/Validation/fixtures/image2.svg
@@ -1,0 +1,2 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 400 600">
+</svg>


### PR DESCRIPTION
Added `image/svg` MIME support to `validateDimensions()` function.

During the image dimensions validation there is a `getMimeType()` function called on a ` Illuminate\Http\UploadedFile` class (inherited from `Symfony\Component\HttpFoundation\File\UploadedFile` <- `Symfony\Component\HttpFoundation\File\File`) class.

It utilizes the `Symfony\Component\Mime\MimeTypes`  which calls the `guessMimeType()` on the `Symfony\Component\Mime\FileinfoMimeTypeGuesser` class.

At this point `finfo` class is used:
```php
if (!$finfo = new \finfo(FILEINFO_MIME_TYPE, $this->magicFile)) {
	return null;
}

return $finfo->file($path);
```

I've found it can return two different values for SVG files: `image/svg+xml` and `image/svg`.

I didn't find any documentation about this behavior (only a magic test: https://github.com/php/php-src/blob/master/ext/fileinfo/tests/magic), but it can be easily reproduced via this Gist:
https://gist.github.com/0xB4LINT/0d90ddaa02c91147635667b2a8b90f9b

The only difference between the source files is the lack of `<?xml ... ?>` row.

By the W3's SVG standard document there are more valid [document structures](https://www.w3.org/TR/SVG2/struct.html) defined:
`<?xml ... ?><svg ...` or `<svg xmlns="...`

Extends https://github.com/laravel/framework/pull/30009: replaced `getClientMimeType()` with `getMimeType()`, but doesn't handle the `image/svg` MIME.