### PR TITLE
[6.x] Add selectConcat() builder method and related DB grammar

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -78,6 +78,13 @@ class Builder
     public $columns;
 
     /**
+     * The aliased concatenation columns.
+     *
+     * @var array
+     */
+    public $concats = [];
+
+    /**
      * Indicates if the query returns distinct results.
      *
      * Occasionally contains the columns that should be distinct.
@@ -372,6 +379,20 @@ class Builder
                 $this->columns[] = $column;
             }
         }
+
+        return $this;
+    }
+
+    /**
+     * Adds a concatenated column as an alias.
+     *
+     * @param  array $parts The concatenation parts.
+     * @param  string $as The name of the alias for the compiled concatenation.
+     * @return $this
+     */
+    public function selectConcat(array $parts, string $as)
+    {
+        $this->concats[$as] = $parts;
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -167,7 +167,7 @@ class Grammar extends BaseGrammar
             $columns[] = $this->compileConcat($parts, $as);
         }
 
-        return ', ' . implode(', ', $columns);
+        return ', '.implode(', ', $columns);
     }
 
     /**
@@ -189,11 +189,11 @@ class Grammar extends BaseGrammar
                 if (preg_match('/^[\'"]*(.*?)[\'"]*$/', $part, $matches)) {
                     $part = $matches[1];
                 }
-                $compileParts[] = $this->wrap(new Expression('"' . $part . '"'));
+                $compileParts[] = $this->wrap(new Expression('"'.$part.'"'));
             }
         }
 
-        return 'concat(' . implode(', ', $compileParts) . ') as ' . $this->wrap($as);
+        return 'concat('.implode(', ', $compileParts).') as '.$this->wrap($as);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -185,11 +185,7 @@ class Grammar extends BaseGrammar
             if (preg_match('/^[a-z_@#][a-z0-9@$#_]*$/', $part)) {
                 $compileParts[] = $this->wrap($part);
             } else {
-                // Removes quotes from quoted strings
-                if (preg_match('/^[\'"]*(.*?)[\'"]*$/', $part, $matches)) {
-                    $part = $matches[1];
-                }
-                $compileParts[] = $this->wrap(new Expression('"'.$part.'"'));
+                $compileParts[] = $this->wrap(new Expression('"'.trim($part, '\'"').'"'));
             }
         }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -109,7 +109,13 @@ class PostgresGrammar extends Grammar
             $select = 'select ';
         }
 
-        return $select.$this->columnize($columns);
+        $select .= $this->columnize($columns);
+
+        if (count($query->concats)) {
+            $select .= $this->compileConcats($query);
+        }
+
+        return $select;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -39,11 +39,11 @@ class SQLiteGrammar extends Grammar
                 if (preg_match('/^[\'"]*(.*?)[\'"]*$/', $part, $matches)) {
                     $part = $matches[1];
                 }
-                $compileParts[] = $this->wrap(new Expression('"' . $part . '"'));
+                $compileParts[] = $this->wrap(new Expression('"'.$part.'"'));
             }
         }
 
-        return implode(' || ', $compileParts) . ' as ' . $this->wrap($as);
+        return implode(' || ', $compileParts).' as '.$this->wrap($as);
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -35,11 +35,7 @@ class SQLiteGrammar extends Grammar
             if (preg_match('/^[a-z_@#][a-z0-9@$#_]*$/', $part)) {
                 $compileParts[] = $this->wrap($part);
             } else {
-                // Removes quotes from quoted strings
-                if (preg_match('/^[\'"]*(.*?)[\'"]*$/', $part, $matches)) {
-                    $part = $matches[1];
-                }
-                $compileParts[] = $this->wrap(new Expression('"'.$part.'"'));
+                $compileParts[] = $this->wrap(new Expression('"'.trim($part, '\'"').'"'));
             }
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -64,7 +64,13 @@ class SqlServerGrammar extends Grammar
             $select .= 'top '.$query->limit.' ';
         }
 
-        return $select.$this->columnize($columns);
+        $select .= $this->columnize($columns);
+
+        if (count($query->concats)) {
+            $select .= $this->compileConcats($query);
+        }
+
+        return $select;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3465,6 +3465,50 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
+    public function testSelectConcatOnSqlite()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->from('test');
+        $builder->selectConcat(['test_field_1', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, "test_field_1" || " " || "test_field_2" as "concat_test" from "test"', $builder->toSql());
+
+        $builder->selectConcat(['"test_field_1"', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, "test_field_1" || " " || "test_field_2" as "concat_test" from "test"', $builder->toSql());
+    }
+
+    public function testSelectConcatOnMySQL()
+    {
+        $builder = $this->getMySqlBuilder();
+        $builder->from('test');
+        $builder->selectConcat(['test_field_1', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat(`test_field_1`, " ", `test_field_2`) as `concat_test` from `test`', $builder->toSql());
+
+        $builder->selectConcat(['"test_field_1"', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat("test_field_1", " ", `test_field_2`) as `concat_test` from `test`', $builder->toSql());
+    }
+
+    public function testSelectConcatOnPostgres()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->from('test');
+        $builder->selectConcat(['test_field_1', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat("test_field_1", " ", "test_field_2") as "concat_test" from "test"', $builder->toSql());
+
+        $builder->selectConcat(['"test_field_1"', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat("test_field_1", " ", "test_field_2") as "concat_test" from "test"', $builder->toSql());
+    }
+
+    public function testSelectConcatOnSqlServer()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->from('test');
+        $builder->selectConcat(['test_field_1', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat([test_field_1], " ", [test_field_2]) as [concat_test] from [test]', $builder->toSql());
+
+        $builder->selectConcat(['"test_field_1"', ' ', 'test_field_2'], 'concat_test');
+        $this->assertSame('select *, concat("test_field_1", " ", [test_field_2]) as [concat_test] from [test]', $builder->toSql());
+    }
+
     protected function getBuilder()
     {
         $grammar = new Grammar;


### PR DESCRIPTION
This PR adds a new method to the query builder, `selectConcat`, which provides a way to add concatenated values as an alias in the query, to be used later in the query, or returned to the models. This happens external to the normal `select` method and defined columns.

This work was originally done for October CMS (https://github.com/octobercms/library/pull/434) however, we felt it would be a useful addition to Laravel and so have put it forward for consideration.

The method accepts an array parameter `$parts` which make up the parts of the concatenated string. If a value looks to be a column name, it is wrapped with column quotes. For all other values, it wrap them in string quotes. If a column name or operator is to be used, it can be double-quoted in order to force it to be considered as a string. The second parameter is a string parameter that defines the alias name of the concatenated value.

The concatenated alias is populated as an attribute in the model after the query is run, allowing models to use the values as well.

I'm happy to take advice on any improvements or changes required.