### PR TITLE
[6.x] Dispatch event when a scheduled command was filtered from running

### DIFF
--- a/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskSkipped.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+
+class ScheduledTaskSkipped
+{
+    /**
+     * The scheduled event being run.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $task;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Illuminate\Console\Scheduling\Event  $task
+     * @return void
+     */
+    public function __construct(Event $task)
+    {
+        $this->task = $task;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -4,6 +4,7 @@ namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\Events\ScheduledTaskFinished;
+use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Facades\Date;
@@ -78,6 +79,8 @@ class ScheduleRunCommand extends Command
 
         foreach ($this->schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
+                $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
+
                 continue;
             }
 


### PR DESCRIPTION
If a scheduled command is run with a truth constraint, it is not simple to check whether the task didn't run at all, or if it was filtered running from a known system constraint.

Firing an event when the task is intentionally skipped allows monitoring over the task executing as scheduled, based on the truth constraint.