### PR TITLE
[6.x] Improve formatPostGisType method readability

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -889,10 +889,10 @@ class PostgresGrammar extends Grammar
     private function formatPostGisType(string $type, Fluent $column)
     {
         if ($column->isGeometry !== null) {
-            return "geometry($type".($column->projection === null ? '' : ", $column->projection").')';
+            return sprintf('geometry(%s%s)', $type, $column->projection === null ? '' : ", {$column->projection}");
         }
 
-        return "geography($type, ".($column->projection ?? '4326').')';
+        return sprintf('geography(%s, %s)', $type, $column->projection ?? '4326');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -888,11 +888,15 @@ class PostgresGrammar extends Grammar
      */
     private function formatPostGisType(string $type, Fluent $column)
     {
-        if ($column->isGeometry !== null) {
-            return sprintf('geometry(%s%s)', $type, $column->projection === null ? '' : ", {$column->projection}");
+        if ($column->isGeometry === null) {
+            return sprintf('geography(%s, %s)', $type, $column->projection ?? '4326');
         }
 
-        return sprintf('geography(%s, %s)', $type, $column->projection ?? '4326');
+        if ($column->projection !== null) {
+            return sprintf('geometry(%s, %s)', $type, $column->projection);
+        }
+
+        return "geometry({$type})";
     }
 
     /**


### PR DESCRIPTION
Follow-up to the PR #30545

It's hard to read the code because too many parenthesis and alternation of different quotes. This PR replaces it with `sptrinf` method and breaks down inline ternary operator.