### PR TITLE
[7.x] Allow multiple items for Collection::push

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -806,14 +806,16 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Push an item onto the end of the collection.
+     * Push one or more items onto the end of the collection.
      *
-     * @param  mixed  $value
+     * @param  mixed  $values [optional]
      * @return $this
      */
-    public function push($value)
+    public function push(...$values)
     {
-        $this->items[] = $value;
+        foreach ($values as $value) {
+            $this->items[] = $value;
+        }
 
         return $this;
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2836,6 +2836,51 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $c->prepend(0, 'zero')->all());
     }
 
+    public function testPushWithOneItem()
+    {
+        $expected = [
+            0 => 4,
+            1 => 5,
+            2 => 6,
+            3 => ['a', 'b', 'c'],
+            4 => ['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe'],
+            5 => 'Jonny from Laroe',
+        ];
+
+        $data = new Collection([4, 5, 6]);
+        $data->push(['a', 'b', 'c']);
+        $data->push(['who' => 'Jonny', 'preposition' => 'from', 'where' => 'Laroe']);
+        $actual = $data->push('Jonny from Laroe')->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testPushWithMultipleItems()
+    {
+        $expected = [
+            0 => 4,
+            1 => 5,
+            2 => 6,
+            3 => 'Jonny',
+            4 => 'from',
+            5 => 'Laroe',
+            6 => 'Jonny',
+            7 => 'from',
+            8 => 'Laroe',
+            9 => 'a',
+            10 => 'b',
+            11 => 'c',
+        ];
+
+        $data = new Collection([4, 5, 6]);
+        $data->push('Jonny', 'from', 'Laroe');
+        $data->push(...[11 => 'Jonny', 12 => 'from', 13 => 'Laroe']);
+        $data->push(...collect(['a', 'b', 'c']));
+        $actual = $data->push(...[])->toArray();
+
+        $this->assertSame($expected, $actual);
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR aligns the `Collection::push()` method to the `array_push()`-function.

[array_push()](https://www.php.net/manual/en/function.array-push.php) allows 0 or more (1 or more before PHP7.3) parameters as values to push to the referenced array, while Collection::push() allows only exactly one value.

The similar method `Collection::concat()` does return a new instance instead of modifying the original collection.

---
Existing implementations work the same way as before:
```php
$collection->push(5);
$collection->push('string')
$collection->push(['a', 'b', 'c'])
$collection->push(['x' => 'a', 'y' => 'b', 'z' => 'c'])
```

But additionally, we support now:
```php
// push multiple items as parameters
$collection->push($item, $anotherItem, $thirdItem);

// push multiple items from array
$collection->push(...$itemsArray);

// we can even pass another collection without ->toArray()
$collection->push(...$itemsCollection);

// and our push can be empty as well
$collection->push();
$collection->push(...[]);
```
