### PR TITLE
[6.x] Notification facade autocompletion

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -11,6 +11,13 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
  * @method static void sendNow(\Illuminate\Support\Collection|array|mixed $notifiables, $notification)
  * @method static mixed channel(string|null $name = null)
  * @method static \Illuminate\Notifications\ChannelManager locale(string|null $locale)
+ * @method static void assertSentTo(\Illuminate\Support\Collection|array|mixed $notifiable, string $notification, callable $callback = null)
+ * @method static void assertSentToTimes(mixed $notifiable, string $notification, int $times = 1)
+ * @method static void assertNotSentTo(\Illuminate\Support\Collection|array|mixed $notifiable, string $notification, callable $callback = null)
+ * @method static void assertNothingSent()
+ * @method static void assertTimesSent(int $expectedCount, string $notification)
+ * @method static \Illuminate\Support\Collection sent(mixed $notifiable, string $notification, callable $callback = null)
+ * @method static bool hasSent(mixed $notifiable, string $notification)
  *
  * @see \Illuminate\Notifications\ChannelManager
  */


### PR DESCRIPTION
This PR adds the methods from the `NotificationFake` class as doclets to the `Notification` facade. This allows for autocompletion in IDE's like PHPStorm.