### PR TITLE
[7.x] Fix: Always unset BelongsTo relation when associate() received model ID

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -207,7 +207,7 @@ class BelongsTo extends Relation
 
         if ($model instanceof Model) {
             $this->child->setRelation($this->relationName, $model);
-        } elseif ($this->child->isDirty($this->foreignKey)) {
+        } else {
             $this->child->unsetRelation($this->relationName);
         }
 

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -131,7 +131,10 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
+
+        // Always set relation when we received Model
         $parent->shouldReceive('setRelation')->once()->with('relation', null);
+
         $relation->dissociate();
     }
 
@@ -141,8 +144,11 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
-        $parent->shouldReceive('isDirty')->once()->andReturn(true);
+
+        // Always unset relation when we received id, regardless of dirtiness
+        $parent->shouldReceive('isDirty')->never();
         $parent->shouldReceive('unsetRelation')->once()->with($relation->getRelationName());
+
         $relation->associate(1);
     }
 


### PR DESCRIPTION
Fixes #30691.

```diff
@@ -207,7 +207,7 @@ public function associate($model)
        if ($model instanceof Model) {
            $this->child->setRelation($this->relationName, $model);
-       } elseif ($this->child->isDirty($this->foreignKey)) {
+       } else {
            $this->child->unsetRelation($this->relationName);
        }
```

Previously, the relation was kept when incoming model ID does not pollute Model. However, the relation may get stale even if the model ID is clean.

This PR changes behavior of `BelongsTo::associate()` to consistently unset the relation when we handle model ID.