### PR TITLE
[6.x] Nested route binding

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -39,7 +39,7 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-           if (count($chunks = explode('__from__', $parameterName)) > 1) {
+            if (count($chunks = explode('__from__', $parameterName)) > 1) {
                 $parentName = $chunks[1];
                 $parentParameter = $route->parameters()[$parentName] ?? $parentName;
 

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -109,7 +109,7 @@ class ImplicitRouteBinding
     protected static function findNestedParameter($name, $parameters)
     {
         return array_filter($parameters, function ($parameterName) use ($name) {
-            return strpos($parameterName, $name . '__from__') !== false;
+            return strpos($parameterName, $name.'__from__') !== false;
         }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -20,10 +20,15 @@ class ImplicitRouteBinding
     public static function resolveForRoute($container, $route)
     {
         $parameters = $route->parameters();
+        $signatureParameters = $route->signatureParameters(UrlRoutable::class);
 
-        foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
+        foreach ($signatureParameters as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->name, $parameters)) {
-                continue;
+                if (!static::isNestedParameter($parameter->name, $parameters)) {
+                    continue;
+                }
+
+                $parameterName = static::getNestedParameterName($parameter->name, $parameters);
             }
 
             $parameterValue = $parameters[$parameterName];
@@ -34,7 +39,17 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-            if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+            if (count($chunks = explode('__from__', $parameterName)) > 1)
+            {
+                $parentName = $chunks[1];
+                $parentParameter = $route->parameters()[$parentName] ?? $parentName;
+
+                $model = $instance->where($instance->getRouteKeyName(), $parameterValue)
+                    ->whereHas($parentName, function($query) use ($parentParameter) {
+                        $query->where($parentParameter->getRouteKeyName(), $parentParameter->getRouteKey());
+                    })
+                    ->first();
+            } else if (! $model = $instance->resolveRouteBinding($parameterValue)) {
                 throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
             }
 
@@ -58,5 +73,44 @@ class ImplicitRouteBinding
         if (array_key_exists($snakedName = Str::snake($name), $parameters)) {
             return $snakedName;
         }
+    }
+
+    /**
+     * Check if parameter is nested
+     *
+     * @param string $name
+     * @return bool
+     */
+    protected static function isNestedParameter($name, $parameters)
+    {
+        return count(static::findNestedParameter(...func_get_args()));
+    }
+
+    /**
+     * Get nested parameter name
+     *
+     * @param string $name
+     * @param array $parameters
+     * @return string
+     */
+    protected static function getNestedParameterName($name, $parameters)
+    {
+        $nestedName = key(static::findNestedParameter(...func_get_args()));
+
+        return $nestedName;
+    }
+
+    /**
+     * Find parameter
+     *
+     * @param string $name
+     * @param array $parameters
+     * @return array
+     */
+    protected static function findNestedParameter($name, $parameters)
+    {
+        return array_filter($parameters, function ($parameterName) use ($name) {
+            return strpos($parameterName, $name . '__from__') !== false;
+        }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -24,7 +24,7 @@ class ImplicitRouteBinding
 
         foreach ($signatureParameters as $parameter) {
             if (! $parameterName = static::getParameterName($parameter->name, $parameters)) {
-                if (!static::isNestedParameter($parameter->name, $parameters)) {
+                if (! static::isNestedParameter($parameter->name, $parameters)) {
                     continue;
                 }
 
@@ -39,17 +39,16 @@ class ImplicitRouteBinding
 
             $instance = $container->make($parameter->getClass()->name);
 
-            if (count($chunks = explode('__from__', $parameterName)) > 1)
-            {
+           if (count($chunks = explode('__from__', $parameterName)) > 1) {
                 $parentName = $chunks[1];
                 $parentParameter = $route->parameters()[$parentName] ?? $parentName;
 
                 $model = $instance->where($instance->getRouteKeyName(), $parameterValue)
-                    ->whereHas($parentName, function($query) use ($parentParameter) {
+                    ->whereHas($parentName, function ($query) use ($parentParameter) {
                         $query->where($parentParameter->getRouteKeyName(), $parentParameter->getRouteKey());
                     })
                     ->first();
-            } else if (! $model = $instance->resolveRouteBinding($parameterValue)) {
+            } elseif (! $model = $instance->resolveRouteBinding($parameterValue)) {
                 throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
             }
 
@@ -76,7 +75,7 @@ class ImplicitRouteBinding
     }
 
     /**
-     * Check if parameter is nested
+     * Check if parameter is nested.
      *
      * @param string $name
      * @return bool
@@ -87,7 +86,7 @@ class ImplicitRouteBinding
     }
 
     /**
-     * Get nested parameter name
+     * Get nested parameter name.
      *
      * @param string $name
      * @param array $parameters
@@ -101,7 +100,7 @@ class ImplicitRouteBinding
     }
 
     /**
-     * Find parameter
+     * Find parameter.
      *
      * @param string $name
      * @param array $parameters


### PR DESCRIPTION
I offer my solution to this problem: https://github.com/laravel/ideas/issues/1911
Declaring nested route able with keyword `__from__[parent]`
Example: 
```
Route::get('/courses/{course}/{page__from__course}', [PageController::class, 'show']);
```