### PR TITLE
[6.x] Add existsOr and doesntExistOr to the querybuilder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2407,6 +2407,28 @@ class Builder
     }
 
     /**
+     * Execute the given callback if no rows exist for the current query.
+     *
+     * @param  \Closure $callback
+     * @return mixed
+     */
+    public function existsOr(Closure $callback)
+    {
+        return $this->exists() ? true : $callback();
+    }
+
+    /**
+     * Execute the given callback if rows exist for the current query.
+     *
+     * @param  \Closure $callback
+     * @return mixed
+     */
+    public function doesntExistOr(Closure $callback)
+    {
+        return $this->doesntExist() ? true : $callback();
+    }
+
+    /**
      * Retrieve the "count" result of the query.
      *
      * @param  string  $columns

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1825,6 +1825,38 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertTrue($results);
     }
 
+    public function testExistsOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->doesntExistOr(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->doesntExistOr(function () {
+            throw new RuntimeException();
+        });
+        $this->assertTrue($results);
+    }
+
+    public function testDoesntExistsOr()
+    {
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 0]]);
+        $results = $builder->from('users')->existsOr(function () {
+            return 123;
+        });
+        $this->assertSame(123, $results);
+        $builder = $this->getBuilder();
+        $builder->getConnection()->shouldReceive('select')->andReturn([['exists' => 1]]);
+        $results = $builder->from('users')->existsOr(function () {
+            throw new RuntimeException();
+        });
+        $this->assertTrue($results);
+    }
+
     public function testAggregateResetFollowedByGet()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
Resubmit of https://github.com/laravel/framework/pull/30479

In my controllers, I often use something like this to validate requests:
```php
$hasOpenDossier = $user->dossiers()
    ->whereNull('closed_at')
    ->exists();

if ($hasOpenDossier) {
    abort(422, 'User already has an open dossier');
}
```

With this PR, I can do this instead:
```php
$user->dossiers()
    ->whereNull('closed_at')
    ->doesntExistOr(function () {
        abort(422, 'User already has an open dossier');
    });
````

This way I don't have to create a temporary variable, and the code is more logically grouped together (which is especially nice in more complex projects where you can have three of these checks in a row). 

I would almost always use this feature for aborting. It could also be used for other things, but to be honest I can't really think of any. (maybe adding a `doesntExistOrAbort` macro to my projects would be a better solution).

---

An alternative to adding two new methods is adding an optional `$callback` argument to the `exists()` and `doesntExist()` methods. I think adding two new methods is a cleaner way of doing it, mainly because it keeps the parameters and return type of `exists()` and `doesntExist()` simple.
