### PR TITLE
[7.x] Add Collection::sortDesc()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1066,6 +1066,21 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Sort items in descending order.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortDesc($options = SORT_REGULAR)
+    {
+        $items = $this->items;
+
+        arsort($items, $options);
+
+        return new static($items);
+    }
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  callable|string  $callback

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -761,6 +761,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function sort(callable $callback = null);
 
     /**
+     * Sort items in descending order.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortDesc($options = SORT_REGULAR);
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  callable|string  $callback

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1027,6 +1027,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Sort items in descending order.
+     *
+     * @param  int  $options
+     * @return static
+     */
+    public function sortDesc($options = SORT_REGULAR)
+    {
+        return $this->passthru('sortDesc', func_get_args());
+    }
+
+    /**
      * Sort the collection using the given callback.
      *
      * @param  callable|string  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1347,6 +1347,27 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortDesc($collection)
+    {
+        $data = (new $collection([5, 3, 1, 2, 4]))->sortDesc();
+        $this->assertEquals([5, 4, 3, 2, 1], $data->values()->all());
+
+        $data = (new $collection([-1, -3, -2, -4, -5, 0, 5, 3, 1, 2, 4]))->sortDesc();
+        $this->assertEquals([5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5], $data->values()->all());
+
+        $data = (new $collection(['bar-1', 'foo', 'bar-10']))->sortDesc();
+        $this->assertEquals(['foo', 'bar-10', 'bar-1'], $data->values()->all());
+
+        $data = (new $collection(['T2', 'T1', 'T10']))->sortDesc();
+        $this->assertEquals(['T2', 'T10', 'T1'], $data->values()->all());
+
+        $data = (new $collection(['T2', 'T1', 'T10']))->sortDesc(SORT_NATURAL);
+        $this->assertEquals(['T10', 'T2', 'T1'], $data->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortWithCallback($collection)
     {
         $data = (new $collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -897,6 +897,17 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testSortDescIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->sortDesc();
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->sortDesc()->all();
+        });
+    }
+
     public function testSortByIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
Currently it is not possible to sort a collection like this `collection(['a', 'b', 'c'])` in descending order.
The `Collection` class has a `sort()` but not a `sortDesc()` 
Every other sorting method has a desc variation except the `sort()`, For exemple `sortBy` and `sortByDesc`, `sortKeys` and `sortKeysDesc`.
This PR adds a new method `sortDesc()` to the `Collection`, `LazyCollection` classes to allow for that.
The sorting supports using flags as well.

My use case : 
I have a collection that i work on.

```php
$collection = collection($models)
->filter(function($item) {
    // Filter logic
})
->groupBy(function($item){
    // Group by logic
})
->map(function($item){
    // Sum up some stuff and return an integer
})
// At this point i have an array of ints that i want to sort in descending order.

//Before PR
$values = $collection->toArray();
arsort($values);

// After PR, continue chaining
$collection->sortDesc();
```
Since the method `sortDesc()` does not exist i have to use `toArray()` and sort the array in descending order.

I targeted the master branch because this involves adding the new method to the `\Illuminate\Support\Enumerable` which may break some applications that are implementing the interface on their own.