### PR TITLE
[6.x] Revert adding head method to router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -133,18 +133,6 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
-     * Register a new HEAD route with the router.
-     *
-     * @param  string  $uri
-     * @param  \Closure|array|string|callable|null  $action
-     * @return \Illuminate\Routing\Route
-     */
-    public function head($uri, $action = null)
-    {
-        return $this->addRoute('HEAD', $uri, $action);
-    }
-
-    /**
      * Register a new GET route with the router.
      *
      * @param  string  $uri

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -5,7 +5,6 @@ namespace Illuminate\Support\Facades;
 /**
  * @method static \Illuminate\Routing\Route fallback(\Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route get(string $uri, \Closure|array|string|callable|null $action = null)
- * @method static \Illuminate\Routing\Route head(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route post(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route put(string $uri, \Closure|array|string|callable|null $action = null)
  * @method static \Illuminate\Routing\Route delete(string $uri, \Closure|array|string|callable|null $action = null)


### PR DESCRIPTION
This reverts https://github.com/laravel/framework/pull/30646 because it's incomplete and currently breaks the route:list command.

Closes https://github.com/laravel/framework/issues/30708
