### PR TITLE
[6.x] Allow to create fake file with content

### DIFF
--- a/src/Illuminate/Http/Testing/File.php
+++ b/src/Illuminate/Http/Testing/File.php
@@ -58,6 +58,18 @@ class File extends UploadedFile
     }
 
     /**
+     * Create a new fake file with content.
+     *
+     * @param  string  $name
+     * @param  string  $content
+     * @return \Illuminate\Http\Testing\File
+     */
+    public static function createWithContent($name, $content)
+    {
+        return (new FileFactory)->createWithContent($name, $content);
+    }
+
+    /**
      * Create a new fake image.
      *
      * @param  string  $name

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -21,6 +21,23 @@ class FileFactory
     }
 
     /**
+     * Create a new fake file with content.
+     *
+     * @param  string  $name
+     * @param  string  $content
+     * @return \Illuminate\Http\Testing\File
+     */
+    public function createWithContent($name, $content)
+    {
+        $tmpfile = tmpfile();
+        fwrite($tmpfile, $content);
+
+        return tap(new File($name, $tmpfile), function ($file) use ($tmpfile) {
+            $file->sizeToReport = fstat($tmpfile)['size'];
+        });
+    }
+
+    /**
      * Create a new fake image.
      *
      * @param  string  $name


### PR DESCRIPTION
This allows to create a fake file with specifying the content.

My personal use case is the following; in my system people can upload a file but i need to do some action when the file content changes. To do that i'm comparing the files md5 to detect if the file changed.

In tests when using File::create() laravel is creating an empty file each time, so there is no difference
between the two md5, this is why i need to be able to have a different content each time so the md5 can be different during the test.