### PR TITLE
[6.x] Use Str::contains() instead of strpos()

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -715,7 +715,7 @@ class Gate implements GateContract
      */
     protected function formatAbilityToMethod($ability)
     {
-        return strpos($ability, '-') !== false ? Str::camel($ability) : $ability;
+        return Str::contains($ability, '-') ? Str::camel($ability) : $ability;
     }
 
     /**


### PR DESCRIPTION
We already load the class `Str` in this file, so use `Str::contains()` instead of `strpos()`.