### PR TITLE
[7.x] Waiting before retrying password reset

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -55,8 +55,7 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
-        if (method_exists($this->tokens, 'recentlyCreatedToken') &&
-            $this->tokens->recentlyCreatedToken($user)) {
+        if ($this->tokens->recentlyCreatedToken($user)) {
             return static::RESET_THROTTLED;
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -96,7 +96,7 @@ class PasswordBrokerManager implements FactoryContract
             $config['table'],
             $key,
             $config['expire'],
-            $config['throttle'] ?? 0
+            $config['throttle']
         );
     }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -96,7 +96,7 @@ class PasswordBrokerManager implements FactoryContract
             $config['table'],
             $key,
             $config['expire'],
-            $config['throttle']
+            $config['throttle'] ?? 0
         );
     }
 

--- a/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
+++ b/src/Illuminate/Auth/Passwords/TokenRepositoryInterface.php
@@ -24,6 +24,14 @@ interface TokenRepositoryInterface
     public function exists(CanResetPasswordContract $user, $token);
 
     /**
+     * Determine if the given user recently created a password reset token.
+     *
+     * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @return bool
+     */
+    public function recentlyCreatedToken(CanResetPasswordContract $user);
+
+    /**
      * Delete a token record.
      *
      * @param  \Illuminate\Contracts\Auth\CanResetPassword  $user

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -32,7 +32,6 @@ class AuthPasswordBrokerTest extends TestCase
     public function testIfTokenIsRecentlyCreated()
     {
         $mocks = $this->getMocks();
-        $mocks['tokens'] = m::mock(TestTokenRepositoryInterface::class);
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(true);
@@ -65,6 +64,7 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks = $this->getMocks();
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
@@ -123,12 +123,4 @@ class AuthPasswordBrokerTest extends TestCase
             'view'   => 'resetLinkView',
         ];
     }
-}
-
-// Before 7.x we have to check the existence of a new method. In 7.x, this code must be moved to
-// Illuminate\Auth\Passwords\TokenRepositoryInterface
-
-interface TestTokenRepositoryInterface extends TokenRepositoryInterface
-{
-    public function recentlyCreatedToken(CanResetPassword $user);
 }


### PR DESCRIPTION
https://github.com/laravel/framework/pull/30340 finalization.
Method `recentlyCreatedToken` has been added to `TokenRepositoryInterface` interface and tests have been adapted.