### PR TITLE
Add ddd method to collections and query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3012,6 +3012,16 @@ class Builder
     }
 
     /**
+     * Die and dump the current SQL and bindings using Ignition.
+     *
+     * @return void
+     */
+    public function ddd()
+    {
+        ddd($this->toSql(), $this->getBindings());
+    }
+
+    /**
      * Handle dynamic method calls into the method.
      *
      * @param  string  $method

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -149,6 +149,25 @@ trait EnumeratesValues
     }
 
     /**
+     * Dump the items and end the script using Ignition.
+     *
+     * @param  mixed  ...$args
+     * @return void
+     */
+    public function ddd(...$args)
+    {
+        $items = (new static(func_get_args()))->push($this);
+
+        $last = $items->pop();
+
+        $items->each(function ($item) {
+            VarDumper::dump($item);
+        });
+
+        ddd($last);
+    }
+
+    /**
      * Dump the items.
      *
      * @return $this


### PR DESCRIPTION
This PR adds support for `ddd`, which works the same as `dd` except that it uses [Ignition](https://flareapp.io/blog/1-introducing-ddd-a-new-global-helper-for-laravel).