### PR TITLE
[6.x] Internal Redirects

### DIFF
--- a/src/Illuminate/Http/InternalRedirectResponse.php
+++ b/src/Illuminate/Http/InternalRedirectResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Illuminate\Http;
+
+class InternalRedirectResponse
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param  string  $name
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Http\InternalRedirectResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Store as SessionStore;
 use Illuminate\Support\Traits\Macroable;
@@ -188,6 +189,15 @@ class Redirector
     public function action($action, $parameters = [], $status = 302, $headers = [])
     {
         return $this->to($this->generator->action($action, $parameters), $status, $headers);
+    }
+
+    /**
+     * @param  string  $name
+     * @return \Illuminate\Http\InternalRedirectResponse
+     */
+    public function internal($name)
+    {
+        return new InternalRedirectResponse($name);
     }
 
     /**

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -598,7 +598,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function respondWithRoute($name)
     {
-        if (!$this->routes->hasNamedRoute($name)) {
+        if (! $this->routes->hasNamedRoute($name)) {
             throw new RouteNotFoundException("Route [{$name}] not defined for the internal redirect.");
         }
 

--- a/tests/Http/HttpInternalRedirectResponseTest.php
+++ b/tests/Http/HttpInternalRedirectResponseTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Http;
+
+use Illuminate\Http\InternalRedirectResponse;
+use PHPUnit\Framework\TestCase;
+
+class HttpInternalRedirectResponseTest extends TestCase
+{
+    public function testNameIsSetCorrectly()
+    {
+        $this->assertEquals('foo', (new InternalRedirectResponse('foo'))->getName());
+    }
+}

--- a/tests/Integration/Routing/InternalRedirectTest.php
+++ b/tests/Integration/Routing/InternalRedirectTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+/**
+ * @group integration
+ */
+class InternalRedirectTest extends TestCase
+{
+    public function testBasicInternalRedirect()
+    {
+        Route::get('foo', function () {
+            return redirect()->internal('bar');
+        });
+
+        Route::get('bar', function () {
+            return 'baz';
+        })->name('bar');
+
+        $this->assertStringContainsString('baz', $this->get('/foo')->getContent());
+    }
+
+    public function testInternalRedirectWithPrefix()
+    {
+        Route::name('prefix.')->group(function () {
+            Route::get('foo', function () {
+                return redirect()->internal('prefix.bar');
+            });
+
+            Route::get('bar', function () {
+                return 'baz';
+            })->name('bar');
+        });
+
+        $this->assertStringContainsString('baz', $this->get('/foo')->getContent());
+    }
+
+    public function testInternalRedirectRouteDoesNotExist()
+    {
+        $this->expectException(RouteNotFoundException::class);
+        $this->expectExceptionMessage('Route [bar] not defined for the internal redirect.');
+
+        Route::get('foo', function () {
+            return redirect()->internal('bar');
+        });
+
+        $this->withoutExceptionHandling()->get('/foo');
+    }
+}

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Routing;
 
+use Illuminate\Http\InternalRedirectResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
@@ -167,5 +168,13 @@ class RoutingRedirectorTest extends TestCase
 
         $result = $this->redirect->setIntendedUrl('http://foo.com/bar');
         $this->assertNull($result);
+    }
+
+    public function testInternalRedirect()
+    {
+        $response = $this->redirect->internal('bar');
+
+        $this->assertInstanceOf(InternalRedirectResponse::class, $response);
+        $this->assertEquals('bar', $response->getName());
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\InternalRedirectResponse;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -1701,6 +1702,21 @@ class RoutingRouteTest extends TestCase
         $response = $router->dispatch($request);
         $this->assertTrue($response->isRedirect('contact'));
         $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    public function testInternalRedirect()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo', function () {
+            return new InternalRedirectResponse('bar');
+        });
+
+        $router->name('bar')->get('bar', function () {
+            return 'baz';
+        });
+
+        $this->assertSame('baz', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
     protected function getRouter()


### PR DESCRIPTION
This allows the Router to re-route during execution by returning an `InternalRedirectResponse` from the initial route execution.

One pretty awesome (IMO) use case for this is handling Exceptions. Currently our handler will automatically convert HTTP Exceptions into rendered views. This means we can simply create a `404.blade.php` file, and if a 404 Exception is thrown, Laravel will automatically serve this view.  This is nice, but a little limited.

Let's say for whatever reason we need to inject some data into the view, or add some additional headers to the response. With internal redirects, you can handle these just like you would in any controller method.

**Routes File**
```php
Route::get('throw400', function() {
    return redirect()->internal('errors.400');
});

Route::get('throw404', function() {
    return redirect()->internal('errors.404');
});

Route::get('throw500', function() {
    return redirect()->internal('errors.500');
});

Route::get('errors/400', 'ErrorController@error400')->name('errors.400');
Route::get('errors/404', 'ErrorController@error404')->name('errors.404');
Route::get('errors/500', 'ErrorController@error500')->name('errors.500');
```

**Handler**
```php
class Handler extends ExceptionHandler
{
    public function render($request, Exception $exception)
    {
        if ($exception instanceof HttpException && $exception->getStatusCode() === 400) {
             return redirect()->internal('errors.400');
        }

        if ($exception instanceof HttpException && $exception->getStatusCode() === 404) {
             return redirect()->internal('errors.404');
        }

        if ($exception instanceof HttpException && $exception->getStatusCode() === 500) {
             return redirect()->internal('errors.500');
        }
    }
}
```

**Controller**
```php
class ErrorController extends Controller
{
     public function error400(Request $request)
    {
        return response()->view('errors.400', [], 400);
    }

    public function error404(Request $request)
    {
        // this will return an array of similar named routes that
        // we can display to the user, and provide them quick
        // access to where they may have liked to visit
        $pageGuesses = (new PageGuesser)->guessSimilarPages($request->route);

        return response()->view('errors.404', compact('pageGuesses'), 404);
    }

    public function error500(Request $request)
    {
        $user = $request()->user();

        return response()->view('errors.500', compact('user'), 500);
    }
}
```

If you were to visit www.example.com/throw404, you would be internally redirected to the `ErrorController@error404`, and the page might be able to ask you if you meant to visit www.example.com/contact or www.example.com/about-us.

One of the really nice benefits of this is it allows users to serve responses in a consistent and standardized way if they so choose.  **Everything** can be handled through a Controller.

### Going Forward

I think a nice improvement to make would be to automatically perform an internal redirect for HTTP Exceptions, rather than serving up the view automatically. 

One thing this cannot currently handle is redirecting to a named route that needs parameters.  Currently, the bindings will not be updated, so whatever the original bindings are will be passed to the new route as well.

Another thing of note here is that we can perform an internal redirect to a named route that **does not** match the correct HTTP verb of the original request. I don't think this is an issue, but would love other peoples' thoughts on it.
