### PR TITLE
[6.x] Allow response to return first view

### DIFF
--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -70,7 +70,7 @@ class ResponseFactory implements FactoryContract
     /**
      * Create a new response for a given view.
      *
-     * @param  string  $view
+     * @param  string|array  $view
      * @param  array  $data
      * @param  int  $status
      * @param  array  $headers
@@ -78,6 +78,10 @@ class ResponseFactory implements FactoryContract
      */
     public function view($view, $data = [], $status = 200, array $headers = [])
     {
+        if (is_array($view)) {
+            return $this->make($this->view->first($view, $data), $status, $headers);
+        }
+
         return $this->make($this->view->make($view, $data), $status, $headers);
     }
 


### PR DESCRIPTION
There are currently a couple ways to return a view.  The simple standard way is:

```php
return view('my/view', ['data']);
```

If you need to customize the response a little you can tweak it to this:

```php
return response()->view('my/view, ['data'], 404, ['headers']);
```

Some code takes advantage of the ability to pass an array of views, and return the first one that exists.

```php
return view()->first(['my/view1', 'my/view2'], ['data']);
```

It would be nice to be able to manipulate the response status and headers, but also use the view first functionality.

I'm proposing allowing `response()->view()` to accept either a string or array as the first parameter. If the first parameter is a string, it will behave as it does currently.  If it receives an array, it will use the view first logic.

```php
return response()->view(['my/view1', 'my/view2'], ['data'], 404, ['headers']);
```

If we're uncomfortable adding some magic to this method, I also considered making it a separate method on the ResponseFactory so it would be called as:

```php
return response()->viewFirst(['my/view1', 'my/view2'], ['data'], 404, ['headers']);
```

which I could switch to.

I was also having trouble locating where tests are for this logic. If someone could point me in the right direction that would be appreciated.