### PR TITLE
[6.x] Fixed docblock

### DIFF
--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -504,7 +504,7 @@ class Repository implements ArrayAccess, CacheContract
     /**
      * Get the default cache time.
      *
-     * @return int
+     * @return int|null
      */
     public function getDefaultCacheTime()
     {


### PR DESCRIPTION
The `getDefaultCacheTime()` method returns `$this->default`.

`$default` is `int|null`:

```php
 /**
  * The default number of seconds to store items.
  *
  * @var int|null
  */
  protected $default = 3600;
```