### PR TITLE
[6.x] Possibility to replace error place-holders in rule class

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -194,14 +195,23 @@ trait FormatsMessages
     /**
      * Replace all error message place-holders with actual values.
      *
-     * @param  string  $message
-     * @param  string  $attribute
-     * @param  string  $rule
-     * @param  array   $parameters
+     * @param  string               $message
+     * @param  string               $attribute
+     * @param  string|RuleContract  $rule
+     * @param  array                $parameters
+     *
      * @return string
      */
     public function makeReplacements($message, $attribute, $rule, $parameters)
     {
+        if ($rule instanceof RuleContract) {
+            if (method_exists($rule, 'replace')) {
+                $message = $rule->replace($message, $attribute);
+            }
+
+            $rule = get_class($rule);
+        }
+
         $message = $this->replaceAttributePlaceholder(
             $message, $this->getDisplayableAttribute($attribute)
         );

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -576,7 +576,7 @@ class Validator implements ValidatorContract
 
             foreach ($messages as $message) {
                 $this->messages->add($attribute, $this->makeReplacements(
-                    $message, $attribute, get_class($rule), []
+                    $message, $attribute, $rule, []
                 ));
             }
         }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -572,7 +572,11 @@ class Validator implements ValidatorContract
         if (! $rule->passes($attribute, $value)) {
             $this->failedRules[$attribute][get_class($rule)] = [];
 
-            $messages = $rule->message() ? (array) $rule->message() : [get_class($rule)];
+            if (! is_null($inlineMessage = $this->getInlineMessage($attribute, get_class($rule)))) {
+                $messages = (array) $inlineMessage;
+            } else {
+                $messages = $rule->message() ? (array) $rule->message() : [get_class($rule)];
+            }
 
             foreach ($messages as $message) {
                 $this->messages->add($attribute, $this->makeReplacements(

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4569,6 +4569,40 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame('name must be taylor', $v->errors()->get('name')[0]);
         $this->assertSame('name must be a first name', $v->errors()->get('name')[1]);
         $this->assertSame('validation.string', $v->errors()->get('name')[2]);
+
+        $v = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['number' => 4],
+            ['number' => [new class(18, 20) implements Rule {
+                private $min;
+
+                private $max;
+
+                public function __construct($min, $max)
+                {
+                    $this->min = $min;
+                    $this->max = $max;
+                }
+
+                public function passes($attribute, $value)
+                {
+                    return $value > $this->min && $value < $this->max;
+                }
+
+                public function message()
+                {
+                    return 'The :attribute must be between :min and :max.';
+                }
+
+                public function replace($message, $attribute)
+                {
+                    return str_replace([':min', ':max'], [$this->min, $this->max], $message);
+                }
+            }]]
+        );
+
+        $this->assertTrue($v->fails());
+        $this->assertSame('The number must be between 18 and 20.', $v->errors()->get('number')[0]);
     }
 
     public function testImplicitCustomValidationObjects()


### PR DESCRIPTION
Hi. This makes possible to replace error place-holders in rule class and keep all validation related logic in one place.

Example:

```php
use Illuminate\Contracts\Validation\Rule;

class BetweenRule implements Rule
{
    private $min;
    private $max;

    public function __construct($min, $max)
    {
        $this->min = $min;
        $this->max = $max;
    }

    public function passes($attribute, $value)
    {
        return $value > $this->min && $value < $this->max;
    }

    public function message()
    {
        return 'The :attribute must be between :min and :max.';
    }

    public function replace($message, $attribute)
    {
        return str_replace([':min', ':max'], [$this->min, $this->max], $message);
    }
}
```

Btw fixed laravel/ideas#1897