### PR TITLE
[6.x] Add a more readable "missing" method to Filesystem and FilesystemAdapter

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -24,6 +24,17 @@ class Filesystem
     }
 
     /**
+     * Determine if a file or directory is missing.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function missing($path)
+    {
+        return !$this->exists($path);
+    }
+
+    /**
      * Get the contents of a file.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -31,7 +31,7 @@ class Filesystem
      */
     public function missing($path)
     {
-        return !$this->exists($path);
+        return ! $this->exists($path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -97,6 +97,17 @@ class FilesystemAdapter implements CloudFilesystemContract
     }
 
     /**
+     * Determine if a file or directory is missing.
+     *
+     * @param  string  $path
+     * @return bool
+     */
+    public function missing($path)
+    {
+        return !$this->exists($path);
+    }
+
+    /**
      * Get the full path for the file at the given "short" path.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -104,7 +104,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function missing($path)
     {
-        return !$this->exists($path);
+        return ! $this->exists($path);
     }
 
     /**

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -89,6 +89,12 @@ class FilesystemAdapterTest extends TestCase
         $this->assertTrue($filesystemAdapter->exists('file.txt'));
     }
 
+    public function testMissing()
+    {
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+        $this->assertTrue($filesystemAdapter->missing('file.txt'));
+    }
+
     public function testPath()
     {
         $this->filesystem->write('file.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -132,6 +132,12 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
+    public function testMissingFile()
+    {
+        $files = new Filesystem;
+        $this->assertTrue($files->missing($this->tempDir.'/file.txt'));
+    }
+
     public function testDeleteDirectory()
     {
         mkdir($this->tempDir.'/foo');


### PR DESCRIPTION
This PR adds a new `missing()` method to both `Illuminate\Filesystem\Filesystem` and of course `Illuminate\Filesystem\FilesystemAdapter` so we can check missing files or directories in a more readable way.

In other word, instead of following condition checkings:
```php
if (!Storage::exists('file.txt')) {
   // ...
}

if (!File::exists('file.txt')) {
   // ...
}
```

We can do:
```php
if (Storage::missing('file.txt')) {
   // ...
}

if (File::missing('file.txt')) {
   // ...
}
```

There is no much logic behind the methods and I think they don't add maintenance overload.