### PR TITLE
[6.x] Float database types fix

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -833,9 +833,7 @@ class Blueprint
      */
     public function unsignedDecimal($column, $total = 8, $places = 2)
     {
-        return $this->addColumn('decimal', $column, [
-            'total' => $total, 'places' => $places, 'unsigned' => true,
-        ]);
+        return $this->decimal($column, $total, $places, true);
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -787,11 +787,12 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
+     * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function float($column, $total = 8, $places = 2)
+    public function float($column, $total = 8, $places = 2, $unsigned = false)
     {
-        return $this->addColumn('float', $column, compact('total', 'places'));
+        return $this->addColumn('float', $column, compact('total', 'places', 'unsigned'));
     }
 
     /**
@@ -800,11 +801,12 @@ class Blueprint
      * @param  string  $column
      * @param  int|null  $total
      * @param  int|null  $places
+     * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function double($column, $total = null, $places = null)
+    public function double($column, $total = null, $places = null, $unsigned = false)
     {
-        return $this->addColumn('double', $column, compact('total', 'places'));
+        return $this->addColumn('double', $column, compact('total', 'places', 'unsigned'));
     }
 
     /**
@@ -813,11 +815,12 @@ class Blueprint
      * @param  string  $column
      * @param  int  $total
      * @param  int  $places
+     * @param  bool  $unsigned
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function decimal($column, $total = 8, $places = 2)
+    public function decimal($column, $total = 8, $places = 2, $unsigned = false)
     {
-        return $this->addColumn('decimal', $column, compact('total', 'places'));
+        return $this->addColumn('decimal', $column, compact('total', 'places', 'unsigned'));
     }
 
     /**


### PR DESCRIPTION
At the moment it's **impossible to change unsigned float/decimal columns to signed using Laravel Blueprint methods**. This change fixes the problem (uses unsigned=false by default) and addition allows to pass unsigned state to methods when creating columns. 

For consitency same change was done for double however it's impossible to update double colum out of the box using doctribe/dbal.

Proof of problem:

1st migration:

```
Schema::create('users', function (Blueprint $table) {
    $table->bigIncrements('id');
    $table->integer('a')->unsigned();
    $table->float('b')->unsigned();
    $table->decimal('d')->unsigned();
});
```

2nd migration:

```
Schema::table('users', function (Blueprint $table) {
    $table->integer('a')->change();
    $table->float('b')->change();
    $table->decimal('d')->change();
});

```

Run first migration and then run `migrate --pretend` as a result you get:

```
ALTER TABLE users CHANGE a a INT NOT NULL, CHANGE b b DOUBLE PRECISION UNSIGNED NOT NULL, CHANGE d d NUMERIC(8, 2) UNSIGNED NOT NULL
```

As you see integer column was changed to signed, however float and decimal weren't. After fix result of this is:

```
ALTER TABLE users CHANGE a a INT NOT NULL, CHANGE b b DOUBLE PRECISION NOT NULL, CHANGE d d NUMERIC(8, 2) NOT NULL
```

as expected.
