### PR TITLE
[6.x] Cache & discover observers similar to caching events & listeners

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -968,6 +968,26 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     }
 
     /**
+     * Determine if the application observers are cached.
+     *
+     * @return bool
+     */
+    public function observersAreCached()
+    {
+        return $this['files']->exists($this->getCachedObserversPath());
+    }
+
+    /**
+     * Get the path to the observers cache file.
+     *
+     * @return string
+     */
+    public function getCachedObserversPath()
+    {
+        return $this->normalizeCachePath('APP_OBSERVERS_CACHE', 'cache/observers.php');
+    }
+
+    /**
      * Normalize a relative or absolute path to a cache file.
      *
      * @param  string  $key

--- a/src/Illuminate/Foundation/Console/ObserverCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverCacheCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider;
+
+class ObserverCacheCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'observer:cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Discover and cache the application's observers";
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->call('observer:clear');
+
+        file_put_contents(
+            $this->laravel->getCachedObserversPath(),
+            '<?php return '.var_export($this->getObservers(), true).';'
+        );
+
+        $this->info('Observers cached successfully!');
+    }
+
+    /**
+     * Get all of the observers configured for the application.
+     *
+     * @return array
+     */
+    protected function getObservers()
+    {
+        $observers = [];
+
+        foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
+            $providerObservers = array_merge_recursive($provider->shouldDiscoverObservers() ? $provider->discoverObservers() : [], $provider->observes());
+
+            $observers[get_class($provider)] = $providerObservers;
+        }
+
+        return $observers;
+    }
+}

--- a/src/Illuminate/Foundation/Console/ObserverClearCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverClearCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class ObserverClearCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'observer:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Clear all cached observers';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new config clear command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function handle()
+    {
+        $this->files->delete($this->laravel->getCachedObserversPath());
+
+        $this->info('Cached observers cleared!');
+    }
+}

--- a/src/Illuminate/Foundation/Observers/DiscoverObservers.php
+++ b/src/Illuminate/Foundation/Observers/DiscoverObservers.php
@@ -14,9 +14,8 @@ class DiscoverObservers
     /**
      * Get all of the observers by searching the given observer directory.
      *
-     * @param string $observerPath
-     * @param string $basePath
-     *
+     * @param  string  $observerPath
+     * @param  string  $basePath
      * @return array
      */
     public static function within($observerPath, $basePath)
@@ -30,9 +29,8 @@ class DiscoverObservers
     /**
      * Get all of the observers and their corresponding models.
      *
-     * @param iterable $observers
-     * @param string   $basePath
-     *
+     * @param  iterable  $observers
+     * @param  string    $basePath
      * @return arrays
      */
     protected static function getObservers($observers, $basePath)
@@ -65,9 +63,8 @@ class DiscoverObservers
     /**
      * Extract the class name from the given file path.
      *
-     * @param SplFileInfo $file
-     * @param string      $basePath
-     *
+     * @param \SplFileInfo $file
+     * @param string       $basePath
      * @return string
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)

--- a/src/Illuminate/Foundation/Observers/DiscoverObservers.php
+++ b/src/Illuminate/Foundation/Observers/DiscoverObservers.php
@@ -30,7 +30,7 @@ class DiscoverObservers
      * Get all of the observers and their corresponding models.
      *
      * @param  iterable  $observers
-     * @param  string    $basePath
+     * @param  string  $basePath
      * @return arrays
      */
     protected static function getObservers($observers, $basePath)
@@ -63,8 +63,8 @@ class DiscoverObservers
     /**
      * Extract the class name from the given file path.
      *
-     * @param \SplFileInfo $file
-     * @param string       $basePath
+     * @param  \SplFileInfo  $file
+     * @param  string  $basePath
      * @return string
      */
     protected static function classFromFile(SplFileInfo $file, $basePath)

--- a/src/Illuminate/Foundation/Observers/DiscoverObservers.php
+++ b/src/Illuminate/Foundation/Observers/DiscoverObservers.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Foundation\Observers;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionMethod;
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+
+class DiscoverObservers
+{
+    /**
+     * Get all of the observers by searching the given observer directory.
+     *
+     * @param string $observerPath
+     * @param string $basePath
+     *
+     * @return array
+     */
+    public static function within($observerPath, $basePath)
+    {
+        return collect(static::getObservers(
+            (new Finder())->files()->in($observerPath),
+            $basePath
+        ))->all();
+    }
+
+    /**
+     * Get all of the observers and their corresponding models.
+     *
+     * @param iterable $observers
+     * @param string   $basePath
+     *
+     * @return arrays
+     */
+    protected static function getObservers($observers, $basePath)
+    {
+        $observerMapping = [];
+
+        foreach ($observers as $observer) {
+            $observer = new ReflectionClass(
+                static::classFromFile($observer, $basePath)
+            );
+
+            if (! $observer->isInstantiable()) {
+                continue;
+            }
+
+            foreach ($observer->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                $parameter = optional($method->getParameters()[0]->getClass());
+
+                if ($parameter && $parameter->isSubclassOf(Model::class)) {
+                    $observerMapping[$parameter->name][] = $observer->name;
+
+                    break;
+                }
+            }
+        }
+
+        return $observerMapping;
+    }
+
+    /**
+     * Extract the class name from the given file path.
+     *
+     * @param SplFileInfo $file
+     * @param string      $basePath
+     *
+     * @return string
+     */
+    protected static function classFromFile(SplFileInfo $file, $basePath)
+    {
+        $class = trim(Str::replaceFirst($basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+
+        return str_replace(
+            [DIRECTORY_SEPARATOR, ucfirst(basename(app()->path())).'\\'],
+            ['\\', app()->getNamespace()],
+            ucfirst(Str::replaceLast('.php', '', $class))
+        );
+    }
+}

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -353,6 +353,7 @@ class FoundationApplicationTest extends TestCase
         $this->assertSame('/base/path/bootstrap/cache/config.php', $app->getCachedConfigPath());
         $this->assertSame('/base/path/bootstrap/cache/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/base/path/bootstrap/cache/events.php', $app->getCachedEventsPath());
+        $this->assertSame('/base/path/bootstrap/cache/observers.php', $app->getCachedObserversPath());
     }
 
     public function testEnvPathsAreUsedForCachePathsWhenSpecified()
@@ -363,19 +364,22 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_CONFIG_CACHE'] = '/absolute/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = '/absolute/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = '/absolute/path/events.php';
+        $_SERVER['APP_OBSERVERS_CACHE'] = '/absolute/path/observers.php';
 
         $this->assertSame('/absolute/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/absolute/path/packages.php', $app->getCachedPackagesPath());
         $this->assertSame('/absolute/path/config.php', $app->getCachedConfigPath());
         $this->assertSame('/absolute/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/absolute/path/events.php', $app->getCachedEventsPath());
+        $this->assertSame('/absolute/path/observers.php', $app->getCachedObserversPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
-            $_SERVER['APP_EVENTS_CACHE']
+            $_SERVER['APP_EVENTS_CACHE'],
+            $_SERVER['APP_OBSERVERS_CACHE']
         );
     }
 
@@ -387,19 +391,22 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
+        $_SERVER['APP_OBSERVERS_CACHE'] = 'relative/path/observers.php';
 
         $this->assertSame('/base/path/relative/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/base/path/relative/path/packages.php', $app->getCachedPackagesPath());
         $this->assertSame('/base/path/relative/path/config.php', $app->getCachedConfigPath());
         $this->assertSame('/base/path/relative/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/base/path/relative/path/events.php', $app->getCachedEventsPath());
+        $this->assertSame('/base/path/relative/path/observers.php', $app->getCachedObserversPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
-            $_SERVER['APP_EVENTS_CACHE']
+            $_SERVER['APP_EVENTS_CACHE'],
+            $_SERVER['APP_OBSERVERS_CACHE']
         );
     }
 
@@ -411,19 +418,22 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_CONFIG_CACHE'] = 'relative/path/config.php';
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
+        $_SERVER['APP_OBSERVERS_CACHE'] = 'relative/path/observers.php';
 
         $this->assertSame('/relative/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/relative/path/packages.php', $app->getCachedPackagesPath());
         $this->assertSame('/relative/path/config.php', $app->getCachedConfigPath());
         $this->assertSame('/relative/path/routes.php', $app->getCachedRoutesPath());
         $this->assertSame('/relative/path/events.php', $app->getCachedEventsPath());
+        $this->assertSame('/relative/path/observers.php', $app->getCachedObserversPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
             $_SERVER['APP_PACKAGES_CACHE'],
             $_SERVER['APP_CONFIG_CACHE'],
             $_SERVER['APP_ROUTES_CACHE'],
-            $_SERVER['APP_EVENTS_CACHE']
+            $_SERVER['APP_EVENTS_CACHE'],
+            $_SERVER['APP_OBSERVERS_CACHE']
         );
     }
 }

--- a/tests/Integration/Foundation/DiscoverObserversTest.php
+++ b/tests/Integration/Foundation/DiscoverObserversTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation;
+
+use Illuminate\Foundation\Observers\DiscoverObservers;
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models\ModelOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models\ModelTwo;
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverOne;
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverThree;
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverTwo;
+use Orchestra\Testbench\TestCase;
+
+class DiscoverObserversTest extends TestCase
+{
+    public function testObserversCanBeDiscovered()
+    {
+        class_alias(ObserverOne::class, 'Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverOne');
+        class_alias(ObserverTwo::class, 'Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverTwo');
+        class_alias(ObserverThree::class, 'Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers\ObserverThree');
+
+        $observers = DiscoverObservers::within(__DIR__.'/Fixtures/ObserverDiscovery/Observers', getcwd());
+
+        $this->assertEquals([
+            ModelOne::class => [
+                ObserverOne::class,
+            ],
+            ModelTwo::class => [
+                ObserverTwo::class,
+            ],
+        ], $observers);
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Models/ModelOne.php
+++ b/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Models/ModelOne.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelOne extends Model
+{
+    //
+}

--- a/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Models/ModelTwo.php
+++ b/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Models/ModelTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelTwo extends Model
+{
+    //
+}

--- a/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverOne.php
+++ b/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverOne.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models\ModelOne;
+
+class ObserverOne
+{
+    public function saving(ModelOne $model)
+    {
+        //
+    }
+}

--- a/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverThree.php
+++ b/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverThree.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers;
+
+class ObserverThree
+{
+    //
+}

--- a/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverTwo.php
+++ b/tests/Integration/Foundation/Fixtures/ObserverDiscovery/Observers/ObserverTwo.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Observers;
+
+use Illuminate\Tests\Integration\Foundation\Fixtures\ObserverDiscovery\Models\ModelTwo;
+
+class ObserverTwo
+{
+    public function saving(ModelTwo $model)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR implements caching behavior & discovery for observers, similar as already available for events & listeners. The gains are straightforward I guess.

The `$observe` property in `EventServiceProvider` expects the following format:
```php
protected $observe = [
    User::class => [
        UserObserver::class,
        AnotherUserObserver::class,
    ],

    AnotherModel::class => [],
];
```

Discovery of observers scans all public methods for a type-hinted `Model` parameter to guess the observable model. If none is found, then the class is skipped.