### PR TITLE
[7.x] Handle missing url parameter when other parameters are present

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -4,7 +4,6 @@ namespace Illuminate\Routing;
 
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 
 class RouteUrlGenerator
 {
@@ -200,12 +199,10 @@ class RouteUrlGenerator
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
-            return (empty($parameters) && ! Str::endsWith($match[0], '?}'))
-                        ? $match[0]
-                        : Arr::pull($parameters, 0);
+            return Arr::pull($parameters, 0, $match[0]);
         }, $path);
 
-        return trim(preg_replace('/\{.*?\?\}/', '', $path), '/');
+        return trim(preg_replace('/\{[^}]*?\?\}/', '', $path), '/');
     }
 
     /**
@@ -224,7 +221,8 @@ class RouteUrlGenerator
                 return $this->defaultParameters[$m[1]];
             }
 
-            return $m[0];
+            // Here we make parameter optional if it was explicitly nulled out
+            return Arr::exists($parameters, $m[1]) ? '{'.$m[1].'?}' : $m[0];
         }, $path);
     }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -518,6 +518,23 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com:8080/foo', $url->route('foo'));
     }
 
+    public function testUrlGenerationForControllersRequiresPassingOfRequiredParametersWhenUnrelatedParametersArePresent()
+    {
+        $this->expectException(UrlGenerationException::class);
+
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com:8080/')
+        );
+
+        $route = new Route(['GET'], 'foo/{one}/{two?}/{three?}', ['as' => 'foo', function () {
+            //
+        }]);
+        $routes->add($route);
+
+        $url->route('foo', ['unrelated' => 'present']);
+    }
+
     public function testForceRootUrl()
     {
         $url = new UrlGenerator(

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -517,7 +517,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->assertSame('http://www.foo.com:8080/foo', $url->route('foo'));
+        $url->route('foo');
     }
 
     public function testUrlGenerationForControllersRequiresPassingOfRequiredParametersWhenUnrelatedParametersArePresent()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -249,6 +249,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/bar?foo=bar', $url->route('foo', ['foo' => 'bar'], false));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall']));
         $this->assertSame('http://www.foo.com/foo/bar/otwell/breeze/taylor?fly=wall', $url->route('bar', ['boom' => 'taylor', 'baz' => 'otwell', 'fly' => 'wall']));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foobar', [null]));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('foobar', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar/2', $url->route('foobar', 2));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('foobar', 'taylor'));
         $this->assertSame('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall'], false));


### PR DESCRIPTION
This pull request makes the route generator when a required parameter is missing. Unlike my previous pull request this does not validates the content of it if present.

This bug was introduced in pull request #29778, by pulling only numeric parameters from the parameters there could exist a situation where the parameters array is not empty but a parameter can not be pulled from it. Previously this was not a problem because elements were simply shifted from the array so the only way to not have available elements was when the array was empty.

Example for the buggy behavior:
`/{foo}` will result in `/?bar=baz` when `['bar' => 'baz']` is passed to the generator, since bar cannot be used as route parameter it should behave the same way as calling the generator without that parameter.

Tests are provided for the correct behavior.

In my opinion this is a bug and should be fixed in the current version but based on the responses from the last time I'm targeting master. If needed I will make a new pull request against v6.x.