### PR TITLE
[6.x] Model dirty check bug fix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1172,6 +1172,9 @@ trait HasAttributes
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===
                    $this->fromDateTime($original);
+        } elseif ($this->hasCast($key, ['object', 'collection'])) {
+            return $this->castAttribute($key, $current) ==
+                $this->castAttribute($key, $original);
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -116,6 +116,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('datetimeAttribute'));
     }
 
+    public function testDirtyOnCastedObjects()
+    {
+        $model = new EloquentModelCastingStub;
+        $model->setRawAttributes([
+            'objectAttribute'     => '["one", "two", "three"]',
+            'collectionAttribute' => '["one", "two", "three"]',
+        ]);
+        $model->syncOriginal();
+
+        $model->objectAttribute = ['one', 'two', 'three'];
+        $model->collectionAttribute = ['one', 'two', 'three'];
+
+        $this->assertFalse($model->isDirty());
+        $this->assertFalse($model->isDirty('objectAttribute'));
+        $this->assertFalse($model->isDirty('collectionAttribute'));
+    }
+
     public function testCleanAttributes()
     {
         $model = new EloquentModelStub(['foo' => '1', 'bar' => 2, 'baz' => 3]);


### PR DESCRIPTION
for attributes that are cast to any type of Object, the strict equivalency (`===`) will never return `true`, because even though the values may be equal, the Objects they reference will be different.

this changes checks if the cast type is either `object` or `collection`, both which return Objects, and uses loose equivalency to compare them.

even though date casting also returns an Object, we don't need to handle that since it's handled in the previous conditional.

the test represents a scenario that occurs when using JSON fields in MySQL. MySQL returns the value with spaces between the elements, but `json_encode` returns a string **without** spaces between the elements.

References:

#30564
#28029