### PR TITLE
[6.x] Allow developer to preserve query parameters on paginated Api Resources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -7,6 +7,33 @@ use Illuminate\Support\Arr;
 class PaginatedResourceResponse extends ResourceResponse
 {
     /**
+     * Determines whether to preserve all query parameters when generating the navigation links.
+     *
+     * @var bool
+     */
+    private static $queryParameters;
+
+    /**
+     * Preserve all query parameters when generating the navigation links.
+     *
+     * @return void
+     */
+    public static function preserveQueryParameters()
+    {
+        self::$queryParameters = true;
+    }
+
+    /**
+     * Restore default behavior of ignoring query parameters when generating the navigation links.
+     *
+     * @return void
+     */
+    public static function ignoreQueryParameters()
+    {
+        self::$queryParameters = false;
+    }
+
+    /**
      * Create an HTTP response that represents the object.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -39,6 +66,10 @@ class PaginatedResourceResponse extends ResourceResponse
      */
     protected function paginationInformation($request)
     {
+        if (self::$queryParameters) {
+            $this->resource->appends($request->query());
+        }
+
         $paginated = $this->resource->resource->toArray();
 
         return [


### PR DESCRIPTION
When returning Api responses with the great JsonResource feature, paginated resources gets automatically handled and include navigation `links` to go back and forth between the pages. Unfortunately, all query parameters are lost and have to be managed by the frontend application.

The reason why I think the framework should provide a way to keep the query parameters is because when navigating without them, the collection of resources can be different (e.g. the links don't include filter parameters). For the links to actually navigate the correct resource collection, the parameters have to be kept. I understand that cannot be the default behavior anymore as it might entail a big breaking change, hence the alternative.