### PR TITLE
[7.x] Only load ids when retrying jobs

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Queue\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Arr;
 
 class RetryCommand extends Command
 {

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -53,7 +53,7 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            $ids = $this->laravel['queue.failer']->ids();
         }
 
         return $ids;

--- a/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseFailedJobProvider.php
@@ -74,6 +74,16 @@ class DatabaseFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
+     * Get a list of ids from all the failed jobs.
+     *
+     * @return array
+     */
+    public function ids()
+    {
+        return $this->getTable()->orderBy('id', 'desc')->pluck('id')->all();
+    }
+
+    /**
      * Get a single failed job.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -111,6 +111,29 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
+     * Get a list of ids from all the failed jobs.
+     *
+     * @return array
+     */
+    public function ids()
+    {
+        $results = $this->dynamo->query([
+            'TableName' => $this->table,
+            'Select' => 'SPECIFIC_ATTRIBUTES',
+            'ProjectionExpression' => 'uuid',
+            'KeyConditionExpression' => 'application = :application',
+            'ExpressionAttributeValues' => [
+                ':application' => ['S' => $this->applicationName],
+            ],
+            'ScanIndexForward' => false,
+        ]);
+
+        return collect($results['Items'])->map(function ($result) {
+            return $result['uuid']['S'];
+        })->all();
+    }
+
+    /**
      * Get a single failed job.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
+++ b/src/Illuminate/Queue/Failed/FailedJobProviderInterface.php
@@ -23,6 +23,13 @@ interface FailedJobProviderInterface
     public function all();
 
     /**
+     * Get a list of ids from all the failed jobs.
+     *
+     * @return array
+     */
+    public function ids();
+
+    /**
      * Get a single failed job.
      *
      * @param  mixed  $id

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -29,6 +29,16 @@ class NullFailedJobProvider implements FailedJobProviderInterface
     }
 
     /**
+     * Get a list of ids from all the failed jobs.
+     *
+     * @return array
+     */
+    public function ids()
+    {
+        return [];
+    }
+
+    /**
      * Get a single failed job.
      *
      * @param  mixed  $id


### PR DESCRIPTION
Right now the `FailedJobProviderInterface` implementations would load the full payload of all jobs to iterate over and then query each job by it's identifier when calling `php artisan queue:retry all`, this uses a lot of memory and can be reduced by quite a bit by only selecting the identifier and therefore only loading relevant information to iterate over as we're already getting the whole job per loop.

This adds a method to the interface and therefore targets the `7.x` release.

I'm not 100% certain about the DynamoDB implementation as i don't have much experience with it, but this is what i came up with from the docs.