### PR TITLE
[6.x] Add Filesystem presignedUrl() method

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -586,7 +586,7 @@ class FilesystemAdapter implements CloudFilesystemContract
 
         $command = $client->getCommand('putObject', array_merge([
             'Bucket' => $adapter->getBucket(),
-            'Key' => $adapter->getPathPrefix() . $path,
+            'Key' => $adapter->getPathPrefix().$path,
         ], $options));
 
         return (string) $client->createPresignedRequest(


### PR DESCRIPTION
```php
Storage::disk('s3')->presignedUrl('path/to/upload/file', Carbon::now()->addMinutes(10));
```

## Why?

In a serverless environment as Vapor, it is advised to upload files directly to a cloud storage system as AWS S3. The `laravel/vapor-core` package adds a route to your project that creates such a presigned url, but the creation of those urls is linked to vapor env settings. You might want to allow uploads to a different (AWS S3) storage system. It also does not allow you to create a presigned url without a request to that vapor route.

This PR adds a method that makes it easy to create a presigned url, on any storage system you want, using any settings you want.

## How?

I used the same code structure as the existing `temporaryUrl()` / `getAwsTemporaryUrl()` methods. This allows the `presignedUrl()` method to be added on other (third-party) storage adapters as well.

## Remarks

* I did not add any tests for this PR, as there seem to be none present for the existing `temporaryUrl()` / `getAwsTemporaryUrl()` methods.
* If this PR gets accepted, I will create a PR to update the documentation.