### PR TITLE
Added login and register uri configuration

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1149,14 +1149,14 @@ class Router implements BindingRegistrar, RegistrarContract
     public function auth(array $options = [])
     {
         // Authentication Routes...
-        $this->get('login', 'Auth\LoginController@showLoginForm')->name('login');
-        $this->post('login', 'Auth\LoginController@login');
+        $this->get($options['login_uri'] ?? 'login', 'Auth\LoginController@showLoginForm')->name('login');
+        $this->post($options['login_uri'] ?? 'login', 'Auth\LoginController@login');
         $this->post('logout', 'Auth\LoginController@logout')->name('logout');
 
         // Registration Routes...
         if ($options['register'] ?? true) {
-            $this->get('register', 'Auth\RegisterController@showRegistrationForm')->name('register');
-            $this->post('register', 'Auth\RegisterController@register');
+            $this->get($options['register_uri'] ?? 'register', 'Auth\RegisterController@showRegistrationForm')->name('register');
+            $this->post($options['register_uri'] ?? 'register', 'Auth\RegisterController@register');
         }
 
         // Password Reset Routes...


### PR DESCRIPTION
**Description**: this update allows the developer to easily configure auth routes. At the moment, the developer has to write a custom route to update /login to /mylogin.
**Benefit**: authentication URLs can easily be detected on vulnerability scanning tools. I faced the same issue and wanted to change the default auth URIs. 
**Break**: I have added a coalesce operator with default values.
**Usage**: I have integrated the options on the Auth Class so it's easier to configure.
**Tests**: None. I couldn't find any tests for other options so I couldn't reproduce. But it was tested on a sample project and it works.
```
Auth::routes([
	'login_path' => 'mylogin',
	'register_path' => 'myregister',
]);
```