### PR TITLE
[6.x] Update error message if redis extension is not loaded

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -69,9 +69,11 @@ class PhpRedisConnector implements Connector
     {
         return tap(new Redis, function ($client) use ($config) {
             if ($client instanceof RedisFacade) {
-                throw new LogicException(
-                    'Please remove or rename the Redis facade alias in your "app" configuration file in order to avoid collision with the PHP Redis extension.'
-                );
+                $message = 'Please remove or rename the Redis facade alias in your "app" configuration file in order to avoid collision with the PHP Redis extension.';
+                if (!extension_loaded('redis')) {
+                    $message = 'Please make sure the PHP Redis extension is installed and enabled.';
+                }
+                throw new LogicException($message);
             }
 
             $this->establishConnection($client, $config);

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -70,7 +70,7 @@ class PhpRedisConnector implements Connector
         return tap(new Redis, function ($client) use ($config) {
             if ($client instanceof RedisFacade) {
                 $message = 'Please remove or rename the Redis facade alias in your "app" configuration file in order to avoid collision with the PHP Redis extension.';
-                if (!extension_loaded('redis')) {
+                if (! extension_loaded('redis')) {
                     $message = 'Please make sure the PHP Redis extension is installed and enabled.';
                 }
                 throw new LogicException($message);


### PR DESCRIPTION
Based on https://github.com/laravel/framework/issues/29864 I would say it is time for better error messages than what has always been provided (pre-6.x).

After spending around 30 minutes to an hour figuring out that the PHP Redis extension was **installed** but not **enabled** I found myself displeased with the unhelpful default error message. To help all future developers we should be detecting if `redis` extension is not loaded and then provide a more helpful message.

Given the class `PhpRedisConnector` is only used for the `phpredis` driver, no checks other than `!extension_loaded('redis')` is needed.

Tested on machine **without** extension loaded:
```php
forge@solitary-thunder:~$ php -a
Interactive mode enabled

php > var_dump(extension_loaded('redis'));
bool(false)
php >
```
and one **with** the extension loaded:
```php
forge@fathomless-breeze:~$ php -a
Interactive mode enabled

php > var_dump(extension_loaded('redis'));
bool(true)
php >
```