### PR TITLE
[7.x] Adds higher order "when" proxy

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Concerns;
 use Illuminate\Container\Container;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\HigherOrderWhenProxy;
 
 trait BuildsQueries
 {
@@ -147,12 +148,16 @@ trait BuildsQueries
      * Apply the callback's query changes if the given "value" is true.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return mixed|$this
      */
-    public function when($value, $callback, $default = null)
+    public function when($value, $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
@@ -177,12 +182,16 @@ trait BuildsQueries
      * Apply the callback's query changes if the given "value" is false.
      *
      * @param  mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return mixed|$this
      */
-    public function unless($value, $callback, $default = null)
+    public function unless($value, $callback = null, $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, ! $value);
+        }
+
         if (! $value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {

--- a/src/Illuminate/Support/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Support/HigherOrderWhenProxy.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Support;
+
+class HigherOrderWhenProxy
+{
+    /**
+     * The resource being operated on.
+     *
+     * @var mixed
+     */
+    protected $resource;
+
+    /**
+     * The condition for the query.
+     *
+     * @var mixed
+     */
+    protected $condition;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  mixed  $resource
+     * @param  mixed  $condition
+     */
+    public function __construct($resource, $condition)
+    {
+        $this->resource = $resource;
+        $this->condition = $condition;
+    }
+
+    /**
+     * Proxy the call onto the resource.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if ($this->condition) {
+            return $this->resource->{$method}(...$parameters);
+        }
+
+        return $this->resource;
+    }
+}

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
+use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
@@ -407,8 +408,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback, callable $default = null)
+    public function when($value, callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value);
         } elseif ($default) {
@@ -425,8 +430,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function whenEmpty(callable $callback, callable $default = null)
+    public function whenEmpty(callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $this->isEmpty());
+        }
+
         return $this->when($this->isEmpty(), $callback, $default);
     }
 
@@ -437,8 +446,12 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function whenNotEmpty(callable $callback, callable $default = null)
+    public function whenNotEmpty(callable $callback = null, callable $default = null)
     {
+        if (is_null($callback)) {
+            return new HigherOrderWhenProxy($this, $this->isNotEmpty());
+        }
+
         return $this->when($this->isNotEmpty(), $callback, $default);
     }
 
@@ -450,7 +463,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unless($value, callable $callback, callable $default = null)
+    public function unless($value, callable $callback = null, callable $default = null)
     {
         return $this->when(! $value, $callback, $default);
     }
@@ -462,7 +475,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unlessEmpty(callable $callback, callable $default = null)
+    public function unlessEmpty(callable $callback = null, callable $default = null)
     {
         return $this->whenNotEmpty($callback, $default);
     }
@@ -474,7 +487,7 @@ trait EnumeratesValues
      * @param  callable  $default
      * @return static|mixed
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null)
+    public function unlessNotEmpty(callable $callback = null, callable $default = null)
     {
         return $this->whenEmpty($callback, $default);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -220,6 +220,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhenHigherOrderProxy()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when('truthy')->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(0)->where('email', 'foo');
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testUnlessCallback()
     {
         $callback = function ($query, $condition) {
@@ -277,6 +290,19 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->select('*')->from('users')->unless('truthy', $callback, $default)->where('email', 'foo');
         $this->assertSame('select * from "users" where "id" = ? and "email" = ?', $builder->toSql());
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
+    }
+
+    public function testUnlessHigherOrderProxy()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->unless(0)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+        $this->assertEquals([0 => 'foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->unless('truthy')->where('email', 'foo');
+        $this->assertSame('select * from "users"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
     }
 
     public function testTapCallback()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3661,6 +3661,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(true)->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->when(false)->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3692,6 +3710,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->whenEmpty(function ($data) {
             return $data->concat(['adam']);
         });
+
+        $this->assertSame(['adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhenEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->whenEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->whenEmpty()->concat(['adam']);
 
         $this->assertSame(['adam'], $data->toArray());
     }
@@ -3737,6 +3773,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhenNotEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->whenNotEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->whenNotEmpty()->concat(['adam']);
+
+        $this->assertSame([], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhenNotEmptyDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3768,6 +3822,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->unless(true, function ($data) {
             return $data->concat(['caleb']);
         });
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unless(false)->concat(['caleb']);
+
+        $this->assertSame(['michael', 'tom', 'caleb'], $data->toArray());
+
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unless(true)->concat(['caleb']);
 
         $this->assertSame(['michael', 'tom'], $data->toArray());
     }
@@ -3813,6 +3885,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testUnlessEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unlessEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom', 'adam'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->unlessEmpty()->concat(['adam']);
+
+        $this->assertSame([], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testUnlessEmptyDefault($collection)
     {
         $data = new $collection(['michael', 'tom']);
@@ -3844,6 +3934,24 @@ class SupportCollectionTest extends TestCase
         $data = $data->unlessNotEmpty(function ($data) {
             return $data->concat(['adam']);
         });
+
+        $this->assertSame(['adam'], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUnlessNotEmptyHigherOrderProxy($collection)
+    {
+        $data = new $collection(['michael', 'tom']);
+
+        $data = $data->unlessNotEmpty()->concat(['adam']);
+
+        $this->assertSame(['michael', 'tom'], $data->toArray());
+
+        $data = new $collection;
+
+        $data = $data->unlessNotEmpty()->concat(['adam']);
 
         $this->assertSame(['adam'], $data->toArray());
     }


### PR DESCRIPTION
As per the suggestion in laravel/ideas#1881, this PR adds the ability to use higher order messaging when using the `when` (and `unless`) functions in query builders/collections.

This would make using the `when` (and `unless`) functions a bit cleaner when someone is only adding one conditional method call, e.g.:

```php
// Before...
User::query()
    ->when($condition, function ($query) use ($bar) {
        $query->where('foo', $bar);
    })
    ->when($another, function ($query) use ($qux) {
        $query->where('baz', $quz)
    })
    ->get();

// After...
User::query()
    ->when($condition)->where('foo', $bar)
    ->when($another)->where('baz', $qux)
    ->get();
```