### PR TITLE
[7.x] Allow Contextual Binding outside of constructors

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -167,9 +167,9 @@ class BoundMethod
 
             unset($parameters[$parameter->getClass()->name]);
         } elseif ($parameter->getClass()) {
-            $target = is_array($callback) ? get_class($callback[0]) : NULL;
+            $target = is_array($callback) ? get_class($callback[0]) : null;
 
-            $dependencies[] = $container->makeFor($parameter->getClass()->name, [], $target);
+            $dependencies[] = $container->makeFor($parameter->getClass()->name, $target);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
         }
@@ -183,7 +183,7 @@ class BoundMethod
      */
     protected static function getCallableSign($callback)
     {
-        return self::hasCallableSign($callback, '@')  ? '@'  : (
+        return self::hasCallableSign($callback, '@') ? '@' : (
                self::hasCallableSign($callback, '::') ? '::' : '');
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -630,19 +630,19 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
-     * Resolve the given type from the container for a specific parent
+     * Resolve the given type from the container for a specific parent.
      *
      * @param  string  $abstract
+     * @param  string  $target
      * @param  array  $parameters
-     * @param  string|NULL  $target
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function makeFor($abstract, array $parameters = [], $target)
+    public function makeFor($abstract, $target, array $parameters = [])
     {
         $this->buildStack[] = $target;
-        
+
         return $this->make($abstract, $parameters);
     }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -630,6 +630,23 @@ class Container implements ArrayAccess, ContainerContract
     }
 
     /**
+     * Resolve the given type from the container for a specific parent
+     *
+     * @param  string  $abstract
+     * @param  array  $parameters
+     * @param  string|NULL  $target
+     * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function makeFor($abstract, array $parameters = [], $target)
+    {
+        $this->buildStack[] = $target;
+        
+        return $this->make($abstract, $parameters);
+    }
+
+    /**
      *  {@inheritdoc}
      */
     public function get($id)

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -334,12 +334,12 @@ interface IContainerContextWorkerStub
 
 class ContainerContextWorkerInstance implements IContainerContextWorkerStub
 {
-  static $calls = 0;
+    public static $calls = 0;
 
-  public function work()
-  {
-    static::$calls++;
-  }
+    public function work()
+    {
+        static::$calls++;
+    }
 }
 
 class ContainerTestContextWithHandleMethod

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -231,6 +231,23 @@ class ContextualBindingTest extends TestCase
         );
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->implTwo->impl);
     }
+
+    public function testContextualBindingWorksForJobHandleMethod()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextWithHandleMethod::class)
+                  ->needs(IContainerContextWorkerStub::class)
+                  ->give(ContainerContextWorkerInstance::class);
+
+        $instance = $container->make(ContainerTestContextWithHandleMethod::class);
+
+        $this->assertEquals(ContainerContextWorkerInstance::$calls, 0);
+
+        $container->call([$instance, 'handle']);
+
+        $this->assertEquals(ContainerContextWorkerInstance::$calls, 1);
+    }
 }
 
 interface IContainerContextContractStub
@@ -307,5 +324,28 @@ class ContainerTestContextWithOptionalInnerDependency
     public function __construct(ContainerTestContextInjectOne $inner = null)
     {
         $this->inner = $inner;
+    }
+}
+
+interface IContainerContextWorkerStub
+{
+    public function work();
+}
+
+class ContainerContextWorkerInstance implements IContainerContextWorkerStub
+{
+  static $calls = 0;
+
+  public function work()
+  {
+    static::$calls++;
+  }
+}
+
+class ContainerTestContextWithHandleMethod
+{
+    public function handle(IContainerContextWorkerStub $impl)
+    {
+        $impl->work();
     }
 }


### PR DESCRIPTION
This PR fixes [a long standing bug](https://github.com/laravel/framework/issues/23602) where [Contextual Binding](https://laravel.com/docs/5.8/container#contextual-binding) wouldn't work outside of the constructor of a class.

Notable relevant userland examples include the `handle` method of a Queue Job, and the injected services for a Controller.

As for the exact implementation here, I just added a new method which directly modifies the 'build stack', as that seemed to be the least intrusive way of getting stuff done. Initially I just passed along the extra parameter in `makeFor`, but that became messy very quickly.

I'm not sure wat this should be targeted to. It's a backwards compatible bugfix, but it also adds a 'new feature' in the sense that there's a new public method on the container. Any advice here would be welcome.