### PR TITLE
[6.x] Fixed types of command description and help

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -59,14 +59,14 @@ class Command extends SymfonyCommand
     /**
      * The console command description.
      *
-     * @var string
+     * @var string|null
      */
     protected $description;
 
     /**
      * The console command help text.
      *
-     * @var string
+     * @var string|null
      */
     protected $help;
 
@@ -116,9 +116,9 @@ class Command extends SymfonyCommand
         // Once we have constructed the command, we'll set the description and other
         // related properties of the command. If a signature wasn't used to build
         // the command we'll set the arguments and the options on this command.
-        $this->setDescription($this->description);
+        $this->setDescription((string) $this->description);
 
-        $this->setHelp($this->help);
+        $this->setHelp((string) $this->help);
 
         $this->setHidden($this->isHidden());
 


### PR DESCRIPTION
The description and help message of a Laravel command might be null, by Symfony is expecting a string. We should:

1. Correctly document that these properties might be null.
2. Cast to a string before handing over to Symfony.

This is important, because in Symfony 5, strict types are enabled, so commands crash on construction without this correction.