### PR TITLE
[7.x] Add existsOr and doesntExistOr to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2421,7 +2421,7 @@ class Builder
      * Execute the given callback if rows exist for the current query.
      *
      * @param  \Closure $callback
-     * @return bool|mixed
+     * @return mixed
      */
     public function doesntExistOr(Closure $callback)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2376,16 +2376,13 @@ class Builder
     /**
      * Determine if any rows exist for the current query.
      *
-     * @param  \Closure $callback
-     * @return bool|mixed
+     * @return bool
      */
-    public function exists(Closure $callback = null)
+    public function exists()
     {
         $results = $this->connection->select(
             $this->grammar->compileExists($this), $this->getBindings(), ! $this->useWritePdo
         );
-
-        $exists = false;
 
         // If the results has rows, we will get the row and see if the exists column is a
         // boolean true. If there is no results for this query we will return false as
@@ -2393,23 +2390,42 @@ class Builder
         if (isset($results[0])) {
             $results = (array) $results[0];
 
-            $exists = (bool) $results['exists'];
+            return (bool) $results['exists'];
         }
 
-        return $exists && $callback ? $callback() : $exists;
+        return false;
     }
 
     /**
      * Determine if no rows exist for the current query.
      *
+     * @return bool
+     */
+    public function doesntExist()
+    {
+        return ! $this->exists();
+    }
+
+    /**
+     * Execute the given callback if no rows exist for the current query.
+     *
+     * @param  \Closure $callback
+     * @return mixed
+     */
+    public function existsOr(Closure $callback)
+    {
+        return $this->exists() ? true : $callback();
+    }
+
+    /**
+     * Execute the given callback if rows exist for the current query.
+     *
      * @param  \Closure $callback
      * @return bool|mixed
      */
-    public function doesntExist(Closure $callback = null)
+    public function doesntExistOr(Closure $callback)
     {
-        $doesntExist = ! $this->exists();
-
-        return $doesntExist && $callback ? $callback() : $doesntExist;
+        return $this->doesntExist() ? true : $callback();
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2376,13 +2376,16 @@ class Builder
     /**
      * Determine if any rows exist for the current query.
      *
-     * @return bool
+     * @param  \Closure $callback
+     * @return bool|mixed
      */
-    public function exists()
+    public function exists(Closure $callback = null)
     {
         $results = $this->connection->select(
             $this->grammar->compileExists($this), $this->getBindings(), ! $this->useWritePdo
         );
+
+        $exists = false;
 
         // If the results has rows, we will get the row and see if the exists column is a
         // boolean true. If there is no results for this query we will return false as
@@ -2390,20 +2393,23 @@ class Builder
         if (isset($results[0])) {
             $results = (array) $results[0];
 
-            return (bool) $results['exists'];
+            $exists = (bool) $results['exists'];
         }
 
-        return false;
+        return $exists && $callback ? $callback() : $exists;
     }
 
     /**
      * Determine if no rows exist for the current query.
      *
-     * @return bool
+     * @param  \Closure $callback
+     * @return bool|mixed
      */
-    public function doesntExist()
+    public function doesntExist(Closure $callback = null)
     {
-        return ! $this->exists();
+        $doesntExist = ! $this->exists();
+
+        return $doesntExist && $callback ? $callback() : $doesntExist;
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1825,6 +1825,40 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($results);
     }
 
+    public function testExistsWithCallback()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->exists(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->exists(function () {
+            throw new RuntimeException();
+        });
+        $this->assertFalse($results);
+    }
+
+    public function testDoesntExistsWithCallback()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->doesntExist(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->doesntExist(function () {
+            throw new RuntimeException();
+        });
+        $this->assertFalse($results);
+    }
+
     public function testAggregateResetFollowedByGet()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1825,38 +1825,38 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($results);
     }
 
-    public function testExistsWithCallback()
+    public function testExistsOr()
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
-        $results = $builder->from('users')->exists(function () {
+        $results = $builder->from('users')->doesntExistOr(function () {
             return 123;
         });
         $this->assertSame(123, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
-        $results = $builder->from('users')->exists(function () {
+        $results = $builder->from('users')->doesntExistOr(function () {
             throw new RuntimeException();
         });
-        $this->assertFalse($results);
+        $this->assertTrue($results);
     }
 
-    public function testDoesntExistsWithCallback()
+    public function testDoesntExistsOr()
     {
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
-        $results = $builder->from('users')->doesntExist(function () {
+        $results = $builder->from('users')->existsOr(function () {
             return 123;
         });
         $this->assertSame(123, $results);
 
         $builder = $this->getBuilder();
         $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
-        $results = $builder->from('users')->doesntExist(function () {
+        $results = $builder->from('users')->existsOr(function () {
             throw new RuntimeException();
         });
-        $this->assertFalse($results);
+        $this->assertTrue($results);
     }
 
     public function testAggregateResetFollowedByGet()


### PR DESCRIPTION
In my controllers, I often use something like this to validate requests:
```php
$hasOpenDossier = $user->dossiers()
    ->whereNull('closed_at')
    ->exists();

if ($hasOpenDossier) {
    abort(422, 'User already has an open dossier');
}
```

With this PR, I can do this instead:
```php
$user->dossiers()
    ->whereNull('closed_at')
    ->doesntExistOr(function () {
        abort(422, 'User already has an open dossier');
    });
````

This way I don't have to create a temporary variable, and the code is more logically grouped together (which is especially nice in more complex projects where you can have three of these checks in a row). 

I would almost always use this feature for aborting. It could also be used for other things, but to be honest I can't really think of any. (maybe adding a `doesntExistOrAbort` macro to my projects would be a better solution).

---

An alternative to adding two new methods is adding an optional `$callback` argument to the `exists()` and `doesntExist()` methods. I think adding two new methods is a cleaner way of doing it, mainly because it keeps the parameters and return type of `exists()` and `doesntExist()` simple.
