### PR TITLE
[6.x] Show expected status code in assertion message

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -130,7 +130,7 @@ class TestResponse
     {
         PHPUnit::assertTrue(
             $this->isNotFound(),
-            'Response status code ['.$this->getStatusCode().'] is not a not found status code.'
+            'Response status code ['.$this->getStatusCode().'] is not a 404 not found status code.'
         );
 
         return $this;
@@ -145,7 +145,7 @@ class TestResponse
     {
         PHPUnit::assertTrue(
             $this->isForbidden(),
-            'Response status code ['.$this->getStatusCode().'] is not a forbidden status code.'
+            'Response status code ['.$this->getStatusCode().'] is not a 403 forbidden status code.'
         );
 
         return $this;
@@ -162,7 +162,7 @@ class TestResponse
 
         PHPUnit::assertTrue(
             401 === $actual,
-            'Response status code ['.$actual.'] is not an unauthorized status code.'
+            'Response status code ['.$actual.'] is not a 401 unauthorized status code.'
         );
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -168,7 +168,7 @@ class FoundationTestResponseTest extends TestCase
         $statusCode = 500;
 
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a not found status code.');
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a 404 not found status code.');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -184,7 +184,7 @@ class FoundationTestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a forbidden status code.');
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a 403 forbidden status code.');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
@@ -200,7 +200,7 @@ class FoundationTestResponseTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
 
-        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not an unauthorized status code.');
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a 401 unauthorized status code.');
 
         $baseResponse = tap(new Response, function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);


### PR DESCRIPTION
This PR makes assertions like `assertForbidden()` or `assertUnauthorized()` show the expected status code when the assertion fails.

Currently, if the assertion fails and you can't remember if forbidden is 401 or 403, you have to either dive into the code to see, or you'd have to look it up online.