### PR TITLE
[6.x] Fixed some functions visibility to be public as other ones in the same class

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlBuilder.php
+++ b/src/Illuminate/Database/Schema/MySqlBuilder.php
@@ -105,7 +105,7 @@ class MySqlBuilder extends Builder
      *
      * @return array
      */
-    protected function getAllViews()
+    public function getAllViews()
     {
         return $this->connection->select(
             $this->grammar->compileGetAllViews()

--- a/src/Illuminate/Database/Schema/PostgresBuilder.php
+++ b/src/Illuminate/Database/Schema/PostgresBuilder.php
@@ -114,7 +114,7 @@ class PostgresBuilder extends Builder
      *
      * @return array
      */
-    protected function getAllViews()
+    public function getAllViews()
     {
         return $this->connection->select(
             $this->grammar->compileGetAllViews((array) $this->connection->getConfig('schema'))
@@ -126,7 +126,7 @@ class PostgresBuilder extends Builder
      *
      * @return array
      */
-    protected function getAllTypes()
+    public function getAllTypes()
     {
         return $this->connection->select(
             $this->grammar->compileGetAllTypes()


### PR DESCRIPTION
Hi,
I've noticed that there are some protected functions for MySql and Postgres schema builder that were inaccessible from the Schema's Facade.

![image](https://user-images.githubusercontent.com/21217247/70156032-9439e280-16b3-11ea-84d2-1dc50e560d45.png)

![image](https://user-images.githubusercontent.com/21217247/70155973-78ced780-16b3-11ea-9a78-054514630a7b.png)

For that reason I think it's convenient to update the visibility of those functions so that they are public and can be used with the Facade.

I hope it helps!
Thanks,
Franc Auxach