### PR TITLE
[6.x] $key could be null in Arr::get()

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -275,7 +275,7 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int  $key
+     * @param  string|int|null  $key
      * @param  mixed   $default
      * @return mixed
      */


### PR DESCRIPTION
...as it is checked by `isnull()`
