### PR TITLE
[6.x] Optimize eager loading memory handling

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1094,7 +1094,7 @@ class Builder
 
                 [$name, $constraints] = Str::contains($name, ':')
                             ? $this->createSelectWithConstraint($name)
-                            : [$name, function () {
+                            : [$name, static function () {
                                 //
                             }];
             }
@@ -1118,7 +1118,7 @@ class Builder
      */
     protected function createSelectWithConstraint($name)
     {
-        return [explode(':', $name)[0], function ($query) use ($name) {
+        return [explode(':', $name)[0], static function ($query) use ($name) {
             $query->select(explode(',', explode(':', $name)[1]));
         }];
     }
@@ -1141,7 +1141,7 @@ class Builder
             $progress[] = $segment;
 
             if (! isset($results[$last = implode('.', $progress)])) {
-                $results[$last] = function () {
+                $results[$last] = static function () {
                     //
                 };
             }


### PR DESCRIPTION
Fixes #30114 

This pull request fixes a memory leak issue reported in the mentioned issue, ~~I think this may be a bug in PHP itself so I will report to them too~~.

The problem is that the Eloquent builder is creating closures for the relations, these relations are stored in the eagerLoads property of the class because these closures are containing a reference to the builder the GC thinks the class is still referenced. By refactoring these closures to static ones this reference does not get stored so the GC can correctly clean up the builder earlier.

edit: Turns out this just delays the GC, it gets detected later when memory usage hits ~24MB. Updated the title to optimize.

These methods does not use the `$this` reference so there is no other change needed.