### PR TITLE
[6.x] Change DatabaseNotification keyType to match uuid

### DIFF
--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class DatabaseNotification extends Model
 {
     /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool


### PR DESCRIPTION
The default primary key for database notifications is a UUID, but the default `keyType` (from the base model) is an `int`. This causes ids with string UUIDs to be force cast as integers in MorphTo and other relationships.

https://github.com/laravel/framework/blob/f5c3c60d52eccd77274e586fc4c775374e826b0f/src/Illuminate/Database/Eloquent/Relations/Relation.php#L310-L323

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
