### PR TITLE
[6.x] Fix FilesystemManager unwanted changes

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -113,7 +113,11 @@ class FilesystemManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        $name = $config['driver'] ?? $name;
+        if (empty($config['driver'])) {
+            throw new InvalidArgumentException("Disk [{$name}] does not have a configured driver.");
+        }
+
+        $name = $config['driver'];
 
         if (isset($this->customCreators[$name])) {
             return $this->callCustomCreator($config);

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -12,12 +12,12 @@ class FilesystemManagerTest extends TestCase
     public function testExceptionThrownOnUnsupportedDriver()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Driver [unsupported-disk] is not supported.');
+        $this->expectExceptionMessage('Disk [local] does not have a configured driver.');
 
         $filesystem = new FilesystemManager(tap(new Application, function ($app) {
-            $app['config'] = ['filesystems.disks.unsupported-disk' => null];
+            $app['config'] = ['filesystems.disks.local' => null];
         }));
 
-        $filesystem->disk('unsupported-disk');
+        $filesystem->disk('local');
     }
 }


### PR DESCRIPTION
#30331 Introduced the following changes:

> When a disk named local have no driver it thrown an exception in the previous version (through multiple levels of non-existing array keys). With this merge it will resolve to local driver.
> 
> Also it will try to create drivers for non existing disks: if filesystems.php has no disk named local the Storage::disk('local') will still try to create a local disk (actually it will fail because it tries to pass a null to a method which has an array typehint, but that's an other story).

This pull request
- restores the original working principle
- handles the root problem that made #30331 necessary
- Updates the test to use local disk, so a similar problem wont happen again