### PR TITLE
[6.x] RedisBroadcaster - Ignore Redis Prefix When Verifying Channel Access

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -47,14 +47,13 @@ class RedisBroadcaster extends Broadcaster
      */
     public function auth($request)
     {
-        $channelName = $this->normalizeChannelName($request->channel_name);
+        $channelName = str_replace(config('database.redis.options.prefix', ''), '', $request->channel_name);
+        $channelName = $this->normalizeChannelName($channelName);
 
         if ($this->isGuardedChannel($request->channel_name) &&
             ! $this->retrieveUser($request, $channelName)) {
             throw new AccessDeniedHttpException;
         }
-
-        $channelName = str_replace(config('redis.options.prefix', ''), '', $channelName);
 
         return parent::verifyUserCanAccessChannel(
             $request, $channelName

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -54,6 +54,8 @@ class RedisBroadcaster extends Broadcaster
             throw new AccessDeniedHttpException;
         }
 
+        $channelName = str_replace(config('redis.options.prefix', ''), '', $channelName);
+
         return parent::verifyUserCanAccessChannel(
             $request, $channelName
         );

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Tests\Broadcasting;
 
 use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +22,11 @@ class RedisBroadcasterTest extends TestCase
         parent::setUp();
 
         $this->broadcaster = m::mock(RedisBroadcaster::class)->makePartial();
+        $container = Container::setInstance(new Container);
+
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
     }
 
     protected function tearDown(): void
@@ -137,6 +144,20 @@ class RedisBroadcasterTest extends TestCase
                 'c' => 'd',
             ])
         );
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([
+            'redis' => [
+                'options' => ['prefix' => 'laravel_database_'],
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Since [5.8](https://github.com/laravel/laravel/pull/4982) Laravel ships with Redis configured with a prefix to prevent conflicts when apps share a Redis store. This prefix is also used in the RedisBroadcaster to broadcast events and verify channels.

While using [Laravel Echo Server](https://github.com/tlaverdure/laravel-echo-server) some developers want to match the prefixing in their configurations with that in their Laravel app. This can work by add the keyPrefix to the server config, however, when authorizing private channels the prefix conflicts with the private channel definition in Laravel. For example:

```php
Broadcast::channel('App.User.{id}', function ($user, $id) {
    return (int) $user->id === (int) $id;
});
``` 

With prefixing the channel is read as `laravel_database_private-App.User.1` in `RedisBroadcaster::auth` instead of `private-App.User.1`.
