### PR TITLE
[7.0] Builder single return types

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -239,7 +239,7 @@ class Builder
      * @param  \Closure|array|string  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return \Illuminate\Database\Eloquent\Builder|static
+     * @return $this
      */
     public function orWhere($column, $operator = null, $value = null)
     {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -243,7 +243,7 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      *
      * @throws \InvalidArgumentException
      */
@@ -261,7 +261,7 @@ class Builder
      *
      * @param  string  $expression
      * @param  array  $bindings
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function selectRaw($expression, array $bindings = [])
     {
@@ -279,7 +279,7 @@ class Builder
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
      * @param  string  $as
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      *
      * @throws \InvalidArgumentException
      */
@@ -295,7 +295,7 @@ class Builder
      *
      * @param  string  $expression
      * @param  mixed  $bindings
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function fromRaw($expression, $bindings = [])
     {
@@ -456,7 +456,7 @@ class Builder
      * @param  string  $operator
      * @param  string  $second
      * @param  string  $type
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function joinWhere($table, $first, $operator, $second, $type = 'inner')
     {
@@ -473,7 +473,7 @@ class Builder
      * @param  string|null  $second
      * @param  string  $type
      * @param  bool  $where
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      *
      * @throws \InvalidArgumentException
      */
@@ -495,7 +495,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function leftJoin($table, $first, $operator = null, $second = null)
     {
@@ -509,7 +509,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string  $operator
      * @param  string  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function leftJoinWhere($table, $first, $operator, $second)
     {
@@ -524,7 +524,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function leftJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -538,7 +538,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function rightJoin($table, $first, $operator = null, $second = null)
     {
@@ -552,7 +552,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string  $operator
      * @param  string  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function rightJoinWhere($table, $first, $operator, $second)
     {
@@ -567,7 +567,7 @@ class Builder
      * @param  \Closure|string  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function rightJoinSub($query, $as, $first, $operator = null, $second = null)
     {
@@ -581,7 +581,7 @@ class Builder
      * @param  \Closure|string|null  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function crossJoin($table, $first = null, $operator = null, $second = null)
     {
@@ -778,7 +778,7 @@ class Builder
      * @param  \Closure|string|array  $column
      * @param  mixed  $operator
      * @param  mixed  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhere($column, $operator = null, $value = null)
     {
@@ -796,7 +796,7 @@ class Builder
      * @param  string|null  $operator
      * @param  string|null  $second
      * @param  string|null  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereColumn($first, $operator = null, $second = null, $boolean = 'and')
     {
@@ -832,7 +832,7 @@ class Builder
      * @param  string|array  $first
      * @param  string|null  $operator
      * @param  string|null  $second
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereColumn($first, $operator = null, $second = null)
     {
@@ -861,7 +861,7 @@ class Builder
      *
      * @param  string  $sql
      * @param  mixed  $bindings
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereRaw($sql, $bindings = [])
     {
@@ -914,7 +914,7 @@ class Builder
      *
      * @param  string  $column
      * @param  mixed  $values
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereIn($column, $values)
     {
@@ -927,7 +927,7 @@ class Builder
      * @param  string  $column
      * @param  mixed  $values
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereNotIn($column, $values, $boolean = 'and')
     {
@@ -939,7 +939,7 @@ class Builder
      *
      * @param  string  $column
      * @param  mixed  $values
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereNotIn($column, $values)
     {
@@ -1008,7 +1008,7 @@ class Builder
      * Add an "or where null" clause to the query.
      *
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereNull($column)
     {
@@ -1020,7 +1020,7 @@ class Builder
      *
      * @param  string|array  $columns
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereNotNull($columns, $boolean = 'and')
     {
@@ -1052,7 +1052,7 @@ class Builder
      *
      * @param  string  $column
      * @param  array  $values
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereBetween($column, array $values)
     {
@@ -1065,7 +1065,7 @@ class Builder
      * @param  string  $column
      * @param  array  $values
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereNotBetween($column, array $values, $boolean = 'and')
     {
@@ -1077,7 +1077,7 @@ class Builder
      *
      * @param  string  $column
      * @param  array  $values
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereNotBetween($column, array $values)
     {
@@ -1088,7 +1088,7 @@ class Builder
      * Add an "or where not null" clause to the query.
      *
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereNotNull($column)
     {
@@ -1102,7 +1102,7 @@ class Builder
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereDate($column, $operator, $value = null, $boolean = 'and')
     {
@@ -1123,7 +1123,7 @@ class Builder
      * @param  string  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereDate($column, $operator, $value = null)
     {
@@ -1141,7 +1141,7 @@ class Builder
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereTime($column, $operator, $value = null, $boolean = 'and')
     {
@@ -1162,7 +1162,7 @@ class Builder
      * @param  string  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereTime($column, $operator, $value = null)
     {
@@ -1180,7 +1180,7 @@ class Builder
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereDay($column, $operator, $value = null, $boolean = 'and')
     {
@@ -1205,7 +1205,7 @@ class Builder
      * @param  string  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereDay($column, $operator, $value = null)
     {
@@ -1223,7 +1223,7 @@ class Builder
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereMonth($column, $operator, $value = null, $boolean = 'and')
     {
@@ -1248,7 +1248,7 @@ class Builder
      * @param  string  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereMonth($column, $operator, $value = null)
     {
@@ -1266,7 +1266,7 @@ class Builder
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereYear($column, $operator, $value = null, $boolean = 'and')
     {
@@ -1287,7 +1287,7 @@ class Builder
      * @param  string  $column
      * @param  string  $operator
      * @param  \DateTimeInterface|string|int|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereYear($column, $operator, $value = null)
     {
@@ -1324,7 +1324,7 @@ class Builder
      *
      * @param  \Closure  $callback
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereNested(Closure $callback, $boolean = 'and')
     {
@@ -1346,7 +1346,7 @@ class Builder
     /**
      * Add another query builder as a nested where to the query builder.
      *
-     * @param  \Illuminate\Database\Query\Builder|static  $query
+     * @param  $this  $query
      * @param  string  $boolean
      * @return $this
      */
@@ -1415,7 +1415,7 @@ class Builder
      *
      * @param  \Closure  $callback
      * @param  bool  $not
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereExists(Closure $callback, $not = false)
     {
@@ -1427,7 +1427,7 @@ class Builder
      *
      * @param  \Closure  $callback
      * @param  string  $boolean
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function whereNotExists(Closure $callback, $boolean = 'and')
     {
@@ -1438,7 +1438,7 @@ class Builder
      * Add a where not exists clause to the query.
      *
      * @param  \Closure  $callback
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orWhereNotExists(Closure $callback)
     {
@@ -1725,7 +1725,7 @@ class Builder
      * @param  string  $column
      * @param  string|null  $operator
      * @param  string|null  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orHaving($column, $operator = null, $value = null)
     {
@@ -1743,7 +1743,7 @@ class Builder
      * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function havingBetween($column, array $values, $boolean = 'and', $not = false)
     {
@@ -1780,7 +1780,7 @@ class Builder
      *
      * @param  string  $sql
      * @param  array  $bindings
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function orHavingRaw($sql, array $bindings = [])
     {
@@ -1835,7 +1835,7 @@ class Builder
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function latest($column = 'created_at')
     {
@@ -1846,7 +1846,7 @@ class Builder
      * Add an "order by" clause for a timestamp to the query.
      *
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function oldest($column = 'created_at')
     {
@@ -1886,7 +1886,7 @@ class Builder
      * Alias to set the "offset" value of the query.
      *
      * @param  int  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function skip($value)
     {
@@ -1912,7 +1912,7 @@ class Builder
      * Alias to set the "limit" value of the query.
      *
      * @param  int  $value
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function take($value)
     {
@@ -1941,7 +1941,7 @@ class Builder
      *
      * @param  int  $page
      * @param  int  $perPage
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function forPage($page, $perPage = 15)
     {
@@ -1954,7 +1954,7 @@ class Builder
      * @param  int  $perPage
      * @param  int|null  $lastId
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function forPageBeforeId($perPage = 15, $lastId = 0, $column = 'id')
     {
@@ -1974,7 +1974,7 @@ class Builder
      * @param  int  $perPage
      * @param  int|null  $lastId
      * @param  string  $column
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function forPageAfterId($perPage = 15, $lastId = 0, $column = 'id')
     {
@@ -2008,7 +2008,7 @@ class Builder
      *
      * @param  \Illuminate\Database\Query\Builder|\Closure  $query
      * @param  bool  $all
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function union($query, $all = false)
     {
@@ -2027,7 +2027,7 @@ class Builder
      * Add a union all statement to the query.
      *
      * @param  \Illuminate\Database\Query\Builder|\Closure  $query
-     * @return \Illuminate\Database\Query\Builder|static
+     * @return $this
      */
     public function unionAll($query)
     {


### PR DESCRIPTION
Where are a lot of methods which have different return types in their phpDocs, for example, 
* `whereNull`- `$this`
* `whereNotNull` - `\Illuminate\Database\Query\Builder|static`

I have encountered a problem with Larastan:
Method ExampleModel::scopeAnything() should return Illuminate\Database\Eloquent\Builder but returns Illuminate\Database\Query\Builder with `whereNotNull` method. If you will try to use `whereNull` method the test will success.

The PR set `$this` for all methods as return type