### PR TITLE
[6.x] Add json_unqoute() as optional with '->>'

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2531,7 +2531,7 @@ class DatabaseQueryBuilderTest extends TestCase
     public function testMySqlWrappingJsonWithString()
     {
         $builder = $this->getMySqlBuilder();
-        $builder->select('*')->from('users')->where('items->sku', '=', 'foo-bar');
+        $builder->select('*')->from('users')->where('items->>sku', '=', 'foo-bar');
         $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."sku"\')) = ?', $builder->toSql());
         $this->assertCount(1, $builder->getRawBindings()['where']);
         $this->assertSame('foo-bar', $builder->getRawBindings()['where'][0]);
@@ -2541,14 +2541,14 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1);
-        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."price"\') = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithDouble()
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price', '=', 1.5);
-        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."price"\') = ?', $builder->toSql());
     }
 
     public function testMySqlWrappingJsonWithBoolean()
@@ -2566,7 +2566,7 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true)->where('items->active', '=', false)->where('items->number_available', '=', 0);
-        $this->assertSame('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_unquote(json_extract(`items`, \'$."number_available"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."available"\') = true and json_extract(`items`, \'$."active"\') = false and json_extract(`items`, \'$."number_available"\') = ?', $builder->toSql());
     }
 
     public function testJsonPathEscaping()
@@ -2576,19 +2576,19 @@ select json_unquote(json_extract(`json`, '$."\'))#"'))
 SQL;
 
         $builder = $this->getMySqlBuilder();
-        $builder->select("json->'))#");
+        $builder->select("json->>'))#");
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select("json->\'))#");
+        $builder->select("json->>\'))#");
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select("json->\\'))#");
+        $builder->select("json->>\\'))#");
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
-        $builder->select("json->\\\'))#");
+        $builder->select("json->>\\\'))#");
         $this->assertEquals($expectedWithJsonEscaped, $builder->toSql());
     }
 
@@ -2600,15 +2600,15 @@ SQL;
 
         $builder = $this->getMySqlBuilder();
         $builder->select('items->price')->from('users')->where('users.items->price', '=', 1)->orderBy('items->price');
-        $this->assertSame('select json_unquote(json_extract(`items`, \'$."price"\')) from `users` where json_unquote(json_extract(`users`.`items`, \'$."price"\')) = ? order by json_unquote(json_extract(`items`, \'$."price"\')) asc', $builder->toSql());
+        $this->assertSame('select json_extract(`items`, \'$."price"\') from `users` where json_extract(`users`.`items`, \'$."price"\') = ? order by json_extract(`items`, \'$."price"\') asc', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1);
-        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."price"."in_usd"\') = ?', $builder->toSql());
 
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->where('items->price->in_usd', '=', 1)->where('items->age', '=', 2);
-        $this->assertSame('select * from `users` where json_unquote(json_extract(`items`, \'$."price"."in_usd"\')) = ? and json_unquote(json_extract(`items`, \'$."age"\')) = ?', $builder->toSql());
+        $this->assertSame('select * from `users` where json_extract(`items`, \'$."price"."in_usd"\') = ? and json_extract(`items`, \'$."age"\') = ?', $builder->toSql());
     }
 
     public function testPostgresWrappingJson()


### PR DESCRIPTION
when use aggregates (such as min or max) or use order_by if use json_unquote integer columns returned as string so this funcs not work correct!!!

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
