### PR TITLE
[6.x] Add withoutMix and withMix test helpers

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -3,10 +3,18 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Closure;
+use Illuminate\Foundation\Mix;
 use Mockery;
 
 trait InteractsWithContainer
 {
+    /**
+     * The original Laravel Mix handler.
+     *
+     * @var \Illuminate\Foundation\Mix|null
+     */
+    protected $originalMix;
+
     /**
      * Register an instance of an object in the container.
      *
@@ -67,5 +75,37 @@ trait InteractsWithContainer
     protected function spy($abstract, Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
+    }
+
+    /**
+     * Register an empty handler for Laravel Mix in the container.
+     *
+     * @return $this
+     */
+    protected function withoutMix()
+    {
+        if ($this->originalMix == null) {
+            $this->originalMix = app(Mix::class);
+        }
+
+        $this->swap(Mix::class, function () {
+            return '';
+        });
+
+        return $this;
+    }
+
+    /**
+     * Register an empty handler for Laravel Mix in the container.
+     *
+     * @return $this
+     */
+    protected function withMix()
+    {
+        if ($this->originalMix) {
+            $this->app->instance(Mix::class, $this->originalMix);
+        }
+
+        return $this;
     }
 }

--- a/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
+++ b/tests/Foundation/Testing/Concerns/InteractsWithContainerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing\Concerns;
+
+use Illuminate\Foundation\Mix;
+use Orchestra\Testbench\TestCase;
+
+class InteractsWithContainerTest extends TestCase
+{
+    public function testWithoutMixBindsEmptyHandlerAndReturnsInstance()
+    {
+        $instance = $this->withoutMix();
+
+        $this->assertSame('', mix('path/to/asset.png'));
+        $this->assertSame($this, $instance);
+    }
+
+    public function testWithMixRestoresOriginalHandlerAndReturnsInstance()
+    {
+        $handler = new \stdClass();
+        $this->app->instance(Mix::class, $handler);
+
+        $this->withoutMix();
+        $instance = $this->withMix();
+
+        $this->assertSame($handler, resolve(Mix::class));
+        $this->assertSame($this, $instance);
+    }
+}


### PR DESCRIPTION
Similar to `withoutExceptionHandling` and `withExceptionHandling`, these two test helpers allow developers to quickly unbinding and rebinding Laravel Mix in the container during testing.

This behavior was added in #26289, but still requires intimate knowledge of the underlying `Mix` class and proper binding function. Furthermore, it adds a relatively obscure, big block of code for a simple need.

**Before**
```php
$this->swap(\Illuminate\Foundation\Mix::class, function () {
    return '';
});
```

**After**
```php
$this->withoutMix();
```

**Note:** Inline with other `TestCase` methods, `withoutMix` returns the instance allowing it to be chained with other fluent methods, e.g. `$this->withoutMix()->withoutExceptionHandling()->get('/');`