### PR TITLE
[6.x] Fix model date fields serialization

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -127,6 +127,10 @@ trait HasAttributes
                 continue;
             }
 
+            if (empty($attributes[$key]) && ! is_numeric($attributes[$key])) {
+                continue;
+            }
+
             $attributes[$key] = $this->serializeDate(
                 $this->asDateTime($attributes[$key])
             );

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -845,6 +845,27 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([1, 2, 3], $array['list_items']);
     }
 
+    public function testToArrayDateAttributes()
+    {
+        $model = new EloquentDateModelStub;
+        $model->setDateFormat('Y-m-d H:i:s');
+
+        $model->setCreatedAt(Carbon::now());
+        $this->assertSame(['created_at' => Carbon::now()->format('Y-m-d H:i:s')], $model->toArray());
+
+        $model->setCreatedAt(0);
+        $this->assertSame(['created_at' => '1970-01-01 00:00:00'], $model->toArray());
+
+        $model->setCreatedAt(null);
+        $this->assertSame(['created_at' => null], $model->toArray());
+
+        $model->setCreatedAt(false);
+        $this->assertSame(['created_at' => false], $model->toArray());
+
+        $model->setCreatedAt('');
+        $this->assertSame(['created_at' => ''], $model->toArray());
+    }
+
     public function testHidden()
     {
         $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);


### PR DESCRIPTION
Closes #28047

When a model date field contains an invalid value like an empty string, Carbon throws an exception and the serialization (after calling toArray()) fails.

With this pull request, the value is verified if it is an empty value, and if it is, we skip it, avoiding then the error described in the related issue.