### PR TITLE
[6.x] Configurable redirectTo path during authentication (RedirectsUsers trait)

### DIFF
--- a/src/Illuminate/Foundation/Auth/RedirectsUsers.php
+++ b/src/Illuminate/Foundation/Auth/RedirectsUsers.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Support\Facades\Config;
+
 trait RedirectsUsers
 {
     /**
@@ -15,6 +17,8 @@ trait RedirectsUsers
             return $this->redirectTo();
         }
 
-        return property_exists($this, 'redirectTo') ? $this->redirectTo : '/home';
+        return property_exists($this, 'redirectTo')
+            ? $this->redirectTo
+            : Config::get('auth.redirect_to', '/home');
     }
 }


### PR DESCRIPTION
<!--
In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Today this tweets caught my attention on this issue that I myself have experienced in the past.
[Tweet 1](https://twitter.com/TontonsB/status/1204197457825075200?s=20) [Tweet 2](https://twitter.com/goldie_/status/1204202870079279104?s=20) [Tweet 3](https://twitter.com/roniestein/status/1204222881011556352?s=20) [Tweet 4](https://twitter.com/kurucu83/status/1204239754314665984?s=20)

The `redirectTo` property is hard-coded in the trait `RedirectsUsers` and in this files `ConfirmPasswordController, LoginController, RegisterController, ResetPasswordController, VerificationController` from the laravel/laravel

A solution to this would be to modify the `RedirectsUsers` trait to fetch the value from the auth configuration file, and remove the property `redirectTo` from the files mentioned above in the laravel/laravel project.

This should not break any compatibility as it defaults to `/home` from the config Facade.

I may need to address this in the docs.






