### PR TITLE
[6.x] Allow TransformsRequest middlewares to update keys as well

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -91,7 +91,7 @@ class TransformsRequest
         return $this->transform($key, $value);
     }
 
-     /**
+    /**
      * Transform the given key.
      *
      * @param  string  $key

--- a/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php
@@ -58,9 +58,21 @@ class TransformsRequest
      */
     protected function cleanArray(array $data, $keyPrefix = '')
     {
-        return collect($data)->map(function ($value, $key) use ($keyPrefix) {
-            return $this->cleanValue($keyPrefix.$key, $value);
+        return collect($data)->mapWithKeys(function ($value, $key) use ($keyPrefix) {
+            return [$this->cleanKey($key, $keyPrefix) => $this->cleanValue($keyPrefix.$key, $value)];
         })->all();
+    }
+
+    /**
+     * Clean the given key.
+     *
+     * @param  string  $key
+     * @param  string  $keyPrefix
+     * @return mixed
+     */
+    protected function cleanKey($key, $keyPrefix = '')
+    {
+        return $this->transformKey($key, $keyPrefix);
     }
 
     /**
@@ -77,6 +89,18 @@ class TransformsRequest
         }
 
         return $this->transform($key, $value);
+    }
+
+     /**
+     * Transform the given key.
+     *
+     * @param  string  $key
+     * @param  string  $keyPrefix
+     * @return string
+     */
+    protected function transformKey($key, $keyPrefix = '')
+    {
+        return $key;
     }
 
     /**

--- a/tests/Foundation/Http/Middleware/TransformsRequestTest.php
+++ b/tests/Foundation/Http/Middleware/TransformsRequestTest.php
@@ -10,6 +10,23 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class TransformsRequestTest extends TestCase
 {
+    public function testTransformKeyOncePerKeyWhenMethodIsGet()
+    {
+        $middleware = new TruncateKey;
+        $symfonyRequest = new SymfonyRequest([
+            '123' => 'bar',
+            'abc' => 'baz',
+        ]);
+        $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
+        $request = Request::createFromBase($symfonyRequest);
+
+        $middleware->handle($request, function (Request $request) {
+            $this->assertSame('bar', $request->get('12'));
+            $this->assertSame('baz', $request->get('ab'));
+            $this->assertNull($request->get('123'));
+        });
+    }
+
     public function testTransformOncePerKeyWhenMethodIsGet()
     {
         $middleware = new TruncateInput;
@@ -131,5 +148,13 @@ class TruncateInput extends TransformsRequest
     protected function transform($key, $value)
     {
         return substr($value, 0, -1);
+    }
+}
+
+class TruncateKey extends TransformsRequest
+{
+    protected function transformKey($key)
+    {
+        return substr($key, 0, -1);
     }
 }


### PR DESCRIPTION
Middlewares like TrimStrings only change values but that kind of middleware could also want to change keys like encode/decode keys to prevent bots to validate the form.
This PR is just to allow that possibility.
