### PR TITLE
[7.x] Make Str::startsWith return false when given a null value

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -517,7 +517,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+            if ((string) $needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -54,6 +54,11 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith('jason', ['day', 'jas']));
         $this->assertFalse(Str::startsWith('jason', 'day'));
         $this->assertFalse(Str::startsWith('jason', ['day']));
+        $this->assertFalse(Str::startsWith('jason', null));
+        $this->assertFalse(Str::startsWith('jason', [null]));
+        $this->assertFalse(Str::startsWith('0123', [null]));
+        $this->assertTrue(Str::startsWith('0123', 0));
+        $this->assertFalse(Str::startsWith('jason', 'J'));
         $this->assertFalse(Str::startsWith('jason', ''));
         $this->assertFalse(Str::startsWith('7', ' 7'));
         $this->assertTrue(Str::startsWith('7a', '7'));
@@ -79,6 +84,9 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('jason', 'no'));
         $this->assertFalse(Str::endsWith('jason', ['no']));
         $this->assertFalse(Str::endsWith('jason', ''));
+        $this->assertFalse(Str::endsWith('jason', [null]));
+        $this->assertFalse(Str::endsWith('jason', null));
+        $this->assertFalse(Str::endsWith('jason', 'N'));
         $this->assertFalse(Str::endsWith('7', ' 7'));
         $this->assertTrue(Str::endsWith('a7', '7'));
         $this->assertTrue(Str::endsWith('a7', 7));


### PR DESCRIPTION
Currently, if you give `Str::startsWith` an array of needles where one of the needles is `null`, it will always return true.

```php
Str::startsWith('some string', null); // false
Str::startsWith('some string' [null]); // true
```

This PR makes `Str::startsWith` always return false when given a `null` value. 

`Str::endsWith` did not have this problem, I've added a test to assert that. I've also added a test with a case-sensitive value, because there weren't any of those yet.

