### PR TITLE
[6.x] Added `unless` condition to Blade custom `if` directives

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -435,6 +435,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
+        $this->directive('unless'.$name, function ($expression) use ($name) {
+            return $expression !== ''
+                ? "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
+                : "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
+        });
+
         $this->directive('else'.$name, function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -127,6 +127,19 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testCustomUnlessConditions()
+    {
+        $this->compiler->if('custom', function ($anything) {
+            return true;
+        });
+
+        $string = '@unlesscustom($user)
+@endcustom';
+        $expected = '<?php if (! \Illuminate\Support\Facades\Blade::check(\'custom\', $user)): ?>
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testCustomConditionsAccepts0AsArgument()
     {
         $this->compiler->if('custom', function ($number) {


### PR DESCRIPTION
The `Blade::if()` method currently automatically registers the following directives (using the example "custom" as the `$name` argument):

- `@custom` (positive `if` condition)
- `@elsecustom` (`elseif` condition)
- `@endcustom` (`endif`)

This PR registers an additional `@unlesscustom` directive (a negative `if` condition).

To illustrate, the example in the docs is:

```
@env('local')
    // The application is in the local environment...
@elseenv('testing')
    // The application is in the testing environment...
@else
    // The application is not in the local or testing environment...
@endenv
```

This PR would enable the following:
```
@unlessenv('production')
    // The application is not in the production environment...
@endenv
````

This simple case would otherwise have to be done with an empty first condition, e.g.:
```
@env('production')
@else
    // The application is not in the production environment...
@endenv
````

This feels like a minor non-breaking change, so I've submitted to the 6.x branch. Apologies if I've got this wrong.