### PR TITLE
Strip comments first in blade compile process

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -186,6 +186,10 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function compileString($value)
     {
+        // Strip all comments first. They could contain @verbatim, @php or other
+        // tokens that would otherwise be processed before a comment is removed.
+        $value = $this->compileComments($value);
+
         if (strpos($value, '@verbatim') !== false) {
             $value = $this->storeVerbatimBlocks($value);
         }


### PR DESCRIPTION
I found a problem when I had commented out a `@verbatim` block, e.g.
```
{{-- @verbatim ... @endverbatim --}}.
```
On compiling, the `@verbatim` token was still being processed because it happens before the comment tokens are processed.
The same would happen with `@php` tokens in the existing `compileString()` method.
Stripping all comments first would fix this problem (if it doesn't cause other problems I haven't thought of).

If this proposal is accepted, maybe the existing `compileComments()` step within the `token_get_all()` loop below becomes redundant?