### PR TITLE
[6.x] TransactionCommitted event doesn’t contain transaction level I’d expect it to

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -171,9 +171,9 @@ trait ManagesTransactions
             $this->getPdo()->commit();
         }
 
-        $this->transactions = max(0, $this->transactions - 1);
-
         $this->fireConnectionEvent('committed');
+
+        $this->transactions = max(0, $this->transactions - 1);
     }
 
     /**


### PR DESCRIPTION
 Fire transactionCommitted event before decrementing the transaction level ! as described here #30756 