### PR TITLE
[7.x] Disable password confirmation routes by default

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -1165,8 +1165,7 @@ class Router implements BindingRegistrar, RegistrarContract
         }
 
         // Password Confirmation Routes...
-        if ($options['confirm'] ??
-            class_exists($this->prependGroupNamespace('Auth\ConfirmPasswordController'))) {
+        if ($options['confirm'] ?? false) {
             $this->confirmPassword();
         }
 


### PR DESCRIPTION
In version 6.2 the password confirmation introduced a breaking change by registering new routes by default while the related controller was in the laravel/laravel repository. To alleviate this I sent a pull request which checked the existence of the controller, because disabling the feature was not possible after weeks of introduction (it could broke already existing implementations.

As I stated in that PR this check should be removed because:
- This causes the autoloader to load that file on every request.
- Every other feature has an explicit default, so this should have one to.

This pull request sets this feature disabled by default because it targets a narrow slice of the projects just like the email verification which also have it's routes disabled by default.

After this is merged I will send a PR to the docs to mention this in the Authentication section and also to mention this in the upgrade guide.