### PR TITLE
[6.x] Fix ApiAuthenticationWithEloquentTest.php for people on MySQL 8

### DIFF
--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -39,7 +39,7 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
         $this->expectException(QueryException::class);
 
-        $this->expectExceptionMessage("SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES) (SQL: select * from `users` where `api_token` = whatever limit 1)");
+        $this->expectExceptionMessage("Access denied for user 'root'@'localhost'");
 
         try {
             $this->withoutExceptionHandling()->get('/auth', ['Authorization' => 'Bearer whatever']);


### PR DESCRIPTION
due to the differences in how MySQL 5 vs MySQL 8 handles passwords, the error message will be different depending on the version you use.

v5 will give you a 1045 error, while v8 will give you a 1698 error.

It doesn't seem like the exact content of the error message is important here, so I shortened it to something both versions contain, but please correct me if I'm wrong.