### PR TITLE
[6.x] Add possibility to set custom displayName in Mailable and Notification

### DIFF
--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -59,6 +59,10 @@ class SendQueuedMailable
      */
     public function displayName()
     {
+        if (method_exists($this->mailable, 'displayName')) {
+            return $this->mailable->displayName();
+        }
+
         return get_class($this->mailable);
     }
 

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -81,6 +81,10 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
+        if (method_exists($this->notification, 'displayName')) {
+            return $this->notification->displayName();
+        }
+
         return get_class($this->notification);
     }
 


### PR DESCRIPTION
Currently it's not possible to set a custom display name for queue'd Mail/Notifications, in the current situation the Mail/Notifications will always end up with the ClassName as DisplayName 

```php
// displayName: App\Mail\CustomMail

Mail::to('mail@mail.tld')->queue(
    (new \App\Mail\CustomMail())->delay(now()->addHour())
);

// displayName: App\Notifications\CustomNotification

Auth::user()->notify(
    (new \App\Notifications\CustomNotification())->delay(now()->addHour())
);
```

After this PullRequest it's possible to set a displayName on the Mailable and Notification

```php

class CustomMail extends Mailable
{
    use Queueable, SerializesModels;

    //

    /**
     * Get the display name for the queued job.
     *
     * @return string
     */
    public function displayName()
    {
        return 'Custom Mail';
    }

    //
}

class CustomNotification extends Notification implements ShouldQueue
{
    use Queueable;
	
    //

    /**
     * Get the display name for the queued job.
     *
     * @return string
     */
    public function displayName()
    {
        return 'Custom Notification';
    }

    //
}
```