### PR TITLE
[6.x] Add message to NotFoundHttpException exception

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -176,7 +176,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException("Route not found.");
     }
 
     /**

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -176,7 +176,7 @@ class RouteCollection implements Countable, IteratorAggregate
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException("Route not found.");
+        throw new NotFoundHttpException('Route not found.');
     }
 
     /**


### PR DESCRIPTION
Hi,

Right now if we hit a route that does not exists with postman it throws a 404 with blank message.
If a mobile app is consuming the apis, it is very helpful to show them a message rather than empty string.