### PR TITLE
[6.x] Add exclude_if validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1412,6 +1412,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Indicate that an attribute should be excluded when another attribute has a given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateExcludeIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'exclude_if');
+
+        $other = Arr::get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (is_bool($other)) {
+            $values = $this->convertValuesToBoolean($values);
+        }
+
+        return ! in_array($other, $values);
+    }
+
+    /**
      * Convert the given values to boolean if they are string "true" / "false".
      *
      * @param  array  $values

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1396,13 +1396,7 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'required_if');
 
-        $other = Arr::get($this->data, $parameters[0]);
-
-        $values = array_slice($parameters, 1);
-
-        if (is_bool($other)) {
-            $values = $this->convertValuesToBoolean($values);
-        }
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
 
         if (in_array($other, $values)) {
             return $this->validateRequired($attribute, $value);
@@ -1423,19 +1417,13 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'exclude_if');
 
-        $other = Arr::get($this->data, $parameters[0]);
-
-        $values = array_slice($parameters, 1);
-
-        if (is_bool($other)) {
-            $values = $this->convertValuesToBoolean($values);
-        }
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
 
         return ! in_array($other, $values);
     }
 
     /**
-     * Indicate that an attribute should be excluded when another attribute does not have given value.
+     * Indicate that an attribute should be excluded when another attribute does not have a given value.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1446,6 +1434,19 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'exclude_unless');
 
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
+
+        return in_array($other, $values);
+    }
+
+    /**
+     * Prepare the values and the other value for validation.
+     *
+     * @param  array  $parameters
+     * @return array
+     */
+    protected function prepareValuesAndOther($parameters)
+    {
         $other = Arr::get($this->data, $parameters[0]);
 
         $values = array_slice($parameters, 1);
@@ -1454,7 +1455,7 @@ trait ValidatesAttributes
             $values = $this->convertValuesToBoolean($values);
         }
 
-        return in_array($other, $values);
+        return [$values, $other];
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1435,6 +1435,29 @@ trait ValidatesAttributes
     }
 
     /**
+     * Indicate that an attribute should be excluded when another attribute does not have given value.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateExcludeUnless($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(2, $parameters, 'exclude_unless');
+
+        $other = Arr::get($this->data, $parameters[0]);
+
+        $values = array_slice($parameters, 1);
+
+        if (is_bool($other)) {
+            $values = $this->convertValuesToBoolean($values);
+        }
+
+        return in_array($other, $values);
+    }
+
+    /**
      * Convert the given values to boolean if they are string "true" / "false".
      *
      * @param  array  $values

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -189,7 +189,7 @@ class Validator implements ValidatorContract
      *
      * @var array
      */
-    protected $excludeRules = ['ExcludeIf'];
+    protected $excludeRules = ['ExcludeIf', 'ExcludeUnless'];
 
     /**
      * The size related validation rules.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -351,7 +351,7 @@ class Validator implements ValidatorContract
      */
     protected function removeAttribute($attribute)
     {
-        unset($this->rules[$attribute]);
+        unset($this->data[$attribute], $this->rules[$attribute]);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5010,7 +5010,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($validator->passes());
         $this->assertSame(['cat' => 'Felix'], $validator->validated());
 
-
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['cat' => 'Felix'],
@@ -5019,7 +5018,6 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($validator->passes());
         $this->assertSame(['cat' => 'Felix'], $validator->validated());
 
-
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
             ['cat' => 'Tom', 'mouse' => 'Jerry'],
@@ -5027,7 +5025,6 @@ class ValidationValidatorTest extends TestCase
         );
         $this->assertTrue($validator->passes());
         $this->assertSame(['cat' => 'Tom', 'mouse' => 'Jerry'], $validator->validated());
-
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5035,6 +5035,28 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['mouse' => ['validation.required']], $validator->messages()->toArray());
     }
 
+    public function testExcludeValuesAreReallyRemoved()
+    {
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Tom', 'mouse' => 'Jerry'],
+            ['cat' => 'required|string', 'mouse' => 'exclude_if:cat,Tom|required|string']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['cat' => 'Tom'], $validator->validated());
+        $this->assertSame(['cat' => 'Tom'], $validator->valid());
+        $this->assertSame([], $validator->invalid());
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Tom', 'mouse' => null],
+            ['cat' => 'required|string', 'mouse' => 'exclude_if:cat,Felix|required|string']
+        );
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['cat' => 'Tom'], $validator->valid());
+        $this->assertSame(['mouse' => null], $validator->invalid());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4783,7 +4783,7 @@ class ValidationValidatorTest extends TestCase
                     'appointment_date' => ['exclude_if:has_appointment,false', 'required', 'date'],
                 ], [
                     'has_appointment' => false,
-                    'appointment_date' => 'should be excluded'
+                    'appointment_date' => 'should be excluded',
                 ], [
                     'has_appointment' => false,
                 ],
@@ -4821,7 +4821,7 @@ class ValidationValidatorTest extends TestCase
                     'doctor_appointment_date' => '2019-12-13',
                 ], [
                     'has_no_appointments' => true,
-                ]
+                ],
             ],
             [
                 [

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5000,6 +5000,44 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame($expectedMessages, $validator->messages()->toArray());
     }
 
+    public function testExcludeUnless()
+    {
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Felix', 'mouse' => 'Jerry'],
+            ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['cat' => 'Felix'], $validator->validated());
+
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Felix'],
+            ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['cat' => 'Felix'], $validator->validated());
+
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Tom', 'mouse' => 'Jerry'],
+            ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
+        );
+        $this->assertTrue($validator->passes());
+        $this->assertSame(['cat' => 'Tom', 'mouse' => 'Jerry'], $validator->validated());
+
+
+        $validator = new Validator(
+            $this->getIlluminateArrayTranslator(),
+            ['cat' => 'Tom'],
+            ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
+        );
+        $this->assertTrue($validator->fails());
+        $this->assertSame(['mouse' => ['validation.required']], $validator->messages()->toArray());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4790,6 +4790,17 @@ class ValidationValidatorTest extends TestCase
             ],
             [
                 [
+                    'cat' => ['required', 'string'],
+                    'mouse' => ['exclude_if:cat,Tom', 'required', 'file'],
+                ], [
+                    'cat' => 'Tom',
+                    'mouse' => 'should be excluded',
+                ], [
+                    'cat' => 'Tom',
+                ],
+            ],
+            [
+                [
                     'has_appointment' => ['required', 'bool'],
                     'appointment_date' => ['exclude_if:has_appointment,false', 'required', 'date'],
                 ], [
@@ -4837,6 +4848,60 @@ class ValidationValidatorTest extends TestCase
                     'has_doctor_appointment' => false,
                 ],
             ],
+            'nested-01' => [
+                [
+                    'has_appointments' => ['required', 'bool'],
+                    'appointments.*' => ['exclude_if:has_appointments,false', 'required', 'date'],
+                ], [
+                    'has_appointments' => false,
+                    'appointments' => ['2019-05-15', '2020-05-15'],
+                ], [
+                    'has_appointments' => false,
+                ],
+            ],
+            'nested-02' => [
+                [
+                    'has_appointments' => ['required', 'bool'],
+                    'appointments.*.date' => ['exclude_if:has_appointments,false', 'required', 'date'],
+                    'appointments.*.name' => ['exclude_if:has_appointments,false', 'required', 'string'],
+                ], [
+                    'has_appointments' => false,
+                    'appointments' => [
+                        ['date' => 'should be excluded', 'name' => 'should be excluded'],
+                    ],
+                ], [
+                    'has_appointments' => false,
+                ],
+            ],
+            'nested-03' => [
+                [
+                    'has_appointments' => ['required', 'bool'],
+                    'appointments' => ['exclude_if:has_appointments,false', 'required', 'array'],
+                    'appointments.*.date' => ['required', 'date'],
+                    'appointments.*.name' => ['required', 'string'],
+                ], [
+                    'has_appointments' => false,
+                    'appointments' => [
+                        ['date' => 'should be excluded', 'name' => 'should be excluded'],
+                    ],
+                ], [
+                    'has_appointments' => false,
+                ],
+            ],
+            'nested-04' => [
+                [
+                    'has_appointments' => ['required', 'bool'],
+                    'appointments.*.date' => ['required', 'date'],
+                    'appointments' => ['exclude_if:has_appointments,false', 'required', 'array'],
+                ], [
+                    'has_appointments' => false,
+                    'appointments' => [
+                        ['date' => 'should be excluded', 'name' => 'should be excluded'],
+                    ],
+                ], [
+                    'has_appointments' => false,
+                ],
+            ],
         ];
     }
 
@@ -4879,6 +4944,34 @@ class ValidationValidatorTest extends TestCase
                     'appointment_date' => ['validation.required'],
                 ],
             ],
+            [
+                [
+                    'cat' => ['required', 'string'],
+                    'mouse' => ['exclude_if:cat,Tom', 'required', 'file'],
+                ], [
+                    'cat' => 'Bob',
+                    'mouse' => 'not a file',
+                ], [
+                    'mouse' => ['validation.file'],
+                ],
+            ],
+            [
+                [
+                    'has_appointments' => ['required', 'bool'],
+                    'appointments' => ['exclude_if:has_appointments,false', 'required', 'array'],
+                    'appointments.*.date' => ['required', 'date'],
+                    'appointments.*.name' => ['required', 'string'],
+                ], [
+                    'has_appointments' => true,
+                    'appointments' => [
+                        ['date' => 'invalid', 'name' => 'Bob'],
+                        ['date' => '2019-05-15'],
+                    ],
+                ], [
+                    'appointments.0.date' => ['validation.date'],
+                    'appointments.1.name' => ['validation.required'],
+                ],
+            ],
         ];
     }
 
@@ -4898,7 +4991,7 @@ class ValidationValidatorTest extends TestCase
         if (! $fails) {
             $message = sprintf("Validation unexpectedly passed:\nRules: %s\nData: %s",
                 json_encode($rules, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
-                json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+                json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
             );
         }
 


### PR DESCRIPTION
The goal of this PR is to make it easy to exclude attributes from a request based on the value of other attributes. This is useful when having to validate data from a form where certain checkboxes hide or show other inputs.

For example, imagine a form with an `has_doctor_appointment` checkbox, that when checked, toggles an `appointment_date` and `doctor_name` input. A user can check the checkbox, fill in a date, and then uncheck the checkbox. The date input is no longer visible, but still contains a value. When using Redux Form, even when the input is not visible, the value still gets posted.

Usually, you would validate the form above something like this:
```json
// Post data
{"has_appointment": false, "appointment_date": "2019-12-13"}
```
```php
public function post(Request $request)
{
    $data = $request->validate([
        'has_doctor_appointment' => 'required|bool',
        'appointment_date' => 'required_if:has_doctor_appointment,true|date',
        'doctor_name' => 'required_if:has_doctor_appointment,true|string'
    ]);

    // $data === ['has_doctor_appointment' => false, 'appointment_date' => '2019-12-13']

    SomeModel::create($data);
}
```

The database now contains a record where has_appointment is false, but that has an appointment_date. This is not right. As far as i know, the only way to ensure you never store data like this is by adding statements like this to your controller/validator:
```php
if (! $data['has_doctor_appointment') {
    $data['appointment_date'] = null;
    $data['doctor_name'] = null;
}
```

With the exclude_if validation rule, you can validate like this instead:
```json
// Post data:
{"has_appointment": false, "appointment_date": "2019-12-13"}
```
```php
public function post(Request $request)
{
    $data = $request->validate([
        'has_doctor_appointment' => 'required|bool',
        'appointment_date' => 'exclude_if:has_appointment,false|required|date',
        'doctor_name' => 'exclude_if:has_appointment,false|required|string',
    ]);

    // $data === ['has_appointment' => false]

    SomeModel::create($data);
}
```

---

The idea for this validation rule comes from a project we are working on at the office. It has multiple large forms, that all have many checkboxes that toggle other inputs. The way we solve this now is by making sure the inputs are reset when they are hidden. When they are reset Redux Form doesn't include them in the post data. Making sure the fields are properly reset has been troublesome in the past. This approach also does not prevent users from theoretically posting their own incorrect data to the endpoint.

With this new validation rule, the front-end doesn't have to reset any of the fields, since the back-end can easily exclude values.

---
This PR is still a work in progress. I would like to get some feedback on it before i spend more time on it.

Todo:
- [x] More tests
- [x] Nested attributes 1 level deep
- [x] exclude_unless rule

Not tested:
Nested attributes 2+ levels deep (I'm not sure if this is supported at all)




