### PR TITLE
[6.x] Queued notifications respect user's preferred locale

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -184,9 +184,7 @@ class NotificationSender
 
                 $notification->id = $notificationId;
 
-                if (! is_null($this->locale)) {
-                    $notification->locale = $this->locale;
-                }
+                $notification->locale = $this->preferredLocale($notifiable, $notification);
 
                 $this->bus->dispatch(
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))


### PR DESCRIPTION
We use both queued and non-queued notifications and rely on the **preferredLocale** method for determining the notification's locale. While the non-queued one's are translated using the correct locale, the queued one's still used the default app locale.

It turns out queued notifications can only be configured using the **locale** fluent method. The preferredLocale method isn't referenced or available in this case. The [documentation](https://laravel.com/docs/6.x/notifications#localizing-notifications) doesn't mention this exception.

This allows you use the preferredLocale method for notifications, whether you use queuing or not.