### PR TITLE
[6.x] Force usage getting timestamps columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -866,7 +866,10 @@ trait HasAttributes
      */
     public function getDates()
     {
-        $defaults = [static::CREATED_AT, static::UPDATED_AT];
+        $defaults = [
+            $this->getCreatedAtColumn(),
+            $this->getUpdatedAtColumn(),
+        ];
 
         return $this->usesTimestamps()
                     ? array_unique(array_merge($this->dates, $defaults))

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -38,12 +38,13 @@ trait HasTimestamps
     {
         $time = $this->freshTimestamp();
 
-        if (! is_null(static::UPDATED_AT) && ! $this->isDirty(static::UPDATED_AT)) {
+        $updatedAtColumn = $this->getUpdatedAtColumn();
+        if (! is_null($updatedAtColumn) && ! $this->isDirty($updatedAtColumn)) {
             $this->setUpdatedAt($time);
         }
 
-        if (! $this->exists && ! is_null(static::CREATED_AT) &&
-            ! $this->isDirty(static::CREATED_AT)) {
+        $createdAtColumn = $this->getCreatedAtColumn();
+        if (! $this->exists && ! is_null($createdAtColumn) && ! $this->isDirty($createdAtColumn)) {
             $this->setCreatedAt($time);
         }
     }
@@ -56,7 +57,7 @@ trait HasTimestamps
      */
     public function setCreatedAt($value)
     {
-        $this->{static::CREATED_AT} = $value;
+        $this->{$this->getCreatedAtColumn()} = $value;
 
         return $this;
     }
@@ -69,7 +70,7 @@ trait HasTimestamps
      */
     public function setUpdatedAt($value)
     {
-        $this->{static::UPDATED_AT} = $value;
+        $this->{$this->getUpdatedAtColumn()} = $value;
 
         return $this;
     }


### PR DESCRIPTION
https://github.com/laravel/ideas/issues/1932

The trait has 2 functions getCreatedAtColumn and getUpdatedAtColumn, but dont use it exclusively.
Better would be a single point to get the right columns.

In the end, the user has the same 2 options to set the column names: via const or via getXColumn(). But now you dont need to change both, cause the constants are only used in the getXColumn-methods.