### PR TITLE
[6.x] Allow developer to preserve query parameters on paginated Api resources

### DIFF
--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -94,7 +94,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     }
 
     /**
-     * Create an paginate-aware HTTP response.
+     * Create a paginate-aware HTTP response.
      *
      * @param \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\JsonResponse

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -30,7 +30,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      *
      * @var bool
      */
-    private $queryParameters;
+    protected $queryParameters;
 
     /**
      * Create a new resource instance.

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -99,7 +99,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      * @param \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\JsonResponse
      */
-    private function preparePaginatedResponse($request)
+    protected function preparePaginatedResponse($request)
     {
         if ($this->queryParameters) {
             $this->resource->appends($request->query());

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -96,7 +96,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     /**
      * Create a paginate-aware HTTP response.
      *
-     * @param \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\JsonResponse
      */
     protected function preparePaginatedResponse($request)

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -26,6 +26,13 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     public $collection;
 
     /**
+     * Determines whether to preserve all query parameters when generating the navigation links.
+     *
+     * @var bool
+     */
+    private $queryParameters;
+
+    /**
      * Create a new resource instance.
      *
      * @param  mixed  $resource
@@ -36,6 +43,18 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
         parent::__construct($resource);
 
         $this->resource = $this->collectResource($resource);
+    }
+
+    /**
+     * Preserve all query parameters when generating the navigation links.
+     *
+     * @return $this
+     */
+    public function preserveQueryParameters()
+    {
+        $this->queryParameters = true;
+
+        return $this;
     }
 
     /**
@@ -67,8 +86,25 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
      */
     public function toResponse($request)
     {
-        return $this->resource instanceof AbstractPaginator
-                    ? (new PaginatedResourceResponse($this))->toResponse($request)
-                    : parent::toResponse($request);
+        if ($this->resource instanceof AbstractPaginator) {
+            return $this->preparePaginatedResponse($request);
+        }
+
+        return parent::toResponse($request);
+    }
+
+    /**
+     * Create an paginate-aware HTTP response.
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    private function preparePaginatedResponse($request)
+    {
+        if ($this->queryParameters) {
+            $this->resource->appends($request->query());
+        }
+
+        return (new PaginatedResourceResponse($this))->toResponse($request);
     }
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -486,6 +486,49 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testPaginatorResourceCanPreserveQueryParameters()
+    {
+        Route::get('/', function () {
+            $collection = collect([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
+            $paginator = new LengthAwarePaginator(
+                $collection, 3, 1, 2
+            );
+
+            return PostCollectionResource::make($paginator)->preserveQueryParameters();
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/?framework=laravel&author=Otwell&page=2', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                [
+                    'id' => 2,
+                    'title' => 'Laravel Nova',
+                ],
+            ],
+            'links' => [
+                'first' => '/?framework=laravel&author=Otwell&page=1',
+                'last' => '/?framework=laravel&author=Otwell&page=3',
+                'prev' => '/?framework=laravel&author=Otwell&page=1',
+                'next' => '/?framework=laravel&author=Otwell&page=3',
+            ],
+            'meta' => [
+                'current_page' => 2,
+                'from' => 2,
+                'last_page' => 3,
+                'path' => '/',
+                'per_page' => 1,
+                'to' => 2,
+                'total' => 3,
+            ],
+        ]);
+    }
+
+
     public function testToJsonMayBeLeftOffOfCollection()
     {
         Route::get('/', function () {

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -528,7 +528,6 @@ class ResourceTest extends TestCase
         ]);
     }
 
-
     public function testToJsonMayBeLeftOffOfCollection()
     {
         Route::get('/', function () {


### PR DESCRIPTION
Reattempt at #30729 without static configuration.

Instead of statically configuring it once, the developer would have to call `->preserveQueryParameters()` after instantiating the Resource Collection, but I still like the DX with this case.

```
class MyHandler
{
    public function __invoke(MyRepository $repository)
    {
        return MyResourceCollection::make($repository->paginate())->preserveQueryParameters();
    }
}
```

