### PR TITLE
[6.x] Extends tap helper function to continually return instances

### DIFF
--- a/src/Illuminate/Support/HigherOrderTapProxy.php
+++ b/src/Illuminate/Support/HigherOrderTapProxy.php
@@ -33,6 +33,6 @@ class HigherOrderTapProxy
     {
         $this->target->{$method}(...$parameters);
 
-        return $this->target;
+        return new self($this->target);
     }
 }


### PR DESCRIPTION
The tap helper function returns the same instance it is created with but
with this change it will perpetually return the same instance after each
method call.

Before this change the following would work:
class A
{
    private $b;

    public function __construct($b = 0)
    {
        $this->b = $b;
    }

    public function increment()
    {
        $this->b += 1;
    }
}
tap(new A())
   ->increment()  // $b is 1
   ->increment(); // $b is 2

But an error would result in further calls:
tap(new A())
   ->increment()  // $b is 1
   ->increment()  // $b is 2
   ->increment(); // PHP Error - Call to a member function increment on null

After this change the instance is continually returned, allowing
perpetual calls. Now the following will work:
tap(new A())
   ->increment()  // $b is 1
   ->increment()  // $b is 2
   ->increment()  // $b is 3
   ->increment()  // $b is 4
   ->increment(); // $b is 5

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
