### PR TITLE
[7.x] Restore default connection after Artisan migrate/seed call

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -49,6 +49,7 @@ class StatusCommand extends BaseCommand
      */
     public function handle()
     {
+        $previousConnection = $this->migrator->getConnection();
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {
@@ -66,6 +67,8 @@ class StatusCommand extends BaseCommand
         } else {
             $this->error('No migrations found');
         }
+
+        $this->migrator->restorePriorConnection($previousConnection);
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -50,6 +50,7 @@ class StatusCommand extends BaseCommand
     public function handle()
     {
         $previousConnection = $this->migrator->getConnection();
+
         $this->migrator->setConnection($this->option('database'));
 
         if (! $this->migrator->repositoryExists()) {

--- a/src/Illuminate/Database/Console/Seeds/SeedCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeedCommand.php
@@ -57,11 +57,17 @@ class SeedCommand extends Command
             return;
         }
 
+        $previousConnection = $this->resolver->getDefaultConnection();
+
         $this->resolver->setDefaultConnection($this->getDatabase());
 
         Model::unguarded(function () {
             $this->getSeeder()->__invoke();
         });
+
+        if ($previousConnection) {
+            $this->resolver->setDefaultConnection($previousConnection);
+        }
 
         $this->info('Database seeding completed successfully.');
     }

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -547,6 +547,7 @@ class Migrator
     {
         if ($name) {
             $this->previousConnection = $this->resolver->getDefaultConnection();
+
             $this->resolver->setDefaultConnection($name);
         }
 
@@ -570,7 +571,6 @@ class Migrator
      * Restore prior connection after migration runs.
      *
      * @param  string  $passedPreviousConnection
-     *
      * @return void
      */
     public function restorePriorConnection($passedPreviousConnection = null)

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -52,6 +52,13 @@ class Migrator
     protected $connection;
 
     /**
+     * The connection name before migration is run.
+     *
+     * @var string
+     */
+    protected $previousConnection = null;
+
+    /**
      * The paths to all of the migration files.
      *
      * @var array
@@ -141,6 +148,8 @@ class Migrator
         if (count($migrations) === 0) {
             $this->note('<info>Nothing to migrate.</info>');
 
+            $this->restorePriorConnection();
+
             return;
         }
 
@@ -165,6 +174,8 @@ class Migrator
                 $batch++;
             }
         }
+
+        $this->restorePriorConnection();
 
         $this->fireMigrationEvent(new MigrationsEnded);
     }
@@ -223,6 +234,8 @@ class Migrator
         if (count($migrations) === 0) {
             $this->note('<info>Nothing to rollback.</info>');
 
+            $this->restorePriorConnection();
+
             return [];
         }
 
@@ -280,6 +293,8 @@ class Migrator
             );
         }
 
+        $this->restorePriorConnection();
+
         $this->fireMigrationEvent(new MigrationsEnded);
 
         return $rolledBack;
@@ -301,6 +316,8 @@ class Migrator
 
         if (count($migrations) === 0) {
             $this->note('<info>Nothing to rollback.</info>');
+
+            $this->restorePriorConnection();
 
             return [];
         }
@@ -528,7 +545,8 @@ class Migrator
      */
     public function setConnection($name)
     {
-        if (! is_null($name)) {
+        if ($name) {
+            $this->previousConnection = $this->resolver->getDefaultConnection();
             $this->resolver->setDefaultConnection($name);
         }
 
@@ -546,6 +564,20 @@ class Migrator
     public function resolveConnection($connection)
     {
         return $this->resolver->connection($connection ?: $this->connection);
+    }
+
+    /**
+     * Restore prior connection after migration runs.
+     *
+     * @param  string  $passedPreviousConnection
+     *
+     * @return void
+     */
+    public function restorePriorConnection($passedPreviousConnection = null)
+    {
+        if ($previousConnection = $passedPreviousConnection ?? $this->previousConnection) {
+            $this->resolver->setDefaultConnection($previousConnection);
+        }
     }
 
     /**

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -32,6 +32,11 @@ class DatabaseMigratorIntegrationTest extends TestCase
             'database'  => ':memory:',
         ]);
 
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ], 'sqlite2');
+
         $db->setAsGlobal();
 
         $container = new Container;
@@ -52,6 +57,12 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         if (! $repository->repositoryExists()) {
             $repository->createRepository();
+        }
+
+        $repository2 = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations');
+        $repository2->setSource('sqlite2');
+        if (! $repository2->repositoryExists()) {
+            $repository2->createRepository();
         }
     }
 
@@ -169,5 +180,46 @@ class DatabaseMigratorIntegrationTest extends TestCase
         ];
 
         $this->assertEquals($expected, $migrationsFilesFullPaths);
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterMigration()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterRollback()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedWhenNoOutstandingMigrationsExist()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedWhenNothingToRollback()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
+    }
+
+    public function testConnectionPriorToMigrationIsNotChangedAfterMigrateReset()
+    {
+        $this->migrator->setConnection('default');
+        $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->migrator->reset([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
+        $this->assertEquals('default', $this->migrator->getConnection());
     }
 }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -28,13 +28,13 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->db = $db = new DB;
 
         $db->addConnection([
-            'driver'    => 'sqlite',
-            'database'  => ':memory:',
+            'driver' => 'sqlite',
+            'database' => ':memory:',
         ]);
 
         $db->addConnection([
-            'driver'    => 'sqlite',
-            'database'  => ':memory:',
+            'driver' => 'sqlite',
+            'database' => ':memory:',
         ], 'sqlite2');
 
         $db->setAsGlobal();
@@ -61,6 +61,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
 
         $repository2 = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations');
         $repository2->setSource('sqlite2');
+
         if (! $repository2->repositoryExists()) {
             $repository2->createRepository();
         }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -25,6 +25,7 @@ class SeedCommandTest extends TestCase
         $seeder->shouldReceive('__invoke')->once();
 
         $resolver = m::mock(ConnectionResolverInterface::class);
+        $resolver->shouldReceive('getDefaultConnection')->once();
         $resolver->shouldReceive('setDefaultConnection')->once()->with('sqlite');
 
         $container = m::mock(Container::class);


### PR DESCRIPTION
This will be useful when having an application that handle migrations
for more than one database connection.

The side affect of current implementation is that until the request
(web/console) is terminated the database will used the latest migration
connection as default.

Solved #28253

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
