### PR TITLE
[6.x] Move comment to match logout method

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -540,11 +540,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $user = $this->user();
 
+        $this->clearUserDataFromStorage();
+
         // If we have an event dispatcher instance, we can fire off the logout event
         // so any further processing can be done. This allows the developer to be
         // listening for anytime a user signs out of this application manually.
-        $this->clearUserDataFromStorage();
-
         if (isset($this->events)) {
             $this->events->dispatch(new Events\CurrentDeviceLogout($this->name, $user));
         }


### PR DESCRIPTION
Following up on #30332 where this comment was moved in to a more appropriate place in the `logout` method . This moves the comment to match the relevant code in the `logoutCurrentDevice` method.