### PR TITLE
[6.x] Allow using the signed route middleware with relative signed URLs

### DIFF
--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -12,13 +12,15 @@ class ValidateSignature
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
+     * @param  \string|\null $relative Should be the word "relative" or null.
      * @return \Illuminate\Http\Response
      *
      * @throws \Illuminate\Routing\Exceptions\InvalidSignatureException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, Closure $next, $relative = null)
     {
-        if ($request->hasValidSignature()) {
+        // Consumers of the middleware can use the syntax "signed:relative".
+        if ($request->hasValidSignature($relative !== 'relative')) {
             return $next($request);
         }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -85,6 +85,21 @@ class UrlSigningTest extends TestCase
         $this->assertIsString($url = URL::signedRoute('foo', $model));
         $this->assertSame('routable', $this->get($url)->original);
     }
+
+    public function testSignedUrlMiddlewareWithRelativePath()
+    {
+        Route::get('/foo/ipsum', function () {
+            return 'works';
+        })->name('foo')->middleware('signed:relative');
+
+        $this->assertEquals(
+            'works',
+            $this->get(url('https://fake.test'.URL::signedRoute('foo', [], null, false)))->original
+        );
+
+        $response = $this->get('/foo/ipsum');
+        $response->assertStatus(403);
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
### Changed

- Adds support for relative signed URLs in the `ValidateSignature` middleware
