### PR TITLE
[6.x] Add `dropAllViews` functionality to the SQL Server builder

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -328,6 +328,21 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the command to drow all views.
+     *
+     * @return string
+     */
+    public function compileDropAllViews()
+    {
+        return "DECLARE @sql NVARCHAR(MAX) = N'';
+            SELECT @sql += 'DROP VIEW ' + QUOTENAME(OBJECT_SCHEMA_NAME(object_id))
+                + '.' + QUOTENAME(name) + ';'
+            FROM sys.views;
+
+            EXEC sp_executesql @sql;";
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -328,7 +328,7 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile the command to drow all views.
+     * Compile the command to drop all views.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -335,8 +335,7 @@ class SqlServerGrammar extends Grammar
     public function compileDropAllViews()
     {
         return "DECLARE @sql NVARCHAR(MAX) = N'';
-            SELECT @sql += 'DROP VIEW ' + QUOTENAME(OBJECT_SCHEMA_NAME(object_id))
-                + '.' + QUOTENAME(name) + ';'
+            SELECT @sql += 'DROP VIEW ' + QUOTENAME(OBJECT_SCHEMA_NAME(object_id)) + '.' + QUOTENAME(name) + ';'
             FROM sys.views;
 
             EXEC sp_executesql @sql;";

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -15,4 +15,14 @@ class SqlServerBuilder extends Builder
 
         $this->connection->statement($this->grammar->compileDropAllTables());
     }
+
+    /**
+     * Drop all views from the database.
+     *
+     * @return void
+     */
+    public function dropAllViews()
+    {
+        $this->connection->statement($this->grammar->compileDropAllViews());
+    }
 }


### PR DESCRIPTION
Currently, trying to drop all views on a SQL Server database (e.g. with `protected $dropViews = true;` in your test case) throws a `LogicException` because the SQL Server builder does not override `dropAllViews()`.

This PR adds that functionality, overriding `dropAllViews()` in `Illuminate\Database\Schema\SqlServerBuilder`.