### PR TITLE
[6.x] Add autocomplete support for BusFake assertions on the Bus facade

### DIFF
--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static bool|mixed getCommandHandler($command)
  * @method static \Illuminate\Contracts\Bus\Dispatcher pipeThrough(array $pipes)
  * @method static \Illuminate\Contracts\Bus\Dispatcher map(array $map)
+ * @method static void assertDispatched(string $command, callable|int $callback = null)
+ * @method static void assertDispatchedTimes(string $command, int $times = 1)
+ * @method static void assertNotDispatched(string $command, callable|int $callback = null)
  *
  * @see \Illuminate\Contracts\Bus\Dispatcher
  */


### PR DESCRIPTION
Similar to #30300, this PR adds IDE autocompletion for the assertion methods of the BusFake on the Bus facade.