### PR TITLE
[6.x] Fix RedirectController parameters pop

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -19,9 +19,11 @@ class RedirectController extends Controller
     {
         $parameters = collect($request->route()->parameters());
 
-        $status = $parameters->pop();
+        $status = $parameters->get('status');
 
-        $destination = $parameters->pop();
+        $destination = $parameters->get('destination');
+
+        $parameters->forget('status')->forget('destination');
 
         $route = (new Route('GET', $destination, [
             'as' => 'laravel_route_redirect_destination',


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/30639

Using pop() to access parameters is not precise and can leads to bugs like the one described in the issue. So using get() is a safer approach.