### PR TITLE
[6.x] Add 'setRawAttribute' method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -980,6 +980,25 @@ trait HasAttributes
     }
 
     /**
+     * Set the model attribute. No checking is done.
+     *
+     * @param  string  $key
+     * @param  mixed $value
+     * @param  bool  $sync
+     * @return $this
+     */
+    public function setRawAttribute($key, $value, $sync = false)
+    {
+        $this->attributes[$key] = $value;
+
+        if ($sync) {
+            $this->syncOriginalAttribute($key);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the model's original attribute values.
      *
      * @param  string|null  $key


### PR DESCRIPTION
```php
// Set attribute to value.
$model->setRawAttribute('key', $value);

// Set attribute to value and also sync to original attribute.
$model->setRawAttribute('key', $value, true);
```

Currently it's not possible to skip a mutator of one specific attribute.
The `setRawAttributes` method exists, but that requires you to provide values for all attributes.

I did not add any tests, because I could not find one for `setRawAttributes`. Let me know if I should add one.