### PR TITLE
[7.x] Remove object_get method from Support/helpers.php

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -141,7 +141,7 @@ class MailgunTransport extends Transport
      */
     protected function getMessageId($response)
     {
-        return object_get(
+        return data_get(
             json_decode($response->getBody()->getContents()), 'id'
         );
     }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -305,33 +305,6 @@ if (! function_exists('last')) {
     }
 }
 
-if (! function_exists('object_get')) {
-    /**
-     * Get an item from an object using "dot" notation.
-     *
-     * @param  object  $object
-     * @param  string  $key
-     * @param  mixed   $default
-     * @return mixed
-     */
-    function object_get($object, $key, $default = null)
-    {
-        if (is_null($key) || trim($key) == '') {
-            return $object;
-        }
-
-        foreach (explode('.', $key) as $segment) {
-            if (! is_object($object) || ! isset($object->{$segment})) {
-                return value($default);
-            }
-
-            $object = $object->{$segment};
-        }
-
-        return $object;
-    }
-}
-
 if (! function_exists('optional')) {
     /**
      * Provide access to optional objects.

--- a/tests/Mail/MailgunTransportTest.php
+++ b/tests/Mail/MailgunTransportTest.php
@@ -27,7 +27,7 @@ class MailgunTransportTest extends TestCase
             ->method('request')
             ->with(
                 'POST',
-                "https://api.mailgun.net/v3/barDomain/messages.mime",
+                'https://api.mailgun.net/v3/barDomain/messages.mime',
                 $this->payload($message)
             )
             ->willReturn($sendRawEmailMock);
@@ -75,7 +75,7 @@ class sendRawEmailMock
     public function getContents()
     {
         return json_encode([
-            "id" => $this->messageId,
+            'id' => $this->messageId,
         ]);
     }
 }

--- a/tests/Mail/MailgunTransportTest.php
+++ b/tests/Mail/MailgunTransportTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use GuzzleHttp\ClientInterface;
+use Illuminate\Mail\Transport\MailgunTransport;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+use Swift_Message;
+
+class MailgunTransportTest extends TestCase
+{
+    public function testSend()
+    {
+        $message = new Swift_Message('Foo subject', 'Bar body');
+        $message->setSender('myself@example.com');
+        $message->setTo('me@example.com');
+
+        $client = $this->getMockBuilder(ClientInterface::class)->getMock();
+        $transport = new MailgunTransport($client, 'fooKey', 'barDomain');
+
+        // Generate a messageId for our mock to return to ensure that the post-sent message
+        // has X-Mailgun-Message-ID in its headers
+        $messageId = Str::random(32);
+        $sendRawEmailMock = new sendRawEmailMock($messageId);
+        $client->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                "https://api.mailgun.net/v3/barDomain/messages.mime",
+                $this->payload($message)
+            )
+            ->willReturn($sendRawEmailMock);
+
+        $transport->send($message);
+        $this->assertEquals($messageId, $message->getHeaders()->get('X-Mailgun-Message-ID')->getFieldBody());
+    }
+
+    private function payload($message)
+    {
+        return [
+            'auth' => [
+                'api',
+                'fooKey',
+            ],
+            'multipart' => [
+                [
+                    'name' => 'to',
+                    'contents' => 'me@example.com',
+                ],
+                [
+                    'name' => 'message',
+                    'contents' => $message->toString(),
+                    'filename' => 'message.mime',
+                ],
+            ],
+        ];
+    }
+}
+
+class sendRawEmailMock
+{
+    protected $messageId;
+
+    public function __construct($messageId)
+    {
+        $this->messageId = $messageId;
+    }
+
+    public function getBody()
+    {
+        return $this;
+    }
+
+    public function getContents()
+    {
+        return json_encode([
+            "id" => $this->messageId,
+        ]);
+    }
+}

--- a/tests/Mail/MailgunTransportTest.php
+++ b/tests/Mail/MailgunTransportTest.php
@@ -22,7 +22,7 @@ class MailgunTransportTest extends TestCase
         // Generate a messageId for our mock to return to ensure that the post-sent message
         // has X-Mailgun-Message-ID in its headers
         $messageId = Str::random(32);
-        $sendRawEmailMock = new sendRawEmailMock($messageId);
+        $sendEmailMock = new sendEmailMock($messageId);
         $client->expects($this->once())
             ->method('request')
             ->with(
@@ -30,7 +30,7 @@ class MailgunTransportTest extends TestCase
                 'https://api.mailgun.net/v3/barDomain/messages.mime',
                 $this->payload($message)
             )
-            ->willReturn($sendRawEmailMock);
+            ->willReturn($sendEmailMock);
 
         $transport->send($message);
         $this->assertEquals($messageId, $message->getHeaders()->get('X-Mailgun-Message-ID')->getFieldBody());
@@ -58,7 +58,7 @@ class MailgunTransportTest extends TestCase
     }
 }
 
-class sendRawEmailMock
+class sendEmailMock
 {
     protected $messageId;
 

--- a/tests/Mail/MailgunTransportTest.php
+++ b/tests/Mail/MailgunTransportTest.php
@@ -33,6 +33,7 @@ class MailgunTransportTest extends TestCase
             ->willReturn($sendEmailMock);
 
         $transport->send($message);
+
         $this->assertEquals($messageId, $message->getHeaders()->get('X-Mailgun-Message-ID')->getFieldBody());
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -41,15 +41,6 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
-    public function testObjectGet()
-    {
-        $class = new stdClass;
-        $class->name = new stdClass;
-        $class->name->first = 'Taylor';
-
-        $this->assertSame('Taylor', object_get($class, 'name.first'));
-    }
-
     public function testDataGet()
     {
         $object = (object) ['users' => ['name' => ['Taylor', 'Otwell']]];

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Optional;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use stdClass;
 
 class SupportHelpersTest extends TestCase
 {


### PR DESCRIPTION
this **PR** removes **object_get()** method . and adds **MailgunTransportTest** .

reason for removing **object_get()** cause it's not documented in laravel documentation & it can be replaced by **data_get()** like in **MailgunTransport**.

also i thought since we have **data_fill()** & **data_set()**  some PRs may add **object_fill()** or **object_set()** . which is considered redundant functions .