### PR TITLE
[6.x] normalizeCachePath added windows support

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -980,7 +980,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             return $this->bootstrapPath($default);
         }
 
-        return Str::startsWith($env, '/')
+        return Str::startsWith($env, '/') || preg_match("/^[a-z]:/i", $env)
                 ? $env
                 : $this->basePath($env);
     }


### PR DESCRIPTION
Added support for Windows systems in normalizeCachePath
Under windows paths start with a letter (drive) and a colon
using a simple regexp we can detect if the app is running under windows and in case we can allow programmers to change the cache with an absolute windows path.
