### PR TITLE
[6.x] Zend framework license link fix

### DIFF
--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -100,7 +100,7 @@ class MessageSelector
      * Get the index to use for pluralization.
      *
      * The plural rules are derived from code of the Zend Framework (2010-09-25), which
-     * is subject to the new BSD license (http://framework.zend.com/license/new-bsd)
+     * is subject to the new BSD license (https://framework.zend.com/license)
      * Copyright (c) 2005-2010 - Zend Technologies USA Inc. (http://www.zend.com)
      *
      * @param  string  $locale


### PR DESCRIPTION
Fixing license URL for Zend Framework