### PR TITLE
[6.x] Fix routing bug that causes missing parameters to be ignored

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -200,7 +200,7 @@ class RouteUrlGenerator
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
-            return (empty($parameters) && ! Str::endsWith($match[0], '?}'))
+            return (!isset($parameters[0]) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
                         : Arr::pull($parameters, 0);
         }, $path);

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -200,7 +200,7 @@ class RouteUrlGenerator
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 
-            return (!isset($parameters[0]) && ! Str::endsWith($match[0], '?}'))
+            return (! isset($parameters[0]) && ! Str::endsWith($match[0], '?}'))
                         ? $match[0]
                         : Arr::pull($parameters, 0);
         }, $path);

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -515,7 +515,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->assertSame('http://www.foo.com:8080/foo', $url->route('foo'));
+        $this->assertSame('http://www.foo.com:8080/foo?test=123', $url->route('foo', ['test' => 123]));
     }
 
     public function testForceRootUrl()


### PR DESCRIPTION
I noticed there's a bug with creating a URL. When there's a named parameter that's not in the route, it gets added to the query string. But when there's no other parameters, the missing parameter gets ignored.

For example, I had a route similar to this:

```php
Route::delete('/foo/{bar}/test')->name('test-route');
```

When using it like this:

```php
route('test-route', ['foo' => 'bar'])
```

Previously this would be the result: `/foo/bar/test`. But since the change that the name should match, this is no longer the case. Then it should fail and throw an error because there's a missing parameter, but instead it removes the parameter token and leaves an invalid URL: `/foo//test?foo=bar`.