### PR TITLE
[6.x] Add 'factoryRelation' helper that simplifies writing factories

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -506,6 +506,52 @@ if (! function_exists('factory')) {
     }
 }
 
+if (! function_exists('factoryRelation')) {
+    /**
+     * Returns a value for the given relationship key from a created model factory builder for a given class and name.
+     *
+     * @param  dynamic  class|[class,name]|class,deferred|class,deferred,relationshipKey
+     * @return mixed
+     */
+    function factoryRelation()
+    {
+        $factory = app(EloquentFactory::class);
+
+        $arguments = func_get_args();
+
+        list($class, $name, $deferred, $relationshipKey) = [$arguments[0], 'default', true, null];
+
+        if (is_array($arguments[0])) {
+            if (count($arguments[0]) === 1) {
+                $arguments[0] = \Illuminate\Support\Arr::flatten($arguments[0]);
+            }
+            list($class, $name) = $arguments[0];
+        }
+
+        $deferred = isset($arguments[1]) && is_bool($arguments[1])? $arguments[1] : true;
+
+        if (isset($arguments[1]) && is_string($arguments[1])) {
+            $relationshipKey = $arguments[1];
+        } elseif (isset($arguments[2]) && is_string($arguments[2])) {
+            $relationshipKey = $arguments[2];
+        }
+
+        if (is_null($relationshipKey)) {
+            $model = (new $class);
+            $relationshipKey = ($model)->getKeyName();
+            unset($model);
+        }
+
+        if ($deferred) {
+            return function () use ($factory, $class, $name, $relationshipKey) {
+                return $factory->of($class, $name)->create()->{$relationshipKey};
+            };
+        }
+
+        return $factory->of($class, $name)->create()->{$relationshipKey};
+    }
+}
+
 if (! function_exists('info')) {
     /**
      * Write some information to the log.

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -519,16 +519,16 @@ if (! function_exists('factoryRelation')) {
 
         $arguments = func_get_args();
 
-        list($class, $name, $deferred, $relationshipKey) = [$arguments[0], 'default', true, null];
+        [$class, $name, $relationshipKey] = [$arguments[0], 'default', null];
 
         if (is_array($arguments[0])) {
             if (count($arguments[0]) === 1) {
                 $arguments[0] = \Illuminate\Support\Arr::flatten($arguments[0]);
             }
-            list($class, $name) = $arguments[0];
+            [$class, $name] = $arguments[0];
         }
 
-        $deferred = isset($arguments[1]) && is_bool($arguments[1])? $arguments[1] : true;
+        $deferred = isset($arguments[1]) && is_bool($arguments[1]) ? $arguments[1] : true;
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
             $relationshipKey = $arguments[1];


### PR DESCRIPTION
This PR introduces a proposal to a new helper function that simplifies referencing values created from a `ModelFactory` used for relationships between `Models`. Illustrated by the below example:

We have 2 models `User` & `Role` that we want to create a model factory that depend on another one.

Current:
```
// UserFactory.php
$factory->define(User::class, function (Faker $faker) {
    return [
....
        'role_id' => function () {
            return factory(\App\Role::class)->create()->id;
        },
....
    ];
});

``` 

Proposal:
```
// UserFactory.php
$factory->define(User::class, function (Faker $faker) {
    return [
....
        'role_id' => factoryRelation(\App\Role::class),
....
    ];
});
```

In the background, by default we create a closure that contains the factory creation and retrieval of the relationshipKey value. We assume that the `primaryKey` is the `relationshipKey`.

**Customizing:**
- We're able to customize the relationshipKey by passing the field we're interested in, for example: 
```
factoryRelation(\App\Role::class, 'uuid');
```
- We can choose between deferred or not:
non-deferred
```
 'role_id' => factoryRelation(\App\Role::class, false, 'uuid');
// translates to
'role_id' => factory(\App\Role::class)->create()->id;
```
- We can even create a factory by a given name as follows:
```
 'role_id' => factoryRelation([\App\Role::class, 'nonDefault'], false, 'uuid');
// translates to
'role_id' => factory(\App\Role::class, 'nonDefault')->create()->id;
```

I think this will save some time when writing factories specially that has a lot of relations with other factories.