### PR TITLE
[6.x] Add NotFilled validation option

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -895,6 +895,22 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the given attribute is not filled if it is present.
+     *
+     * @param  string  $attribute
+     * @param  mixed   $value
+     * @return bool
+     */
+    public function validateNotFilled($attribute, $value)
+    {
+        if (Arr::has($this->data, $attribute)) {
+            return ! $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is greater than another attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -668,6 +668,25 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateNotFilled()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, [], ['name' => 'not_filled']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => ''], ['name' => 'not_filled']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => 1], []]], ['foo.*.id' => 'not_filled']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => '']]], ['foo.*.id' => 'not_filled']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => [['id' => null]]], ['foo.*.id' => 'not_filled']);
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidationStopsAtFailedPresenceCheck()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
## What is it?
This is essentially just the inverse of the [filled validation method](https://github.com/laravel/framework/blob/2f98a614104a240d76de133a5c054c43c42e0fc5/src/Illuminate/Validation/Concerns/ValidatesAttributes.php#L888). 

## Inspiration and Use Case
My use case was inspired by [Spatie's Honeypot spam catcher](https://freek.dev/1240-preventing-spam-submitted-through-forms). But, I didn't want to download a whole package when I only have one or two public facing forms on each app. Plus, the whole time measuring element of the package,  while really cool, would probably blow up my automated tests. 

### My Use Case
I have a hidden field on the public facing forms that is empty by default. Since it is a hidden field, regular users would never complete it. However, spam-bots tend to fill in all fields (again inspired by the Honeypot package), so the validation of `not_filled` would prevent the forms from being submitted in the spam-bot cases. 

### Potential Other Use Case
Very contrived, but maybe an "I agree" type field that you would only complete if you disagreed? 😬 Honestly, I don't have any other valid use cases in mind. But maybe someone else will 🤷‍♂ 

## Merge or Not
If you decide not to merge this, I would totally understand. I was **hoping someone else would have some other use cases** besides my spam catcher thought. Also, I already wrote a custom validation rule on one of my apps for this. If this was merged, I wouldn't have to repeat that process on all the other apps. 

## Tests
Tests were added for this new validation method and everything is passing on my machine. 