### PR TITLE
[6.x] Add methods to get qualified timestamps column

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -126,4 +126,24 @@ trait HasTimestamps
     {
         return static::UPDATED_AT;
     }
+
+    /**
+     * Get the fully qualified "created at" column.
+     *
+     * @return string
+     */
+    public function getQualifiedCreatedAtColumn()
+    {
+        return $this->qualifyColumn($this->getCreatedAtColumn());
+    }
+
+    /**
+     * Get the fully qualified "updated at" column.
+     *
+     * @return string
+     */
+    public function getQualifiedUpdatedAtColumn()
+    {
+        return $this->qualifyColumn($this->getUpdatedAtColumn());
+    }
 }


### PR DESCRIPTION
sometimes we need to get the fully qualified timestamps column in `JOIN` queries.