### PR TITLE
[7.x] Accept field for Route binding

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -21,8 +21,9 @@ interface UrlRoutable
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
+     * @param  mixed   $value
+     * @param  string  $field
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value);
+    public function resolveRouteBinding($value, $field = null);
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1471,12 +1471,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
+     * @param  mixed   $value
+     * @param  string  $field
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value)
+    public function resolveRouteBinding($value, $field = null)
     {
-        return $this->where($this->getRouteKeyName(), $value)->first();
+        return $this->where($field ?? $this->getRouteKeyName(), $value)->first();
     }
 
     /**

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -32,12 +32,13 @@ trait DelegatesToResource
     /**
      * Retrieve the model for a bound value.
      *
-     * @param  mixed  $value
+     * @param  mixed   $value
+     * @param  string  $field
      * @return void
      *
      * @throws \Exception
      */
-    public function resolveRouteBinding($value)
+    public function resolveRouteBinding($value, $field = null)
     {
         throw new Exception('Resources may not be implicitly resolved from route bindings.');
     }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -101,7 +101,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'routable';
     }
 
-    public function resolveRouteBinding($routeKey)
+    public function resolveRouteBinding($routeKey, $field = null)
     {
         //
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -643,7 +643,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'key';
     }
 
-    public function resolveRouteBinding($routeKey)
+    public function resolveRouteBinding($routeKey, $field = null)
     {
         //
     }


### PR DESCRIPTION
### Scenario

Assume we have a Model called `App\Page` with the following table structure.

- id
- title
- slug

When accessing it in a user facing Route via implicit binding (`example.com/my-page-slug`) we want to query the Model via the `slug` property, but when accessing it from an administration facing Route via implicit binding (`example.com/admin/pages/1/edit`) we want to query off the default `id` property.

We currently have the ability to change which field the Model uses to query off of by overriding the `getRouteKeyName()` method. Unfortunately, this is global and does not allow us to do it selectively.

What I would propose is we can override the query field via the Route definition for Route localized needs.

```php
Route::resource('admin.pages, 'AdminPageController');

Route::get('{page}', 'PageController@show')->by(['page' => 'slug']);
```

### Proposed Solution

This is part 1 of a 2 part solution. This PR allows us pass an override `$field` to the `resolveRouteBinding()` method.  The default will be `null` so existing calls will not be affected, and the fallback for the parameter will be the default `getRouteKeyName()`.

Part 2 will require passing the override values in from the Route definition. My first thought would be to add these as more "actions", but I'd be open to other suggestions. Also open to naming, since  I don't have any good ones yet.

### Master

PRing to master since there are Contract changes.