### PR TITLE
[7.x] Fix resource to json

### DIFF
--- a/src/Illuminate/Database/Eloquent/JsonEncodingException.php
+++ b/src/Illuminate/Database/Eloquent/JsonEncodingException.php
@@ -19,6 +19,20 @@ class JsonEncodingException extends RuntimeException
     }
 
     /**
+     * Create a new JSON encoding exception for the resource.
+     *
+     * @param  \Illuminate\Http\Resources\Json\JsonResource  $resource
+     * @param  string  $message
+     * @return static
+     */
+    public static function forResource($resource, $message)
+    {
+        $model = $resource->resource;
+
+        return new static('Error encoding resource ['.get_class($resource).'] with model ['.get_class($model).'] with ID ['.$model->getKey().'] to JSON: '.$message);
+    }
+
+    /**
      * Create a new JSON encoding exception for an attribute.
      *
      * @param  mixed  $model

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Http\Resources\ConditionallyLoadsAttributes;
 use Illuminate\Http\Resources\DelegatesToResource;
 use JsonSerializable;
@@ -118,6 +119,25 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
         return is_array($this->resource)
             ? $this->resource
             : $this->resource->toArray();
+    }
+
+    /**
+     * Convert the model instance to JSON.
+     *
+     * @param  int  $options
+     * @return string
+     *
+     * @throws \Illuminate\Database\Eloquent\JsonEncodingException
+     */
+    public function toJson($options = 0)
+    {
+        $json = json_encode($this->jsonSerialize(), $options);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw JsonEncodingException::forResource($this, json_last_error_msg());
+        }
+
+        return $json;
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -38,6 +38,7 @@ class ResourceTest extends TestCase
             return new PostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
+                'abstract' => 'Test abstract',
             ]));
         });
 
@@ -53,6 +54,17 @@ class ResourceTest extends TestCase
                 'title' => 'Test Title',
             ],
         ]);
+    }
+
+    public function testResourcesMayBeConvertedToJsonWithToJsonMethod()
+    {
+        $resource = new PostResource(new Post([
+            'id' => 5,
+            'title' => 'Test Title',
+            'abstract' => 'Test abstract',
+        ]));
+
+        $this->assertEquals('{"id":5,"title":"Test Title","custom":true}', $resource->toJson());
     }
 
     public function testResourcesMayHaveNoWrap()


### PR DESCRIPTION
At the moment when you call `toJson` on a Json resource it skips the `toArray` method and directly calls toJson on the Eloquent model because of the `ForwardsCalls` trait. This seems unwanted because if you're formatting the resource in a specific way through the `toArray` method you'd expect it to be honoured when calling toJson I believe. `toJson` isn't documented on the Json Resources documentation but I still believe that this should be honoured.

This is technically a breaking change so I'm targeting the next release.

Fixes https://github.com/laravel/framework/issues/27091
