### PR TITLE
Add $globalAddressTypes to MailServiceProvider

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -11,7 +11,7 @@ use Swift_Mailer;
 
 class MailServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    $globalAddressTypes = ['from', 'reply_to', 'to'];
+    protected $globalAddressTypes = ['from', 'reply_to', 'to'];
     
     /**
      * Register the service provider.

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -11,6 +11,8 @@ use Swift_Mailer;
 
 class MailServiceProvider extends ServiceProvider implements DeferrableProvider
 {
+    $globalAddressTypes = ['from', 'reply_to', 'to'];
+    
     /**
      * Register the service provider.
      *
@@ -47,7 +49,7 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
             // Next we will set all of the global addresses on this mailer, which allows
             // for easy unification of all "from" addresses as well as easy debugging
             // of sent messages since they get be sent into a single email address.
-            foreach (['from', 'reply_to', 'to'] as $type) {
+            foreach ($globalAddressTypes as $type) {
                 $this->setGlobalAddress($mailer, $config, $type);
             }
 


### PR DESCRIPTION
With this piece of code, you can specify which types of global addresses are added to the mailer.

This code moves an array to a variable, so you are able to override it in a custom MailServiceProvider, so it will not break anything.