### PR TITLE
[6.x] Make use of higher order message for "each" method on collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -673,9 +673,7 @@ trait HasRelationships
 
                 $this->$relation->touchOwners();
             } elseif ($this->$relation instanceof Collection) {
-                $this->$relation->each(function (Model $relation) {
-                    $relation->touchOwners();
-                });
+                $this->$relation->each->touchOwners();
             }
         }
     }

--- a/src/Illuminate/Notifications/DatabaseNotificationCollection.php
+++ b/src/Illuminate/Notifications/DatabaseNotificationCollection.php
@@ -13,9 +13,7 @@ class DatabaseNotificationCollection extends Collection
      */
     public function markAsRead()
     {
-        $this->each(function ($notification) {
-            $notification->markAsRead();
-        });
+        $this->each->markAsRead();
     }
 
     /**
@@ -25,8 +23,6 @@ class DatabaseNotificationCollection extends Collection
      */
     public function markAsUnread()
     {
-        $this->each(function ($notification) {
-            $notification->markAsUnread();
-        });
+        $this->each->markAsUnread();
     }
 }


### PR DESCRIPTION
Higher order messages for `each` collection method are used in a few places where there's only one method called on iterated item. Functionality is not changed, code is just condensed.

Cheers!

P.S. Huge fan on higher order messages :slightly_smiling_face: 