### PR TITLE
[6.x] Remove unnecessary variable

### DIFF
--- a/src/Illuminate/Auth/GenericUser.php
+++ b/src/Illuminate/Auth/GenericUser.php
@@ -41,9 +41,7 @@ class GenericUser implements UserContract
      */
     public function getAuthIdentifier()
     {
-        $name = $this->getAuthIdentifierName();
-
-        return $this->attributes[$name];
+        return $this->attributes[$this->getAuthIdentifierName()];
     }
 
     /**


### PR DESCRIPTION
Remove unnecessary variable `$name` because we only use it once.