### PR TITLE
[7.x] Traslator modified  to return only strings

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -123,7 +123,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
                 if (! is_null($line = $this->getLine(
                     $namespace, $group, $locale, $item, $replace
                 ))) {
-                    return $line ?? $key;
+                    return ($line && is_string($line)) ? $line : $key;
                 }
             }
         }
@@ -131,7 +131,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
-        return $this->makeReplacements($line ?: $key, $replace);
+        return $this->makeReplacements(($line && is_string($line)) ? $line : $key, $replace);
     }
 
     /**


### PR DESCRIPTION
- Returns the key if the entry pointed to by the key is not a string. Otherwise returns the key itself
- Fixes: https://github.com/laravel/ideas/issues/1936

## What this PR hopes to fix:
In the latest laravel version, the translator looks only for the entry pointed to by the key. If it points to an array, the array is returned causing the following error in a blade view:
`htmlspecialchars() expects parameter 1 to be string, array given`

## Steps to reproduce:
In a blade file include this line:
```html
<button> {{ __('validation') }} </button>
```

Additional information:

On linux servers the error is thrown only if the string being validated matches exactly (same case) with one of the files inside the lang directory. So the following blade snippet will not cause error:
```html
<button> {{ __('Validation') }} </button>
```

However the above snippet will cause the error on a windows server. I assume this is because in windows file names are case-insensitive.

## What this PR does?
It modifies the Translator.php@get function and adds a check to verify that the identified translation line is actually a string. If it is not it returns the key instead.