### PR TITLE
[6.x] Added new @blank and @endblank Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -179,6 +179,27 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the blank statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileBlank($expression)
+    {
+        return "<?php if(blank{$expression}): ?>";
+    }
+
+    /**
+     * Compile the end-blank statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndBlank()
+    {
+        return "<?php endif; ?>";
+    }
+
+    /**
      * Compile the switch statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -196,7 +196,7 @@ trait CompilesConditionals
      */
     protected function compileEndBlank()
     {
-        return "<?php endif; ?>";
+        return '<?php endif; ?>';
     }
 
     /**

--- a/tests/View/Blade/BladeIfBlankStatementsTest.php
+++ b/tests/View/Blade/BladeIfBlankStatementsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeIfBlankStatementsTest extends AbstractBladeTestCase
+{
+    public function testIfStatementsAreCompiled()
+    {
+        $string = '@blank($test)
+breeze
+@endblank';
+        $expected = '<?php if(blank($test)): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds 2 new if-like Blade directives, utilising the `blank()` function.

I recently had to use the `blank()` function inside of an if statement, figured it would make code a bit cleaner if there was a separate directive for the function.

I also created a new test for this directive, inline with the already existing BladeIf{*}StatementsTest files.
