### PR TITLE
[6.x] Unset relations on models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -795,6 +795,18 @@ trait HasRelationships
     }
 
     /**
+     * Unset all relations on the model.
+     *
+     * @return $this
+     */
+    public function unsetRelations()
+    {
+        $this->relations = [];
+
+        return $this;
+    }
+
+    /**
      * Get the relationships that are touched on save.
      *
      * @return array

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -37,6 +37,17 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertFalse($parent->relationLoaded('foo'));
     }
 
+    public function testUnsetExistingRelations()
+    {
+        $parent = new EloquentRelationResetModelStub;
+        $relation = new EloquentRelationResetModelStub;
+        $parent->setRelation('foo', $relation);
+        $parent->setRelation('bar', $relation);
+        $parent->unsetRelations();
+        $this->assertFalse($parent->relationLoaded('foo'));
+        $this->assertFalse($parent->relationLoaded('bar'));
+    }
+
     public function testTouchMethodUpdatesRelatedTimestamps()
     {
         $builder = m::mock(Builder::class);


### PR DESCRIPTION
This PR adds an unset relations method. 

Recently, I had a use case where I had to unset relations before saving. I had three relations and I had to unset each one manually using the `$model->unsetRelation($relation)` method. I had to do something like:

```php
$blog->unsetRelation('comments');
$blog->unsetRelation('user');
$blog->unsetRelation('category');
```

I thought it would be wonderful for convenience to have a `$model->unsetRelations()` method. So the above code would be reduced to:

```php
$blog->unsetRelations();
```

This PR includes the method and a small unit test to verify the relations have been unset. I believe that this is a minor feature that is fully backwards compatible as the method doesn't currently exist.

Comments welcome :)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
