### PR TITLE
[6.x] Fix Str::snake to handle wider range of input strings

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -203,9 +203,66 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::is([], 'test'));
     }
 
-    public function testKebab()
+    public function testKebab() // testKebabFromStudly
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+    }
+
+    public function testKebabWithNumbers()
+    {
+        $this->assertSame('laravel6-php-frame-work', Str::kebab('laravel6 php FrameWork'));
+        $this->assertSame('laravel6-p-h-p-framework', Str::kebab('laravel6PHPFramework'));
+    }
+
+    public function testKebabFromCamel()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebab('laravelPhpFramework'));
+    }
+
+    public function testKebabFromSnake()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebab('laravel_php_framework'));
+    }
+
+    public function testKebabFromSnakeCaps()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebab('Laravel_Php_Framework'));
+    }
+
+    public function testKebabFromUrl()
+    {
+        $this->assertSame('http://hello-world.org', Str::kebab('http://HelloWorld.org'));
+    }
+
+    public function testKebabFromCamelNestedMember()
+    {
+        $this->assertSame('i-am.the-nested.member', Str::kebab('iAm.theNested.member'));
+    }
+
+    public function testKebabFromStudlyNestedMember()
+    {
+        $this->assertSame('i-am.the-nested.member', Str::kebab('IAm.TheNested.Member'));
+    }
+
+    public function testKebabFromSnakeNestedMember()
+    {
+        $this->assertSame('i-am.the-nested.member', Str::kebab('i_am.the_nested.member'));
+    }
+
+    public function testKebabWithWildChars()
+    {
+        $this->assertSame('i-am.*.last-member', Str::kebab('iAm.*.lastMember'));
+    }
+
+    public function testKebabWithMultibyte()
+    {
+        $this->assertSame('malmö-jönköping', Str::kebab('Malmö Jönköping'));
+    }
+
+    public function testKebabWithMultibyteCaps()
+    {
+        $this->assertSame('łukasz-żądełko', Str::kebab('ŁukaszŻądełko'));
+        $this->assertSame('łukasz.żądełko', Str::kebab('Łukasz.Żądełko'));
     }
 
     public function testLower()
@@ -298,6 +355,73 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+    }
+
+    public function testSnakeWithNumbers()
+    {
+        $this->assertSame('laravel6_php_frame_work', Str::snake('laravel6 php FrameWork'));
+        $this->assertSame('laravel6_p_h_p_framework', Str::snake('laravel6PHPFramework'));
+    }
+
+    public function testSnakeFromCamel()
+    {
+        $this->assertSame('laravel_php_framework', Str::snake('laravelPhpFramework'));
+    }
+
+    public function testSnakeFromKebab()
+    {
+        $this->assertSame('laravel_php_framework', Str::snake('laravel-php-framework'));
+    }
+
+    public function testSnakeFromSnakeCaps()
+    {
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel_Php_Framework'));
+    }
+
+    public function testSnakeFromKebabCaps()
+    {
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel-Php-Framework'));
+    }
+
+    public function testSnakeFromUrl()
+    {
+        $this->assertSame('http://hello_world.org', Str::snake('http://HelloWorld.org'));
+    }
+
+    public function testSnakeFromCamelNestedMember()
+    {
+        $this->assertSame('i_am.the_nested.member', Str::snake('iAm.theNested.member'));
+    }
+
+    public function testSnakeFromStudlyNestedMember()
+    {
+        $this->assertSame('i_am.the_nested.member', Str::snake('IAm.TheNested.Member'));
+    }
+
+    public function testSnakeFromKebabNestedMember()
+    {
+        $this->assertSame('i_am.the_nested.member', Str::snake('i-am.the-nested.member'));
+    }
+
+    public function testSnakeWithWildCard()
+    {
+        $this->assertSame('i_am.*.last_member', Str::snake('iAm.*.lastMember'));
+    }
+
+    public function testSnakeWithWildChars()
+    {
+        $this->assertSame('some_of_the_chars_like:_(!@#$%^&*)_remain_unchanged',
+               Str::snake('Some of theCharsLike:   (!@#$%^&*) remain unchanged'));
+    }
+
+    public function testSnakeWithMultibyte()
+    {
+        $this->assertSame('malmö_jönköping', Str::snake('Malmö Jönköping'));
+    }
+
+    public function testSnakeWithMultibyteCaps()
+    {
+        $this->assertSame('łukasz_żądełko', Str::snake('ŁukaszŻądełko'));
     }
 
     public function testStudly()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -208,6 +208,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
     }
 
+    public function testKebabWithWeirdWhitespaces()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebab("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('--laravel-php-framework--', Str::kebab(' _ Laravel  Php Framework    _    '));
+        $this->assertSame('/-laravel-php-framework-?', Str::kebab(' / Laravel  Php Framework    ?    '));
+    }
+
     public function testKebabWithNumbers()
     {
         $this->assertSame('laravel6-php-frame-work', Str::kebab('laravel6 php FrameWork'));
@@ -249,9 +256,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('i-am.the-nested.member', Str::kebab('i_am.the_nested.member'));
     }
 
-    public function testKebabWithWildChars()
+    public function testKebabWithWildCards()
     {
         $this->assertSame('i-am.*.last-member', Str::kebab('iAm.*.lastMember'));
+    }
+
+    public function testKebabWithStrangeChars()
+    {
+        $this->assertSame('all-the-strange-chars-like:-(!@#$%^&*)-remain-unchanged',
+               Str::kebab('All the strangeCharsLike:   (!@#$%^&*) remain unchanged'));
     }
 
     public function testKebabWithMultibyte()
@@ -261,8 +274,83 @@ class SupportStrTest extends TestCase
 
     public function testKebabWithMultibyteCaps()
     {
+        $this->assertSame('łu-kasz.żą-dełko', Str::kebab('ŁuKasz.ŻąDełko'));
         $this->assertSame('łukasz-żądełko', Str::kebab('ŁukaszŻądełko'));
-        $this->assertSame('łukasz.żądełko', Str::kebab('Łukasz.Żądełko'));
+    }
+
+    public function testKebabIdenFromStudly()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebabIden('LaravelPhpFramework'));
+    }
+
+    public function testKebabIdenWithNumbers()
+    {
+        $this->assertSame('laravel6-php-frame-work', Str::kebabIden('laravel6 php FrameWork'));
+        $this->assertSame('laravel6-php-framework', Str::kebabIden('laravel6PHPFramework'));
+    }
+
+    public function testKebabIdenWithWeirdWhitespaces()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebabIden("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('--laravel-php-framework--', Str::kebabIden(' _ Laravel  Php Framework    _    '));
+        $this->assertSame('--laravel-php-framework--', Str::kebabIden(' / Laravel  Php Framework    ?    '));
+    }
+
+    public function testKebabIdenFromCamel()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebabIden('laravelPhpFramework'));
+    }
+
+    public function testKebabIdenFromSnake()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebabIden('laravel_php_framework'));
+    }
+
+    public function testKebabIdenFromSnakeCaps()
+    {
+        $this->assertSame('laravel-php-framework', Str::kebabIden('Laravel_Php_Framework'));
+    }
+
+    public function testKebabIdenFromUrl()
+    {
+        $this->assertSame('http---hello-world-org', Str::kebabIden('http://HelloWorld.org'));
+    }
+
+    public function testKebabIdenFromCamelNestedMember()
+    {
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('iAm.theNested.member'));
+    }
+
+    public function testKebabIdenFromStudlyNestedMember()
+    {
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('IAm.TheNested.Member'));
+    }
+
+    public function testKebabIdenFromSnakeNestedMember()
+    {
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('i_am.the_nested.member'));
+    }
+
+    public function testKebabIdenWithWildCards()
+    {
+        $this->assertSame('i-am---last-member', Str::kebabIden('iAm.*.lastMember'));
+    }
+
+    public function testKebabIdenWithStrangeChars()
+    {
+        $this->assertSame('all-the-strange-chars-like-------------get-replaced',
+               Str::kebabIden('All the strangeCharsLike:   (!@#$%^&*) get/replaced'));
+    }
+
+    public function testKebabIdenWithMultibyte()
+    {
+        $this->assertSame('malmö-jönköping', Str::kebabIden('Malmö Jönköping'));
+    }
+
+    public function testKebabIdenWithMultibyteCaps()
+    {
+        $this->assertSame('łu-kasz-żą-dełko', Str::kebabIden('ŁuKasz.ŻąDełko'));
+        $this->assertSame('łukasz-żądełko', Str::kebabIden('ŁukaszŻądełko'));
     }
 
     public function testLower()
@@ -357,6 +445,13 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
     }
 
+    public function testSnakeWithWeirdWhitespaces()
+    {
+        $this->assertSame('laravel_php_framework', Str::snake("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('__laravel_php_framework__', Str::snake(' - Laravel  Php Framework    -    '));
+        $this->assertSame('/_laravel_php_framework_?', Str::snake(' / Laravel  Php Framework    ?    '));
+    }
+
     public function testSnakeWithNumbers()
     {
         $this->assertSame('laravel6_php_frame_work', Str::snake('laravel6 php FrameWork'));
@@ -408,10 +503,10 @@ class SupportStrTest extends TestCase
         $this->assertSame('i_am.*.last_member', Str::snake('iAm.*.lastMember'));
     }
 
-    public function testSnakeWithWildChars()
+    public function testSnakeWithStrangeChars()
     {
-        $this->assertSame('some_of_the_chars_like:_(!@#$%^&*)_remain_unchanged',
-               Str::snake('Some of theCharsLike:   (!@#$%^&*) remain unchanged'));
+        $this->assertSame('all_the_strange_chars_like:_(!@#$%^&*)_remain_unchanged',
+               Str::snake('All the strangeCharsLike:   (!@#$%^&*) remain unchanged'));
     }
 
     public function testSnakeWithMultibyte()
@@ -421,7 +516,97 @@ class SupportStrTest extends TestCase
 
     public function testSnakeWithMultibyteCaps()
     {
+        $this->assertSame('łukasz.żądełko', Str::snake('Łukasz.Żądełko'));
         $this->assertSame('łukasz_żądełko', Str::snake('ŁukaszŻądełko'));
+    }
+
+    public function testSnakeIden()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('LaravelPHPFramework'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('LaravelPhpFramework'));
+        $this->assertSame('laravel php framework', Str::snakeIden('LaravelPhpFramework', ' '));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel Php Framework'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel    Php      Framework   '));
+        // ensure cache keys don't overlap
+        $this->assertSame('laravel__php__framework', Str::snakeIden('LaravelPhpFramework', '__'));
+        $this->assertSame('laravel_php_framework_', Str::snakeIden('LaravelPhpFramework_', '_'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravel php Framework'));
+        $this->assertSame('laravel_php_frame_work', Str::snakeIden('laravel php FrameWork'));
+    }
+
+    public function testSnakeIdenWithNumbers()
+    {
+        $this->assertSame('laravel6_php_frame_work', Str::snakeIden('laravel6 php FrameWork'));
+        $this->assertSame('laravel6_php_framework', Str::snakeIden('laravel6PHPFramework'));
+    }
+
+    public function testSnakeIdenWithWeirdWhitespaces()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('__laravel_php_framework__', Str::snakeIden(' - Laravel  Php Framework    _    '));
+        $this->assertSame('__laravel_php_framework__', Str::snakeIden(' / Laravel  Php Framework    ?    '));
+    }
+
+    public function testSnakeIdenFromCamel()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravelPhpFramework'));
+    }
+
+    public function testSnakeIdenFromKebab()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravel-php-framework'));
+    }
+
+    public function testSnakeIdenFromSnakeCaps()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel_Php_Framework'));
+    }
+
+    public function testSnakeIdenFromKebabCaps()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel-Php-Framework'));
+    }
+
+    public function testSnakeIdenFromUrl()
+    {
+        $this->assertSame('http___hello_world_org', Str::snakeIden('http://HelloWorld.org'));
+    }
+
+    public function testSnakeIdenFromCamelNestedMember()
+    {
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('iAm.theNested.member'));
+    }
+
+    public function testSnakeIdenFromStudlyNestedMember()
+    {
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('IAm.TheNested.Member'));
+    }
+
+    public function testSnakeIdenFromKebabNestedMember()
+    {
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('i-am.the-nested.member'));
+    }
+
+    public function testSnakeIdenWithWildCard()
+    {
+        $this->assertSame('i_am___last_member', Str::snakeIden('iAm.*.lastMember'));
+    }
+
+    public function testSnakeIdenWithStrangeChars()
+    {
+        $this->assertSame('all_the_strange_chars_like_____________get_replaced',
+               Str::snakeIden('All the strangeCharsLike:   (!@#$%^&*) get/replaced'));
+    }
+
+    public function testSnakeIdenWithMultibyte()
+    {
+        $this->assertSame('malmö_jönköping', Str::snakeIden('Malmö Jönköping'));
+    }
+
+    public function testSnakeIdenWithMultibyteCaps()
+    {
+        $this->assertSame('łu_kasz_żą_dełko', Str::snakeIden('ŁuKasz.ŻąDełko'));
+        $this->assertSame('łukasz_żądełko', Str::snakeIden('ŁukaszŻądełko'));
     }
 
     public function testStudly()


### PR DESCRIPTION
1. Fixes problems with kebab-case to snake_case (and vice-versa) conversions.
2. Provides test for handling identifiers with numbers to establish the convention (see #28709 #28710).
3. Provides two new functions ``snakeIden()``/``kebabIden()``, which: 
    - replace all non-alnum characters with ``'_'``/``'-'``,
    - avoid exploding sequences of uppercase chars, such as ``'PHP'``. The ``xxxIden()`` functions turn ``thePHPVersion`` into ``the_php_version`` and not ``the_p_h_p_version`` (as it is in ``non-Iden()`` functions).
4. Multiple consecutive spaces are treated as single delimiter. Trailing spaces ``trim()``med.
5. Handle unicode strings, including multibyte MixedCase like ``'małaŻołtaŁódka'``.
