### PR TITLE
[6.x] Fix non-eloquent model validation

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -819,8 +819,7 @@ trait ValidatesAttributes
         [$connection, $table] = Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
 
         if (Str::contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
-            $model = new $table;
-            $table = $model->getTable();
+            $table = (new $table)->getTable();
         }
 
         return [$connection, $table];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -818,12 +818,9 @@ trait ValidatesAttributes
     {
         [$connection, $table] = Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
 
-        if (Str::contains($table, '\\') && class_exists($table)) {
+        if (Str::contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
             $model = new $table;
-
-            if ($model instanceof Model) {
-                $table = $model->getTable();
-            }
+            $table = $model->getTable();
         }
 
         return [$connection, $table];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4307,6 +4307,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(null, $explicit_no_connection[0]);
         $this->assertEquals('explicits', $explicit_no_connection[1]);
 
+        $noneloquent_no_connection = $v->parseTable(NonEloquentModel::class);
+        $this->assertEquals(null, $noneloquent_no_connection[0]);
+        $this->assertEquals(NonEloquentModel::class, $noneloquent_no_connection[1]);
+
         $raw_no_connection = $v->parseTable('table');
         $this->assertEquals(null, $raw_no_connection[0]);
         $this->assertEquals('table', $raw_no_connection[1]);
@@ -4318,6 +4322,10 @@ class ValidationValidatorTest extends TestCase
         $explicit_connection = $v->parseTable('connection.'.ExplicitTableModel::class);
         $this->assertEquals('connection', $explicit_connection[0]);
         $this->assertEquals('explicits', $explicit_connection[1]);
+
+        $noneloquent_connection = $v->parseTable('connection.'.NonEloquentModel::class);
+        $this->assertEquals('connection', $noneloquent_connection[0]);
+        $this->assertEquals(NonEloquentModel::class, $noneloquent_connection[1]);
 
         $raw_connection = $v->parseTable('connection.table');
         $this->assertEquals('connection', $raw_connection[0]);
@@ -4799,3 +4807,6 @@ class ExplicitTableModel extends Model
     protected $guarded = [];
     public $timestamps = false;
 }
+
+class NonEloquentModel
+{}

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4809,4 +4809,5 @@ class ExplicitTableModel extends Model
 }
 
 class NonEloquentModel
-{}
+{
+}


### PR DESCRIPTION
https://github.com/laravel/framework/commit/5728c66b0a444086a34b5bc1fe5ac866251fab90 broke validation for models/entities that don't inherit from Laravels Model class ([laravel-doctrine](https://github.com/laravel-doctrine/orm)), because [parseTable](https://github.com/laravel/framework/commit/5728c66b0a444086a34b5bc1fe5ac866251fab90#diff-bfe2e79d87a34030e1cd049713a78cdaL816) assumes an Eloquent Model if the provided table/model string is a class. This PR adds a check before instantiating the class and falls back to the previous behavior if it's not an Eloquent Model.