### PR TITLE
[7.x] Return API style responses on requests to logout

### DIFF
--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -165,7 +165,13 @@ trait AuthenticatesUsers
 
         $request->session()->invalidate();
 
-        return $this->loggedOut($request) ?: redirect('/');
+        if ($response = $this->loggedOut($request)) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+            ? new Response('', 204)
+            : redirect($this->redirectPath());
     }
 
     /**


### PR DESCRIPTION
On #30855, Taylor missed the `logout` method. This PR also makes it respect the `$this->redirectPath()` when a redirection after logout is needed.
