### PR TITLE
[6.x] Introduce a locking mechanism for the array cache driver

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Carbon\Carbon;
+
+class ArrayLock extends Lock
+{
+    /**
+     * The parent array cache store.
+     *
+     * @var \Illuminate\Cache\ArrayStore
+     */
+    protected $store;
+
+    /**
+     * Create a new lock instance.
+     *
+     * @param  \Illuminate\Cache\ArrayStore  $store
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct($store, $name, $seconds, $owner = null)
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->store = $store;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        $expiration = $this->store->locks[$this->name]['expiresAt'] ?? Carbon::now()->addSecond();
+
+        if ($this->exists() && $expiration->isFuture()) {
+            return false;
+        }
+
+        $this->store->locks[$this->name] = [
+            'owner' => $this->owner,
+            'expiresAt' => $this->seconds === 0 ? null : Carbon::now()->addSeconds($this->seconds),
+        ];
+
+        return true;
+    }
+
+    /**
+     * Determine if the current lock exists.
+     *
+     * @return bool
+     */
+    protected function exists()
+    {
+        return isset($this->store->locks[$this->name]);
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        if (! $this->isOwnedByCurrentProcess()) {
+            return false;
+        }
+
+        $this->forceRelease();
+
+        return true;
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return string
+     */
+    protected function getCurrentOwner()
+    {
+        return $this->store->locks[$this->name]['owner'];
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        unset($this->store->locks[$this->name]);
+    }
+}

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -2,9 +2,10 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Support\InteractsWithTime;
 
-class ArrayStore extends TaggableStore
+class ArrayStore extends TaggableStore implements LockProvider
 {
     use InteractsWithTime, RetrievesMultipleKeys;
 
@@ -14,6 +15,13 @@ class ArrayStore extends TaggableStore
      * @var array
      */
     protected $storage = [];
+
+    /**
+     * The array of locks.
+     *
+     * @var array
+     */
+    public $locks = [];
 
     /**
      * Retrieve an item from the cache by key.
@@ -161,5 +169,30 @@ class ArrayStore extends TaggableStore
     protected function toTimestamp($seconds)
     {
         return $seconds > 0 ? $this->availableAt($seconds) : 0;
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string $name
+     * @param  int $seconds
+     * @param  string|null $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new ArrayLock($this, $name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
     }
 }


### PR DESCRIPTION
This PR introduces a locking mechanism to the array cache driver, for testing.

It is currently not possible to substitute the array cache driver in tests for any driver that supports locking if your test suite / app relies on the locking functionality.

This PR changes that and is something I've wanted for on projects I work on.

This allows me to run the test suite without having to have a lock supporting cache driver running / setup on my machine - which is nice coming into a project and working on parts of a project that don't interact with the cache locking mechanism because it means I can setup and digging into code faster - and it also means a test environment can be setup without requiring a "real" driver like Redis / memcached to be setup and configured.

It's also nice that once you do go down the path of introducing cache locking into your project, you don't have to also change you testing driver. It just continues to work as expected. Related: https://github.com/laravel/framework/issues/29161

I'm happy to package this up if it isn't something you want to add / maintain in the framework.

I'd love if someone could triple check the [expiration tests](https://github.com/laravel/framework/pull/30253/files#diff-784af36eb6e6818d1a45f12de11e3ce7R121-R141) to make sure my logic is sold there, and I don't need to shift the boundary forward a microsecond

Not that is really matters, because the in memory cache drivers are so fast...but this is faster than, say, memcached. But, like, both are so quick...it isn't going to have a speed impact because the difference is negligible. I just thought I'd mention it.