### PR TITLE
Str::afterLast() and Str::beforeLast() helpers

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v6.4.1...6.x)
 
+### Added
+- Added `LazyCollection::remember()` method ([#30443](https://github.com/laravel/framework/pull/30443))
+
+### Changed
+- Added reconnect if missing connection when beginning transaction ([#30474](https://github.com/laravel/framework/pull/30474))
+
+### TODO
+- Set Redis cluster prefix with PhpRedis ([#30461](https://github.com/laravel/framework/pull/30461))
+- Added `unless` condition to Blade custom `if` directives ([#30492](https://github.com/laravel/framework/pull/30492))
+
 
 ## [v6.4.1 (2019-10-29)](https://github.com/laravel/framework/compare/v6.4.0...v6.4.1)
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -275,7 +275,7 @@ class Arr
      * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
-     * @param  string|int  $key
+     * @param  string|int|null  $key
      * @param  mixed   $default
      * @return mixed
      */

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -42,7 +42,7 @@ class Str
     protected static $uuidFactory;
 
     /**
-     * Return the remainder of a string after a given value.
+     * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
@@ -51,6 +51,18 @@ class Str
     public static function after($subject, $search)
     {
         return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+    }
+
+    /**
+     * Return the remainder of a string after the last occurrence of a  given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function afterLast($subject, $search)
+    {
+        return $search === '' ? $subject : array_reverse(explode($search, $subject))[0];
     }
 
     /**
@@ -66,7 +78,7 @@ class Str
     }
 
     /**
-     * Get the portion of a string before a given value.
+     * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
@@ -75,6 +87,27 @@ class Str
     public static function before($subject, $search)
     {
         return $search === '' ? $subject : explode($search, $subject)[0];
+    }
+
+    /**
+     * Get the portion of a string before the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function beforeLast($subject, $search)
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $rpos = mb_strrpos($subject, $search);
+        if ($rpos === false) {
+            return $subject;
+        }
+
+        return static::substr($subject, 0, $rpos);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -435,6 +435,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
+        $this->directive('unless'.$name, function ($expression) use ($name) {
+            return $expression !== ''
+                ? "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
+                : "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
+        });
+
         $this->directive('else'.$name, function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -114,6 +114,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han2nah', 2));
     }
 
+    public function testStrBeforeLast()
+    {
+        $this->assertSame('yve', Str::beforeLast('yvette', 'tte'));
+        $this->assertSame('yvet', Str::beforeLast('yvette', 't'));
+        $this->assertSame('ééé ', Str::beforeLast('ééé yvette', 'yve'));
+        $this->assertSame('', Str::beforeLast('yvette', 'yve'));
+        $this->assertSame('yvette', Str::beforeLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', Str::beforeLast('yvette', ''));
+        $this->assertSame('yv0et', Str::beforeLast('yv0et0te', '0'));
+        $this->assertSame('yv0et', Str::beforeLast('yv0et0te', 0));
+        $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));
@@ -124,6 +137,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('nah', Str::after('han0nah', '0'));
         $this->assertSame('nah', Str::after('han0nah', 0));
         $this->assertSame('nah', Str::after('han2nah', 2));
+    }
+
+    public function testStrAfterLast()
+    {
+        $this->assertSame('tte', Str::afterLast('yvette', 'yve'));
+        $this->assertSame('e', Str::afterLast('yvette', 't'));
+        $this->assertSame('e', Str::afterLast('ééé yvette', 't'));
+        $this->assertSame('', Str::afterLast('yvette', 'tte'));
+        $this->assertSame('yvette', Str::afterLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', Str::afterLast('yvette', ''));
+        $this->assertSame('te', Str::afterLast('yv0et0te', '0'));
+        $this->assertSame('te', Str::afterLast('yv0et0te', 0));
+        $this->assertSame('te', Str::afterLast('yv2et2te', 2));
     }
 
     public function testStrContains()

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -127,6 +127,19 @@ class BladeCustomTest extends AbstractBladeTestCase
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testCustomUnlessConditions()
+    {
+        $this->compiler->if('custom', function ($anything) {
+            return true;
+        });
+
+        $string = '@unlesscustom($user)
+@endcustom';
+        $expected = '<?php if (! \Illuminate\Support\Facades\Blade::check(\'custom\', $user)): ?>
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testCustomConditionsAccepts0AsArgument()
     {
         $this->compiler->if('custom', function ($number) {


### PR DESCRIPTION
This PR adds `afterLast()` and `beforeLast()` to the `Str` helper.

These are useful in many situations, recently I have used it to find the `type` in database notifications, where morph maps cannot be used:

```php
$type = 'App\Notifications\Tasks\TaskUpdated';
Str::afterLast($type, '\\'); // TaskUpdated
```

and to get the full file name (minus extension) when there are `.` in the filename. This is useful when processing many file paths from external services (s3) where loading each file is too slow.

```php
$filename = 'photo.2019.11.04.jpg';
Str::beforeLast($filename, '.'); // photo.2019.11.04
```

Note: PR #28218 added these functions with a case insensitive flag.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
