### PR TITLE
[7.x] Upgrade to phpdotenv v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/routing": "^5.0",
         "symfony/var-dumper": "^5.0",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^3.3",
+        "vlucas/phpdotenv": "^4.0",
         "voku/portable-ascii": "^1.2.3"
     },
     "replace": {

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -84,9 +84,9 @@ class LoadEnvironmentVariables
     protected function createDotenv($app)
     {
         return Dotenv::create(
+            Env::getRepository(),
             $app->environmentPath(),
-            $app->environmentFile(),
-            Env::getFactory()
+            $app->environmentFile()
         );
     }
 

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Support;
 
-use Dotenv\Environment\Adapter\EnvConstAdapter;
-use Dotenv\Environment\Adapter\PutenvAdapter;
-use Dotenv\Environment\Adapter\ServerConstAdapter;
-use Dotenv\Environment\DotenvFactory;
+use Dotenv\Repository\Adapter\EnvConstAdapter;
+use Dotenv\Repository\Adapter\PutenvAdapter;
+use Dotenv\Repository\Adapter\ServerConstAdapter;
+use Dotenv\Repository\RepositoryBuilder;
 use PhpOption\Option;
 
 class Env
@@ -18,18 +18,11 @@ class Env
     protected static $putenv = true;
 
     /**
-     * The environment factory instance.
+     * The environment repository instance.
      *
-     * @var \Dotenv\Environment\FactoryInterface|null
+     * @var \Dotenv\Repository\RepositoryInterface|null
      */
-    protected static $factory;
-
-    /**
-     * The environment variables instance.
-     *
-     * @var \Dotenv\Environment\VariablesInterface|null
-     */
-    protected static $variables;
+    protected static $repository;
 
     /**
      * Enable the putenv adapter.
@@ -39,8 +32,7 @@ class Env
     public static function enablePutenv()
     {
         static::$putenv = true;
-        static::$factory = null;
-        static::$variables = null;
+        static::$repository = null;
     }
 
     /**
@@ -51,41 +43,30 @@ class Env
     public static function disablePutenv()
     {
         static::$putenv = false;
-        static::$factory = null;
-        static::$variables = null;
+        static::$repository = null;
     }
 
     /**
-     * Get the environment factory instance.
+     * Get the environment repository instance.
      *
-     * @return \Dotenv\Environment\FactoryInterface
+     * @return \Dotenv\Repository\RepositoryInterface
      */
-    public static function getFactory()
+    public static function getRepository()
     {
-        if (static::$factory === null) {
+        if (static::$repository === null) {
             $adapters = array_merge(
                 [new EnvConstAdapter, new ServerConstAdapter],
                 static::$putenv ? [new PutenvAdapter] : []
             );
 
-            static::$factory = new DotenvFactory($adapters);
+            static::$repository = RepositoryBuilder::create()
+                ->withReaders($adapters)
+                ->withWriters($adapters)
+                ->immutable()
+                ->get();
         }
 
-        return static::$factory;
-    }
-
-    /**
-     * Get the environment variables instance.
-     *
-     * @return \Dotenv\Environment\VariablesInterface
-     */
-    public static function getVariables()
-    {
-        if (static::$variables === null) {
-            static::$variables = static::getFactory()->createImmutable();
-        }
-
-        return static::$variables;
+        return static::$repository;
     }
 
     /**
@@ -97,7 +78,7 @@ class Env
      */
     public static function get($key, $default = null)
     {
-        return Option::fromValue(static::getVariables()->get($key))
+        return Option::fromValue(static::getRepository()->get($key))
             ->map(function ($value) {
                 switch (strtolower($value)) {
                     case 'true':

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -63,7 +63,7 @@ class Env
                 ->withReaders($adapters)
                 ->withWriters($adapters)
                 ->immutable()
-                ->get();
+                ->make();
         }
 
         return static::$repository;

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -44,7 +44,7 @@
         "ramsey/uuid": "Required to use Str::uuid() (^3.7).",
         "symfony/process": "Required to use the composer class (^5.0).",
         "symfony/var-dumper": "Required to use the dd function (^5.0).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^3.3)."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^4.0)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
The functional advantages of v3 vs v4:

* Single quote semantics is now the same as bash (https://github.com/vlucas/phpdotenv/pull/380)
* Support escaping dollars in unquoted and double quoted strings (https://github.com/vlucas/phpdotenv/pull/380)
* Right to left processing of environment variable interpolation (https://github.com/vlucas/phpdotenv/pull/380)