### PR TITLE
[6.x] Allow "each" method on Eloquent Builder to be used through higher order proxy

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
+ * @property-read HigherOrderBuilderProxy $each
  * @property-read HigherOrderBuilderProxy $orWhere
  *
  * @mixin \Illuminate\Database\Query\Builder
@@ -73,6 +74,15 @@ class Builder
     protected $passthru = [
         'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
         'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection',
+    ];
+
+    /**
+     * The methods that can be proxied.
+     *
+     * @var array
+     */
+    protected static $proxies = [
+        'each', 'orWhere',
     ];
 
     /**
@@ -1306,7 +1316,7 @@ class Builder
      */
     public function __get($key)
     {
-        if ($key === 'orWhere') {
+        if (in_array($key, static::$proxies)) {
             return new HigherOrderBuilderProxy($this, $key);
         }
 


### PR DESCRIPTION
There were times when I wished I could use `each` method on Eloquent Builder the same way I can use `each` method on collections, like a higher order message.

This PR gives the ability to use it that way. So in an imagined situation:
```php
User::verified()->each(function ($user) {
    $user->sendWelcomeEmail();
});
```
could be written like this:
```php
User::verified()->each->sendWelcomeEmail();
```
Using `each` method on Eloquent Builder this way has a drawback of not being able to customize chunk size, but that is a conscious decision made when used like this. I think the default chunk size of 1000 (at the moment of writing) is good enough for most cases, and if customization is required `each` method can always be used the same as before. This PR just adds the ability to use it in a different way without breaking the existing API.

Hope others find it useful and I'd really like some feedback on this :slightly_smiling_face: 
If this is accepted, next step would be to allow the same on relations.

Cheers!
