### PR TITLE
[7.x] Support generating pivot tables

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -76,12 +76,12 @@ class MigrateMakeCommand extends BaseCommand
 
         $pivot = [
             'is' => $this->input->getOption('pivot') ?: false,
-            'prefixes' => $this->input->getOption('pivot-prefixes')
+            'prefixes' => $this->input->getOption('pivot-prefixes'),
         ];
 
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
-        // to pass a table name into this option as a short-cut for creating.
+        // to pass a table name into this opt   ion as a short-cut for creating.
         if (! $table && is_string($create)) {
             $table = $create;
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -81,7 +81,7 @@ class MigrateMakeCommand extends BaseCommand
 
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
-        // to pass a table name into this opt   ion as a short-cut for creating.
+        // to pass a table name into this option as a short-cut for creating.
         if (! $table && is_string($create)) {
             $table = $create;
 
@@ -106,13 +106,13 @@ class MigrateMakeCommand extends BaseCommand
     /**
      * Write the migration file to disk.
      *
-     * @param string $name
-     * @param string $table
-     * @param bool $create
-     * @param $pivot
+     * @param  string  $name
+     * @param  string  $table
+     * @param  bool  $create
+     * @param  array  $pivot
      * @return string
      */
-    protected function writeMigration($name, $table, $create, $pivot)
+    protected function writeMigration($name, $table, $create, array $pivot)
     {
         $file = $this->creator->create(
             $name, $this->getMigrationPath(), $table, $create, $pivot

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -18,7 +18,9 @@ class MigrateMakeCommand extends BaseCommand
         {--table= : The table to migrate}
         {--path= : The location where the migration file should be created}
         {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
-        {--fullpath : Output the full path of the migration}';
+        {--fullpath : Output the full path of the migration}
+        {--pivot : Generates pivot table}
+        {--pivot-prefixes= : Field prefixes that pivot is related}';
 
     /**
      * The console command description.
@@ -72,6 +74,11 @@ class MigrateMakeCommand extends BaseCommand
 
         $create = $this->input->getOption('create') ?: false;
 
+        $pivot = [
+            'is' => $this->input->getOption('pivot') ?: false,
+            'prefixes' => $this->input->getOption('pivot-prefixes')
+        ];
+
         // If no table was given as an option but a create option is given then we
         // will use the "create" option as the table name. This allows the devs
         // to pass a table name into this option as a short-cut for creating.
@@ -91,7 +98,7 @@ class MigrateMakeCommand extends BaseCommand
         // Now we are ready to write the migration out to disk. Once we've written
         // the migration out, we will dump-autoload for the entire framework to
         // make sure that the migrations are registered by the class loaders.
-        $this->writeMigration($name, $table, $create);
+        $this->writeMigration($name, $table, $create, $pivot);
 
         $this->composer->dumpAutoloads();
     }
@@ -99,15 +106,16 @@ class MigrateMakeCommand extends BaseCommand
     /**
      * Write the migration file to disk.
      *
-     * @param  string  $name
-     * @param  string  $table
-     * @param  bool    $create
+     * @param string $name
+     * @param string $table
+     * @param bool $create
+     * @param $pivot
      * @return string
      */
-    protected function writeMigration($name, $table, $create)
+    protected function writeMigration($name, $table, $create, $pivot)
     {
         $file = $this->creator->create(
-            $name, $this->getMigrationPath(), $table, $create
+            $name, $this->getMigrationPath(), $table, $create, $pivot
         );
 
         if (! $this->option('fullpath')) {

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -37,14 +37,14 @@ class MigrationCreator
     /**
      * Create a new migration at the given path.
      *
-     * @param string $name
-     * @param string $path
-     * @param string|null $table
-     * @param bool $create
-     * @param array $pivot
+     * @param  string  $name
+     * @param  string  $path
+     * @param  string|null  $table
+     * @param  bool  $create
+     * @param  array  $pivot
      * @return string
      */
-    public function create($name, $path, $table = null, $create = false, $pivot = [])
+    public function create($name, $path, $table = null, $create = false, array $pivot = [])
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
@@ -70,7 +70,7 @@ class MigrationCreator
      * Ensure that a migration with the given name doesn't already exist.
      *
      * @param  string  $name
-     * @param  string  $migrationPath
+     * @param  string|null  $migrationPath
      * @return void
      *
      * @throws \InvalidArgumentException
@@ -95,10 +95,10 @@ class MigrationCreator
      *
      * @param  string|null  $table
      * @param  bool  $create
-     * @param  $pivot
+     * @param  array  $pivot
      * @return string
      */
-    protected function getStub($table, $create, $pivot)
+    protected function getStub($table, $create, array $pivot)
     {
         if (is_null($table)) {
             return $this->files->get($this->stubPath().'/blank.stub');
@@ -107,7 +107,7 @@ class MigrationCreator
         // We also have stubs for creating new tables and modifying existing tables
         // to save the developer some typing when they are creating a new tables
         // or modifying existing tables. We'll grab the appropriate stub here.
-        $stub = $create ? ($pivot['is'] ? 'pivot.stub' : 'create.stub') : 'update.stub';
+        $stub = $create ? (isset($pivot['is']) && $pivot['is'] ? 'pivot.stub' : 'create.stub') : 'update.stub';
 
         return $this->files->get($this->stubPath()."/{$stub}");
     }
@@ -121,7 +121,7 @@ class MigrationCreator
      * @param  array  $pivot
      * @return string
      */
-    protected function populateStub($name, $stub, $table, $pivot)
+    protected function populateStub($name, $stub, $table, array $pivot)
     {
         $stub = str_replace('DummyClass', $this->getClassName($name), $stub);
 
@@ -133,7 +133,7 @@ class MigrationCreator
         }
 
         // if it's pivot table, replace fields and table names by given prefixes
-        if ($pivot['is']) {
+        if (isset($pivot['is']) && $pivot['is']) {
             [$first, $second] = explode(
                 $pivot['prefixes'] ? ',' : '_',
                 $pivot['prefixes'] ?: $table

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -43,7 +43,6 @@ class MigrationCreator
      * @param bool $create
      * @param array $pivot
      * @return string
-     *
      */
     public function create($name, $path, $table = null, $create = false, $pivot = [])
     {
@@ -140,8 +139,8 @@ class MigrationCreator
                 $pivot['prefixes'] ?: $table
             );
             $stub = str_replace(
-                ['firstPivotId','secondPivotId','firstPivotTable','secondPivotTable'],
-                [$first.'_id', $second."_id", Str::plural($first), Str::plural($second)],
+                ['firstPivotId', 'secondPivotId', 'firstPivotTable', 'secondPivotTable'],
+                [$first.'_id', $second.'_id', Str::plural($first), Str::plural($second)],
                 $stub
             );
         }

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -37,26 +37,26 @@ class MigrationCreator
     /**
      * Create a new migration at the given path.
      *
-     * @param  string  $name
-     * @param  string  $path
-     * @param  string|null  $table
-     * @param  bool    $create
+     * @param string $name
+     * @param string $path
+     * @param string|null $table
+     * @param bool $create
+     * @param array $pivot
      * @return string
      *
-     * @throws \Exception
      */
-    public function create($name, $path, $table = null, $create = false)
+    public function create($name, $path, $table = null, $create = false, $pivot = [])
     {
         $this->ensureMigrationDoesntAlreadyExist($name, $path);
 
         // First we will get the stub file for the migration, which serves as a type
         // of template for the migration. Once we have those we will populate the
         // various place-holders, save the file, and run the post create event.
-        $stub = $this->getStub($table, $create);
+        $stub = $this->getStub($table, $create, $pivot);
 
         $this->files->put(
             $path = $this->getPath($name, $path),
-            $this->populateStub($name, $stub, $table)
+            $this->populateStub($name, $stub, $table, $pivot)
         );
 
         // Next, we will fire any hooks that are supposed to fire after a migration is
@@ -95,10 +95,11 @@ class MigrationCreator
      * Get the migration stub file.
      *
      * @param  string|null  $table
-     * @param  bool    $create
+     * @param  bool  $create
+     * @param  $pivot
      * @return string
      */
-    protected function getStub($table, $create)
+    protected function getStub($table, $create, $pivot)
     {
         if (is_null($table)) {
             return $this->files->get($this->stubPath().'/blank.stub');
@@ -107,7 +108,7 @@ class MigrationCreator
         // We also have stubs for creating new tables and modifying existing tables
         // to save the developer some typing when they are creating a new tables
         // or modifying existing tables. We'll grab the appropriate stub here.
-        $stub = $create ? 'create.stub' : 'update.stub';
+        $stub = $create ? ($pivot['is'] ? 'pivot.stub' : 'create.stub') : 'update.stub';
 
         return $this->files->get($this->stubPath()."/{$stub}");
     }
@@ -118,9 +119,10 @@ class MigrationCreator
      * @param  string  $name
      * @param  string  $stub
      * @param  string|null  $table
+     * @param  array  $pivot
      * @return string
      */
-    protected function populateStub($name, $stub, $table)
+    protected function populateStub($name, $stub, $table, $pivot)
     {
         $stub = str_replace('DummyClass', $this->getClassName($name), $stub);
 
@@ -129,6 +131,19 @@ class MigrationCreator
         // or update migration from the console instead of typing it manually.
         if (! is_null($table)) {
             $stub = str_replace('DummyTable', $table, $stub);
+        }
+
+        // if it's pivot table, replace fields and table names by given prefixes
+        if ($pivot['is']) {
+            [$first, $second] = explode(
+                $pivot['prefixes'] ? ',' : '_',
+                $pivot['prefixes'] ?: $table
+            );
+            $stub = str_replace(
+                ['firstPivotId','secondPivotId','firstPivotTable','secondPivotTable'],
+                [$first.'_id', $second."_id", Str::plural($first), Str::plural($second)],
+                $stub
+            );
         }
 
         return $stub;

--- a/src/Illuminate/Database/Migrations/stubs/pivot.stub
+++ b/src/Illuminate/Database/Migrations/stubs/pivot.stub
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DummyClass extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('DummyTable', function (Blueprint $table) {
+            $table->unsignedBigInteger('firstPivotId');
+            $table->unsignedBigInteger('secondPivotId');
+
+            $table->foreign('firstPivotId')->references('id')
+                ->on('firstPivotTable')->onDelete('cascade');
+            $table->foreign('secondPivotId')->references('id')
+                ->on('secondPivotTable')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('DummyTable');
+    }
+}


### PR DESCRIPTION
I added `--pivot` and `--pivot-prefixes` options to `make:migration` command to generate pivot tables with ease

Sample usage: ` php artisan make:migration create_category_post_table --pivot`

Above command will generate below migration file.

```php
public function up()
    {
        Schema::create('category_post', function (Blueprint $table) {
            $table->unsignedBigInteger('category_id');
            $table->unsignedBigInteger('post_id');

            $table->foreign('category_id')->references('id')
                ->on('categories')->onDelete('cascade');
            $table->foreign('post_id')->references('id')
                ->on('posts')->onDelete('cascade');
        });
    }
```

