### PR TITLE
[6.x] Removed unused dev dep and fixed symfony/cache min version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,8 +87,7 @@
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^8.3",
         "predis/predis": "^1.1.1",
-        "symfony/cache": "^4.3",
-        "true/punycode": "^2.1"
+        "symfony/cache": "^4.3.4"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
1. `true/punycode` is unused by Laravel and is not even tested on PHP 7.2, 7.3 or 7.4.
2. All the other symfony deps are at `^4.3.4`, and so is the version of `symfony/cache` in "suggest".