### PR TITLE
[6.x] Add methods to get updated_at and created_at values

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -123,4 +123,24 @@ trait HasTimestamps
     {
         return static::UPDATED_AT;
     }
+
+    /**
+     * Get the value of the "created at" column.
+     *
+     * @return mixed
+     */
+    public function getCreatedAt()
+    {
+        return $this->getAttribute($this->getCreatedAtColumn());
+    }
+
+    /**
+     * Get the value of the "updated at" column.
+     *
+     * @return mixed
+     */
+    public function getUpdatedAt()
+    {
+        return $this->getAttribute($this->getUpdatedAtColumn());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Problem :

When you change a model's primary key name, you can get the name with `$model->getKeyName()` or directly the value with `$model->getKey()`.

When you change the model's timestamps columns names, you can get the column name with `$model->getCreatedAtColumn()` but you don't have a method to directly get the column value.

### Proposed solution :

This PR adds two methods to allow this, whatever the model's timestamps columns names are : 
```php
// Get the "created at" value
$model->getCreatedAt();

// Get the "updated at" value
$model->getUpdatedAt();
```

### Advantage :

You don't have to do things like 
```php
$model->custom_created_at
```
or to do yourself
```php
$model->getAttribute($model->getCreatedAtColumn())
```
to get the creation date.