### PR TITLE
[6.x] Update `artisan down` output to be consistent with `artisan up`

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -34,6 +34,12 @@ class DownCommand extends Command
     public function handle()
     {
         try {
+            if (file_exists(storage_path('framework/down'))) {
+                $this->comment('Application is already down.');
+
+                return true;
+            }
+
             file_put_contents(storage_path('framework/down'),
                               json_encode($this->getDownFilePayload(),
                               JSON_PRETTY_PRINT));


### PR DESCRIPTION
This makes the output of `artisan down` like `artisan up` if there's no change in maintenance mode.

The application was already **up**, so this is expected behavior:

```diff
# Running `up` twice in a row (from a down state)

$ php artisan up
Application is now live.
$ php artisan up
Application is already up.
```
## Effect of this change:
The application was already **down**:

```diff
# Running `down` twice in a row (from an up state)

$ php artisan down
Application is now in maintenance mode.
$ php artisan down
- Application is now in maintenance mode.
+ Application is already down.
```

It checks the same way the [`UpCommand.php` checks](https://github.com/laravel/framework/blob/17830b2170361eb2b3b59837b33ef8605d2d6200/src/Illuminate/Foundation/Console/UpCommand.php#L32-L36) (added via PR #28765)
