### PR TITLE
[7.x] Enable dot notation to set nested visibilities for eloquent serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -240,8 +240,8 @@ trait HasAttributes
         $attributes = [];
 
         // Get visibility directives that should be set on the relations.
-		$nestedVisible = $this->getNestedVisibilityDirectives($this->getVisible());
-		$nestedHidden = $this->getNestedVisibilityDirectives($this->getHidden());
+        $nestedVisible = $this->getNestedVisibilityDirectives($this->getVisible());
+        $nestedHidden = $this->getNestedVisibilityDirectives($this->getHidden());
 
         foreach ($this->getArrayableRelations() as $key => $value) {
             // If the values implements the Arrayable interface we will pass the
@@ -300,17 +300,17 @@ trait HasAttributes
         // Put the directives in an array keyed by relation name and with the
         // values containing an array that can be directly used in makeHidden
         // and makeVisible methods.
-		$relationDirectives = [];
+        $relationDirectives = [];
 
-		foreach ($directives as $key) {
-			$expandedKey = explode('.', $key, 2);
+        foreach ($directives as $key) {
+            $expandedKey = explode('.', $key, 2);
 
-			if (isset($expandedKey[1])) {
-				$relationDirectives[$expandedKey[0]][] = $expandedKey[1];
-			}
-		}
+            if (isset($expandedKey[1])) {
+                $relationDirectives[$expandedKey[0]][] = $expandedKey[1];
+            }
+        }
 
-		return $relationDirectives;
+        return $relationDirectives;
     }
 
     /**
@@ -320,8 +320,8 @@ trait HasAttributes
      */
     protected function setNestedVisibilities($value, $visible, $hidden)
     {
-		$value->makeVisible($visible);
-		$value->makeHidden($hidden);
+        $value->makeVisible($visible);
+        $value->makeHidden($hidden);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -295,7 +295,7 @@ trait HasAttributes
      *
      * @return array
      */
-    protected function getNestedVisibilityDirectives($directives)
+    protected function getNestedVisibilityDirectives(array $directives)
     {
         // Put the directives in an array keyed by relation name and with the
         // values containing an array that can be directly used in makeHidden

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -815,6 +815,41 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame(['bam' => ['boom']], $array);
     }
 
+    public function testNestedHiddenTricklesToRelationships()
+    {
+        $model = new EloquentModelStub;
+        $model->foo = 'foo';
+
+        $relatedModel = new EloquentModelStub;
+        $relatedModel->bar = 'bar';
+        $relatedModel->baz = 'baz';
+
+        $model->setRelation('barz', $relatedModel);
+
+        $model->setHidden(['barz.bar']);
+        $array = $model->toArray();
+
+        $this->assertEquals(['foo' => 'foo', 'barz' => ['baz' => 'baz']], $array);
+    }
+
+    public function testNestedVisibleTricklesToRelationships()
+    {
+        $model = new EloquentModelStub;
+        $model->foo = 'foo';
+
+        $relatedModel = new EloquentModelStub;
+        $relatedModel->bar = 'bar';
+        $relatedModel->baz = 'baz';
+        $relatedModel->setHidden(['baz']);
+
+        $model->setRelation('barz', $relatedModel);
+
+        $model->setVisible(['barz.baz']);
+        $array = $model->toArray();
+
+        $this->assertEquals(['foo' => 'foo', 'barz' => ['bar' => 'bar', 'baz' => 'baz']], $array);
+    }
+
     public function testToArraySnakeAttributes()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -754,12 +754,12 @@ class DatabaseEloquentModelTest extends TestCase
         $model->age = null;
         $model->password = 'password1';
         $model->setHidden(['password']);
-        $model->setRelation('names', new BaseCollection([
+        $model->setRelation('names', new Collection([
             new EloquentModelStub(['bar' => 'baz']), new EloquentModelStub(['bam' => 'boom']),
         ]));
         $model->setRelation('partner', new EloquentModelStub(['name' => 'abby']));
         $model->setRelation('group', null);
-        $model->setRelation('multi', new BaseCollection);
+        $model->setRelation('multi', new Collection);
         $array = $model->toArray();
 
         $this->assertIsArray($array);
@@ -844,7 +844,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->setRelation('barz', $relatedModel);
 
-        $model->setVisible(['barz.baz']);
+        $model->setVisible(['foo', 'barz', 'barz.baz']);
         $array = $model->toArray();
 
         $this->assertEquals(['foo' => 'foo', 'barz' => ['bar' => 'bar', 'baz' => 'baz']], $array);
@@ -853,7 +853,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testToArraySnakeAttributes()
     {
         $model = new EloquentModelStub;
-        $model->setRelation('namesList', new BaseCollection([
+        $model->setRelation('namesList', new Collection([
             new EloquentModelStub(['bar' => 'baz']), new EloquentModelStub(['bam' => 'boom']),
         ]));
         $array = $model->toArray();
@@ -862,7 +862,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('boom', $array['names_list'][1]['bam']);
 
         $model = new EloquentModelCamelStub;
-        $model->setRelation('namesList', new BaseCollection([
+        $model->setRelation('namesList', new Collection([
             new EloquentModelStub(['bar' => 'baz']), new EloquentModelStub(['bam' => 'boom']),
         ]));
         $array = $model->toArray();


### PR DESCRIPTION
This allows dot notation for the `visible` and `hidden` directives so one could show/hide a field on a relation. This enables things like:

```
$collection = MyModel::with('relatives', 'relative')->get();

$collection->makeHidden('relatives.id');
$collection->makeVisible('relatives', 'relative', 'relative.email');

$collection->toArray();
```

This uses the `hidden`/`visible` properties on the model and sets them accordingly on the related one. Any other way of setting visibilities would also work including `$hidden = [relative.address]` in the model class and `$model->setVisible(['friends.home.phone'])`.

Currently it is not possible to affect visibility on relations without explicitly setting them on the related models (or their collections) themselves.

A feature like this has been requested in #8945 as well as on [multiple](https://stackoverflow.com/questions/42390595/laravel-model-with-and-makehidden) [questions](https://stackoverflow.com/questions/57027777/how-can-i-chain-makehidden-when-eager-loading-a-belongstomany-relationship) on [other](https://laracasts.com/discuss/channels/eloquent/nested-attributes-in-makehidden) [sites](https://laracasts.com/discuss/channels/eloquent/makehidden-for-relationship-columns).

The usual workaround is to select only the needed columns when eager loading:

```
$collection = MyModel::with(['relatives' => function($relative) {
    $relative->select('id', 'name', 'nickname');
}])->get();
```

However, that's not a solution if you want to hide the foreign key (the relation just gets lost) or make visible something that's not visible on the related model.