### PR TITLE
[7.x] Simplify hidden attributes on models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -380,7 +380,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function makeHidden($attributes)
     {
-        return $this->each->addHidden($attributes);
+        return $this->each->makeHidden($attributes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -78,30 +78,19 @@ trait HidesAttributes
     }
 
     /**
-     * Add visible attributes for the model.
-     *
-     * @param  array|string|null  $attributes
-     * @return void
-     */
-    public function addVisible($attributes = null)
-    {
-        $this->visible = array_merge(
-            $this->visible, is_array($attributes) ? $attributes : func_get_args()
-        );
-    }
-
-    /**
      * Make the given, typically hidden, attributes visible.
      *
-     * @param  array|string  $attributes
+     * @param  array|string|null  $attributes
      * @return $this
      */
     public function makeVisible($attributes)
     {
-        $this->hidden = array_diff($this->hidden, (array) $attributes);
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        $this->hidden = array_diff($this->hidden, $attributes);
 
         if (! empty($this->visible)) {
-            $this->addVisible($attributes);
+            $this->visible = array_merge($this->visible, $attributes);
         }
 
         return $this;
@@ -110,16 +99,14 @@ trait HidesAttributes
     /**
      * Make the given, typically visible, attributes hidden.
      *
-     * @param  array|string  $attributes
+     * @param  array|string|null  $attributes
      * @return $this
      */
     public function makeHidden($attributes)
     {
-        $attributes = (array) $attributes;
-
-        $this->visible = array_diff($this->visible, $attributes);
-
-        $this->hidden = array_unique(array_merge($this->hidden, $attributes));
+        $this->hidden = array_merge(
+            $this->hidden, is_array($attributes) ? $attributes : func_get_args()
+        );
 
         return $this;
     }


### PR DESCRIPTION
This PR is aimed to make the method behaviour more predicatable, consistent and to slightly simplify the codebase.

The state before this PR is the following:

- Methods `makeHidden` and `makeVisible` are featured on documentation and tested, `addHidden` and `addVisible` are not. And each of `add*` only has a single use in the codebase.
- Method `makeHidden` may produce surprising results on an edge case:
    - Calling `makeHidden['col1']` on a model that has `$visible = ['col1']` would clear (and thus disable) the whitelist, making everything visible (except `col1`).
- Method `addVisible` may produce unexpected results on two cases
    - If the model's `$visible` was empty, `addVisible('col1')` will make everything but `col1` invisible;
    - If `col1` is hidden, `addVisible('col1')` would not make it visible.
- Other than the three quirks above, the differences between `makeHidden`/`makeVisible` and `addHidden`/`addVisible` are just these:
    - `make*` returns model, `add*` returns void.
    - `add*` accepts unwrapped lists of arguments `('col1', 'col2')` in addition to single string `('col1')` and arrays `(['col1', 'col2'])` which are accepted by both.

To solve the inconsistencies and surprises, simplify the work with the methods and reduce amount of similar methods, I propose here to:

- Make `makeHidden` and `makeVisible` accept unwrapped lists of arguments `('col1', 'col2')` in addition to current `('col1')` and `(['col1', 'col2'])`. That's for convenience and consistency with methods like `with()`.
- Remove `addHidden` and `addVisible`.
- Move previous `addVisible` logic into `makeVisible` (it's still one line).
- Simplify `makeHidden` to only add entries to `$hidden`, but not remove the from `$visible`.

Explanation on the final point: adding to blacklist `$hidden` is enough as the blacklist is applied last. The only case where removing from `$visible` would affect behaviour is the aforementioned quirk that makes everything else visible and such behaviour just shouldn't be here.