### PR TITLE
[6.x] Throw an exception when signing route if a parameter key is 'signature'

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -315,10 +315,18 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
      * @param  bool  $absolute
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
     public function signedRoute($name, $parameters = [], $expiration = null, $absolute = true)
     {
         $parameters = $this->formatParameters($parameters);
+
+        if(array_key_exists('signature', $parameters)) {
+            throw new InvalidArgumentException(
+                'Do not use [signature] as a parameter name when creating a signed route.'
+            );
+        }
 
         if ($expiration) {
             $parameters = $parameters + ['expires' => $this->availableAt($expiration)];


### PR DESCRIPTION
Following up on #30439. This makes UrlGenerator->signedRoute throw an InvalidArgumentException when the passed $parameters array contains the key 'signature'.