### PR TITLE
[6.x] Render clickable hyperlinks in console

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -530,6 +530,31 @@ class Command extends SymfonyCommand
     }
 
     /**
+     * Write a string as hyperlink output.
+     *
+     * @param  string  $href
+     * @param  string|null  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function hyperlink($href, $string = null, $verbosity = null)
+    {
+        $this->line($this->getHyperlink($href, $string), null, $verbosity);
+    }
+
+    /**
+     * Format a string as a hyperlink.
+     *
+     * @param  string  $href
+     * @param  string|null  $string
+     * @return string
+     */
+    protected function getHyperlink($href, $string = null)
+    {
+        return sprintf('<href=%s>%s</>', $href, $string ?? $href);
+    }
+
+    /**
      * Write a string as question output.
      *
      * @param  string  $string

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -73,7 +73,7 @@ abstract class GeneratorCommand extends Command
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
 
-        $this->info($this->type.' created successfully.');
+        $this->info($this->getHyperlink('file://'.$path, $this->type).' created successfully.');
     }
 
     /**

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -111,7 +111,7 @@ class MigrateMakeCommand extends BaseCommand
         );
 
         if (! $this->option('fullpath')) {
-            $file = pathinfo($file, PATHINFO_FILENAME);
+            $file = $this->getHyperlink('file://'.$file, pathinfo($file, PATHINFO_FILENAME));
         }
 
         $this->line("<info>Created Migration:</info> {$file}");

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -42,7 +42,9 @@ class ServeCommand extends Command
     {
         chdir(public_path());
 
-        $this->line("<info>Laravel development server started:</info> http://{$this->host()}:{$this->port()}");
+        $this->line(sprintf('<info>Laravel development server started:</info> %s',
+            $this->getHyperlink("http://{$this->host()}:{$this->port()}")
+        ));
 
         passthru($this->serverCommand(), $status);
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -278,7 +278,7 @@ class VendorPublishCommand extends Command
     {
         $from = str_replace(base_path(), '', realpath($from));
 
-        $to = str_replace(base_path(), '', realpath($to));
+        $to = $this->getHyperlink('file://'.realpath($to), str_replace(base_path(), '', realpath($to)));
 
         $this->line('<info>Copied '.$type.'</info> <comment>['.$from.']</comment> <info>To</info> <comment>['.$to.']</comment>');
     }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -65,6 +65,20 @@ class ConsoleApplicationTest extends TestCase
 
         $this->assertTrue($this->app->resolved(Schedule::class));
     }
+
+    public function testArtisanWithHyperlink()
+    {
+        $this->app[Kernel::class]->registerCommand(new HyperlinkCommandStub);
+
+        $mock = $this->artisan('foo:hyperlink');
+        $mock->expectsOutput('Laravel');
+
+        $mock = $this->artisan('foo:hyperlink', ['--ansi' => true]);
+        $mock->expectsOutput("\033]8;;https://laravel.com\033\\Laravel\033]8;;\033\\");
+
+        $mock = $this->artisan('foo:hyperlink', ['--no-ansi' => true]);
+        $mock->expectsOutput('Laravel');
+    }
 }
 
 class FooCommandStub extends Command
@@ -84,5 +98,21 @@ class ScheduleCommandStub extends Command
     public function handle(Schedule $schedule)
     {
         //
+    }
+}
+
+class HyperlinkCommandStub extends Command
+{
+    protected $signature = 'foo:hyperlink';
+
+    public function handle()
+    {
+        if ($this->option('ansi')) {
+            $this->output->setDecorated(true);
+        } elseif ($this->option('no-ansi')) {
+            $this->output->setDecorated(false);
+        }
+
+        $this->hyperlink('https://laravel.com', 'Laravel');
     }
 }

--- a/tests/Integration/Console/ConsoleApplicationTest.php
+++ b/tests/Integration/Console/ConsoleApplicationTest.php
@@ -68,16 +68,18 @@ class ConsoleApplicationTest extends TestCase
 
     public function testArtisanWithHyperlink()
     {
-        $this->app[Kernel::class]->registerCommand(new HyperlinkCommandStub);
+        $kernel = $this->app[Kernel::class];
 
-        $mock = $this->artisan('foo:hyperlink');
-        $mock->expectsOutput('Laravel');
+        $kernel->registerCommand(new HyperlinkCommandStub);
 
-        $mock = $this->artisan('foo:hyperlink', ['--ansi' => true]);
-        $mock->expectsOutput("\033]8;;https://laravel.com\033\\Laravel\033]8;;\033\\");
+        $kernel->call('foo:hyperlink');
+        $this->assertEquals("Laravel\n", $kernel->output());
 
-        $mock = $this->artisan('foo:hyperlink', ['--no-ansi' => true]);
-        $mock->expectsOutput('Laravel');
+        $kernel->call('foo:hyperlink', ['--ansi' => true]);
+        $this->assertEquals("\033]8;;https://laravel.com\033\\Laravel\033]8;;\033\\\n", $kernel->output());
+
+        $kernel->call('foo:hyperlink', ['--no-ansi' => true]);
+        $this->assertEquals("Laravel\n", $kernel->output());
     }
 }
 
@@ -107,12 +109,6 @@ class HyperlinkCommandStub extends Command
 
     public function handle()
     {
-        if ($this->option('ansi')) {
-            $this->output->setDecorated(true);
-        } elseif ($this->option('no-ansi')) {
-            $this->output->setDecorated(false);
-        }
-
         $this->hyperlink('https://laravel.com', 'Laravel');
     }
 }


### PR DESCRIPTION
![console-hyperlinks-1x](https://user-images.githubusercontent.com/667144/70480144-9e127a00-1ae7-11ea-8219-47c91ba0f3c5.png)

Since Symfony 4.3 supports [console hyperlinks](https://symfony.com/blog/new-in-symfony-4-3-console-hyperlinks), we can use them on the commands in the framework and in userland.

This PR implements a `hyperlink` method to render lines as hyperlinks in console commands:
```php
$this->hyperlink('https://laravel.com', 'Laravel');
```
And a helper method to format hyperlinks for inline use:
```php
$documentation = $this->getHyperlink('https://laravel.com/docs', 'documentation');
$this->info("See the {$documentation}.");
```

With that in place, we can use this feature to render hyperlinks for generated classes using commands like `make:migration`, `make:model`, etc. This is also useful for published files/directories using `vendor:publish`.

When a user click on those hyperlinks, the file will open in their editor if the terminal supports it. This feature could be enhanced by specifying the IDE and generating editor-specific links, like Ignition does, but I felt that was out of scope and did not include it in this PR.