### PR TITLE
[6.x] Add autocomplete support for the Queue-Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -15,6 +15,11 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static \Illuminate\Contracts\Queue\Job|null pop(string $queue = null)
  * @method static string getConnectionName()
  * @method static \Illuminate\Contracts\Queue\Queue setConnectionName(string $name)
+ * @method static void assertNothingPushed()
+ * @method static void assertNotPushed(string $job, \Closure $callback = null)
+ * @method static void assertPushed(string $job, \Closure|int $callback = null)
+ * @method static void assertPushedOn(string $job, int $times = 1)
+ * @method static void assertPushedWithChain(string $queue, string $job, \Closure $callback = null)
  *
  * @see \Illuminate\Queue\QueueManager
  * @see \Illuminate\Queue\Queue


### PR DESCRIPTION
Add auto completion for the IDE. Currently the IDE does not know which assert-methods exist for the Queue-Facade.

The Mail-Facade and other Facades already have this included: See https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/Facades/Mail.php#L15-L20

With this change the IDE will know which assert-methods exist:
![PHPStorm Example](https://user-images.githubusercontent.com/14092921/66911012-fb221000-f00f-11e9-81e3-30b7227ca462.png)
