### PR TITLE
[6.x] Changed `data` column type to `JSON`

### DIFF
--- a/src/Illuminate/Notifications/Console/stubs/notifications.stub
+++ b/src/Illuminate/Notifications/Console/stubs/notifications.stub
@@ -17,7 +17,7 @@ class CreateNotificationsTable extends Migration
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
+            $table->json('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
This PR. add ability to use `json` queries in notifications table.
For example :
```
$user->unreadNotifications()->where('data->post_id', $post->id)->get()->markAsRead();
```
```
/**
 * Get all notifications that associated the post.
 *
 * @return \Illuminate\Database\Eloquent\Relations\HasMany
 */
public function notifications()
{
    return $this->hasMany(DatabaseNotification::class, 'data->post_id');
}
```