### PR TITLE
[6.x] add a timeout reset feature

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -50,6 +50,10 @@ class RequirePassword
                 $this->urlGenerator->route($redirectToRoute ?? 'password.confirm')
             );
         }
+        
+        if (config('auth.password_timeout_reset', false)) {
+            $request->session()->put('auth.password_confirmed_at', time());
+        }
 
         return $next($request);
     }

--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -50,7 +50,7 @@ class RequirePassword
                 $this->urlGenerator->route($redirectToRoute ?? 'password.confirm')
             );
         }
-        
+
         if (config('auth.password_timeout_reset', false)) {
             $request->session()->put('auth.password_confirmed_at', time());
         }


### PR DESCRIPTION
if the programmer decides to turns this on, the timer will reset every time a route using this middleware is visited and the user has provided their password for heightened security.

my package originally had this default to `true`, but I think `false` would be more appropriate, as it would be the more strict security option.

if this PR is accepted, I will make the necessary changes to `laravel/laravel` and `laravel/docs`