### PR TITLE
Prevent event override when running make:event

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -35,7 +35,7 @@ class EventMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName);
+        return class_exists($this->qualifyClass($rawName));
     }
 
     /**


### PR DESCRIPTION
Events are being overwritten every time you run the `php artisan make:event` command with the same name.
Laravel is using only the event name, not the fully qualified class name to determine if the event class already exists.