### PR TITLE
[6.x] Support intended URLs in EnsureEmailIsVerified

### DIFF
--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -35,7 +35,7 @@ trait RegistersUsers
         $this->guard()->login($user);
 
         return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+                        ?: redirect()->intended($this->redirectPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -19,7 +19,7 @@ trait VerifiesEmails
     public function show(Request $request)
     {
         return $request->user()->hasVerifiedEmail()
-                        ? redirect($this->redirectPath())
+                        ? redirect()->intended($this->redirectPath())
                         : view('auth.verify');
     }
 
@@ -41,14 +41,14 @@ trait VerifiesEmails
         }
 
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return redirect()->intended($this->redirectPath());
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect($this->redirectPath())->with('verified', true);
+        return redirect()->intended($this->redirectPath())->with('verified', true);
     }
 
     /**


### PR DESCRIPTION
This change will be helpful for developers that need someone redirected back to an intended url after registering a user account. Similar to how they are redirected after authenticating.

To achieve this I refactored the EnsureEmailIsVerified middleware to match code in RequirePassword middleware. The intended url is kept intact through the email verification process as well.

The refactor has the added benefit of returning json resource when json is requested instead of using abort helper. Which I believe is a bug and I reported in #30663 .