### PR TITLE
[6.x] Added a new mutator cast type - `time`

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -508,6 +508,8 @@ trait HasAttributes
             case 'datetime':
             case 'custom_datetime':
                 return $this->asDateTime($value);
+            case 'time':
+                return $this->asTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
             default:
@@ -835,6 +837,19 @@ trait HasAttributes
         return empty($value) ? $value : $this->asDateTime($value)->format(
             $this->getDateFormat()
         );
+    }
+
+    /**
+     * Return a timestamp as DateTime object with the current date.
+     *
+     * @param  mixed  $value
+     * @return false|\Illuminate\Support\Carbon
+     */
+    protected function asTime($value)
+    {
+        return $value instanceof CarbonInterface
+            ? Date::instance($value)
+            : Date::createFromFormat('H:i:s', $value)->startOfSecond();
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelTimeCastingTest.php
+++ b/tests/Integration/Database/EloquentModelTimeCastingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentModelTimeCastingTest extends DatabaseTestCase
+{
+    public function testTimesAreCastable()
+    {
+        $item = TestTimeModel::create([
+            'time_field' => '08:11:27',
+        ]);
+
+        $this->assertEquals(date_create('08:11:27'), $item->time_field);
+        $this->assertEquals(date_create('08:11:27'), $item->toArray()['time_field']);
+        $this->assertSame('08:11:27', $item->time_field->format('H:i:s'));
+        $this->assertSame('08:11', $item->time_field->format('H:i'));
+        $this->assertInstanceOf(Carbon::class, $item->time_field);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->time('time_field')->nullable();
+        });
+    }
+}
+
+class TestTimeModel extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'test_model1';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'time_field' => 'time',
+    ];
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adding a new type of mutator will make it easier to work with time comparisons.

For example:
```php
$model = App\Models\Foo::first();
$now = now();

return $now->gte($this->open_at) && $now->lt($this->close_at);
    ? __('Opened')
    : __('Closed');
```