### PR TITLE
[6.x] Add implodeForHumans method to the string helpers class (Str).

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -413,12 +413,12 @@ class Str
      * @param  string|null  $lastGlue
      * @return string
      */
-    public static function implodeForHumans($glue , $pieces, $lastGlue = null)
+    public static function implodeForHumans($glue, $pieces, $lastGlue = null)
     {
-        if(count($pieces) > 2){
+        if (count($pieces) > 2) {
             $lastElement = array_pop($pieces);
-            return implode($glue, $pieces) . (rtrim($glue) . ' ' . ltrim($lastGlue)) . $lastElement;
-        }else{
+            return implode($glue, $pieces).(rtrim($glue).' '.ltrim($lastGlue)).$lastElement;
+        } else {
             return implode(is_null($lastGlue) ? $glue : $lastGlue, $pieces);
         }
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -406,6 +406,24 @@ class Str
     }
 
     /**
+     * Join array elements with a glue string except for the last element, which can be joined with an additional glue (the Oxford comma way).
+     *
+     * @param  string  $glue
+     * @param  array  $pieces
+     * @param  string|null  $lastGlue
+     * @return string
+     */
+    public static function implodeForHumans($glue , $pieces, $lastGlue = null)
+    {
+        if(count($pieces) > 2){
+            $lastElement = array_pop($pieces);
+            return implode($glue, $pieces) . (rtrim($glue) . ' ' . ltrim($lastGlue)) . $lastElement;
+        }else{
+            return implode(is_null($lastGlue) ? $glue : $lastGlue, $pieces);
+        }
+    }
+
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -417,6 +417,7 @@ class Str
     {
         if (count($pieces) > 2) {
             $lastElement = array_pop($pieces);
+            
             return implode($glue, $pieces).(rtrim($glue).' '.ltrim($lastGlue)).$lastElement;
         } else {
             return implode(is_null($lastGlue) ? $glue : $lastGlue, $pieces);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -286,6 +286,20 @@ class SupportStrTest extends TestCase
         $this->assertSame('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
+    public function testImplodeForHumans()
+    {
+        $this->assertSame('', Str::implodeForHumans(', ', []));
+        $this->assertSame('cats', Str::implodeForHumans(', ', ['cats']));
+        $this->assertSame('cats, dogs', Str::implodeForHumans(', ', ['cats', 'dogs']));
+        $this->assertSame('cats, dogs, cows', Str::implodeForHumans(', ', ['cats', 'dogs', 'cows']));
+        $this->assertSame('', Str::implodeForHumans(', ', [], ' and '));
+        $this->assertSame('cats', Str::implodeForHumans(', ', ['cats'], ' and '));
+        $this->assertSame('cats and dogs', Str::implodeForHumans(', ', ['cats', 'dogs'], ' and '));
+        $this->assertSame('cats, dogs, and cows', Str::implodeForHumans(', ', ['cats', 'dogs', 'cows'], ' and '));
+        // Test for multibyte string support
+        $this->assertSame('Malmö, Jönköping, or Klaus', Str::implodeForHumans(', ', ['Malmö', 'Jönköping', 'Klaus'], ' or '));
+    }
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));


### PR DESCRIPTION
This PR adds an implodeForHumans method to the string helper, Str, class.

The method can be a drop-in replacement for implode() and will act the same way if the last parameter is not passed, which means it can easily be swapped in and out without breaking your code.

It follows the "Oxford comma" way of treating the coordinating conjunction (usually 'and' or 'or'). This method can be very useful when trying to make human-readable error messages from an array of words or sentences.

**Examples:**
```
Str::implodeForHumans(', ', ['cats'], ' and ');
// cats

Str::implodeForHumans(', ', ['cats', 'dogs'], ' and ');
// cats and dogs

Str::implodeForHumans(', ', ['cats', 'dogs', 'cows'], ' and ');
// cats, dogs, and cows

Str::implodeForHumans(', ', ['cats', 'dogs']);
// cats, dogs
```

The PR includes a test method (testImplodeForHumans) that tests most of the possible cases.