### PR TITLE
[6.x] Add the exceptionContext method to the exception handler

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -115,8 +115,12 @@ class Handler implements ExceptionHandlerContract
 
         $logger->error(
             $e->getMessage(),
-            array_merge($this->context(), ['exception' => $e]
-        ));
+            array_merge(
+                $this->exceptionContext($e),
+                $this->context(),
+                ['exception' => $e]
+            )
+        );
     }
 
     /**
@@ -143,6 +147,17 @@ class Handler implements ExceptionHandlerContract
         return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
             return $e instanceof $type;
         }));
+    }
+
+    /**
+     * Get the default exception context variables for logging.
+     *
+     * @param  \Exception  $e
+     * @return array
+     */
+    protected function exceptionContext(Exception $e)
+    {
+        return [];
     }
 
     /**


### PR DESCRIPTION
This PR will add the exceptionContext method to the exception handler to allow exception specific data to be added to the logging context.

Currently if you need to get context off of an exception to pass it to the logger you would need to override the whole report method and do it there.

Adding this method allows us to add context off of an exception by simply implementing the method in the applications Handler class. This is not a breaking change.

Example: 

```PHP

throw (new CustomException())->setCustomProperty('foo');

// App/Exceptions/Handler.php
protected function exceptionContext(Exception $e)
{
    if ($e instanceof CustomException) {
        return ['custom_context' => $e->getCustomProperty()];
    }
}
````

Now the logger can get the custom exception context and handle it just like it handles the other context.