### PR TITLE
[6.x] Allow passing an array to resource::collection()

### DIFF
--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Resources;
 
 use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 trait CollectsResources
@@ -17,6 +18,10 @@ trait CollectsResources
     {
         if ($resource instanceof MissingValue) {
             return $resource;
+        }
+
+        if (is_array($resource)) {
+            $resource = new Collection($resource);
         }
 
         $collects = $this->collects();

--- a/tests/Integration/Http/Fixtures/ObjectResource.php
+++ b/tests/Integration/Http/Fixtures/ObjectResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ObjectResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->first_name,
+            'age' => $this->age,
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
 use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
+use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
 use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
@@ -53,6 +54,47 @@ class ResourceTest extends TestCase
                 'title' => 'Test Title',
             ],
         ]);
+    }
+
+    public function testAnObjectsMayBeConvertedToJson()
+    {
+        Route::get('/', function () {
+            return ObjectResource::make(
+                (object) ['first_name' => 'Bob', 'age' => 40]
+            );
+        });
+
+        $this->withoutExceptionHandling()
+            ->get('/', ['Accept' => 'application/json'])
+            ->assertStatus(200)
+            ->assertExactJson([
+                'data' => [
+                    'name' => 'Bob',
+                    'age' => 40,
+                ],
+            ]);
+    }
+
+    public function testArraysWithObjectsMayBeConvertedToJson()
+    {
+        Route::get('/', function () {
+            $objects = [
+                (object) ['first_name' => 'Bob', 'age' => 40],
+                (object) ['first_name' => 'Jack', 'age' => 25],
+            ];
+
+            return ObjectResource::collection($objects);
+        });
+
+        $this->withoutExceptionHandling()
+            ->get('/', ['Accept' => 'application/json'])
+            ->assertStatus(200)
+            ->assertExactJson([
+                'data' => [
+                    ['name' => 'Bob', 'age' => 40],
+                    ['name' => 'Jack', 'age' => 25],
+                ],
+            ]);
     }
 
     public function testResourcesMayHaveNoWrap()


### PR DESCRIPTION
This PR is similar to https://github.com/laravel/framework/pull/25213. I'm trying to use a resource for an array of "normal" classes/objects:
```php
public function index()
{
    /** @var SomeClass[] $array */
    $array = $this->getClasses();

    return SomeResource::collection($array);
}
```

This currently doesn't work, and throws the following exception: `Call to a member function first() on array at /Illuminate/Http/Resources/CollectsResources.php:24`.

For now, I'm wrapping the array in a collection, and then passing it to the resource:
```php
return SomeResource::collection(collect($array));
```
With this PR, I can just pass the array directly.