### PR TITLE
[6.x] Add Str::explodeIntoCollection() method To Illuminate\Support\Str

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -190,6 +190,18 @@ class Str
     }
 
     /**
+     * Explode a given string into a Collection using the given delimiter
+     *
+     * @param  string  $string
+     * @param  string  $delimiter
+     * @return Collection
+     */
+    public static function explodeIntoCollection($string, $delimiter = ',')
+    {
+        return new Collection(explode($delimiter, $string));
+    }
+
+    /**
      * Cap a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -190,7 +190,7 @@ class Str
     }
 
     /**
-     * Explode a given string into a Collection using the given delimiter
+     * Explode a given string into a Collection using the given delimiter.
      *
      * @param  string  $string
      * @param  string  $delimiter

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\UuidInterface;
@@ -386,6 +387,24 @@ class SupportStrTest extends TestCase
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
+    }
+
+    public function testExplodeIntoCollectionWithValidString()
+    {
+        $this->assertInstanceOf(Collection::class, Str::explodeIntoCollection('Foo'));
+        $this->assertInstanceOf(Collection::class, Str::explodeIntoCollection('Foo,Bar,Biz'));
+        $this->assertCount(3, Str::explodeIntoCollection('Foo,Bar,Biz'));
+        $this->assertEquals('Foo', Str::explodeIntoCollection('Foo,Bar')->first());
+        $this->assertEquals('Bar', Str::explodeIntoCollection('Foo,Bar')->last());
+    }
+
+    public function testExplodeIntoCollectionWithASpecifiedDelimiter()
+    {
+        $this->assertInstanceOf(Collection::class, Str::explodeIntoCollection('Foo', '|'));
+        $this->assertInstanceOf(Collection::class, Str::explodeIntoCollection('Foo|Bar|Biz', '|'));
+        $this->assertCount(3, Str::explodeIntoCollection('Foo|Bar|Biz', '|'));
+        $this->assertEquals('Foo', Str::explodeIntoCollection('Foo|Bar', '|')->first());
+        $this->assertEquals('Bar', Str::explodeIntoCollection('Foo|Bar', '|')->last());
     }
 }
 


### PR DESCRIPTION
This is a method I add to most of my Laravel projects and one I thought could be a benefit to others.

The method takes a string, explodes it on a given delimiter (Defaulted to `,`) and return a new Collection from the resulting array.

It is only a simple addition to the `Illuminate\Support\Str` class which doesn't effect any existing functionality, and I have added a couple of tests on the new method.

A use case which I find myself regularly using it is from a form on the front end that returns, for example, a comma delimited list of tags (For a blog post for example) or a comma delimited list of IDs, which I then create a Collection from and work my way through using Collection methods.