### PR TITLE
[6.x] Display only valid listeners in event:list command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -48,9 +48,7 @@ class EventListCommand extends Command
         $events = [];
 
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge_recursive($provider->discoverEvents(), $provider->listens());
-
-            $events = array_merge_recursive($events, $providerEvents);
+            $events = array_merge_recursive($events, $provider->getEvents());
         }
 
         if ($this->filteringByEvent()) {


### PR DESCRIPTION
Event list command currently can show invalid listeners in two ways:
- it displays autodiscovered events even if autodiscovery is turned off (#30360)
- if the events are cached it still shows the current configuration instead of the cached one

This pull request addresses these two problems.

Fixes: #30360 