### PR TITLE
[6.x] Update 'windows_os()' helper to use PHP_OS_FAMILY

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -529,7 +529,7 @@ if (! function_exists('windows_os')) {
      */
     function windows_os()
     {
-        return strtolower(substr(PHP_OS, 0, 3)) === 'win';
+        return PHP_OS_FAMILY === 'Windows';
     }
 }
 


### PR DESCRIPTION
Originally opened against `7.x`, see #30658.

Since Laravel 6+ depends on PHP 7.2 or later, the [`PHP_OS_FAMILY`](https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family) constant is available.

Whereas the `PHP_OS` constant can be `WINNT`, `WIN32`, `Windows`, etc., the `PHP_OS_FAMILY` will always be `Windows` if PHP is built for Windows (and has a [predefined list of available values](https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family)).

The performance of [`PHP_OS_FAMILY`](https://3v4l.org/TGL6P/perf#output) is a micro-optimisation, compared to the existing [`PHP_OS` usage](https://3v4l.org/6M476/perf#output) (except for on PHP 7.1, which isn't supported by Laravel 6), but it seems to be handled better when used in iterations. However, the existing method works fine, so I understand this probably won't be merged. I'd be interested to hear peoples opinions on using this over the older method. 👍

I've tested this in Windows, Windows Subsystem for Linux (WSL), MinGW, MacOS, and Ubuntu.