### PR TITLE
[6.x] Handle ajax requests in RequirePassword middleware

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -46,6 +46,10 @@ class RequirePassword
     public function handle($request, Closure $next, $redirectToRoute = null)
     {
         if ($this->shouldConfirmPassword($request)) {
+            if ($request->expectsJson()) {
+                abort(423, 'Password confirmation required.');
+            }
+
             return $this->responseFactory->redirectGuest(
                 $this->urlGenerator->route($redirectToRoute ?? 'password.confirm')
             );


### PR DESCRIPTION
The newly introduced RequirePassword middleware does not handle ajax requests very well.

This pull request addresses this problem, for easier handling via ajax frontend libraries (like axios), I'm proposing that the error should be sent with error code `423 Locked` as this would allow relatively easy handling with response interceptors.

Considered alternative error codes:
- 400 Bad Request: Simply too broad to be easily handled.
- 401 Unauthorized: This response is used when the authorization is missing or invalid, both of these are not true in this case. Furthermore many implementations use this error code to trigger a login flow.
- 403 Forbidden: This response is used when the user does not have permission to access the resource, here we don't know that yet (it's handled later).
- 423 Locked: Semantically correct because the accessed resource is locked behind the password confirmation. Also it is not used for anything else by Laravel.

I'm open for different error code ideas.