### PR TITLE
[6.x] Prevent running RefreshDatabase trait in production

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -15,7 +15,7 @@ trait RefreshDatabase
     public function refreshDatabase()
     {
         $env = config('app.env');
-        if ($env === 'prod' || $env === 'production') {
+        if ($this->app->isProduction()) {
             throw new RuntimeException('Application In Production! Using RefreshDatabase will delete your data.');
         }
         $this->usingInMemoryDatabase()

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -15,7 +15,7 @@ trait RefreshDatabase
     public function refreshDatabase()
     {
         $env = config('app.env');
-        if($env === 'prod' || $env === 'production'){
+        if ($env === 'prod' || $env === 'production') {
             throw new RuntimeException('Application In Production! Using RefreshDatabase will delete your data.');
         }
         $this->usingInMemoryDatabase()

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Illuminate\Contracts\Console\Kernel;
+use RuntimeException;
 
 trait RefreshDatabase
 {
@@ -13,6 +14,10 @@ trait RefreshDatabase
      */
     public function refreshDatabase()
     {
+        $env = config('app.env');
+        if($env === 'prod' || $env === 'production'){
+            throw new RuntimeException('Application In Production! Using RefreshDatabase will delete your data.');
+        }
         $this->usingInMemoryDatabase()
                         ? $this->refreshInMemoryDatabase()
                         : $this->refreshTestDatabase();


### PR DESCRIPTION
Presently running `php artisan migrate:fresh` warns the user that they will be deleting all production data if they proceed. 

The same consideration is not made when testing, where RefreshDatabase is dropping all tables and re-running all of the migrations potentially directly on a production database. Obviously this is probably not intended behavior and I doubt there's a use-case where people depend on their production data all being wiped clean every time they run their test suites.

Please note that due to `php artisan config:cache`, people may not even be aware they are running their tests against production, thinking their phpunit.xml will override their config values, forgetting that the config is cached.