### PR TITLE
[6.x] Add previous exception to EntryNotFoundException thrown in Container.php

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -641,7 +641,7 @@ class Container implements ArrayAccess, ContainerContract
                 throw $e;
             }
 
-            throw new EntryNotFoundException($id);
+            throw new EntryNotFoundException($id, $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
The title says it all.

To allow for easier debugging of container resolving issues. The exception thrown should be included in the EntryNotFoundException.