### PR TITLE
[6.x] Waiting before retrying password reset

### DIFF
--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -46,7 +46,7 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
     protected $expires;
 
     /**
-     * Minimum number of seconds before re-redefining the token.
+     * Minimum number of seconds before redefining the token.
      *
      * @var int
      */

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -55,6 +55,12 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
+        // An attacker can make a lot of password reset requests,
+        // which will lead to spam in user's mailbox.
+        if ($this->tokens->recentlyCreated($user)) {
+            return static::RESEND_TIMEOUT;
+        }
+
         // Once we have the reset token, we are ready to send the message out to this
         // user with a link to reset their password. We will then redirect back to
         // the current URI having nothing set in the session to indicate errors.

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -55,10 +55,14 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
-        // An attacker can make a lot of password reset requests,
-        // which will lead to spam in user's mailbox.
-        if ($this->tokens->recentlyCreated($user)) {
-            return static::RESEND_TIMEOUT;
+        // Before 7.x we have to check the existence of a new method.
+        // In 7.x, this code must be removed.
+        if (method_exists($this->tokens, 'recentlyCreated')) {
+            // An attacker can make a lot of password reset requests,
+            // which will lead to spam in user's mailbox.
+            if ($this->tokens->recentlyCreated($user)) {
+                return static::RESEND_TIMEOUT;
+            }
         }
 
         // Once we have the reset token, we are ready to send the message out to this

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -96,7 +96,9 @@ class PasswordBrokerManager implements FactoryContract
             $config['table'],
             $key,
             $config['expire'],
-            $config['timeout']
+            // Before 7.x this element in the configuration may not exist.
+            // In 7.x, this check must be removed.
+            $config['timeout'] ?? 0
         );
     }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -95,7 +95,8 @@ class PasswordBrokerManager implements FactoryContract
             $this->app['hash'],
             $config['table'],
             $key,
-            $config['expire']
+            $config['expire'],
+            $config['timeout']
         );
     }
 

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -35,6 +35,13 @@ interface PasswordBroker
     const INVALID_TOKEN = 'passwords.token';
 
     /**
+     * Constant representing the wait before password reset link resending.
+     *
+     * @var string
+     */
+    const RESEND_TIMEOUT = 'passwords.timeout';
+
+    /**
      * Send a password reset link to a user.
      *
      * @param  array  $credentials

--- a/tests/Auth/AuthDatabaseTokenRepositoryTest.php
+++ b/tests/Auth/AuthDatabaseTokenRepositoryTest.php
@@ -98,6 +98,44 @@ class AuthDatabaseTokenRepositoryTest extends TestCase
         $this->assertFalse($repo->exists($user, 'wrong-token'));
     }
 
+    public function testRecentlyCreatedReturnsFalseIfNoRowFoundForUser()
+    {
+        $repo = $this->getRepo();
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $query->shouldReceive('first')->once()->andReturn(null);
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->recentlyCreated($user));
+    }
+
+    public function testRecentlyCreatedReturnsTrueIfRecordIsRecentlyCreated()
+    {
+        $repo = $this->getRepo();
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subSeconds(59)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertTrue($repo->recentlyCreated($user));
+    }
+
+    public function testRecentlyCreatedReturnsFalseIfValidRecordExists()
+    {
+        $repo = $this->getRepo();
+        $repo->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($query = m::mock(stdClass::class));
+        $query->shouldReceive('where')->once()->with('email', 'email')->andReturn($query);
+        $date = Carbon::now()->subSeconds(61)->toDateTimeString();
+        $query->shouldReceive('first')->once()->andReturn((object) ['created_at' => $date, 'token' => 'hashed-token']);
+        $user = m::mock(CanResetPassword::class);
+        $user->shouldReceive('getEmailForPasswordReset')->once()->andReturn('email');
+
+        $this->assertFalse($repo->recentlyCreated($user));
+    }
+
     public function testDeleteMethodDeletesByToken()
     {
         $repo = $this->getRepo();

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -117,7 +117,7 @@ class AuthPasswordBrokerTest extends TestCase
     protected function getMocks()
     {
         return [
-            'tokens' => m::mock(TokenRepositoryInterface::class),
+            'tokens' => m::mock(TestTokenRepositoryInterface::class),
             'users'  => m::mock(UserProvider::class),
             'mailer' => m::mock(Mailer::class),
             'view'   => 'resetLinkView',
@@ -125,15 +125,10 @@ class AuthPasswordBrokerTest extends TestCase
     }
 }
 
-// Before 7.x we have to check the existence of a new method. In 7.x, this code must be removed.
+// Before 7.x we have to check the existence of a new method. In 7.x, this code must be moved to
+// Illuminate\Auth\Passwords\TokenRepositoryInterface
 
-namespace Illuminate\Auth\Passwords;
-
-function method_exists($object, $method_name)
+interface TestTokenRepositoryInterface extends TokenRepositoryInterface
 {
-    if ($method_name == 'recentlyCreated') {
-        return true;
-    }
-
-    return \method_exists($object, $method_name);
+    public function recentlyCreated(CanResetPassword $user);
 }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -29,6 +29,17 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
     }
 
+    public function testIfTokenIsRecentlyCreated()
+    {
+        $mocks = $this->getMocks();
+        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('recentlyCreated')->once()->with($user)->andReturn(true);
+        $user->shouldReceive('sendPasswordResetNotification')->with('token');
+
+        $this->assertEquals(PasswordBrokerContract::RESEND_TIMEOUT, $broker->sendResetLink(['foo']));
+    }
+
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
     {
         $this->expectException(UnexpectedValueException::class);
@@ -53,13 +64,11 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks = $this->getMocks();
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('recentlyCreated')->once()->with($user)->andReturn(false);
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
-        $callback = function () {
-            //
-        };
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
-        $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo'], $callback));
+        $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
     }
 
     public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -124,3 +124,16 @@ class AuthPasswordBrokerTest extends TestCase
         ];
     }
 }
+
+// Before 7.x we have to check the existence of a new method. In 7.x, this code must be removed.
+
+namespace Illuminate\Auth\Passwords;
+
+function method_exists($object, $method_name)
+{
+    if ($method_name == 'recentlyCreated') {
+        return true;
+    }
+
+    return \method_exists($object, $method_name);
+}

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -32,6 +32,7 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfTokenIsRecentlyCreated()
     {
         $mocks = $this->getMocks();
+        $mocks['tokens'] = m::mock(TestTokenRepositoryInterface::class);
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('recentlyCreated')->once()->with($user)->andReturn(true);
@@ -64,7 +65,6 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks = $this->getMocks();
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
-        $mocks['tokens']->shouldReceive('recentlyCreated')->once()->with($user)->andReturn(false);
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
@@ -117,7 +117,7 @@ class AuthPasswordBrokerTest extends TestCase
     protected function getMocks()
     {
         return [
-            'tokens' => m::mock(TestTokenRepositoryInterface::class),
+            'tokens' => m::mock(TokenRepositoryInterface::class),
             'users'  => m::mock(UserProvider::class),
             'mailer' => m::mock(Mailer::class),
             'view'   => 'resetLinkView',


### PR DESCRIPTION
Hello!
An attacker can use the password recovery function to spam the user's mailbox and / or overload the mail server.
This can be avoided by delaying the next attempt to use the password recovery function.
Also changes to laravel/laravel are submited.
Thanks!
P.S. Test coverage added.
P.P.S. As suggested, in the second commit, I added checks to safely include this code in the 6.x branch. After accepting this PR in master, I will do another PR to remove these checks and add recentlyCreated to the interface TokenRepositoryInterface.