### PR TITLE
[7.x] Remove default throttle on password resets

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -96,7 +96,7 @@ class PasswordBrokerManager implements FactoryContract
             $config['table'],
             $key,
             $config['expire'],
-            $config['throttle'] ?? 0
+            $config['throttle']
         );
     }
 


### PR DESCRIPTION
In pull request #30340 a password reset throttling feature was introduced and to be compatible with the current version it was disable by default when no config key were provided. In the follow up pull request (#30373) this check was removed, but this was not merged.

This pull request removes this default because the following reasons:
- Existing users should decide if they want this feature or not, they also should be notified of this change in the upgrade guide.
- More importantly leaving this line as is makes this feature **silently getting disabled** when one accidentally deletes this configuration entry. In my opinion a security related feature should not have this behavior.

Major releases usually contain at least on or two config changes so it should not be a problem to add another one. After this is merged I will send a PR to the docs to mention this in the upgrade guide.