### PR TITLE
[7.x] Fix #30267 Remove transliteration of 'ия' in tests

### DIFF
--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -42,7 +42,7 @@ class SupportStrTest extends TestCase
 
     public function testStringAsciiWithSpecificLocale()
     {
-        $this->assertSame('h H sht Sht a A ia yo', Str::ascii('х Х щ Щ ъ Ъ ия йо', 'bg'));
+        $this->assertSame('h H sht Sht a A ia yo', Str::ascii('х Х щ Щ ъ Ъ иа йо', 'bg'));
         $this->assertSame('ae oe ue Ae Oe Ue', Str::ascii('ä ö ü Ä Ö Ü', 'de'));
     }
 


### PR DESCRIPTION
Since voku/portable-ascii 1.3.0:
'ия' is transliterated correctly to 'iya'
when transliterating 'и' and 'я' on their own.
Furthermore transliterated 'ia' would be pronounced 'иа'.
https://github.com/voku/portable-ascii/commit/62f9521b77693bb7a7be8fe855e86fa347e75f70#diff-07a0c79489ea27ae5e059a433ba83a34