### PR TITLE
[6.x] Removing non-existing AbstractCache parent class

### DIFF
--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -3,9 +3,8 @@
 namespace Illuminate\Filesystem;
 
 use Illuminate\Contracts\Cache\Repository;
-use League\Flysystem\Cached\Storage\AbstractCache;
 
-class Cache extends AbstractCache
+class Cache
 {
     /**
      * The cache repository implementation.


### PR DESCRIPTION
I was mapping all Laravel files for some reasons and I encountered a class extending non-existing class. It was `Illuminate\Filesystem\Cache` trying to extend `League\Flysystem\Cached\Storage\AbstractCache`. 

I checked League's Flysystem and there's no file like that at least from version 1.0.0-alpha1 (June 2015). Laravel is requiring `"league/flysystem": "^1.0.8"`, so this inheritance is impossible.

I allowed myself to remove it from the `Cache` class.