### PR TITLE
[6.x] Change Facade::getFacadeAccessor() to an abstract method

### DIFF
--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -170,13 +170,8 @@ abstract class Facade
      * Get the registered name of the component.
      *
      * @return string
-     *
-     * @throws \RuntimeException
      */
-    protected static function getFacadeAccessor()
-    {
-        throw new RuntimeException('Facade does not implement getFacadeAccessor method.');
-    }
+    abstract protected static function getFacadeAccessor();
 
     /**
      * Resolve the facade root instance from the container.


### PR DESCRIPTION
In this case, require subclasses to provide implementations for this method can expose problems early in coding phase, rather than exposing problems through RuntimeException at actual runtime.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
