### PR TITLE
[6.x] Add checkout feature and promote chain operation for session

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -112,6 +112,15 @@ interface Session
     public function flush();
 
     /**
+     * Switch session or create new session.
+     *
+     * @param  string $id
+     * @param  bool $destroy
+     * @return $this
+     */
+    public function checkout($id = null, $destroy = false);
+
+    /**
      * Generate a new session ID for the session.
      *
      * @param  bool  $destroy


### PR DESCRIPTION
Hi, I'm here to submit PR again. Although, previous submissions were rejected. 

But I still love `laravel`. If you read my instructions carefully this time and choose to reject it, I hope you can give me some more tips, not just:  `I think it's OK for now`.

**New Feature**
During **SSO** (single sign on), session switching is usually used to prevent the current session from polluting the main session.

Client -> passport.domain.com -> master session （*.domain.com) -> current session (a.domain.com | b.domain.com) 

- Switch from the current session to the master session

```php
$session = $request->session();

$id = $session->get('master_session_id');

$session->checkout($id, false);

// Enter the main session domain

```

- Switch from the master  session to the current session

```
$session = $request->session();

$id = $request->cookies->get($session->getName());

// If the same, a new session should be created
if ($id === $session->getId()) {
    $id = null;
}

$session->checkout($id);

```

**Chain**
Most methods of `illuminate\session\store` object return void, which makes chain operation complicated.

