### PR TITLE
[6.x] Fixed migration's data source configuration does not take effect

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -382,11 +382,24 @@ class Migrator
 
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
+                $defaultConnectionName = $this->resolver->getDefaultConnection();
+
+                // Use connection defined in migration as default connection, as
+                // a result, we can use different data sources when we run the
+                // migration.
+                $this->resolver->setDefaultConnection(
+                    $this->resolveConnectionName(
+                        $migration->getConnection()
+                    )
+                );
+
                 $this->fireMigrationEvent(new MigrationStarted($migration, $method));
 
                 $migration->{$method}();
 
                 $this->fireMigrationEvent(new MigrationEnded($migration, $method));
+
+                $this->resolver->setDefaultConnection($defaultConnectionName);
             }
         };
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -382,16 +382,16 @@ class Migrator
 
         $callback = function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
-                $defaultConnectionName = $this->resolver->getDefaultConnection();
+                if ($runInConnection = $migration->getConnection()) {
+                    $defaultConnectionName = $this->resolver->getDefaultConnection();
 
-                // Use connection defined in migration as default connection, as
-                // a result, we can use different data sources when we run the
-                // migration.
-                $this->resolver->setDefaultConnection(
-                    $this->resolveConnectionName(
+                    // Use connection defined in migration as default connection, as
+                    // a result, we can use different data sources when we run the
+                    // migration.
+                    $this->resolver->setDefaultConnection(
                         $migration->getConnection()
-                    )
-                );
+                    );
+                }
 
                 $this->fireMigrationEvent(new MigrationStarted($migration, $method));
 
@@ -399,7 +399,9 @@ class Migrator
 
                 $this->fireMigrationEvent(new MigrationEnded($migration, $method));
 
-                $this->resolver->setDefaultConnection($defaultConnectionName);
+                if (isset($defaultConnectionName)) {
+                    $this->resolver->setDefaultConnection($defaultConnectionName);
+                }
             }
         };
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -538,6 +538,17 @@ class Migrator
     }
 
     /**
+     * Resolve the database connection name.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function resolveConnectionName($connection)
+    {
+        return $connection ?: $this->connection;
+    }
+
+    /**
      * Resolve the database connection instance.
      *
      * @param  string  $connection
@@ -545,7 +556,9 @@ class Migrator
      */
     public function resolveConnection($connection)
     {
-        return $this->resolver->connection($connection ?: $this->connection);
+        return $this->resolver->connection(
+            $this->resolveConnectionName($connection)
+        );
     }
 
     /**


### PR DESCRIPTION
When we use statement like `Schema::create` in Migration, the connection property defined in Migration do not take effect. This is because Schema uses the default data connection. This pull request makes Migration as it describes it.

```php
<?php

namespace Illuminate\Database\Migrations;

abstract class Migration
{
    /**
     * The name of the database connection to use.
     *
     * @var string|null
     */
    protected $connection;

    // ...

    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('users', function (Blueprint $table) {
            // ...
        });
    }
}
```