### PR TITLE
[6.x] Fix method and remove duplication

### DIFF
--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -34,6 +34,7 @@ class FileFactory
     public function createWithContent($name, $content)
     {
         $tmpfile = tmpfile();
+
         fwrite($tmpfile, $content);
 
         return tap(new File($name, $tmpfile), function ($file) use ($tmpfile) {

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -16,7 +16,7 @@ class FileFactory
     public function create($name, $kilobytes = 0)
     {
         if (is_string($kilobytes)) {
-            return  $this->createWithContent($name, $kilobytes);
+            return $this->createWithContent($name, $kilobytes);
         }
 
         return tap(new File($name, tmpfile()), function ($file) use ($kilobytes) {

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -15,14 +15,12 @@ class FileFactory
      */
     public function create($name, $kilobytes = 0)
     {
-        $tmp = tmpfile();
-
         if (is_string($kilobytes)) {
-            file_put_contents($tmp, $kilobytes);
+            return  $this->createWithContent($name, $kilobytes);
         }
 
-        return tap(new File($name, $tmp), function ($file) use ($kilobytes) {
-            $file->sizeToReport = is_string($kilobytes) ? fstat($tmp)['size'] : ($kilobytes * 1024);
+        return tap(new File($name, tmpfile()), function ($file) use ($kilobytes) {
+            $file->sizeToReport = $kilobytes * 1024;
         });
     }
 


### PR DESCRIPTION
The tweak made by taylor on the on the `FileFactory::create()` has two problems

1- Using file_put_contents() on a resource this causes the following problem
`ErrorException : file_put_contents() expects parameter 1 to be a valid path, resource given`

2- Second one using the `$tmp` inside the closure without passing it via `use()` this will cause an undefined variable error.

Instead of applying fixes to these two problems i restaured the original code of the `create()` method plus checking if the `$kilobytes` is a string, if so i'll just call the `createWithContent()` instead