### PR TITLE
[6.x] Fixes Lumen loadViewsFrom issue retrieving view config before the component is loaded

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -87,15 +87,17 @@ abstract class ServiceProvider
      */
     protected function loadViewsFrom($path, $namespace)
     {
+        $view = $this->app['view'];
+
         if (is_array($this->app->config['view']['paths'])) {
             foreach ($this->app->config['view']['paths'] as $viewPath) {
                 if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
-                    $this->app['view']->addNamespace($namespace, $appPath);
+                    $view->addNamespace($namespace, $appPath);
                 }
             }
         }
 
-        $this->app['view']->addNamespace($namespace, $path);
+        $view->addNamespace($namespace, $path);
     }
 
     /**


### PR DESCRIPTION
PHP 7.4 introduces a new error on a fresh install of Lumen when using the `loadViewsFrom` method:

<img width="1039" alt="Screenshot 2019-10-23 at 20 09 06" src="https://user-images.githubusercontent.com/25469238/67426105-4ff5f580-f5d1-11e9-8010-6ccd64d37f5a.png">

## Steps to recreate:
- Fresh Lumen installation
- $app->register(Illuminate\Pagination\PaginationServiceProvider::class);

## Proposed solution
Assign the view factory to a variable before iterating the config so that Lumen can register the view component first.