### PR TITLE
[6.x] Signed URL generation fails silently when a parameter is named 'signature'

### DIFF
--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -627,6 +627,30 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertFalse($url->hasValidSignature($request, false));
     }
+    
+    public function testSignedUrlWithARouteParameterNamedSignature()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            $request = Request::create('http://www.foo.com/')
+        );
+        $url->setKeyResolver(function () {
+            return 'secret';
+        });
+
+        $route = new Route(['GET'], 'foo/{signature}', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $request = Request::create($url->signedRoute('foo', ['signature' => 'boom']));
+
+        $this->assertTrue($url->hasValidSignature($request));
+
+        $request = Request::create($url->signedRoute('foo', [ 'signature' => 'boom']).'?tempered=true');
+
+        $this->assertFalse($url->hasValidSignature($request));
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
This is a bug report in the form of a pull request containing a failing test, as recommended in the contribution guide.

### Bug
When a route contains a parameter named 'signature', generation of a signed URL for that route fails silently. UrlGenerator->signedRoute returns the unsigned route instead.

### Why does it matter?
Signatures can be things in the real world. For example, documents like contracts or petitions have signatures. Or a forum user or e-mail account may have a default signature that is appended to every message. 

So there are cases where App\Signature is an Eloquent model and could end up as a parameter in a route, like '/emailaccounts/{account}/signatures/{signature}', or '/petition/signatures/{signature}'. 

If this is a signed route (for example '/contracts/{contract}/signatures/{signature}/verify'), UrlGenerator->signedRoute currently silently fails and returns the unsigned route instead.

This behavior is confusing. I don't know if it can be fixed, but at least URLGenerator->signedRoute should throw an exception when one of the parameters is called 'signature'.