### PR TITLE
[7.x] Allow models to parse dates that does not match the preferred format

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -778,15 +778,14 @@ trait HasAttributes
 
         $format = $this->getDateFormat();
 
-        // https://bugs.php.net/bug.php?id=75577
-        if (version_compare(PHP_VERSION, '7.3.0-dev', '<')) {
-            $format = str_replace('.v', '.u', $format);
-        }
-
         // Finally, we will just assume this date is in the format used by default on
         // the database connection and use that format to create the Carbon object
         // that is returned back out to the developers after we convert it here.
-        return Date::createFromFormat($format, $value);
+        if (Date::hasFormat($value, $format)) {
+            return Date::createFromFormat($format, $value);
+        }
+
+        return Date::parse($value);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -20,7 +20,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Tests\Integration\Database\Fixtures\Post;
 use Illuminate\Tests\Integration\Database\Fixtures\User;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1294,7 +1294,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('2017-11-14 08:23:19.000', $model->fromDateTime($model->getAttribute('created_at')));
     }
 
-    public function testTimestampsUsingOldSqlServerDateFormatFailInEdgeCases()
+    public function testTimestampsUsingOldSqlServerDateFormatFallbackToDefaultParsing()
     {
         $model = new EloquentTestUser;
         $model->setDateFormat('Y-m-d H:i:s.000'); // Old SQL Server date format


### PR DESCRIPTION
Here is a proposal to make date parsing cooler.

It makes `$dateFormat` no longer a required format, but a preferred format. And if the format does not match (for example microseconds precision date vs. second or millisecond precision), `asDateTime` will still try to parse the date using `Carbon::parse()`