### PR TITLE
Integrate event cache with optimize command

### DIFF
--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -31,6 +31,7 @@ class OptimizeClearCommand extends Command
         $this->call('cache:clear');
         $this->call('route:clear');
         $this->call('config:clear');
+        $this->call('event:clear');
         $this->call('clear-compiled');
 
         $this->info('Caches cleared successfully!');

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -29,7 +29,9 @@ class OptimizeCommand extends Command
     {
         $this->call('config:cache');
         $this->call('route:cache');
-
+        $this->call('view:cache');
+        $this->call('event:cache');
+ 
         $this->info('Files cached successfully!');
     }
 }


### PR DESCRIPTION
All native framework caching command should be called in the optimize / optimize:clear command if you ask me. Hope you guys think the same 👍 