### PR TITLE
[6.x] Fixed code that depended on getenv

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -30,8 +30,8 @@ trait InteractsWithRedis
     public function setUpRedis()
     {
         $app = $this->app ?? new Application;
-        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
-        $port = getenv('REDIS_PORT') ?: 6379;
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
 
         if (! extension_loaded('redis')) {
             $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
@@ -63,7 +63,7 @@ trait InteractsWithRedis
         try {
             $this->redis['phpredis']->connection()->flushdb();
         } catch (Exception $e) {
-            if ($host === '127.0.0.1' && $port === 6379 && getenv('REDIS_HOST') === false) {
+            if ($host === '127.0.0.1' && $port === 6379 && env('REDIS_HOST') === null) {
                 static::$connectionFailedOnceWithDefaultsSkip = true;
                 $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Exception;
+use Illuminate\Support\Env;
 use Illuminate\Foundation\Application;
 use Illuminate\Redis\RedisManager;
 
@@ -30,8 +31,8 @@ trait InteractsWithRedis
     public function setUpRedis()
     {
         $app = $this->app ?? new Application;
-        $host = env('REDIS_HOST', '127.0.0.1');
-        $port = env('REDIS_PORT', 6379);
+        $host = Env::get('REDIS_HOST', '127.0.0.1');
+        $port = Env::get('REDIS_PORT', 6379);
 
         if (! extension_loaded('redis')) {
             $this->markTestSkipped('The redis extension is not installed. Please install the extension to enable '.__CLASS__);
@@ -63,7 +64,7 @@ trait InteractsWithRedis
         try {
             $this->redis['phpredis']->connection()->flushdb();
         } catch (Exception $e) {
-            if ($host === '127.0.0.1' && $port === 6379 && env('REDIS_HOST') === null) {
+            if ($host === '127.0.0.1' && $port === 6379 && Env::get('REDIS_HOST') === null) {
                 static::$connectionFailedOnceWithDefaultsSkip = true;
                 $this->markTestSkipped('Trying default host/port failed, please set environment variable REDIS_HOST & REDIS_PORT to enable '.__CLASS__);
             }

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithRedis.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Exception;
-use Illuminate\Support\Env;
 use Illuminate\Foundation\Application;
 use Illuminate\Redis\RedisManager;
+use Illuminate\Support\Env;
 
 trait InteractsWithRedis
 {

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -554,8 +554,8 @@ class RedisConnectionTest extends TestCase
             'phpredis' => $this->redis['phpredis']->connection(),
         ];
 
-        $host = getenv('REDIS_HOST') ?: '127.0.0.1';
-        $port = getenv('REDIS_PORT') ?: 6379;
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
 
         $prefixedPhpredis = new RedisManager(new Application, 'phpredis', [
             'cluster' => false,


### PR DESCRIPTION
If the env variables are loaded without using `putenv`, then `getenv` won't be able to see them, so the current code is wrong. It should use Laravel's `env` helper.