### PR TITLE
[6.x] Add "missing" method to Request class

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -92,19 +92,6 @@ trait InteractsWithInput
     }
 
     /**
-     * Determine if the request is missing a given input item key.
-     *
-     * @param  string|array  $key
-     * @return bool
-     */
-    public function missing($key)
-    {
-        $keys = is_array($key) ? $key : func_get_args();
-
-        return ! $this->has($keys);
-    }
-
-    /**
      * Determine if the request contains any of the given inputs.
      *
      * @param  string|array  $keys
@@ -161,6 +148,19 @@ trait InteractsWithInput
         }
 
         return false;
+    }
+
+    /**
+     * Determine if the request is missing a given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        return ! $this->has($keys);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -92,6 +92,19 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request contains a given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        return ! $this->has($keys);
+    }
+
+    /**
      * Determine if the request contains any of the given inputs.
      *
      * @param  string|array  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -92,7 +92,7 @@ trait InteractsWithInput
     }
 
     /**
-     * Determine if the request contains a given input item key.
+     * Determine if the request is missing a given input item key.
      *
      * @param  string|array  $key
      * @return bool

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -300,6 +300,31 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
+    public function testMissingMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+        $this->assertFalse($request->missing('name'));
+        $this->assertFalse($request->missing('age'));
+        $this->assertFalse($request->missing('city'));
+        $this->assertTrue($request->missing('foo'));
+        $this->assertTrue($request->missing('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
+        $this->assertFalse($request->missing('name'));
+        $this->assertFalse($request->missing('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar', 'bar']]);
+        $this->assertFalse($request->missing('foo'));
+
+        $request = Request::create('/', 'GET', ['foo' => '', 'bar' => null]);
+        $this->assertFalse($request->missing('foo'));
+        $this->assertFalse($request->missing('bar'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertFalse($request->missing('foo.bar'));
+        $this->assertFalse($request->missing('foo.baz'));
+    }
+
     public function testHasAnyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
Just a simple method to check if a given key(s) is missing in the request object.

Instead of doing
```php
if (! $request->has('foo')) {
    //
}
```
you could do
```php
if ($request->missing('foo')) {
    //
}
```
