### PR TITLE
[6.x] Fix zero parameter for routes

### DIFF
--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -218,7 +218,7 @@ class RouteUrlGenerator
     protected function replaceNamedParameters($path, &$parameters)
     {
         return preg_replace_callback('/\{(.*?)(\?)?\}/', function ($m) use (&$parameters) {
-            if (isset($parameters[$m[1]]) && $parameters[$m[1]] != '') {
+            if (isset($parameters[$m[1]]) && $parameters[$m[1]] !== '') {
                 return Arr::pull($parameters, $m[1]);
             } elseif (isset($this->defaultParameters[$m[1]])) {
                 return $this->defaultParameters[$m[1]];

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -249,6 +249,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/bar?foo=bar', $url->route('foo', ['foo' => 'bar'], false));
         $this->assertSame('http://www.foo.com/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall']));
         $this->assertSame('http://www.foo.com/foo/bar/otwell/breeze/taylor?fly=wall', $url->route('bar', ['boom' => 'taylor', 'baz' => 'otwell', 'fly' => 'wall']));
+        $this->assertSame('http://www.foo.com/foo/bar/0', $url->route('foobar', 0));
         $this->assertSame('http://www.foo.com/foo/bar/2', $url->route('foobar', 2));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('foobar', 'taylor'));
         $this->assertSame('/foo/bar/taylor/breeze/otwell?fly=wall', $url->route('bar', ['taylor', 'otwell', 'fly' => 'wall'], false));
@@ -261,6 +262,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional'));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => null]));
         $this->assertSame('http://www.foo.com/foo/bar', $url->route('optional', ['baz' => '']));
+        $this->assertSame('http://www.foo.com/foo/bar/0', $url->route('optional', ['baz' => 0]));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', 'taylor'));
         $this->assertSame('http://www.foo.com/foo/bar/taylor', $url->route('optional', ['taylor']));
         $this->assertSame('http://www.foo.com/foo/bar/taylor?breeze', $url->route('optional', ['taylor', 'breeze']));


### PR DESCRIPTION
Routes should be allowed to accept a 0 as a route parameter.

Fixes https://github.com/laravel/framework/issues/30760
