### PR TITLE
[6.x] Fix that the sql server connection is broken

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -39,6 +39,7 @@ trait DetectsLostConnections
             'Adaptive Server connection failed',
             'Communication link failure',
             'connection is no longer usable',
+            'Login timeout expired',
         ]);
     }
 }


### PR DESCRIPTION
This issue happens a few times out of every several ten thousand sql queries that occur.

> SQLSTATE[HYT00]: [unixODBC][Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired

Immediately retrying the job or query resolves the issue as it seems to either be a quirk with Azure DB or even the PHP SQL Server driver.