### PR TITLE
[6.x] Handle passing too many arguments to `@slot`

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -3,8 +3,8 @@
 namespace Illuminate\View\Concerns;
 
 use Illuminate\Support\Arr;
-use InvalidArgumentException;
 use Illuminate\Support\HtmlString;
+use InvalidArgumentException;
 
 trait ManagesComponents
 {
@@ -107,7 +107,7 @@ trait ManagesComponents
     public function slot($name, $content = null)
     {
         if (func_num_args() > 2) {
-            throw new InvalidArgumentException('You passed the slot [' . $name . '] too many arguments.');
+            throw new InvalidArgumentException('You passed the slot ['.$name.'] too many arguments.');
         } elseif (func_num_args() === 2) {
             $this->slots[$this->currentComponent()][$name] = $content;
         } elseif (ob_start()) {

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Concerns;
 
 use Illuminate\Support\Arr;
+use InvalidArgumentException;
 use Illuminate\Support\HtmlString;
 
 trait ManagesComponents
@@ -105,14 +106,14 @@ trait ManagesComponents
      */
     public function slot($name, $content = null)
     {
-        if (func_num_args() === 2) {
+        if (func_num_args() > 2) {
+            throw new InvalidArgumentException('You passed the slot [' . $name . '] too many arguments.');
+        } elseif (func_num_args() === 2) {
             $this->slots[$this->currentComponent()][$name] = $content;
-        } else {
-            if (ob_start()) {
-                $this->slots[$this->currentComponent()][$name] = '';
+        } elseif (ob_start()) {
+            $this->slots[$this->currentComponent()][$name] = '';
 
-                $this->slotStack[$this->currentComponent()][] = $name;
-            }
+            $this->slotStack[$this->currentComponent()][] = $name;
         }
     }
 


### PR DESCRIPTION
### Problem

Passing too many arguments to a `@slot` directive will start an output buffer without closing it.

This can cause the cryptic "Test code or tested code did not (only) close its own output buffers" error message.

### Solution

This PR checks to see if more than 2 parameters have been passed to the `@slot`, and throws an Exception with an explanation of the issue.
