### PR TITLE
[6.x] add type to method of middleware stub

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/middleware.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware.stub
@@ -3,6 +3,7 @@
 namespace DummyNamespace;
 
 use Closure;
+use Illuminate\Http\Request;
 
 class DummyClass
 {
@@ -13,7 +14,7 @@ class DummyClass
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
         return $next($request);
     }


### PR DESCRIPTION
There is type hinting, but there was no type declaration.
I add type declaration to middleware stub.

When you execute command below, the stub will be used.
```
php artisan make:middleware new_middleware_name
```
