### PR TITLE
[6.x] Add support for nested arrays with `assertViewHas`

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -857,9 +857,9 @@ class TestResponse implements ArrayAccess
         if (is_null($value)) {
             PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
         } elseif ($value instanceof Closure) {
-            PHPUnit::assertTrue($value($this->original->gatherData()[$key]));
+            PHPUnit::assertTrue($value(Arr::get($this->original->gatherData(), $key)));
         } elseif ($value instanceof Model) {
-            PHPUnit::assertTrue($value->is($this->original->gatherData()[$key]));
+            PHPUnit::assertTrue($value->is(Arr::get($this->original->gatherData(), $key)));
         } else {
             PHPUnit::assertEquals($value, Arr::get($this->original->gatherData(), $key));
         }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -861,7 +861,7 @@ class TestResponse implements ArrayAccess
         } elseif ($value instanceof Model) {
             PHPUnit::assertTrue($value->is($this->original->gatherData()[$key]));
         } else {
-            PHPUnit::assertEquals($value, $this->original->gatherData()[$key]);
+            PHPUnit::assertEquals($value, Arr::get($this->original->gatherData(), $key));
         }
 
         return $this;

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -56,6 +56,42 @@ class FoundationTestResponseTest extends TestCase
         $response->assertViewHas('foo', $model);
     }
 
+    public function testAssertViewHasWithClosure()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewHas('foo', function ($value) {
+            return $value === 'bar';
+        });
+    }
+
+    public function testAssertViewHasWithValue()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewHas('foo', 'bar');
+    }
+
+    public function testAssertViewHasWithNestedValue()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => [
+                'foo' => [
+                    'nested' => 'bar'
+                ]
+            ],
+        ]);
+
+        $response->assertViewHas('foo.nested', 'bar');
+    }
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -84,7 +84,7 @@ class FoundationTestResponseTest extends TestCase
             'render' => 'hello world',
             'gatherData' => [
                 'foo' => [
-                    'nested' => 'bar'
+                    'nested' => 'bar',
                 ],
             ],
         ]);

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -85,7 +85,7 @@ class FoundationTestResponseTest extends TestCase
             'gatherData' => [
                 'foo' => [
                     'nested' => 'bar'
-                ]
+                ],
             ],
         ]);
 


### PR DESCRIPTION
This PR adds nested array support to the `assertViewHas` method.

Here's an example of the before/after usage:

```php
// controller

return Inertia::render('PageComponent', [
    'user_name' => 'John Doe'
]);
```

Testing before PR:

```php
// test class

$this->get('/page')
    ->assertViewHas('page', [
        'component' => 'PageComponent',
        'url' => '/page',
        'version' => null,
        'props' => [
            'user_name' => 'John Doe'
        ]
    ]);
```

Testing after PR:

```php
$this->get('/page')
    ->assertViewHas('page.props', [
        'user_name' => 'John Doe'
    ]);
```

So in this example, I'm using Inertia to render a page. Inertia attaches multiple "props" to the `page` key passed to the view. I only really care to test that the data I returned from my controller is set correctly.

I think this could be useful for usage outside of Inertia as well, where a controller may return nested data to a view and a test wants to pick out a nested key.

I've also added a couple extra tests that were missing for `assertViewHas`.