### PR TITLE
[6.x] Check if class is already prefixed with namespace to prevent duplication when creating a route

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -530,7 +530,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $group = end($this->groupStack);
 
-        return isset($group['namespace']) && strpos($class, '\\') !== 0 && !Str::startsWith($class, $group['namespace'])
+        return isset($group['namespace']) && strpos($class, '\\') !== 0 && ! Str::startsWith($class, $group['namespace'])
                 ? $group['namespace'].'\\'.$class : $class;
     }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -530,7 +530,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $group = end($this->groupStack);
 
-        return isset($group['namespace']) && strpos($class, '\\') !== 0
+        return isset($group['namespace']) && strpos($class, '\\') !== 0 && !Str::startsWith($class, $group['namespace'])
                 ? $group['namespace'].'\\'.$class : $class;
     }
 


### PR DESCRIPTION
Added a check to prevent the namespace from being duplicated when the Router tries to prepend the group namespace to the class.

This conveniently allows to define routes using the fully qualified class name instead of just a string, which is always helpful:

```php
use App\Http\Controllers\AccountController;
use App\Http\Controllers\UserController;

Route::get('/account', AccountController::class);  // Instead of Route::get('/account', 'AccountController');
Route::resource('/users', UserController::class);  // Instead of Route::resource('/users', 'UserController');
```

For this example, the `AccountController` class is supposed to be invokable.