### PR TITLE
[6.x] Schema-qualify table names when dropping all FKs in SQL Server

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -320,10 +320,11 @@ class SqlServerGrammar extends Grammar
     public function compileDropAllForeignKeys()
     {
         return "DECLARE @sql NVARCHAR(MAX) = N'';
-            SELECT @sql += 'ALTER TABLE ' + QUOTENAME(OBJECT_NAME(parent_object_id)) 
+            SELECT @sql += 'ALTER TABLE '
+                + QUOTENAME(OBJECT_SCHEMA_NAME(parent_object_id)) + '.' + + QUOTENAME(OBJECT_NAME(parent_object_id))
                 + ' DROP CONSTRAINT ' + QUOTENAME(name) + ';'
             FROM sys.foreign_keys;
-            
+
             EXEC sp_executesql @sql;";
     }
 


### PR DESCRIPTION
The `compileDropAllForeignKeys` function in the SQL Server grammar previously assumed that all tables were in the default schema of the database connection, and so did not need to be qualified. The generated SQL would look for example like `ALTER TABLE foos DROP CONSTRAINT ...`.

With this change, the SQL will now look like `ALTER TABLE dbo.foos DROP CONSTRAINT ...`. Importantly this means that if there are other schemas used by the application, tables in them will have their FKs dropped correctly, as in `ALTER TABLE app.bars DROP CONSTRAINT ...`.