### PR TITLE
[6.x] Improvements on subqueries

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -311,8 +311,6 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
      * @return array
-     *
-     * @throws \InvalidArgumentException
      */
     protected function createSub($query)
     {
@@ -540,8 +538,6 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
-     *
-     * @throws \InvalidArgumentException
      */
     public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -585,8 +581,6 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
-     *
-     * @throws \InvalidArgumentException
      */
     public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -2673,8 +2667,6 @@ class Builder
      * @param  array  $columns
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @return int
-     *
-     * @throws \InvalidArgumentException
      */
     public function insertUsing(array $columns, $query)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -228,11 +228,7 @@ class Builder
         $columns = is_array($columns) ? $columns : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && (
-                $column instanceof self ||
-                $column instanceof EloquentBuilder ||
-                $column instanceof Closure
-            )) {
+            if (is_string($as) && $this->isQueryable($column)) {
                 $this->selectSub($column, $as);
             } else {
                 $this->columns[] = $column;
@@ -348,6 +344,19 @@ class Builder
     }
 
     /**
+     * Determine if the value is a query builder instance or a closure.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isQueryable($value)
+    {
+        return $value instanceof self ||
+               $value instanceof EloquentBuilder ||
+               $value instanceof Closure;
+    }
+
+    /**
      * Add a new select column to the query.
      *
      * @param  array|mixed  $column
@@ -358,11 +367,7 @@ class Builder
         $columns = is_array($column) ? $column : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && (
-                $column instanceof self ||
-                $column instanceof EloquentBuilder ||
-                $column instanceof Closure
-            )) {
+            if (is_string($as) && $this->isQueryable($column)) {
                 if (is_null($this->columns)) {
                     $this->select($this->from.'.*');
                 }
@@ -403,9 +408,7 @@ class Builder
      */
     public function from($table, $as = null)
     {
-        if ($table instanceof self ||
-            $table instanceof EloquentBuilder ||
-            $table instanceof Closure) {
+        if ($this->isQueryable($table)) {
             return $this->fromSub($table, $as);
         }
 
@@ -890,9 +893,7 @@ class Builder
         // If the value is a query builder instance we will assume the developer wants to
         // look for any values that exists within this given query. So we will add the
         // query accordingly so that this query is properly executed when it is run.
-        if ($values instanceof self ||
-            $values instanceof EloquentBuilder ||
-            $values instanceof Closure) {
+        if ($this->isQueryable($values)) {
             [$query, $bindings] = $this->createSub($values);
 
             $values = [new Expression($query)];
@@ -1806,9 +1807,7 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if ($column instanceof self ||
-            $column instanceof EloquentBuilder ||
-            $column instanceof Closure) {
+        if ($this->isQueryable($column)) {
             [$query, $bindings] = $this->createSub($column);
 
             $column = new Expression('('.$query.')');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -311,6 +311,8 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function createSub($query)
     {
@@ -331,6 +333,8 @@ class Builder
      *
      * @param  mixed  $query
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function parseSub($query)
     {
@@ -339,7 +343,9 @@ class Builder
         } elseif (is_string($query)) {
             return [$query, []];
         } else {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException(
+                'The subquery must be an instance of Closure or Builder, or a string.'
+            );
         }
     }
 
@@ -534,6 +540,8 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
      */
     public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -577,6 +585,8 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
      */
     public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -2663,6 +2673,8 @@ class Builder
      * @param  array  $columns
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @return int
+     *
+     * @throws \InvalidArgumentException
      */
     public function insertUsing(array $columns, $query)
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1658,6 +1658,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $expected .= 'inner join (select * from "contacts" where "name" = ?) as "sub2" on "users"."id" = "sub2"."user_id"';
         $this->assertEquals($expected, $builder->toSql());
         $this->assertEquals(['foo', 1, 'bar'], $builder->getRawBindings()['join']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->joinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testJoinSubWithPrefix()
@@ -1673,6 +1677,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->from('users')->leftJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
         $this->assertSame('select * from "users" left join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->leftJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testRightJoinSub()
@@ -1680,6 +1688,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->from('users')->rightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
         $this->assertSame('select * from "users" right join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->rightJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testRawExpressionsInSelect()
@@ -1915,6 +1927,13 @@ class DatabaseQueryBuilderTest extends TestCase
         );
 
         $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingInvalidSubquery()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('table1')->insertUsing(['foo'], ['bar']);
     }
 
     public function testInsertOrIgnoreMethod()
@@ -2869,6 +2888,10 @@ SQL;
         $builder->selectSub($subBuilder, 'sub');
         $this->assertEquals($expectedSql, $builder->toSql());
         $this->assertEquals($expectedBindings, $builder->getBindings());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getPostgresBuilder();
+        $builder->selectSub(['foo'], 'sub');
     }
 
     public function testSqlServerWhereDate()
@@ -3421,6 +3444,10 @@ SQL;
         }, 'sessions')->where('bar', '<', '10');
         $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions" where "foo" = ?) as "sessions" where "bar" < ?', $builder->toSql());
         $this->assertEquals(['1', '10'], $builder->getBindings());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->fromSub(['invalid'], 'sessions')->where('bar', '<', '10');
     }
 
     public function testFromSubWithPrefix()
@@ -3441,6 +3468,10 @@ SQL;
             $query->select(new Raw('max(last_seen_at) as last_seen_at'))->from('user_sessions');
         }, 'sessions');
         $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->fromSub(['invalid'], 'sessions');
     }
 
     public function testFromRaw()


### PR DESCRIPTION
### Determine if the value is queryable

This method allows the query builder to check if a value is queryable and can be used to perform subqueries.

Those checks were performed in 4 different places in the query builder so the repetition is now extracted to a single method.

### Add more context about invalid subqueries

The valid values for performing subqueries are query builder instances, closures and strings.

If the value is not one of the above, an InvalidArgumentException was thrown without any message. I've added a sensible message, and also some `@throws` docblock tags to the affected methods.

I've also added some tests that confirm these methods can indeed throw exceptions when misused.
