### PR TITLE
[7.x] Resolve `MigrationRepositoryInterface` under handle instead of constructor.

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -23,35 +23,16 @@ class InstallCommand extends Command
     protected $description = 'Create the migration repository';
 
     /**
-     * The repository instance.
-     *
-     * @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
-     */
-    protected $repository;
-
-    /**
-     * Create a new migration install command instance.
+     * Execute the console command.
      *
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
      * @return void
      */
-    public function __construct(MigrationRepositoryInterface $repository)
+    public function handle(MigrationRepositoryInterface $repository)
     {
-        parent::__construct();
+        $repository->setSource($this->input->getOption('database'));
 
-        $this->repository = $repository;
-    }
-
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
-    public function handle()
-    {
-        $this->repository->setSource($this->input->getOption('database'));
-
-        $this->repository->createRepository();
+        $repository->createRepository();
 
         $this->info('Migration table created successfully.');
     }


### PR DESCRIPTION
This avoid DI to be resolved on all artisan request instead of just when calling migrate:install command.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
