### PR TITLE
[6.x] Add assertion method for 429 Too Many Requests HTTP response

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -169,6 +169,23 @@ class TestResponse
     }
 
     /**
+     * Assert that the response has a 429 Too Many Requests status code.
+     *
+     * @return $this
+     */
+    public function assertTooManyRequests()
+    {
+        $actual = $this->getStatusCode();
+
+        PHPUnit::assertTrue(
+            429 === $actual,
+            'Response status code ['.$actual.'] does not match expected 429 Too Many Requests status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has the given status code.
      *
      * @param  int  $status

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -210,6 +210,22 @@ class FoundationTestResponseTest extends TestCase
         $response->assertUnauthorized();
     }
 
+    public function testAssertTooManyRequests()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] does not match expected 429 Too Many Requests status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertTooManyRequests();
+    }
+
     public function testAssertNoContentAsserts204StatusCodeByDefault()
     {
         $statusCode = 500;


### PR DESCRIPTION
This pull request adds a new `assertTooManyRequests` method to `Illuminate\Foundation\Testing\TestResponse`. It basically asserts that response code equals to `429` in a more elegant way than `assertStatus(429)`.

The reason behind this assertion method is that `throttle` middleware [responses](https://github.com/laravel/framework/blob/e04a7ffba8b80b934506783a7d0a161dd52eb2ef/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php#L21) a `429` HTTP code whenever its limit is triggered. For rate-critical applications, we usually have to use `throttle` middleware and thus, we need to test the case with many number of requests to assert if the route is being protected finally.

Since there is no `isTooManyRequests` method or similar one on base HTTP [Response](https://github.com/symfony/http-foundation/blob/master/Response.php) too, I think we can use this assertion method to make things more readable.

Of course there might be better names for this method such as `assertThrottled`.