### PR TITLE
[7.x] Only return strings with __ helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -896,15 +896,13 @@ if (! function_exists('__')) {
      * @param  string|null  $key
      * @param  array  $replace
      * @param  string|null  $locale
-     * @return string|array|null
+     * @return string
      */
     function __($key = null, $replace = [], $locale = null)
     {
-        if (is_null($key)) {
-            return $key;
-        }
+        $value = trans($key, $replace, $locale);
 
-        return trans($key, $replace, $locale);
+        return is_string($value) ? $value : $key;
     }
 }
 

--- a/tests/Integration/Translation/TranslationTest.php
+++ b/tests/Integration/Translation/TranslationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Translation;
+
+use Orchestra\Testbench\TestCase;
+
+class TranslationTest extends TestCase
+{
+    public function testTheUnderscoreHelperOnlyReturnsStrings()
+    {
+        $this->assertIsString(__('validation'));
+    }
+
+    public function testTheUnderscoreHelperReturnsTheGivenKeyIfTheTranslationCannotBeFound()
+    {
+        $this->assertEquals('nonexistent_key', __('nonexistent_key'));
+    }
+}


### PR DESCRIPTION
This PR modifies the `__` helper to only return strings. This allows for it to be safely used, even if it collides with translation files. The `trans` helper remains unaffected.