### PR TITLE
[7.x] Introduce an array session handler

### DIFF
--- a/src/Illuminate/Session/ArraySessionHandler.php
+++ b/src/Illuminate/Session/ArraySessionHandler.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Session;
+
+use Illuminate\Support\InteractsWithTime;
+use SessionHandlerInterface;
+
+class ArraySessionHandler implements SessionHandlerInterface
+{
+    use InteractsWithTime;
+
+    /**
+     * The array of stored values.
+     *
+     * @var array
+     */
+    protected $storage = [];
+
+    /**
+     * The number of minutes the session should be valid.
+     *
+     * @var int
+     */
+    protected $minutes;
+
+    /**
+     * Create a new array driven handler instance.
+     *
+     * @param  int  $minutes
+     * @return void
+     */
+    public function __construct($minutes)
+    {
+        $this->minutes = $minutes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($sessionId)
+    {
+        if (! isset($this->storage[$sessionId])) {
+            return '';
+        }
+
+        $session = $this->storage[$sessionId];
+
+        $expiration = $this->calculateExpiration($this->minutes * 60);
+
+        if (isset($session['time']) && $session['time'] >= $expiration) {
+            return $session['data'];
+        }
+
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($sessionId, $data)
+    {
+        $this->storage[$sessionId] = [
+            'data' => $data,
+            'time' => $this->currentTime(),
+        ];
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function destroy($sessionId)
+    {
+        if (isset($this->storage[$sessionId])) {
+            unset($this->storage[$sessionId]);
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function gc($lifetime)
+    {
+        $expiration = $this->calculateExpiration($lifetime);
+
+        foreach ($this->storage as $sessionId => $session) {
+            if ($session['time'] < $expiration) {
+                unset($this->storage[$sessionId]);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the expiration time of the session.
+     *
+     * @param  int  $seconds
+     * @return int
+     */
+    protected function calculateExpiration($seconds)
+    {
+        return $this->currentTime() - $seconds;
+    }
+}

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -214,6 +214,6 @@ class StartSession
     {
         $config = $config ?: $this->manager->getSessionConfig();
 
-        return ! in_array($config['driver'], [null, 'array']);
+        return ! is_null($config['driver'] ?? null);
     }
 }

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -18,13 +18,25 @@ class SessionManager extends Manager
     }
 
     /**
+     * Create an instance of the "null" session driver.
+     *
+     * @return \Illuminate\Session\Store
+     */
+    protected function createNullDriver()
+    {
+        return $this->buildSession(new NullSessionHandler);
+    }
+
+    /**
      * Create an instance of the "array" session driver.
      *
      * @return \Illuminate\Session\Store
      */
     protected function createArrayDriver()
     {
-        return $this->buildSession(new NullSessionHandler);
+        return $this->buildSession(new ArraySessionHandler(
+            $this->config->get('session.lifetime')
+        ));
     }
 
     /**

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Illuminate\Tests\Session;
+
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+use SessionHandlerInterface;
+
+class ArraySessionHandlerTest extends TestCase
+{
+    public function test_it_implements_the_session_handler_interface()
+    {
+        $this->assertInstanceOf(SessionHandlerInterface::class, new ArraySessionHandler(10));
+    }
+
+    public function test_it_initializes_the_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertTrue($handler->open('', ''));
+    }
+
+    public function test_it_closes_the_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertTrue($handler->close());
+    }
+
+    public function test_it_reads_data_from_the_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $handler->write('foo', 'bar');
+
+        $this->assertEquals('bar', $handler->read('foo'));
+    }
+
+    public function test_it_reads_data_from_an_almost_expired_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $handler->write('foo', 'bar');
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(10));
+        $this->assertEquals('bar', $handler->read('foo'));
+        Carbon::setTestNow();
+    }
+
+    public function test_it_reads_data_from_an_expired_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $handler->write('foo', 'bar');
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
+        $this->assertEquals('', $handler->read('foo'));
+        Carbon::setTestNow();
+    }
+
+    public function test_it_reads_data_from_a_non_existing_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertEquals('', $handler->read('foo'));
+    }
+
+    public function test_it_writes_session_data()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertTrue($handler->write('foo', 'bar'));
+        $this->assertEquals('bar', $handler->read('foo'));
+
+        $this->assertTrue($handler->write('foo', 'baz'));
+        $this->assertEquals('baz', $handler->read('foo'));
+    }
+
+    public function test_it_destroys_a_session()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertTrue($handler->destroy('foo'));
+
+        $handler->write('foo', 'bar');
+
+        $this->assertTrue($handler->destroy('foo'));
+        $this->assertEquals('', $handler->read('foo'));
+    }
+
+    public function test_it_cleans_up_old_sessions()
+    {
+        $handler = new ArraySessionHandler(10);
+
+        $this->assertTrue($handler->gc(300));
+
+        $handler->write('foo', 'bar');
+        $this->assertTrue($handler->gc(300));
+        $this->assertEquals('bar', $handler->read('foo'));
+
+        Carbon::setTestNow(Carbon::now()->addSecond());
+
+        $handler->write('baz', 'qux');
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(5));
+
+        $this->assertTrue($handler->gc(300));
+        $this->assertEquals('', $handler->read('foo'));
+        $this->assertEquals('qux', $handler->read('baz'));
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
This PR introduces a more realistic handler for the `array` session driver.

Currently the `array` driver uses the `NullSessionHandler`.
For testing, this handler has a few downsides:

- There is no persistence of the session data, as it is only stored in the session store.
- There is no way to reuse the session between requests, as the `StartSession` middleware is not attaching the cookie to the response for non-persistent session drivers.
- There is no way to regenerate/migrate the session in a non-destructive way without loosing the data.
- There is no expiration or garbage collection, so testing expired sessions is impossible.

The `ArraySessionHandler` overcomes these obstacles and behaves almost like a real session driver, as the sessions are persisted during the lifetime of the test/application.

Its implementation is similar to the `ArrayStore` for the `array` cache driver, as it writes the sessions to an array, and reads them back while checking the expiration time.

This means we can test the behavior of the application when the session expires. E.g.:

```php
Session::put('foo', 'bar');
$this->get('/')->assertSessionHas('foo');

Carbon::setTestNow(Carbon::now()->addHours(3));

$this->get('/')->assertSessionMissing('foo');
```

We can even simulate multiple sessions/devices:

```php
$mobile = Session::getId();
Session::put('device', 'mobile');
Session::save();

Session::flush();
Session::migrate(false);

$tablet = Session::getId();
Session::put('device', 'tablet');
Session::save();

$this->withCookie(Session::getName(), $mobile)->get('/')->assertSessionHas('device', 'mobile');
$this->withCookie(Session::getName(), $tablet)->get('/')->assertSessionHas('device', 'tablet');
```

Obviously this is a breaking change for cases that expect the array session not to be persisted, so this is targeted for 7.x.

Another pain point is authenticating users with the session guard. With the current behavior, when users are being authenticated, they are set to the guard instance which is a singleton. Which means that even if the session changes, in subsequent requests (in the same test) the user will always be returned from the same `SessionGuard` instance, instead of being resolved from the session or the recaller cookie.