### PR TITLE
[7.x] Make consistent names of Auth Factory Contract aliases

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Auth;
 
 use Closure;
-use Illuminate\Contracts\Auth\Factory as FactoryContract;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use InvalidArgumentException;
 
-class AuthManager implements FactoryContract
+class AuthManager implements AuthFactory
 {
     use CreatesUserProviders;
 

--- a/src/Illuminate/Auth/Middleware/Authenticate.php
+++ b/src/Illuminate/Auth/Middleware/Authenticate.php
@@ -4,7 +4,7 @@ namespace Illuminate\Auth\Middleware;
 
 use Closure;
 use Illuminate\Auth\AuthenticationException;
-use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 
 class Authenticate
 {
@@ -21,7 +21,7 @@ class Authenticate
      * @param  \Illuminate\Contracts\Auth\Factory  $auth
      * @return void
      */
-    public function __construct(Auth $auth)
+    public function __construct(AuthFactory $auth)
     {
         $this->auth = $auth;
     }


### PR DESCRIPTION
In the following files:

1. helpers.php
2. AuthenticateSession.php
3. AuthenticateWithBasicAuth.php
 
auth factory contract alias are named "AuthFactory". 

Just to make things consistent I renamed aliases in AuthManager.php and Authenticate.php files.
