### PR TITLE
[6.x] Fix model date fields serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use LogicException;
 
 trait HasAttributes
@@ -127,9 +128,13 @@ trait HasAttributes
                 continue;
             }
 
-            $attributes[$key] = $this->serializeDate(
-                $this->asDateTime($attributes[$key])
-            );
+            $date = $this->asDateTime($attributes[$key]);
+
+            if ($date !== false) {
+                $attributes[$key] = $this->serializeDate(
+                    $this->asDateTime($date)
+                );
+            }
         }
 
         return $attributes;
@@ -770,47 +775,52 @@ trait HasAttributes
      */
     protected function asDateTime($value)
     {
-        // If this value is already a Carbon instance, we shall just return it as is.
-        // This prevents us having to re-instantiate a Carbon instance when we know
-        // it already is one, which wouldn't be fulfilled by the DateTime check.
-        if ($value instanceof Carbon || $value instanceof CarbonInterface) {
-            return Date::instance($value);
+        try {
+            // If this value is already a Carbon instance, we shall just return it as is.
+            // This prevents us having to re-instantiate a Carbon instance when we know
+            // it already is one, which wouldn't be fulfilled by the DateTime check.
+            if ($value instanceof Carbon || $value instanceof CarbonInterface) {
+                return Date::instance($value);
+            }
+
+            // If the value is already a DateTime instance, we will just skip the rest of
+            // these checks since they will be a waste of time, and hinder performance
+            // when checking the field. We will just return the DateTime right away.
+            if ($value instanceof DateTimeInterface) {
+                return Date::parse(
+                    $value->format('Y-m-d H:i:s.u'),
+                    $value->getTimezone()
+                );
+            }
+
+            // If this value is an integer, we will assume it is a UNIX timestamp's value
+            // and format a Carbon object from this timestamp. This allows flexibility
+            // when defining your date fields as they might be UNIX timestamps here.
+            if (is_numeric($value)) {
+                return Date::createFromTimestamp($value);
+            }
+
+            // If the value is in simply year, month, day format, we will instantiate the
+            // Carbon instances from that format. Again, this provides for simple date
+            // fields on the database, while still supporting Carbonized conversion.
+            if ($this->isStandardDateFormat($value)) {
+                return Date::instance(Carbon::createFromFormat('Y-m-d', $value)->startOfDay());
+            }
+
+            $format = $this->getDateFormat();
+
+            // https://bugs.php.net/bug.php?id=75577
+            if (version_compare(PHP_VERSION, '7.3.0-dev', '<')) {
+                $format = str_replace('.v', '.u', $format);
+            }
+
+            // Finally, we will just assume this date is in the format used by default on
+            // the database connection and use that format to create the Carbon object
+            // that is returned back out to the developers after we convert it here.
+            return Date::createFromFormat($format, $value);
+        } catch (InvalidArgumentException $e) {
+            return false;
         }
-
-        // If the value is already a DateTime instance, we will just skip the rest of
-        // these checks since they will be a waste of time, and hinder performance
-        // when checking the field. We will just return the DateTime right away.
-        if ($value instanceof DateTimeInterface) {
-            return Date::parse(
-                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
-            );
-        }
-
-        // If this value is an integer, we will assume it is a UNIX timestamp's value
-        // and format a Carbon object from this timestamp. This allows flexibility
-        // when defining your date fields as they might be UNIX timestamps here.
-        if (is_numeric($value)) {
-            return Date::createFromTimestamp($value);
-        }
-
-        // If the value is in simply year, month, day format, we will instantiate the
-        // Carbon instances from that format. Again, this provides for simple date
-        // fields on the database, while still supporting Carbonized conversion.
-        if ($this->isStandardDateFormat($value)) {
-            return Date::instance(Carbon::createFromFormat('Y-m-d', $value)->startOfDay());
-        }
-
-        $format = $this->getDateFormat();
-
-        // https://bugs.php.net/bug.php?id=75577
-        if (version_compare(PHP_VERSION, '7.3.0-dev', '<')) {
-            $format = str_replace('.v', '.u', $format);
-        }
-
-        // Finally, we will just assume this date is in the format used by default on
-        // the database connection and use that format to create the Carbon object
-        // that is returned back out to the developers after we convert it here.
-        return Date::createFromFormat($format, $value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -776,6 +776,27 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('appended', $array['appendable']);
     }
 
+    public function testToArrayDateAttributes()
+    {
+        $model = new EloquentDateModelStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        $model->setCreatedAt(Carbon::now());
+        $this->assertSame(['created_at' => Carbon::now()->format('Y-m-d H:i:s')], $model->toArray());
+
+        $model->setCreatedAt(0);
+        $this->assertSame(['created_at' => '1970-01-01 00:00:00'], $model->toArray());
+
+        $model->setCreatedAt(null);
+        $this->assertSame(['created_at' => null], $model->toArray());
+
+        $model->setCreatedAt(false);
+        $this->assertSame(['created_at' => false], $model->toArray());
+
+        $model->setCreatedAt('');
+        $this->assertSame(['created_at' => ''], $model->toArray());
+    }
+
     public function testVisibleCreatesArrayWhitelist()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
Closes #28047

When a model date field contains an invalid value like an empty string, Carbon throws an exception and the serialization (after calling `toArray()`) fails.

With this pull request, this exception is handled and the serialization of the field is skipped.