### PR TITLE
[6.x] Serialization of models on PHP 7.4 with compatibility with PHP 7.3 and below

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -2,20 +2,12 @@
 
 namespace Illuminate\Queue;
 
-use Illuminate\Contracts\Database\ModelIdentifier;
 use ReflectionClass;
 use ReflectionProperty;
 
 trait SerializesModels
 {
     use SerializesAndRestoresModelIdentifiers;
-
-    /**
-     * The list of serialized model identifiers.
-     *
-     * @var array
-     */
-    protected $modelIdentifiers = [];
 
     /**
      * Prepare the instance for serialization.
@@ -27,22 +19,9 @@ trait SerializesModels
         $properties = (new ReflectionClass($this))->getProperties();
 
         foreach ($properties as $property) {
-            if ($property->getName() === 'modelIdentifiers') {
-                continue;
-            }
-
-            $serializedValue = $this->getSerializedPropertyValue(
-                $value = $this->getPropertyValue($property)
-            );
-
-            if ($serializedValue instanceof ModelIdentifier) {
-                $this->modelIdentifiers[$property->getName()] = $serializedValue;
-
-                // Empty instance of the model or collection to support typed properties...
-                $property->setValue($this, new $value);
-            } else {
-                $property->setValue($this, $value);
-            }
+            $property->setValue($this, $this->getSerializedPropertyValue(
+                $this->getPropertyValue($property)
+            ));
         }
 
         return array_values(array_filter(array_map(function ($p) {
@@ -58,20 +37,78 @@ trait SerializesModels
     public function __wakeup()
     {
         foreach ((new ReflectionClass($this))->getProperties() as $property) {
-            if ($property->isStatic() || $property->getName() === 'modelIdentifiers') {
+            if ($property->isStatic()) {
                 continue;
             }
 
-            if (isset($this->modelIdentifiers[$property->getName()])) {
-                $value = $this->modelIdentifiers[$property->getName()];
-            } else {
-                $value = $this->getPropertyValue($property);
-            }
-
             $property->setValue($this, $this->getRestoredPropertyValue(
-                $value
+                $this->getPropertyValue($property)
             ));
         }
+    }
+
+    /**
+     * Prepare the instance values for serialization.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $values = [];
+
+        $properties = (new ReflectionClass($this))->getProperties();
+
+        foreach ($properties as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $name = $property->getName();
+
+            if ($property->isPrivate()) {
+                $name = "\0A\0{$name}";
+            } elseif ($property->isProtected()) {
+                $name = "\0*\0{$name}";
+            }
+
+            $values[$name] = $this->getSerializedPropertyValue($this->getPropertyValue($property));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Restore the model after serialization.
+     *
+     * @param  array  $values
+     * @return array
+     */
+    public function __unserialize(array $values)
+    {
+        $properties = (new ReflectionClass($this))->getProperties();
+
+        foreach ($properties as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $name = $property->getName();
+
+            if ($property->isPrivate()) {
+                $name = "\0A\0{$name}";
+            } elseif ($property->isProtected()) {
+                $name = "\0*\0{$name}";
+            }
+
+            if (! array_key_exists($name, $values)) {
+                continue;
+            }
+
+            $property->setAccessible(true);
+            $property->setValue($this, $this->getRestoredPropertyValue($values[$name]));
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -58,6 +58,8 @@ trait SerializesModels
 
         $properties = (new ReflectionClass($this))->getProperties();
 
+        $class = get_class($this);
+
         foreach ($properties as $property) {
             if ($property->isStatic()) {
                 continue;
@@ -66,7 +68,7 @@ trait SerializesModels
             $name = $property->getName();
 
             if ($property->isPrivate()) {
-                $name = "\0A\0{$name}";
+                $name = "\0{$class}\0{$name}";
             } elseif ($property->isProtected()) {
                 $name = "\0*\0{$name}";
             }
@@ -87,6 +89,8 @@ trait SerializesModels
     {
         $properties = (new ReflectionClass($this))->getProperties();
 
+        $class = get_class($this);
+
         foreach ($properties as $property) {
             if ($property->isStatic()) {
                 continue;
@@ -95,7 +99,7 @@ trait SerializesModels
             $name = $property->getName();
 
             if ($property->isPrivate()) {
-                $name = "\0A\0{$name}";
+                $name = "\0{$class}\0{$name}";
             } elseif ($property->isProtected()) {
                 $name = "\0*\0{$name}";
             }

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -305,7 +305,8 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 
-    public function test_model_serialization_structure() {
+    public function test_model_serialization_structure()
+    {
         $user = ModelSerializationTestUser::create([
             'email' => 'taylor@laravel.com',
         ]);
@@ -313,8 +314,7 @@ class ModelSerializationTest extends TestCase
         $serialized = serialize(new ModelSerializationAccessibleTestClass($user, $user, $user));
 
         $this->assertEquals(
-            'O:72:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass":3:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"' . "\0" . 'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass' . "\0" . 'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"' . "\0" . 'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass' . "\0" . 'user3";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}'
-            , $serialized
+            'O:72:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass":3:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"'."\0".'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"'."\0".'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass'."\0".'user3";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
         );
     }
 }
@@ -440,7 +440,6 @@ class ModelSerializationAccessibleTestClass
     public $user;
     private $user2;
     private $user3;
-
 
     public function __construct($user, $user2, $user3)
     {

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -292,8 +292,8 @@ class ModelSerializationTest extends TestCase
 
         $this->assertSame('testbench', $unSerialized->user->getConnectionName());
         $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
-        $this->assertSame(5, $unSerialized->id);
-        $this->assertSame(['James', 'Taylor', 'Mohamed'], $unSerialized->names);
+        $this->assertSame(5, $unSerialized->getId());
+        $this->assertSame(['James', 'Taylor', 'Mohamed'], $unSerialized->getNames());
 
         $serialized = serialize(new TypedPropertyCollectionTestClass(ModelSerializationTestUser::on('testbench')->get()));
 
@@ -305,14 +305,17 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 
-    public function test_model_serialization_structure(){
+    public function test_model_serialization_structure() {
         $user = ModelSerializationTestUser::create([
             'email' => 'taylor@laravel.com',
         ]);
 
-        $serialized = serialize(new ModelSerializationTestClass($user));
+        $serialized = serialize(new ModelSerializationAccessibleTestClass($user, $user, $user));
 
-        $this->assertEquals('O:62:"Illuminate\Tests\Integration\Queue\ModelSerializationTestClass":1:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\Tests\Integration\Queue\ModelSerializationTestUser";s:2:"id";i:'.$user->id.';s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized);
+        $this->assertEquals(
+            'O:72:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass":3:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"' . "\0" . 'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass' . "\0" . 'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"' . "\0" . 'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass' . "\0" . 'user3";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}'
+            , $serialized
+        );
     }
 }
 
@@ -427,6 +430,23 @@ class ModelSerializationTestClass
     public function __construct($user)
     {
         $this->user = $user;
+    }
+}
+
+class ModelSerializationAccessibleTestClass
+{
+    use SerializesModels;
+
+    public $user;
+    private $user2;
+    private $user3;
+
+
+    public function __construct($user, $user2, $user3)
+    {
+        $this->user = $user;
+        $this->user2 = $user2;
+        $this->user3 = $user3;
     }
 }
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -304,6 +304,16 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('testbench', $unSerialized->users[1]->getConnectionName());
         $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
+
+    public function test_model_serialization_structure(){
+        $user = ModelSerializationTestUser::create([
+            'email' => 'taylor@laravel.com',
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $this->assertEquals('O:62:"Illuminate\Tests\Integration\Queue\ModelSerializationTestClass":1:{s:4:"user";O:45:"Illuminate\Contracts\Database\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\Tests\Integration\Queue\ModelSerializationTestUser";s:2:"id";i:'.$user->id.';s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized);
+    }
 }
 
 class ModelSerializationTestUser extends Model

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -311,10 +311,10 @@ class ModelSerializationTest extends TestCase
             'email' => 'taylor@laravel.com',
         ]);
 
-        $serialized = serialize(new ModelSerializationAccessibleTestClass($user, $user, $user));
+        $serialized = serialize(new ModelSerializationParentAccessibleTestClass($user, $user, $user));
 
         $this->assertEquals(
-            'O:72:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass":3:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"'."\0".'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:79:"'."\0".'Illuminate\\Tests\\Integration\\Queue\\ModelSerializationAccessibleTestClass'."\0".'user3";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
+            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:8:"' . "\0" . '*' . "\0" . 'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
         );
     }
 }
@@ -438,7 +438,7 @@ class ModelSerializationAccessibleTestClass
     use SerializesModels;
 
     public $user;
-    private $user2;
+    protected $user2;
     private $user3;
 
     public function __construct($user, $user2, $user3)
@@ -447,6 +447,10 @@ class ModelSerializationAccessibleTestClass
         $this->user2 = $user2;
         $this->user3 = $user3;
     }
+}
+
+class ModelSerializationParentAccessibleTestClass extends ModelSerializationAccessibleTestClass{
+
 }
 
 class ModelRelationSerializationTestClass

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -314,7 +314,7 @@ class ModelSerializationTest extends TestCase
         $serialized = serialize(new ModelSerializationParentAccessibleTestClass($user, $user, $user));
 
         $this->assertEquals(
-            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:8:"' . "\0" . '*' . "\0" . 'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
+            'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
         );
     }
 }
@@ -449,8 +449,9 @@ class ModelSerializationAccessibleTestClass
     }
 }
 
-class ModelSerializationParentAccessibleTestClass extends ModelSerializationAccessibleTestClass{
-
+class ModelSerializationParentAccessibleTestClass extends ModelSerializationAccessibleTestClass
+{
+    //
 }
 
 class ModelRelationSerializationTestClass

--- a/tests/Integration/Queue/typed-properties.php
+++ b/tests/Integration/Queue/typed-properties.php
@@ -11,15 +11,31 @@ class TypedPropertyTestClass
 
     public ModelSerializationTestUser $user;
 
-    public int $id;
+    protected int $id;
 
-    public array $names;
+    private array $names;
 
     public function __construct(ModelSerializationTestUser $user, int $id, array $names)
     {
         $this->user = $user;
         $this->id = $id;
         $this->names = $names;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNames()
+    {
+        return $this->names;
     }
 }
 


### PR DESCRIPTION
This is rewrited https://github.com/laravel/framework/pull/30604 with using [__serialize/__unserialize](https://wiki.php.net/rfc/custom_object_serialization)

Tests are leaved from https://github.com/laravel/framework/pull/30604

This implementation no needed of additional property and backward compatibility with older version of PHP(<7.4)