### PR TITLE
[6.x] Implement withoutRelations method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -723,6 +723,18 @@ trait HasRelationships
     }
 
     /**
+     * Unset all the loaded relations for the instance.
+     *
+     * @return $this
+     */
+    public function withoutRelations()
+    {
+        $this->relations = [];
+
+        return $this;
+    }
+
+    /**
      * Get all the loaded relations for the instance.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -723,11 +723,23 @@ trait HasRelationships
     }
 
     /**
-     * Unset all the loaded relations for the instance.
+     * Duplicate the instance and unset all the loaded relations.
      *
      * @return $this
      */
     public function withoutRelations()
+    {
+        $model = clone $this;
+
+        return $model->unsetRelations();
+    }
+
+    /**
+     * Unset all the loaded relations for the instance.
+     *
+     * @return $this
+     */
+    public function unsetRelations()
     {
         $this->relations = [];
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -236,15 +236,22 @@ class DatabaseEloquentRelationTest extends TestCase
 
     public function testWithoutRelations()
     {
-        $model = new EloquentNoTouchingModelStub;
+        $original = new EloquentNoTouchingModelStub;
 
-        $model->setRelation('foo', 'baz');
+        $original->setRelation('foo', 'baz');
 
-        $this->assertEquals('baz', $model->getRelation('foo'));
+        $this->assertEquals('baz', $original->getRelation('foo'));
 
-        $model = $model->withoutRelations();
+        $model = $original->withoutRelations();
 
         $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertTrue($original->relationLoaded('foo'));
+        $this->assertFalse($model->relationLoaded('foo'));
+
+        $model = $original->unsetRelations();
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertFalse($original->relationLoaded('foo'));
         $this->assertFalse($model->relationLoaded('foo'));
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -234,6 +234,20 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testWithoutRelations()
+    {
+        $model = new EloquentNoTouchingModelStub;
+
+        $model->setRelation('foo', 'baz');
+
+        $this->assertEquals('baz', $model->getRelation('foo'));
+
+        $model = $model->withoutRelations();
+
+        $this->assertInstanceOf(EloquentNoTouchingModelStub::class, $model);
+        $this->assertFalse($model->relationLoaded('foo'));
+    }
+
     public function testMacroable()
     {
         Relation::macro('foo', function () {


### PR DESCRIPTION
This will allow to unload all of the model's relations so it can be used, for example, to not overload queued jobs. This allows for example to do this in a queued job:

    protected $podcast;

    public function __construct(Podcast $podcast)
    {
        $this->podcast = $podcast->withoutRelations();
    }

This way those queued jobs won't be overloaded. I'll document this once it's merged.

Fixes https://github.com/laravel/framework/issues/27148