### PR TITLE
[6.x] Routing parameter replacement fixes

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -260,7 +260,7 @@ class RouteUrlGenerator
         // First we will get all of the string parameters that are remaining after we
         // have replaced the route wildcards. We'll then build a query string from
         // these string parameters then use it as a starting point for the rest.
-        if (count($parameters) === 0) {
+        if (count(array_filter($parameters)) === 0) {
             return '';
         }
 

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -4,7 +4,6 @@ namespace Illuminate\Routing;
 
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 class RouteUrlGenerator
 {
@@ -87,7 +86,7 @@ class RouteUrlGenerator
             $route
         ), $parameters);
 
-        if (preg_match('/\{.*?\}/', $uri)) {
+        if (preg_match('/{.*?}/', $uri)) {
             throw UrlGenerationException::forMissingParameters($route);
         }
 
@@ -196,7 +195,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/{.*?}/', function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
@@ -205,7 +204,7 @@ class RouteUrlGenerator
             return (string) $value !== '' ? $value : $match[0];
         }, $path);
 
-        return trim(preg_replace('/\{[^}]*\?\}/', '', $path), '/');
+        return trim(preg_replace('/{[^}]*\?}/', '', $path), '/');
     }
 
     /**
@@ -217,7 +216,7 @@ class RouteUrlGenerator
      */
     protected function replaceNamedParameters($path, &$parameters)
     {
-        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
+        return preg_replace_callback('/{(.*?)\??}/', function ($m) use (&$parameters) {
             $value = Arr::pull($parameters, $m[1]);
 
             if ((string) $value === '') {

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -200,12 +200,12 @@ class RouteUrlGenerator
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
-            return (empty($parameters) && ! Str::endsWith($match[0], '?}'))
-                        ? $match[0]
-                        : Arr::pull($parameters, 0);
+            $value = Arr::pull($parameters, 0);
+
+            return (string) $value !== '' ? $value : $match[0];
         }, $path);
 
-        return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
+        return trim(preg_replace('/\{[^}]*\?\}/', '', $path), '/');
     }
 
     /**
@@ -218,13 +218,13 @@ class RouteUrlGenerator
     protected function replaceNamedParameters($path, &$parameters)
     {
         return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
-            if (isset($parameters[$m[1]])) {
-                return Arr::pull($parameters, $m[1]);
-            } elseif (isset($this->defaultParameters[$m[1]])) {
-                return $this->defaultParameters[$m[1]];
+            $value = Arr::pull($parameters, $m[1]);
+
+            if ((string) $value === '') {
+                $value = $this->defaultParameters[$m[1]] ?? null;
             }
 
-            return $m[0];
+            return (string) $value !== '' ? $value : $m[0];
         }, $path);
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -243,6 +243,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('/', $url->route('plain', [], false));
         $this->assertSame('/?foo=bar', $url->route('plain', ['foo' => 'bar'], false));
+        $this->assertSame('/', $url->route('plain', ['foo' => null], false));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('foo'));
         $this->assertSame('/foo/bar', $url->route('foo', [], false));
         $this->assertSame('/foo/bar?foo=bar', $url->route('foo', ['foo' => 'bar'], false));
@@ -269,6 +270,111 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/bar?foo=bar#derp', $url->route('fragment', ['foo' => 'bar'], false));
         $this->assertSame('/foo/bar?baz=%C3%A5%CE%B1%D1%84#derp', $url->route('fragment', ['baz' => 'åαф'], false));
         $this->assertSame('http://en.example.com/foo', $url->route('defaults'));
+    }
+
+    public function testUrlGenerationRequiresPassingOfRequiredParametersWhenOtherParametersPresent()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', ['other' => 'baz']);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeNull()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', ['one' => null]);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeEmptyString()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', ['one' => '']);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeFalse()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', ['one' => false]);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeNullWhenPassedUnkeyed()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', [null]);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeEmptyStringWhenPassedUnkeyed()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', ['']);
+    }
+
+    public function testUrlGenerationRequiresNamedParameterNotToBeFalseWhenPassedUnkeyed()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}', ['as' => 'foo']);
+        $routes->add($route);
+
+        $url->route('foo', [false]);
     }
 
     public function testFluentRouteNameDefinitions()


### PR DESCRIPTION
This pull request addresses three bugs in the routing:

1) When an url defined as`something/{id}` and called with missing parameter it generates wrong link instead of throwing an exception.

   - parameters: `['otherparam' => 2]`
   - result: `something?otherparam=2`
   - expected result: Exception because id is not defined

2) When an url defined as`something/{id}` and called with "empty" parameter it generates wrong link instead of throwing an exception.
   - parameters: `['id'=>null]` or `['id'=>'']`
   - result: `something`
   - expected result: Exception

3) When an url defined as`something` and called with parameters containing only nulls it appends a question mark.
   - parameters: `['foo' => null]`
   - result: `something?`
   - expected result: `something`
