### PR TITLE
[7.x] Middleware priority using interfaces

### DIFF
--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -40,7 +40,7 @@ class SortedMiddleware extends Collection
                 continue;
             }
 
-            $priorityIndex = $this->priorityIndex($priorityMap, $middleware);
+            $priorityIndex = $this->priorityMapIndex($priorityMap, $middleware);
 
             if (! is_null($priorityIndex)) {
                 // This middleware is in the priority map. If we have encountered another middleware
@@ -81,7 +81,7 @@ class SortedMiddleware extends Collection
     }
 
     /**
-     * Calculate the priority index of the middleware.
+     * Calculate the priority map index of the middleware.
      *
      * This calculated by first seeing if the name exists in the priority list,
      * and if it doesn't we see if it implements any interfaces in the list.
@@ -93,7 +93,7 @@ class SortedMiddleware extends Collection
     protected function priorityMapIndex($priorityMap, $middleware)
     {
         foreach ($this->middlewareNames($middleware) as $name) {
-            $priorityIndex = array_search($stripped, $priorityMap);
+            $priorityIndex = array_search($name, $priorityMap);
             if ($priorityIndex !== false) {
                 return $priorityIndex;
             }

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -40,11 +40,9 @@ class SortedMiddleware extends Collection
                 continue;
             }
 
-            $stripped = head(explode(':', $middleware));
+            $priorityIndex = $this->priorityIndex($priorityMap, $middleware);
 
-            if (in_array($stripped, $priorityMap)) {
-                $priorityIndex = array_search($stripped, $priorityMap);
-
+            if (! is_null($priorityIndex)) {
                 // This middleware is in the priority map. If we have encountered another middleware
                 // that was also in the priority map and was at a lower priority than the current
                 // middleware, we will move this middleware to be above the previous encounter.
@@ -80,5 +78,46 @@ class SortedMiddleware extends Collection
         unset($middlewares[$from + 1]);
 
         return $middlewares;
+    }
+
+    /**
+     * Calculate the priority index of the middleware.
+     *
+     * This calculated by first seeing if the name exists in the priority list,
+     * and if it doesn't we see if it implements any interfaces in the list.
+     *
+     * @param  array  $priorityMap
+     * @param  string  $middleware
+     * @return int|null
+     */
+    protected function priorityMapIndex($priorityMap, $middleware)
+    {
+        foreach ($this->middlewareNames($middleware) as $name) {
+            $priorityIndex = array_search($stripped, $priorityMap);
+            if ($priorityIndex !== false) {
+                return $priorityIndex;
+            }
+        }
+    }
+
+    /**
+     * Calculate the middleware names to look for in the priority array.
+     *
+     * @param  string  $middleware
+     * @return \Generator
+     */
+    protected function middlewareNames($middleware)
+    {
+        $stripped = head(explode(':', $middleware));
+
+        yield $stripped;
+
+        $interfaces = @class_implements($stripped);
+
+        if ($interfaces !== false) {
+            foreach ($interfaces as $interface) {
+                yield $interface;
+            }
+        }
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -846,12 +846,13 @@ class RoutingRouteTest extends TestCase
             SubstituteBindings::class,
             Placeholder2::class,
             Authenticate::class,
+            ExampleMiddleware::class,
             Placeholder3::class,
         ];
 
         $router = $this->getRouter();
 
-        $router->middlewarePriority = [Authenticate::class, SubstituteBindings::class, Authorize::class];
+        $router->middlewarePriority = [ExampleMiddlewareContract::class, Authenticate::class, SubstituteBindings::class, Authorize::class];
 
         $route = $router->get('foo', ['middleware' => $middleware, 'uses' => function ($name) {
             return $name;
@@ -859,6 +860,7 @@ class RoutingRouteTest extends TestCase
 
         $this->assertEquals([
             Placeholder1::class,
+            ExampleMiddleware::class,
             Authenticate::class,
             SubstituteBindings::class,
             Placeholder2::class,
@@ -2091,5 +2093,18 @@ class ActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+}
+
+interface ExampleMiddlewareContract
+{
+    //
+}
+
+class ExampleMiddleware implements ExampleMiddlewareContract
+{
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
     }
 }


### PR DESCRIPTION
Look at what an middleware implements when computing the priority. This allows specification of priority using interfaces, without knowing the actual class ahead of time.

---

This means that users don't need to bind an interface within the container to use the priorities: https://github.com/laravel/laravel/pull/5182.