### PR TITLE
[7.x] Flushing cleanup

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -1197,6 +1197,17 @@ class Container implements ArrayAccess, ContainerContract
         $this->bindings = [];
         $this->instances = [];
         $this->abstractAliases = [];
+        $this->methodBindings = [];
+        $this->buildStack = [];
+        $this->extenders = [];
+        $this->tags = [];
+        $this->with = [];
+        $this->contextual = [];
+        $this->reboundCallbacks = [];
+        $this->globalResolvingCallbacks = [];
+        $this->globalAfterResolvingCallbacks = [];
+        $this->resolvingCallbacks = [];
+        $this->afterResolvingCallbacks = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1201,16 +1201,12 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         parent::flush();
 
-        $this->buildStack = [];
         $this->loadedProviders = [];
         $this->bootedCallbacks = [];
         $this->bootingCallbacks = [];
+        $this->terminatingCallbacks = [];
         $this->deferredServices = [];
-        $this->reboundCallbacks = [];
         $this->serviceProviders = [];
-        $this->resolvingCallbacks = [];
-        $this->afterResolvingCallbacks = [];
-        $this->globalResolvingCallbacks = [];
     }
 
     /**


### PR DESCRIPTION
Properties defined in the Container class were flushed in the Application, but the Container class has a flush() method on it's own.
I moved the Container properties to it's own flush() method and added missing ones. The Application class also has a property that didn't get flushed.