### PR TITLE
[6.x] Corrected dispatcher doc

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -49,7 +49,7 @@ class ScheduleRunCommand extends Command
     /**
      * The event dispatcher.
      *
-     * @var \Illuminate\Contracts\Notifications\Dispatcher
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
     protected $dispatcher;
 


### PR DESCRIPTION
 - we have a mistake in the PHPDoc for the dispatcher property. So, I have fixed to the actual one. As we can see dispatcher have called dispatch method. This method is avaliable in the `\Illuminate\Contracts\Events\Dispatcher` (not in the `\Illuminate\Contracts\Notifications\Dispatcher`)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
