### PR TITLE
[6.x] Allow 'null' CacheDriver 

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Cache;
 
+use Aws\DynamoDb\DynamoDbClient;
 use Closure;
+use Illuminate\Contracts\Cache\Factory as FactoryContract;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use Aws\DynamoDb\DynamoDbClient;
-use Illuminate\Contracts\Cache\Store;
-use Illuminate\Contracts\Cache\Factory as FactoryContract;
-use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 /**
  * @mixin \Illuminate\Contracts\Cache\Repository
@@ -39,8 +39,7 @@ class CacheManager implements FactoryContract
     /**
      * Create a new Cache manager instance.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
      * @return void
      */
     public function __construct($app)
@@ -51,8 +50,7 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache store instance by name, wrapped in a repository.
      *
-     * @param string|null $name
-     *
+     * @param  string|null  $name
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function store($name = null)
@@ -65,8 +63,7 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache driver instance.
      *
-     * @param string|null $driver
-     *
+     * @param  string|null  $driver
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function driver($driver = null)
@@ -77,8 +74,7 @@ class CacheManager implements FactoryContract
     /**
      * Attempt to get the store from the local cache.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function get($name)
@@ -89,11 +85,10 @@ class CacheManager implements FactoryContract
     /**
      * Resolve the given store.
      *
-     * @param string $name
+     * @param  string  $name
+     * @return \Illuminate\Contracts\Cache\Repository
      *
      * @throws \InvalidArgumentException
-     *
-     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function resolve($name)
     {
@@ -106,7 +101,7 @@ class CacheManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         } else {
-            $driverMethod = 'create' . ucfirst($config['driver']) . 'Driver';
+            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
 
             if (method_exists($this, $driverMethod)) {
                 return $this->{$driverMethod}($config);
@@ -119,6 +114,7 @@ class CacheManager implements FactoryContract
     /**
      * Call a custom driver creator.
      *
+     * @param  array  $config
      * @return mixed
      */
     protected function callCustomCreator(array $config)
@@ -129,13 +125,14 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the APC cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createApcDriver(array $config)
     {
         $prefix = $this->getPrefix($config);
 
-        return $this->repository(new ApcStore(new ApcWrapper(), $prefix));
+        return $this->repository(new ApcStore(new ApcWrapper, $prefix));
     }
 
     /**
@@ -145,12 +142,13 @@ class CacheManager implements FactoryContract
      */
     protected function createArrayDriver()
     {
-        return $this->repository(new ArrayStore());
+        return $this->repository(new ArrayStore);
     }
 
     /**
      * Create an instance of the file cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createFileDriver(array $config)
@@ -161,6 +159,7 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the Memcached cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createMemcachedDriver(array $config)
@@ -184,12 +183,13 @@ class CacheManager implements FactoryContract
      */
     protected function createNullDriver()
     {
-        return $this->repository(new NullStore());
+        return $this->repository(new NullStore);
     }
 
     /**
      * Create an instance of the Redis cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createRedisDriver(array $config)
@@ -204,6 +204,7 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the database cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createDatabaseDriver(array $config)
@@ -212,9 +213,7 @@ class CacheManager implements FactoryContract
 
         return $this->repository(
             new DatabaseStore(
-                $connection,
-                $config['table'],
-                $this->getPrefix($config)
+                $connection, $config['table'], $this->getPrefix($config)
             )
         );
     }
@@ -222,6 +221,7 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the DynamoDB cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createDynamodbDriver(array $config)
@@ -234,8 +234,7 @@ class CacheManager implements FactoryContract
 
         if ($config['key'] && $config['secret']) {
             $dynamoConfig['credentials'] = Arr::only(
-                $config,
-                ['key', 'secret', 'token']
+                $config, ['key', 'secret', 'token']
             );
         }
 
@@ -254,6 +253,7 @@ class CacheManager implements FactoryContract
     /**
      * Create a new cache repository with the given implementation.
      *
+     * @param  \Illuminate\Contracts\Cache\Store  $store
      * @return \Illuminate\Cache\Repository
      */
     public function repository(Store $store)
@@ -272,6 +272,7 @@ class CacheManager implements FactoryContract
     /**
      * Get the cache prefix.
      *
+     * @param  array  $config
      * @return string
      */
     protected function getPrefix(array $config)
@@ -282,8 +283,7 @@ class CacheManager implements FactoryContract
     /**
      * Get the cache connection configuration.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return array
      */
     protected function getConfig($name)
@@ -308,8 +308,7 @@ class CacheManager implements FactoryContract
     /**
      * Set the default cache driver name.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return void
      */
     public function setDefaultDriver($name)
@@ -320,8 +319,7 @@ class CacheManager implements FactoryContract
     /**
      * Unset the given driver instances.
      *
-     * @param array|string|null $name
-     *
+     * @param  array|string|null  $name
      * @return $this
      */
     public function forgetDriver($name = null)
@@ -340,8 +338,8 @@ class CacheManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param string $driver
-     *
+     * @param  string  $driver
+     * @param  \Closure  $callback
      * @return $this
      */
     public function extend($driver, Closure $callback)
@@ -354,9 +352,8 @@ class CacheManager implements FactoryContract
     /**
      * Dynamically call the default driver instance.
      *
-     * @param string $method
-     * @param array  $parameters
-     *
+     * @param  string  $method
+     * @param  array  $parameters
      * @return mixed
      */
     public function __call($method, $parameters)

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -288,7 +288,11 @@ class CacheManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        return $this->app['config']["cache.stores.{$name}"];
+        if (! is_null($name)) {
+            return $this->app['config']["cache.stores.{$name}"];
+        }
+
+        return ['driver' => 'null'];
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -2,13 +2,13 @@
 
 namespace Illuminate\Cache;
 
-use Aws\DynamoDb\DynamoDbClient;
 use Closure;
-use Illuminate\Contracts\Cache\Factory as FactoryContract;
-use Illuminate\Contracts\Cache\Store;
-use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
+use Aws\DynamoDb\DynamoDbClient;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Cache\Factory as FactoryContract;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 
 /**
  * @mixin \Illuminate\Contracts\Cache\Repository
@@ -39,7 +39,8 @@ class CacheManager implements FactoryContract
     /**
      * Create a new Cache manager instance.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     *
      * @return void
      */
     public function __construct($app)
@@ -50,7 +51,8 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache store instance by name, wrapped in a repository.
      *
-     * @param  string|null  $name
+     * @param string|null $name
+     *
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function store($name = null)
@@ -63,7 +65,8 @@ class CacheManager implements FactoryContract
     /**
      * Get a cache driver instance.
      *
-     * @param  string|null  $driver
+     * @param string|null $driver
+     *
      * @return \Illuminate\Contracts\Cache\Repository
      */
     public function driver($driver = null)
@@ -74,7 +77,8 @@ class CacheManager implements FactoryContract
     /**
      * Attempt to get the store from the local cache.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function get($name)
@@ -85,10 +89,11 @@ class CacheManager implements FactoryContract
     /**
      * Resolve the given store.
      *
-     * @param  string  $name
-     * @return \Illuminate\Contracts\Cache\Repository
+     * @param string $name
      *
      * @throws \InvalidArgumentException
+     *
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function resolve($name)
     {
@@ -101,7 +106,7 @@ class CacheManager implements FactoryContract
         if (isset($this->customCreators[$config['driver']])) {
             return $this->callCustomCreator($config);
         } else {
-            $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+            $driverMethod = 'create' . ucfirst($config['driver']) . 'Driver';
 
             if (method_exists($this, $driverMethod)) {
                 return $this->{$driverMethod}($config);
@@ -114,7 +119,6 @@ class CacheManager implements FactoryContract
     /**
      * Call a custom driver creator.
      *
-     * @param  array  $config
      * @return mixed
      */
     protected function callCustomCreator(array $config)
@@ -125,14 +129,13 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the APC cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createApcDriver(array $config)
     {
         $prefix = $this->getPrefix($config);
 
-        return $this->repository(new ApcStore(new ApcWrapper, $prefix));
+        return $this->repository(new ApcStore(new ApcWrapper(), $prefix));
     }
 
     /**
@@ -142,13 +145,12 @@ class CacheManager implements FactoryContract
      */
     protected function createArrayDriver()
     {
-        return $this->repository(new ArrayStore);
+        return $this->repository(new ArrayStore());
     }
 
     /**
      * Create an instance of the file cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createFileDriver(array $config)
@@ -159,7 +161,6 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the Memcached cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createMemcachedDriver(array $config)
@@ -183,13 +184,12 @@ class CacheManager implements FactoryContract
      */
     protected function createNullDriver()
     {
-        return $this->repository(new NullStore);
+        return $this->repository(new NullStore());
     }
 
     /**
      * Create an instance of the Redis cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createRedisDriver(array $config)
@@ -204,7 +204,6 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the database cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createDatabaseDriver(array $config)
@@ -213,7 +212,9 @@ class CacheManager implements FactoryContract
 
         return $this->repository(
             new DatabaseStore(
-                $connection, $config['table'], $this->getPrefix($config)
+                $connection,
+                $config['table'],
+                $this->getPrefix($config)
             )
         );
     }
@@ -221,7 +222,6 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the DynamoDB cache driver.
      *
-     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
     protected function createDynamodbDriver(array $config)
@@ -234,7 +234,8 @@ class CacheManager implements FactoryContract
 
         if ($config['key'] && $config['secret']) {
             $dynamoConfig['credentials'] = Arr::only(
-                $config, ['key', 'secret', 'token']
+                $config,
+                ['key', 'secret', 'token']
             );
         }
 
@@ -253,7 +254,6 @@ class CacheManager implements FactoryContract
     /**
      * Create a new cache repository with the given implementation.
      *
-     * @param  \Illuminate\Contracts\Cache\Store  $store
      * @return \Illuminate\Cache\Repository
      */
     public function repository(Store $store)
@@ -272,7 +272,6 @@ class CacheManager implements FactoryContract
     /**
      * Get the cache prefix.
      *
-     * @param  array  $config
      * @return string
      */
     protected function getPrefix(array $config)
@@ -283,12 +282,13 @@ class CacheManager implements FactoryContract
     /**
      * Get the cache connection configuration.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return array
      */
     protected function getConfig($name)
     {
-        if (! is_null($name)) {
+        if (! is_null($name) && 'null' !== $name) {
             return $this->app['config']["cache.stores.{$name}"];
         }
 
@@ -308,7 +308,8 @@ class CacheManager implements FactoryContract
     /**
      * Set the default cache driver name.
      *
-     * @param  string  $name
+     * @param string $name
+     *
      * @return void
      */
     public function setDefaultDriver($name)
@@ -319,7 +320,8 @@ class CacheManager implements FactoryContract
     /**
      * Unset the given driver instances.
      *
-     * @param  array|string|null  $name
+     * @param array|string|null $name
+     *
      * @return $this
      */
     public function forgetDriver($name = null)
@@ -338,8 +340,8 @@ class CacheManager implements FactoryContract
     /**
      * Register a custom driver creator Closure.
      *
-     * @param  string  $driver
-     * @param  \Closure  $callback
+     * @param string $driver
+     *
      * @return $this
      */
     public function extend($driver, Closure $callback)
@@ -352,8 +354,9 @@ class CacheManager implements FactoryContract
     /**
      * Dynamically call the default driver instance.
      *
-     * @param  string  $method
-     * @param  array  $parameters
+     * @param string $method
+     * @param array  $parameters
+     *
      * @return mixed
      */
     public function __call($method, $parameters)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently the `NullDriver` for cache is available but only if you add a config like

```php
'connections' => [
  //..
  'none' => [
    'driver' => 'null'
  ]
]
```
and using `CACHE_DRIVER=none` in the `.env` file. The driver cannot be named `null` because the null value is not handled in the `getConfig()` method of the `CacheManager` class.

This PR aims to make the behavior of the `Cache` and `Broadcast`-NullDriver consistent.

---

To ensure the configuration is also consistent the following should be added to the [cache  config](https://github.com/laravel/laravel/blob/master/config/cache.php#L87) in the *laravel/laravel* repo

```php
`null` => [
  'driver' => 'null'
]
```