### PR TITLE
[6.x] Update RequirePassword Middleware DocBlock

### DIFF
--- a/src/Illuminate/Auth/Middleware/RequirePassword.php
+++ b/src/Illuminate/Auth/Middleware/RequirePassword.php
@@ -40,7 +40,7 @@ class RequirePassword
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
-     * @param  string  $redirectToRoute
+     * @param  string|null  $redirectToRoute
      * @return mixed
      */
     public function handle($request, Closure $next, $redirectToRoute = null)


### PR DESCRIPTION
Add null to param type since it is not required