### PR TITLE
Allow delete() method to accept attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -876,13 +876,15 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
     /**
      * Delete the model from the database.
-     *
+     * @param  array  $attributes
      * @return bool|null
      *
      * @throws \Exception
      */
-    public function delete()
+    public function delete(array $attributes = [])
     {
+        $this->fill($attributes)->save();
+        
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }


### PR DESCRIPTION
When performing a soft delete, this would allow for attributes to be passed in which are saved before the soft delete occurs.
i.e. $model->delete(['deleted_by' => $user->id]);

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
