### PR TITLE
[6.x] Introduce StrProxy for collection like string manipulation

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -263,6 +263,16 @@ class Str
     }
 
     /**
+     * Get a string proxy for the text passed.
+     *
+     * @return \Illuminate\Support\StrProxy
+     */
+    public static function make(string $text = ''): StrProxy
+    {
+        return new StrProxy($text);
+    }
+
+    /**
      * Limit the number of words in a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/StrProxy.php
+++ b/src/Illuminate/Support/StrProxy.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support;
 
 /**
- * Class StrProxy
+ * Class StrProxy.
  *
  * @method \Illuminate\Support\StrProxy after(string $search)
  * @method \Illuminate\Support\StrProxy ascii(string $language = 'en')

--- a/src/Illuminate/Support/StrProxy.php
+++ b/src/Illuminate/Support/StrProxy.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * Class StrProxy
+ *
+ * @method \Illuminate\Support\StrProxy after(string $search)
+ * @method \Illuminate\Support\StrProxy ascii(string $language = 'en')
+ * @method \Illuminate\Support\StrProxy before(string $search)
+ * @method \Illuminate\Support\StrProxy camel()
+ * @method \Illuminate\Support\StrProxy finish(string $cap)
+ * @method \Illuminate\Support\StrProxy kebab()
+ * @method \Illuminate\Support\StrProxy limit(int $limit = 100, string $end = '...')
+ * @method \Illuminate\Support\StrProxy lower()
+ * @method \Illuminate\Support\StrProxy plural(int $count = 2)
+ * @method \Illuminate\Support\StrProxy random(int $length = 16)
+ * @method \Illuminate\Support\StrProxy replaceArray(string $search, array $replace)
+ * @method \Illuminate\Support\StrProxy replaceFirst(string $search, string $replace)
+ * @method \Illuminate\Support\StrProxy replaceLast(string $search, string $replace)
+ * @method \Illuminate\Support\StrProxy singular()
+ * @method \Illuminate\Support\StrProxy slug(string $separator = '-', string $language = 'en')
+ * @method \Illuminate\Support\StrProxy snake(string $delimiter = '_')
+ * @method \Illuminate\Support\StrProxy start(string $prefix)
+ * @method \Illuminate\Support\StrProxy studly()
+ * @method \Illuminate\Support\StrProxy substr(int $start, int $length = null)
+ * @method \Illuminate\Support\StrProxy title()
+ * @method \Illuminate\Support\StrProxy ucfirst()
+ * @method \Illuminate\Support\StrProxy upper()
+ * @method \Illuminate\Support\StrProxy words(int $words = 100, string $end = '...')
+ * @method \Ramsey\Uuid\UuidInterface orderedUuid()
+ * @method \Ramsey\Uuid\UuidInterface uuid()
+ * @method array parseCallback(string $default = null)
+ * @method bool contains(array|string $needles)
+ * @method bool containsAll(array $needles)
+ * @method bool endsWith(array|string $needles)
+ * @method bool is(array|string $pattern)
+ * @method bool startsWith(array|string $needles)
+ * @method int length(string $encoding = null)
+ */
+class StrProxy
+{
+    protected const METHOD_IS = 'is';
+    protected const METHOD_RANDOM = 'random';
+    protected const METHOD_REPLACE_ARRAY = 'replaceArray';
+    protected const METHOD_REPLACE_FIRST = 'replaceFirst';
+    protected const METHOD_REPLACE_LAST = 'replaceLast';
+
+    protected $text = '';
+
+    /**
+     * Create a string proxy instance.
+     *
+     * @param  string  $text
+     * @return void
+     */
+    public function __construct(string $text = '')
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * Dynamically pass a method to the \Illuminate\Support\Str object.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return array|bool|int|self
+     * @throws \Exception
+     */
+    public function __call($name, $arguments)
+    {
+        $parameters = $this->constructorParameterShouldBeOmitted($name)
+            ? $arguments
+            : array_merge([$this->text], $arguments);
+
+        if ($this->parametersShouldBeReversed($name)) {
+            $parameters = array_reverse($parameters);
+        }
+
+        if ($this->constructorParameterShouldBePushedToEnd($name)) {
+            $parameters[] = $this->text;
+        }
+
+        $this->text = Str::{$name}(...$parameters);
+
+        if ($this->shouldReturnTextValue()) {
+            return $this->text;
+        }
+
+        if (! is_string($this->text)) {
+            throw new \Exception('Invalid change made to the text.');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert the object to its string representation.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * Die and dump the current text state.
+     *
+     * @return void
+     */
+    public function dd(): void
+    {
+        dd($this->text);
+    }
+
+    /**
+     * Get the current text state.
+     *
+     * @return string
+     */
+    public function get(): string
+    {
+        return $this->text;
+    }
+
+    /**
+     * Handle dynamic static method calls into the method.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        return Str::{$method}(...$parameters);
+    }
+
+    /**
+     * Check if constructor parameter should be omitted in order to
+     * match the underlying \Illuminate\Support\Str implementation.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function constructorParameterShouldBeOmitted(string $name): bool
+    {
+        return in_array($name, [
+            static::METHOD_RANDOM,
+            static::METHOD_REPLACE_ARRAY,
+            static::METHOD_REPLACE_FIRST,
+            static::METHOD_REPLACE_LAST,
+        ]);
+    }
+
+    /**
+     * Check if constructor parameter should be pushed to the end in order
+     * to match the underlying \Illuminate\Support\Str implementation.
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected function constructorParameterShouldBePushedToEnd(string $name): bool
+    {
+        return in_array($name, [
+            static::METHOD_REPLACE_ARRAY,
+            static::METHOD_REPLACE_FIRST,
+            static::METHOD_REPLACE_LAST,
+        ]);
+    }
+
+    /**
+     * Check if constructor parameter should be reversed in order to
+     * match the underlying \Illuminate\Support\Str implementation.
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected function parametersShouldBeReversed(string $name): bool
+    {
+        return in_array($name, [
+            static::METHOD_IS,
+        ]);
+    }
+
+    /**
+     * Check if text property should be returned.
+     *
+     * @return bool
+     */
+    protected function shouldReturnTextValue(): bool
+    {
+        if (is_array($this->text)) {
+            return true;
+        }
+
+        if (is_bool($this->text)) {
+            return true;
+        }
+
+        if (is_int($this->text)) {
+            return true;
+        }
+
+        if (is_object($this->text)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
+use Illuminate\Support\StrProxy;
 
 if (! function_exists('append_config')) {
     /**
@@ -404,6 +405,19 @@ if (! function_exists('retry')) {
 
             goto beginning;
         }
+    }
+}
+
+if (! function_exists('str')) {
+    /**
+     * Create a String object from the given value.
+     *
+     * @param  string  $text
+     * @return \Illuminate\Support\StrProxy
+     */
+    function str($text = '')
+    {
+        return new StrProxy($text);
     }
 }
 

--- a/tests/Support/SupportStrProxyTest.php
+++ b/tests/Support/SupportStrProxyTest.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\StrProxy;
+use PHPUnit\Framework\TestCase;
+
+class SupportStrProxyTest extends TestCase
+{
+    /** @test */
+    public function str_after(): void
+    {
+        $this->assertSame(
+            Str::after('This is my name', 'This is'),
+            (new StrProxy('This is my name'))->after('This is')->get()
+        );
+    }
+
+    /** @test */
+    public function str_ascii(): void
+    {
+        $this->assertSame(Str::ascii('@'), (new StrProxy('@'))->ascii()->get());
+        $this->assertSame(Str::ascii('ü'), (new StrProxy('ü'))->ascii()->get());
+        $this->assertSame(Str::ascii('х Х щ Щ ъ Ъ ь Ь', 'bg'), (new StrProxy('х Х щ Щ ъ Ъ ь Ь'))->ascii('bg')->get());
+        $this->assertSame(Str::ascii('ä ö ü Ä Ö Ü', 'de'), (new StrProxy('ä ö ü Ä Ö Ü'))->ascii('de')->get());
+    }
+
+    /** @test */
+    public function str_before(): void
+    {
+        $this->assertSame(
+            Str::before('This is my name', 'my name'),
+            (new StrProxy('This is my name'))->before('my name')->get()
+        );
+    }
+
+    /** @test */
+    public function str_camel(): void
+    {
+        $this->assertSame(Str::camel('foo_bar'), (new StrProxy('foo_bar'))->camel()->get());
+    }
+
+    /** @test */
+    public function str_contains(): void
+    {
+        $this->assertSame(
+            Str::contains('This is my name', 'my'),
+            (new StrProxy('This is my name'))->contains('my')
+        );
+        $this->assertSame(
+            Str::contains('This is my name', ['my', 'foo']),
+            (new StrProxy('This is my name'))->contains(['my', 'foo'])
+        );
+    }
+
+    /** @test */
+    public function str_contains_all(): void
+    {
+        $this->assertSame(
+            Str::containsAll('This is my name', ['my', 'name']),
+            (new StrProxy('This is my name'))->containsAll(['my', 'name'])
+        );
+    }
+
+    /** @test */
+    public function str_ends_with(): void
+    {
+        $this->assertSame(
+            Str::endsWith('This is my name', 'name'),
+            (new StrProxy('This is my name'))->endsWith('name')
+        );
+    }
+
+    /** @test */
+    public function str_finish(): void
+    {
+        $this->assertSame(Str::finish('this/string', '/'), (new StrProxy('this/string'))->finish('/')->get());
+        $this->assertSame(Str::finish('this/string/', '/'), (new StrProxy('this/string/'))->finish('/')->get());
+    }
+
+    /** @test */
+    public function str_is(): void
+    {
+        $this->assertSame(Str::is('foo*', 'foobar'), (new StrProxy('foobar'))->is('foo*'));
+        $this->assertSame(Str::is('baz*', 'foobar'), (new StrProxy('foobar'))->is('baz*'));
+    }
+
+    /** @test */
+    public function str_kebab(): void
+    {
+        $this->assertSame(Str::kebab('fooBar'), (new StrProxy('fooBar'))->kebab()->get());
+    }
+
+    /** @test */
+    public function str_length(): void
+    {
+        $this->assertSame(Str::length('foo bar baz'), (new StrProxy('foo bar baz'))->length());
+        $this->assertSame(Str::length('foo bar baz', 'UTF-8'), (new StrProxy('foo bar baz'))->length('UTF-8'));
+    }
+
+    /** @test */
+    public function str_limit(): void
+    {
+        $this->assertSame(
+            Str::limit('The quick brown fox jumps over the lazy dog', 20),
+            (new StrProxy('The quick brown fox jumps over the lazy dog'))->limit(20)->get()
+        );
+        $this->assertSame(
+            Str::limit('The quick brown fox jumps over the lazy dog', 20, ' (...)'),
+            (new StrProxy('The quick brown fox jumps over the lazy dog'))->limit(20, ' (...)')->get()
+        );
+    }
+
+    /** @test */
+    public function str_lower(): void
+    {
+        $this->assertSame(Str::lower('FOO BAR BAZ'), (new StrProxy('FOO BAR BAZ'))->lower()->get());
+        $this->assertSame(Str::lower('fOo Bar bAz'), (new StrProxy('fOo Bar bAz'))->lower()->get());
+    }
+
+    /** @test */
+    public function str_ordered_uuid(): void
+    {
+        $pattern = '/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/';
+        $this->assertRegExp($pattern, (string) Str::orderedUuid());
+        $this->assertRegExp($pattern, (string) (new StrProxy(''))->orderedUuid());
+    }
+
+    /** @test */
+    public function str_parse_callback(): void
+    {
+        $this->assertSame(
+            Str::parseCallback('Class@method', 'foo'),
+            (new StrProxy('Class@method'))->parseCallback('foo')
+        );
+        $this->assertSame(
+            Str::parseCallback('Class', 'foo'),
+            (new StrProxy('Class'))->parseCallback('foo')
+        );
+    }
+
+    /** @test */
+    public function str_plural(): void
+    {
+        $this->assertSame(Str::plural('car'), (new StrProxy('car'))->plural()->get());
+        $this->assertSame(Str::plural('child'), (new StrProxy('child'))->plural()->get());
+        $this->assertSame(Str::plural('child', 2), (new StrProxy('child'))->plural(2)->get());
+        $this->assertSame(Str::plural('child', 1), (new StrProxy('child'))->plural(1)->get());
+    }
+
+    /** @test */
+    public function str_random(): void
+    {
+        $pattern = '/\w{40}/';
+        $this->assertRegExp($pattern, Str::random(40));
+        // StrProxy
+        $string = new StrProxy('');
+        $this->assertRegExp($pattern, $string->random(40)->get());
+    }
+
+    /** @test */
+    public function str_replace_array(): void
+    {
+        $this->assertSame(
+            Str::replaceArray('?', ['8:30', '9:00'], 'The event will take place between ? and ?'),
+            (new StrProxy('The event will take place between ? and ?'))->replaceArray('?', ['8:30', '9:00'])->get()
+        );
+    }
+
+    /** @test */
+    public function str_replace_first(): void
+    {
+        $this->assertSame(
+            Str::replaceFirst('the', 'a', 'the quick brown fox jumps over the lazy dog'),
+            (new StrProxy('the quick brown fox jumps over the lazy dog'))->replaceFirst('the', 'a')->get()
+        );
+    }
+
+    /** @test */
+    public function str_replace_last(): void
+    {
+        $this->assertSame(
+            Str::replaceLast('the', 'a', 'the quick brown fox jumps over the lazy dog'),
+            (new StrProxy('the quick brown fox jumps over the lazy dog'))->replaceLast('the', 'a')->get()
+        );
+    }
+
+    /** @test */
+    public function str_singular(): void
+    {
+        $this->assertSame(Str::singular('cars'), (new StrProxy('cars'))->singular()->get());
+        $this->assertSame(Str::singular('children'), (new StrProxy('children'))->singular()->get());
+    }
+
+    /** @test */
+    public function str_slug(): void
+    {
+        $this->assertSame(
+            Str::slug('Laravel 5 Framework', '-'),
+            (new StrProxy('Laravel 5 Framework'))->slug('-')->get()
+        );
+    }
+
+    /** @test */
+    public function str_snake(): void
+    {
+        $this->assertSame(Str::snake('fooBar'), (new StrProxy('fooBar'))->snake()->get());
+    }
+
+    /** @test */
+    public function str_start(): void
+    {
+        $this->assertSame(Str::start('this/string', '/'), (new StrProxy('this/string'))->start('/')->get());
+        $this->assertSame(Str::start('/this/string', '/'), (new StrProxy('/this/string'))->start('/')->get());
+    }
+
+    /** @test */
+    public function str_starts_with(): void
+    {
+        $this->assertSame(
+            Str::startsWith('This is my name', 'This'),
+            (new StrProxy('This is my name'))->startsWith('This')
+        );
+    }
+
+    /** @test */
+    public function str_studly(): void
+    {
+        $this->assertSame(Str::studly('foo_bar'), (new StrProxy('foo_bar'))->studly()->get());
+    }
+
+    /** @test */
+    public function str_substr(): void
+    {
+        $this->assertSame(Str::substr('foobar', -1), (new StrProxy('foobar'))->substr(-1)->get());
+    }
+
+    /** @test */
+    public function str_title(): void
+    {
+        $this->assertSame(
+            Str::title('a nice title uses the correct case'),
+            (new StrProxy('a nice title uses the correct case'))->title()->get()
+        );
+    }
+
+    /** @test */
+    public function str_uc_first(): void
+    {
+        $this->assertSame(Str::ucfirst('laravel'), (new StrProxy('laravel'))->ucfirst()->get());
+        $this->assertSame(Str::ucfirst('laravel framework'), (new StrProxy('laravel framework'))->ucfirst()->get());
+    }
+
+    /** @test */
+    public function str_upper(): void
+    {
+        $this->assertSame(Str::upper('foo bar baz'), (new StrProxy('foo bar baz'))->upper()->get());
+        $this->assertSame(Str::upper('foO bAr BaZ'), (new StrProxy('foO bAr BaZ'))->upper()->get());
+    }
+
+    /** @test */
+    public function str_uuid(): void
+    {
+        $pattern = '/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/';
+        $this->assertRegExp($pattern, (string) Str::uuid());
+        $this->assertRegExp($pattern, (string) (new StrProxy(''))->uuid());
+    }
+
+    /** @test */
+    public function str_words(): void
+    {
+        $this->assertSame(
+            Str::words('Perfectly balanced, as all things should be.', 3, ' >>>'),
+            (new StrProxy('Perfectly balanced, as all things should be.'))->words(3, ' >>>')->get()
+        );
+    }
+
+    /** @test */
+    public function utterly_not_so_complex_example(): void
+    {
+        $this->assertSame(
+            Str::title(Str::replaceArray('_', [' '], Str::snake('fooBar'))),
+            (new StrProxy('fooBar'))->snake()->replaceArray('_', [' '])->title()->get()
+        );
+    }
+}


### PR DESCRIPTION
Right now if we want to do any manipulation with strings we face same problem like with an array before collections where we have to read the code inside out.

```php
use Illuminate\Support\Str;

$title = Str::title(Str::replaceArray('_', [' '], Str::snake('fooBar')));
```

Also Str object in Laravel does not accept the string that is being manipulated as the first argument across all methods like `replaceArray()`.

It would be great to bring that kind of power and functionality to Laravel and surpass current language limitations.

```php
use Illuminate\Support\StrProxy;

$title = (new StrProxy('fooBar'))->snake()->replaceArray('_', [' '])->title()->get();
```

Also `str` helper function or `Str::make` to make it even cleaner.

```php
use Illuminate\Support\Str;

$title = Str::make('fooBar')->snake()->replaceArray('_', [' '])->title()->get();
$title = str('fooBar')->snake()->replaceArray('_', [' '])->title()->get();
```

Having `dd()` on that object is a must :D

```php
$title = str('fooBar')->snake()->replaceArray('_', [' '])->dd()->title()->get();
```