### PR TITLE
Support last_modified parameter

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -31,6 +31,18 @@ class SetCacheHeaders
         if (isset($options['etag']) && $options['etag'] === true) {
             $options['etag'] = md5($response->getContent());
         }
+        
+        if (isset($options['last_modified']))
+		{
+			if (is_numeric($options['last_modified'])) 
+			{
+                $options['last_modified']=new \DateTime('@'.$options['last_modified']);
+			}
+			else
+			{
+                $options['last_modified']=new \DateTime($options['last_modified']);						
+			}
+        }        
 
         $response->setCache($options);
         $response->isNotModified($request);


### PR DESCRIPTION
setCache last_modified requires a DateTime object and currently the Middleware passes a String no mater what.

Now you can pass an integer (assumed a unix timestamp) or an arbitrary string that will be passed as a DateTime object.

Regards

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
