### PR TITLE
[7.x] Allow passing flags to Collection::sort()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1054,13 +1054,13 @@ class Collection implements ArrayAccess, Enumerable
      * @param  callable|null  $callback
      * @return static
      */
-    public function sort(callable $callback = null)
+    public function sort($callback = null)
     {
         $items = $this->items;
 
-        $callback
+        $callback && is_callable($callback)
             ? uasort($items, $callback)
-            : asort($items);
+            : asort($items, $callback);
 
         return new static($items);
     }

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -755,10 +755,10 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null  $callback
+     * @param  callable|null|int  $callback
      * @return static
      */
-    public function sort(callable $callback = null);
+    public function sort($callback = null);
 
     /**
      * Sort the collection using the given callback.

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1018,10 +1018,10 @@ class LazyCollection implements Enumerable
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null  $callback
+     * @param  callable|null|int  $callback
      * @return static
      */
-    public function sort(callable $callback = null)
+    public function sort($callback = null)
     {
         return $this->passthru('sort', func_get_args());
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1342,6 +1342,12 @@ class SupportCollectionTest extends TestCase
 
         $data = (new $collection(['foo', 'bar-10', 'bar-1']))->sort();
         $this->assertEquals(['bar-1', 'bar-10', 'foo'], $data->values()->all());
+
+        $data = (new $collection(['T2', 'T1', 'T10']))->sort();
+        $this->assertEquals(['T1', 'T10', 'T2'], $data->values()->all());
+
+        $data = (new $collection(['T2', 'T1', 'T10']))->sort(SORT_NATURAL);
+        $this->assertEquals(['T1', 'T2', 'T10'], $data->values()->all());
     }
 
     /**


### PR DESCRIPTION
I have a collection of strings that i want to sort using the `SORT_NATURAL` flag.

The method that should be used here is `sort()` since i'm dealing with strings. The problem is that `sort()` does not accept flags.
All the other sorting related methods on the `Collection` class accepts flags.

```php
// Not possible before the PR
collect(['T2-OS2', 'T10-OS1', 'T1-OS1'])->sort(SORT_NATURAL);
``` 

This PR adds support for using flags with `sort()`. (Tests included)

The PR is targeted at the master branch because it contain a possibility of breaking change to some applications.
The `Enumerable` interface which the `Collection` class implements forces the `$callback` argument to be a callable. So if someone is implementing this interface he should update the new signature that does not force the `$callback` to be callable.
