### PR TITLE
Fixed json_unquote for aggregate

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -229,7 +229,11 @@ class MySqlGrammar extends Grammar
     {
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
-        return 'json_unquote(json_extract('.$field.$path.'))';
+        if (count(explode('->>', $value, 2)) > 1) {
+            return 'json_unquote(json_extract('.$field.$path.'))';
+        } else {
+            return 'json_extract('.$field.$path.')';
+        }
     }
 
     /**
@@ -243,5 +247,30 @@ class MySqlGrammar extends Grammar
         [$field, $path] = $this->wrapJsonFieldAndPath($value);
 
         return 'json_extract('.$field.$path.')';
+    }
+    
+    /**
+     * Split the given JSON selector into the field and the optional path and wrap them separately.
+     *
+     * @param  string  $column
+     * @return array
+     */
+    protected function wrapJsonFieldAndPath($column)
+    {
+        if (count($parts = explode('->>', $column, 2)) > 1) {
+            $field = $this->wrap($parts[0]);
+
+            $path = ', '.$this->wrapJsonPath($parts[1], '->>');
+
+            return [$field, $path];
+        } else {
+            $parts = explode('->', $column, 2);
+
+            $field = $this->wrap($parts[0]);
+
+            $path = count($parts) > 1 ? ', '.$this->wrapJsonPath($parts[1], '->') : '';
+
+            return [$field, $path];
+        }
     }
 }


### PR DESCRIPTION
when you called a column in select(e.g. sum()) or in group_by if use '->>' you forced to use json_unquote

**when use aggregates (such as min or max) or use order_by if use json_unquote integer columns returned as string so this funcs not work correct!!!**
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
