### PR TITLE
[6.x] Prevent event override when running make:event

### DIFF
--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -35,7 +35,7 @@ class EventMakeCommand extends GeneratorCommand
      */
     protected function alreadyExists($rawName)
     {
-        return class_exists($rawName);
+        return class_exists($this->qualifyClass($rawName));
     }
 
     /**


### PR DESCRIPTION
Events are being overwritten every time you run the php artisan make:event command with the same name (related to #30468).

### Recreating the issue
1. Install Laravel
2. Run the command `php artisan make:event SomeRandomEvent` and make some changes to the `App\Events\SomeRandomEvent` class
3. Run the command `php artisan make:event SomeRandomEvent` again and the previously generated event will be overwritten.

### The problem
Laravel is using only the event name, in this case `SomeRandomEvent`, to check if the event class already exists, when it should use the fully qualified class name `App\Events\SomeRandomEvent`.
