### PR TITLE
[6.x] Fixed breaking compatability with multi-schema postgres

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -233,23 +233,23 @@ class PostgresGrammar extends Grammar
     /**
      * Compile the SQL needed to retrieve all table names.
      *
-     * @param  string  $schema
+     * @param  array  $schema
      * @return string
      */
     public function compileGetAllTables($schema)
     {
-        return "select tablename from pg_catalog.pg_tables where schemaname = '{$schema}'";
+        return "select tablename from pg_catalog.pg_tables where schemaname in ('".implode("','", $schema)."')";
     }
 
     /**
      * Compile the SQL needed to retrieve all view names.
      *
-     * @param  string  $schema
+     * @param  array  $schema
      * @return string
      */
     public function compileGetAllViews($schema)
     {
-        return "select viewname from pg_catalog.pg_views where schemaname = '{$schema}'";
+        return "select viewname from pg_catalog.pg_views where schemaname in ('".implode("','", $schema)."')";
     }
 
     /**

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -104,8 +104,12 @@ class PostgresBuilder extends Builder
      */
     public function getAllTables()
     {
+        if (! is_array($schema = $this->connection->getConfig('schema'))) {
+            $schema = [$schema];
+        }
+
         return $this->connection->select(
-            $this->grammar->compileGetAllTables($this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllTables($schema)
         );
     }
 
@@ -116,8 +120,12 @@ class PostgresBuilder extends Builder
      */
     protected function getAllViews()
     {
+        if (! is_array($schema = $this->connection->getConfig('schema'))) {
+            $schema = [$schema];
+        }
+
         return $this->connection->select(
-            $this->grammar->compileGetAllViews($this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllViews($schema)
         );
     }
 

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -104,12 +104,8 @@ class PostgresBuilder extends Builder
      */
     public function getAllTables()
     {
-        if (! is_array($schema = $this->connection->getConfig('schema'))) {
-            $schema = [$schema];
-        }
-
         return $this->connection->select(
-            $this->grammar->compileGetAllTables($schema)
+            $this->grammar->compileGetAllTables((array)$this->connection->getConfig('schema'))
         );
     }
 
@@ -120,12 +116,8 @@ class PostgresBuilder extends Builder
      */
     protected function getAllViews()
     {
-        if (! is_array($schema = $this->connection->getConfig('schema'))) {
-            $schema = [$schema];
-        }
-
         return $this->connection->select(
-            $this->grammar->compileGetAllViews($schema)
+            $this->grammar->compileGetAllViews((array)$this->connection->getConfig('schema'))
         );
     }
 

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -105,7 +105,7 @@ class PostgresBuilder extends Builder
     public function getAllTables()
     {
         return $this->connection->select(
-            $this->grammar->compileGetAllTables((array)$this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllTables((array) $this->connection->getConfig('schema'))
         );
     }
 
@@ -117,7 +117,7 @@ class PostgresBuilder extends Builder
     protected function getAllViews()
     {
         return $this->connection->select(
-            $this->grammar->compileGetAllViews((array)$this->connection->getConfig('schema'))
+            $this->grammar->compileGetAllViews((array) $this->connection->getConfig('schema'))
         );
     }
 

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -30,7 +30,7 @@ class PostgresBuilder extends Builder
     {
         $tables = [];
 
-        $excludedTables = ['spatial_ref_sys'];
+        $excludedTables = $this->connection->getConfig('excluded_drop_tables') ?? ['spatial_ref_sys'];
 
         foreach ($this->getAllTables() as $row) {
             $row = (array) $row;


### PR DESCRIPTION
The Postgres engine supports a multi-schema search path, and parts of the PostgresBuilder do not.

This PR addresses multiple schema support in a non-breaking way for 6.x.

Furthermore, to give more granular control, I allowed the $excludedTables portion of the dropAllTables() method to be set via configuration values, while gracefully falling back to the original value.

This level of granularity is particularly important when it comes to postgresql extensions and the tables they sometimes create.


