### PR TITLE
[6.x] Allow callback scopes on Query Builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1831,6 +1831,25 @@ class Builder
     }
 
     /**
+     * Run a callback against the query.
+     *
+     * @param  mixed  $callback
+     * @return $this
+     */
+    public function apply(...$callbacks)
+    {
+        $callbacks = is_array($callbacks[0]) ? $callbacks[0] : $callbacks;
+
+        foreach ($callbacks as $callback) {
+            if (is_callable($callback)) {
+                $callback($this);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Add a descending "order by" clause to the query.
      *
      * @param  string  $column

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -198,7 +198,7 @@ class QueryBuilderTest extends DatabaseTestCase
 
     public function testApplyMultipleScopes()
     {
-        $result = DB::table('posts')->apply(new PostFrom2017Scope, function (Builder $builder){
+        $result = DB::table('posts')->apply(new PostFrom2017Scope, function (Builder $builder) {
             $builder->select('title');
         })->get();
 


### PR DESCRIPTION
Laravel Query Builder allow for some pretty dynamic code execution. We can pass a `callback` to `select`, `addSelect`, `where`, `join` and so on. However, we cannot pass a callback/closure to `groupBy`.
It's been a while since I've wanted to apply any dynamic scope to Query Builder and this time, instead of contributing just to `groupBy` I thought I'd give it a shot.

### How it works

```
DB::table('my-table')->apply(new MyDesiredScope)->get();
```

This will send the Query Builder to the callable method (if `MyDesiredScope` is callable) and let it mutate the Query Builder. I've been doing a lot of this with `where` already and it works great:

```
Post::newQuery()->where(new PostsWithNewReplies);
```

I just had the need to do that at the `groupBy` clause instead and noticed I couldn't, hence the contribution to a broader audience.

### Signature

`apply` will accept a single `Scope`, multiple arguments of scope or an array of Scopes. all cases are covered by tests.

Docs: https://github.com/laravel/docs/pull/5533