### PR TITLE
[6.x] Remove Container dependency on Illuminate\Support

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -75,7 +75,7 @@ class BoundMethod
     protected static function callBoundMethod($container, $callback, $default)
     {
         if (! is_array($callback)) {
-            return value($default);
+            return Util::unwrapIfClosure($default);
         }
 
         // Here we need to turn the array callable into a Class@method string we can use to
@@ -87,7 +87,7 @@ class BoundMethod
             return $container->callMethodBinding($method, $callback[0]);
         }
 
-        return value($default);
+        return Util::unwrapIfClosure($default);
     }
 
     /**

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -7,7 +7,6 @@ use Closure;
 use Exception;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Container\Container as ContainerContract;
-use Illuminate\Support\Arr;
 use LogicException;
 use ReflectionClass;
 use ReflectionException;
@@ -144,7 +143,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $aliases = [];
 
-        foreach (Arr::wrap($concrete) as $c) {
+        foreach (Util::arrayWrap($concrete) as $c) {
             $aliases[] = $this->getAlias($c);
         }
 

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -4,7 +4,6 @@ namespace Illuminate\Container;
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Container\ContextualBindingBuilder as ContextualBindingBuilderContract;
-use Illuminate\Support\Arr;
 
 class ContextualBindingBuilder implements ContextualBindingBuilderContract
 {
@@ -63,7 +62,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function give($implementation)
     {
-        foreach (Arr::wrap($this->concrete) as $concrete) {
+        foreach (Util::arrayWrap($this->concrete) as $concrete) {
             $this->container->addContextualBinding($concrete, $this->needs, $implementation);
         }
     }

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Container;
+
+// Utility functions pulled from Illuminate\Support to remove the need to pull in all of Support
+// when using the container standalone.
+class Util
+{
+    /**
+     * If the given value is not an array and not null, wrap it in one.
+     *
+     * From Arr::wrap() in Illuminate\Support.
+     *
+     * @param  mixed  $value
+     * @return array
+     */
+    public static function arrayWrap($value)
+    {
+        if (is_null($value)) {
+            return [];
+        }
+
+        return is_array($value) ? $value : [$value];
+    }
+
+    /**
+     * Return the default value of the given value.
+     *
+     * From global value() helper in Illuminate\Support.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public static function unwrapIfClosure($value)
+    {
+        return $value instanceof \Closure ? $value() : $value;
+    }
+}

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Container;
 
-// Utility functions pulled from Illuminate\Support to remove the need to pull in all of Support
-// when using the container standalone.
 class Util
 {
     /**

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -16,7 +16,6 @@
     "require": {
         "php": "^7.2",
         "illuminate/contracts": "^6.0",
-        "illuminate/support": "^6.0",
         "psr/container": "^1.0"
     },
     "autoload": {

--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Tests\Container;
+
+use Illuminate\Container\Util;
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+    public function testUnwrapIfClosure()
+    {
+        $this->assertSame('foo', Util::unwrapIfClosure('foo'));
+        $this->assertSame('foo', UtiL::unwrapIfClosure(function () {
+            return 'foo';
+        }));
+    }
+
+    public function testArrayWrap()
+    {
+        $string = 'a';
+        $array = ['a'];
+        $object = new \stdClass;
+        $object->value = 'a';
+        $this->assertEquals(['a'], Util::arrayWrap($string));
+        $this->assertEquals($array, Util::arrayWrap($array));
+        $this->assertEquals([$object], Util::arrayWrap($object));
+        $this->assertEquals([], Util::arrayWrap(null));
+        $this->assertEquals([null], Util::arrayWrap([null]));
+        $this->assertEquals([null, null], Util::arrayWrap([null, null]));
+        $this->assertEquals([''], Util::arrayWrap(''));
+        $this->assertEquals([''], Util::arrayWrap(['']));
+        $this->assertEquals([false], Util::arrayWrap(false));
+        $this->assertEquals([false], Util::arrayWrap([false]));
+        $this->assertEquals([0], Util::arrayWrap(0));
+
+        $obj = new \stdClass;
+        $obj->value = 'a';
+        $obj = unserialize(serialize($obj));
+        $this->assertEquals([$obj], Util::arrayWrap($obj));
+        $this->assertSame($obj, Util::arrayWrap($obj)[0]);
+    }
+}


### PR DESCRIPTION
For standalone projects, pulling in all of Illuminate\Support is a bit overkill, given that we're using only a couple of functions from the package. This chage opts to duplicate the two helper functions inside the container namespace (so they'll be picked up by a subtree split), which also removes reliance on any custom global functions.

This goes beyond effectively reverting #29959, as the container used Arr::wrap() before adding in the value() helper.

Tests are carbon copies of the equivalent Illuminate\Support tests.