### PR TITLE
[6.x] Sorts listeners for output on the event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -58,6 +58,8 @@ class EventListCommand extends Command
         }
 
         return collect($events)->map(function ($listeners, $event) {
+            sort($listeners);
+
             return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
         })->sortBy('Event')->values()->toArray();
     }


### PR DESCRIPTION
As a developer I like to see the output of this command sort the event listener classes in alphabetical order so that they are easier to scan.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
