### PR TITLE
[6.x] Add using route name support for redirect after email verification

### DIFF
--- a/src/Illuminate/Foundation/Auth/RedirectsUsers.php
+++ b/src/Illuminate/Foundation/Auth/RedirectsUsers.php
@@ -17,4 +17,18 @@ trait RedirectsUsers
 
         return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
     }
+
+    /**
+     * Get the post register / login redirect route.
+     *
+     * @return string
+     */
+    public function redirectRoute()
+    {
+        if (method_exists($this, 'redirectRoute')) {
+            return $this->redirectRoute();
+        }
+
+        return property_exists($this, 'redirectRoute') ? $this->redirectRoute : false;
+    }
 }

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -11,6 +11,19 @@ trait VerifiesEmails
     use RedirectsUsers;
 
     /**
+     * Redirect to path or route.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function redirect()
+    {
+        if($this->redirectRoute() !== false)
+            return redirect()->route($this->redirectRoute());
+
+        return redirect($this->redirectPath());
+    }
+
+    /**
      * Show the email verification notice.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -19,7 +32,7 @@ trait VerifiesEmails
     public function show(Request $request)
     {
         return $request->user()->hasVerifiedEmail()
-                        ? redirect($this->redirectPath())
+                        ? $this->redirect()
                         : view('auth.verify');
     }
 
@@ -41,14 +54,14 @@ trait VerifiesEmails
         }
 
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return $this->redirect();
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect($this->redirectPath())->with('verified', true);
+        return $this->redirect()->with('verified', true);
     }
 
     /**
@@ -60,7 +73,7 @@ trait VerifiesEmails
     public function resend(Request $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return $this->redirect();
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -17,8 +17,9 @@ trait VerifiesEmails
      */
     public function redirect()
     {
-        if($this->redirectRoute() !== false)
+        if ($this->redirectRoute() !== false) {
             return redirect()->route($this->redirectRoute());
+        }
 
         return redirect($this->redirectPath());
     }


### PR DESCRIPTION
This PR support using route name instead route path for email verification to developers. Now, developers add redirect path hardcoded in to controllers. This way is not make sense. Because route paths is may change but route names is not change. 

I think should be using route name instead route paths.