### PR TITLE
[6.x] Casts values from the getOriginal method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -961,12 +961,6 @@ trait HasAttributes
      */
     public function getOriginal($key = null, $default = null)
     {
-        // Casts of type array are already processed, so return value in this case
-        if ($this->hasCast($key)
-            && $this->getCastType($key) === 'array') {
-            return Arr::get($this->original, $key, $default);
-        }
-
         return $this->getValue($key, Arr::get($this->original, $key, $default));
     }
 
@@ -1145,22 +1139,20 @@ trait HasAttributes
             return false;
         }
 
+        $attribute = $this->getAttribute($key);
         $original = $this->getOriginal($key);
 
-        if ($current === $original) {
+        if ($attribute === $original) {
             return true;
-        } elseif (is_null($current)) {
+        } elseif (is_null($attribute)) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
-            return $this->fromDateTime($current) ===
+            return $this->fromDateTime($attribute) ===
                    $this->fromDateTime($original);
-        } elseif ($this->hasCast($key)) {
-            return $this->castAttribute($key, $current) ===
-                   $this->castAttribute($key, $original);
         }
 
-        return is_numeric($current) && is_numeric($original)
-                && strcmp((string) $current, (string) $original) === 0;
+        return is_numeric($attribute) && is_numeric($original)
+                && strcmp((string) $attribute, (string) $original) === 0;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -692,10 +692,6 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        if (! \is_string($value)) {
-            $value = \json_encode($value);
-        }
-
         return json_decode($value, ! $asObject);
     }
 
@@ -965,6 +961,12 @@ trait HasAttributes
      */
     public function getOriginal($key = null, $default = null)
     {
+        // Casts of type array are already processed, so return value in this case
+        if ($this->hasCast($key)
+            && $this->getCastType($key) === 'array') {
+            return Arr::get($this->original, $key, $default);
+        }
+
         return $this->getValue($key, Arr::get($this->original, $key, $default));
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -692,7 +692,7 @@ trait HasAttributes
      */
     public function fromJson($value, $asObject = false)
     {
-        if (!\is_string($value)) {
+        if (! \is_string($value)) {
             $value = \json_encode($value);
         }
 
@@ -1231,7 +1231,8 @@ trait HasAttributes
         return $matches[1];
     }
 
-    private function getValue($key, $value) {
+    private function getValue($key, $value)
+    {
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
         // retrieval from the model to a form that is more useful for usage.

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1943,6 +1943,9 @@ class DatabaseEloquentModelTest extends TestCase
 
     /**
      * Test that the getOriginal method on an Eloquent model also uses the casts array.
+     *
+     * @param void
+     * @return void
      */
     public function testGetOriginalCastsAttributes()
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1940,6 +1940,44 @@ class DatabaseEloquentModelTest extends TestCase
             Model::isIgnoringTouch(EloquentModelWithoutTimestamps::class)
         );
     }
+
+    public function testGetOriginalCastsAttributes()
+    {
+        $model = new EloquentModelCastingStub();
+        $model->intAttribute = '1';
+        $model->floatAttribute = '0.1234';
+        $model->stringAttribute = 432;
+        $model->boolAttribute = '1';
+        $model->booleanAttribute = '0';
+
+        $model->syncOriginal();
+
+        $model->intAttribute = 2;
+        $model->floatAttribute = 0.443;
+        $model->stringAttribute = '12';
+        $model->boolAttribute = true;
+        $model->booleanAttribute = false;
+
+        $this->assertIsInt($model->getOriginal('intAttribute'));
+        $this->assertEquals(1, $model->getOriginal('intAttribute'));
+        $this->assertEquals(2, $model->intAttribute);
+
+        $this->assertIsFloat($model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.1234, $model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.443, $model->floatAttribute);
+
+        $this->assertIsString($model->getOriginal('stringAttribute'));
+        $this->assertEquals('432', $model->getOriginal('stringAttribute'));
+        $this->assertEquals('12', $model->stringAttribute);
+
+        $this->assertIsBool($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->boolAttribute);
+
+        $this->assertIsBool($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->booleanAttribute);
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1956,7 +1956,7 @@ class DatabaseEloquentModelTest extends TestCase
         $stdClass->json_key = 'json_value';
         $model->objectAttribute = $stdClass;
         $array = [
-            'foo' => 'bar'
+            'foo' => 'bar',
         ];
         $model->arrayAttribute = $array;
         $model->jsonAttribute = $array;
@@ -1970,10 +1970,10 @@ class DatabaseEloquentModelTest extends TestCase
         $model->booleanAttribute = false;
         $model->objectAttribute = $stdClass;
         $model->arrayAttribute = [
-            'foo' => 'bar2'
+            'foo' => 'bar2',
         ];
         $model->jsonAttribute = [
-            'foo' => 'bar2'
+            'foo' => 'bar2',
         ];
 
         $this->assertIsInt($model->getOriginal('intAttribute'));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1942,7 +1942,7 @@ class DatabaseEloquentModelTest extends TestCase
     }
 
     /**
-     * Test that the getOriginal method on an Eloquent model also uses the casts array
+     * Test that the getOriginal method on an Eloquent model also uses the casts array.
      */
     public function testGetOriginalCastsAttributes()
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1941,6 +1941,9 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+    /**
+     * Test that the getOriginal method on an Eloquent model also uses the casts array
+     */
     public function testGetOriginalCastsAttributes()
     {
         $model = new EloquentModelCastingStub();
@@ -1949,6 +1952,14 @@ class DatabaseEloquentModelTest extends TestCase
         $model->stringAttribute = 432;
         $model->boolAttribute = '1';
         $model->booleanAttribute = '0';
+        $stdClass = new stdClass;
+        $stdClass->json_key = 'json_value';
+        $model->objectAttribute = $stdClass;
+        $array = [
+            'foo' => 'bar'
+        ];
+        $model->arrayAttribute = $array;
+        $model->jsonAttribute = $array;
 
         $model->syncOriginal();
 
@@ -1957,10 +1968,18 @@ class DatabaseEloquentModelTest extends TestCase
         $model->stringAttribute = '12';
         $model->boolAttribute = true;
         $model->booleanAttribute = false;
+        $model->objectAttribute = $stdClass;
+        $model->arrayAttribute = [
+            'foo' => 'bar2'
+        ];
+        $model->jsonAttribute = [
+            'foo' => 'bar2'
+        ];
 
         $this->assertIsInt($model->getOriginal('intAttribute'));
         $this->assertEquals(1, $model->getOriginal('intAttribute'));
         $this->assertEquals(2, $model->intAttribute);
+        $this->assertEquals(2, $model->getAttribute('intAttribute'));
 
         $this->assertIsFloat($model->getOriginal('floatAttribute'));
         $this->assertEquals(0.1234, $model->getOriginal('floatAttribute'));
@@ -1977,6 +1996,17 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertIsBool($model->getOriginal('booleanAttribute'));
         $this->assertFalse($model->getOriginal('booleanAttribute'));
         $this->assertFalse($model->booleanAttribute);
+
+        $this->assertEquals($stdClass, $model->getOriginal('objectAttribute'));
+        $this->assertEquals($model->getAttribute('objectAttribute'), $model->getOriginal('objectAttribute'));
+
+        $this->assertEquals($array, $model->getOriginal('arrayAttribute'));
+        $this->assertEquals(['foo' => 'bar'], $model->getOriginal('arrayAttribute'));
+        $this->assertEquals(['foo' => 'bar2'], $model->getAttribute('arrayAttribute'));
+
+        $this->assertEquals($array, $model->getOriginal('jsonAttribute'));
+        $this->assertEquals(['foo' => 'bar'], $model->getOriginal('jsonAttribute'));
+        $this->assertEquals(['foo' => 'bar2'], $model->getAttribute('jsonAttribute'));
     }
 }
 

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -65,15 +65,15 @@ class EloquentModelStringCastingTest extends TestCase
             'json_attributes' => ['json_key'=>'json_value'],
             'object_attributes' => ['json_key'=>'json_value'],
         ]);
-        $this->assertSame('{"key1":"value1"}', $model->getOriginal('array_attributes'));
+        $this->assertSame(['key1'=>'value1'], $model->getOriginal('array_attributes'));
         $this->assertSame(['key1'=>'value1'], $model->getAttribute('array_attributes'));
 
-        $this->assertSame('{"json_key":"json_value"}', $model->getOriginal('json_attributes'));
+        $this->assertSame(['json_key'=>'json_value'], $model->getOriginal('json_attributes'));
         $this->assertSame(['json_key'=>'json_value'], $model->getAttribute('json_attributes'));
 
-        $this->assertSame('{"json_key":"json_value"}', $model->getOriginal('object_attributes'));
         $stdClass = new stdClass;
         $stdClass->json_key = 'json_value';
+        $this->assertEquals($stdClass, $model->getOriginal('object_attributes'));
         $this->assertEquals($stdClass, $model->getAttribute('object_attributes'));
     }
 
@@ -85,13 +85,13 @@ class EloquentModelStringCastingTest extends TestCase
             'json_attributes' => [],
             'object_attributes' => [],
         ]);
-        $this->assertSame('[]', $model->getOriginal('array_attributes'));
+        $this->assertSame([], $model->getOriginal('array_attributes'));
         $this->assertSame([], $model->getAttribute('array_attributes'));
 
-        $this->assertSame('[]', $model->getOriginal('json_attributes'));
+        $this->assertSame([], $model->getOriginal('json_attributes'));
         $this->assertSame([], $model->getAttribute('json_attributes'));
 
-        $this->assertSame('[]', $model->getOriginal('object_attributes'));
+        $this->assertSame([], $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
     }
 


### PR DESCRIPTION
# Summary
This merge request fixed the fact that the `getOriginal` doesn't cast the attributes if defined in the $casts array.

# Problem description
The way the `getAttribute` fetches a value differs from `getOriginal`. Take into consideration the following code:

```php
$model = new EloquentModelCastingStub();
$model->intAttribute = '1';
$model->syncOriginal();
$model->intAttribute = '1';
dump($model->getAttribute('intAttribute'), $model->getOriginal('intAttribute'));
```
This will return:

```
1
"1"
```

I've encountered this with SQLite and Oracle DB adapters when fetching a model, changing the value and comparing the original and new values
 
# Expectations
It is expected that both values are returned as integer

# Solution
See pull request, both methods should have the same logic to return the value
