### PR TITLE
[6.x] Add Route::gone(), which returns 410 Gone response

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/410.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/410.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Gone'))
+@section('code', '410')
+@section('message', __('Gone'))

--- a/src/Illuminate/Routing/GoneController.php
+++ b/src/Illuminate/Routing/GoneController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Http\Request;
+
+class GoneController extends Controller
+{
+    /**
+     * Invoke the controller method.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        $view = "errors::410";
+        if(view()->exists($view)){
+            return response()->view($view, [], 410);
+        }
+
+        return response(__("Gone"), 410);
+    }
+}

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -260,6 +260,17 @@ class Router implements BindingRegistrar, RegistrarContract
     }
 
     /**
+     * Register a route which returns 410 Gone.
+     *
+     * @param  string  $uri
+     * @return \Illuminate\Routing\Route
+     */
+    public function gone($uri)
+    {
+        return $this->any($uri, '\Illuminate\Routing\GoneController');
+    }
+
+    /**
      * Register a new route that returns a view.
      *
      * @param  string  $uri

--- a/tests/Filesystem/tmp/foo.txt
+++ b/tests/Filesystem/tmp/foo.txt
@@ -1,1 +1,0 @@
-some-data

--- a/tests/Filesystem/tmp/foo.txt
+++ b/tests/Filesystem/tmp/foo.txt
@@ -1,0 +1,1 @@
+some-data

--- a/tests/Integration/Routing/Fixtures/errors/410.blade.php
+++ b/tests/Integration/Routing/Fixtures/errors/410.blade.php
@@ -1,0 +1,5 @@
+@extends('errors::minimal')
+
+@section('title', __('Gone'))
+@section('code', '410')
+@section('message', __('Gone'))

--- a/tests/Integration/Routing/Fixtures/errors/minimal.blade.php
+++ b/tests/Integration/Routing/Fixtures/errors/minimal.blade.php
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+
+        <title>@yield('title')</title>
+
+        <!-- Fonts -->
+        <link rel="dns-prefetch" href="//fonts.gstatic.com">
+        <link href="https://fonts.googleapis.com/css?family=Nunito" rel="stylesheet">
+
+        <!-- Styles -->
+        <style>
+            html, body {
+                background-color: #fff;
+                color: #636b6f;
+                font-family: 'Nunito', sans-serif;
+                font-weight: 100;
+                height: 100vh;
+                margin: 0;
+            }
+
+            .full-height {
+                height: 100vh;
+            }
+
+            .flex-center {
+                align-items: center;
+                display: flex;
+                justify-content: center;
+            }
+
+            .position-ref {
+                position: relative;
+            }
+
+            .code {
+                border-right: 2px solid;
+                font-size: 26px;
+                padding: 0 15px 0 15px;
+                text-align: center;
+            }
+
+            .message {
+                font-size: 18px;
+                text-align: center;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="flex-center position-ref full-height">
+            <div class="code">
+                @yield('code')
+            </div>
+
+            <div class="message" style="padding: 10px;">
+                @yield('message')
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/Integration/Routing/RouteGoneTest.php
+++ b/tests/Integration/Routing/RouteGoneTest.php
@@ -11,16 +11,17 @@ use Orchestra\Testbench\TestCase;
  */
 class RouteGoneTest extends TestCase
 {
-    public function testRouteGoneReturnsResponse()
+    public function testRouteGoneReturnsResponseWhenNoViewExists()
     {
         Route::gone('old_page');
 
         $response = $this->get('/old_page');
         $this->assertEquals(410, $response->getStatusCode());
+        $this->assertStringNotContainsString('html', $response->getContent());
         $this->assertEquals('Gone', $response->getContent());
     }
 
-    public function testRouteGoneReturnsView()
+    public function testRouteGoneReturnsViewWhenViewExists()
     {
         Route::gone('old_page');
 
@@ -28,16 +29,29 @@ class RouteGoneTest extends TestCase
 
         $response = $this->get('/old_page');
         $this->assertEquals(410, $response->getStatusCode());
+        $this->assertStringContainsString('html', $response->getContent());
         $this->assertStringContainsString('Gone', $response->getContent());
     }
 
-//    public function testRouteViewWithParams()
-//    {
-//        Route::view('route/{param}/{param2?}', 'view', ['foo' => 'bar']);
-//
-//        View::addLocation(__DIR__.'/Fixtures');
-//
-//        $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
-//        $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
-//    }
+    public function testRouteGoneWithParamsReturnsResponseWhenNoViewExists()
+    {
+        Route::gone('old_page/{param}/{param2?}');
+
+        $response = $this->get('/old_page/foo');
+        $this->assertEquals(410, $response->getStatusCode());
+        $this->assertStringNotContainsString('html', $response->getContent());
+        $this->assertStringContainsString('Gone', $response->getContent());
+    }
+
+    public function testRouteGoneWithParamsReturnsReturnsViewWhenViewExists()
+    {
+        Route::gone('old_page/{param}/{param2?}');
+
+        View::addNamespace('errors', __DIR__.'/Fixtures/errors');
+
+        $response = $this->get('/old_page/bar');
+        $this->assertEquals(410, $response->getStatusCode());
+        $this->assertStringContainsString('html', $response->getContent());
+        $this->assertStringContainsString('Gone', $response->getContent());
+    }
 }

--- a/tests/Integration/Routing/RouteGoneTest.php
+++ b/tests/Integration/Routing/RouteGoneTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Routing;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\View;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class RouteGoneTest extends TestCase
+{
+    public function testRouteGoneReturnsResponse()
+    {
+        Route::gone('old_page');
+
+        $response = $this->get('/old_page');
+        $this->assertEquals(410, $response->getStatusCode());
+        $this->assertEquals('Gone', $response->getContent());
+    }
+
+    public function testRouteGoneReturnsView()
+    {
+        Route::gone('old_page');
+
+        View::addNamespace('errors', __DIR__.'/Fixtures/errors');
+
+        $response = $this->get('/old_page');
+        $this->assertEquals(410, $response->getStatusCode());
+        $this->assertStringContainsString('Gone', $response->getContent());
+    }
+
+//    public function testRouteViewWithParams()
+//    {
+//        Route::view('route/{param}/{param2?}', 'view', ['foo' => 'bar']);
+//
+//        View::addLocation(__DIR__.'/Fixtures');
+//
+//        $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
+//        $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
+//    }
+}


### PR DESCRIPTION
This PR adds the ability to define a route which will return a 410 response using `Route::gone('uri');`

Came across the need to "410 Gone" a number of routes yesterday. Couldn't spot an easy way to do this, so I created a macro for it, then realised it might be useful for others as well.

I've added `410.blade.php` in the same place as the error blade files, but I don't seem to be able to load it when using it in a Laravel app? This is my first time touching any of the Laravel internals, so i'm not really sure what i'm doing. If someone could point me in the right direction, i'm happy to make the required changes.

I'll continue looking into how to do this tomorrow, but I thought i'd open the PR to get feedback on if this would get accepted (once complete), and if so, what changes would need to be made.