### PR TITLE
[6.x] Implemented parse ID on find method for many to many relation

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -505,7 +505,7 @@ class BelongsToMany extends Relation
     public function find($id, $columns = ['*'])
     {
         return is_array($id) ? $this->findMany($id, $columns) : $this->where(
-            $this->getRelated()->getQualifiedKeyName(), '=', $id
+            $this->getRelated()->getQualifiedKeyName(), '=', $this->parseId($id)
         )->first($columns);
     }
 
@@ -519,7 +519,7 @@ class BelongsToMany extends Relation
     public function findMany($ids, $columns = ['*'])
     {
         return empty($ids) ? $this->getRelated()->newCollection() : $this->whereIn(
-            $this->getRelated()->getQualifiedKeyName(), $ids
+            $this->getRelated()->getQualifiedKeyName(), $this->parseIds($ids)
         )->get($columns);
     }
 


### PR DESCRIPTION
I implemented the `parseId()` on the `find()` method for the `BelongsToMany` trait, meaning that a related model can be found using either a primary key, or an existing model instance.

Example: `$project->users()->find($user);` can be used as well as `$project->users()->find($user->id);`.

This is useful looking up pivot table data for two existing model instances: `$project->users->find($user)->pivot->role;`.

I think this is more consistent with other methods in the `BelongsToMany` trait, such as `updateExistingPivot()`, which implements `parseId()` meaning a model instance or ID can be passed.