### PR TITLE
[6.x] Allow absolute file path for Storage::putFileAs()

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -248,6 +248,8 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function putFileAs($path, $file, $name, $options = [])
     {
+        // TODO:
+        
         $stream = fopen($file->getRealPath(), 'r');
 
         // Next, we will format the path of the file and store the file using a stream since

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -241,16 +241,16 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Store the uploaded file on the disk with a given name.
      *
      * @param  string  $path
-     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile  $file
+     * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $file
      * @param  string  $name
      * @param  array  $options
      * @return string|false
      */
     public function putFileAs($path, $file, $name, $options = [])
     {
-        // TODO:
-        
-        $stream = fopen($file->getRealPath(), 'r');
+        $filePath = is_string($file) ? $file : $file->getRealPath();
+
+        $stream = fopen($filePath, 'r');
 
         // Next, we will format the path of the file and store the file using a stream since
         // they provide better performance than alternatives. Once we write the file this

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Stream;
 use Illuminate\Contracts\Filesystem\FileExistsException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Http\UploadedFile;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
@@ -239,5 +240,35 @@ class FilesystemAdapterTest extends TestCase
 
         $spy->shouldHaveReceived('putStream');
         $this->assertEquals('some-data', $filesystemAdapter->get('bar.txt'));
+    }
+
+    public function testPutFile()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $uploadedFile = new UploadedFile($filePath, 'org.txt', null, null, true);
+
+        $storagePath = $filesystemAdapter->putFile('/', $uploadedFile);
+
+        $this->assertFileExists($filePath);
+
+        $filesystemAdapter->assertExists($storagePath);
+
+        $this->assertSame('uploaded file content', $filesystemAdapter->read($storagePath));
+    }
+
+    public function testPutFileWithAbsoluteFilePath()
+    {
+        file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
+
+        $filesystemAdapter = new FilesystemAdapter($this->filesystem);
+
+        $storagePath = $filesystemAdapter->putFileAs('/', $filePath, 'new.txt');
+
+        $this->assertSame('new.txt', $storagePath);
+
+        $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -242,7 +242,7 @@ class FilesystemAdapterTest extends TestCase
         $this->assertEquals('some-data', $filesystemAdapter->get('bar.txt'));
     }
 
-    public function testPutFile()
+    public function testPutFileAs()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'uploaded file content');
 
@@ -250,7 +250,9 @@ class FilesystemAdapterTest extends TestCase
 
         $uploadedFile = new UploadedFile($filePath, 'org.txt', null, null, true);
 
-        $storagePath = $filesystemAdapter->putFile('/', $uploadedFile);
+        $storagePath = $filesystemAdapter->putFileAs('/', $uploadedFile, 'new.txt');
+
+        $this->assertSame('new.txt', $storagePath);
 
         $this->assertFileExists($filePath);
 
@@ -259,15 +261,13 @@ class FilesystemAdapterTest extends TestCase
         $this->assertSame('uploaded file content', $filesystemAdapter->read($storagePath));
     }
 
-    public function testPutFileWithAbsoluteFilePath()
+    public function testPutFileAsWithAbsoluteFilePath()
     {
         file_put_contents($filePath = $this->tempDir.'/foo.txt', 'normal file content');
 
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
 
         $storagePath = $filesystemAdapter->putFileAs('/', $filePath, 'new.txt');
-
-        $this->assertSame('new.txt', $storagePath);
 
         $this->assertSame('normal file content', $filesystemAdapter->read($storagePath));
     }


### PR DESCRIPTION
Currently, trying to store an absolute file path to storage is inconvenient. As far as I know the easiest way to do it is like this:
```php
Storage::put(
    '/some/path/foo.txt',
    $handle = fopen($filePath, 'r')
);

fclose($handle);
```

With this PR, you can do the following instead:
```php
Storage::putFileAs('/some/path/', $filePath, 'foo.txt');
```

---

~I haven't changed `Storage::putFile`. That method uses the `UploadedFile` to guess the file extension and generate a random file name.~ See PR https://github.com/laravel/framework/pull/31040

