### PR TITLE
[6.x] receivesBroadcastNotificationsOn can return array for multiple channels of user

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -60,13 +60,23 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $channels;
         }
 
-        return [new PrivateChannel($this->channelName())];
+        $channelNames = $this->channelName();
+        if (is_string($channelNames)) {
+            return [new PrivateChannel($channelNames)];
+        }
+
+        $channels = [];
+        foreach ($channelNames as $channel) {
+            $channels[] = new PrivateChannel($channel);
+        }
+
+        return $channels;
     }
 
     /**
      * Get the broadcast channel name for the event.
      *
-     * @return string
+     * @return string|array
      */
     protected function channelName()
     {


### PR DESCRIPTION
if the user is logged on to multiple devices (each session has different channel names), receivesBroadcastNotificationsOn is able to retrieve and use all channel names. This means that the receivesBroadcastNotificationsOn function can now return an array, not just a string.

This innovation not disrupts any existing feature.