### PR TITLE
[6.x] Str::afterLast() and Str::beforeLast() helpers

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -111,12 +111,13 @@ class Str
             return $subject;
         }
 
-        $rpos = mb_strrpos($subject, $search);
-        if ($rpos === false) {
+        $pos = mb_strrpos($subject, $search);
+
+        if ($pos === false) {
             return $subject;
         }
 
-        return static::substr($subject, 0, $rpos);
+        return static::substr($subject, 0, $pos);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -41,7 +41,7 @@ class Str
     protected static $uuidFactory;
 
     /**
-     * Return the remainder of a string after a given value.
+     * Return the remainder of a string after the first occurrence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
@@ -50,6 +50,18 @@ class Str
     public static function after($subject, $search)
     {
         return $search === '' ? $subject : array_reverse(explode($search, $subject, 2))[0];
+    }
+
+    /**
+     * Return the remainder of a string after the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function afterLast($subject, $search)
+    {
+        return $search === '' ? $subject : array_reverse(explode($search, $subject))[0];
     }
 
     /**
@@ -75,7 +87,7 @@ class Str
     }
 
     /**
-     * Get the portion of a string before a given value.
+     * Get the portion of a string before the first occurrence of a given value.
      *
      * @param  string  $subject
      * @param  string  $search
@@ -84,6 +96,27 @@ class Str
     public static function before($subject, $search)
     {
         return $search === '' ? $subject : explode($search, $subject)[0];
+    }
+
+    /**
+     * Get the portion of a string before the last occurrence of a given value.
+     *
+     * @param  string  $subject
+     * @param  string  $search
+     * @return string
+     */
+    public static function beforeLast($subject, $search)
+    {
+        if ($search === '') {
+            return $subject;
+        }
+
+        $rpos = mb_strrpos($subject, $search);
+        if ($rpos === false) {
+            return $subject;
+        }
+
+        return static::substr($subject, 0, $rpos);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -106,6 +106,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('han', Str::before('han2nah', 2));
     }
 
+    public function testStrBeforeLast()
+    {
+        $this->assertSame('yve', Str::beforeLast('yvette', 'tte'));
+        $this->assertSame('yvet', Str::beforeLast('yvette', 't'));
+        $this->assertSame('ééé ', Str::beforeLast('ééé yvette', 'yve'));
+        $this->assertSame('', Str::beforeLast('yvette', 'yve'));
+        $this->assertSame('yvette', Str::beforeLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', Str::beforeLast('yvette', ''));
+        $this->assertSame('yv0et', Str::beforeLast('yv0et0te', '0'));
+        $this->assertSame('yv0et', Str::beforeLast('yv0et0te', 0));
+        $this->assertSame('yv2et', Str::beforeLast('yv2et2te', 2));
+    }
+
     public function testStrAfter()
     {
         $this->assertSame('nah', Str::after('hannah', 'han'));
@@ -116,6 +129,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('nah', Str::after('han0nah', '0'));
         $this->assertSame('nah', Str::after('han0nah', 0));
         $this->assertSame('nah', Str::after('han2nah', 2));
+    }
+
+    public function testStrAfterLast()
+    {
+        $this->assertSame('tte', Str::afterLast('yvette', 'yve'));
+        $this->assertSame('e', Str::afterLast('yvette', 't'));
+        $this->assertSame('e', Str::afterLast('ééé yvette', 't'));
+        $this->assertSame('', Str::afterLast('yvette', 'tte'));
+        $this->assertSame('yvette', Str::afterLast('yvette', 'xxxx'));
+        $this->assertSame('yvette', Str::afterLast('yvette', ''));
+        $this->assertSame('te', Str::afterLast('yv0et0te', '0'));
+        $this->assertSame('te', Str::afterLast('yv0et0te', 0));
+        $this->assertSame('te', Str::afterLast('yv2et2te', 2));
     }
 
     public function testStrContains()


### PR DESCRIPTION
This PR adds `afterLast()` and `beforeLast()` to the `Str` helper.

These are useful in many situations, recently I have used it to find the `type` in database notifications, where morph maps cannot be used:

```php
$type = 'App\Notifications\Tasks\TaskUpdated';
Str::afterLast($type, '\\'); // TaskUpdated
```

and to get the full file name (minus extension) when there are `.` in the filename. This is useful when processing many file paths from external services (s3) where loading each file is too slow.

```php
$filename = 'photo.2019.11.04.jpg';
Str::beforeLast($filename, '.'); // photo.2019.11.04
```

Note: PR #28218 added these functions with a case insensitive flag.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
