### PR TITLE
[6.x] Add assertDeleted for database testing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -53,6 +53,25 @@ trait InteractsWithDatabase
      * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDeleted($table, array $data = [], $connection = null)
+    {
+        if ($table instanceof Model) {
+            return $this->assertDatabaseMissing($table->getTable(), [$table->getKeyName() => $table->getKey()], $table->getConnectionName());
+        }
+
+        $this->assertDatabaseMissing($table, $data, $connection);
+
+        return $this;
+    }
+
+    /**
+     * Assert the given record has been "soft deleted".
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
+     * @param  array  $data
+     * @param  string|null  $connection
      * @param  string|null  $deletedAtColumn
      * @return $this
      */

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -100,6 +100,48 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
+    public function testAssertDeletedPassesWhenDoesNotFindResults()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseMissing($this->table, $this->data);
+    }
+
+    public function testAssertDeletedFailsWhenFindsResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+
+        $this->assertDatabaseMissing($this->table, $this->data);
+    }
+
+    public function testAssertDeletedPassesWhenDoesNotFindModelResults()
+    {
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDeleted(new ProductStub($this->data));
+    }
+
+    public function testAssertDeletedFailsWhenFindsModelResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->data = ['id' => 1];
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+
+        $this->assertDeleted(new ProductStub($this->data));
+    }
+
     public function testAssertSoftDeletedInDatabaseFindsResults()
     {
         $this->mockCountBuilder(1);


### PR DESCRIPTION
While there are numerous ways to test a record has been deleted, all are relatively lengthy to assert and don't communicate well. 

**Before**
```php
$this->assertDatabaseMissing('posts', [
    'id' => $post->id
]);
```

There is an `assertSoftDeleted` which can actually be passed a _model_. Upon doing so, it conveniently builds the appropriate expectations.

An `assertDeleted` method is symmetrical with this existing method and improves the developer experience by wrapping all the same behavior of `assertDatabaseMissing` in an intently named method.

**After**
```php
$this->assertDeleted($post);
```