### PR TITLE
[6.x] Allow commands to overwrite their input and output handlers

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -377,7 +377,7 @@ class Command extends SymfonyCommand
      * Confirm a question with the user.
      *
      * @param  string  $question
-     * @param  bool    $default
+     * @param  bool  $default
      * @return bool
      */
     public function confirm($question, $default = false)
@@ -433,7 +433,7 @@ class Command extends SymfonyCommand
      * Prompt the user for input but hide the answer from the console.
      *
      * @param  string  $question
-     * @param  bool    $fallback
+     * @param  bool  $fallback
      * @return mixed
      */
     public function secret($question, $fallback = true)
@@ -449,10 +449,10 @@ class Command extends SymfonyCommand
      * Give the user a single choice from an array of answers.
      *
      * @param  string  $question
-     * @param  array   $choices
+     * @param  array  $choices
      * @param  string|null  $default
-     * @param  mixed|null   $attempts
-     * @param  bool|null    $multiple
+     * @param  mixed|null  $attempts
+     * @param  bool|null  $multiple
      * @return string
      */
     public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
@@ -467,10 +467,10 @@ class Command extends SymfonyCommand
     /**
      * Format input to textual table.
      *
-     * @param  array   $headers
+     * @param  array  $headers
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $tableStyle
-     * @param  array   $columnStyles
+     * @param  array  $columnStyles
      * @return void
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
@@ -591,7 +591,7 @@ class Command extends SymfonyCommand
     /**
      * Set the input interface implementation.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface $input
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @return void
      */
     public function setInput(InputInterface $input)
@@ -602,7 +602,7 @@ class Command extends SymfonyCommand
     /**
      * Set the output interface implementation.
      *
-     * @param  \Illuminate\Console\OutputStyle $output
+     * @param  \Illuminate\Console\OutputStyle  $output
      * @return void
      */
     public function setOutput(OutputStyle $output)

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -591,8 +591,8 @@ class Command extends SymfonyCommand
     /**
      * Set the input interface implementation.
      *
-     * @param InputInterface $input
-     * @return void
+     * @param  \Symfony\Component\Console\Input\InputInterface $input
+     * @return  void
      */
     public function setInput(InputInterface $input)
     {
@@ -602,8 +602,8 @@ class Command extends SymfonyCommand
     /**
      * Set the output interface implementation.
      *
-     * @param OutputStyle $output
-     * @return void
+     * @param  \Illuminate\Console\OutputStyle $output
+     * @return  void
      */
     public function setOutput(OutputStyle $output)
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -592,7 +592,7 @@ class Command extends SymfonyCommand
      * Set the input interface implementation.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface $input
-     * @return  void
+     * @return void
      */
     public function setInput(InputInterface $input)
     {
@@ -603,7 +603,7 @@ class Command extends SymfonyCommand
      * Set the output interface implementation.
      *
      * @param  \Illuminate\Console\OutputStyle $output
-     * @return  void
+     * @return void
      */
     public function setOutput(OutputStyle $output)
     {

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -589,6 +589,28 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Set the input interface implementation.
+     *
+     * @param InputInterface $input
+     * @return void
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * Set the output interface implementation.
+     *
+     * @param OutputStyle $output
+     * @return void
+     */
+    public function setOutput(OutputStyle $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
      * Set the verbosity level.
      *
      * @param  string|int  $level

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -9,6 +9,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -86,5 +87,29 @@ class CommandTest extends TestCase
         $this->assertequals('test-second-argument', $command->argument('argument-two'));
         $this->assertEquals('test-first-option', $command->option('option-one'));
         $this->assertEquals('test-second-option', $command->option('option-two'));
+    }
+
+    public function testTheInputSetterOverwrite()
+    {
+        $input = m::mock(InputInterface::class);
+        $input->shouldReceive('hasArgument')->once()->with('foo')->andReturn(false);
+
+        $command = new Command;
+        $command->setInput($input);
+
+        $this->assertFalse($command->hasArgument('foo'));
+    }
+
+    public function testTheOutputSetterOverwrite()
+    {
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('writeln')->once()->withArgs(function (...$args) {
+            return $args[0] === '<info>foo</info>';
+        });
+
+        $command = new Command;
+        $command->setOutput($output);
+
+        $command->info('foo');
     }
 }


### PR DESCRIPTION
This `[PR]` allows commands to overwrite the input and output handlers.

This is useful when you need to swap out a current handler on runtime execution. It also adds an easy way to test commands as `Units` without the need to extend from the `framework` test case class to write tests as it is in [here](https://laravel.com/docs/6.x/console-tests).

There is another way to hook into this cycle by `mocking` the `Laravel` value, but you need to get into setting all the expectations needed as shown in this [Test](https://github.com/laravel/framework/blob/6.x/tests/Console/CommandTest.php#L26)