### PR TITLE
[6.x] Remove validator methods from Password facade

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -7,8 +7,6 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 /**
  * @method static string sendResetLink(array $credentials)
  * @method static mixed reset(array $credentials, \Closure $callback)
- * @method static void validator(\Closure $callback)
- * @method static bool validateNewPassword(array $credentials)
  *
  * @see \Illuminate\Auth\Passwords\PasswordBroker
  */


### PR DESCRIPTION
`validator` and `validateNewPassword` does not exist anymore in `PasswordBroker`, so we should remove them from `Password` Facade.