### PR TITLE
[6.x] Fix docs function fireCustomModelEvent

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -194,7 +194,7 @@ trait HasEvents
      *
      * @param  string  $event
      * @param  string  $method
-     * @return mixed|null
+     * @return mixed|void
      */
     protected function fireCustomModelEvent($event, $method)
     {


### PR DESCRIPTION
We have 2 case function doesn't return things. 
1. When not isset `$this->dispatchesEvents[$event]`
2. When `is_null` `$result`

If function doesn't return things, it's `void`, I think it clear than more

Refer: [Should a function use: return null;?](https://stackoverflow.com/questions/8749091/should-a-function-use-return-null)
I hope your team will update in next time 
