### PR TITLE
[6.x] Fix class name capitalisation

### DIFF
--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -10,7 +10,7 @@ class UtilTest extends TestCase
     public function testUnwrapIfClosure()
     {
         $this->assertSame('foo', Util::unwrapIfClosure('foo'));
-        $this->assertSame('foo', UtiL::unwrapIfClosure(function () {
+        $this->assertSame('foo', Util::unwrapIfClosure(function () {
             return 'foo';
         }));
     }


### PR DESCRIPTION
Really minor, but just noticed this in a recent commit. Fixed the capitalisation in a test case.