### PR TITLE
Allow translation of verification middleware response

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -22,7 +22,7 @@ class EnsureEmailIsVerified
             ($request->user() instanceof MustVerifyEmail &&
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
-                    ? abort(403, 'Your email address is not verified.')
+                    ? abort(403, trans('auth.unverified'))
                     : Redirect::route($redirectToRoute ?: 'verification.notice');
         }
 


### PR DESCRIPTION
I noticed the EnsureEmailIsVerified middleware would basically have to be copied to support translating the JSON response message.
I feel like it makes sense to leverage translations and add a default value.
What do you think?

A fork of laravel/laravel can be found [here](https://github.com/ciidyr/laravel), that contains the matching string.

