### PR TITLE
[6.x] Reconnect missing connection when beginning transaction

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -117,6 +117,8 @@ trait ManagesTransactions
     protected function createTransaction()
     {
         if ($this->transactions == 0) {
+            $this->reconnectIfMissingConnection();
+
             try {
                 $this->getPdo()->beginTransaction();
             } catch (Exception $e) {

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -158,6 +158,18 @@ class DatabaseConnectionTest extends TestCase
         $this->assertEquals(1, $connection->transactionLevel());
     }
 
+    public function testBeginTransactionMethodReconnectsMissingConnection()
+    {
+        $connection = $this->getMockConnection();
+        $connection->setReconnector(function ($connection) {
+            $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);
+            $connection->setPdo($pdo);
+        });
+        $connection->disconnect();
+        $connection->beginTransaction();
+        $this->assertEquals(1, $connection->transactionLevel());
+    }
+
     public function testBeginTransactionMethodNeverRetriesIfWithinTransaction()
     {
         $pdo = $this->createMock(DatabaseConnectionTestMockPDO::class);


### PR DESCRIPTION
This PR adds a check that a connection is not missing before beginning a transaction, and reconnects if it is. This is the same check added in 143f7a93289eec54ea9f3efc3fba9f17511fcd92 that is performed before running a query in [`Illuminate\Database\Connection::run()`](https://github.com/laravel/framework/blob/1bbe5528568555d597582fdbec73e31f8a818dbc/src/Illuminate/Database/Connection.php#L617).

I ran into this while running a [Laravel Excel](https://github.com/Maatwebsite/Laravel-Excel) queued import on Vapor. Vapor disconnects all database connections at the end of each queued job execution in [`QueueHandler::terminate()`](https://github.com/laravel/vapor-core/blob/9a486ab614e92c01cbd2d089b01cc0124c8eff0a/src/Runtime/Handlers/QueueHandler.php#L82). When the worker executes the next job, `app('db.connection')->getPdo()` returns `null` unless the connection is re-established, which currently only happens when running a query. So when the `ReadChunk` queued job in Laravel Excel attempts to begin a transaction before running a query [here](https://github.com/Maatwebsite/Laravel-Excel/blob/3.1/src/Jobs/ReadChunk.php#L120), `$this->getPdo()->beginTransaction()` in [`ManagesTransactions`](https://github.com/laravel/framework/blob/1bbe5528568555d597582fdbec73e31f8a818dbc/src/Illuminate/Database/Concerns/ManagesTransactions.php#L121) results in the error `Call to a member function beginTransaction() on null`.