### PR TITLE
[6.x] Allow groups of pluralization

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -8,7 +8,7 @@ class MessageSelector
 {
     /**
      * Select a proper translation string based on the given number.
-     * Supporting groups inside the string
+     * Supporting groups inside the string.
      *
      * @param  string  $line
      * @param  int  $number
@@ -18,14 +18,14 @@ class MessageSelector
     public function chooseGroups($line, $number, $locale)
     {
         // Find all brackets that contain at least one logical
-        // "or" symbol `|` for example "(...|...|...)"        
+        // "or" symbol `|` for example "(...|...|...)"
         $regex = '#\(([^)]*\|.*?)\)#';
         preg_match_all($regex, $line, $matches);
 
         // Select proper translation string of each bracket
         $replace = [];
         // Iterate matches without brackets
-        foreach($matches[1] as $match){
+        foreach ($matches[1] as $match) {
             $replace[] = $this->choose($match, $number, $locale);
         }
         // Replace matches including brackets

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -6,6 +6,25 @@ use Illuminate\Support\Str;
 
 class MessageSelector
 {
+    public function chooseGroups($line, $number, $locale)
+    {
+        // Find all brackets in string $line
+        // that contain at least one character |
+        // for example "(...|...|...)"
+        $regex = '#\(([^)]*\|.*?)\)#';
+        preg_match_all($regex, $line, $matches);
+
+        // Select proper translation string of each bracket
+        $replace = [];
+        foreach($matches[1] as $match){
+            $replace[] = $this->choose($match, $number, $locale);
+        }
+
+        $line = str_replace($matches[0], $replace, $line);
+
+        return $this->choose($line, $number, $locale);
+    }
+
     /**
      * Select a proper translation string based on the given number.
      *

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -6,11 +6,19 @@ use Illuminate\Support\Str;
 
 class MessageSelector
 {
+    /**
+     * Select a proper translation string based on the given number.
+     * Supporting groups inside the string
+     *
+     * @param  string  $line
+     * @param  int  $number
+     * @param  string  $locale
+     * @return mixed
+     */
     public function chooseGroups($line, $number, $locale)
     {
-        // Find all brackets in string $line
-        // that contain at least one character |
-        // for example "(...|...|...)"
+        // Find all brackets that contain at least one logical
+        // "or" symbol `|` for example "(...|...|...)"        
         $regex = '#\(([^)]*\|.*?)\)#';
         preg_match_all($regex, $line, $matches);
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -16,10 +16,11 @@ class MessageSelector
 
         // Select proper translation string of each bracket
         $replace = [];
+        // Iterate matches without brackets
         foreach($matches[1] as $match){
             $replace[] = $this->choose($match, $number, $locale);
         }
-
+        // Replace matches including brackets
         $line = str_replace($matches[0], $replace, $line);
 
         return $this->choose($line, $number, $locale);

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -159,7 +159,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         $replace['count'] = $number;
 
         return $this->makeReplacements(
-            $this->getSelector()->choose($line, $number, $locale), $replace
+            $this->getSelector()->chooseGroups($line, $number, $locale), $replace
         );
     }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -14,7 +14,18 @@ class TranslationMessageSelectorTest extends TestCase
     {
         $selector = new MessageSelector;
 
-        $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
+        $this->assertEquals($expected, $selector->chooseGroups($id, $number, 'en'));
+    }
+
+    public function testChooseGroups()
+    {
+        $selector = new MessageSelector;
+
+        $phrase   = 'There are ({0}none|[1,19]some|[20,*]many). There are ({0}x|[1,19]y|[20,*]z). (x).';
+
+        $this->assertEquals('There are none. There are x. (x).', $selector->chooseGroups($phrase, 0, 'en'));
+        $this->assertEquals('There are some. There are y. (x).', $selector->chooseGroups($phrase, 15, 'en'));
+        $this->assertEquals('There are many. There are z. (x).', $selector->chooseGroups($phrase, 20, 'en'));
     }
 
     public function chooseTestData()

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -21,7 +21,7 @@ class TranslationMessageSelectorTest extends TestCase
     {
         $selector = new MessageSelector;
 
-        $phrase   = 'There are ({0}none|[1,19]some|[20,*]many). There are ({0}x|[1,19]y|[20,*]z). (x).';
+        $phrase = 'There are ({0}none|[1,19]some|[20,*]many). There are ({0}x|[1,19]y|[20,*]z). (x).';
 
         $this->assertEquals('There are none. There are x. (x).', $selector->chooseGroups($phrase, 0, 'en'));
         $this->assertEquals('There are some. There are y. (x).', $selector->chooseGroups($phrase, 15, 'en'));


### PR DESCRIPTION
The goal of this PR is to simplify usage of localization [pluralization](https://laravel.com/docs/6.x/localization#pluralization).

Currently, its only possible to choose between complete sentences in pluralization: 

    'apples' => '{0} There are none|[1,19] There are some|[20,*] There are many',

However, in many languages, only 1-2 words change for singular/plural and it is cumbersome and redundant to copy/paste the complete sentence for pluralization. 

For exampe, the above string could be reduced to the more readable version:

    'apples' => 'There are ({0}none|[1,19]some|[20,*]many)',


This PR also supports multiple groups of pluralization. For example, this realistic German phrase:

    'anbei Deine Rechnung für Deine :orgas Mitgliedschaftsgebühr für :year.|anbei Eure Rechnung für Eure :orgas Mitgliedschaftsgebühr für :year.'

has the same output as this very readable version:

    'anbei (Deine|Eure) Rechnung für (Deine|Eure) :orgas Mitgliedschaftsgebühr für :year.'


PS: If this gets merged, I would create a separate PR to update the docs.
