### PR TITLE
[6.x] Alleviate breaking change introduced by password confirm feature 

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1165,7 +1165,7 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         // Password Confirmation Routes...
-        if ($options['confirm'] ?? true) {
+        if ($options['confirm'] ?? class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
             $this->confirmPassword();
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1165,7 +1165,8 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         // Password Confirmation Routes...
-        if ($options['confirm'] ?? class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
+        if ($options['confirm'] ?? 
+            class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
             $this->confirmPassword();
         }
 


### PR DESCRIPTION
In Laravel 7.2 the password confirmation was introduced, this feature sadly brought a breaking change with it:
The Route::auth method registers the confirmation routes by default.

This results in:
- The breakage of route:list command
- Server error 500 response upon accessing the `password/confirm` routes
- Addition of two new route endpoint (which does not introduce any exploitable behavior even if the controller is present)

The best solution for this would be to disable this function by default but after 15 days this could introduce problems in many live systems. This pull request does the second best solution and enables these routes only if the controller exists.

Because this middleware targets a narrow range of the userbase (just like the VerifiesEmail middleware) I'm also proposing to make these routes disabled by default in 7.x.

Fixes #30382 