### PR TITLE
[7.x] Let the job itself decide which queue to use

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -145,7 +145,7 @@ class Dispatcher implements QueueingDispatcher
      */
     public function dispatchToQueue($command)
     {
-        $connection = $command->connection ?? null;
+        $connection = $command->connection ?? (method_exists($command, 'getConnection') ? $command->getConnection() : null);
 
         $queue = call_user_func($this->queueResolver, $connection);
 
@@ -169,12 +169,14 @@ class Dispatcher implements QueueingDispatcher
      */
     protected function pushCommandToQueue($queue, $command)
     {
-        if (isset($command->queue, $command->delay)) {
-            return $queue->laterOn($command->queue, $command->delay, $command);
+        $queueName = $command->queue ?? (method_exists($command, 'getQueue') ? $command->getQueue() : null);
+        
+        if (isset($queueName, $command->delay)) {
+            return $queue->laterOn($queueName, $command->delay, $command);
         }
 
-        if (isset($command->queue)) {
-            return $queue->pushOn($command->queue, $command);
+        if (isset($queueName)) {
+            return $queue->pushOn($queueName, $command);
         }
 
         if (isset($command->delay)) {

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -170,7 +170,7 @@ class Dispatcher implements QueueingDispatcher
     protected function pushCommandToQueue($queue, $command)
     {
         $queueName = $command->queue ?? (method_exists($command, 'getQueue') ? $command->getQueue() : null);
-        
+
         if (isset($queueName, $command->delay)) {
             return $queue->laterOn($queueName, $command->delay, $command);
         }


### PR DESCRIPTION
class Job implements ShouldQueue
{
    use Dispatchable, Queueable;
    
    public function getConnection()
    {
        return 'foo1';
    }
    
    public function getQueue()
    {
        return 'bar1';
    }
}

// Send to "foo:bar"
dispatch(new Job)->onConnection('foo')->onQueue('bar');

// Send to "foo1:bar1"
dispatch(new Job);

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
