### PR TITLE
[6.x] Make ThrottleRequestsException extend TooManyRequestsHttpException

### DIFF
--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class PostTooLargeException extends HttpException
 {
     /**
-     * PostTooLargeException constructor.
+     * Create a new post too large exception instance.
      *
      * @param  string|null  $message
      * @param  \Exception|null  $previous

--- a/src/Illuminate/Http/Exceptions/PostTooLargeException.php
+++ b/src/Illuminate/Http/Exceptions/PostTooLargeException.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 class PostTooLargeException extends HttpException
 {
     /**
-     * Create a new post too large exception instance.
+     * Create a new "post too large" exception instance.
      *
      * @param  string|null  $message
      * @param  \Exception|null  $previous

--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Http\Exceptions;
 
 use Exception;
-use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
-class ThrottleRequestsException extends HttpException
+class ThrottleRequestsException extends TooManyRequestsHttpException
 {
     /**
      * Create a new exception instance.
@@ -18,6 +18,6 @@ class ThrottleRequestsException extends HttpException
      */
     public function __construct($message = null, Exception $previous = null, array $headers = [], $code = 0)
     {
-        parent::__construct(429, $message, $previous, $headers, $code);
+        parent::__construct(null, $message, $previous, $code, $headers);
     }
 }

--- a/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/Illuminate/Http/Exceptions/ThrottleRequestsException.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 class ThrottleRequestsException extends TooManyRequestsHttpException
 {
     /**
-     * Create a new exception instance.
+     * Create a new throttle requests exception instance.
      *
      * @param  string|null  $message
      * @param  \Exception|null  $previous


### PR DESCRIPTION
1. Laravel's `ThrottleRequestsException` should extend `TooManyRequestsHttpException` rather than just `HttpException`.
2. This is not a breaking change, since TooManyRequestsHttpException extends `HttpException`.