### PR TITLE
[6.x] Small textual correction in comment of eloquent trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -396,7 +396,7 @@ trait HasAttributes
 
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
-        // and hydrate the relationship's value on the "relationships" array.
+        // and hydrate the relationship's value on the "relations" array.
         if (method_exists($this, $key)) {
             return $this->getRelationshipFromMethod($key);
         }


### PR DESCRIPTION
a class property (array) named "relationships" is referenced in a comment within the getRelationValue() method of the HasAttributes trait. However, it is actually called "relations".

maybe not really PR-worthy, but just something I noticed on a quick source dive