### PR TITLE
[6.x] Fix sqlsrv reuses broken connection

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -38,6 +38,7 @@ trait DetectsLostConnections
             'Packets out of order. Expected',
             'Adaptive Server connection failed',
             'Communication link failure',
+            'connection is no longer usable',
         ]);
     }
 }


### PR DESCRIPTION
Starting with Laravel 6.x, once in a while one of my queue jobs throws an exception:

> SQLSTATE[08S01]: [Microsoft][ODBC Driver 17 for SQL Server]The connection is no longer usable because the server response for a previously executed statement was incorrectly formatted.

As can be seen in the error message, I'm using the SQL Server driver. Unfortunately, I couldn't locate the exact issue so far. It only occured within the queue workers until now, not within the application itself. No very rare jobs are executed, it happens within very regularly executed jobs (i.e. it's unlikely the code of the jobs is the issue).

In general, it doesn't botter me too much as it only happens once a week so far with an average job count of 50k per week. The problem is that the queue workers simply escalate the exception of the job and then reuse the broken connection. To solve this, the PR attempts to force a reconnect if the exceptions contains the mentioned error message. This seems a very fitting strategy as the error explicitely says the connection _is no longer usable_.

The error itself seems to be very rare as there are next to no reports even outside the Laravel community.