### PR TITLE
[7.x] Change Migrator dependency from OutputStyle to OutputInterface

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Migrations;
 
-use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Events\MigrationEnded;
@@ -13,6 +12,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
 {
@@ -61,7 +61,7 @@ class Migrator
     /**
      * The output interface implementation.
      *
-     * @var \Illuminate\Console\OutputStyle
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 
@@ -598,10 +598,10 @@ class Migrator
     /**
      * Set the output implementation that should be used by the console.
      *
-     * @param  \Illuminate\Console\OutputStyle  $output
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
      * @return $this
      */
-    public function setOutput(OutputStyle $output)
+    public function setOutput(OutputInterface $output)
     {
         $this->output = $output;
 

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -19,7 +19,8 @@
         "ext-json": "*",
         "illuminate/container": "^7.0",
         "illuminate/contracts": "^7.0",
-        "illuminate/support": "^7.0"
+        "illuminate/support": "^7.0",
+        "symfony/console": "^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I'm maintaining a Symfony bundle integrating `illuminate/database` in Symfony. I was looking into Symfony 5 support. Fornunately, `illuminate/database` and `illuminate/events` don't depend on a Symfony package. However, this one method call requires my bundle to depend on `illuminate/console` (which depends on `symfony/console`).

The `$output` here is strictly coupled to Illuminate's `OutputStyle` implementation, but only `$this->output->writeln()` is used. I would very much like if it depends on Symfony's `OutputInterface` instead.

As I'm not sure how breaking changes like this are dealed with in Laravel, I took the master branch as base. I couldn't find any changelog/upgrade guide for 7.x, is there another place where I should document this? I btw don't expect this to break any project, as it's a quite internal method call.