### PR TITLE
[6.x] Fix the Filesystem manager's exception on unsupported driver

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -112,17 +112,18 @@ class FilesystemManager implements FactoryContract
     protected function resolve($name)
     {
         $config = $this->getConfig($name);
+        $name = $config['driver'] ?? $name;
 
-        if (isset($this->customCreators[$config['driver']])) {
+        if (isset($this->customCreators[$name])) {
             return $this->callCustomCreator($config);
         }
 
-        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+        $driverMethod = 'create'.ucfirst($name).'Driver';
 
         if (method_exists($this, $driverMethod)) {
             return $this->{$driverMethod}($config);
         } else {
-            throw new InvalidArgumentException("Driver [{$config['driver']}] is not supported.");
+            throw new InvalidArgumentException("Driver [{$name}] is not supported.");
         }
     }
 
@@ -298,7 +299,7 @@ class FilesystemManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["filesystems.disks.{$name}"];
+        return $this->app['config']["filesystems.disks.{$name}"] ?: [];
     }
 
     /**

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Tests\Filesystem;
+
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class FilesystemManagerTest extends TestCase
+{
+    public function testExceptionThrownOnUnsupportedDriver()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Driver [unsupported-disk] is not supported.');
+
+        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+            $app['config'] = ['filesystems.disks.unsupported-disk' => null];
+        }));
+
+        $filesystem->disk('unsupported-disk');
+    }
+}


### PR DESCRIPTION
This will fix the exception message on unsupported driver.

For example `Storage::disk('unsupported-disk')`;

**Before**
`Driver [] is not supported.`

**After**
`Driver [unsupported-disk] is not supported.`