### PR TITLE
[7.x] Set the id on the model when using findOrNew

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -386,7 +386,7 @@ class Builder
             return $model;
         }
 
-        return $this->newModelInstance();
+        return $this->newModelInstance([$this->model->getKeyName() => $id]);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -435,7 +435,7 @@ class BelongsToMany extends Relation
     public function findOrNew($id, $columns = ['*'])
     {
         if (is_null($instance = $this->find($id, $columns))) {
-            $instance = $this->related->newInstance();
+            $instance = $this->related->newInstance([$this->related->getKeyName() => $id]);
         }
 
         return $instance;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -181,7 +181,7 @@ abstract class HasOneOrMany extends Relation
     public function findOrNew($id, $columns = ['*'])
     {
         if (is_null($instance = $this->find($id, $columns))) {
-            $instance = $this->related->newInstance();
+            $instance = $this->related->newInstance([$this->related->getKeyName() => $id]);
 
             $this->setForeignAttributesForCreate($instance);
         }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -47,7 +47,8 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('getKeyName')->once()->with()->andReturn('id');
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['id' => 'foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
         $this->assertInstanceOf(Model::class, $relation->findOrNew('foo'));

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -355,6 +355,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $user1 = EloquentTestUser::on('second_connection')->findOrNew(1);
         $user2 = EloquentTestUser::on('second_connection')->findOrNew(2);
+        $this->assertEquals(1, $user1->id);
+        $this->assertEquals(2, $user2->id);
         $this->assertFalse($user1->exists);
         $this->assertTrue($user2->exists);
         $this->assertSame('second_connection', $user1->getConnectionName());

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -106,7 +106,8 @@ class DatabaseEloquentMorphTest extends TestCase
     {
         $relation = $this->getOneRelation();
         $relation->getQuery()->shouldReceive('find')->once()->with('foo', ['*'])->andReturn(null);
-        $relation->getRelated()->shouldReceive('newInstance')->once()->with()->andReturn($model = m::mock(Model::class));
+        $relation->getRelated()->shouldReceive('getKeyName')->once()->with()->andReturn('id');
+        $relation->getRelated()->shouldReceive('newInstance')->once()->with(['id' => 'foo'])->andReturn($model = m::mock(Model::class));
         $model->shouldReceive('setAttribute')->once()->with('morph_id', 1);
         $model->shouldReceive('setAttribute')->once()->with('morph_type', get_class($relation->getParent()));
         $model->shouldReceive('save')->never();

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -238,10 +238,12 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $this->createUsers();
 
         $result = SoftDeletesTestUser::findOrNew(1);
-        $this->assertNull($result->id);
+        $this->assertEquals(1, $result->id);
+        $this->assertNull($result->email);
 
         $result = SoftDeletesTestUser::withTrashed()->findOrNew(1);
         $this->assertEquals(1, $result->id);
+        $this->assertEquals('taylorotwell@gmail.com', $result->email);
     }
 
     public function testFirstOrCreate()


### PR DESCRIPTION
Follow up to #10214

Benefit: This brings the method more in line with how the firstOrNew method works when the attributes are set on the model if the model is not found in the database. If the user is specifying an ID, it stands to reason they expect to save the model with that ID as well. 

B/C: It alters the behaviour so unfortunately can't go into 6.x

