### PR TITLE
[7.x] Make LengthAwarePaginator::elements() public

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -99,7 +99,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @return array
      */
-    protected function elements()
+    public function elements()
     {
         $window = UrlWindow::make($this);
 


### PR DESCRIPTION
I need the ability to push this method's data to a Vue component via the controller, as it stands at the moment I can only push get access to this method via `render` but this returns the whole HTML.

I've targeted this PR to master as I wasn't sure if this is deemed a BC. 