### PR TITLE
[7.x] Revert comment change for increments() method

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -539,7 +539,7 @@ class Blueprint
     }
 
     /**
-     * Create a new auto-incrementing big integer (8-byte) column on the table.
+     * Create a new auto-incrementing integer (4-byte) column on the table.
      *
      * @param  string  $column
      * @return \Illuminate\Database\Schema\ColumnDefinition


### PR DESCRIPTION
I think the comment was inadvertently changed in a0c73f0c5dab7a8a943ad57297dbdfec34e89b48