### PR TITLE
[6.x] Fix QueueFake docblocks on Queue facade

### DIFF
--- a/src/Illuminate/Support/Facades/Queue.php
+++ b/src/Illuminate/Support/Facades/Queue.php
@@ -16,10 +16,10 @@ use Illuminate\Support\Testing\Fakes\QueueFake;
  * @method static string getConnectionName()
  * @method static \Illuminate\Contracts\Queue\Queue setConnectionName(string $name)
  * @method static void assertNothingPushed()
- * @method static void assertNotPushed(string $job, \Closure $callback = null)
- * @method static void assertPushed(string $job, \Closure|int $callback = null)
- * @method static void assertPushedOn(string $job, int $times = 1)
- * @method static void assertPushedWithChain(string $queue, string $job, \Closure $callback = null)
+ * @method static void assertNotPushed(string $job, callable $callback = null)
+ * @method static void assertPushed(string $job, callable|int $callback = null)
+ * @method static void assertPushedOn(string $queue, string $job, callable|int $callback = null)
+ * @method static void assertPushedWithChain(string $job, array $expectedChain = [], callable $callback = null)
  *
  * @see \Illuminate\Queue\QueueManager
  * @see \Illuminate\Queue\Queue


### PR DESCRIPTION
The `@method` docblocks on the Queue facade introduced in #30300 are a bit different than the method signatures on the QueueFake.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
