### PR TITLE
[6.x] Allow to use resource 'when' method as Higher Order Proxy

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Resources;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\HigherOrderWhenProxy;
 
 trait ConditionallyLoadsAttributes
 {
@@ -97,15 +98,21 @@ trait ConditionallyLoadsAttributes
      * @param  bool  $condition
      * @param  mixed  $value
      * @param  mixed  $default
-     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     * @return \Illuminate\Http\Resources\MissingValue|\Illuminate\Support\HigherOrderWhenProxy|mixed
      */
-    protected function when($condition, $value, $default = null)
+    protected function when($condition, $value = null, $default = null)
     {
-        if ($condition) {
-            return value($value);
+        if (func_num_args() === 1) {
+            return new HigherOrderWhenProxy($this, !$condition);
         }
 
-        return func_num_args() === 3 ? value($default) : new MissingValue;
+        if (!$condition) {
+            return func_num_args() === 3
+                ? value($default)
+                : new MissingValue;
+        }
+
+        return value($value);
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -60,8 +60,8 @@ trait ConditionallyLoadsAttributes
         }
 
         return $this->removeMissingValues(array_slice($data, 0, $index, true) +
-                $merge +
-                $this->filter(array_slice($data, $index + 1, null, true)));
+            $merge +
+            $this->filter(array_slice($data, $index + 1, null, true)));
     }
 
     /**
@@ -77,8 +77,8 @@ trait ConditionallyLoadsAttributes
         foreach ($data as $key => $value) {
             if (($value instanceof PotentiallyMissing && $value->isMissing()) ||
                 ($value instanceof self &&
-                $value->resource instanceof PotentiallyMissing &&
-                $value->isMissing())) {
+                    $value->resource instanceof PotentiallyMissing &&
+                    $value->isMissing())) {
                 unset($data[$key]);
             } else {
                 $numericKeys = $numericKeys && is_numeric($key);
@@ -90,29 +90,6 @@ trait ConditionallyLoadsAttributes
         }
 
         return $numericKeys ? array_values($data) : $data;
-    }
-
-    /**
-     * Retrieve a value based on a given condition.
-     *
-     * @param  bool  $condition
-     * @param  mixed  $value
-     * @param  mixed  $default
-     * @return \Illuminate\Http\Resources\MissingValue|\Illuminate\Support\HigherOrderWhenProxy|mixed
-     */
-    protected function when($condition, $value = null, $default = null)
-    {
-        if (func_num_args() === 1) {
-            return new HigherOrderWhenProxy($this, !$condition);
-        }
-
-        if (!$condition) {
-            return func_num_args() === 3
-                ? value($default)
-                : new MissingValue;
-        }
-
-        return value($value);
     }
 
     /**
@@ -211,9 +188,32 @@ trait ConditionallyLoadsAttributes
         return $this->when(
             $this->resource->$accessor &&
             ($this->resource->$accessor instanceof $table ||
-            $this->resource->$accessor->getTable() === $table),
+                $this->resource->$accessor->getTable() === $table),
             ...[$value, $default]
         );
+    }
+
+    /**
+     * Retrieve a value based on a given condition.
+     *
+     * @param  bool  $condition
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|\Illuminate\Support\HigherOrderWhenProxy|mixed
+     */
+    protected function when($condition, $value = null, $default = null)
+    {
+        if (func_num_args() === 1) {
+            return new HigherOrderWhenProxy($this, ! $condition);
+        }
+
+        if (! $condition) {
+            return func_num_args() === 3
+                ? value($default)
+                : new MissingValue;
+        }
+
+        return value($value);
     }
 
     /**

--- a/src/Illuminate/Support/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Support/HigherOrderWhenProxy.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Http\Resources\MissingValue;
+
+class HigherOrderWhenProxy
+{
+    /**
+     * The target being proxied.
+     *
+     * @var mixed
+     */
+    public $target;
+
+    /**
+     * The target is missing
+     *
+     * @var boolean
+     */
+    private $isMissing;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  mixed  $target
+     * @return void
+     */
+    public function __construct($target, bool $isMissing)
+    {
+        $this->target = $target;
+        $this->isMissing = $isMissing;
+    }
+
+    /**
+     * Dynamically pass method calls to the target.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->isMissing
+            ? new MissingValue()
+            : $this->target->{$method}(...$parameters);
+    }
+
+    /**
+     * Dynamically pass attribute calls to the target
+     *
+     * @param string $attributeName
+     * @return mixed
+     */
+    public function __get($attributeName)
+    {
+        return $this->isMissing
+             ? new MissingValue()
+             : $this->target->{$attributeName};
+    }
+}

--- a/src/Illuminate/Support/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Support/HigherOrderWhenProxy.php
@@ -14,9 +14,9 @@ class HigherOrderWhenProxy
     public $target;
 
     /**
-     * The target is missing
+     * The target is missing.
      *
-     * @var boolean
+     * @var bool
      */
     private $isMissing;
 
@@ -24,6 +24,7 @@ class HigherOrderWhenProxy
      * Create a new proxy instance.
      *
      * @param  mixed  $target
+     * @param  bool $isMissing
      * @return void
      */
     public function __construct($target, bool $isMissing)
@@ -47,15 +48,15 @@ class HigherOrderWhenProxy
     }
 
     /**
-     * Dynamically pass attribute calls to the target
+     * Dynamically pass attribute calls to the target.
      *
-     * @param string $attributeName
+     * @param  string  $attributeName
      * @return mixed
      */
     public function __get($attributeName)
     {
         return $this->isMissing
-             ? new MissingValue()
-             : $this->target->{$attributeName};
+            ? new MissingValue()
+            : $this->target->{$attributeName};
     }
 }

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithHigherOrderWhenProxy.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithHigherOrderWhenProxy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AuthorResourceWithHigherOrderWhenProxy extends JsonResource
+{
+    public function toArray($request)
+    {
+        $isConditionPasses = $request->conditionPasses === 'true';
+
+        return [
+            'name' => $this->when($isConditionPasses)->name,
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -1096,7 +1096,7 @@ class ResourceTest extends TestCase
 
     public function testHigherOrderWhenMethodWhenConditionPasses()
     {
-         Route::get('/', function () {
+        Route::get('/', function () {
             return AuthorResourceWithHigherOrderWhenProxy::make(
                 (object) ['name' => 'Bob']
             );
@@ -1114,7 +1114,7 @@ class ResourceTest extends TestCase
 
     public function testHigherOrderWhenMethodWhenConditionDoesntPass()
     {
-         Route::get('/', function () {
+        Route::get('/', function () {
             return AuthorResourceWithHigherOrderWhenProxy::make(
                 (object) ['name' => 'Bob']
             );
@@ -1139,6 +1139,4 @@ class ResourceTest extends TestCase
             ->assertStatus(200)
             ->assertExactJson($expectedJson);
     }
-
-
 }

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -10,6 +10,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
+use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithHigherOrderWhenProxy;
 use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
@@ -1093,6 +1094,40 @@ class ResourceTest extends TestCase
         ], ['data' => [0 => 10, 1 => 20, 'total' => 30]]);
     }
 
+    public function testHigherOrderWhenMethodWhenConditionPasses()
+    {
+         Route::get('/', function () {
+            return AuthorResourceWithHigherOrderWhenProxy::make(
+                (object) ['name' => 'Bob']
+            );
+        });
+
+        $this->withoutExceptionHandling()
+            ->get('/?conditionPasses=true', ['Accept' => 'application/json'])
+            ->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    'name' => 'Bob',
+                ],
+            ]);
+    }
+
+    public function testHigherOrderWhenMethodWhenConditionDoesntPass()
+    {
+         Route::get('/', function () {
+            return AuthorResourceWithHigherOrderWhenProxy::make(
+                (object) ['name' => 'Bob']
+            );
+        });
+
+        $this->withoutExceptionHandling()
+            ->get('/?conditionPasses=false', ['Accept' => 'application/json'])
+            ->assertStatus(200)
+            ->assertJsonMissing([
+                'data' => ['name'],
+            ]);
+    }
+
     private function assertJsonResourceResponse($data, $expectedJson)
     {
         Route::get('/', function () use ($data) {
@@ -1104,4 +1139,6 @@ class ResourceTest extends TestCase
             ->assertStatus(200)
             ->assertExactJson($expectedJson);
     }
+
+
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is my first PR on Laravel Framework Repository.

This PR is a development of an idea that I posted in Laravel Ideas repository (https://github.com/laravel/ideas/issues/1962)

Currently, when we need show a resource attribute based on a condition, we should use the 'when' method. But, the 'when' method needs a Closure as second argument. When we need choose to show a simple model attribute (for example), the code is quite polluted.

Example:

``` php
class Invoice extends Resource
{
    /**
     * Transform the resource into an array.
     *
     * @param  Request  $request
     * @return array
     */
    public function toArray($request)
    {
        return [
            'payer' => $this->when($this->status == 'processed', function () {
                  return $this->payer;
           })
       ]; 
    }
}
```

This PR allows to use a higher-order 'when' when isn't passed the second argument:
``` php
class Invoice extends Resource
{
    /**
     * Transform the resource into an array.
     *
     * @param  Request  $request
     * @return array
     */
    public function toArray($request)
    {
        return [
            'payer' => $this->when($this->status == 'processed')->payer;
       ];
    }
}
```