### PR TITLE
[6.x] Add `raw` method to Eloquent Builder passthru

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -72,7 +72,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
-        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
+        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw',
     ];
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -624,6 +624,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('insertUsing')->once()->with(['bar'], 'baz')->andReturn('foo');
 
         $this->assertSame('foo', $builder->insertUsing(['bar'], 'baz'));
+
+        $builder = $this->getBuilder();
+        $builder->getQuery()->shouldReceive('raw')->once()->with('bar')->andReturn('foo');
+
+        $this->assertSame('foo', $builder->raw('bar'));
     }
 
     public function testQueryScopes()


### PR DESCRIPTION
This PR adds the `raw` method to the Eloquent's Builder `$passthru` property, which results in returned an instance of the Expression class instead of the query builder itself.

```php
echo get_class(Model::query()->raw('expression'));
// -> Expected: "Illuminate\Database\Query\Expression"
// ->   Actual: "Illuminate\Database\Eloquent\Builder"
```

This removes the need to use the `DB` facade or calling `$query->getQuery()` to use raw database expressions. Example:

```php
Order::with(['customer' => function ($query) {
    // Before: $query->getQuery()->raw('...') -OR- DB::raw('...')
    return $query->select(['id', $query->raw('CONCAT(`first_name`, ' ', `last_name`)')]);
})->get();
```