### PR TITLE
[6.x] Fix implementation of spop in PHPRedis implementation

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -190,9 +190,9 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  int|null  $count
      * @return mixed|false
      */
-    public function spop($key, $count = null)
+    public function spop($key, $count = 1)
     {
-        return $this->command('spop', [$key]);
+        return $this->command('spop', [$key, $count]);
     }
 
     /**


### PR DESCRIPTION
Hello, 
You guys forgot to forward count argument to Redis, and, also, 1 should be default, instead of `null`. 