### PR TITLE
[6.x] Implement new password rule and password confirmation

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Illuminate\Auth\Middleware;
+
+use Closure;
+use Illuminate\Routing\Redirector;
+
+class RequirePassword
+{
+    /**
+     * The Redirector instance.
+     *
+     * @var \Illuminate\Routing\Redirector
+     */
+    protected $redirector;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Routing\Redirector  $redirector
+     * @return void
+     */
+    public function __construct(Redirector $redirector)
+    {
+        $this->redirector = $redirector;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $redirectToRoute
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $redirectToRoute = null)
+    {
+        if ($this->shouldConfirmPassword($request)) {
+            return $this->redirector->guest(
+                $this->redirector->getUrlGenerator()->route($redirectToRoute ?? 'password.confirm')
+            );
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the confirmation timeout has expired.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function shouldConfirmPassword($request)
+    {
+        $confirmedAt = strtotime('now') - $request->session()->get('auth.password_confirmed_at', 0);
+
+        return $confirmedAt > config('auth.password_timeout', 10800);
+    }
+}

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -52,7 +52,7 @@ class RequirePassword
      */
     protected function shouldConfirmPassword($request)
     {
-        $confirmedAt = strtotime('now') - $request->session()->get('auth.password_confirmed_at', 0);
+        $confirmedAt = time() - $request->session()->get('auth.password_confirmed_at', 0);
 
         return $confirmedAt > config('auth.password_timeout', 10800);
     }

--- a/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Foundation\Auth;
+
+use Illuminate\Http\Request;
+
+trait ConfirmsPasswords
+{
+    use RedirectsUsers;
+
+    /**
+     * Display the password confirmation view.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function showConfirmForm()
+    {
+        return view('auth.passwords.confirm');
+    }
+
+    /**
+     * Confirm the given user's password.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function confirm(Request $request)
+    {
+        $request->validate($this->rules(), $this->validationErrorMessages());
+
+        $this->resetPasswordConfirmationTimeout($request);
+
+        return redirect()->intended($this->redirectPath());
+    }
+
+    /**
+     * Reset the password confirmation timeout.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function resetPasswordConfirmationTimeout(Request $request)
+    {
+        $request->session()->put('auth.password_confirmed_at', strtotime('now'));
+    }
+
+    /**
+     * Get the password confirmation validation rules.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return [
+            'password' => 'required|password',
+        ];
+    }
+
+    /**
+     * Get the password confirmation validation error messages.
+     *
+     * @return array
+     */
+    protected function validationErrorMessages()
+    {
+        return [];
+    }
+}

--- a/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
@@ -41,7 +41,7 @@ trait ConfirmsPasswords
      */
     protected function resetPasswordConfirmationTimeout(Request $request)
     {
-        $request->session()->put('auth.password_confirmed_at', strtotime('now'));
+        $request->session()->put('auth.password_confirmed_at', time());
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1164,6 +1164,11 @@ class Router implements BindingRegistrar, RegistrarContract
             $this->resetPassword();
         }
 
+        // Password Confirmation Routes...
+        if ($options['confirm'] ?? true) {
+            $this->confirmPassword();
+        }
+
         // Email Verification Routes...
         if ($options['verify'] ?? false) {
             $this->emailVerification();
@@ -1181,6 +1186,17 @@ class Router implements BindingRegistrar, RegistrarContract
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('password.email');
         $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('password.reset');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset')->name('password.update');
+    }
+
+    /**
+     * Register the typical confirm password routes for an application.
+     *
+     * @return void
+     */
+    public function confirmPassword()
+    {
+        $this->get('password/confirm', 'Auth\ConfirmPasswordController@showConfirmForm')->name('password.confirm');
+        $this->post('password/confirm', 'Auth\ConfirmPasswordController@confirm');
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1280,6 +1280,28 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that the current logged in user's password matches the given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    protected function validatePassword($attribute, $value, $parameters)
+    {
+        $auth = $this->container->make('auth');
+        $hasher = $this->container->make('hash');
+
+        $guard = $auth->guard(Arr::first($parameters));
+
+        if ($guard->guest()) {
+            return false;
+        }
+
+        return $hasher->check($value, $guard->user()->getAuthPassword());
+    }
+
+    /**
      * Validate that an attribute exists even if not filled.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5,6 +5,9 @@ namespace Illuminate\Tests\Validation;
 use DateTime;
 use DateTimeImmutable;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule;
@@ -689,11 +692,11 @@ class ValidationValidatorTest extends TestCase
     public function testValidatePassword()
     {
         // Fails when user is not logged in.
-        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->andReturn($auth);
         $auth->shouldReceive('guest')->andReturn(true);
 
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
 
         $container = m::mock(Container::class);
         $container->shouldReceive('make')->with('auth')->andReturn($auth);
@@ -708,15 +711,15 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         // Fails when password is incorrect.
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
-        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->andReturn($auth);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->andReturn(false);
 
         $container = m::mock(Container::class);
@@ -732,15 +735,15 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         // Succeeds when password is correct.
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
-        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->andReturn($auth);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->andReturn(true);
 
         $container = m::mock(Container::class);
@@ -756,15 +759,15 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         // We can use a specific guard.
-        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user = m::mock(Authenticatable::class);
         $user->shouldReceive('getAuthPassword');
 
-        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth = m::mock(Guard::class);
         $auth->shouldReceive('guard')->with('custom')->andReturn($auth);
         $auth->shouldReceive('guest')->andReturn(false);
         $auth->shouldReceive('user')->andReturn($user);
 
-        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher = m::mock(Hasher::class);
         $hasher->shouldReceive('check')->andReturn(true);
 
         $container = m::mock(Container::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -686,6 +686,100 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['validation.present'], $v->errors()->get('name'));
     }
 
+    public function testValidatePassword()
+    {
+        // Fails when user is not logged in.
+        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guard')->andReturn($auth);
+        $auth->shouldReceive('guest')->andReturn(true);
+
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getTranslator();
+        $trans->shouldReceive('get');
+
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+
+        $this->assertFalse($v->passes());
+
+        // Fails when password is incorrect.
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user->shouldReceive('getAuthPassword');
+
+        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guard')->andReturn($auth);
+        $auth->shouldReceive('guest')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(false);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getTranslator();
+        $trans->shouldReceive('get');
+
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+
+        $this->assertFalse($v->passes());
+
+        // Succeeds when password is correct.
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user->shouldReceive('getAuthPassword');
+
+        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guard')->andReturn($auth);
+        $auth->shouldReceive('guest')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(true);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getTranslator();
+        $trans->shouldReceive('get');
+
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password']);
+        $v->setContainer($container);
+
+        $this->assertTrue($v->passes());
+
+        // We can use a specific guard.
+        $user = m::mock(\Illuminate\Contracts\Auth\Authenticatable::class);
+        $user->shouldReceive('getAuthPassword');
+
+        $auth = m::mock(\Illuminate\Contracts\Auth\Guard::class);
+        $auth->shouldReceive('guard')->with('custom')->andReturn($auth);
+        $auth->shouldReceive('guest')->andReturn(false);
+        $auth->shouldReceive('user')->andReturn($user);
+
+        $hasher = m::mock(\Illuminate\Contracts\Hashing\Hasher::class);
+        $hasher->shouldReceive('check')->andReturn(true);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('auth')->andReturn($auth);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $trans = $this->getTranslator();
+        $trans->shouldReceive('get');
+
+        $v = new Validator($trans, ['password' => 'foo'], ['password' => 'password:custom']);
+        $v->setContainer($container);
+
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidatePresent()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
These changes add a new password validation rule and the new password confirmation functionality. 

The validation rule offers to validate a password input field and checks if the password matches the currently authed user's password. You can also pass a guard name as a parameter.

The password confirmation functionality behaves exactly like the Github confirmation screen, allowing you to set a `password.confirm` middleware on sensitive routes you want password protected. When a user enters a valid password, the time will be added to the session and its session will stay valid for a default of three hours (can be configured in the `auth.php` config file here: https://github.com/laravel/laravel/pull/5129). Underneath the hood it makes use of the intended url to redirect the user to wherever they were going when the password confirmation was done.

![Screen Shot 2019-10-08 at 13 24 35](https://user-images.githubusercontent.com/594614/66394535-b1b13f80-e9d5-11e9-881f-bcf6eb5b1485.png)

Some remarks:
- I went back and forth on some other naming like "reauthenticate" and "reconfirm password" but eventually settled for what was displayed in the UI (like Github)
- The `auth.password_timeout` config option might need a better name but couldn't think of one
- The "guest" method name of the `Redirector` class might need a rename because I noticed that this is actually a bad naming for what it actually does.

Feel free to provide feedback.

Kudos to @freekmurze, @mpociot, @christophrumpel and all the others that helped out with validating this idea. I first started working on this but later discovered [this article](https://medium.com/@browner12/laravel-reauthenticate-274c48f2b642) below by @browner12 which inspired me a bit for this PR. Thanks!

laravel/ui PR: https://github.com/laravel/ui/pull/34
laravel/laravel PR: https://github.com/laravel/laravel/pull/5129