### PR TITLE
[7.x] Unwrap ravioli in Illuminate/Database/Eloquent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -965,7 +965,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function newModelQuery()
     {
         return $this->newEloquentBuilder(
-            $this->newBaseQueryBuilder()
+            $this->getConnection()->query()
         )->setModel($this);
     }
 
@@ -1039,16 +1039,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function newEloquentBuilder($query)
     {
         return new Builder($query);
-    }
-
-    /**
-     * Get a new query builder instance for the connection.
-     *
-     * @return \Illuminate\Database\Query\Builder
-     */
-    protected function newBaseQueryBuilder()
-    {
-        return $this->getConnection()->query();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -27,7 +27,6 @@ use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use stdClass;
 
 class DatabaseEloquentModelTest extends TestCase
@@ -796,23 +795,6 @@ class DatabaseEloquentModelTest extends TestCase
         $array = $model->toArray();
 
         $this->assertEquals(['name' => 'Taylor'], $array);
-    }
-
-    public function testGetArrayableRelationsFunctionExcludeHiddenRelationships()
-    {
-        $model = new EloquentModelStub;
-
-        $class = new ReflectionClass($model);
-        $method = $class->getMethod('getArrayableRelations');
-        $method->setAccessible(true);
-
-        $model->setRelation('foo', ['bar']);
-        $model->setRelation('bam', ['boom']);
-        $model->setHidden(['foo']);
-
-        $array = $method->invokeArgs($model, []);
-
-        $this->assertSame(['bam' => ['boom']], $array);
     }
 
     public function testToArraySnakeAttributes()


### PR DESCRIPTION
I propose unwrapping some methods to make the codebase more maintainable and transparent (=easier to follow), simplify debugging and reduce call stack.

Initially I came upon some ravioli issues in `Illuminate/Database/Eloquent/Concerns/HasAttributes`. Afterwards I went through all the other files in the `Illuminate/Database/Eloquent` namespace, but only discovered a single method appropriate for unwrapping, so it seems that `HasAttributes` was a bit not like the other kids in that regard.

I unwrapped only such methods that are

- protected
- single line
- not useful for testing
- readable unwrapped

Some examples:
```
// json_encode is as short as $this->asJson, but more transparent and without the additional call
protected function asJson($value)	
{	
    return json_encode($value);	
}

// is used only in a self-documenting switch statement
protected function asTimestamp($value)	
{	
    return $this->asDateTime($value)->getTimestamp();	
}

// the actual body contains the same "get arrayable relations" words in the same order
// doing it explicitly instead of a method reduces confusion by 1 entry in the call stack
protected function getArrayableRelations()	
{	
    return $this->getArrayableItems($this->relations);	
}
```

I also removed one test that only tested the behaviour of a protected method. The external behaviour of that feature is tested by a neighbour test `testHiddenCanAlsoExcludeRelationships`, the other test jwas just a constraint on refactoring.

I **did not** remove break apart useful raviolis like the following:

```
// used for testing
protected function newHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
{
	return new HasMany($query, $parent, $foreignKey, $localKey);
}

// name makes it simpler and the intention becomes clear
protected function canUseExistsForExistenceCheck($operator, $count)
{
	return ($operator === '>=' || $operator === '<') && $count === 1;
}
``` 