### PR TITLE
[6.x] Allow model serialization for typed properties

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,8 @@
 php:
   preset: laravel
+  finder:
+    not-name:
+      - typed-properties.php
 js:
   finder:
     not-name:

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -11,11 +11,11 @@ trait SerializesModels
     use SerializesAndRestoresModelIdentifiers;
 
     /**
-     * A list of serialized model identifiers.
+     * The list of serialized model identifiers.
      *
      * @var array
      */
-    protected $identifiers = [];
+    protected $modelIdentifiers = [];
 
     /**
      * Prepare the instance for serialization.
@@ -27,7 +27,7 @@ trait SerializesModels
         $properties = (new ReflectionClass($this))->getProperties();
 
         foreach ($properties as $property) {
-            if ($property->getName() === 'identifiers') {
+            if ($property->getName() === 'modelIdentifiers') {
                 continue;
             }
 
@@ -36,9 +36,9 @@ trait SerializesModels
             );
 
             if ($serializedValue instanceof ModelIdentifier) {
-                $this->identifiers[$property->getName()] = $serializedValue;
+                $this->modelIdentifiers[$property->getName()] = $serializedValue;
 
-                // Set an empty instance of the model or collection to support typed properties...
+                // Empty instance of the model or collection to support typed properties...
                 $property->setValue($this, new $value);
             } else {
                 $property->setValue($this, $value);
@@ -58,12 +58,12 @@ trait SerializesModels
     public function __wakeup()
     {
         foreach ((new ReflectionClass($this))->getProperties() as $property) {
-            if ($property->isStatic() || $property->getName() === 'identifiers') {
+            if ($property->isStatic() || $property->getName() === 'modelIdentifiers') {
                 continue;
             }
 
-            if (isset($this->identifiers[$property->getName()])) {
-                $value = $this->identifiers[$property->getName()];
+            if (isset($this->modelIdentifiers[$property->getName()])) {
+                $value = $this->modelIdentifiers[$property->getName()];
             } else {
                 $value = $this->getPropertyValue($property);
             }

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -2,12 +2,20 @@
 
 namespace Illuminate\Queue;
 
+use Illuminate\Contracts\Database\ModelIdentifier;
 use ReflectionClass;
 use ReflectionProperty;
 
 trait SerializesModels
 {
     use SerializesAndRestoresModelIdentifiers;
+
+    /**
+     * A list of serialized model identifiers.
+     *
+     * @var array
+     */
+    protected $identifiers = [];
 
     /**
      * Prepare the instance for serialization.
@@ -19,9 +27,22 @@ trait SerializesModels
         $properties = (new ReflectionClass($this))->getProperties();
 
         foreach ($properties as $property) {
-            $property->setValue($this, $this->getSerializedPropertyValue(
-                $this->getPropertyValue($property)
-            ));
+            if ($property->getName() === 'identifiers') {
+                continue;
+            }
+
+            $serializedValue = $this->getSerializedPropertyValue(
+                $value = $this->getPropertyValue($property)
+            );
+
+            if ($serializedValue instanceof ModelIdentifier) {
+                $this->identifiers[$property->getName()] = $serializedValue;
+
+                // Set an empty instance of the model or collection to support typed properties...
+                $property->setValue($this, new $value);
+            } else {
+                $property->setValue($this, $value);
+            }
         }
 
         return array_values(array_filter(array_map(function ($p) {
@@ -37,12 +58,18 @@ trait SerializesModels
     public function __wakeup()
     {
         foreach ((new ReflectionClass($this))->getProperties() as $property) {
-            if ($property->isStatic()) {
+            if ($property->isStatic() || $property->getName() === 'identifiers') {
                 continue;
             }
 
+            if (isset($this->identifiers[$property->getName()])) {
+                $value = $this->identifiers[$property->getName()];
+            } else {
+                $value = $this->getPropertyValue($property);
+            }
+
             $property->setValue($this, $this->getRestoredPropertyValue(
-                $this->getPropertyValue($property)
+                $value
             ));
         }
     }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -90,14 +90,14 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('testbench', $unSerialized->user->getConnectionName());
         $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
 
-        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('testbench')->get()));
+        $serialized = serialize(new CollectionSerializationTestClass(ModelSerializationTestUser::on('testbench')->get()));
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertSame('testbench', $unSerialized->user[0]->getConnectionName());
-        $this->assertSame('mohamed@laravel.com', $unSerialized->user[0]->email);
-        $this->assertSame('testbench', $unSerialized->user[1]->getConnectionName());
-        $this->assertSame('taylor@laravel.com', $unSerialized->user[1]->email);
+        $this->assertSame('testbench', $unSerialized->users[0]->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->users[0]->email);
+        $this->assertSame('testbench', $unSerialized->users[1]->getConnectionName());
+        $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 
     public function testItSerializeUserOnDifferentConnection()
@@ -117,14 +117,14 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('custom', $unSerialized->user->getConnectionName());
         $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
 
-        $serialized = serialize(new ModelSerializationTestClass(ModelSerializationTestUser::on('custom')->get()));
+        $serialized = serialize(new CollectionSerializationTestClass(ModelSerializationTestUser::on('custom')->get()));
 
         $unSerialized = unserialize($serialized);
 
-        $this->assertSame('custom', $unSerialized->user[0]->getConnectionName());
-        $this->assertSame('mohamed@laravel.com', $unSerialized->user[0]->email);
-        $this->assertSame('custom', $unSerialized->user[1]->getConnectionName());
-        $this->assertSame('taylor@laravel.com', $unSerialized->user[1]->email);
+        $this->assertSame('custom', $unSerialized->users[0]->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->users[0]->email);
+        $this->assertSame('custom', $unSerialized->users[1]->getConnectionName());
+        $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 
     public function testItFailsIfModelsOnMultiConnections()
@@ -140,7 +140,7 @@ class ModelSerializationTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
-        $serialized = serialize(new ModelSerializationTestClass(
+        $serialized = serialize(new CollectionSerializationTestClass(
             new Collection([$user, $user2])
         ));
 
@@ -214,7 +214,7 @@ class ModelSerializationTest extends TestCase
 
     public function testItSerializesAnEmptyCollection()
     {
-        $serialized = serialize(new ModelSerializationTestClass(
+        $serialized = serialize(new CollectionSerializationTestClass(
             new Collection([])
         ));
 
@@ -268,6 +268,41 @@ class ModelSerializationTest extends TestCase
         $unserialized = unserialize($serialized);
 
         $this->assertInstanceOf(ModelSerializationTestCustomUserCollection::class, $unserialized->users);
+    }
+
+    public function testItSerializesTypedProperties()
+    {
+        if (version_compare(phpversion(), '7.4.0-dev', '<')) {
+            $this->markTestSkipped('Typed properties are only available from PHP 7.4 and up.');
+        }
+
+        require_once(__DIR__.'/typed-properties.php');
+
+        $user = ModelSerializationTestUser::create([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $serialized = serialize(new TypedPropertyTestClass($user, 5, ['James', 'Taylor', 'Mohamed']));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertSame('testbench', $unSerialized->user->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
+        $this->assertSame(5, $unSerialized->id);
+        $this->assertSame(['James', 'Taylor', 'Mohamed'], $unSerialized->names);
+
+        $serialized = serialize(new TypedPropertyCollectionTestClass(ModelSerializationTestUser::on('testbench')->get()));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertSame('testbench', $unSerialized->users[0]->getConnectionName());
+        $this->assertSame('mohamed@laravel.com', $unSerialized->users[0]->email);
+        $this->assertSame('testbench', $unSerialized->users[1]->getConnectionName());
+        $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -276,7 +276,7 @@ class ModelSerializationTest extends TestCase
             $this->markTestSkipped('Typed properties are only available from PHP 7.4 and up.');
         }
 
-        require_once(__DIR__.'/typed-properties.php');
+        require_once __DIR__.'/typed-properties.php';
 
         $user = ModelSerializationTestUser::create([
             'email' => 'mohamed@laravel.com',

--- a/tests/Integration/Queue/typed-properties.php
+++ b/tests/Integration/Queue/typed-properties.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Queue\SerializesModels;
+
+class TypedPropertyTestClass
+{
+    use SerializesModels;
+
+    public ModelSerializationTestUser $user;
+
+    public int $id;
+
+    public array $names;
+
+    public function __construct(ModelSerializationTestUser $user, int $id, array $names)
+    {
+        $this->user = $user;
+        $this->id = $id;
+        $this->names = $names;
+    }
+}
+
+class TypedPropertyCollectionTestClass
+{
+    use SerializesModels;
+
+    public Collection $users;
+
+    public function __construct(Collection $users)
+    {
+        $this->users = $users;
+    }
+}


### PR DESCRIPTION
At the moment it's not possible to use model serialization on jobs with typed properties (which is coming to PHP 7.4). The reason for this is that the property values get replaced with a `ModelIdentifier` instance which contains all the info to unserialize the model or collection later on.

This new implementation takes the approach of saving those ModelIdentifiers on a separate `$identifiers` property and replaces the original property values with empty instances of those models or collections. This way, type safety is preserved and we can use typed properties on queueable jobs.

This is technically a breaking change because if you expect the properties to contain the `ModelIdentifier` you'll now get an empty model or collection after serialization. But this is also only happening if you're doing anything with the model after serialization and before sending it to the queue, which seems unlikely.

Fixes https://github.com/laravel/framework/issues/30494 

Small side note: one small other thing that I thought of was if people would be overriding a model constructor with different arguments other than the default that this wouldn't work but I found out that in the current unserialization process the same approach is taken and thus that wouldn't work anyway at the moment. It's also my personal opinion that people shouldn't override a collection or model's constructor but best use named constructors in these cases.