### PR TITLE
[6.x] Changed type for `when` value

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -402,7 +402,7 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  mixed  $value
+     * @param  bool|mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
      * @return static|mixed

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -402,7 +402,7 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool  $value
+     * @param  mixed  $value
      * @param  callable  $callback
      * @param  callable  $default
      * @return static|mixed


### PR DESCRIPTION
Allow to pass to Collection::when any type values.

IDE mark value as wrong if value is not boolean. But second argument in callback have not sense if pass only boolean.