### PR TITLE
Changes to optimize and optimize:clear commands

### DIFF
--- a/src/Illuminate/Foundation/Console/EventClearCommand.php
+++ b/src/Illuminate/Foundation/Console/EventClearCommand.php
@@ -52,6 +52,6 @@ class EventClearCommand extends Command
     {
         $this->files->delete($this->laravel->getCachedEventsPath());
 
-        $this->info('Cached events cleared!');
+        $this->info('Events cache cleared!');
     }
 }

--- a/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeClearCommand.php
@@ -31,6 +31,7 @@ class OptimizeClearCommand extends Command
         $this->call('cache:clear');
         $this->call('route:clear');
         $this->call('config:clear');
+        $this->call('event:clear');
         $this->call('clear-compiled');
 
         $this->info('Caches cleared successfully!');

--- a/src/Illuminate/Foundation/Console/OptimizeCommand.php
+++ b/src/Illuminate/Foundation/Console/OptimizeCommand.php
@@ -29,6 +29,8 @@ class OptimizeCommand extends Command
     {
         $this->call('config:cache');
         $this->call('route:cache');
+        $this->call('view:cache');
+        $this->call('event:cache');
 
         $this->info('Files cached successfully!');
     }


### PR DESCRIPTION
For consistency all the native framework caching commands should be called in the optimize / optimize:clear command if you ask me.

Hope you guys think the same 👍