### PR TITLE
[6.x] Casts values from the getOriginal method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -692,10 +692,6 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        if (! \is_string($value)) {
-            $value = \json_encode($value);
-        }
-
         return json_decode($value, ! $asObject);
     }
 
@@ -965,6 +961,12 @@ trait HasAttributes
      */
     public function getOriginal($key = null, $default = null)
     {
+        // Casts of type array are already processed, so return value in this case
+        if ($this->hasCast($key)
+            && $this->getCastType($key) === 'array') {
+            return Arr::get($this->original, $key, $default);
+        }
+
         return $this->getValue($key, Arr::get($this->original, $key, $default));
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -692,7 +692,7 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        if (!\is_string($value)) {
+        if (! \is_string($value)) {
             $value = \json_encode($value);
         }
 
@@ -1231,7 +1231,8 @@ trait HasAttributes
         return $matches[1];
     }
 
-    private function getValue($key, $value) {
+    private function getValue($key, $value)
+    {
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1940,6 +1940,44 @@ class DatabaseEloquentModelTest extends TestCase
             Model::isIgnoringTouch(EloquentModelWithoutTimestamps::class)
         );
     }
+
+    public function testGetOriginalCastsAttributes()
+    {
+        $model = new EloquentModelCastingStub();
+        $model->intAttribute = '1';
+        $model->floatAttribute = '0.1234';
+        $model->stringAttribute = 432;
+        $model->boolAttribute = '1';
+        $model->booleanAttribute = '0';
+
+        $model->syncOriginal();
+
+        $model->intAttribute = 2;
+        $model->floatAttribute = 0.443;
+        $model->stringAttribute = '12';
+        $model->boolAttribute = true;
+        $model->booleanAttribute = false;
+
+        $this->assertIsInt($model->getOriginal('intAttribute'));
+        $this->assertEquals(1, $model->getOriginal('intAttribute'));
+        $this->assertEquals(2, $model->intAttribute);
+
+        $this->assertIsFloat($model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.1234, $model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.443, $model->floatAttribute);
+
+        $this->assertIsString($model->getOriginal('stringAttribute'));
+        $this->assertEquals('432', $model->getOriginal('stringAttribute'));
+        $this->assertEquals('12', $model->stringAttribute);
+
+        $this->assertIsBool($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->boolAttribute);
+
+        $this->assertIsBool($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->booleanAttribute);
+    }
 }
 
 class EloquentTestObserverStub


### PR DESCRIPTION
# Summary
This merge request fixed the fact that the `getOriginal` doesn't cast the attributes if defined in the $casts array.

# Problem description
The way the `getAttribute` fetches a value differs from `getOriginal`. Take into consideration the following code:

```php
$model = new EloquentModelCastingStub();
$model->intAttribute = '1';
$model->syncOriginal();
$model->intAttribute = '1';
dump($model->getAttribute('intAttribute'), $model->getOriginal('intAttribute'));
```
This will return:

```
1
"1"
```

I've encountered this with SQLite and Oracle DB adapters when fetching a model, changing the value and comparing the original and new values
 
# Expectations
It is expected that both values are returned as integer

# Solution
See pull request, both methods should have the same logic to return the value
