### PR TITLE
[6.x] Add deleted_at property

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -6,6 +6,8 @@ namespace Illuminate\Database\Eloquent;
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withoutTrashed()
+ *
+ * @property \Carbon\Carbon $deleted_at
  */
 trait SoftDeletes
 {


### PR DESCRIPTION
This will add auto completion for the IDE. Otherwise the IDE does not know that this attribute exists.

An Example for PHPStorm:
![Auto Complete Example](https://user-images.githubusercontent.com/14092921/66911850-a089b380-f011-11e9-9cdc-8681c6e4832a.png)
