### PR TITLE
[6.x] Add cookies to json test requests

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -388,11 +388,12 @@ trait MakesHttpRequests
      * @param  string  $uri
      * @param  array  $data
      * @param  array  $headers
-     * @return \Illuminate\Foundation\Testing\TestResponse
+     * @param  bool  $encryptCookies
+     * @return  \Illuminate\Foundation\Testing\TestResponse
      */
-    public function json($method, $uri, array $data = [], array $headers = [])
+    public function json($method, $uri, array $data = [], array $headers = [], bool $encryptCookies = false)
     {
-        $files = $this->extractFilesFromDataArray($data);
+        $this->encryptCookies = $encryptCookies;
 
         $content = json_encode($data);
 
@@ -402,8 +403,12 @@ trait MakesHttpRequests
             'Accept' => 'application/json',
         ], $headers);
 
+        $cookies = $this->prepareCookiesForRequest();
+        $files = $this->extractFilesFromDataArray($data);
+        $server = $this->transformHeadersToServerVars($headers);
+
         return $this->call(
-            $method, $uri, [], [], $files, $this->transformHeadersToServerVars($headers), $content
+            $method, $uri, [], $cookies, $files, $server, $content
         );
     }
 


### PR DESCRIPTION
This extends the new methods for sending cookies with test requests (#30101) introduced by @jasonmccreary.

## Changes
### Before

`$defaultCookies` were only sent along with "web" test requests.

### After

`$defaultCookies` are sent along with "web" and "json" test requests. This means that `withCookie(string $name, string $value)` and `withCookies(array $cookies)` methods now work for all test requests.

## Caveats

+ Cookies are not encrypted by default for "json" test requests.
+ It's my first pull request ever, so please be indulgent if I've done something wrong