### PR TITLE
Revert "[6.x] Composer fix monolog version range (#30635)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "egulias/email-validator": "^2.1.10",
         "erusev/parsedown": "^1.7",
         "league/flysystem": "^1.0.8",
-        "monolog/monolog": "^1.12 || ^2.0",
+        "monolog/monolog": "^1.12|^2.0",
         "nesbot/carbon": "^2.0",
         "opis/closure": "^3.1",
         "psr/container": "^1.0",


### PR DESCRIPTION
This reverts commit 0c4624b14e83dbeff4ab89ec1daa4c2272cb4848.
