### PR TITLE
Collection push() should use offsetSet() instead of directly setting items

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -813,7 +813,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function push($value)
     {
-        $this->items[] = $value;
+        $this->offsetSet(null, $value);
 
         return $this;
     }


### PR DESCRIPTION
In Laravel 5.x the Collection `push()` method used to call the `offsetSet()` method to add the new item to the items array. 

This has been changed in 6.x to set the items directly but it breaks compatibility in apps which override the `offsetSet()` method and is not consistent with other methods like `put()`, `groupBy()` from 6.x which still use the `offsetSet()` method.