### PR TITLE
[7.x] Remove Factory "types"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -69,29 +69,15 @@ class Factory implements ArrayAccess
     }
 
     /**
-     * Define a class with a given short-name.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  callable  $attributes
-     * @return $this
-     */
-    public function defineAs($class, $name, callable $attributes)
-    {
-        return $this->define($class, $attributes, $name);
-    }
-
-    /**
      * Define a class with a given set of attributes.
      *
      * @param  string  $class
      * @param  callable  $attributes
-     * @param  string  $name
      * @return $this
      */
-    public function define($class, callable $attributes, $name = 'default')
+    public function define($class, callable $attributes)
     {
-        $this->definitions[$class][$name] = $attributes;
+        $this->definitions[$class] = $attributes;
 
         return $this;
     }
@@ -180,19 +166,6 @@ class Factory implements ArrayAccess
     }
 
     /**
-     * Create an instance of the given model and type and persist it to the database.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  array  $attributes
-     * @return mixed
-     */
-    public function createAs($class, $name, array $attributes = [])
-    {
-        return $this->of($class, $name)->create($attributes);
-    }
-
-    /**
      * Create an instance of the given model.
      *
      * @param  string  $class
@@ -205,43 +178,16 @@ class Factory implements ArrayAccess
     }
 
     /**
-     * Create an instance of the given model and type.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  array  $attributes
-     * @return mixed
-     */
-    public function makeAs($class, $name, array $attributes = [])
-    {
-        return $this->of($class, $name)->make($attributes);
-    }
-
-    /**
-     * Get the raw attribute array for a given named model.
-     *
-     * @param  string  $class
-     * @param  string  $name
-     * @param  array  $attributes
-     * @return array
-     */
-    public function rawOf($class, $name, array $attributes = [])
-    {
-        return $this->raw($class, $attributes, $name);
-    }
-
-    /**
      * Get the raw attribute array for a given model.
      *
      * @param  string  $class
      * @param  array  $attributes
-     * @param  string  $name
      * @return array
      */
-    public function raw($class, array $attributes = [], $name = 'default')
+    public function raw($class, array $attributes = [])
     {
         return array_merge(
-            call_user_func($this->definitions[$class][$name], $this->faker), $attributes
+            call_user_func($this->definitions[$class], $this->faker), $attributes
         );
     }
 
@@ -249,13 +195,12 @@ class Factory implements ArrayAccess
      * Create a builder for the given model.
      *
      * @param  string  $class
-     * @param  string  $name
      * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
-    public function of($class, $name = 'default')
+    public function of($class)
     {
         return new FactoryBuilder(
-            $class, $name, $this->definitions, $this->states,
+            $class, $this->definitions, $this->states,
             $this->afterMaking, $this->afterCreating, $this->faker
         );
     }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -25,13 +25,6 @@ class FactoryBuilder
     protected $class;
 
     /**
-     * The name of the model being built.
-     *
-     * @var string
-     */
-    protected $name = 'default';
-
-    /**
      * The database connection on which the model instance should be persisted.
      *
      * @var string
@@ -84,7 +77,6 @@ class FactoryBuilder
      * Create an new builder instance.
      *
      * @param  string  $class
-     * @param  string  $name
      * @param  array  $definitions
      * @param  array  $states
      * @param  array  $afterMaking
@@ -92,10 +84,9 @@ class FactoryBuilder
      * @param  \Faker\Generator  $faker
      * @return void
      */
-    public function __construct($class, $name, array $definitions, array $states,
+    public function __construct($class, array $definitions, array $states,
                                 array $afterMaking, array $afterCreating, Faker $faker)
     {
-        $this->name = $name;
         $this->class = $class;
         $this->faker = $faker;
         $this->states = $states;
@@ -265,12 +256,12 @@ class FactoryBuilder
      */
     protected function getRawAttributes(array $attributes = [])
     {
-        if (! isset($this->definitions[$this->class][$this->name])) {
-            throw new InvalidArgumentException("Unable to locate factory with name [{$this->name}] [{$this->class}].");
+        if (! isset($this->definitions[$this->class])) {
+            throw new InvalidArgumentException("Unable to locate factory for [{$this->class}].");
         }
 
         $definition = call_user_func(
-            $this->definitions[$this->class][$this->name],
+            $this->definitions[$this->class],
             $this->faker, $attributes
         );
 
@@ -403,7 +394,7 @@ class FactoryBuilder
      */
     protected function callAfter(array $afterCallbacks, $models)
     {
-        $states = array_merge([$this->name], $this->activeStates);
+        $states = array_merge(['default'], $this->activeStates);
 
         $models->each(function ($model) use ($states, $afterCallbacks) {
             foreach ($states as $state) {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -484,24 +484,21 @@ if (! function_exists('event')) {
 
 if (! function_exists('factory')) {
     /**
-     * Create a model factory builder for a given class, name, and amount.
+     * Create a model factory builder for a given class and amount.
      *
-     * @param  dynamic  class|class,name|class,amount|class,name,amount
+     * @param  string  $class
+     * @param  int  $amount
      * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
-    function factory()
+    function factory($class, $amount = null)
     {
         $factory = app(EloquentFactory::class);
 
-        $arguments = func_get_args();
-
-        if (isset($arguments[1]) && is_string($arguments[1])) {
-            return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);
-        } elseif (isset($arguments[1])) {
-            return $factory->of($arguments[0])->times($arguments[1]);
+        if (isset($amount) && is_int($amount)) {
+            return $factory->of($class)->times($amount);
         }
 
-        return $factory->of($arguments[0]);
+        return $factory->of($class);
     }
 }
 


### PR DESCRIPTION
Way back in October 2016, I created the factory "states" feature, and added documentation for it.

https://github.com/laravel/framework/pull/14241
https://github.com/laravel/docs/pull/2735/files

A couple days later Taylor removed all reference to factory "types" from the documentation.

https://github.com/laravel/docs/commit/e38e88b48fe0f3af3cae848a8ab4b37415a624cc#diff-1620181c4412a72179f78bc2be6c6e68

Going on 3 years here I think we're good to remove the old functionality from the FW in the next major.

It appears the feature was never tested, so everything is still green with no changes to the tests.