### PR TITLE
[6.x] Support retryAfter Option on Queued Listeners

### DIFF
--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -38,7 +38,7 @@ class CallQueuedListener implements ShouldQueue
      * @var int
      */
     public $tries;
-    
+
     /**
      * The number of seconds to wait before retrying the job.
      *

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -38,6 +38,13 @@ class CallQueuedListener implements ShouldQueue
      * @var int
      */
     public $tries;
+    
+    /**
+     * The number of seconds to wait before retrying the job.
+     *
+     * @var int
+     */
+    public $retryAfter;
 
     /**
      * The timestamp indicating when the job should timeout.

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -502,6 +502,7 @@ class Dispatcher implements DispatcherContract
     {
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
+            $job->retryAfter = $listener->retryAfter ?? null;
             $job->timeout = $listener->timeout ?? null;
             $job->timeoutAt = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;


### PR DESCRIPTION
Queued event listeners currently do not support the `retryAfter` option.
This PR is adding the missing support.

Related MR's:
- https://github.com/laravel/framework/pull/28265
- https://github.com/laravel/framework/pull/28484
