### PR TITLE
[7.x] Don't enable immutability when loading the .env file

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -62,7 +62,6 @@ class Env
             static::$repository = RepositoryBuilder::create()
                 ->withReaders($adapters)
                 ->withWriters($adapters)
-                ->immutable()
                 ->make();
         }
 


### PR DESCRIPTION
Since Laravel has had `.env` files, immutability has always been enabled, although it was not always called that, it's always been there. I propose in Laravel 7, we stop using this.

The naming is a little confusing... The difference between mutability and immutability is that if an environment variable was already set before the `.env`file was loaded, then the variable from the file will be ignored if we are in "immutable" mode.

TLDR: mutable vs immutable is actually about if the `.env` file loading can overwrite existing variables. Most people will probably want mutable mode, and wouldn't even be aware that immutable mode was a thing.

---

Twitter poll: https://twitter.com/GrahamJCampbell/status/1210543678835634179.