### PR TITLE
[7.x] Don't allow report to return anything

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -103,7 +103,9 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (is_callable($reportCallable = [$e, 'report'])) {
-            return $this->container->call($reportCallable);
+            $this->container->call($reportCallable);
+
+            return;
         }
 
         try {


### PR DESCRIPTION
The contract has `void` return type, but for some reason, the returned value from the `call` was being returned. Even though the contract said `void`, it's possible someone is still using the returned value, so I've targeted 7.x.