### PR TITLE
[6.x] Fix CookieJar's docs

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -140,7 +140,9 @@ class CookieJar implements JarContract
      */
     public function queue(...$parameters)
     {
-        if (! ($cookie = head($parameters)) instanceof Cookie) {
+        $cookie = head($parameters);
+
+        if (! $cookie instanceof Cookie) {
             $cookie = call_user_func_array([$this, 'make'], $parameters);
         }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -50,14 +50,14 @@ class CookieJar implements JarContract
     /**
      * Create a new cookie instance.
      *
-     * @param  string       $name
-     * @param  string       $value
-     * @param  int          $minutes
+     * @param  string  $name
+     * @param  string  $value
+     * @param  int  $minutes
      * @param  string|null  $path
      * @param  string|null  $domain
-     * @param  bool|null    $secure
-     * @param  bool         $httpOnly
-     * @param  bool         $raw
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -73,13 +73,13 @@ class CookieJar implements JarContract
     /**
      * Create a cookie that lasts "forever" (five years).
      *
-     * @param  string       $name
-     * @param  string       $value
+     * @param  string  $name
+     * @param  string  $value
      * @param  string|null  $path
      * @param  string|null  $domain
-     * @param  bool|null    $secure
-     * @param  bool         $httpOnly
-     * @param  bool         $raw
+     * @param  bool|null  $secure
+     * @param  bool  $httpOnly
+     * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -117,7 +117,7 @@ class CookieJar implements JarContract
      * Get a queued cookie instance.
      *
      * @param  string  $key
-     * @param  mixed   $default
+     * @param  mixed  $default
      * @param  string  $path
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
@@ -140,9 +140,7 @@ class CookieJar implements JarContract
      */
     public function queue(...$parameters)
     {
-        if (head($parameters) instanceof Cookie) {
-            $cookie = head($parameters);
-        } else {
+        if (! ($cookie = head($parameters)) instanceof Cookie) {
             $cookie = call_user_func_array([$this, 'make'], $parameters);
         }
 
@@ -157,7 +155,7 @@ class CookieJar implements JarContract
      * Remove a cookie from the queue.
      *
      * @param  string  $name
-     * @param  string|null $path
+     * @param  string|null  $path
      * @return void
      */
     public function unqueue($name, $path = null)
@@ -178,9 +176,9 @@ class CookieJar implements JarContract
     /**
      * Get the path and domain, or the default values.
      *
-     * @param  string    $path
-     * @param  string    $domain
-     * @param  bool|null $secure
+     * @param  string  $path
+     * @param  string  $domain
+     * @param  bool|null  $secure
      * @param  string|null  $sameSite
      * @return array
      */
@@ -194,7 +192,7 @@ class CookieJar implements JarContract
      *
      * @param  string  $path
      * @param  string  $domain
-     * @param  bool    $secure
+     * @param  bool  $secure
      * @param  string|null  $sameSite
      * @return $this
      */


### PR DESCRIPTION
This PR fixes (like #30741, but this time it really simplifies the if-else statement):
- The docblock spaces
- Prevents the duplicated `head` usage