### PR TITLE
[6.x] Use ::class notation in Router

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -242,7 +242,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function redirect($uri, $destination, $status = 302)
     {
-        return $this->any($uri, '\Illuminate\Routing\RedirectController')
+        return $this->any($uri, RedirectController::class)
                 ->defaults('destination', $destination)
                 ->defaults('status', $status);
     }
@@ -269,7 +269,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function view($uri, $view, $data = [])
     {
-        return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
+        return $this->match(['GET', 'HEAD'], $uri, ViewController::class)
                 ->defaults('view', $view)
                 ->defaults('data', $data);
     }


### PR DESCRIPTION
Follow-up to PR #30935 by @GrahamCampbell 

This PR replaces Controller classes string notation to `::class` notation in `\Illuminate\Routing\Router` to improve IDE experience, refactoring automation and automated dependency analysis.