### PR TITLE
[6.x] Add the option to not cycle remember me token

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -483,6 +483,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Log the user out of the application.
      *
+     * @param  string  $attribute
      * @return void
      */
     public function logout($cycleRememberToken = true)

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -485,13 +485,13 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      *
      * @return void
      */
-    public function logout()
+    public function logout($cycleRememberToken = true)
     {
         $user = $this->user();
 
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
+        if (! is_null($this->user) && ! empty($user->getRememberToken()) && $cycleRememberToken) {
             $this->cycleRememberToken($user);
         }
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -483,7 +483,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Log the user out of the application.
      *
-     * @param  string  $attribute
+     * @param  bool  $cycleRememberToken
      * @return void
      */
     public function logout($cycleRememberToken = true)


### PR DESCRIPTION
By default, Laravel recycles the remember_token in the users table when logout is called on the guard. This helps with security in a lot of cases and should stay in place by as the default option.

The issue myself and others have been having is the following:

1. Jack logs into Macbook Air and clicks 'Remember Me'
2. Jack logs into Mac Mini and clicks 'Remember Me'
3. Jack logs into iPhone and clicks 'Remember Me' (this PR is not sponsored by Apple)
4. Jack clicks logout on 'Macbook Air'
5. Jack's sessions expire on all other devices and his remember me cookie doesn't log him back in because the token has been recycled
6. Jack has to login to all devices again

This isn't a bug, this is intended functionality, but I believe we should offer users the option to override the default functionality and then implement their own "logout from all devices" functionality. We could go crazy and try and introduce some sort of "tokens" table, but I think that overcomplicates things. The simplest way to achieve this is by passing a boolean parameter to the logout method. We do this from the LoginController::logout() method. The developer could then offer some sort of "logout from all devices" option too. Any "Netflix / Facebook-like" functionality (where you can see each device that's logged in) should be left to developers / external packages.

This first came up nearly 2 years ago and there was interest: https://github.com/laravel/ideas/issues/971

I'd love some feedback on this and to hear what everyone thinks.