### PR TITLE
[6.x] Add new validateWithBag macro to Request

### DIFF
--- a/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Providers;
 use Illuminate\Http\Request;
 use Illuminate\Support\AggregateServiceProvider;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Validation\ValidationException;
 
 class FoundationServiceProvider extends AggregateServiceProvider
 {
@@ -53,6 +54,16 @@ class FoundationServiceProvider extends AggregateServiceProvider
     {
         Request::macro('validate', function (array $rules, ...$params) {
             return validator()->validate($this->all(), $rules, ...$params);
+        });
+
+        Request::macro('validateWithBag', function (string $errorBag, array $rules, ...$params) {
+            try {
+                return $this->validate($rules, ...$params);
+            } catch (ValidationException $e) {
+                $e->errorBag = $errorBag;
+
+                throw $e;
+            }
         });
     }
 

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -28,4 +28,24 @@ class RequestValidationTest extends TestCase
 
         $request->validate(['name' => 'string']);
     }
+
+    public function testValidateWithBagMacro()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor']);
+
+        $validated = $request->validateWithBag('some_bag', ['name' => 'string']);
+
+        $this->assertSame(['name' => 'Taylor'], $validated);
+    }
+
+    public function testValidateWithBagMacroWhenItFails()
+    {
+        $request = Request::create('/', 'GET', ['name' => null]);
+
+        try {
+            $request->validateWithBag('some_bag', ['name' => 'string']);
+        } catch (ValidationException $validationException) {
+            $this->assertEquals('some_bag', $validationException->errorBag);
+        }
+    }
 }


### PR DESCRIPTION
# Add new validateWithBag macro to the Request class.

This method will allow people to specify the name of the bag validation errors should be put in.

## Why?

This convenience method already existed in the `ValidatesRequests` trait. 

Adding it as a macro will help people keep their code consistent and either stick to the `Request` macros for validation or the `ValidatesRequests` trait. 