### PR TITLE
[6.x] Add assertion method for 201 Created HTTP response

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -90,6 +90,23 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has a 201 status code.
+     *
+     * @return $this
+     */
+    public function assertCreated()
+    {
+        $actual = $this->getStatusCode();
+
+        PHPUnit::assertTrue(
+            201 === $actual,
+            'Response status code ['.$actual.'] does not match expected 201 status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the given status code and no content.
      *
      * @param  int  $status

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -147,6 +147,22 @@ class FoundationTestResponseTest extends TestCase
         $response->assertOk();
     }
 
+    public function testAssertCreated()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] does not match expected 201 status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertCreated();
+    }
+
     public function testAssertNotFound()
     {
         $statusCode = 500;


### PR DESCRIPTION
This pull request adds a new `assertCreated` method to `Illuminate\Foundation\Testing\TestResponse`. It basically asserts that response code equals to `201` in a more elegant way than `assertStatus(201)`.

The reason behind this assertion method is that [Eloquent API Resources](https://laravel.com/docs/6.x/eloquent-resources) response with a `201` code if the model is just created and this is a case which is widely expected on CRUDs for example. In other hand, there is no similar method to `isCreated` on base HTTP [Response](https://github.com/symfony/http-foundation/blob/master/Response.php) thus we have to assert `201` code directly.