### PR TITLE
[6.x] Avoid using the env superglobal in the tests

### DIFF
--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -15,7 +15,7 @@ class DynamoDbStoreTest extends TestCase
     {
         parent::setUp();
 
-        if (!env('DYNAMODB_CACHE_TABLE'])) {
+        if (! env('DYNAMODB_CACHE_TABLE')) {
             $this->markTestSkipped('DynamoDB not configured.');
         }
     }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -15,7 +15,7 @@ class DynamoDbStoreTest extends TestCase
     {
         parent::setUp();
 
-        if (! isset($_ENV['DYNAMODB_CACHE_TABLE'])) {
+        if (!env('DYNAMODB_CACHE_TABLE'])) {
             $this->markTestSkipped('DynamoDB not configured.');
         }
     }

--- a/tests/Integration/Cache/DynamoDbStoreTest.php
+++ b/tests/Integration/Cache/DynamoDbStoreTest.php
@@ -15,7 +15,7 @@ class DynamoDbStoreTest extends TestCase
     {
         parent::setUp();
 
-        if (! env('DYNAMODB_CACHE_TABLE')) {
+        if (env('DYNAMODB_CACHE_TABLE') !== null) {
             $this->markTestSkipped('DynamoDB not configured.');
         }
     }


### PR DESCRIPTION
All the other tests use the `env` helper, such as the redis tests. This test should too.