### PR TITLE
[7.x] Make assertJsonPath strict only

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -480,20 +480,15 @@ class TestResponse
     }
 
     /**
-     * Assert that the expected value exists at the given path in the response.
+     * Assert that the expected value and type exists at the given path in the response.
      *
      * @param  string  $path
      * @param  mixed  $expect
-     * @param  bool  $strict
      * @return $this
      */
-    public function assertJsonPath($path, $expect, $strict = false)
+    public function assertJsonPath($path, $expect)
     {
-        if ($strict) {
-            PHPUnit::assertSame($expect, $this->json($path));
-        } else {
-            PHPUnit::assertEquals($expect, $this->json($path));
-        }
+        PHPUnit::assertSame($expect, $this->json($path));
 
         return $this;
     }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -336,11 +336,11 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonPath('foobar.foobar_foo', 'foo')->assertJsonPath('foobar.foobar_bar', 'bar');
 
         $response->assertJsonPath('bars', [
-            ['foo' => 'bar 0', 'bar' => 'foo 0'],
-            ['foo' => 'bar 1', 'bar' => 'foo 1'],
-            ['foo' => 'bar 2', 'bar' => 'foo 2'],
+            ['bar' => 'foo 0', 'foo' => 'bar 0'],
+            ['bar' => 'foo 1', 'foo' => 'bar 1'],
+            ['bar' => 'foo 2', 'foo' => 'bar 2'],
         ]);
-        $response->assertJsonPath('bars.0', ['foo' => 'bar 0', 'bar' => 'foo 0']);
+        $response->assertJsonPath('bars.0', ['bar' => 'foo 0', 'foo' => 'bar 0']);
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
@@ -349,23 +349,14 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonPath('2.id', 30);
     }
 
-    public function testAssertJsonPathStrict()
-    {
-        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
-
-        $response->assertJsonPath('0.id', 10, true);
-        $response->assertJsonPath('1.id', 20, true);
-        $response->assertJsonPath('2.id', 30, true);
-    }
-
-    public function testAssertJsonPathStrictCanFail()
+    public function testAssertJsonPathCanFail()
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Failed asserting that 10 is identical to \'10\'.');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceWithIntegersStub));
 
-        $response->assertJsonPath('0.id', '10', true);
+        $response->assertJsonPath('0.id', '10');
     }
 
     public function testAssertJsonFragment()


### PR DESCRIPTION
Removes the `$strict` parameter from `assertJsonPath` added in #30142 and make it strict only.

Discussed in #30152.

Introduces breaking changes.

**Example**
```json
{
    "int": 10,
    "array": [
        "foo",
        "bar"
    ]
}
```

```php
$result->assertJsonPath('int', 10); // pass
$result->assertJsonPath('int', '10'); // fail

$result->assertJsonPath('array', ['foo', 'bar']); // pass
$result->assertJsonPath('array', ['bar', 'foo']); // fail
```