### PR TITLE
[6.x] Fixed setting up memcached on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ services:
 
 before_install:
   - phpenv config-rm xdebug.ini || true
-  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - printf "\n" | pecl install -f redis
+  - printf "\n" | pecl install -f memcached redis
   - travis_retry composer self-update
   - mysql -e 'CREATE DATABASE forge;'
 


### PR DESCRIPTION
The install seems to have been failing but without crashing the setup, and then phpunit was just skipping the tests that needed memcached.