### PR TITLE
Allow wildcard notations in validation.php 'attributes' field like they are allowed in the 'custom' field.

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -256,7 +256,7 @@ trait FormatsMessages
         return str_replace('_', ' ', Str::snake($attribute));
     }
 
-   /**
+    /**
      * Get the given attribute from the attribute translations.
      *
      * @param  string  $name


### PR DESCRIPTION
Allow wildcard notations in validation.php 'attributes' field like they are allowed in the 'custom' field.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
