### PR TITLE
[6.x] Fix RouteUrlGenerator accepting empty string for required paramenter

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -222,8 +222,8 @@ class RouteUrlGenerator
                 return Arr::pull($parameters, $m[1]);
             } elseif (isset($this->defaultParameters[$m[1]])) {
                 return $this->defaultParameters[$m[1]];
-            } elseif (! empty($m[2])) {
-                return Arr::pull($parameters, $m[1]);
+            } elseif (isset($parameters[$m[1]])) {
+                Arr::pull($parameters, $m[1]);
             }
 
             return $m[0];

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -217,11 +217,13 @@ class RouteUrlGenerator
      */
     protected function replaceNamedParameters($path, &$parameters)
     {
-        return preg_replace_callback('/\{(.*?)\??\}/', function ($m) use (&$parameters) {
-            if (isset($parameters[$m[1]])) {
+        return preg_replace_callback('/\{(.*?)(\?)?\}/', function ($m) use (&$parameters) {
+            if (isset($parameters[$m[1]]) && $parameters[$m[1]] != '') {
                 return Arr::pull($parameters, $m[1]);
             } elseif (isset($this->defaultParameters[$m[1]])) {
                 return $this->defaultParameters[$m[1]];
+            } elseif (! empty($m[2])) {
+                return Arr::pull($parameters, $m[1]);
             }
 
             return $m[0];

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -260,6 +260,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?wall&woz', $url->route('bar', ['taylor', 'otwell', 'wall', 'woz']));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
+        $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => '']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));
@@ -501,7 +502,18 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters()
+    public function providerRouteParameters() {
+        return [
+            [['test' => 123]],
+            [['one' => null, 'test' => 123]],
+            [['one' => '', 'test' => 123]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerRouteParameters
+     */
+    public function testUrlGenerationForControllersRequiresPassingOfRequiredParameters($parameters)
     {
         $this->expectException(UrlGenerationException::class);
 
@@ -515,7 +527,7 @@ class RoutingUrlGeneratorTest extends TestCase
         }]);
         $routes->add($route);
 
-        $this->assertSame('http://www.foo.com:8080/foo?test=123', $url->route('foo', ['test' => 123]));
+        $this->assertSame('http://www.foo.com:8080/foo?test=123', $url->route('foo', $parameters));
     }
 
     public function testForceRootUrl()

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -502,7 +502,8 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
-    public function providerRouteParameters() {
+    public function providerRouteParameters()
+    {
         return [
             [['test' => 123]],
             [['one' => null, 'test' => 123]],


### PR DESCRIPTION
#30659 fixed RouteUrlGenerator not failing when a required parameter is not passed but it's still not failing if a required parameter is passed empty.
 
```
Route::get('/foo/{required}/test/{optional?}')->name('test-route');
```
```
route('test-route', ['required' => null, 'optional' => null]);
// UrlGenerationException

route('test-route', ['required' => '', 'optional' => null]);
// /foo//test
```
I don't think this could be considered an expected behaviour since normally required means set and not empty.

My PR checks if the required parameter is set and it's not an empty string, if this check fails it will look for default Parameter and as last step checks if parameter was optional.