### PR TITLE
Update Mix.php to not fallback to localhost:8080

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -36,7 +36,7 @@ class Mix
                 return new HtmlString(Str::after($url, ':').$path);
             }
 
-            return new HtmlString("//localhost:8080{$path}");
+            return new HtmlString($path);
         }
 
         $manifestPath = public_path($manifestDirectory.'/mix-manifest.json');


### PR DESCRIPTION
Right now when the public/hot folder is present (and empty), it has a fallback to //localhost:8080, which makes no sense for environments other than a local one (like php artisan serve or Homestead). We're currently testing our new automatic deployments which ensures folders are present and symlinked. When creating the hot folder, all asset URLs (created with asset(mix())) broke, which is how we discovered this issue.

This proposed change simply creates the HtmlString from the path, which already prepends the site's URL, including port, if present. I've tested with both a domain and localhost with port and it works for both.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
