### PR TITLE
[7.x] Improve tests for Blueprint foreignId()

### DIFF
--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -414,7 +414,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrain();
+        $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -319,7 +319,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrain();
+        $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -317,11 +318,18 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testAddingForeignID()
     {
         $blueprint = new Blueprint('users');
-        $blueprint->foreignId('foo');
+        $foreignId = $blueprint->foreignId('foo');
+        $blueprint->foreignId('company_id')->constrain();
+        $blueprint->foreignId('team_id')->references('id')->on('teams');
+
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(1, $statements);
-        $this->assertSame('alter table "users" add column "foo" bigint not null', $statements[0]);
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table "users" add column "foo" bigint not null, add column "company_id" bigint not null, add column "team_id" bigint not null',
+            'alter table "users" add constraint "users_company_id_foreign" foreign key ("company_id") references "companies" ("id")',
+            'alter table "users" add constraint "users_team_id_foreign" foreign key ("team_id") references "teams" ("id")',
+        ], $statements);
     }
 
     public function testAddingBigIncrementingID()

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -303,7 +303,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrain();
+        $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -318,7 +318,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     {
         $blueprint = new Blueprint('users');
         $foreignId = $blueprint->foreignId('foo');
-        $blueprint->foreignId('company_id')->constrain();
+        $blueprint->foreignId('company_id')->constrained();
         $blueprint->foreignId('team_id')->references('id')->on('teams');
 
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());


### PR DESCRIPTION
This improves the tests that I just wrote in #30489 to make sure `->foreignId()` can be chained [as shown](https://twitter.com/taylorotwell/status/1189977857243660288) and generate the correct schema.

```php
$table->foreignId('company_id')->constrained();
$table->foreignId('team_id')->references('id')->on('teams');
```