### PR TITLE
[6.x] Add --all option to migrate:fresh and add --databases to be able to select multiple databases to wipe

### DIFF
--- a/CHANGELOG-5.8.md
+++ b/CHANGELOG-5.8.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/laravel/framework/compare/v5.8.35...5.8)
 
+- Added --all and --databases option to migrate:fresh and db:wipe
 
 ## [v5.8.35 (2019-09-03)](https://github.com/laravel/framework/compare/v5.8.34...v5.8.35)
 

--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -36,9 +36,12 @@ class FreshCommand extends Command
         }
 
         $database = $this->input->getOption('database');
+        $databases = $this->input->getOption('databases');
 
         $this->call('db:wipe', array_filter([
+            '--all' => $this->option('all'),
             '--database' => $database,
+            '--databases' => $databases,
             '--drop-views' => $this->option('drop-views'),
             '--drop-types' => $this->option('drop-types'),
             '--force' => true,
@@ -90,7 +93,9 @@ class FreshCommand extends Command
     protected function getOptions()
     {
         return [
+            ['all', null, InputOption::VALUE_NONE, 'Drop all tables from all databases'],
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['databases', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The databases connection to use'],
             ['drop-views', null, InputOption::VALUE_NONE, 'Drop all tables and views'],
             ['drop-types', null, InputOption::VALUE_NONE, 'Drop all tables and types (Postgres only)'],
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],


### PR DESCRIPTION
As in [Laravel Ideas](https://github.com/laravel/ideas/issues/1026) requested i added the `--add` and `--databases` option.

Currently it is not possible to pass more than one database at a time and `migrate:fresh` does not wipe all databases just the configured default  if no other is provided via `--database=`.

With `migrate:fresh --all` it is possible to iterate through all configured connections and to wipe them before they getting migrated.
With `--databases` you can now provide multiple connections as an array. They get also wiped before the migrate process.

Using this options it is a lot easier to handle projects with multiple connections, like we have it.