### PR TITLE
NEW Allow validation rule to be automatically resolved from the container from FQCN

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -2,18 +2,18 @@
 
 namespace Illuminate\Validation;
 
-use RuntimeException;
 use BadMethodCallException;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Fluent;
-use Illuminate\Support\MessageBag;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Contracts\Validation\ImplicitRule;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Validator implements ValidatorContract
 {
@@ -385,17 +385,21 @@ class Validator implements ValidatorContract
         // If we have made it this far we will make sure the attribute is validatable and if it is
         // we will call the validation method with the attribute. If a method returns false the
         // attribute is invalid and we will add a failure message for this failing attribute.
-        $validatable = $this->isValidatable($rule, $attribute, $value);
+        if (!$this->isValidatable($rule, $attribute, $value)) {
+            return null;
+        }
 
-        if ($rule instanceof RuleContract) {
-            return $validatable
-                    ? $this->validateUsingCustomRule($attribute, $value, $rule)
-                    : null;
+        if (is_a($rule, RuleContract::class, true)) {
+            if (is_string($rule)) {
+                $rule = app($rule, $this->parseNamedParameters($parameters));
+            }
+
+            return $this->validateUsingCustomRule($attribute, $value, $rule);
         }
 
         $method = "validate{$rule}";
 
-        if ($validatable && ! $this->$method($attribute, $value, $parameters, $this)) {
+        if (! $this->$method($attribute, $value, $parameters, $this)) {
             $this->addFailure($attribute, $rule, $parameters);
         }
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4551,6 +4551,40 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
+    public function testRulesCanBeGivenAsFQNs()
+    {
+        $rule = new class(new ContainerConcreteStub, 0) implements Rule {
+            protected $number;
+            public function __construct(ContainerConcreteStub $serviceAssertion, int $number)
+            {
+                $this->number = $number;
+            }
+            public function passes($attribute, $value)
+            {
+                return $value === $this->number;
+            }
+            public function message()
+            {
+                return ":attribute must be {$this->number}.";
+            }
+        };
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $validator = new Validator(
+            $trans,
+            ['a' => 5],
+            ['a' => ['required', get_class($rule).':number=5']]
+        );
+        $this->assertTrue($validator->passes());
+
+        $validator = new Validator(
+            $trans,
+            ['a' => 4],
+            ['a' => ['required', get_class($rule).':number=5']]
+        );
+        $this->assertFalse($validator->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);
@@ -4562,4 +4596,8 @@ class ValidationValidatorTest extends TestCase
             new ArrayLoader, 'en'
         );
     }
+}
+
+class ContainerConcreteStub {
+
 }


### PR DESCRIPTION
Resolves laravel/ideas#1079. See that issue for more context.

This allows configuring rules by using the FQCN of the custom rule class:

```php
$this->validate($request, [
    'email' => [NotBlacklisted::class]
]);
```

I also allowed configuration with named parameters that you can see in action within the test

```php
$this->validate($request, [
    'math_question' => [ExactNumber::class . ':number=5'],
]);
```

I personally would find this useful so I can easily unit test my rules by mocking required services, using the container to automatically discover those services, except in unit tests when I can instantiate the rule myself and mock the required services.

It should not break existing code _except_ in the case that someone has created an instantiable class that implements `Rule` that has the same name as one of the [available validation rules](https://laravel.com/docs/5.8/validation#available-validation-rules)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->