### PR TITLE
[6.x] Composer fix monolog version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
-        "monolog/monolog": "^1.12||^2.0",
+        "monolog/monolog": "^1.12 || ^2.0",
         "nesbot/carbon": "^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
-        "monolog/monolog": "^1.12|^2.0",
+        "monolog/monolog": "^1.12||^2.0",
         "nesbot/carbon": "^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",


### PR DESCRIPTION
Replaces deprecated composer's logical Or from "|" to "||", because official composer's documentation claims that only that should be used.
https://getcomposer.org/doc/articles/versions.md#version-range
`A double pipe (||) will be treated as a logical OR`
Double pipe is Or operator, but single pipe is logical Xor.
Official issue on composer [github](https://github.com/composer/composer/issues/6755)