### PR TITLE
[6.x] Use exit code [1] when migration table not found

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -52,7 +52,9 @@ class StatusCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
-            return $this->error('Migration table not found.');
+            $this->error('Migration table not found.');
+
+            return 1;
         }
 
         $ran = $this->migrator->getRepository()->getRan();


### PR DESCRIPTION
This PR modifies `migrate:status` command to return exit code `1` when the `migrations` table is not found.

Motivation: I plan on using this as a way to see if the database has been migrated at least once. This will be useful when deploying to a new staging environment (when I'm deploying for the first time, I want to run seeders as well).

Thanks for your time!