### PR TITLE
[6.x] - Array deep helper function

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -120,11 +120,12 @@ class Arr
 
         return $results;
     }
+
     /**
-     * Flatten a multi-dimensional associative array with custom deparator.
+     * Flatten a multi-dimensional associative array with custom separator.
      *
      * @param  array   $array
-     * @param  array   $separator
+     * @param  string   $separator
      * @return array
      */
     public static function deepFlatten($array, $separator = '.')

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -120,6 +120,27 @@ class Arr
 
         return $results;
     }
+    /**
+     * Flatten a multi-dimensional associative array with custom deparator.
+     *
+     * @param  array   $array
+     * @param  array   $separator
+     * @return array
+     */
+    public static function deepFlatten($array, $separator = '.')
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) && ! empty($value)) {
+                $results = array_merge($results, static::deepFlatten($value, $key.$separator));
+            } else {
+                $results[$key] = $value;
+            }
+        }
+
+        return $results;
+    }
 
     /**
      * Get all of the given array except for a specified array of keys.

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,6 +113,30 @@ class SupportArrTest extends TestCase
         $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
     }
 
+    public function testDeepFlatten()
+    {
+        $array = Arr::deepFlatten(['foo' => ['bar' => 'baz']]);
+        $this->assertEquals(['foo.bar' => 'baz'], $array);
+
+        $array = Arr::deepFlatten([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::deepFlatten(['foo' => []]);
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::deepFlatten(['foo' => ['bar' => []]]);
+        $this->assertEquals(['foo.bar' => []], $array);
+
+        $array = Arr::deepFlatten(['foo' => ['bar' => []]], '/');
+        $this->assertEquals(['foo/bar' => []], $array);
+
+        $array = Arr::deepFlatten(['name' => 'taylor', 'languages' => ['php' => true]]);
+        $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
+
+        $array = Arr::deepFlatten(['name' => 'taylor', 'languages' => ['php' => true]], '_');
+        $this->assertEquals($array, ['name' => 'taylor', 'languages_php' => true]);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];


### PR DESCRIPTION
This PR aligns the Arr::deepFlaten().

Arr::dot() allows flatten using always "." separator.
The name is very linked with "dot", so a new function was created by changing only the separator

```
use \Illuminate\Support\Arr;

Arr::deepFlaten(['directory1' => ['subdiretory' => 'value'], 'directory2' => 'values'], '/');

/**
*   Will return 
*   [ 
*       'directory1/subdiretory' => 'value',  
*       'directory2' =>  'values'
*    ]
*/
```