### PR TITLE
[6.x] Allow explicit Model definitions in database rules

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Illuminate\Support\Str;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 trait DatabaseRule
 {

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Validation\Rules;
 
-use Closure;
 use Illuminate\Support\Str;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 
 trait DatabaseRule
@@ -55,7 +55,8 @@ trait DatabaseRule
      * @param  string  $table
      * @return string
      */
-    public function resolveTableName($table) {
+    public function resolveTableName($table)
+    {
         if (! Str::contains($table, '\\') || ! class_exists($table)) {
             return $table;
         }
@@ -65,7 +66,7 @@ trait DatabaseRule
         if (! $model instanceof Model) {
             return $table;
         }
-        
+
         return $model->getTable();
     }
 

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -3,6 +3,8 @@
 namespace Illuminate\Validation\Rules;
 
 use Closure;
+use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Model;
 
 trait DatabaseRule
 {
@@ -43,8 +45,28 @@ trait DatabaseRule
      */
     public function __construct($table, $column = 'NULL')
     {
-        $this->table = $table;
+        $this->table = $this->resolveTableName($table);
         $this->column = $column;
+    }
+
+    /**
+     * Resolves the name of the table from the given string.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function resolveTableName($table) {
+        if (! Str::contains($table, '\\') || ! class_exists($table)) {
+            return $table;
+        }
+
+        $model = new $table;
+
+        if (! $model instanceof Model) {
+            return $table;
+        }
+        
+        return $model->getTable();
     }
 
     /**

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -39,6 +39,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('exists:table,NULL,foo,"bar"', (string) $rule);
 
+        $rule = new Exists(User::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:users,NULL,foo,"bar"', (string) $rule);
+
         $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
@@ -194,9 +198,6 @@ class User extends Eloquent
     public $timestamps = false;
 }
 
-/**
- * Eloquent Models.
- */
 class NoTableNameModel extends Eloquent
 {
     protected $guarded = [];

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -42,6 +42,18 @@ class ValidationExistsRuleTest extends TestCase
         $rule = new Exists('table', 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:table,column,foo,"bar"', (string) $rule);
+
+        $rule = new Exists(User::class, 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
+
+        $rule = new Exists('Illuminate\Tests\Validation\User', 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
+
+        $rule = new Exists(NoTableNameModel::class, 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:no_table_name_models,column,foo,"bar"', (string) $rule);
     }
 
     public function testItChoosesValidRecordsUsingWhereInRule()
@@ -49,10 +61,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule = new Exists('users', 'id');
         $rule->whereIn('type', ['foo', 'bar']);
 
-        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
-        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
-        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
-        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['id' => $rule]);
@@ -73,10 +85,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule = new Exists('users', 'id');
         $rule->whereNotIn('type', ['foo', 'bar']);
 
-        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
-        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
-        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
-        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['id' => $rule]);
@@ -97,10 +109,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule = new Exists('users', 'id');
         $rule->whereIn('type', ['foo', 'bar', 'baz'])->whereNotIn('type', ['foo', 'bar']);
 
-        EloquentTestUser::create(['id' => '1', 'type' => 'foo']);
-        EloquentTestUser::create(['id' => '2', 'type' => 'bar']);
-        EloquentTestUser::create(['id' => '3', 'type' => 'baz']);
-        EloquentTestUser::create(['id' => '4', 'type' => 'other']);
+        User::create(['id' => '1', 'type' => 'foo']);
+        User::create(['id' => '2', 'type' => 'bar']);
+        User::create(['id' => '3', 'type' => 'baz']);
+        User::create(['id' => '4', 'type' => 'other']);
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['id' => $rule]);
@@ -175,9 +187,18 @@ class ValidationExistsRuleTest extends TestCase
 /**
  * Eloquent Models.
  */
-class EloquentTestUser extends Eloquent
+class User extends Eloquent
 {
     protected $table = 'users';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+/**
+ * Eloquent Models.
+ */
+class NoTableNameModel extends Eloquent
+{
     protected $guarded = [];
     public $timestamps = false;
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -14,7 +14,24 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('unique:table,NULL,NULL,id,foo,"bar"', (string) $rule);
 
+        $rule = new Unique(EloquentModelStub::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:table,NULL,NULL,id,foo,"bar"', (string) $rule);
+
+        $rule = new Unique(NoTableName::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:no_table_names,NULL,NULL,id,foo,"bar"', (string) $rule);
+
+        $rule = new Unique('Illuminate\Tests\Validation\NoTableName');
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:no_table_names,NULL,NULL,id,foo,"bar"', (string) $rule);
+
         $rule = new Unique('table', 'column');
+        $rule->ignore('Taylor, Otwell', 'id_column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
+
+        $rule = new Unique(EloquentModelStub::class, 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
         $this->assertSame('unique:table,column,"Taylor, Otwell",id_column,foo,"bar"', (string) $rule);
@@ -51,6 +68,13 @@ class ValidationUniqueRuleTest extends TestCase
 
 class EloquentModelStub extends Model
 {
+    protected $table = 'table';
     protected $primaryKey = 'id_column';
     protected $guarded = [];
+}
+
+class NoTableName extends Model
+{
+    protected $guarded = [];
+    public $timestamps = false;
 }


### PR DESCRIPTION
This PR creates the ability to explicitly define models within Database Rule; allowing to pass models to the `exists` and `unique` validation rules.

```
$request->validate([
      'user_id' => 'required|exists:App\User,id'
])
```

```
$request->validate([
      'user_id' => 'required|unique:'.User::class.',id'
])
```

I've always found it a bit strange when I have to write out the database table name within my validation rules when the framework will give you a hand in most other places (such as eloquent relationships). 

This will also prevent issues when you are changing up the table name and you don't have to go through each and every `exists` and `unique` rule to update the table name.