### PR TITLE
[7.x] Return API Style Responses On XHR Requests To Auth Scaffodling

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -112,7 +112,7 @@ trait AuthenticatesUsers
         }
 
         return $request->wantsJson()
-                    ? new Response
+                    ? new Response('', 204)
                     : redirect()->intended($this->redirectPath());
     }
 

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
@@ -106,8 +107,13 @@ trait AuthenticatesUsers
 
         $this->clearLoginAttempts($request);
 
-        return $this->authenticated($request, $this->guard()->user())
-                ?: redirect()->intended($this->redirectPath());
+        if ($response = $this->authenticated($request, $this->guard()->user())) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+                    ? new Response
+                    : redirect()->intended($this->redirectPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 trait ConfirmsPasswords
 {
@@ -30,7 +31,9 @@ trait ConfirmsPasswords
 
         $this->resetPasswordConfirmationTimeout($request);
 
-        return redirect()->intended($this->redirectPath());
+        return $request->wantsJson()
+                    ? new Response
+                    : redirect()->intended($this->redirectPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
+++ b/src/Illuminate/Foundation/Auth/ConfirmsPasswords.php
@@ -32,7 +32,7 @@ trait ConfirmsPasswords
         $this->resetPasswordConfirmationTimeout($request);
 
         return $request->wantsJson()
-                    ? new Response
+                    ? new Response('', 204)
                     : redirect()->intended($this->redirectPath());
     }
 

--- a/src/Illuminate/Foundation/Auth/RegistersUsers.php
+++ b/src/Illuminate/Foundation/Auth/RegistersUsers.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Auth;
 
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 
 trait RegistersUsers
@@ -34,8 +35,13 @@ trait RegistersUsers
 
         $this->guard()->login($user);
 
-        return $this->registered($request, $user)
-                        ?: redirect($this->redirectPath());
+        if ($response = $this->registered($request, $user)) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+                    ? new Response('', 201)
+                    : redirect($this->redirectPath());
     }
 
     /**

--- a/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
+++ b/src/Illuminate/Foundation/Auth/SendsPasswordResetEmails.php
@@ -2,8 +2,10 @@
 
 namespace Illuminate\Foundation\Auth;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
 
 trait SendsPasswordResetEmails
 {
@@ -70,7 +72,9 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkResponse(Request $request, $response)
     {
-        return back()->with('status', trans($response));
+        return $request->wantsJson()
+                    ? new JsonResponse(['message' => trans($response)], 200)
+                    : back()->with('status', trans($response));
     }
 
     /**
@@ -82,6 +86,12 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {
+        if ($request->wantsJson()) {
+            throw ValidationException::withMessages([
+                'email' => [trans($response)],
+            ]);
+        }
+
         return back()
                 ->withInput($request->only('email'))
                 ->withErrors(['email' => trans($response)]);

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -44,7 +44,7 @@ trait VerifiesEmails
 
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
-                        ? new Response
+                        ? new Response('', 204)
                         : redirect($this->redirectPath());
         }
 
@@ -53,7 +53,7 @@ trait VerifiesEmails
         }
 
         return $request->wantsJson()
-                    ? new Response
+                    ? new Response('', 204)
                     : redirect($this->redirectPath())->with('verified', true);
     }
 
@@ -67,7 +67,7 @@ trait VerifiesEmails
     {
         if ($request->user()->hasVerifiedEmail()) {
             return $request->wantsJson()
-                        ? new Response
+                        ? new Response('', 204)
                         : redirect($this->redirectPath());
         }
 

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Auth;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 trait VerifiesEmails
 {
@@ -42,14 +43,18 @@ trait VerifiesEmails
         }
 
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return $request->wantsJson()
+                        ? new Response
+                        : redirect($this->redirectPath());
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect($this->redirectPath())->with('verified', true);
+        return $request->wantsJson()
+                    ? new Response
+                    : redirect($this->redirectPath())->with('verified', true);
     }
 
     /**
@@ -61,11 +66,15 @@ trait VerifiesEmails
     public function resend(Request $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return $request->wantsJson()
+                        ? new Response
+                        : redirect($this->redirectPath());
         }
 
         $request->user()->sendEmailVerificationNotification();
 
-        return back()->with('resent', true);
+        return $request->wantsJson()
+                    ? new Response('', 202)
+                    : back()->with('resent', true);
     }
 }


### PR DESCRIPTION
This updates the authentication scaffolding to return normal 2xx level (or 4xx on validation) responses on XHR requests to the scaffolding backend instead of returning redirects and manipulating the session, etc.

JSON payload is returned where appropriate.