### PR TITLE
[6.x] Arr::dot performance

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -112,7 +112,7 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results = $results + static::dot($value, $prepend.$key.'.');
             } else {
                 $results[$prepend.$key] = $value;
             }


### PR DESCRIPTION
Using array_merge causes an unnecessary performance penalty.
