### PR TITLE
[6.x] Pass the exception to the rescue closure

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -715,7 +715,7 @@ if (! function_exists('rescue')) {
                 report($e);
             }
 
-            return value($rescue);
+            return $rescue instanceof Closure ? $rescue($e) : $rescue;
         }
     }
 }


### PR DESCRIPTION
I'm using the `rescue` helper to make sure a fragile part of my application can't cause a crash. I'm storing both the error message and the object to make debugging easier. The problem is that when using the rescue helper, i can only see the real exception in my logs, and i can't store it in the database.

Currently:
```php
[$error, $object] = rescue(function () use ($file) {
    return [null, new SomeFragileObject($file)];
}, ['An exception was thrown', null]);
```

With this PR i can do this:
```php
[$error, $object] = rescue(function () use ($file) {
    return [null, new SomeFragileObject($file)];
}, function ($e) {
    // $e can be a custom exception with a detailed error message
    return [$e->getMessage(), null];
});
```


