### PR TITLE
new tests in Cache

### DIFF
--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -82,4 +82,25 @@ class CacheTest extends TestCase
             return new Response('some content');
         }, 'invalid');
     }
+    
+    public function testLastModifiedUnixTime()
+    {
+        $time=time();
+
+        $response = (new Cache)->handle(new Request, function () {
+            return new Response('some content');
+        }, "last_modified=$time");
+
+        $this->assertSame($time, $response->getLastModified()->getTimestamp());
+    }
+
+    public function testLastModifiedStringDate() {
+        $birthdate='1973-04-09 10:10:10';
+        $response = (new Cache)->handle(new Request, function () {
+            return new Response('some content');
+        }, "last_modified=$birthdate");
+
+        $this->assertSame(Carbon::parse($birthdate)->timestamp, $response->getLastModified()->getTimestamp());
+    }
+
 }


### PR DESCRIPTION
New tests added:

testLastModifiedUnixTime - tests a requests with last_modified=xxxx where xxxx is a unix timestamp, the test checks that the response has the same time in the LastModified header

testLastModifiedStringDate - test a request with last_modified=1973-04-09 10:10:10 (my birthday), the test checks that the response has the same time in the LastModified header

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
