### PR TITLE
[6.x] Remove duplicate assignment

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -204,7 +204,6 @@ class Validator implements ValidatorContract
     public function __construct(Translator $translator, array $data, array $rules,
                                 array $messages = [], array $customAttributes = [])
     {
-        $this->initialRules = $rules;
         $this->translator = $translator;
         $this->customMessages = $messages;
         $this->data = $this->parseData($data);


### PR DESCRIPTION
Assigned `$rules` argument to `$this->initialRules` property multiple times, once in `__construct()` method and in the `$this->setRules($rules)` method which is a method that also get called in the `__construct()`