### PR TITLE
[6.x] Allow configurable emergency logger

### DIFF
--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -159,13 +159,17 @@ class LogManager implements LoggerInterface
     /**
      * Create an emergency log handler to avoid white screens of death.
      *
-     * @return \Psr\Log\LoggerInterface
+     * @return \Illuminate\Log\Logger|\Psr\Log\LoggerInterface
      */
     protected function createEmergencyLogger()
     {
-        return new Logger(new Monolog('laravel', $this->prepareHandlers([new StreamHandler(
-                $this->app->storagePath().'/logs/laravel.log', $this->level(['level' => 'debug'])
-        )])), $this->app['events']);
+        $config = $this->configurationFor('emergency');
+
+        return new Logger(
+            new Monolog('laravel', $this->prepareHandlers([
+                new StreamHandler($config['path'], $this->level(['level' => 'debug'])),
+            ])), $this->app['events']
+        );
     }
 
     /**

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -165,10 +165,14 @@ class LogManager implements LoggerInterface
     {
         $config = $this->configurationFor('emergency');
 
+        $handler = new StreamHandler(
+            $config['path'] ?? $this->app->storagePath().'/logs/laravel.log',
+            $this->level(['level' => 'debug'])
+        );
+
         return new Logger(
-            new Monolog('laravel', $this->prepareHandlers([
-                new StreamHandler($config['path'] ?? storage_path('logs/laravel.log'), $this->level(['level' => 'debug'])),
-            ])), $this->app['events']
+            new Monolog('laravel', $this->prepareHandlers([$handler])),
+            $this->app['events']
         );
     }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -159,7 +159,7 @@ class LogManager implements LoggerInterface
     /**
      * Create an emergency log handler to avoid white screens of death.
      *
-     * @return \Illuminate\Log\Logger|\Psr\Log\LoggerInterface
+     * @return \Psr\Log\LoggerInterface
      */
     protected function createEmergencyLogger()
     {

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -167,7 +167,7 @@ class LogManager implements LoggerInterface
 
         return new Logger(
             new Monolog('laravel', $this->prepareHandlers([
-                new StreamHandler($config['path'], $this->level(['level' => 'debug'])),
+                new StreamHandler($config['path'] ?? storage_path('logs/laravel.log'), $this->level(['level' => 'debug'])),
             ])), $this->app['events']
         );
     }


### PR DESCRIPTION
This allows for an emergency logger channel config item in config/logging.php

Use case: Serverless environment or Docker container without persistent storage. If main logger fails, logs may be lost. This will help prevent that by allowing us to specify stderr or stdout as the logger's path. (This will allow us to forward logs onto an ELK stack etc.)

Relies on: https://github.com/laravel/laravel/pull/5179