### PR TITLE
[6.x] Don't add extra '?' for empty query string

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -277,7 +277,9 @@ class RouteUrlGenerator
             );
         }
 
-        return '?'.trim($query, '&');
+        $query = trim($query, '&');
+
+        return $query === '' ? '' : "?{$query}";
     }
 
     /**

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -258,6 +258,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));


### PR DESCRIPTION
For route specified as

```
new Route(['GET'], 'foo/bar/{baz?}', ['as' => 'optional'])
```

and generated with

```
route('optional', ['baz' => null])
```

currently it'll generate url with extraneous `?` at the end (`/foo/bar?`).

This PR changes it to generate cleaner url without useless `?` at the end.