### PR TITLE
[6.x] Added support for separation between geometry and geography types 

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -895,7 +895,7 @@ class PostgresGrammar extends Grammar
                 return "geometry($type, $projection)";
             }
         } else {
-            return "geography($type, ".( is_null($column->projection) ? '4326' : $column->projection).')';
+            return "geography($type, ".(is_null($column->projection) ? '4326' : $column->projection).')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -888,14 +888,14 @@ class PostgresGrammar extends Grammar
      */
     private function formatPostGisType(string $type, Fluent $column)
     {
-        if (is_null($column->geography)) {
-            if (is_null($column->projection)) {
+        if ($column->geography !== null) {
+            return "geography($type, ".($column->projection === null ? '4326' : $column->projection).')';
+        } else {
+            if ($column->projection === null) {
                 return "geometry($type)";
             } else {
                 return "geometry($type, $projection)";
             }
-        } else {
-            return "geography($type, ".(is_null($column->projection) ? '4326' : $column->projection).')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -888,14 +888,14 @@ class PostgresGrammar extends Grammar
      */
     private function formatPostGisType(string $type, Fluent $column)
     {
-        if ( is_null($column->geography)) {
-            if ( is_null($column->projection)) {
+        if (is_null($column->geography)) {
+            if (is_null($column->projection)) {
                 return "geometry($type)";
             } else {
                 return "geometry($type, $projection)";
             }
         } else {
-            return "geography($type, " . ( is_null($column->projection) ? '4326' : $column->projection) . ")";
+            return "geography($type, ".( is_null($column->projection) ? '4326' : $column->projection).')';
         }
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -883,7 +883,7 @@ class PostgresGrammar extends Grammar
      * Format the column definition for a PostGIS spatial type.
      *
      * @param  string  $type
-     * @param  Fluent  $column
+     * @param  \Illuminate\Support\Fluent  $column
      * @return string
      */
     private function formatPostGisType(string $type, Fluent $column)

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -888,15 +888,12 @@ class PostgresGrammar extends Grammar
      */
     private function formatPostGisType(string $type, Fluent $column)
     {
-        if ($column->geography !== null) {
-            return "geography($type, ".($column->projection === null ? '4326' : $column->projection).')';
-        } else {
-            if ($column->projection === null) {
-                return "geometry($type)";
-            } else {
-                return "geometry($type, $projection)";
-            }
+
+        if ($column->isGeometry !== null) {
+            return "geometry($type".($column->projection === null ? '' : ", $column->projection").')';
         }
+
+        return "geography($type, ".($column->projection ?? '4326').')';
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -888,7 +888,6 @@ class PostgresGrammar extends Grammar
      */
     private function formatPostGisType(string $type, Fluent $column)
     {
-
         if ($column->isGeometry !== null) {
             return "geometry($type".($column->projection === null ? '' : ", $column->projection").')';
         }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -788,7 +788,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeGeometry(Fluent $column)
     {
-        return $this->formatPostGisType('geometry');
+        return $this->formatPostGisType('geometry', $column);
     }
 
     /**
@@ -799,7 +799,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typePoint(Fluent $column)
     {
-        return $this->formatPostGisType('point');
+        return $this->formatPostGisType('point', $column);
     }
 
     /**
@@ -810,7 +810,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeLineString(Fluent $column)
     {
-        return $this->formatPostGisType('linestring');
+        return $this->formatPostGisType('linestring', $column);
     }
 
     /**
@@ -821,7 +821,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typePolygon(Fluent $column)
     {
-        return $this->formatPostGisType('polygon');
+        return $this->formatPostGisType('polygon', $column);
     }
 
     /**
@@ -832,7 +832,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeGeometryCollection(Fluent $column)
     {
-        return $this->formatPostGisType('geometrycollection');
+        return $this->formatPostGisType('geometrycollection', $column);
     }
 
     /**
@@ -843,7 +843,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeMultiPoint(Fluent $column)
     {
-        return $this->formatPostGisType('multipoint');
+        return $this->formatPostGisType('multipoint', $column);
     }
 
     /**
@@ -854,7 +854,7 @@ class PostgresGrammar extends Grammar
      */
     public function typeMultiLineString(Fluent $column)
     {
-        return $this->formatPostGisType('multilinestring');
+        return $this->formatPostGisType('multilinestring', $column);
     }
 
     /**
@@ -865,7 +865,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeMultiPolygon(Fluent $column)
     {
-        return $this->formatPostGisType('multipolygon');
+        return $this->formatPostGisType('multipolygon', $column);
     }
 
     /**
@@ -876,18 +876,27 @@ class PostgresGrammar extends Grammar
      */
     protected function typeMultiPolygonZ(Fluent $column)
     {
-        return $this->formatPostGisType('multipolygonz');
+        return $this->formatPostGisType('multipolygonz', $column);
     }
 
     /**
      * Format the column definition for a PostGIS spatial type.
      *
      * @param  string  $type
+     * @param  Fluent  $column
      * @return string
      */
-    private function formatPostGisType(string $type)
+    private function formatPostGisType(string $type, Fluent $column)
     {
-        return "geography($type, 4326)";
+        if ( is_null($column->geography)) {
+            if ( is_null($column->projection)) {
+                return "geometry($type)";
+            } else {
+                return "geometry($type, $projection)";
+            }
+        } else {
+            return "geography($type, " . ( is_null($column->projection) ? '4326' : $column->projection) . ")";
+        }
     }
 
     /**


### PR DESCRIPTION
When using postgres with postgis-created types.

This is very important as without these changes, you are pigeon-holed into having to use geography spatial types _only_.

The problem with this has many facets, one being that generally geometry should be used over geography. Defaulting to the more advanced type also limits the availability of functions included in PostGIS. For more information on the advantages versus disadvantages, [the PostGIS literature dives into it here](https://postgis.net/docs/using_postgis_dbmanagement.html#PostGIS_GeographyVSGeometry).

With this in mind, the default PostGIS types have been switched to geometry instead of geography. To enable geography, a fluent property is available, which defaults to SRID 4326:
`$table->column('col')->geography()`

Furthermore, users will now be able to specify spatial reference schemas for projection purposes (which has been available since PostGIS 2.2 (released 2015) and above). You can even add your own spatial reference systems if you decide you want to do spatial geography for non-earth environments. This is made available via the ->projection fluent property, and available on both geography and geometry types.

A geometric type existing in 4326:
`$table->column('col')->projection(4326)`
A geographic type existing in 4326:
`$table->column('col')->geography()->projection(4326)`

To keep things simple, there are some defaults (for instance, geographies must have a spatial reference system, but default to SRID:4326.
