### PR TITLE
[6.x] Reconnect on connection missing to recover horizon

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -4,8 +4,10 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
+use Illuminate\Support\Str;
 use Redis;
 use RedisCluster;
+use RedisException;
 
 /**
  * @mixin \Redis
@@ -16,11 +18,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * Create a new PhpRedis connection.
      *
      * @param  \Redis  $client
+     * @param  callable  $connector
      * @return void
      */
-    public function __construct($client)
+    public function __construct($client, callable $connector = null)
     {
         $this->client = $client;
+        $this->connector = $connector;
     }
 
     /**
@@ -414,6 +418,26 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     public function executeRaw(array $parameters)
     {
         return $this->command('rawCommand', $parameters);
+    }
+
+    /**
+     * Run a command against the Redis database.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function command($method, array $parameters = [])
+    {
+        try {
+            return parent::command($method, $parameters);
+        } catch (RedisException $e) {
+            if (Str::contains($e->getMessage(), 'went away')) {
+                $this->client = $this->connector ? call_user_func($this->connector) : $this->client;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -15,6 +15,13 @@ use RedisException;
 class PhpRedisConnection extends Connection implements ConnectionContract
 {
     /**
+     * The connection creation callback.
+     *
+     * @var callable
+     */
+    protected $connector;
+
+    /**
      * Create a new PhpRedis connection.
      *
      * @param  \Redis  $client

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -22,9 +22,13 @@ class PhpRedisConnector implements Connector
      */
     public function connect(array $config, array $options)
     {
-        return new PhpRedisConnection($this->createClient(array_merge(
-            $config, $options, Arr::pull($config, 'options', [])
-        )));
+        $connector = function () use ($config, $options) {
+            return $this->createClient(array_merge(
+                $config, $options, Arr::pull($config, 'options', [])
+            ));
+        };
+
+        return new PhpRedisConnection($connector(), $connector);
     }
 
     /**


### PR DESCRIPTION
This allows phpredis to reconnect using a simple callback in case of a connection problem. This is needed in order for long-running workers like Horizon to recover once Redis is available again.