### PR TITLE
[6.x] Fix Str::snake to handle wider range of input strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -490,17 +490,19 @@ class Str
      */
     public static function snake($value, $delimiter = '_')
     {
+        if (ctype_lower($value)) {
+            // no need to do anything (processing/cacheing)
+            return $value;
+        }
+
         $key = $value;
 
         if (isset(static::$snakeCache[$key][$delimiter])) {
             return static::$snakeCache[$key][$delimiter];
         }
 
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
-
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
+        $pattern = '/(?:(?:\s+|[^[:alnum:]])|([[:alnum:]])(?=[A-Z]))/u';
+        $value = static::lower(preg_replace($pattern, '$1'.$delimiter, trim($value)));
 
         return static::$snakeCache[$key][$delimiter] = $value;
     }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -206,6 +206,9 @@ class SupportStrTest extends TestCase
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+        $this->assertSame('laravel-php-framework', Str::kebab('Laravel_Php_Framework'));
+        $this->assertSame('laravel-php-framework', Str::kebab('laravel_php_framework'));
+        $this->assertSame('--laravel---php-framework', Str::kebab('  :_laravel  _  Php_framework  '));
     }
 
     public function testLower()
@@ -298,6 +301,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+        // test with numbers
+        $this->assertSame('laravel6_php_frame_work', Str::snake('laravel6 php FrameWork'));
+        $this->assertSame('laravel6_p_h_p_framework', Str::snake('laravel6PHPFramework'));
+        // test from kebab case
+        $this->assertSame('laravel_php__framework', Str::snake('laravel-php--framework'));
+        // test mixed whitespace and non-whitespace delimiters
+        $this->assertSame('https___www_example_org', Str::snake('https://www.example.org'));
+        $this->assertSame('laravel__p_h_p___framework', Str::snake('laravel: PHP// framework'));
+        $this->assertSame('__laravel__p_h____p_framework____', Str::snake(' --Laravel__PH --  PFramework / /  '));
+        // test with unusual whitespaces
+        $this->assertSame('___laravel__p_h_____p_framework____', Str::snake(" \v -\r-Laravel__PH -\n- \n PFramework /\t\r/"));
+        // test multibyte
+        $this->assertSame('__malmö_jönköping', Str::snake('  --Malmö Jönköping    '));
     }
 
     public function testStudly()


### PR DESCRIPTION
1. Fixes problems with kebab-case to snake_case (and vice-versa) conversions.
2. Provides test for handling identifiers with numbers to establish the convention (see #28709 #28710).
3. Treats all non-alnum characters as delimiters converted to ``'_'`` (or to ``$delimiter`` in general).
4. Multiple consecutive spaces are treated as single delimiter.
5. Handle multibyte (UTF-8) strings.

Some conversion examples (covered by unit test):

```
'laravel6 php FrameWork' -> 'laravel6_php_frame_work'
'laravel6PHPFramework' -> 'laravel6_p_h_p_framework'
'laravel-php--framework' -> 'laravel_php__framework'
'http://www.example.org' -> 'http___www_example_org'
' --Laravel__PH --  PFramework / /  ' -> '__laravel__p_h____p_framework____'
'  --Malmö Jönköping    ' -> '__malmö_jönköping'
```