### PR TITLE
[7.x] Fix: replaceInputPlaceholder() should replace :input by its displayable value

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -295,7 +295,7 @@ trait FormatsMessages
         $actualValue = $this->getValue($attribute);
 
         if (is_scalar($actualValue) || is_null($actualValue)) {
-            $message = str_replace(':input', $actualValue, $message);
+            $message = str_replace(':input', $this->getDisplayableValue($attribute, $actualValue), $message);
         }
 
         return $message;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -403,6 +403,27 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(' is not a valid email', $v->messages()->first('email'));
     }
 
+    public function testInputIsReplacedByItsDisplayableValue()
+    {
+        $frameworks = [
+            1 => 'Laravel',
+            2 => 'Symfony',
+            3 => 'Rails',
+        ];
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $trans->addLines(['validation.framework_php' => ':input is not a valid PHP Framework'], 'en');
+
+        $v = new Validator($trans, ['framework' => 3], ['framework' => 'framework_php']);
+        $v->addExtension('framework_php', function ($attribute, $value, $parameters, $validator) {
+            return in_array($value, [1, 2]);
+        });
+        $v->addCustomValues(['framework' => $frameworks]);
+
+        $this->assertFalse($v->passes());
+        $this->assertSame('Rails is not a valid PHP Framework', $v->messages()->first('framework'));
+    }
+
     public function testDisplayableValuesAreReplaced()
     {
         //required_if:foo,bar


### PR DESCRIPTION
# Overview

This PR makes `Validator` to use custom values for replacing `:input` placeholders. The `getDisplayableValue()` method was used in rule-specific placeholders of the following rules but it did not support `:input`.

- `in`
  - `:values`
- `required_if`
  - `:other` `:value`
- `required_unless`
  - `:other` `:values`
- `before`
  - `:date`
- `ends_with`
  - `:values`
- `starts_with`
  - `:values`

From the testing code:

```php
$frameworks = [
    1 => 'Laravel',
    2 => 'Symfony',
    3 => 'Rails',
];

$trans = $this->getIlluminateArrayTranslator();
$trans->addLines(['validation.framework_php' => ':input is not a valid PHP Framework'], 'en');

$v = new Validator($trans, ['framework' => 3], ['framework' => 'framework_php']);
$v->addExtension('framework_php', function ($attribute, $value, $parameters, $validator) {
    return in_array($value, [1, 2]);
});
$v->addCustomValues(['framework' => $frameworks]);

$this->assertFalse($v->passes());

// Previously it was "3 is not a valid PHP Framework"
$this->assertSame('Rails is not a valid PHP Framework', $v->messages()->first('framework'));
```

# Diff

```diff
diff --git a/src/Illuminate/Validation/Concerns/FormatsMessages.php b/src/Illuminate/Validation/Concerns/FormatsMessages.php
index 378eb6c6b4f..b260dbecf58 100644
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -295,7 +295,7 @@ protected function replaceInputPlaceholder($message, $attribute)
         $actualValue = $this->getValue($attribute);
 
         if (is_scalar($actualValue) || is_null($actualValue)) {
-            $message = str_replace(':input', $actualValue, $message);
+            $message = str_replace(':input', $this->getDisplayableValue($attribute, $actualValue), $message);
         }
 
         return $message;
```