### PR TITLE
Unwrap ravioli in Illuminate/Database/Eloquent

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,31 @@
 # Release Notes for 6.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v6.2.0...6.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v6.3.0...6.x)
+
+### TODO:
+- Add autocomplete support for the Queue-Facade ([#30300](https://github.com/laravel/framework/pull/30300))
+
+
+## [v6.3.0 (2019-10-16)](https://github.com/laravel/framework/compare/v6.2.0...v6.3.0)
+
+### Added
+- Added ability to override `setUserPassword` on password reset ([#30218](https://github.com/laravel/framework/pull/30218))
+- Added firing `deleting` \ `deleted` events in `MorphPivot` ([#30229](https://github.com/laravel/framework/pull/30229))
+- Added locking mechanism for the array cache driver ([#30253](https://github.com/laravel/framework/pull/30253))
+- Added `dropAllViews` functionality to the SQL Server builder ([#30222](https://github.com/laravel/framework/pull/30222))
+
+### Optimization
+- Optimize eager loading memory handling ([#30248](https://github.com/laravel/framework/pull/30248))
+
+### Fixed
+- Fixed extra `?` for empty query string in `RouteUrlGenerator::getRouteQueryString()` ([#30280](https://github.com/laravel/framework/pull/30280))
+
+### Changed
+- Updated list of URI schemes for `Url` validator ([#30220](https://github.com/laravel/framework/pull/30220))
+- Added schema name when dropping all FKs in SQL Server ([#30221](https://github.com/laravel/framework/pull/30221))
+- Used contracts in `RequirePassword` middleware ([#30215](https://github.com/laravel/framework/pull/30215))
+- Added ability to return array in `receivesBroadcastNotificationsOn` if `channelName` is array ([#30242](https://github.com/laravel/framework/pull/30242), [2faadcd](https://github.com/laravel/framework/commit/2faadcd288cdc86cf7a1a3644e68e5e0ce641a8b))
+
 
 ## [v6.2.0 (2019-10-08)](https://github.com/laravel/framework/compare/v6.1.0...v6.2.0)
 

--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -6,7 +6,7 @@
 - Add autocomplete support for the Queue-Facade ([#30300](https://github.com/laravel/framework/pull/30300))
 
 
-## [v6.3.0 (2019-10-16)](https://github.com/laravel/framework/compare/v6.2.0...v6.3.0)
+## [v6.3.0 (2019-10-15)](https://github.com/laravel/framework/compare/v6.2.0...v6.3.0)
 
 ### Added
 - Added ability to override `setUserPassword` on password reset ([#30218](https://github.com/laravel/framework/pull/30218))

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -482,15 +482,15 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $user = $this->user();
 
-        // If we have an event dispatcher instance, we can fire off the logout event
-        // so any further processing can be done. This allows the developer to be
-        // listening for anytime a user signs out of this application manually.
         $this->clearUserDataFromStorage();
 
         if (! is_null($this->user) && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 
+        // If we have an event dispatcher instance, we can fire off the logout event
+        // so any further processing can be done. This allows the developer to be
+        // listening for anytime a user signs out of this application manually.
         if (isset($this->events)) {
             $this->events->dispatch(new Events\Logout($this->name, $user));
         }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -52,7 +52,9 @@ class StatusCommand extends BaseCommand
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
-            return $this->error('Migration table not found.');
+            $this->error('Migration table not found.');
+
+            return 1;
         }
 
         $ran = $this->migrator->getRepository()->getRan();

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -965,7 +965,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function newModelQuery()
     {
         return $this->newEloquentBuilder(
-            $this->newBaseQueryBuilder()
+            $this->getConnection()->query()
         )->setModel($this);
     }
 
@@ -1039,16 +1039,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function newEloquentBuilder($query)
     {
         return new Builder($query);
-    }
-
-    /**
-     * Get a new query builder instance for the connection.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    protected function newBaseQueryBuilder()
-    {
-        return $this->getConnection()->query();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -311,8 +311,6 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
      * @return array
-     *
-     * @throws \InvalidArgumentException
      */
     protected function createSub($query)
     {
@@ -540,8 +538,6 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
-     *
-     * @throws \InvalidArgumentException
      */
     public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -585,8 +581,6 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
-     *
-     * @throws \InvalidArgumentException
      */
     public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -2673,8 +2667,6 @@ class Builder
      * @param  array  $columns
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @return int
-     *
-     * @throws \InvalidArgumentException
      */
     public function insertUsing(array $columns, $query)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -228,11 +228,7 @@ class Builder
         $columns = is_array($columns) ? $columns : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && (
-                $column instanceof self ||
-                $column instanceof EloquentBuilder ||
-                $column instanceof Closure
-            )) {
+            if (is_string($as) && $this->isQueryable($column)) {
                 $this->selectSub($column, $as);
             } else {
                 $this->columns[] = $column;
@@ -348,6 +344,19 @@ class Builder
     }
 
     /**
+     * Determine if the value is a query builder instance or a closure.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isQueryable($value)
+    {
+        return $value instanceof self ||
+               $value instanceof EloquentBuilder ||
+               $value instanceof Closure;
+    }
+
+    /**
      * Add a new select column to the query.
      *
      * @param  array|mixed  $column
@@ -358,11 +367,7 @@ class Builder
         $columns = is_array($column) ? $column : func_get_args();
 
         foreach ($columns as $as => $column) {
-            if (is_string($as) && (
-                $column instanceof self ||
-                $column instanceof EloquentBuilder ||
-                $column instanceof Closure
-            )) {
+            if (is_string($as) && $this->isQueryable($column)) {
                 if (is_null($this->columns)) {
                     $this->select($this->from.'.*');
                 }
@@ -403,9 +408,7 @@ class Builder
      */
     public function from($table, $as = null)
     {
-        if ($table instanceof self ||
-            $table instanceof EloquentBuilder ||
-            $table instanceof Closure) {
+        if ($this->isQueryable($table)) {
             return $this->fromSub($table, $as);
         }
 
@@ -890,9 +893,7 @@ class Builder
         // If the value is a query builder instance we will assume the developer wants to
         // look for any values that exists within this given query. So we will add the
         // query accordingly so that this query is properly executed when it is run.
-        if ($values instanceof self ||
-            $values instanceof EloquentBuilder ||
-            $values instanceof Closure) {
+        if ($this->isQueryable($values)) {
             [$query, $bindings] = $this->createSub($values);
 
             $values = [new Expression($query)];
@@ -1806,9 +1807,7 @@ class Builder
      */
     public function orderBy($column, $direction = 'asc')
     {
-        if ($column instanceof self ||
-            $column instanceof EloquentBuilder ||
-            $column instanceof Closure) {
+        if ($this->isQueryable($column)) {
             [$query, $bindings] = $this->createSub($column);
 
             $column = new Expression('('.$query.')');

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -311,6 +311,8 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string $query
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function createSub($query)
     {
@@ -331,6 +333,8 @@ class Builder
      *
      * @param  mixed  $query
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     protected function parseSub($query)
     {
@@ -339,7 +343,9 @@ class Builder
         } elseif (is_string($query)) {
             return [$query, []];
         } else {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException(
+                'The subquery must be an instance of Closure or Builder, or a string.'
+            );
         }
     }
 
@@ -534,6 +540,8 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
      */
     public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -577,6 +585,8 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @return \Illuminate\Database\Query\Builder|static
+     *
+     * @throws \InvalidArgumentException
      */
     public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -2663,6 +2673,8 @@ class Builder
      * @param  array  $columns
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @return int
+     *
+     * @throws \InvalidArgumentException
      */
     public function insertUsing(array $columns, $query)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -342,22 +342,9 @@ class Builder
             return [$query, []];
         } else {
             throw new InvalidArgumentException(
-                'The subquery must be an instance of Closure or Builder, or a string.'
+                'A subquery must be a query builder instance, a Closure, or a string.'
             );
         }
-    }
-
-    /**
-     * Determine if the value is a query builder instance or a closure.
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function isQueryable($value)
-    {
-        return $value instanceof self ||
-               $value instanceof EloquentBuilder ||
-               $value instanceof Closure;
     }
 
     /**
@@ -2960,6 +2947,19 @@ class Builder
         $this->useWritePdo = true;
 
         return $this;
+    }
+
+    /**
+     * Determine if the value is a query builder instance or a Closure.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function isQueryable($value)
+    {
+        return $value instanceof self ||
+               $value instanceof EloquentBuilder ||
+               $value instanceof Closure;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -329,6 +329,20 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile the command to drop all views.
+     *
+     * @return string
+     */
+    public function compileDropAllViews()
+    {
+        return "DECLARE @sql NVARCHAR(MAX) = N'';
+            SELECT @sql += 'DROP VIEW ' + QUOTENAME(OBJECT_SCHEMA_NAME(object_id)) + '.' + QUOTENAME(name) + ';'
+            FROM sys.views;
+
+            EXEC sp_executesql @sql;";
+    }
+
+    /**
      * Create the column definition for a char type.
      *
      * @param  \Illuminate\Support\Fluent  $column

--- a/src/Illuminate/Database/Schema/SqlServerBuilder.php
+++ b/src/Illuminate/Database/Schema/SqlServerBuilder.php
@@ -15,4 +15,14 @@ class SqlServerBuilder extends Builder
 
         $this->connection->statement($this->grammar->compileDropAllTables());
     }
+
+    /**
+     * Drop all views from the database.
+     *
+     * @return void
+     */
+    public function dropAllViews()
+    {
+        $this->connection->statement($this->grammar->compileDropAllViews());
+    }
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -30,7 +30,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '6.2.0';
+    const VERSION = '6.3.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -151,6 +151,19 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request is missing a given input item key.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function missing($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        return ! $this->has($keys);
+    }
+
+    /**
      * Determine if the given input key is an empty string for "has".
      *
      * @param  string  $key

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -60,23 +60,19 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $channels;
         }
 
-        $channelNames = $this->channelName();
-        if (is_string($channelNames)) {
-            return [new PrivateChannel($channelNames)];
+        if (is_string($channels = $this->channelName())) {
+            return [new PrivateChannel($channels)];
         }
 
-        $channels = [];
-        foreach ($channelNames as $channel) {
-            $channels[] = new PrivateChannel($channel);
-        }
-
-        return $channels;
+        return collect($channels)->map(function ($channel) {
+            return new PrivateChannel($channel);
+        })->all();
     }
 
     /**
      * Get the broadcast channel name for the event.
      *
-     * @return string|array
+     * @return array|string
      */
     protected function channelName()
     {

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -60,13 +60,23 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return $channels;
         }
 
-        return [new PrivateChannel($this->channelName())];
+        $channelNames = $this->channelName();
+        if (is_string($channelNames)) {
+            return [new PrivateChannel($channelNames)];
+        }
+
+        $channels = [];
+        foreach ($channelNames as $channel) {
+            $channels[] = new PrivateChannel($channel);
+        }
+
+        return $channels;
     }
 
     /**
      * Get the broadcast channel name for the event.
      *
-     * @return string
+     * @return string|array
      */
     protected function channelName()
     {

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -277,7 +277,9 @@ class RouteUrlGenerator
             );
         }
 
-        return '?'.trim($query, '&');
+        $query = trim($query, '&');
+
+        return $query === '' ? '' : "?{$query}";
     }
 
     /**

--- a/src/Illuminate/Support/Facades/DB.php
+++ b/src/Illuminate/Support/Facades/DB.php
@@ -23,6 +23,7 @@ namespace Illuminate\Support\Facades;
  * @method static void rollBack()
  * @method static int transactionLevel()
  * @method static array pretend(\Closure $callback)
+ * @method static void listen(\Closure $callback)
  *
  * @see \Illuminate\Database\DatabaseManager
  * @see \Illuminate\Database\Connection

--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -15,6 +15,11 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static \Illuminate\Contracts\Queue\Job|null pop(string $queue = null)
  * @method static string getConnectionName()
  * @method static \Illuminate\Contracts\Queue\Queue setConnectionName(string $name)
+ * @method static void assertNothingPushed()
+ * @method static void assertNotPushed(string $job, \Closure $callback = null)
+ * @method static void assertPushed(string $job, \Closure|int $callback = null)
+ * @method static void assertPushedOn(string $job, int $times = 1)
+ * @method static void assertPushedWithChain(string $queue, string $job, \Closure $callback = null)
  *
  * @see \Illuminate\Queue\QueueManager
  * @see \Illuminate\Queue\Queue

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -19,9 +19,8 @@ trait Macroable
     /**
      * Register a custom macro.
      *
-     * @param  string $name
+     * @param  string  $name
      * @param  object|callable  $macro
-     *
      * @return void
      */
     public static function macro($name, $macro)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -27,7 +27,6 @@ use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use stdClass;
 
 class DatabaseEloquentModelTest extends TestCase

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -798,23 +798,6 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['name' => 'Taylor'], $array);
     }
 
-    public function testGetArrayableRelationsFunctionExcludeHiddenRelationships()
-    {
-        $model = new EloquentModelStub;
-
-        $class = new ReflectionClass($model);
-        $method = $class->getMethod('getArrayableRelations');
-        $method->setAccessible(true);
-
-        $model->setRelation('foo', ['bar']);
-        $model->setRelation('bam', ['boom']);
-        $model->setHidden(['foo']);
-
-        $array = $method->invokeArgs($model, []);
-
-        $this->assertSame(['bam' => ['boom']], $array);
-    }
-
     public function testToArraySnakeAttributes()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1658,6 +1658,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $expected .= 'inner join (select * from "contacts" where "name" = ?) as "sub2" on "users"."id" = "sub2"."user_id"';
         $this->assertEquals($expected, $builder->toSql());
         $this->assertEquals(['foo', 1, 'bar'], $builder->getRawBindings()['join']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->joinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testJoinSubWithPrefix()
@@ -1673,6 +1677,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->from('users')->leftJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
         $this->assertSame('select * from "users" left join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->leftJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testRightJoinSub()
@@ -1680,6 +1688,10 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->from('users')->rightJoinSub($this->getBuilder()->from('contacts'), 'sub', 'users.id', '=', 'sub.id');
         $this->assertSame('select * from "users" right join (select * from "contacts") as "sub" on "users"."id" = "sub"."id"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('users')->rightJoinSub(['foo'], 'sub', 'users.id', '=', 'sub.id');
     }
 
     public function testRawExpressionsInSelect()
@@ -1915,6 +1927,13 @@ class DatabaseQueryBuilderTest extends TestCase
         );
 
         $this->assertEquals(1, $result);
+    }
+
+    public function testInsertUsingInvalidSubquery()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->from('table1')->insertUsing(['foo'], ['bar']);
     }
 
     public function testInsertOrIgnoreMethod()
@@ -2869,6 +2888,10 @@ SQL;
         $builder->selectSub($subBuilder, 'sub');
         $this->assertEquals($expectedSql, $builder->toSql());
         $this->assertEquals($expectedBindings, $builder->getBindings());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getPostgresBuilder();
+        $builder->selectSub(['foo'], 'sub');
     }
 
     public function testSqlServerWhereDate()
@@ -3421,6 +3444,10 @@ SQL;
         }, 'sessions')->where('bar', '<', '10');
         $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions" where "foo" = ?) as "sessions" where "bar" < ?', $builder->toSql());
         $this->assertEquals(['1', '10'], $builder->getBindings());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->fromSub(['invalid'], 'sessions')->where('bar', '<', '10');
     }
 
     public function testFromSubWithPrefix()
@@ -3441,6 +3468,10 @@ SQL;
             $query->select(new Raw('max(last_seen_at) as last_seen_at'))->from('user_sessions');
         }, 'sessions');
         $this->assertSame('select * from (select max(last_seen_at) as last_seen_at from "user_sessions") as "sessions"', $builder->toSql());
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder = $this->getBuilder();
+        $builder->fromSub(['invalid'], 'sessions');
     }
 
     public function testFromRaw()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -300,6 +300,31 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
+    public function testMissingMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+        $this->assertFalse($request->missing('name'));
+        $this->assertFalse($request->missing('age'));
+        $this->assertFalse($request->missing('city'));
+        $this->assertTrue($request->missing('foo'));
+        $this->assertTrue($request->missing('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'email' => 'foo']);
+        $this->assertFalse($request->missing('name'));
+        $this->assertFalse($request->missing('name', 'email'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar', 'bar']]);
+        $this->assertFalse($request->missing('foo'));
+
+        $request = Request::create('/', 'GET', ['foo' => '', 'bar' => null]);
+        $this->assertFalse($request->missing('foo'));
+        $this->assertFalse($request->missing('bar'));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar' => null, 'baz' => '']]);
+        $this->assertFalse($request->missing('foo.bar'));
+        $this->assertFalse($request->missing('foo.baz'));
+    }
+
     public function testHasAnyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -258,6 +258,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['wall', 'woz', 'boom' => 'otwell', 'baz' => 'taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -298,6 +298,11 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel_php_framework_', Str::snake('LaravelPhpFramework_', '_'));
         $this->assertSame('laravel_php_framework', Str::snake('laravel php Framework'));
         $this->assertSame('laravel_php_frame_work', Str::snake('laravel php FrameWork'));
+        // prevent breaking changes
+        $this->assertSame('foo-bar', Str::snake('foo-bar'));
+        $this->assertSame('foo-_bar', Str::snake('Foo-Bar'));
+        $this->assertSame('foo__bar', Str::snake('Foo_Bar'));
+        $this->assertSame('żółtałódka', Str::snake('ŻółtaŁódka'));
     }
 
     public function testStudly()


### PR DESCRIPTION
I propose unwrapping some methods to make the codebase more maintainable and transparent (=easier to follow), simplify debugging and reduce call stack.

Initially I came upon some ravioli issues in `Illuminate/Database/Eloquent/Concerns/HasAttributes`. Afterwards I went through all the other files in the `Illuminate/Database/Eloquent` namespace, but only discovered a single method appropriate for unwrapping, so it seems that `HasAttributes` was a bit not like the other kids in that regard.

I unwrapped only such methods that are

- protected
- single line
- not useful for testing
- readable unwrapped

Some examples:
```
// json_encode is as short as $this->asJson, but more transparent and without the additional call
protected function asJson($value)	
{	
    return json_encode($value);	
}

// is used only in a self-documenting switch statement
protected function asTimestamp($value)	
{	
    return $this->asDateTime($value)->getTimestamp();	
}

// the actual body contains the same "get arrayable relations" words in the same order
// doing it explicitly instead of a method reduces confusion by 1 entry in the call stack
protected function getArrayableRelations()	
{	
    return $this->getArrayableItems($this->relations);	
}
```

I also removed one test that only tested the behaviour of a protected method. The external behaviour of that feature is tested by a neighbour test `testHiddenCanAlsoExcludeRelationships`, the other test jwas just a constraint on refactoring.

I **did not** remove break apart useful raviolis like the following:

```
// used for testing
protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
{
	return new HasMany($query, $parent, $foreignKey, $localKey);
}

// name makes it simpler and the intention becomes clear
protected function canUseExistsForExistenceCheck($operator, $count)
{
	return ($operator === '>=' || $operator === '<') && $count === 1;
}
``` 