### PR TITLE
[6.x] Add LazyCollection@remember method

### DIFF
--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -110,6 +110,44 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Cache values as they're enumerated.
+     *
+     * @return static
+     */
+    public function remember()
+    {
+        $iterator = $this->getIterator();
+
+        $iteratorIndex = 0;
+
+        $cache = [];
+
+        return new static(function () use ($iterator, &$iteratorIndex, &$cache) {
+            for ($index = 0; true; $index++) {
+                if (array_key_exists($index, $cache)) {
+                    yield $cache[$index][0] => $cache[$index][1];
+
+                    continue;
+                }
+
+                if ($iteratorIndex < $index) {
+                    $iterator->next();
+
+                    $iteratorIndex++;
+                }
+
+                if (! $iterator->valid()) {
+                    break;
+                }
+
+                $cache[$index] = [$iterator->key(), $iterator->current()];
+
+                yield $cache[$index][0] => $cache[$index][1];
+            }
+        });
+    }
+
+    /**
      * Get the average value of a given key.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -763,6 +763,27 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testRememberIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->remember();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection = $collection->remember();
+
+            $collection->all();
+            $collection->all();
+        });
+
+        $this->assertEnumerates(5, function ($collection) {
+            $collection = $collection->remember();
+
+            $collection->take(5)->all();
+            $collection->take(5)->all();
+        });
+    }
+
     public function testReplaceIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
This PR adds a `remember` method to the `LazyCollection` class.

Calling `remember` returns a new lazy collection that will remember any values that are enumerated, and will not pull it again from the source when it's enumerated again. Here are two examples:

#### Example 1

```php
$users = User::cursor()->remember();

// No query has been executed yet.

$users->all();

// All values have been pulled from the DB.

$users->all();

// We did not hit the DB again. We got the users from `remember`'s cache.
```

#### Example 2

```php

$users = User::cursor()->remember();

// No query has been executed yet.

$users->take(5)->all();

// The query has been executed, and the first 5 users have been streamed from the DB.

$users->take(20)->all();

// The first 5 users came from the cache. The rest continued the stream from the DB.
```

This PR includes extensive tests ensuring that it's fully lazy, and that two simultaneous runners don't step on each other's toes.

---

## The `partition` method

After this is merged, I'll rewrite the `partition` method using this.

Currently, calling `partition` immediately enumerates the whole collection, since we had no way to create two streams for the same dataset.

Now with `remember`, we can get a truly lazy version of `partition`!