### PR TITLE
[6.x] Igbinary for RedisStore

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -198,7 +198,13 @@ class CacheManager implements FactoryContract
 
         $connection = $config['connection'] ?? 'default';
 
-        return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
+        if (isset($config['serializer']) && $config['serializer'] === 'igbinary') {
+            $store = new RedisStoreIgbinary($redis, $this->getPrefix($config), $connection);
+        } else {
+            $store = new RedisStore($redis, $this->getPrefix($config), $connection);
+        }
+
+        return $this->repository($store);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStoreIgbinary.php
+++ b/src/Illuminate/Cache/RedisStoreIgbinary.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Contracts\Redis\Factory as Redis;
+
+class RedisStoreIgbinary extends RedisStore
+{
+    /**
+     * Create a new Redis store.
+     *
+     * @param  \Illuminate\Contracts\Redis\Factory  $redis
+     * @param  string  $prefix
+     * @param  string  $connection
+     * @return void
+     */
+    public function __construct(Redis $redis, $prefix = '', $connection = 'default')
+    {
+        if (
+            ! function_exists('igbinary_serialize') ||
+            ! function_exists('igbinary_unserialize')
+        ) {
+            throw new \InvalidArgumentException('Igbinary extension not found');
+        }
+
+        parent::__construct($redis, $prefix, $connection);
+    }
+
+    /**
+     * Serialize the value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function serialize($value)
+    {
+        return is_numeric($value) ? $value : igbinary_serialize($value);
+    }
+
+    /**
+     * Unserialize the value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    protected function unserialize($value)
+    {
+        return is_numeric($value) ? $value : igbinary_unserialize($value);
+    }
+}


### PR DESCRIPTION
Support Igbinary for RedisStore

[https://github.com/igbinary/igbinary](https://github.com/igbinary/igbinary)
Igbinary stores php data structures in a compact binary form

Use:
Add key **serializer** with value **igbinary** in **config/cache.php**:

```
 'redis' => [
 	'driver' => 'redis',
 	'connection' => 'cache',
 	'serializer' => 'igbinary',
 ]
```

**Note!** After changing the serializer, you need to clear the cache