### PR TITLE
[6.x] Add make:auth command

### DIFF
--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -35,9 +35,11 @@ class AuthMakeCommand extends Command
             throw new InvalidArgumentException('Invalid preset.');
         }
 
+        $composer = $this->findComposer();
+
         $this->info('Running this command will install laravel/ui package.');
         $this->confirm('Would you like to proceed?');
-        $this->callSilent('composer require laravel/ui --dev');
+        $this->callSilent($composer.' require laravel/ui --dev');
 
         if ($this->option('auth')){
             $this->callSilent('php artisan ui '.$this->argument('scaffold').' --auth');
@@ -47,5 +49,19 @@ class AuthMakeCommand extends Command
             $this->callSilent('php artisan ui '.$this->argument('scaffold'));
             $this->info(ucfirst($this->argument('scaffold')).' scaffolding successfully installed.'); 
         }
+    }
+
+    /**
+     * Get the composer command for the environment.
+     *
+     * @return string
+     */
+    protected function findComposer()
+    {
+        $composerPath = getcwd().'/composer.phar';
+        if (file_exists($composerPath)) {
+            return '"'.PHP_BINARY.'" '.$composerPath;
+        }
+        return 'composer';
     }
 }

--- a/src/Illuminate/Auth/Console/AuthMakeCommand.php
+++ b/src/Illuminate/Auth/Console/AuthMakeCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Auth\Console;
+
+use InvalidArgumentException;
+use Illuminate\Console\Command;
+
+class AuthMakeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:auth {scaffold=vue}
+                            {--auth : Only scaffold the authentication views}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install laravel/ui package and scaffold basic login and registration views and routes';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     * 
+     * @throws \InvalidArgumentException
+     */
+    public function handle()
+    {
+        if (! in_array($this->argument('scaffold'), ['bootstrap', 'vue', 'react'])) {
+            throw new InvalidArgumentException('Invalid preset.');
+        }
+
+        $this->info('Running this command will install laravel/ui package.');
+        $this->confirm('Would you like to proceed?');
+        $this->callSilent('composer require laravel/ui --dev');
+
+        if ($this->option('auth')){
+            $this->callSilent('php artisan ui '.$this->argument('scaffold').' --auth');
+            $this->info('Authentication and '.ucfirst($this->argument('scaffold')).' scaffolding successfully installed.');
+        }
+        else {
+            $this->callSilent('php artisan ui '.$this->argument('scaffold'));
+            $this->info(ucfirst($this->argument('scaffold')).' scaffolding successfully installed.'); 
+        }
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
-use App\Console\Commands\AuthMakeCommand;
+use Illuminate\Auth\Console\AuthMakeCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
@@ -187,7 +187,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
             return new AuthMakeCommand;
         });
     }
-    
+
     /**
      * Register the command.
      *

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Providers;
 
+use App\Console\Commands\AuthMakeCommand;
 use Illuminate\Auth\Console\ClearResetsCommand;
 use Illuminate\Cache\Console\CacheTableCommand;
 use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
@@ -117,6 +118,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      * @var array
      */
     protected $devCommands = [
+        'AuthMake' => 'command.auth.make',
         'CacheTable' => 'command.cache.table',
         'ChannelMake' => 'command.channel.make',
         'ConsoleMake' => 'command.console.make',
@@ -174,6 +176,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         $this->commands(array_values($commands));
     }
 
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerAuthMakeCommand()
+    {
+        $this->app->singleton('command.auth.make', function () {
+            return new AuthMakeCommand;
+        });
+    }
+    
     /**
      * Register the command.
      *


### PR DESCRIPTION
Hi,

per @taylorotwell's tweet (https://twitter.com/taylorotwell/status/1183361790576676864?s=20), adding the make:auth command that installs the laravel/ui package and scaffolds the Vue/React/Bootstrap scaffolding with or without authentication.

I tried to stick to the original naming conventions from v5.8 to avoid issues.

Kind regards,
g
