### PR TITLE
[7.x] Remove resource class

### DIFF
--- a/src/Illuminate/Http/Resources/Json/Resource.php
+++ b/src/Illuminate/Http/Resources/Json/Resource.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Illuminate\Http\Resources\Json;
-
-class Resource extends JsonResource
-{
-    //
-}


### PR DESCRIPTION
This class is never used and doesn't provide any value over using JsonResource instead.
