### PR TITLE
[6.X] Allow packages to use custom markdown mail themes

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -4,6 +4,7 @@ namespace Illuminate\Mail;
 
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Parsedown;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -60,8 +60,12 @@ class Markdown
             'mail', $this->htmlComponentPaths()
         )->make($view, $data)->render();
 
+        $viewPath = Str::contains($this->theme, '::')
+            ? $this->theme
+            : 'mail::themes.'.$this->theme;
+
         return new HtmlString(($inliner ?: new CssToInlineStyles)->convert(
-            $contents, $this->view->make('mail::themes.'.$this->theme, $data)->render()
+            $contents, $this->view->make($viewPath, $data)->render()
         ));
     }
 


### PR DESCRIPTION
Right now, view paths must start with `mail::themes`. This makes it impossible for packages to have their own theme support.

With this in place packages can start using themes too, example `mailcoach::mails.layout.mailcoach`