### PR TITLE
[6.x] Waiting before retrying password reset

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -156,7 +156,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      */
     public function recentlyCreated(CanResetPasswordContract $user)
     {
-        $record = (array)$this->getTable()->where(
+        $record = (array) $this->getTable()->where(
             'email', $user->getEmailForPasswordReset()
         )->first();
 

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -46,6 +46,13 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     protected $expires;
 
     /**
+     * Minimum number of seconds before re-redefining the token.
+     *
+     * @var int
+     */
+    protected $timeout;
+
+    /**
      * Create a new token repository instance.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
@@ -53,15 +60,17 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
      * @param  string  $table
      * @param  string  $hashKey
      * @param  int  $expires
+     * @param  int $timeout
      * @return void
      */
     public function __construct(ConnectionInterface $connection, HasherContract $hasher,
-                                $table, $hashKey, $expires = 60)
+                                $table, $hashKey, $expires = 60, $timeout = 60)
     {
         $this->table = $table;
         $this->hasher = $hasher;
         $this->hashKey = $hashKey;
         $this->expires = $expires * 60;
+        $this->timeout = $timeout;
         $this->connection = $connection;
     }
 
@@ -137,6 +146,32 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     protected function tokenExpired($createdAt)
     {
         return Carbon::parse($createdAt)->addSeconds($this->expires)->isPast();
+    }
+
+    /**
+     * Determine if a token record exists and was recently created.
+     *
+     * @param \Illuminate\Contracts\Auth\CanResetPassword $user
+     * @return bool
+     */
+    public function recentlyCreated(CanResetPasswordContract $user)
+    {
+        $record = (array)$this->getTable()->where(
+            'email', $user->getEmailForPasswordReset()
+        )->first();
+
+        return $record && $this->tokenRecentlyCreated($record['created_at']);
+    }
+
+    /**
+     * Determine if the token was recently created.
+     *
+     * @param string $createdAt
+     * @return bool
+     */
+    protected function tokenRecentlyCreated($createdAt)
+    {
+        return Carbon::parse($createdAt)->addSeconds($this->timeout)->isFuture();
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -55,6 +55,12 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
+        // An attacker can make a lot of password reset requests,
+        // which will lead to spam in user's mailbox.
+        if ($this->tokens->recentlyCreated($user)) {
+            return static::RESEND_TIMEOUT;
+        }
+
         // Once we have the reset token, we are ready to send the message out to this
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -95,7 +95,8 @@ class PasswordBrokerManager implements FactoryContract
             $this->app['hash'],
             $config['table'],
             $key,
-            $config['expire']
+            $config['expire'],
+            $config['timeout']
         );
     }
 

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -35,6 +35,13 @@ interface PasswordBroker
     const INVALID_TOKEN = 'passwords.token';
 
     /**
+     * Constant representing the wait before password reset link resending.
+     *
+     * @var string
+     */
+    const RESEND_TIMEOUT = 'passwords.timeout';
+
+    /**
      * Send a password reset link to a user.
      *
      * @param  array  $credentials


### PR DESCRIPTION
<!--
In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello!
An attacker can use the password recovery function to spam the user's mailbox and / or overload the mail server.
This can be avoided by delaying the next attempt to use the password recovery function.
Also changes to laravel/laravel are submited.
Thanks!
P.S. My English is not so good. I will be happy to make corrections to the request.