### PR TITLE
collation and charset null for change of column to integer during migration

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -130,7 +130,11 @@ class ChangeColumn
         if (in_array($fluent['type'], ['smallinteger', 'integer', 'biginteger'])) {
             $options['customSchemaOptions'] = [
                 'collation' => null,
-                'charSet' => null
+                'charset' => null
+            ];
+            $options['platformOptions'] = [
+                'collation' => null,
+                'charset' => null
             ];
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -127,6 +127,13 @@ class ChangeColumn
             ];
         }
 
+        if (in_array($fluent['type'], ['smallinteger', 'integer', 'biginteger'])) {
+            $options['customSchemaOptions'] = [
+                'collation' => null,
+                'charSet' => null
+            ];
+        }
+
         return $options;
     }
 

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -127,7 +127,7 @@ class ChangeColumn
             ];
         }
 
-        if (in_array($fluent['type'], ['smallinteger', 'integer', 'biginteger'])) {
+        if (in_array($fluent['type'], ['smallInteger', 'integer', 'bigInteger'])) {
             $options['customSchemaOptions'] = [
                 'collation' => null,
                 'charset' => null


### PR DESCRIPTION
Referencing https://github.com/laravel/framework/issues/30539
@lcobucci & @driesvints 
changing customSchemaOptions collation and charset to null was not sufficient so I did it for platformOptions as well. What do you think, how dirty is it? In my use case, I was able to finish migration with doctrine/dbal 2.10.0 and do a rollback.
Thanks for guidance.