### PR TITLE
[7.x] Fix Str::snake()/Str::kebab() to handle wider range of strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -18,7 +18,7 @@ class Str
      *
      * @var array
      */
-    protected static $snakeCache = [];
+    protected static $lowerDelimitedCache = [];
 
     /**
      * The cache of camel-cased words.
@@ -209,15 +209,68 @@ class Str
         return ASCII::is_ascii($value);
     }
 
+    //
+    // Different methods of converting arbitrary strings to char-delimited.
+    //
+    // - DELIM_ORIG
+    //
+    //   Backward compatible. It only replaces spaces and '-'/'_' with
+    //   $delimiter char and separates pairs of mixed or upper case letters
+    //   like 'aA' or 'AA' using the $delimiter ('aA' becomes 'a_A', 'AA' becomes
+    //   'A_A', but 'Aa' is left unchanged).
+    //
+    // - DELIM_IDEN
+    //
+    //   May be used to generate identifiers such as variable or attribute
+    //   names. It replaces all non-[:alnum:] characters with $delimiter and
+    //   tries keep together sequences of upper letters such as 'PHP'.
+    //   For example, 'LaravelPHPFramework' turns into 'Laravel_PHP_Framework'
+    //   (the DELIM_ORIG method would generate 'Laravel_P_H_P_Framework').
+    //
+    // Both methods squash multiple whitespaces and replace them whith a single
+    // $delimiter.
+    //
+    const DELIM_ORIG = 0;
+    const DELIM_IDEN = 1;
+
+    //
+    // '%' in the $delimParams[*]['replace'] will be substituted with the value
+    // of $delimiter argument (see delimited() below).
+    //
+    protected static $delimParams = [
+        self::DELIM_ORIG => [
+            'pattern' => '/(?:(?:\s+|[_-])|(?:([[:alnum:]])(?=[[:upper:]])))/u',
+            'replace' => '$1%',
+        ],
+        self::DELIM_IDEN => [
+            'pattern' => '/(?:\s+|[^[:alnum:]])|'.
+                         '(?:([[:lower:][:digit:]])(?=[[:upper:]]))|'.
+                         '(?:([[:upper:]])(?=[[:upper:]][[:lower:]]))/u',
+            'replace' => '$1$2%',
+        ],
+    ];
+
     /**
      * Convert a string to kebab case.
      *
      * @param  string  $value
      * @return string
      */
-    public static function kebab($value)
+    public static function kebab($value, $delimiter = '-')
     {
-        return static::snake($value, '-');
+        return static::lowerDelimited($value, $delimiter, static::DELIM_ORIG);
+    }
+
+    /**
+     * Convert a string to kebab case identifier.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function kebabIden($value, $delimiter = '-')
+    {
+        return static::lowerDelimited($value, $delimiter, static::DELIM_IDEN);
     }
 
     /**
@@ -492,19 +545,63 @@ class Str
      */
     public static function snake($value, $delimiter = '_')
     {
+        return static::lowerDelimited($value, $delimiter, static::DELIM_ORIG);
+    }
+
+    /**
+     * Convert a string to snake case identifier.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function snakeIden($value, $delimiter = '_')
+    {
+        return static::lowerDelimited($value, $delimiter, static::DELIM_IDEN);
+    }
+
+    /*
+     * Returns words delimited with $delimiter, with camelCase words separated.
+     *
+     * @param string $value
+     * @param string $delimiter
+     * @param int $method one of the DELIM_xxxx constants
+     *
+     * @return string
+     */
+    protected static function delimited($value, $delimiter, $method)
+    {
+        $pattern = static::$delimParams[$method]['pattern'];
+        $replace = str_replace('%', $delimiter, static::$delimParams[$method]['replace']);
+
+        return preg_replace($pattern, $replace, trim($value));
+    }
+
+    /**
+     * Workhorse for snake() and kebab().
+     *
+     * @param string $value
+     * @param string $delimiter
+     * @param int $method one of the DELIM_xxxx constants
+     *
+     * @return string
+     */
+    protected static function lowerDelimited($value, $delimiter, $method)
+    {
+        if (ctype_lower($value)) {
+            // no need to do anything (processing/cacheing)
+            return $value;
+        }
+
         $key = $value;
 
-        if (isset(static::$snakeCache[$key][$delimiter])) {
-            return static::$snakeCache[$key][$delimiter];
+        if (isset(static::$lowerDelimitedCache[$key][$delimiter][$method])) {
+            return static::$lowerDelimitedCache[$key][$delimiter][$method];
         }
 
-        if (! ctype_lower($value)) {
-            $value = preg_replace('/\s+/u', '', ucwords($value));
+        $value = static::lower(static::delimited($value, $delimiter, $method));
 
-            $value = static::lower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
-        }
-
-        return static::$snakeCache[$key][$delimiter] = $value;
+        return static::$lowerDelimitedCache[$key][$delimiter][$method] = $value;
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -205,7 +205,76 @@ class SupportStrTest extends TestCase
 
     public function testKebab()
     {
+        // sfrom StudlyCase
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
+        // weird whitespaces
+        $this->assertSame('laravel-php-framework', Str::kebab("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('--laravel-php-framework--', Str::kebab(' _ Laravel  Php Framework    _    '));
+        $this->assertSame('/-laravel-php-framework-?', Str::kebab(' / Laravel  Php Framework    ?    '));
+        // numbers
+        $this->assertSame('laravel6-php-frame-work', Str::kebab('laravel6 php FrameWork'));
+        $this->assertSame('laravel6-p-h-p-framework', Str::kebab('laravel6PHPFramework'));
+        // from camelCase
+        $this->assertSame('laravel-php-framework', Str::kebab('laravelPhpFramework'));
+        // from snake_case
+        $this->assertSame('laravel-php-framework', Str::kebab('laravel_php_framework'));
+        // from Snake_Caps
+        $this->assertSame('laravel-php-framework', Str::kebab('Laravel_Php_Framework'));
+        // from Url
+        $this->assertSame('http://hello-world.org', Str::kebab('http://HelloWorld.org'));
+        // from camelCase.nestedMember
+        $this->assertSame('i-am.the-nested.member', Str::kebab('iAm.theNested.member'));
+        // from StudlyCase.NestedMember
+        $this->assertSame('i-am.the-nested.member', Str::kebab('IAm.TheNested.Member'));
+        // from snake_case.nested_member
+        $this->assertSame('i-am.the-nested.member', Str::kebab('i_am.the_nested.member'));
+        // from string with wildcards (I've seen this somewhere in laravel/framework)
+        $this->assertSame('i-am.*.last-member', Str::kebab('iAm.*.lastMember'));
+        // from string with strange characters
+        $this->assertSame('all-the-strange-chars-like:-(!@#$%^&*)-remain-unchanged',
+               Str::kebab('All the strangeCharsLike:   (!@#$%^&*) remain unchanged'));
+        // from string with multibyte
+        $this->assertSame('malmö-jönköping', Str::kebab('Malmö Jönköping'));
+        // from string with multibyte caps
+        $this->assertSame('łu-kasz.żą-dełko', Str::kebab('ŁuKasz.ŻąDełko'));
+        $this->assertSame('łukasz-żądełko', Str::kebab('ŁukaszŻądełko'));
+    }
+
+    public function testKebabIden()
+    {
+        // from StudlyCase
+        $this->assertSame('laravel-php-framework', Str::kebabIden('LaravelPhpFramework'));
+        // with numbers
+        $this->assertSame('laravel6-php-frame-work', Str::kebabIden('laravel6 php FrameWork'));
+        $this->assertSame('laravel6-php-framework', Str::kebabIden('laravel6PHPFramework'));
+        // with weird whitespaces
+        $this->assertSame('laravel-php-framework', Str::kebabIden("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('--laravel-php-framework--', Str::kebabIden(' _ Laravel  Php Framework    _    '));
+        $this->assertSame('--laravel-php-framework--', Str::kebabIden(' / Laravel  Php Framework    ?    '));
+        // from camelCase
+        $this->assertSame('laravel-php-framework', Str::kebabIden('laravelPhpFramework'));
+        // from snake_case
+        $this->assertSame('laravel-php-framework', Str::kebabIden('laravel_php_framework'));
+        // from Snake_Caps
+        $this->assertSame('laravel-php-framework', Str::kebabIden('Laravel_Php_Framework'));
+        // from Url
+        $this->assertSame('http---hello-world-org', Str::kebabIden('http://HelloWorld.org'));
+        // from camelCase.nestedMember
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('iAm.theNested.member'));
+        // from StudlyCase.NestedMember
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('IAm.TheNested.Member'));
+        // from snake_case.nester_member
+        $this->assertSame('i-am-the-nested-member', Str::kebabIden('i_am.the_nested.member'));
+        // from strings with wildcards (I've seen this somewhere in laravel/framework)
+        $this->assertSame('i-am---last-member', Str::kebabIden('iAm.*.lastMember'));
+        // with strange chars
+        $this->assertSame('all-the-strange-chars-like-------------get-replaced',
+               Str::kebabIden('All the strangeCharsLike:   (!@#$%^&*) get/replaced'));
+        // with multibyte strings
+        $this->assertSame('malmö-jönköping', Str::kebabIden('Malmö Jönköping'));
+        // with multibyte caps
+        $this->assertSame('łu-kasz-żą-dełko', Str::kebabIden('ŁuKasz.ŻąDełko'));
+        $this->assertSame('łukasz-żądełko', Str::kebabIden('ŁukaszŻądełko'));
     }
 
     public function testLower()
@@ -298,6 +367,86 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+        // with weird whitespaces
+        $this->assertSame('laravel_php_framework', Str::snake("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('__laravel_php_framework__', Str::snake(' - Laravel  Php Framework    -    '));
+        $this->assertSame('/_laravel_php_framework_?', Str::snake(' / Laravel  Php Framework    ?    '));
+        // with numbers
+        $this->assertSame('laravel6_php_frame_work', Str::snake('laravel6 php FrameWork'));
+        $this->assertSame('laravel6_p_h_p_framework', Str::snake('laravel6PHPFramework'));
+        // from camelCase
+        $this->assertSame('laravel_php_framework', Str::snake('laravelPhpFramework'));
+        // from kebab case
+        $this->assertSame('laravel_php_framework', Str::snake('laravel-php-framework'));
+        // from snake caps
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel_Php_Framework'));
+        // from kebab caps
+        $this->assertSame('laravel_php_framework', Str::snake('Laravel-Php-Framework'));
+        // from Url
+        $this->assertSame('http://hello_world.org', Str::snake('http://HelloWorld.org'));
+        // from camelCase.nestedMember
+        $this->assertSame('i_am.the_nested.member', Str::snake('iAm.theNested.member'));
+        // from StudlyCase.NestedMember
+        $this->assertSame('i_am.the_nested.member', Str::snake('IAm.TheNested.Member'));
+        // from kebab-case.nested-member
+        $this->assertSame('i_am.the_nested.member', Str::snake('i-am.the-nested.member'));
+        // from strings with wildcards (I've seen this somewhere in laravel/framework)
+        $this->assertSame('i_am.*.last_member', Str::snake('iAm.*.lastMember'));
+        // with strange characters
+        $this->assertSame('all_the_strange_chars_like:_(!@#$%^&*)_remain_unchanged',
+               Str::snake('All the strangeCharsLike:   (!@#$%^&*) remain unchanged'));
+        // with multibyte strings
+        $this->assertSame('malmö_jönköping', Str::snake('Malmö Jönköping'));
+        // with multibyte caps
+        $this->assertSame('łukasz.żądełko', Str::snake('Łukasz.Żądełko'));
+        $this->assertSame('łukasz_żądełko', Str::snake('ŁukaszŻądełko'));
+    }
+
+    public function testSnakeIden()
+    {
+        $this->assertSame('laravel_php_framework', Str::snakeIden('LaravelPHPFramework'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('LaravelPhpFramework'));
+        $this->assertSame('laravel php framework', Str::snakeIden('LaravelPhpFramework', ' '));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel Php Framework'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel    Php      Framework   '));
+        // ensure cache keys don't overlap
+        $this->assertSame('laravel__php__framework', Str::snakeIden('LaravelPhpFramework', '__'));
+        $this->assertSame('laravel_php_framework_', Str::snakeIden('LaravelPhpFramework_', '_'));
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravel php Framework'));
+        $this->assertSame('laravel_php_frame_work', Str::snakeIden('laravel php FrameWork'));
+        // with weird whitespaces
+        $this->assertSame('laravel_php_framework', Str::snakeIden("\v  Laravel \n\t   Php \r \n \v     Framework   "));
+        $this->assertSame('__laravel_php_framework__', Str::snakeIden(' - Laravel  Php Framework    _    '));
+        $this->assertSame('__laravel_php_framework__', Str::snakeIden(' / Laravel  Php Framework    ?    '));
+        // with numbers
+        $this->assertSame('laravel6_php_frame_work', Str::snakeIden('laravel6 php FrameWork'));
+        $this->assertSame('laravel6_php_framework', Str::snakeIden('laravel6PHPFramework'));
+        // from camelCase
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravelPhpFramework'));
+        // from kebab-case
+        $this->assertSame('laravel_php_framework', Str::snakeIden('laravel-php-framework'));
+        // from Snake_Caps
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel_Php_Framework'));
+        // from Kebab-Caps
+        $this->assertSame('laravel_php_framework', Str::snakeIden('Laravel-Php-Framework'));
+        // from Url
+        $this->assertSame('http___hello_world_org', Str::snakeIden('http://HelloWorld.org'));
+        // from camelCase.nestedMember
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('iAm.theNested.member'));
+        // from StudlyCase.NestedMember
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('IAm.TheNested.Member'));
+        // from kebab-case.nested-member
+        $this->assertSame('i_am_the_nested_member', Str::snakeIden('i-am.the-nested.member'));
+        // from strings with wildcards (I've seen this somewhere in laravel/framework)
+        $this->assertSame('i_am___last_member', Str::snakeIden('iAm.*.lastMember'));
+        // with strange chars
+        $this->assertSame('all_the_strange_chars_like_____________get_replaced',
+               Str::snakeIden('All the strangeCharsLike:   (!@#$%^&*) get/replaced'));
+        // with multibyte strings
+        $this->assertSame('malmö_jönköping', Str::snakeIden('Malmö Jönköping'));
+        // with multibyte caps
+        $this->assertSame('łu_kasz_żą_dełko', Str::snakeIden('ŁuKasz.ŻąDełko'));
+        $this->assertSame('łukasz_żądełko', Str::snakeIden('ŁukaszŻądełko'));
     }
 
     public function testStudly()


### PR DESCRIPTION
1. Fixes problems with ``Str::kebab()`` and ``Str::snake()``. Some fixed failures are listed below:
    - ``Str::kebab('laravel_php_framework')`` returns ``'laravel_php_framework'``, I believe it should be ``'laravel-php-framework'``; similarly for ``Str::snake('laravel-php-framework')`` which yields ``'laravel-php-framework'`` but it should ``'laravel_php_framework'``.
    - ``Str::kebab('Laravel_Php_Framework')`` returns ``laravel_-php_-framework''``, I believe expected result is ``'laravel-php-framework'`` (similar thing for ``Str::snake('Laravel-Php-Framework'`` which currently returns ``'laravel-_php-_framework'``).
    - ``Str::kebab('http://HelloWorld.org')`` returns ``http://-hello-world.org``, I believe it should be ``'http://hello-world.org'``; same for ``Str::snake('http://HelloWorld.org)``.
    - ``Str::kebab('IAm.TheNested.Member')`` returns ``'i-am.-the-nested.-member'``, which IMHO should be ``'i-am.the-nested.member'``, similar thing for ``Str::snake('IAm.TheNested.Member')`` which returns ``'i_am._the_nested._member'``.
    - ``Str::kebab('ŁukaszŻądełko')`` (multibyte caps) returns ``'łukaszżądełko'``, but it should return ``'łukasz-żądełko'``, similar bug for ``Str::snake()``.
    - ``Str::snake('Laravel_Php_Framework')`` returns ``'laravel__php__framework'``, but my intuition says it should return ``'laravel_php_framework'``, similarly ``Str::kebab('Laravel-Php-Framework'))`` returns ``'laravel--php--framework'``.
2. Provides test for handling identifiers with numbers to establish the convention (see #28709 #28710). The test ensures, that a digit is not being separated from its preceding word.
3. Provides two new functions ``snakeIden()``/``kebabIden()``, which: 
    - replace all non-alnum characters with ``'_'``/``'-'``,
    - avoid exploding sequences of uppercase chars, such as ``'PHP'``. The ``xxxIden()`` functions turn ``thePHPVersion`` into ``the_php_version`` and not ``the_p_h_p_version`` (as it is in ``non-Iden()`` functions).
4. Multiple consecutive spaces are treated as single delimiter. Trailing spaces ``trim()``med.
5. Handle unicode strings, including multibyte MixedCase like ``'małaŻołtaŁódka'``.

The new functions ``kebabIden()`` and ``snakeIden()`` are meant to generate "identifiers", e.g. variable name. The resultant string contains only alphanumeric characters and the delimiter (either ``'_'`` or ``'-'``). For example, ``Str::snakeIden('http://HelloWorld.org')`` returns ``'http___hello_world_org'``, whereas  ``Str::snake('http://HelloWorld.org')`` (fixed) returns ``'http://hello_world.org'``. The original ``Str::snake`` and ``Str::kebab`` couldn't be made to generate such "identifiers", because some pieces of laravel's code depend on the fact that ``Str::snake`` preserves dot characters. There may also be a code in the wild that requires these functions to preserve other non-alnum characters.

Added optional argument to signature of ``Str::kebab()`` for symmetry with ``Str::snake()``. The array ``Str::$snakeCache`` was replaced with ``Str::$lowerDelimitedCache`` which is used by all four functions: ``Str::snake(), Str::kebab(), Str::snakeIden(), Str::kebabIden()``.
