### PR TITLE
30302 fix empty object casting

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -685,7 +685,8 @@ trait HasAttributes
      */
     protected function castAttributeAsJson($key, $value)
     {
-        $value = $this->asJson($value);
+        $options = $this->hasCast($key, ['object']) ? JSON_FORCE_OBJECT : null;
+        $value = $this->asJson($value, $options);
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
@@ -700,11 +701,12 @@ trait HasAttributes
      * Encode the given value as JSON.
      *
      * @param  mixed  $value
+     * @param int $options
      * @return string
      */
-    protected function asJson($value)
+    protected function asJson($value, $options = null)
     {
-        return json_encode($value);
+        return json_encode($value, $options);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1653,6 +1653,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('1969-07-20 00:00:00', $arr['dateAttribute']);
     }
 
+    public function testModelEmptyObjectAttributeCastingReturnsEmptyObjectJson()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->objectAttribute = [];
+        $this->assertSame('{}', $model->objectAttributeValue());
+    }
+
     public function testModelAttributeCastingPreservesNull()
     {
         $model = new EloquentModelCastingStub;
@@ -2295,6 +2302,11 @@ class EloquentModelCastingStub extends Model
     public function jsonAttributeValue()
     {
         return $this->attributes['jsonAttribute'];
+    }
+
+    public function objectAttributeValue()
+    {
+        return $this->attributes['objectAttribute'];
     }
 }
 

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -91,7 +91,7 @@ class EloquentModelStringCastingTest extends TestCase
         $this->assertSame('[]', $model->getOriginal('json_attributes'));
         $this->assertSame([], $model->getAttribute('json_attributes'));
 
-        $this->assertSame('[]', $model->getOriginal('object_attributes'));
+        $this->assertSame('{}', $model->getOriginal('object_attributes'));
         $this->assertSame([], $model->getAttribute('object_attributes'));
     }
 


### PR DESCRIPTION
### Description:
This PR fixes a strange behavior in the Model 'object' casting. If you have a model with field declared as 'object' and you'll pass an empty array into it you will get an '[]' instead of '{}' when you will cast it back to the JSON.

### Steps To Reproduce:
class ExampleModel extends Model
{
    protected $casts = [
        'field' => 'object',
    ];
}

$model = new ExampleModel();
$model->field = [];
$model->toJson() // return {'field': []} instead of {'field': {}}