### PR TITLE
[6.x] Ability to override `set user's password` on password reset

### DIFF
--- a/src/Illuminate/Foundation/Auth/ResetsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ResetsPasswords.php
@@ -102,7 +102,7 @@ trait ResetsPasswords
      */
     protected function resetPassword($user, $password)
     {
-        $user->password = Hash::make($password);
+        $this->setUserPassword($user, $password);
 
         $user->setRememberToken(Str::random(60));
 
@@ -111,6 +111,18 @@ trait ResetsPasswords
         event(new PasswordReset($user));
 
         $this->guard()->login($user);
+    }
+
+    /**
+     * Set the user's password.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param  string  $password
+     * @return void
+     */
+    protected function setUserPassword($user, $password)
+    {
+        $user->password = Hash::make($password);
     }
 
     /**


### PR DESCRIPTION
This PR solves the issue of hashing the password twice when using a mutator like `setPasswordAttribute` in User model.

Also, avoiding to override the whole [method](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Foundation/Auth/ResetsPasswords.php#L103-L114) in `Illuminate\Foundation\Auth\ResetsPasswords` to solve this issue.

**Related:** #11012