### PR TITLE
[7.x] Add actingAsGuest Authentication testing helper

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -85,10 +85,10 @@ trait GuardHelpers
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return $this
      */
-    public function setUser(AuthenticatableContract $user)
+    public function setUser(?AuthenticatableContract $user)
     {
         $this->user = $user;
 

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -85,10 +85,10 @@ trait GuardHelpers
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function setUser(?AuthenticatableContract $user)
+    public function setUser(AuthenticatableContract $user)
     {
         $this->user = $user;
 
@@ -114,5 +114,15 @@ trait GuardHelpers
     public function setProvider(UserProvider $provider)
     {
         $this->provider = $provider;
+    }
+
+    /**
+     * Log the user out of the application.
+     *
+     * @return void
+     */
+    public function logout()
+    {
+        $this->user = null;
     }
 }

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -788,11 +788,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return $this
      */
-    public function setUser(AuthenticatableContract $user)
+    public function setUser(?AuthenticatableContract $user)
     {
+        if ($user === null) {
+            $this->logout();
+
+            return $this;
+        }
+
         $this->user = $user;
 
         $this->loggedOut = false;

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -788,17 +788,11 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function setUser(?AuthenticatableContract $user)
+    public function setUser(AuthenticatableContract $user)
     {
-        if ($user === null) {
-            $this->logout();
-
-            return $this;
-        }
-
         $this->user = $user;
 
         $this->loggedOut = false;

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -43,8 +43,8 @@ interface Guard
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @return void
      */
-    public function setUser(Authenticatable $user);
+    public function setUser(?Authenticatable $user);
 }

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -43,8 +43,15 @@ interface Guard
     /**
      * Set the current user.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function setUser(?Authenticatable $user);
+    public function setUser(Authenticatable $user);
+
+    /**
+     * Log the user out of the application.
+     *
+     * @return void
+     */
+    public function logout();
 }

--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -53,11 +53,4 @@ interface StatefulGuard extends Guard
      * @return bool
      */
     public function viaRemember();
-
-    /**
-     * Log the user out of the application.
-     *
-     * @return void
-     */
-    public function logout();
 }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -9,11 +9,11 @@ trait InteractsWithAuthentication
     /**
      * Set the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  string|null  $driver
      * @return $this
      */
-    public function actingAs(UserContract $user, $driver = null)
+    public function actingAs(?UserContract $user, $driver = null)
     {
         return $this->be($user, $driver);
     }
@@ -21,11 +21,11 @@ trait InteractsWithAuthentication
     /**
      * Set the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  string|null  $driver
      * @return $this
      */
-    public function be(UserContract $user, $driver = null)
+    public function be(?UserContract $user, $driver = null)
     {
         if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
             $user->wasRecentlyCreated = false;

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -9,23 +9,36 @@ trait InteractsWithAuthentication
     /**
      * Set the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @param  string|null  $driver
      * @return $this
      */
-    public function actingAs(?UserContract $user, $driver = null)
+    public function actingAs(UserContract $user, $driver = null)
     {
         return $this->be($user, $driver);
     }
 
     /**
-     * Set the currently logged in user for the application.
+     * Log outs the currently logged in user for the application.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  string|null  $driver
      * @return $this
      */
-    public function be(?UserContract $user, $driver = null)
+    public function actingAsGuest($driver = null)
+    {
+        $this->app['auth']->guard($driver)->logout();
+
+        return $this;
+    }
+
+    /**
+     * Set the currently logged in user for the application.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  string|null  $driver
+     * @return $this
+     */
+    public function be(UserContract $user, $driver = null)
     {
         if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
             $user->wasRecentlyCreated = false;

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -76,7 +76,7 @@ class InteractsWithAuthenticationTest extends TestCase
             ->expectException(AuthenticationException::class);
 
         $this->actingAs($user)
-            ->actingAs(null)
+            ->actingAsGuest()
             ->get('/me');
     }
 
@@ -115,7 +115,7 @@ class InteractsWithAuthenticationTest extends TestCase
             ->expectException(AuthenticationException::class);
 
         $this->actingAs($user, 'api')
-            ->actingAs(null, 'api')
+            ->actingAsGuest('api')
             ->get('/me');
     }
 }


### PR DESCRIPTION
~~Allows for actingAs on testing to be null. This is helpful when testing applications where most routes are auth protected and you have actingAs a test user in the base TestCase but you want to test certain routes as guest. You can now simply use $this->actingAs(null) or even $this->actingAs(null, 'api').~~

Adds an `actingAsGuest()` authentication helper to undo any previous `actingAs` statements. Done by re-adding a `logout` to Guards which simply sets `$this->user` to `null` if using `GuardHelpers` and performs a full `logout` for the `sessionGuard`.

See discussion in https://github.com/laravel/framework/pull/30644

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
