### PR TITLE
[6.x] Fix $groups param type in groupBy() method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1668,7 +1668,7 @@ class Builder
     /**
      * Add a "group by" clause to the query.
      *
-     * @param  array  ...$groups
+     * @param  array|string  ...$groups
      * @return $this
      */
     public function groupBy(...$groups)


### PR DESCRIPTION
As it can be passed like that:
```
->groupBy('created_at')
```

or like that:
```
->groupBy(['created_at'])
```

or even like that:
```
->groupBy('created_at', ['updated_at'])
```