### PR TITLE
[6.x] Enable rule definition based on request type

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DummyClass extends FormRequest
 {
-
     /**
      * Determine if the user is authorized to make this request.
      *

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -11,7 +11,7 @@ class DummyClass extends FormRequest
      *
      * @return bool
      */
-    public function authorize ()
+    public function authorize()
     {
         return false;
     }
@@ -21,7 +21,7 @@ class DummyClass extends FormRequest
      *
      * @return array
      */
-    public function rules ()
+    public function rules()
     {
         switch ($this->method()) {
             case 'POST':
@@ -39,7 +39,7 @@ class DummyClass extends FormRequest
      * 
      * @return array
      */
-    public function createRules ()
+    public function createRules()
     {
         return [];
     }
@@ -49,7 +49,7 @@ class DummyClass extends FormRequest
      *
      * @return array
      */
-    public function updateRules ()
+    public function updateRules()
     {
         return [];
     }

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -6,12 +6,13 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DummyClass extends FormRequest
 {
+
     /**
      * Determine if the user is authorized to make this request.
      *
      * @return bool
      */
-    public function authorize()
+    public function authorize ()
     {
         return false;
     }
@@ -21,10 +22,37 @@ class DummyClass extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules ()
     {
-        return [
-            //
-        ];
+        switch ($this->method()) {
+            case 'POST':
+                return $this->createRules();
+            case 'PUT':
+            case 'PATCH':
+                return $this->updateRules();
+            default:
+                break;
+        }
     }
+
+    /**
+     * Get the validation rules that apply to the request.
+     * 
+     * @return array
+     */
+    public function createRules ()
+    {
+        return [];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function updateRules ()
+    {
+        return [];
+    }
+
 }


### PR DESCRIPTION
Currently the default request stub only caters for POST requests, this update allows for additional rule sets based on other request types, e.g on update you may not want to validate field x or you may wish to have a different validation variant.