### PR TITLE
[6.x] Fixing comment annotation missing attribute on Broadcast Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
 
 /**
  * @method static void connection($name = null);
- * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback)
+ * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback, array $options)
  * @method static mixed auth(\Illuminate\Http\Request $request)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory

--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
 
 /**
  * @method static void connection($name = null);
- * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback, array $options)
+ * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback, array $options = [])
  * @method static mixed auth(\Illuminate\Http\Request $request)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Adding `$options` to more closely match the attributes on the actual `channel` function.

[Reference to `$options`](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php#L47)

I ran into this issue on my IDE. While it's valid to just call the `Broadcast::channel(string, callable|string, array)` function, my IDE would mark the function as incorrect because we're missing this 3rd parameter in the comment annotations.