### PR TITLE
[6.x] Implement RedisClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
+        "cheprasov/php-redis-client": "^1.9",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.4",
         "guzzlehttp/guzzle": "^6.3",

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -93,6 +93,7 @@ trait InteractsWithRedis
     {
         return [
             ['predis'],
+            ['redisclient'],
             ['phpredis'],
         ];
     }

--- a/src/Illuminate/Redis/Connections/Commands.php
+++ b/src/Illuminate/Redis/Connections/Commands.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace Illuminate\Redis\Connections;
+
+use Closure;
+use Redis;
+use RedisCluster;
+
+trait Commands
+{
+    /**
+     * Returns the value of the given key.
+     *
+     * @param  string  $key
+     * @return string|null
+     */
+    public function get($key)
+    {
+        $result = $this->command('get', [$key]);
+
+        return $result !== false ? $result : null;
+    }
+
+    /**
+     * Get the values of all the given keys.
+     *
+     * @param  array  $keys
+     * @return array
+     */
+    public function mget(array $keys)
+    {
+        return array_map(function ($value) {
+            return $value !== false ? $value : null;
+        }, $this->command('mget', [$keys]));
+    }
+
+    /**
+     * Determine if the given keys exist.
+     *
+     * @param  mixed  $keys
+     * @return int
+     */
+    public function exists(...$keys)
+    {
+        $keys = collect($keys)->map(function ($key) {
+            return $this->applyPrefix($key);
+        })->all();
+
+        return $this->executeRaw(array_merge(['exists'], $keys));
+    }
+
+    /**
+     * Delete the given keys.
+     *
+     * @param  mixed  $keys
+     * @return int
+     */
+    public function del(...$keys)
+    {
+        $keys = collect($keys)->map(function ($key) {
+            return $this->applyPrefix($key);
+        })->all();
+
+        return $this->executeRaw(array_merge(['del'], $keys));
+    }
+
+    /**
+     * Set the string value in argument as value of the key.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  string|null  $expireResolution
+     * @param  int|null  $expireTTL
+     * @param  string|null  $flag
+     * @return bool
+     */
+    public function set($key, $value, $expireResolution = null, $expireTTL = null, $flag = null)
+    {
+        return $this->command('set', [
+            $key,
+            $value,
+            $expireResolution ? [$flag, $expireResolution => $expireTTL] : null,
+        ]);
+    }
+
+    /**
+     * Set the given key if it doesn't exist.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return int
+     */
+    public function setnx($key, $value)
+    {
+        return (int) $this->command('setnx', [$key, $value]);
+    }
+
+    /**
+     * Get the value of the given hash fields.
+     *
+     * @param  string  $key
+     * @param  mixed  $dictionary
+     * @return array
+     */
+    public function hmget($key, ...$dictionary)
+    {
+        if (count($dictionary) === 1) {
+            $dictionary = $dictionary[0];
+        }
+
+        return array_values($this->command('hmget', [$key, $dictionary]));
+    }
+
+    /**
+     * Set the given hash fields to their respective values.
+     *
+     * @param  string  $key
+     * @param  mixed  $dictionary
+     * @return int
+     */
+    public function hmset($key, ...$dictionary)
+    {
+        if (count($dictionary) === 1) {
+            $dictionary = $dictionary[0];
+        } else {
+            $input = collect($dictionary);
+
+            $dictionary = $input->nth(2)->combine($input->nth(2, 1))->toArray();
+        }
+
+        return $this->command('hmset', [$key, $dictionary]);
+    }
+
+    /**
+     * Set the given hash field if it doesn't exist.
+     *
+     * @param  string  $hash
+     * @param  string  $key
+     * @param  string  $value
+     * @return int
+     */
+    public function hsetnx($hash, $key, $value)
+    {
+        return (int) $this->command('hsetnx', [$hash, $key, $value]);
+    }
+
+    /**
+     * Removes the first count occurrences of the value element from the list.
+     *
+     * @param  string  $key
+     * @param  int  $count
+     * @param  mixed  $value
+     * @return int|false
+     */
+    public function lrem($key, $count, $value)
+    {
+        return $this->command('lrem', [$key, $value, $count]);
+    }
+
+    /**
+     * Removes and returns the first element of the list stored at key.
+     *
+     * @param  mixed  $arguments
+     * @return array|null
+     */
+    public function blpop(...$arguments)
+    {
+        $result = $this->command('blpop', $arguments);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
+     * Removes and returns the last element of the list stored at key.
+     *
+     * @param  mixed  $arguments
+     * @return array|null
+     */
+    public function brpop(...$arguments)
+    {
+        $result = $this->command('brpop', $arguments);
+
+        return empty($result) ? null : $result;
+    }
+
+    /**
+     * Removes and returns a random element from the set value at key.
+     *
+     * @param  string  $key
+     * @param  int|null  $count
+     * @return mixed|false
+     */
+    public function spop($key, $count = 1)
+    {
+        return $this->command('spop', [$key, $count]);
+    }
+
+    /**
+     * Add one or more members to a sorted set or update its score if it already exists.
+     *
+     * @param  string  $key
+     * @param  mixed  $dictionary
+     * @return int
+     */
+    public function zadd($key, ...$dictionary)
+    {
+        if (is_array(end($dictionary))) {
+            foreach (array_pop($dictionary) as $member => $score) {
+                $dictionary[] = $score;
+                $dictionary[] = $member;
+            }
+        }
+
+        $key = $this->applyPrefix($key);
+
+        return $this->executeRaw(array_merge(['zadd', $key], $dictionary));
+    }
+
+    /**
+     * Return elements with score between $min and $max.
+     *
+     * @param  string  $key
+     * @param  mixed  $min
+     * @param  mixed  $max
+     * @param  array  $options
+     * @return array
+     */
+    public function zrangebyscore($key, $min, $max, $options = [])
+    {
+        if (isset($options['limit'])) {
+            $options['limit'] = [
+                $options['limit']['offset'],
+                $options['limit']['count'],
+            ];
+        }
+
+        return $this->command('zRangeByScore', [$key, $min, $max, $options]);
+    }
+
+    /**
+     * Return elements with score between $min and $max.
+     *
+     * @param  string  $key
+     * @param  mixed  $min
+     * @param  mixed  $max
+     * @param  array  $options
+     * @return array
+     */
+    public function zrevrangebyscore($key, $min, $max, $options = [])
+    {
+        if (isset($options['limit'])) {
+            $options['limit'] = [
+                $options['limit']['offset'],
+                $options['limit']['count'],
+            ];
+        }
+
+        return $this->command('zRevRangeByScore', [$key, $min, $max, $options]);
+    }
+
+    /**
+     * Find the intersection between sets and store in a new set.
+     *
+     * @param  string  $output
+     * @param  array  $keys
+     * @param  array  $options
+     * @return int
+     */
+    public function zinterstore($output, $keys, $options = [])
+    {
+        return $this->command('zinterstore', [$output, $keys,
+            $options['weights'] ?? null,
+            $options['aggregate'] ?? 'sum',
+        ]);
+    }
+
+    /**
+     * Find the union between sets and store in a new set.
+     *
+     * @param  string  $output
+     * @param  array  $keys
+     * @param  array  $options
+     * @return int
+     */
+    public function zunionstore($output, $keys, $options = [])
+    {
+        return $this->command('zunionstore', [$output, $keys,
+            $options['weights'] ?? null,
+            $options['aggregate'] ?? 'sum',
+        ]);
+    }
+
+    /**
+     * Evaluate a LUA script serverside, from the SHA1 hash of the script instead of the script itself.
+     *
+     * @param  string  $script
+     * @param  int  $numkeys
+     * @param  mixed  $arguments
+     * @return mixed
+     */
+    public function evalsha($script, $numkeys, ...$arguments)
+    {
+        return $this->command('evalsha', [
+            $this->script('load', $script), $arguments, $numkeys,
+        ]);
+    }
+
+    /**
+     * Evaluate a script and return its result.
+     *
+     * @param  string  $script
+     * @param  int  $numberOfKeys
+     * @param  mixed  $arguments
+     * @return mixed
+     */
+    public function eval($script, $numberOfKeys, ...$arguments)
+    {
+        return $this->command('eval', [$script, $arguments, $numberOfKeys]);
+    }
+
+    /**
+     * Subscribe to a set of given channels for messages.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function subscribe($channels, Closure $callback)
+    {
+        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
+            $callback($message, $channel);
+        });
+    }
+
+    /**
+     * Subscribe to a set of given channels with wildcards.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public function psubscribe($channels, Closure $callback)
+    {
+        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
+            $callback($message, $channel);
+        });
+    }
+
+    /**
+     * Subscribe to a set of given channels for messages.
+     *
+     * @param  array|string  $channels
+     * @param  \Closure  $callback
+     * @param  string  $method
+     * @return void
+     */
+    public function createSubscription($channels, Closure $callback, $method = 'subscribe')
+    {
+        //
+    }
+
+    /**
+     * Flush the selected Redis database.
+     *
+     * @return void
+     */
+    public function flushdb()
+    {
+        if (! $this->client instanceof RedisCluster) {
+            return $this->command('flushdb');
+        }
+
+        foreach ($this->client->_masters() as [$host, $port]) {
+            tap(new Redis)->connect($host, $port)->flushDb();
+        }
+    }
+}

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Redis\Connections;
 
-use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 use Redis;
-use RedisCluster;
 
 /**
  * @mixin \Redis
  */
 class PhpRedisConnection extends Connection implements ConnectionContract
 {
+    use Commands;
+
     /**
      * Create a new PhpRedis connection.
      *
@@ -24,270 +24,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Returns the value of the given key.
+     * Disconnects from the Redis instance.
      *
-     * @param  string  $key
-     * @return string|null
+     * @return void
      */
-    public function get($key)
+    public function disconnect()
     {
-        $result = $this->command('get', [$key]);
-
-        return $result !== false ? $result : null;
-    }
-
-    /**
-     * Get the values of all the given keys.
-     *
-     * @param  array  $keys
-     * @return array
-     */
-    public function mget(array $keys)
-    {
-        return array_map(function ($value) {
-            return $value !== false ? $value : null;
-        }, $this->command('mget', [$keys]));
-    }
-
-    /**
-     * Determine if the given keys exist.
-     *
-     * @param  mixed  $keys
-     * @return int
-     */
-    public function exists(...$keys)
-    {
-        $keys = collect($keys)->map(function ($key) {
-            return $this->applyPrefix($key);
-        })->all();
-
-        return $this->executeRaw(array_merge(['exists'], $keys));
-    }
-
-    /**
-     * Set the string value in argument as value of the key.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @param  string|null  $expireResolution
-     * @param  int|null  $expireTTL
-     * @param  string|null  $flag
-     * @return bool
-     */
-    public function set($key, $value, $expireResolution = null, $expireTTL = null, $flag = null)
-    {
-        return $this->command('set', [
-            $key,
-            $value,
-            $expireResolution ? [$flag, $expireResolution => $expireTTL] : null,
-        ]);
-    }
-
-    /**
-     * Set the given key if it doesn't exist.
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return int
-     */
-    public function setnx($key, $value)
-    {
-        return (int) $this->command('setnx', [$key, $value]);
-    }
-
-    /**
-     * Get the value of the given hash fields.
-     *
-     * @param  string  $key
-     * @param  mixed  $dictionary
-     * @return array
-     */
-    public function hmget($key, ...$dictionary)
-    {
-        if (count($dictionary) === 1) {
-            $dictionary = $dictionary[0];
-        }
-
-        return array_values($this->command('hmget', [$key, $dictionary]));
-    }
-
-    /**
-     * Set the given hash fields to their respective values.
-     *
-     * @param  string  $key
-     * @param  mixed  $dictionary
-     * @return int
-     */
-    public function hmset($key, ...$dictionary)
-    {
-        if (count($dictionary) === 1) {
-            $dictionary = $dictionary[0];
-        } else {
-            $input = collect($dictionary);
-
-            $dictionary = $input->nth(2)->combine($input->nth(2, 1))->toArray();
-        }
-
-        return $this->command('hmset', [$key, $dictionary]);
-    }
-
-    /**
-     * Set the given hash field if it doesn't exist.
-     *
-     * @param  string  $hash
-     * @param  string  $key
-     * @param  string  $value
-     * @return int
-     */
-    public function hsetnx($hash, $key, $value)
-    {
-        return (int) $this->command('hsetnx', [$hash, $key, $value]);
-    }
-
-    /**
-     * Removes the first count occurrences of the value element from the list.
-     *
-     * @param  string  $key
-     * @param  int  $count
-     * @param  mixed  $value
-     * @return int|false
-     */
-    public function lrem($key, $count, $value)
-    {
-        return $this->command('lrem', [$key, $value, $count]);
-    }
-
-    /**
-     * Removes and returns the first element of the list stored at key.
-     *
-     * @param  mixed  $arguments
-     * @return array|null
-     */
-    public function blpop(...$arguments)
-    {
-        $result = $this->command('blpop', $arguments);
-
-        return empty($result) ? null : $result;
-    }
-
-    /**
-     * Removes and returns the last element of the list stored at key.
-     *
-     * @param  mixed  $arguments
-     * @return array|null
-     */
-    public function brpop(...$arguments)
-    {
-        $result = $this->command('brpop', $arguments);
-
-        return empty($result) ? null : $result;
-    }
-
-    /**
-     * Removes and returns a random element from the set value at key.
-     *
-     * @param  string  $key
-     * @param  int|null  $count
-     * @return mixed|false
-     */
-    public function spop($key, $count = 1)
-    {
-        return $this->command('spop', [$key, $count]);
-    }
-
-    /**
-     * Add one or more members to a sorted set or update its score if it already exists.
-     *
-     * @param  string  $key
-     * @param  mixed  $dictionary
-     * @return int
-     */
-    public function zadd($key, ...$dictionary)
-    {
-        if (is_array(end($dictionary))) {
-            foreach (array_pop($dictionary) as $member => $score) {
-                $dictionary[] = $score;
-                $dictionary[] = $member;
-            }
-        }
-
-        $key = $this->applyPrefix($key);
-
-        return $this->executeRaw(array_merge(['zadd', $key], $dictionary));
-    }
-
-    /**
-     * Return elements with score between $min and $max.
-     *
-     * @param  string  $key
-     * @param  mixed  $min
-     * @param  mixed  $max
-     * @param  array  $options
-     * @return array
-     */
-    public function zrangebyscore($key, $min, $max, $options = [])
-    {
-        if (isset($options['limit'])) {
-            $options['limit'] = [
-                $options['limit']['offset'],
-                $options['limit']['count'],
-            ];
-        }
-
-        return $this->command('zRangeByScore', [$key, $min, $max, $options]);
-    }
-
-    /**
-     * Return elements with score between $min and $max.
-     *
-     * @param  string  $key
-     * @param  mixed  $min
-     * @param  mixed  $max
-     * @param  array  $options
-     * @return array
-     */
-    public function zrevrangebyscore($key, $min, $max, $options = [])
-    {
-        if (isset($options['limit'])) {
-            $options['limit'] = [
-                $options['limit']['offset'],
-                $options['limit']['count'],
-            ];
-        }
-
-        return $this->command('zRevRangeByScore', [$key, $min, $max, $options]);
-    }
-
-    /**
-     * Find the intersection between sets and store in a new set.
-     *
-     * @param  string  $output
-     * @param  array  $keys
-     * @param  array  $options
-     * @return int
-     */
-    public function zinterstore($output, $keys, $options = [])
-    {
-        return $this->command('zinterstore', [$output, $keys,
-            $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum',
-        ]);
-    }
-
-    /**
-     * Find the union between sets and store in a new set.
-     *
-     * @param  string  $output
-     * @param  array  $keys
-     * @param  array  $options
-     * @return int
-     */
-    public function zunionstore($output, $keys, $options = [])
-    {
-        return $this->command('zunionstore', [$output, $keys,
-            $options['weights'] ?? null,
-            $options['aggregate'] ?? 'sum',
-        ]);
+        $this->client->close();
     }
 
     /**
@@ -298,7 +41,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function pipeline(callable $callback = null)
     {
-        $pipeline = $this->client()->pipeline();
+        $pipeline = $this->client->pipeline();
 
         return is_null($callback)
             ? $pipeline
@@ -313,7 +56,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function transaction(callable $callback = null)
     {
-        $transaction = $this->client()->multi();
+        $transaction = $this->client->multi();
 
         return is_null($callback)
             ? $transaction
@@ -321,88 +64,16 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Evaluate a LUA script serverside, from the SHA1 hash of the script instead of the script itself.
+     * Apply prefix to the given key if necessary.
      *
-     * @param  string  $script
-     * @param  int  $numkeys
-     * @param  mixed  $arguments
-     * @return mixed
+     * @param  string  $key
+     * @return string
      */
-    public function evalsha($script, $numkeys, ...$arguments)
+    protected function applyPrefix($key)
     {
-        return $this->command('evalsha', [
-            $this->script('load', $script), $arguments, $numkeys,
-        ]);
-    }
+        $prefix = (string) $this->client->getOption(Redis::OPT_PREFIX);
 
-    /**
-     * Evaluate a script and return its result.
-     *
-     * @param  string  $script
-     * @param  int  $numberOfKeys
-     * @param  dynamic  $arguments
-     * @return mixed
-     */
-    public function eval($script, $numberOfKeys, ...$arguments)
-    {
-        return $this->command('eval', [$script, $arguments, $numberOfKeys]);
-    }
-
-    /**
-     * Subscribe to a set of given channels for messages.
-     *
-     * @param  array|string  $channels
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public function subscribe($channels, Closure $callback)
-    {
-        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
-            $callback($message, $channel);
-        });
-    }
-
-    /**
-     * Subscribe to a set of given channels with wildcards.
-     *
-     * @param  array|string  $channels
-     * @param  \Closure  $callback
-     * @return void
-     */
-    public function psubscribe($channels, Closure $callback)
-    {
-        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
-            $callback($message, $channel);
-        });
-    }
-
-    /**
-     * Subscribe to a set of given channels for messages.
-     *
-     * @param  array|string  $channels
-     * @param  \Closure  $callback
-     * @param  string  $method
-     * @return void
-     */
-    public function createSubscription($channels, Closure $callback, $method = 'subscribe')
-    {
-        //
-    }
-
-    /**
-     * Flush the selected Redis database.
-     *
-     * @return void
-     */
-    public function flushdb()
-    {
-        if (! $this->client instanceof RedisCluster) {
-            return $this->command('flushdb');
-        }
-
-        foreach ($this->client->_masters() as [$host, $port]) {
-            tap(new Redis)->connect($host, $port)->flushDb();
-        }
+        return $prefix.$key;
     }
 
     /**
@@ -414,29 +85,6 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function executeRaw(array $parameters)
     {
         return $this->command('rawCommand', $parameters);
-    }
-
-    /**
-     * Disconnects from the Redis instance.
-     *
-     * @return void
-     */
-    public function disconnect()
-    {
-        $this->client->close();
-    }
-
-    /**
-     * Apply prefix to the given key if necessary.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    private function applyPrefix($key)
-    {
-        $prefix = (string) $this->client->getOption(Redis::OPT_PREFIX);
-
-        return $prefix.$key;
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/RedisClientClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/RedisClientClusterConnection.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Redis\Connections;
+
+class RedisClientClusterConnection extends RedisClientConnection
+{
+    //
+}

--- a/src/Illuminate/Redis/Connections/RedisClientConnection.php
+++ b/src/Illuminate/Redis/Connections/RedisClientConnection.php
@@ -2,10 +2,7 @@
 
 namespace Illuminate\Redis\Connections;
 
-use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
-use Predis\Command\ServerFlushDatabase;
-use Predis\Connection\Aggregate\ClusterInterface;
 
 /**
  * @mixin \RedisClient\RedisClient

--- a/src/Illuminate/Redis/Connections/RedisClientConnection.php
+++ b/src/Illuminate/Redis/Connections/RedisClientConnection.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Redis\Connections;
+
+use Closure;
+use Illuminate\Contracts\Redis\Connection as ConnectionContract;
+use Predis\Command\ServerFlushDatabase;
+use Predis\Connection\Aggregate\ClusterInterface;
+
+/**
+ * @mixin \RedisClient\RedisClient
+ */
+class RedisClientConnection extends Connection implements ConnectionContract
+{
+    use Commands;
+
+    /**
+     * The RedisClient client.
+     *
+     * @var \RedisClient\RedisClient
+     */
+    protected $client;
+
+    /**
+     * The Redis prefix.
+     *
+     * @var string|null
+     */
+    protected $prefix;
+
+    /**
+     * Create a new RedisClient connection.
+     *
+     * @param  \RedisClient\RedisClient  $client
+     * @param  string|null  $prefix
+     * @return void
+     */
+    public function __construct($client, $prefix = null)
+    {
+        $this->client = $client;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Disconnects from the Redis instance.
+     *
+     * @return void
+     */
+    public function disconnect()
+    {
+        $this->client->quit();
+    }
+
+    /**
+     * Add one or more members to a sorted set or update its score if it already exists.
+     *
+     * @param  string  $key
+     * @param  mixed  $dictionary
+     * @return int
+     */
+    public function zrem($key, ...$members)
+    {
+        $key = $this->applyPrefix($key);
+
+        return $this->client->zrem($key, $members);
+    }
+
+    /**
+     * Return elements with score between $min and $max.
+     *
+     * @param  string  $key
+     * @param  mixed  $min
+     * @param  mixed  $max
+     * @param  array  $options
+     * @return array
+     */
+    public function zrevrangebyscore($key, $min, $max, $options = [])
+    {
+        if (isset($options['limit'])) {
+            $limit = [
+                $options['limit']['offset'],
+                $options['limit']['count'],
+            ];
+        }
+
+        return $this->client->zRevRangeByScore($key, $min, $max, $options['withscores'] ?? false, $limit ?? null);
+    }
+
+    /**
+     * Execute commands in a pipeline.
+     *
+     * @param  callable|null  $callback
+     * @return \RedisClient\RedisClient|array
+     */
+    public function pipeline(callable $callback = null)
+    {
+        return $this->client->pipeline($callback);
+    }
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  callable|null  $callback
+     * @return \RedisClient\RedisClient|array
+     */
+    public function transaction(callable $callback = null)
+    {
+        $this->client->multi();
+
+        return is_null($callback)
+            ? $this->client
+            : tap($this->client, $callback)->exec();
+    }
+
+    /**
+     * Execute a raw command.
+     *
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function executeRaw(array $parameters)
+    {
+        return $this->client->executeRaw($parameters);
+    }
+
+    /**
+     * Apply prefix to the given key if necessary.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    protected function applyPrefix($key)
+    {
+        $prefix = (string) $this->prefix;
+
+        return $prefix.$key;
+    }
+}

--- a/src/Illuminate/Redis/Connectors/RedisClientConnector.php
+++ b/src/Illuminate/Redis/Connectors/RedisClientConnector.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Illuminate\Redis\Connectors;
+
+use Illuminate\Contracts\Redis\Connector;
+use Illuminate\Redis\Connections\RedisClientClusterConnection;
+use Illuminate\Redis\Connections\RedisClientConnection;
+use Illuminate\Support\Arr;
+use RedisClient\ClientFactory;
+
+class RedisClientConnector implements Connector
+{
+    /**
+     * Create a new clustered RedisClient connection.
+     *
+     * @param  array  $config
+     * @param  array  $options
+     * @return \Illuminate\Redis\Connections\RedisClientConnection
+     */
+    public function connect(array $config, array $options)
+    {
+        $formattedOptions = array_merge([
+            'server' => $config['url'] ?? $config['host'].':'.$config['port'],
+            'timeout' => 10.0,
+        ], $options, Arr::pull($config, 'options', []));
+
+        return new RedisClientConnection(
+            ClientFactory::create($formattedOptions),
+            Arr::pull($config, 'options.prefix')
+        );
+    }
+
+    /**
+     * Create a new clustered RedisClient connection.
+     *
+     * @param  array  $config
+     * @param  array  $clusterOptions
+     * @param  array  $options
+     * @return \Illuminate\Redis\Connections\RedisClientClusterConnection
+     */
+    public function connectToCluster(array $config, array $clusterOptions, array $options)
+    {
+        $clusterSpecificOptions = Arr::pull($config, 'options', []);
+
+        return new RedisClientClusterConnection(ClientFactory::create(array_merge(
+            array_values($config), $options, $clusterOptions, $clusterSpecificOptions
+        )));
+    }
+}

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -168,6 +168,8 @@ class RedisManager implements Factory
         switch ($this->driver) {
             case 'predis':
                 return new Connectors\PredisConnector;
+            case 'redisclient':
+                return new Connectors\RedisClientConnector;
             case 'phpredis':
                 return new Connectors\PhpRedisConnector;
         }

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -25,6 +25,7 @@
     },
     "suggest": {
         "ext-redis": "Required to use the phpredis connector.",
+        "cheprasov/php-redis-client": "Required to use the redisclient connector (^1.9).",
         "predis/predis": "Required to use the predis connector (^1.0)."
     },
     "extra": {

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -551,6 +551,7 @@ class RedisConnectionTest extends TestCase
     {
         $connections = [
             'predis' => $this->redis['predis']->connection(),
+            'redisclient' => $this->redis['redisclient']->connection(),
             'phpredis' => $this->redis['phpredis']->connection(),
         ];
 


### PR DESCRIPTION
This PR implements a new optional Redis driver called [RedisClient](https://github.com/cheprasov/php-redis-client) as an alternative to Predis. 

Most work still lies in fixing the remaining failing tests and properly configuring clusters.

### Todo
- [ ] Fix tests
- [ ] Implement cluster support