### PR TITLE
[6.x] Added verified method on VerifiesEmails trait

### DIFF
--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -49,7 +49,7 @@ trait VerifiesEmails
             event(new Verified($request->user()));
         }
 
-        return redirect($this->redirectPath())->with('verified', true);
+        return $this->verified($request) ?: redirect($this->redirectPath())->with('verified', true);
     }
 
     /**
@@ -67,5 +67,16 @@ trait VerifiesEmails
         $request->user()->sendEmailVerificationNotification();
 
         return back()->with('resent', true);
+    }
+
+    /**
+     * The user has been verified.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function verified(Request $request)
+    {
+        //
     }
 }


### PR DESCRIPTION
I created a new method for performing actions when a user verifies the email address.

Just as there are authenticated (Login) and registered (Register) methods, I needed a method with the same functionality for VerificationController.

I reused the same implementation of the logout method (AuthenticatesUsers), so it is a very simple modification and should not cause any problems.