### PR TITLE
[6.x] Let PhpRedisConnector support unix sock

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -110,21 +110,21 @@ class PhpRedisConnector implements Connector
     protected function establishConnection($client, array $config)
     {
         $persistent = $config['persistent'] ?? false;
-		if (isset($config['path'])) {
-			$parameters = [$config['path']];
-		} else {
-			$parameters = [
-				$config['host'],
-				$config['port'],
-				Arr::get($config, 'timeout', 0.0),
-				$persistent ? Arr::get($config, 'persistent_id', null) : null,
-				Arr::get($config, 'retry_interval', 0),
-			];
+        if (isset($config['path'])) {
+            $parameters = [$config['path']];
+        } else {
+            $parameters = [
+                $config['host'],
+                $config['port'],
+                Arr::get($config, 'timeout', 0.0),
+           	    $persistent ? Arr::get($config, 'persistent_id', null) : null,
+                Arr::get($config, 'retry_interval', 0),
+            ];
 
-			if (version_compare(phpversion('redis'), '3.1.3', '>=')) {
-				$parameters[] = Arr::get($config, 'read_timeout', 0.0);
-			}
-		}
+            if (version_compare(phpversion('redis'), '3.1.3', '>=')) {
+                $parameters[] = Arr::get($config, 'read_timeout', 0.0);
+            }
+        }
         $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
     }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -117,7 +117,7 @@ class PhpRedisConnector implements Connector
                 $config['host'],
                 $config['port'],
                 Arr::get($config, 'timeout', 0.0),
-           	    $persistent ? Arr::get($config, 'persistent_id', null) : null,
+                $persistent ? Arr::get($config, 'persistent_id', null) : null,
                 Arr::get($config, 'retry_interval', 0),
             ];
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -110,19 +110,21 @@ class PhpRedisConnector implements Connector
     protected function establishConnection($client, array $config)
     {
         $persistent = $config['persistent'] ?? false;
+		if (isset($config['path'])) {
+			$parameters = [$config['path']];
+		} else {
+			$parameters = [
+				$config['host'],
+				$config['port'],
+				Arr::get($config, 'timeout', 0.0),
+				$persistent ? Arr::get($config, 'persistent_id', null) : null,
+				Arr::get($config, 'retry_interval', 0),
+			];
 
-        $parameters = [
-            $config['host'],
-            $config['port'],
-            Arr::get($config, 'timeout', 0.0),
-            $persistent ? Arr::get($config, 'persistent_id', null) : null,
-            Arr::get($config, 'retry_interval', 0),
-        ];
-
-        if (version_compare(phpversion('redis'), '3.1.3', '>=')) {
-            $parameters[] = Arr::get($config, 'read_timeout', 0.0);
-        }
-
+			if (version_compare(phpversion('redis'), '3.1.3', '>=')) {
+				$parameters[] = Arr::get($config, 'read_timeout', 0.0);
+			}
+		}
         $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
     }
 


### PR DESCRIPTION
When I use client predis to connect Redis,

I can connect to unix socket thouth config like below
```   
'redis' => [
    'client' => 'predis',
    'default' => [
        'scheme' => 'unix', 
        'path' => env('REDIS_PATH', '/var/run/redis/cache.sock'),
        'database' => 0,
        'persistent' => true,
    ],
],
```
but with client phpredis implement with PhpRedisConnector, 
I found no way I can config to connect with local redis unix socket.

so I provide this PR to support a config argument 'path' to redis connected through socket like predis can do.

I tested at my local and worked without issue