### PR TITLE
[6.x] Update __ function doc block

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -902,7 +902,7 @@ if (! function_exists('__')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
-     * @return \Illuminate\Contracts\Translation\Translator|string|array|null
+     * @return string|array|null
      */
     function __($key = null, $replace = [], $locale = null)
     {


### PR DESCRIPTION
Remove return option that won't get returned

The main behavior of the `__` function is to translate strings by passing them to the `trans` function. If the `$key` argument to the `trans` function is `null`, an instance of the `Translator` is returned. This shouldn't be possible using the `__` function because if the `$key` argument is `null`, it is simply returned prior to the `trans` function being invoked.

This should help with IDE autocomplete, etc...

I don't have a test since it's not a change to executable code. I'm not familiar with the build process though, so if there are changes that need to be made to facilitate that, please let me know.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
