### PR TITLE
[7.x] Add Model::when() method to register model event listeners

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -159,6 +159,18 @@ trait HasEvents
     }
 
     /**
+     * Register a model event listener.
+     *
+     * @param  string  $event
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function when($event, $callback)
+    {
+        static::registerModelEvent($event, $callback);
+    }
+
+    /**
      * Fire the given event for the model.
      *
      * @param  string  $event


### PR DESCRIPTION
As proposed in https://github.com/laravel/ideas/issues/1975

## Usage example
Let's say we fire a custom event `$this->fireModelEvent('shipped')` in our `Order` model.
Now we can listen to that event and send for example an email notification to the customer:

```php
// Using a callback:
Order::when('shipped', function ($order) {
    Mail::send(new OrderShippedMail($order));
});

// Or a listener:
Order::when('shipped', SendShipmentNotification::class);
```

## Alternatives
- Use another method name, like `listen`. To prevent confusion with `when` on the query builder.
- Make the `registerModelEvent` of `Illuminate\Database\Eloquent\Concerns\HasEvents` public. So we can use that instead of `when`.