### PR TITLE
[7.x] Casts values from the getOriginal method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1112,7 +1112,7 @@ trait HasAttributes
         $dirty = [];
 
         foreach ($this->getAttributes() as $key => $value) {
-            if (! $this->originalIsEquivalent($key, $value)) {
+            if (! $this->originalIsEquivalent($key)) {
                 $dirty[$key] = $value;
             }
         }
@@ -1134,10 +1134,9 @@ trait HasAttributes
      * Determine if the new and old values for a given key are equivalent.
      *
      * @param  string $key
-     * @param  mixed  $current
      * @return bool
      */
-    public function originalIsEquivalent($key, $current)
+    public function originalIsEquivalent($key)
     {
         if (! array_key_exists($key, $this->original)) {
             return false;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -315,11 +315,10 @@ trait HasAttributes
             return;
         }
 
-        // If the attribute exists in the attribute array or has a "get" mutator we will
+        // If the attribute exists in the attribute array we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            $this->hasGetMutator($key)) {
+        if (array_key_exists($key, $this->attributes)) {
             return $this->getAttributeValue($key);
         }
 
@@ -341,31 +340,7 @@ trait HasAttributes
      */
     public function getAttributeValue($key)
     {
-        $value = $this->getAttributeFromArray($key);
-
-        // If the attribute has a get mutator, we will call that then return what
-        // it returns as the value, which is useful for transforming values on
-        // retrieval from the model to a form that is more useful for usage.
-        if ($this->hasGetMutator($key)) {
-            return $this->mutateAttribute($key, $value);
-        }
-
-        // If the attribute exists within the cast array, we will convert it to
-        // an appropriate native PHP type dependant upon the associated value
-        // given with the key in the pair. Dayle made this comment line up.
-        if ($this->hasCast($key)) {
-            return $this->castAttribute($key, $value);
-        }
-
-        // If the attribute is listed as a date, we will convert it to a DateTime
-        // instance on retrieval, which makes it quite convenient to work with
-        // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
-            return $this->asDateTime($value);
-        }
-
-        return $value;
+        return $this->getValue($key, $this->getAttributeFromArray($key));
     }
 
     /**
@@ -985,7 +960,11 @@ trait HasAttributes
      */
     public function getOriginal($key = null, $default = null)
     {
-        return Arr::get($this->original, $key, $default);
+        if (! $key) {
+            return;
+        }
+
+        return $this->getValue($key, Arr::get($this->original, $key, $default));
     }
 
     /**
@@ -1163,22 +1142,20 @@ trait HasAttributes
             return false;
         }
 
+        $attribute = $this->getAttribute($key);
         $original = $this->getOriginal($key);
 
-        if ($current === $original) {
+        if ($attribute === $original) {
             return true;
-        } elseif (is_null($current)) {
+        } elseif (is_null($attribute)) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
-            return $this->fromDateTime($current) ===
+            return $this->fromDateTime($attribute) ===
                    $this->fromDateTime($original);
-        } elseif ($this->hasCast($key)) {
-            return $this->castAttribute($key, $current) ===
-                   $this->castAttribute($key, $original);
         }
 
-        return is_numeric($current) && is_numeric($original)
-                && strcmp((string) $current, (string) $original) === 0;
+        return is_numeric($attribute) && is_numeric($original)
+                && strcmp((string) $attribute, (string) $original) === 0;
     }
 
     /**
@@ -1249,5 +1226,39 @@ trait HasAttributes
         preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches);
 
         return $matches[1];
+    }
+
+    /**
+     * Get the plain value (no relation) of a model respecting the models mutator, casts and dates property
+     *
+     * @param  string  $key
+     * @param  mixed $value
+     * @return mixed|array
+     */
+    private function getValue($key, $value)
+    {
+        // If the attribute has a get mutator, we will call that then return what
+        // it returns as the value, which is useful for transforming values on
+        // retrieval from the model to a form that is more useful for usage.
+        if ($this->hasGetMutator($key)) {
+            return $this->mutateAttribute($key, $value);
+        }
+
+        // If the attribute exists within the cast array, we will convert it to
+        // an appropriate native PHP type dependant upon the associated value
+        // given with the key in the pair. Dayle made this comment line up.
+        if ($this->hasCast($key)) {
+            return $this->castAttribute($key, $value);
+        }
+
+        // If the attribute is listed as a date, we will convert it to a DateTime
+        // instance on retrieval, which makes it quite convenient to work with
+        // date fields without having to create a mutator for each property.
+        if ($value !== null
+            && \in_array($key, $this->getDates(), false)) {
+            return $this->asDateTime($value);
+        }
+
+        return $value;
     }
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -315,10 +315,11 @@ trait HasAttributes
             return;
         }
 
-        // If the attribute exists in the attribute array we will
+        // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes)) {
+        if (array_key_exists($key, $this->attributes) ||
+            $this->hasGetMutator($key)) {
             return $this->getAttributeValue($key);
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1229,7 +1229,7 @@ trait HasAttributes
     }
 
     /**
-     * Get the plain value (no relation) of a model respecting the models mutator, casts and dates property
+     * Get the plain value (no relation) of a model respecting the models mutator, casts and dates property.
      *
      * @param  string  $key
      * @param  mixed $value

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1940,6 +1940,77 @@ class DatabaseEloquentModelTest extends TestCase
             Model::isIgnoringTouch(EloquentModelWithoutTimestamps::class)
         );
     }
+
+    /**
+     * Test that the getOriginal method on an Eloquent model also uses the casts array.
+     *
+     * @param void
+     * @return void
+     */
+    public function testGetOriginalCastsAttributes()
+    {
+        $model = new EloquentModelCastingStub();
+        $model->intAttribute = '1';
+        $model->floatAttribute = '0.1234';
+        $model->stringAttribute = 432;
+        $model->boolAttribute = '1';
+        $model->booleanAttribute = '0';
+        $stdClass = new stdClass;
+        $stdClass->json_key = 'json_value';
+        $model->objectAttribute = $stdClass;
+        $array = [
+            'foo' => 'bar',
+        ];
+        $model->arrayAttribute = $array;
+        $model->jsonAttribute = $array;
+
+        $model->syncOriginal();
+
+        $model->intAttribute = 2;
+        $model->floatAttribute = 0.443;
+        $model->stringAttribute = '12';
+        $model->boolAttribute = true;
+        $model->booleanAttribute = false;
+        $model->objectAttribute = $stdClass;
+        $model->arrayAttribute = [
+            'foo' => 'bar2',
+        ];
+        $model->jsonAttribute = [
+            'foo' => 'bar2',
+        ];
+
+        $this->assertIsInt($model->getOriginal('intAttribute'));
+        $this->assertEquals(1, $model->getOriginal('intAttribute'));
+        $this->assertEquals(2, $model->intAttribute);
+        $this->assertEquals(2, $model->getAttribute('intAttribute'));
+
+        $this->assertIsFloat($model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.1234, $model->getOriginal('floatAttribute'));
+        $this->assertEquals(0.443, $model->floatAttribute);
+
+        $this->assertIsString($model->getOriginal('stringAttribute'));
+        $this->assertEquals('432', $model->getOriginal('stringAttribute'));
+        $this->assertEquals('12', $model->stringAttribute);
+
+        $this->assertIsBool($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->getOriginal('boolAttribute'));
+        $this->assertTrue($model->boolAttribute);
+
+        $this->assertIsBool($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->getOriginal('booleanAttribute'));
+        $this->assertFalse($model->booleanAttribute);
+
+        $this->assertEquals($stdClass, $model->getOriginal('objectAttribute'));
+        $this->assertEquals($model->getAttribute('objectAttribute'), $model->getOriginal('objectAttribute'));
+
+        $this->assertEquals($array, $model->getOriginal('arrayAttribute'));
+        $this->assertEquals(['foo' => 'bar'], $model->getOriginal('arrayAttribute'));
+        $this->assertEquals(['foo' => 'bar2'], $model->getAttribute('arrayAttribute'));
+
+        $this->assertEquals($array, $model->getOriginal('jsonAttribute'));
+        $this->assertEquals(['foo' => 'bar'], $model->getOriginal('jsonAttribute'));
+        $this->assertEquals(['foo' => 'bar2'], $model->getAttribute('jsonAttribute'));
+    }
 }
 
 class EloquentTestObserverStub

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -65,15 +65,15 @@ class EloquentModelStringCastingTest extends TestCase
             'json_attributes' => ['json_key'=>'json_value'],
             'object_attributes' => ['json_key'=>'json_value'],
         ]);
-        $this->assertSame('{"key1":"value1"}', $model->getOriginal('array_attributes'));
+        $this->assertSame(['key1'=>'value1'], $model->getOriginal('array_attributes'));
         $this->assertSame(['key1'=>'value1'], $model->getAttribute('array_attributes'));
 
-        $this->assertSame('{"json_key":"json_value"}', $model->getOriginal('json_attributes'));
+        $this->assertSame(['json_key'=>'json_value'], $model->getOriginal('json_attributes'));
         $this->assertSame(['json_key'=>'json_value'], $model->getAttribute('json_attributes'));
 
-        $this->assertSame('{"json_key":"json_value"}', $model->getOriginal('object_attributes'));
         $stdClass = new stdClass;
         $stdClass->json_key = 'json_value';
+        $this->assertEquals($stdClass, $model->getOriginal('object_attributes'));
         $this->assertEquals($stdClass, $model->getAttribute('object_attributes'));
     }
 
@@ -85,13 +85,13 @@ class EloquentModelStringCastingTest extends TestCase
             'json_attributes' => [],
             'object_attributes' => [],
         ]);
-        $this->assertSame('[]', $model->getOriginal('array_attributes'));
+        $this->assertSame([], $model->getOriginal('array_attributes'));
         $this->assertSame([], $model->getAttribute('array_attributes'));
 
-        $this->assertSame('[]', $model->getOriginal('json_attributes'));
+        $this->assertSame([], $model->getOriginal('json_attributes'));
         $this->assertSame([], $model->getAttribute('json_attributes'));
 
-        $this->assertSame('[]', $model->getOriginal('object_attributes'));
+        $this->assertSame([], $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
     }
 

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -65,11 +65,11 @@ class EloquentModelStringCastingTest extends TestCase
             'json_attributes' => ['json_key'=>'json_value'],
             'object_attributes' => ['json_key'=>'json_value'],
         ]);
-        $this->assertSame(['key1'=>'value1'], $model->getOriginal('array_attributes'));
-        $this->assertSame(['key1'=>'value1'], $model->getAttribute('array_attributes'));
+        $this->assertSame(['key1' => 'value1'], $model->getOriginal('array_attributes'));
+        $this->assertSame(['key1' => 'value1'], $model->getAttribute('array_attributes'));
 
-        $this->assertSame(['json_key'=>'json_value'], $model->getOriginal('json_attributes'));
-        $this->assertSame(['json_key'=>'json_value'], $model->getAttribute('json_attributes'));
+        $this->assertSame(['json_key' => 'json_value'], $model->getOriginal('json_attributes'));
+        $this->assertSame(['json_key' => 'json_value'], $model->getAttribute('json_attributes'));
 
         $stdClass = new stdClass;
         $stdClass->json_key = 'json_value';


### PR DESCRIPTION
# Summary
This merge request fixed the fact that the `getOriginal` doesn't cast the attributes if defined in the $casts array.

# Problem description
The way the `getAttribute` fetches a value differs from `getOriginal`. Take into consideration the following code:

```php
$model = new EloquentModelCastingStub();
$model->intAttribute = '1';
$model->syncOriginal();
$model->intAttribute = '1';
dump($model->getAttribute('intAttribute'), $model->getOriginal('intAttribute'));
```
This will return:

```
1
"1"
```

I've encountered this with SQLite and Oracle DB adapters when fetching a model, changing the value and comparing the original and new values
 
# Expectations
It is expected that both values are returned as integer

# Solution
See pull request, both methods should have the same logic to return the value
