### PR TITLE
[6.x] Add --queued option to event:generate command

### DIFF
--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -5,7 +5,6 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputOption;
 
 class EventGenerateCommand extends Command
 {
@@ -14,7 +13,7 @@ class EventGenerateCommand extends Command
      *
      * @var string
      */
-    protected $name = 'event:generate';
+    protected $signature = 'event:generate {--queued: Indicates the generated event listener(s) should be queued}';
 
     /**
      * The console command description.
@@ -75,12 +74,5 @@ class EventGenerateCommand extends Command
                 ['name' => $listener, '--event' => $event, '--queued' => $this->option('queued')]
             ));
         }
-    }
-
-    protected function getOptions()
-    {
-        return [
-            ['queued', null, InputOption::VALUE_NONE, 'Indicates the generated event listener(s) should be queued'],
-        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/EventGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/EventGenerateCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
 
 class EventGenerateCommand extends Command
 {
@@ -71,8 +72,15 @@ class EventGenerateCommand extends Command
             $listener = preg_replace('/@.+$/', '', $listener);
 
             $this->callSilent('make:listener', array_filter(
-                ['name' => $listener, '--event' => $event]
+                ['name' => $listener, '--event' => $event, '--queued' => $this->option('queued')]
             ));
         }
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['queued', null, InputOption::VALUE_NONE, 'Indicates the generated event listener(s) should be queued'],
+        ];
     }
 }


### PR DESCRIPTION
The `--queued` option exists for the `make:listener` command.

This pr extends this convenience to the `event:generate` command also, where it is a bit more useful when generating multiple listeners which use queue :

`php artisan event:generate --queued`



<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
