### PR TITLE
[6.x] Fix Builder::withCount() binding error when a scope is added into related model with binding in a sub-select

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -390,6 +390,7 @@ trait QueriesRelationships
 
             if (count($query->columns) > 1) {
                 $query->columns = [$query->columns[0]];
+                $query->bindings['select'] = [];
             }
 
             // Finally we will add the proper result column alias to the query and run the subselect

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -864,6 +864,19 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertEquals(['baz', 'qux', 'quuux'], $builder->getBindings());
     }
 
+    public function testWithCountAndConstraintsWithBindingInSelectSub()
+    {
+        $model = new EloquentBuilderTestModelParentStub;
+
+        $builder = $model->newQuery();
+        $builder->withCount(['foo' => function ($q) use ($model) {
+            $q->selectSub($model->newQuery()->where('bam', '=', 3)->selectRaw('count(0)'), 'bam_3_count');
+        }]);
+
+        $this->assertSame('select "eloquent_builder_test_model_parent_stubs".*, (select count(*) from "eloquent_builder_test_model_close_related_stubs" where "eloquent_builder_test_model_parent_stubs"."foo_id" = "eloquent_builder_test_model_close_related_stubs"."id") as "foo_count" from "eloquent_builder_test_model_parent_stubs"', $builder->toSql());
+        $this->assertSame([], $builder->getBindings());
+    }
+
     public function testHasNestedWithConstraints()
     {
         $model = new EloquentBuilderTestModelParentStub;


### PR DESCRIPTION
In current Laravel, Builder::withCount() causes an error if the related model has a scope which adds a sub-select with bindings, for example, the following scope attempts to add a column called "liked" into Likeable models, but causes an error when a model with it is loaded in Builder::withCount().

```
class LikeScope implements Scope
{
    public function apply(Builder $builder, Model $model)
    {
        if ($model instanceof Likeable) {
            if ($builder->getQuery()->columns === null) {
                $builder->select(['*']);
            }
            $builder->selectSub(
                Like::whereColumn('likeable_id', '=', $model->getTable() . '.id')->whereLikeableType($model->getMorphClass())->whereUserId(
                    app(User::class)->id
                )
                    ->selectRaw('count(*)')
                ,
                'liked'
            );
        }
    }
}

```

It's because Builder::withCount() removes extra columns added by the scope when loading the count, but forgets to remove the extra "select" bindings added.

This one-line patch fixes the problem.