### PR TITLE
[6.x] Ability to use a model to build a route

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
@@ -780,6 +781,34 @@ if (! function_exists('route')) {
     function route($name, $parameters = [], $absolute = true)
     {
         return app('url')->route($name, $parameters, $absolute);
+    }
+}
+
+if (! function_exists('route_from_model')) {
+    /**
+     * This allows a route to be dynamically built just from a Model instance.
+     * Imagine a route called "test":
+     *      '/test/{name}/{id}'
+     * Calling:
+     *      Router::fromModel('test', Site::find(8));
+     * will successfully build the route, as "name" and "id" are both attributes on the Site model.
+     *
+     * Further more, once using "fromModel", the route can be changed. Without changing the call:
+     *      Router::fromModel('test', Site::find(8));
+     * You can change the route to be:
+     *      '/test/{name}/{id}/{group->default_blurb->id}/{group->name}/{group->id}'
+     * And the route will successfully change, as all the extra parts can be extracted from the Model.
+     * Relationships can be called and/or chained with "->" (Imagine Model is a CustomerSurveyAnswer):
+     *      {header->customer->site->group->default_blurb->blurb}
+     * Would get the related groups default blurb (which is a custom attribute, which also is valid)
+     * @param string $routeName The route you want to use
+     * @param Model $model
+     * @param array $data
+     * @return string
+     */
+    function route_from_model(string $routeName, Model $model, array $data = [])
+    {
+        return app('url')->routeFromModel($routeName, $model, $data);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -798,9 +798,9 @@ if (! function_exists('route_from_model')) {
      * You can change the route to be:
      *      '/test/{name}/{id}/{group->default_blurb->id}/{group->name}/{group->id}'
      * And the route will successfully change, as all the extra parts can be extracted from the Model.
-     * Relationships can be called and/or chained with "->" (Imagine Model is a CustomerSurveyAnswer):
-     *      {header->customer->site->group->default_blurb->blurb}
-     * Would get the related groups default blurb (which is a custom attribute, which also is valid)
+     * Relationships can be called and/or chained with "->" (Imagine Model is a Order):
+     *      {customer->address->postcode}
+     * Would get the postcode of the customer who owns the order.
      * @param string $routeName The route you want to use
      * @param Model $model
      * @param array $data

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -790,13 +790,13 @@ if (! function_exists('route_from_model')) {
      * Imagine a route called "test":
      *      '/test/{name}/{id}'
      * Calling:
-     *      Router::fromModel('test', Site::find(8));
+     *      routeFromModel('test', Site::find(8));
      * will successfully build the route, as "name" and "id" are both attributes on the Site model.
      *
-     * Further more, once using "fromModel", the route can be changed. Without changing the call:
-     *      Router::fromModel('test', Site::find(8));
+     * Further more, once using "routeFromModel", the route can be changed. Without changing the call:
+     *      routeFromModel('test', Site::find(8));
      * You can change the route to be:
-     *      '/test/{name}/{id}/{group->default_blurb->id}/{group->name}/{group->id}'
+     *      '/test/{name}/{id}/{parent->relationship->value}/{slug}/{otherParent->value}'
      * And the route will successfully change, as all the extra parts can be extracted from the Model.
      * Relationships can be called and/or chained with "->" (Imagine Model is a Order):
      *      {customer->address->postcode}

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use Closure;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -418,6 +419,58 @@ class UrlGenerator implements UrlGeneratorContract
         }
 
         throw new RouteNotFoundException("Route [{$name}] not defined.");
+    }
+
+    /**
+     * This allows a route to be dynamically built just from a Model instance.
+     * Imagine a route called "test":
+     *      '/test/{name}/{id}'
+     * Calling:
+     *      routeFromModel('test', Site::find(8));
+     * will successfully build the route, as "name" and "id" are both attributes on the Site model.
+     *
+     * Further more, once using routeFromModel, the route can be changed. Without changing the call:
+     *      Router::fromModel('test', Site::find(8));
+     * You can change the route to be:
+     *      '/test/{name}/{id}/{group->default_blurb->id}/{group->name}/{group->id}'
+     * And the route will successfully change, as all the extra parts can be extracted from the Model.
+     * Relationships can be called and/or chained with "->" (Imagine Model is a Order):
+     *      {customer->address->postcode}
+     * Would get the postcode of the customer who owns the order.
+     * @param string $routeName The route you want to build
+     * @param Model $model      The model to pull the data from
+     * @param array $data       Data to build into the route when it doesn't exist on the model
+     * @return string           The built URL.
+     */
+    public function routeFromModel(string $routeName, Model $model, array $data = [])
+    {
+        $route = $this->routes->getByName($routeName);
+
+        $params = $route->parameterNames();
+
+        foreach ($params as $name) {
+            if (isset($data[$name])) {
+                continue;
+            }
+
+            $root = $model;
+
+            // Split the name on -> so we can set URL parts from relationships.
+            $exploded = collect(explode('->', $name));
+
+            // Remove the last one, this is the attribute we actually want to get.
+            $last = $exploded->pop();
+
+            // Change the $root to be whatever relationship in necessary.
+            foreach ($exploded as $part) {
+                $root = $root->$part;
+            }
+
+            // Get the value.
+            $data[$name] = $root->$last;
+        }
+
+        return rtrim($this->route($routeName, $data), '?');
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -430,9 +430,9 @@ class UrlGenerator implements UrlGeneratorContract
      * will successfully build the route, as "name" and "id" are both attributes on the Site model.
      *
      * Further more, once using routeFromModel, the route can be changed. Without changing the call:
-     *      Router::fromModel('test', Site::find(8));
+     *      routeFromModel('test', Site::find(8));
      * You can change the route to be:
-     *      '/test/{name}/{id}/{group->default_blurb->id}/{group->name}/{group->id}'
+     *      '/test/{name}/{id}/{parent->relationship->value}/{slug}/{otherParent->value}'
      * And the route will successfully change, as all the extra parts can be extracted from the Model.
      * Relationships can be called and/or chained with "->" (Imagine Model is a Order):
      *      {customer->address->postcode}

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -652,7 +652,7 @@ class RoutingUrlGeneratorTest extends TestCase
     }
 
     /**
-     * Test that a route can be build from a model instance
+     * Test that a route can be build from a model instance.
      */
     public function testGetBuildingRouteFromModel()
     {
@@ -661,7 +661,7 @@ class RoutingUrlGeneratorTest extends TestCase
             $request = Request::create('http://www.foo.com/')
         );
 
-        $route = new Route(['GET'], 'foo/{name}', function(){
+        $route = new Route(['GET'], 'foo/{name}', function () {
             return true;
         });
         $route->name('route');
@@ -674,7 +674,7 @@ class RoutingUrlGeneratorTest extends TestCase
     }
 
     /**
-     * Test a route can be built from a model with a relationship
+     * Test a route can be built from a model with a relationship.
      */
     public function testGetBuildingRouteFromModelWithRelationship()
     {
@@ -683,7 +683,7 @@ class RoutingUrlGeneratorTest extends TestCase
             $request = Request::create('http://www.foo.com/')
         );
 
-        $route = new Route(['GET'], 'foo/{name}/{child->name}', function(){
+        $route = new Route(['GET'], 'foo/{name}/{child->name}', function () {
             return true;
         });
         $route->name('route');
@@ -727,21 +727,22 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame(
             'http://www.foo.com/foo/test/test-child/something',
             $urlGenerator->routeFromModel('route', $model, [
-                'extra' => 'something'
+                'extra' => 'something',
             ])
         );
     }
 }
 
-class ModelTest extends Model {
-
-    public function child(){
+class ModelTest extends Model
+{
+    public function child()
+    {
         return $this->hasOne(ModelChildTest::class);
     }
 }
 
-class ModelChildTest extends Model {
-
+class ModelChildTest extends Model
+{
 }
 
 class RoutableInterfaceStub implements UrlRoutable

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -710,7 +710,7 @@ class RoutingUrlGeneratorTest extends TestCase
             $request = Request::create('http://www.foo.com/')
         );
 
-        $route = new Route(['GET'], 'foo/{name}/{child->name}/{extra}', function(){
+        $route = new Route(['GET'], 'foo/{name}/{child->name}/{extra}', function () {
             return true;
         });
         $route->name('route');


### PR DESCRIPTION
This allows a route to be dynamically built just from a Model instance.

Imagine a route called "test":
    `'/test/{name}/{id}'`
Calling:
    `routeFromModel('test', Site::find(8));`
will successfully build the route, as "name" and "id" are both attributes on the Site model.

Further more, once using "routeFromModel", the route can be changed. Without changing the call:
    `routeFromModel('test', Site::find(8));`
You can change the route to be:
    `'/test/{name}/{id}/{parent->relationship->value}/{slug}/{otherParent->value}'`
And the route will successfully change, as all the extra parts can be extracted from the Model.
Relationships can be called and/or chained with "->" (Imagine Model is a Order):
   `{customer->address->postcode}`
Would get the postcode of the customer who owns the order.