### PR TITLE
[6.x] Added head method to router to allow implicit call via HEAD HTTP method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -145,6 +145,18 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a new HEAD route with the router.
+     *
+     * @param  string  $uri
+     * @param  \Closure|array|string|callable|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function head($uri, $action = null)
+    {
+        return $this->addRoute('HEAD', $uri, $action);
+    }
+
+    /**
      * Register a new POST route with the router.
      *
      * @param  string  $uri

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -133,18 +133,6 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Register a new GET route with the router.
-     *
-     * @param  string  $uri
-     * @param  \Closure|array|string|callable|null  $action
-     * @return \Illuminate\Routing\Route
-     */
-    public function get($uri, $action = null)
-    {
-        return $this->addRoute(['GET', 'HEAD'], $uri, $action);
-    }
-
-    /**
      * Register a new HEAD route with the router.
      *
      * @param  string  $uri
@@ -154,6 +142,18 @@ class Router implements BindingRegistrar, RegistrarContract
     public function head($uri, $action = null)
     {
         return $this->addRoute('HEAD', $uri, $action);
+    }    
+
+    /**
+     * Register a new GET route with the router.
+     *
+     * @param  string  $uri
+     * @param  \Closure|array|string|callable|null  $action
+     * @return \Illuminate\Routing\Route
+     */
+    public function get($uri, $action = null)
+    {
+        return $this->addRoute(['GET', 'HEAD'], $uri, $action);
     }
 
     /**

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Routing\Route get(string $uri, \Closure|array|string|callable|null $action = null)
+ * @method static \Illuminate\Routing\Route head(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route post(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route put(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|callable|null $action = null)


### PR DESCRIPTION
Backwards compatible, but exposes an implicit method for those developing a REST API and don't want to have to rely on `get`.