### PR TITLE
[6.x] added broadcastAs method to BroadcastNotificationCreated

### DIFF
--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -109,4 +109,15 @@ class BroadcastNotificationCreated implements ShouldBroadcast
                     ? $this->notification->broadcastType()
                     : get_class($this->notification);
     }
+
+    /**
+     * Get the name of the notification being broadcast.
+     * @return string
+     */
+    public function broadcastAs()
+    {
+        return method_exists($this->notification, 'broadcastAs')
+            ? $this->notification->broadcastAs()
+            : get_class($this->notification);
+    }
 }

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -112,6 +112,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
     /**
      * Get the name of the notification being broadcast.
+     
      * @return string
      */
     public function broadcastAs()

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -112,7 +112,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
 
     /**
      * Get the name of the notification being broadcast.
-     
+     *
      * @return string
      */
     public function broadcastAs()


### PR DESCRIPTION
This PR relates to issue #30599. It allows changing notification event name on broadcast.