### PR TITLE
Fix "alreadyExists" function on "EventMakeCommand"

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -28,17 +28,6 @@ class EventMakeCommand extends GeneratorCommand
     protected $type = 'Event';
 
     /**
-     * Determine if the class already exists.
-     *
-     * @param  string  $rawName
-     * @return bool
-     */
-    protected function alreadyExists($rawName)
-    {
-        return class_exists($rawName);
-    }
-
-    /**
      * Get the stub file for the generator.
      *
      * @return string


### PR DESCRIPTION
The `make:event` command used a local check to see if the event already existed and this function no longer worked.
By removing the local fuction, the [`alreadyExists` function on the parent class](https://github.com/laravel/framework/blob/ebd8fcc038effa8c5f8791346c48047f7d0ed320/src/Illuminate/Console/GeneratorCommand.php#L118) is used and the check works again.