### PR TITLE
[6.x] Add requeue function to jobs

### DIFF
--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -62,6 +62,19 @@ trait InteractsWithQueue
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int   $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        if ($this->job) {
+            return $this->job->requeue($delay);
+        }
+    }
+
+    /**
      * Set the base queue job instance.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -57,6 +57,23 @@ class DatabaseJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int   $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        parent::release($delay);
+
+        $this->delete();
+
+        $this->job->decrement();
+
+        return $this->database->release($this->queue, $this->job, $delay);
+    }
+
+    /**
      * Delete the job from the queue.
      *
      * @return void

--- a/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
@@ -39,6 +39,18 @@ class DatabaseJobRecord
     }
 
     /**
+     * Decrement the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function decrement()
+    {
+        $this->record->attempts--;
+
+        return $this->record->attempts;
+    }
+
+    /**
      * Update the "reserved at" timestamp of the job.
      *
      * @return int

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -98,6 +98,19 @@ class RedisJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int   $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        parent::release($delay);
+
+        $this->redis->deleteAndRequeue($this->queue, $this, $delay);
+    }
+
+    /**
      * Get the number of times the job has been attempted.
      *
      * @return int

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -50,6 +50,17 @@ class SyncJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job back.
+     *
+     * @param  int   $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        $this->release($delay);
+    }
+
+    /**
      * Get the number of times the job has been attempted.
      *
      * @return int

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -268,6 +268,24 @@ class RedisQueue extends Queue implements QueueContract
     }
 
     /**
+     * Delete a reserved job from the reserved queue and requeue it.
+     *
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\Jobs\RedisJob  $job
+     * @param  int  $delay
+     * @return void
+     */
+    public function deleteAndRequeue($queue, $job, $delay)
+    {
+        $queue = $this->getQueue($queue);
+
+        $this->getConnection()->eval(
+            LuaScripts::requeue(), 2, $queue.':delayed', $queue.':reserved',
+            $job->getReservedJob(), $this->availableAt($delay)
+        );
+    }
+
+    /**
      * Get a random ID string.
      *
      * @return string

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -43,6 +43,15 @@ class QueueRedisJobTest extends TestCase
         $job->release(1);
     }
 
+    public function testRequeueProperlyReleasesJobOntoRedis()
+    {
+        $job = $this->getJob();
+        $job->getRedisQueue()->shouldReceive('deleteAndRequeue')->once()
+            ->with('default', $job, 1);
+
+        $job->requeue(1);
+    }
+
     protected function getJob()
     {
         return new RedisJob(


### PR DESCRIPTION
This pull requests adds a `requeue` method to database and Redis jobs. The idea comes from https://github.com/laravel/ideas/issues/1381

The method does the same as the `release` method, but before putting the job back into queue, it decrements the attempts attribute.

This handles an issue like this, where the job could fail, because the attempts attribute had exceeded the tries attribute.

```php
Redis::throttle('key')->allow(10)->every(60)->then(function () {
    try {
        // API logic
    }
    catch (Exception) {
        // Release the job back into the queue
        return $this->release(10);
    }
}, function () {
    // Could not obtain lock...
    return $this->requeue(10);
});
```