### PR TITLE
[6.x] Speed up runningInConsole method

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -551,11 +551,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        if (Env::get('APP_RUNNING_IN_CONSOLE') !== null) {
-            return Env::get('APP_RUNNING_IN_CONSOLE') === true;
+        $inConsole = Env::get('APP_RUNNING_IN_CONSOLE');
+
+        if ($inConsole !== null) {
+            return $inConsole === true;
         }
 
-        return php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg';
+        return \PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg';
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -132,6 +132,13 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $environmentFile = '.env';
 
     /**
+     * If the application is running in the console.
+     *
+     * @var bool|null
+     */
+    protected $runningInConsole;
+
+    /**
      * The application namespace.
      *
      * @var string
@@ -551,13 +558,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        $inConsole = Env::get('APP_RUNNING_IN_CONSOLE');
-
-        if ($inConsole !== null) {
-            return $inConsole === true;
+        if ($this->runningInConsole === null) {
+            $this->runningInConsole = Env::get('APP_RUNNING_IN_CONSOLE') ?? (\PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg');
         }
 
-        return \PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg';
+        return $this->runningInConsole;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -132,11 +132,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     protected $environmentFile = '.env';
 
     /**
-     * If the application is running in the console.
+     * Indicates if the application is running in the console.
      *
      * @var bool|null
      */
-    protected $runningInConsole;
+    protected $isRunningInConsole;
 
     /**
      * The application namespace.
@@ -558,11 +558,11 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function runningInConsole()
     {
-        if ($this->runningInConsole === null) {
-            $this->runningInConsole = Env::get('APP_RUNNING_IN_CONSOLE') ?? (\PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg');
+        if ($this->isRunningInConsole === null) {
+            $this->isRunningInConsole = Env::get('APP_RUNNING_IN_CONSOLE') ?? (\PHP_SAPI === 'cli' || \PHP_SAPI === 'phpdbg');
         }
 
-        return $this->runningInConsole;
+        return $this->isRunningInConsole;
     }
 
     /**


### PR DESCRIPTION
This code is actually quite hot, since it's called by most (package) service providers.

The new code is faster because:

1. `Env::get` isn't all that cheap, in the case where the env variable was found in the last place we look, and so we should only call it once, and assign the result.
2. The php optimizer can now ahead of time replace `return php_sapi_name() === 'cli' || php_sapi_name() === 'phpdbg';` with either `return true;` or `return false;`, since it is able to replace the constant (that it knows is global due to the slash) with the string value, and then it can evaluate the equality and or, all ahead of time.

---

I detected this optimization when profiling a Laravel app with xdebug tracing btw. ;)