### PR TITLE
[6.x] Mutating JSON attributes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -642,9 +642,15 @@ trait HasAttributes
     {
         [$key, $path] = explode('->', $key, 2);
 
-        $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
+        $value = $this->getArrayAttributeWithValue(
             $path, $key, $value
-        ));
+        );
+
+        if ($this->hasSetMutator($key)) {
+            $this->setAttribute($key, $value);
+        } else {
+            $this->attributes[$key] = $this->asJson($value);
+        }
 
         return $this;
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -968,6 +968,14 @@ class DatabaseEloquentModelTest extends TestCase
             ['meta' => json_encode(['name' => 'foo', 'price' => 'bar', 'size' => ['width' => 'baz']])],
             $model->toArray()
         );
+
+        $model = new EloquentModelStub;
+        $model->fillable(['mutated->name']);
+        $model->fill(['mutated->name' => 'foo']);
+        $this->assertEquals(
+            ['mutated' => json_encode(['name' => 'FOO'])],
+            $model->toArray()
+        );
     }
 
     public function testUnguardAllowsAnythingToBeSet()
@@ -2001,6 +2009,11 @@ class EloquentModelStub extends Model
     public function setListItemsAttribute($value)
     {
         $this->attributes['list_items'] = json_encode($value);
+    }
+
+    public function setMutatedAttribute($value)
+    {
+        $this->attributes['mutated'] = json_encode(array_map('strtoupper', $value));
     }
 
     public function getPasswordAttribute()


### PR DESCRIPTION
This PR introduces a fix for the following situation:

If you use the JSON syntax for setting an attribute (`$model->fill(['foo->bar' => true])`) and the `foo`  attribute has a mutator, this mutator would not be triggered.

I use this combination of features to validate properties on the JSON attribute. eg.:

```php
class Model
{
    public function setFieldsAttribute($value)
    {
        if ($this->invalidField($value)) {
            throw new Exception("...");
        }

        $this->attributes['fields'] = json_encode($value);
    }
}

// with this syntax, I can intercept filling of the
// `fields` property and modify the `foo` value (or
// throw new Exception("foo must be more than 50")
$model->update([
    'fields' => [
        'foo' => 20
    ],
]);

// in this example, my custom mutator is bypassed
$model->update([
    'fields->foo' => 20,
]);
```

Thanks for your time!