### PR TITLE
[6.x] Override BelongsToMany::cursor() to hydrate pivot relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -750,6 +750,22 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Get a lazy collection for the given query.
+     *
+     * @return \Illuminate\Support\LazyCollection
+     */
+    public function cursor()
+    {
+        $this->query->addSelect($this->shouldSelect());
+
+        return $this->query->cursor()->map(function ($model) {
+            $this->hydratePivotRelation([$model]);
+
+            return $model;
+        });
+    }
+
+    /**
      * Hydrate the pivot table relationship on the models.
      *
      * @param  array  $models

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -767,6 +767,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
     }
 
+    public function testBelongsToManyRelationshipModelsAreProperlyHydratedOverCursorRequest()
+    {
+        $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
+        $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
+
+        foreach (EloquentTestUser::first()->friends()->cursor() as $result) {
+            $this->assertSame('abigailotwell@gmail.com', $result->email);
+            $this->assertEquals($user->id, $result->pivot->user_id);
+            $this->assertEquals($friend->id, $result->pivot->friend_id);
+        }
+    }
+
     public function testBasicHasManyEagerLoading()
     {
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);


### PR DESCRIPTION
### Overview

Currently pivot relations are not hydrated over `cursor()` request. We need to override it like `each()` `chunk()` `chunkById()` `paginate()` `simplePaginate()`.

```php
foreach (Post::first()->tags()->cursor() as $tag) {
    dump($tag->pivot->flag); // This cannot be correctly retrieved now
}
```

It seems that `HasManyThrough::cursor()` is already correctly implemented.

### Related PRs

- [[5.7] Fix each() on BelongsToMany relationships by staudenmeir · Pull Request #25832 · laravel/framework](https://github.com/laravel/framework/pull/25832)
- [[5.6] Fix for HasManyThrough returning incorrect results with chunk()… by AmmarRahman · Pull Request #24096 · laravel/framework](https://github.com/laravel/framework/pull/24096)
- [[5.0] Eloquent belongsToMany chunk by codelight89 · Pull Request #8045 · laravel/framework](https://github.com/laravel/framework/pull/8045/files)