### PR TITLE
[6.x] Update CHANGELOG-6.x.md

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -11,7 +11,7 @@
 ### Fixed
 - Fixed default value for $count in `PhpRedisConnection::spop()` method ([#30546](https://github.com/laravel/framework/pull/30546))
 - Fixed breaking compatibility with multi-schema postgres ([#30562](https://github.com/laravel/framework/pull/30562), [6460d2b](https://github.com/laravel/framework/commit/6460d2b1bd89f470a76f5c2c3bddd390fe430e0f))
-- Fixed `Model::isDirty()` with `colelction` \ `object` casts ([#30565](https://github.com/laravel/framework/pull/30565))
+- Fixed `Model::isDirty()` with `collection` \ `object` casts ([#30565](https://github.com/laravel/framework/pull/30565))
 - Fixed `bcc` in `MailgunTransport::send()` ([#30569](https://github.com/laravel/framework/pull/30569))
 
 ### Changed


### PR DESCRIPTION
Fixes a small typo I noticed in the v6.5.1 release.