### PR TITLE
[6.x] Add Str::human() helper method

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -13,20 +13,6 @@ class Str
     use Macroable;
 
     /**
-     * The cache of camel-cased words.
-     *
-     * @var array
-     */
-    protected static $camelCache = [];
-
-    /**
-     * The cache of human-readable words.
-     *
-     * @var array
-     */
-    protected static $humanCache = [];
-
-    /**
      * The cache of snake-cased words.
      *
      * @var array
@@ -34,11 +20,26 @@ class Str
     protected static $snakeCache = [];
 
     /**
+     * The cache of camel-cased words.
+     *
+     * @var array
+     */
+    protected static $camelCache = [];
+
+
+    /**
      * The cache of studly-cased words.
      *
      * @var array
      */
     protected static $studlyCache = [];
+
+    /**
+     * The cache of human-readable words.
+     *
+     * @var array
+     */
+    protected static $humanCache = [];
 
     /**
      * The callback that should be used to generate UUIDs.

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -194,9 +194,7 @@ class Str
 
         $value = str_replace(['-', '_'], ' ', $value);
 
-        $value = static::title($value);
-
-        return static::$humanCache[$key] = $value;
+        return static::$humanCache[$key] = static::title($value);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -13,18 +13,25 @@ class Str
     use Macroable;
 
     /**
-     * The cache of snake-cased words.
-     *
-     * @var array
-     */
-    protected static $snakeCache = [];
-
-    /**
      * The cache of camel-cased words.
      *
      * @var array
      */
     protected static $camelCache = [];
+
+    /**
+     * The cache of human-readable words.
+     *
+     * @var array
+     */
+    protected static $humanCache = [];
+
+    /**
+     * The cache of snake-cased words.
+     *
+     * @var array
+     */
+    protected static $snakeCache = [];
 
     /**
      * The cache of studly-cased words.
@@ -167,6 +174,29 @@ class Str
         $quoted = preg_quote($cap, '/');
 
         return preg_replace('/(?:'.$quoted.')+$/u', '', $value).$cap;
+    }
+
+    /**
+     * Make a string human readable.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function human($value)
+    {
+        $key = $value;
+
+        if (isset(static::$humanCache[$key])) {
+            return static::$humanCache[$key];
+        }
+
+        $value = Str::snake($value);
+
+        $value = str_replace(['-', '_'], ' ', $value);
+
+        $value = static::title($value);
+
+        return static::$humanCache[$key] = $value;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -190,7 +190,7 @@ class Str
             return static::$humanCache[$key];
         }
 
-        $value = Str::snake($value);
+        $value = static::snake($value);
 
         $value = str_replace(['-', '_'], ' ', $value);
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -26,7 +26,6 @@ class Str
      */
     protected static $camelCache = [];
 
-
     /**
      * The cache of studly-cased words.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -194,7 +194,7 @@ class Str
 
         $value = str_replace(['-', '_'], ' ', $value);
 
-        return static::$humanCache[$key] = static::title($value);
+        return static::$humanCache[$key] = static::ucfirst($value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -305,6 +305,15 @@ class SupportStrTest extends TestCase
         $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
     }
 
+    public function testHuman()
+    {
+        $this->assertSame('Taylor Otwell', Str::human('taylor otwell'));
+        $this->assertSame('Taylor Otwell', Str::human('taylor-otwell'));
+        $this->assertSame('Taylor Otwell', Str::human('taylor_otwell'));
+        $this->assertSame('Taylor Otwell', Str::human('taylorOtwell'));
+        $this->assertSame('Taylor Otwell', Str::human('TaylorOtwell'));
+    }
+
     public function testStudly()
     {
         $this->assertSame('LaravelPHPFramework', Str::studly('laravel_p_h_p_framework'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -307,11 +307,11 @@ class SupportStrTest extends TestCase
 
     public function testHuman()
     {
-        $this->assertSame('Taylor Otwell', Str::human('taylor otwell'));
-        $this->assertSame('Taylor Otwell', Str::human('taylor-otwell'));
-        $this->assertSame('Taylor Otwell', Str::human('taylor_otwell'));
-        $this->assertSame('Taylor Otwell', Str::human('taylorOtwell'));
-        $this->assertSame('Taylor Otwell', Str::human('TaylorOtwell'));
+        $this->assertSame('Taylor otwell', Str::human('taylor otwell'));
+        $this->assertSame('Taylor otwell', Str::human('taylor-otwell'));
+        $this->assertSame('Taylor otwell', Str::human('taylor_otwell'));
+        $this->assertSame('Taylor otwell', Str::human('taylorOtwell'));
+        $this->assertSame('Taylor otwell', Str::human('TaylorOtwell'));
     }
 
     public function testStudly()


### PR DESCRIPTION
I know there's a general preference to not add new helper methods, but thought it may be worthwhile to propose this as it's come in handy on a project where I needed to make snake_cased values from a third-party API more human readable.

Nova ships with a `Nova::humanize()` method which gets most of the way there, but it doesn't support values that are snake- or kebab- cased. It's not a totally novel concept either, [Rails has a `humanize` string helper too](https://apidock.com/rails/String/humanize).

I opted to call the method `human` instead, as it has the same feel/vibe as `snake`/`camel`.

The methods in `Str.php` appear to be ordered alphabetically, so I re-ordered the string transformation caches to be alphabetical too.

Regarding macroability - this could be implemented as a macro, but I imagine you'd have to lose the cache functionality if you can't define the static array on the class? 