### PR TITLE
[6.x] Allow validation rule to be automatically resolved from the container

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -391,7 +391,7 @@ class Validator implements ValidatorContract
 
         if (is_a($rule, RuleContract::class, true)) {
             if (is_string($rule)) {
-                $rule = app($rule, $this->parseNamedParameters($parameters));
+                $rule = $this->container->make($rule, $this->parseNamedParameters($parameters));
             }
 
             return $this->validateUsingCustomRule($attribute, $value, $rule);

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -385,17 +385,21 @@ class Validator implements ValidatorContract
         // If we have made it this far we will make sure the attribute is validatable and if it is
         // we will call the validation method with the attribute. If a method returns false the
         // attribute is invalid and we will add a failure message for this failing attribute.
-        $validatable = $this->isValidatable($rule, $attribute, $value);
+        if (! $this->isValidatable($rule, $attribute, $value)) {
+            return;
+        }
 
-        if ($rule instanceof RuleContract) {
-            return $validatable
-                    ? $this->validateUsingCustomRule($attribute, $value, $rule)
-                    : null;
+        if (is_a($rule, RuleContract::class, true)) {
+            if (is_string($rule)) {
+                $rule = app($rule, $this->parseNamedParameters($parameters));
+            }
+
+            return $this->validateUsingCustomRule($attribute, $value, $rule);
         }
 
         $method = "validate{$rule}";
 
-        if ($validatable && ! $this->$method($attribute, $value, $parameters, $this)) {
+        if (! $this->$method($attribute, $value, $parameters, $this)) {
             $this->addFailure($attribute, $rule, $parameters);
         }
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4745,7 +4745,7 @@ class ValidationValidatorTest extends TestCase
 
     public function testRulesCanBeGivenAsFQNs()
     {
-        $rule = new class(new ContainerConcreteStub, 0) implements Rule {
+        $rule = new class(new ContainerConcreteStub, 5) implements Rule {
             protected $number;
 
             public function __construct(ContainerConcreteStub $serviceAssertion, int $number)
@@ -4764,19 +4764,25 @@ class ValidationValidatorTest extends TestCase
             }
         };
 
+        $ruleClass = get_class($rule);
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->twice()->with(ucfirst($ruleClass), ['number' => '5'])->andReturn($rule);
+
         $trans = $this->getIlluminateArrayTranslator();
         $validator = new Validator(
             $trans,
             ['a' => 5],
-            ['a' => ['required', get_class($rule).':number=5']]
+            ['a' => ['required', $ruleClass.':number=5']]
         );
+        $validator->setContainer($container);
         $this->assertTrue($validator->passes());
 
         $validator = new Validator(
             $trans,
             ['a' => 4],
-            ['a' => ['required', get_class($rule).':number=5']]
+            ['a' => ['required', $ruleClass.':number=5']]
         );
+        $validator->setContainer($container);
         $this->assertFalse($validator->passes());
     }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4743,6 +4743,43 @@ class ValidationValidatorTest extends TestCase
         ];
     }
 
+    public function testRulesCanBeGivenAsFQNs()
+    {
+        $rule = new class(new ContainerConcreteStub, 0) implements Rule {
+            protected $number;
+
+            public function __construct(ContainerConcreteStub $serviceAssertion, int $number)
+            {
+                $this->number = $number;
+            }
+
+            public function passes($attribute, $value)
+            {
+                return $value === $this->number;
+            }
+
+            public function message()
+            {
+                return ":attribute must be {$this->number}.";
+            }
+        };
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $validator = new Validator(
+            $trans,
+            ['a' => 5],
+            ['a' => ['required', get_class($rule).':number=5']]
+        );
+        $this->assertTrue($validator->passes());
+
+        $validator = new Validator(
+            $trans,
+            ['a' => 4],
+            ['a' => ['required', get_class($rule).':number=5']]
+        );
+        $this->assertFalse($validator->passes());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);
@@ -4754,4 +4791,8 @@ class ValidationValidatorTest extends TestCase
             new ArrayLoader, 'en'
         );
     }
+}
+
+class ContainerConcreteStub
+{
 }


### PR DESCRIPTION
Resolves laravel/ideas#1079. See that issue for more context.

This allows configuring rules by using the FQCN of the custom rule class:

```php
$this->validate($request, [
    'email' => [NotBlacklisted::class]
]);
```

I also allowed configuration with named parameters that you can see in action within the test

```php
$this->validate($request, [
    'math_question' => [ExactNumber::class . ':number=5'],
]);
```

I personally would find this useful so I can easily unit test my rules by mocking required services, using the container to automatically discover those services, except in unit tests when I can instantiate the rule myself and mock the required services.

It should not break existing code _except_ in the case that someone has created an instantiable class that implements `Rule` that has the same name as one of the [available validation rules](https://laravel.com/docs/5.8/validation#available-validation-rules)

Originally PRed at #30252