### PR TITLE
[6.x] Support Partial Mocks on Facades

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -59,6 +59,22 @@ abstract class Facade
     }
 
     /**
+     * Initiate a partial mock on the facade.
+     *
+     * @return \Mockery\MockInterface
+     */
+    public static function partialMock()
+    {
+        $name = static::getFacadeAccessor();
+
+        $mock = static::isMock()
+            ? static::$resolvedInstance[$name]
+            : static::createFreshMockInstance();
+
+        return $mock->makePartial();
+    }
+
+    /**
      * Initiate a mock expectation on the facade.
      *
      * @return \Mockery\Expectation


### PR DESCRIPTION
Suppose we have a custom Facade called `SomeService` and want to mock just a single method.
This situation is usually leading to an error as follows:

```php
SomeService::shouldReceive('foo')->once();
SomeService::foo();
SomeService::bar(); // Mockery\Exception\BadMethodCallException : Received Mockery_2_App_SomeService::bar(), but no expectations were specified 
```

My patch adds support for partial mocks in two ways:

```php
SomeService::shouldReceive('foo')->once();
SomeService::partialMock();
SomeService::foo(); // this call is mocked
SomeService::bar(); // this call is deferred to it's parent
```

```php
SomeService::partialMock()->shouldReceive('foo')->once();
SomeService::foo(); // this call is mocked
SomeService::bar(); // this call is deferred to it's parent
```

It is already possible to do something very similar relying on undocumented behavior:

```php
SomeService::shouldReceive('foo')->once();
SomeService::makePartial();
SomeService::foo(); // this call is mocked
SomeService::bar(); // this call is deferred to it's parent
```

However my IDE is yelling at me and I strongly prefer a supported option if possible.
Also the above workaround is not as flexible:

```php
SomeService::makePartial()->shouldReceive('foo')->once(); // Error : Call to undefined method SomeService::makePartial()
SomeService::foo();
SomeService::bar();
```