### PR TITLE
[6.x] --lan option for serve command

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -77,7 +77,21 @@ class ServeCommand extends Command
      */
     protected function host()
     {
+        if ($this->input->getOption('lan')) {
+            return $this->lanHost();
+        }
+
         return $this->input->getOption('host');
+    }
+
+    /**
+     * Get the LAN host for the command.
+     *
+     * @return string
+     */
+    protected function lanHost(): string
+    {
+        return explode(PHP_EOL, shell_exec('ifconfig | grep "inet " | grep -Fv 127.0.0.1 | awk \'{print $2}\''))[0];
     }
 
     /**
@@ -116,6 +130,8 @@ class ServeCommand extends Command
             ['port', null, InputOption::VALUE_OPTIONAL, 'The port to serve the application on', Env::get('SERVER_PORT')],
 
             ['tries', null, InputOption::VALUE_OPTIONAL, 'The max number of ports to attempt to serve from', 10],
+
+            ['lan', null, InputOption::VALUE_NONE, 'Use the LAN host'],
         ];
     }
 }


### PR DESCRIPTION
This PR provides an ability to run `php artisan serve --lan`.
As a result, your LAN host will be used as a host.

```
➜  coderello git:(master) art serve --lan
Laravel development server started: <http://192.168.0.104:8000>
```

That's handy for cases when you want to test your application from the device from your LAN.