### PR TITLE
[6.x] Reattach bcc to $message for post events

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -63,6 +63,7 @@ class MailgunTransport extends Transport
         $to = $this->getTo($message);
 
         $bcc = $message->getBcc();
+
         $message->setBcc([]);
 
         $response = $this->client->request(
@@ -76,6 +77,7 @@ class MailgunTransport extends Transport
         );
 
         $message->setBcc($bcc);
+
         $this->sendPerformed($message);
 
         return $this->numberOfRecipients($message);

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -62,6 +62,7 @@ class MailgunTransport extends Transport
 
         $to = $this->getTo($message);
 
+        $bcc = $message->getBcc();
         $message->setBcc([]);
 
         $response = $this->client->request(
@@ -74,6 +75,7 @@ class MailgunTransport extends Transport
             'X-Mailgun-Message-ID', $this->getMessageId($response)
         );
 
+        $message->setBcc($bcc);
         $this->sendPerformed($message);
 
         return $this->numberOfRecipients($message);


### PR DESCRIPTION
This will ensure that the bcc header isn't empty in events such as MessageSent.