### PR TITLE
[6.x] Use provided table name if present in foreign key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -625,7 +625,7 @@ trait HasRelationships
         // just sort the models and join them together to get the table name.
         $segments = [
             $instance ? $instance->joiningTableSegment()
-                      : Str::snake(class_basename($related)),
+                      : Str::singular($instance->getTable()),
             $this->joiningTableSegment(),
         ];
 
@@ -644,7 +644,7 @@ trait HasRelationships
      */
     public function joiningTableSegment()
     {
-        return Str::snake(class_basename($this));
+        return Str::singular($this->getTable());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1486,7 +1486,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->getKeyName();
+        return Str::singular($this->getTable()).'_'.$this->getKeyName();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -344,13 +344,13 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $this->schema()->create('users_default', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
-            $table->unsignedInteger('has_many_through_default_test_country_id');
+            $table->unsignedInteger('countries_default_id');
             $table->timestamps();
         });
 
         $this->schema()->create('posts_default', function ($table) {
             $table->increments('id');
-            $table->integer('has_many_through_default_test_user_id');
+            $table->integer('users_default_id');
             $table->string('title');
             $table->text('body');
             $table->timestamps();

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -300,13 +300,13 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
         $this->schema()->create('users_default', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
-            $table->unsignedInteger('has_one_through_default_test_position_id')->unique()->nullable();
+            $table->unsignedInteger('positions_default_id')->unique()->nullable();
             $table->timestamps();
         });
 
         $this->schema()->create('contracts_default', function ($table) {
             $table->increments('id');
-            $table->integer('has_one_through_default_test_user_id')->unique();
+            $table->integer('users_default_id')->unique();
             $table->string('title');
             $table->text('body');
             $table->timestamps();

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\InteractsWithTime;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;
@@ -1056,7 +1057,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentModelSaveStub::class);
-        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1093,7 +1094,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentModelSaveStub::class);
-        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1167,8 +1168,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->addMockConnection($model);
 
         $relation = $model->belongsToMany(EloquentModelSaveStub::class);
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignPivotKeyName());
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.stub_id', $relation->getQualifiedForeignPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1168,8 +1168,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->addMockConnection($model);
 
         $relation = $model->belongsToMany(EloquentModelSaveStub::class);
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.stub_id', $relation->getQualifiedForeignPivotKeyName());
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
+        $this->assertSame('save_stub_stub.stub_id', $relation->getQualifiedForeignPivotKeyName());
+        $this->assertSame('save_stub_stub.save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -23,7 +23,6 @@ use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\InteractsWithTime;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use Mockery as m;

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         });
 
         $this->schema('default')->create('taggables', function ($table) {
-            $table->integer('eloquent_many_to_many_polymorphic_test_tag_id');
+            $table->integer('tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');
         });


### PR DESCRIPTION
This PR uses the `$table` property through the `getTable()` method in the `getForeignKey()`, `joiningTable()` and `joiningTableSegment()` methods.

The `getTable()` already fallbacks to the current `class_basename` approach.

# Why?

Because, when table name doesn't match the model class naming convention, you have to manually type the actual table name in each relation.

Also, some rare use cases with uppercase model classes (like `URL`) assumes a table name is called `u_r_l_s`  and therefore the foreign key expects `u_r_l_id`.

The current version already respects the `$table` property as the relation table, but not for its columns.

# Example

**Before:**
```php
class URL extends Model
{
    protected $table = 'urls';

    public function labels()
    {
        return $this->belongsToMany(Label::class, null, 'url_id');
    }
}
```

**After:**
```php
class URL extends Model
{
    protected $table = 'urls';

    public function labels()
    {
        return $this->belongsToMany(Label::class);
    }
}
```