### PR TITLE
[6.x] Reuse faker instance between test cases

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -14,6 +14,13 @@ trait WithFaker
     protected $faker;
 
     /**
+     * Static Faker instance shared between test classes.
+     *
+     * @var \Faker\Generator[]
+     */
+    protected static $staticFakers = [];
+
+    /**
      * Setup up the Faker instance.
      *
      * @return void
@@ -42,6 +49,10 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        return Factory::create($locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE));
+        if (! isset(static::$staticFakers[$locale])) {
+            static::$staticFakers[$locale] = Factory::create($locale ?? Factory::DEFAULT_LOCALE);
+        }
+
+        return static::$staticFakers[$locale];
     }
 }


### PR DESCRIPTION
This PR makes faker instance a singleton. This is needed in cases when you use `unique()` modifier on the faker but want to keep that "uniqueness" between multiple test cases.

Explanation:

Imagine you are not using **DatabaseTransaction** trait but using faker to generate unique emails. It is possible for faker to generate same email between different phpunit test cases since new instance is created before each test.

Of course this will not save you from conflicts when tests are run multiple times because database is already populated with emails from past tests (due to missing DatabaseTransaction), but in case of CI jobs when database is created once just for testing, it will prevent conflicts.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
