### PR TITLE
[6.x] Fix Request route() method PHPDoc null return type

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -522,7 +522,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @param  string|null  $param
      * @param  mixed   $default
-     * @return \Illuminate\Routing\Route|object|string
+     * @return \Illuminate\Routing\Route|object|string|null
      */
     public function route($param = null, $default = null)
     {


### PR DESCRIPTION
This pull request adds a missing `null` return type to the `Request::route()` method PHPDoc since it can return a `null` `$route`.

[Request.php#L531](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Http/Request.php#L531)
```php
if (is_null($route) || is_null($param)) {
    return $route;
}
```