### PR TITLE
[6.x] Fixed shouldQueue() check for bound event listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -442,8 +442,10 @@ class Dispatcher implements DispatcherContract
      */
     protected function handlerWantsToBeQueued($class, $arguments)
     {
-        if (method_exists($class, 'shouldQueue')) {
-            return $this->container->make($class)->shouldQueue($arguments[0]);
+        $instance = $this->container->make($class);
+
+        if (method_exists($instance, 'shouldQueue')) {
+            return $instance->shouldQueue($arguments[0]);
         }
 
         return true;


### PR DESCRIPTION
**Problem**
We have an Event Listener that implements the ShouldQueue interface.
Laravel provides a perfect way to handle should handler be queued or not with `shouldQueue` method.

If the listener has `shouldQueue` method and it returns `false` handler won't be queued. 
But if we bind Listener via Service container and implement `shouldQueue`  in the child class  `shouldQueue` method won't be triggered if parent class doesn't have `shouldQueue` method.

This PR fixes this issue by creating an instance before `method_exists` check.