### PR TITLE
[7.x] Handle null value in 'where' database rule - Resolves #25374

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -64,6 +64,10 @@ trait DatabaseRule
             return $this->using($column);
         }
 
+        if (is_null($value)) {
+            return $this->whereNull($column);
+        }
+
         $this->wheres[] = compact('column', 'value');
 
         return $this;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR resolves #25374.

This implementation is to handle `null` value in `where` validation rule based on @staudenmeir solution. Basically, when the value is `null`, it will call `whereNull` to avoid error discussed in the mentioned issue.

I send this to `master` branch to avoid breaking people's validation as @driesvints suggested.

Credits: @staudenmeir, @driesvints
  