### PR TITLE
Support last_modified parameter with Carbon::parse

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Middleware;
 
 use Closure;
+use Carbon\Carbon;
 
 class SetCacheHeaders
 {
@@ -31,6 +32,18 @@ class SetCacheHeaders
         if (isset($options['etag']) && $options['etag'] === true) {
             $options['etag'] = md5($response->getContent());
         }
+        
+        if (isset($options['last_modified']))
+        {
+          if (is_numeric($options['last_modified'])) 
+          {
+            $options['last_modified']=Carbon::createFromTimestamp($options['last_modified']);
+          }
+          else
+          {
+            $options['last_modified']=Carbon::parse($options['last_modified']);						
+          }
+        }        
 
         $response->setCache($options);
         $response->isNotModified($request);


### PR DESCRIPTION
setCache last_modified requires a DateTime object and currently the Middleware passes only a String

Now you can pass an integer (assumed a unix timestamp) or an arbitrary string that will be parsed by Carbon as a DateTime

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
