### PR TITLE
[6.x] Add -filled- ability to the support Arr class

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -343,6 +343,30 @@ class Arr
     }
 
     /**
+     * Check if an item or items are filled in an array using "dot" notation.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|array  $keys
+     * @return bool
+     */
+    public static function filled($array, $keys)
+    {
+        if (! static::has($array, $keys)) {
+            return false;
+        }
+
+        foreach ((array) $keys as $key) {
+            $needle = static::get($array, $key);
+
+            if (empty($needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Determines if an array is associative.
      *
      * An array is "associative" if it doesn't have sequential numerical keys beginning with zero.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -815,4 +815,26 @@ class SupportArrTest extends TestCase
         $this->assertEquals([$obj], Arr::wrap($obj));
         $this->assertSame($obj, Arr::wrap($obj)[0]);
     }
+
+    public function testFilled()
+    {
+        $data = [
+            'one' => 1,
+            'two' => '',
+            'three' => null,
+            'foo' => [
+                'one' => 1,
+                'two' => '',
+                'three' => null,
+            ],
+        ];
+
+        $this->assertTrue(Arr::filled($data, 'one'));
+        $this->assertFalse(Arr::filled($data, 'two'));
+        $this->assertFalse(Arr::filled($data, 'three'));
+
+        $this->assertTrue(Arr::filled($data, 'foo.one'));
+        $this->assertFalse(Arr::filled($data, 'foo.two'));
+        $this->assertFalse(Arr::filled($data, 'foo.three'));
+    }
 }


### PR DESCRIPTION
This `PR` introduces a new method `filled` for the current `\Illuminate\Support\Arr` class.

This method works as you might expect allowing `dot` notation for nested checks.

Here is the method signature & [implementation](https://github.com/laravel/framework/compare/6.x...gocanto:6.x#diff-3827e5712dc6ff2e21499fcd308a18a1R352): 

```php
public static function filled($array, $keys)
{
   //code
}
```

### The reason behind it

As you might know by now, we currently have two methods to check whether we have a given key(s) within a given array. This works fine, but it does not provide the ability to check whether we have a value for a given key. Hence, you will be able to have this behavior if this `PR` is merged.


### Example

```php
$data = [
            'one' => 1,
            'two' => '',
            'three' => null,
            'foo' => [
                'one' => 1,
                'two' => '',
                'three' => null,
            ],
        ];


if (Arr::filled($data, 'one')) {
//good to go!
} 
```

You will be able to see more uses case [here](https://github.com/laravel/framework/compare/6.x...gocanto:6.x#diff-d14ddb2972fa3aa22bf0f479ae091d60R819)

### Nice to have
If this PR is approved, we could also add an `empty` method. So, we have a positive way to ask in given conditions. 


----
Cheers, 
