### PR TITLE
[7.x] Add option to seed refreshed test database

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseMigrations.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Contracts\Console\Kernel;
-
 trait DatabaseMigrations
 {
+    use MigratesDatabase;
+
     /**
      * Define hooks to migrate the database before and after each test.
      *
@@ -13,9 +13,7 @@ trait DatabaseMigrations
      */
     public function runDatabaseMigrations()
     {
-        $this->artisan('migrate:fresh');
-
-        $this->app[Kernel::class]->setArtisan(null);
+        $this->migrateTestDatabase();
 
         $this->beforeApplicationDestroyed(function () {
             $this->artisan('migrate:rollback');

--- a/src/Illuminate/Foundation/Testing/MigratesDatabase.php
+++ b/src/Illuminate/Foundation/Testing/MigratesDatabase.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait MigratesDatabase
+{
+    /**
+     * Refresh the database using a fresh migration.
+     *
+     * @return void
+     */
+    protected function migrateTestDatabase()
+    {
+        $this->artisan('migrate:fresh', [
+            '--drop-views' => $this->shouldDropViews(),
+            '--drop-types' => $this->shouldDropTypes(),
+        ]);
+
+        if ($this->shouldSeed()) {
+            $this->seedTestDatabase();
+        }
+
+        $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    /**
+     * Determine if views should be dropped when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldDropViews()
+    {
+        return $this->dropViews ?? false;
+    }
+
+    /**
+     * Determine if types should be dropped when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldDropTypes()
+    {
+        return $this->dropTypes ?? false;
+    }
+
+    /**
+     * Determine if database should be seeded when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldSeed()
+    {
+        return property_exists($this, 'seed')
+            ? $this->seed : property_exists($this, 'seeder');
+    }
+
+    /**
+     * Seed the database for testing.
+     *
+     * @return void
+     */
+    protected function seedTestDatabase()
+    {
+        $this->seed($this->seeder ?? null);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Illuminate\Contracts\Console\Kernel;
-
 trait RefreshDatabase
 {
+    use MigratesDatabase;
+
     /**
      * Define hooks to migrate the database before and after each test.
      *
@@ -37,9 +37,7 @@ trait RefreshDatabase
      */
     protected function refreshInMemoryDatabase()
     {
-        $this->artisan('migrate');
-
-        $this->app[Kernel::class]->setArtisan(null);
+        $this->migrateTestDatabase();
     }
 
     /**
@@ -50,12 +48,7 @@ trait RefreshDatabase
     protected function refreshTestDatabase()
     {
         if (! RefreshDatabaseState::$migrated) {
-            $this->artisan('migrate:fresh', [
-                '--drop-views' => $this->shouldDropViews(),
-                '--drop-types' => $this->shouldDropTypes(),
-            ]);
-
-            $this->app[Kernel::class]->setArtisan(null);
+            $this->migrateTestDatabase();
 
             RefreshDatabaseState::$migrated = true;
         }
@@ -103,27 +96,5 @@ trait RefreshDatabase
     {
         return property_exists($this, 'connectionsToTransact')
                             ? $this->connectionsToTransact : [null];
-    }
-
-    /**
-     * Determine if views should be dropped when refreshing the database.
-     *
-     * @return bool
-     */
-    protected function shouldDropViews()
-    {
-        return property_exists($this, 'dropViews')
-                            ? $this->dropViews : false;
-    }
-
-    /**
-     * Determine if types should be dropped when refreshing the database.
-     *
-     * @return bool
-     */
-    protected function shouldDropTypes()
-    {
-        return property_exists($this, 'dropTypes')
-                            ? $this->dropTypes : false;
     }
 }


### PR DESCRIPTION
This adds an option to the `RefreshDatabase` trait of the `TestCase` class to seed the test database when it is being refreshed.

The current recommended method of doing this is to call `$this->seed()` inside of a `setUp()` method or at the start of a test. However, this seeds the database before each test when it is not strictly necessary. Instead the database could be seeded once immediately after the migration and before the database transaction begins.

Currently we accomplish this by overriding `RefreshDatabase::refreshTestDatabase()`. This requires that we maintain a duplicate of the internal Laravel method and keep up-to-date with any changes that may be made to it.

```php
abstract class TestCase extends \Illuminate\Foundation\Testing\TestCase
{
    use RefreshDatabase;

    protected function refreshTestDatabase()
    {
        if (! RefreshDatabaseState::$migrated) {
            $this->artisan('migrate:fresh', [
                '--drop-views' => $this->shouldDropViews(),
                '--drop-types' => $this->shouldDropTypes(),
            ]);

            // Seed refreshed database
            $this->seed(TestDatabaseSeeder::class);

            $this->app[Kernel::class]->setArtisan(null);

            RefreshDatabaseState::$migrated = true;
        }

        $this->beginDatabaseTransaction();
    }
}
```

With this change, `TestCase` can declare the property `$seed = true` to enable seeding or declare the property `$seeder = DatabaseSeeder::class` to define the seeder class to use.

```php
abstract class TestCase extends \Illuminate\Foundation\Testing\TestCase
{
    use RefreshDatabase;

    protected $seed = true;
    protected $seeder = TestDatabaseSeeder::class;
}
```

This also factors the logic for running the `migrate:fresh` command to a new trait and method `MigratesDatabase::migrateTestDatabase()`. This method is now called by `refreshInMemoryDatabase()`, `refreshTestDatabase()`, and `DatabaseMigrations::runDatabaseMigrations()`. This lets tests using in-memory databases or the `DatabaseMigrations` trait also enjoy the benefit of dropping the views and types while running the migration command and consolidates some repeated code.

`refreshTestDatabase()` and `runDatabaseMigrations()` already called `migrate:fresh` but `runDatabaseMigrations()` did not allow dropping the views and types. `refreshInMemoryDatabase()` previously only ran the `migrate` command, but since each test starts with an empty database anyway, there is no detriment to running `migrate:fresh` instead and it allows the new seeder to run as well before each test.

This is a breaking change that targets the next major release. It will conflict with an existing `TestCase` implementation that defines its own `$seed` or `$seeder` property, and it will conflict will any implementation that extends the affected internal trait methods.

Related to #9845 #12167 #18691 #25756