### PR TITLE
[7.x] Adds higher order "when" proxy

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
-use Illuminate\Database\HigherOrderWhenProxy;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\HigherOrderWhenProxy;
 
 trait BuildsQueries
 {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\HigherOrderWhenProxy;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 
@@ -147,12 +148,16 @@ trait BuildsQueries
      * Apply the callback's query changes if the given "value" is true.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return mixed|$this
      */
-    public function when($value, $callback, $default = null)
+    public function when($value, $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
@@ -177,12 +182,16 @@ trait BuildsQueries
      * Apply the callback's query changes if the given "value" is false.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return mixed|$this
      */
-    public function unless($value, $callback, $default = null)
+    public function unless($value, $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, ! $value);
+        }
+
         if (! $value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {

--- a/src/Illuminate/Database/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Database/HigherOrderWhenProxy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Database;
+
+class HigherOrderWhenProxy
+{
+    /**
+     * The builder being operated on.
+     *
+     * @var mixed
+     */
+    protected $builder;
+
+    /**
+     * The condition for the query.
+     *
+     * @var mixed
+     */
+    protected $condition;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  mixed  $builder
+     * @param  mixed  $condition
+     */
+    public function __construct($builder, $condition)
+    {
+        $this->builder = $builder;
+        $this->condition = $condition;
+    }
+
+    /**
+     * Proxy the call onto the query builder.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($this->condition) {
+            return $this->builder->{$method}(...$parameters);
+        }
+
+        return $this->builder;
+    }
+}

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -329,6 +329,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the command to drop all views.
+     *
+     * @return string
+     */
+    public function compileDropAllViews()
+    {
+        return "DECLARE @sql NVARCHAR(MAX) = N'';
+            SELECT @sql += 'DROP VIEW ' + QUOTENAME(OBJECT_SCHEMA_NAME(object_id)) + '.' + QUOTENAME(name) + ';'
+            FROM sys.views;
+
+            EXEC sp_executesql @sql;";
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -15,4 +15,14 @@ class SqlServerBuilder extends Builder
 
         $this->connection->statement($this->grammar->compileDropAllTables());
     }
+
+    /**
+     * Drop all views from the database.
+     *
+     * @return void
+     */
+    public function dropAllViews()
+    {
+        $this->connection->statement($this->grammar->compileDropAllViews());
+    }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -60,23 +60,19 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $channels;
         }
 
-        $channelNames = $this->channelName();
-        if (is_string($channelNames)) {
-            return [new PrivateChannel($channelNames)];
+        if (is_string($channels = $this->channelName())) {
+            return [new PrivateChannel($channels)];
         }
 
-        $channels = [];
-        foreach ($channelNames as $channel) {
-            $channels[] = new PrivateChannel($channel);
-        }
-
-        return $channels;
+        return collect($channels)->map(function ($channel) {
+            return new PrivateChannel($channel);
+        })->all();
     }
 
     /**
      * Get the broadcast channel name for the event.
      *
-     * @return string|array
+     * @return array|string
      */
     protected function channelName()
     {

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -60,13 +60,23 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $channels;
         }
 
-        return [new PrivateChannel($this->channelName())];
+        $channelNames = $this->channelName();
+        if (is_string($channelNames)) {
+            return [new PrivateChannel($channelNames)];
+        }
+
+        $channels = [];
+        foreach ($channelNames as $channel) {
+            $channels[] = new PrivateChannel($channel);
+        }
+
+        return $channels;
     }
 
     /**
      * Get the broadcast channel name for the event.
      *
-     * @return string
+     * @return string|array
      */
     protected function channelName()
     {

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -277,7 +277,9 @@ class RouteUrlGenerator
             );
         }
 
-        return '?'.trim($query, '&');
+        $query = trim($query, '&');
+
+        return $query === '' ? '' : "?{$query}";
     }
 
     /**

--- a/src/Illuminate/Support/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Support/HigherOrderWhenProxy.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Illuminate\Database;
+namespace Illuminate\Support;
 
 class HigherOrderWhenProxy
 {
     /**
-     * The builder being operated on.
+     * The resource being operated on.
      *
      * @var mixed
      */
-    protected $builder;
+    protected $resource;
 
     /**
      * The condition for the query.
@@ -21,17 +21,17 @@ class HigherOrderWhenProxy
     /**
      * Create a new proxy instance.
      *
-     * @param  mixed  $builder
+     * @param  mixed  $resource
      * @param  mixed  $condition
      */
-    public function __construct($builder, $condition)
+    public function __construct($resource, $condition)
     {
-        $this->builder = $builder;
+        $this->resource = $resource;
         $this->condition = $condition;
     }
 
     /**
-     * Proxy the call onto the query builder.
+     * Proxy the call onto the resource.
      *
      * @param  string  $method
      * @param  array  $parameters
@@ -40,9 +40,9 @@ class HigherOrderWhenProxy
     public function __call($method, $parameters)
     {
         if ($this->condition) {
-            return $this->builder->{$method}(...$parameters);
+            return $this->resource->{$method}(...$parameters);
         }
 
-        return $this->builder;
+        return $this->resource;
     }
 }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
+use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
@@ -407,8 +408,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback, callable $default = null)
+    public function when($value, callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value);
         } elseif ($default) {
@@ -425,8 +430,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function whenEmpty(callable $callback, callable $default = null)
+    public function whenEmpty(callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $this->isEmpty());
+        }
+
         return $this->when($this->isEmpty(), $callback, $default);
     }
 
@@ -437,8 +446,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function whenNotEmpty(callable $callback, callable $default = null)
+    public function whenNotEmpty(callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $this->isNotEmpty());
+        }
+
         return $this->when($this->isNotEmpty(), $callback, $default);
     }
 
@@ -450,7 +463,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unless($value, callable $callback, callable $default = null)
+    public function unless($value, callable $callback = null, callable $default = null)
     {
         return $this->when(! $value, $callback, $default);
     }
@@ -462,7 +475,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unlessEmpty(callable $callback, callable $default = null)
+    public function unlessEmpty(callable $callback = null, callable $default = null)
     {
         return $this->whenNotEmpty($callback, $default);
     }
@@ -474,7 +487,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null)
+    public function unlessNotEmpty(callable $callback = null, callable $default = null)
     {
         return $this->whenEmpty($callback, $default);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -220,6 +220,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhenHigherOrderProxy()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when('truthy')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(0)->where('email', 'foo');
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testUnlessCallback()
     {
         $callback = function ($query, $condition) {
@@ -277,6 +290,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->unless('truthy', $callback, $default)->where('email', 'foo');
         $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
+    }
+
+    public function testUnlessHigherOrderProxy()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->unless(0)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->unless('truthy')->where('email', 'foo');
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testTapCallback()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -258,6 +258,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3661,6 +3661,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when('adam')->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(false)->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3692,6 +3710,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->whenEmpty(function ($data) {
             return $data->concat(['adam']);
         });
+
+        $this->assertSame(['adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->whenEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->whenEmpty()->concat(['adam']);
 
         $this->assertSame(['adam'], $data->toArray());
     }
@@ -3737,6 +3773,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenNotEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->whenNotEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->whenNotEmpty()->concat(['adam']);
+
+        $this->assertSame([], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenNotEmptyDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3768,6 +3822,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->unless(true, function ($data) {
             return $data->concat(['caleb']);
         });
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unless(false)->concat(['caleb']);
+
+        $this->assertSame(['michael', 'tom', 'caleb'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unless(true)->concat(['caleb']);
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
     }
@@ -3813,6 +3885,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testUnlessEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unlessEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->unlessEmpty()->concat(['adam']);
+
+        $this->assertSame([], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUnlessEmptyDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3844,6 +3934,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->unlessNotEmpty(function ($data) {
             return $data->concat(['adam']);
         });
+
+        $this->assertSame(['adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessNotEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unlessNotEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->unlessNotEmpty()->concat(['adam']);
 
         $this->assertSame(['adam'], $data->toArray());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3665,7 +3665,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when('adam')->concat(['adam']);
+        $data = $data->when(true)->concat(['adam']);
 
         $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
 


### PR DESCRIPTION
As per the suggestion in laravel/ideas#1881, this PR adds the ability to use higher order messaging when using the `when` (and `unless`) functions in query builders/collections.