### PR TITLE
[6.x] Redirect to may has multiple return types

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -87,7 +87,7 @@ class Authenticate
      * Get the path the user should be redirected to when they are not authenticated.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return string
+     * @return string|null
      */
     protected function redirectTo($request)
     {


### PR DESCRIPTION
In most cases the return type of `Illuminate\Auth\Middleware\Authenticate::redirectTo()`is a `String` but by default the method returns nothing.

I updated the docblock to reflect this.