### PR TITLE
[7.x] Remove system and IDE files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-/vendor
-composer.phar
-composer.lock
-.DS_Store
-Thumbs.db
+/.phpunit.result.cache
+/composer.lock
 /phpunit.xml
-/.idea
-/.vscode
-.phpunit.result.cache
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.phpunit.result.cache
+.phpunit.result.cache
 /composer.lock
 /phpunit.xml
 /vendor


### PR DESCRIPTION
These should be in people's system level ignore files. I've also removed composer.phar, since surely people have it globally installed these days, or within docker or something.