### PR TITLE
[6.x] Search for Similar Results

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -77,13 +77,25 @@ class HasInDatabase extends Constraint
     {
         $query = $this->database->table($table);
 
-        $results = $query->limit($this->show)->get();
+        $key = array_key_first($this->data);
+        $value = $this->data[$key];
+        $similarResults = $query->where($key, $value)->limit($this->show)->get();
 
-        if ($results->isEmpty()) {
-            return 'The table is empty';
+        if ($similarResults->isNotEmpty()) {
+            $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
         }
 
-        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+        else {
+            $query = $this->database->table($table);
+
+            $results = $query->limit($this->show)->get();
+
+            if ($results->isEmpty()) {
+                return 'The table is empty';
+            }
+
+            $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+        }
 
         if ($query->count() > $this->show) {
             $description .= sprintf(' and %s others', $query->count() - $this->show);

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -83,9 +83,7 @@ class HasInDatabase extends Constraint
 
         if ($similarResults->isNotEmpty()) {
             $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
-        }
-
-        else {
+        } else {
             $query = $this->database->table($table);
 
             $results = $query->limit($this->show)->get();


### PR DESCRIPTION
When using the `assertDatabaseHas()` assertion, the failure method returns the first couple results out of the database.  This is not incredibly useful since those results are not guaranteed to contain the row of our expected data.

This PR allow the failure message to make an educated guess on the DB row we are most likely trying to compare to. It gives priority to the first key/value pair in our expected data, and performs a query based solely on that 1 piece of information.  If it finds rows matching this data, it will return them.  If it doesn't find any results from its educated guess, it will fallback to the current method of returning results.