### PR TITLE
[7.x] Fix validation same|different with sometimes rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1552,13 +1552,9 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'same');
 
-        if (Arr::has($this->data, $parameters[0])) {
-            $other = Arr::get($this->data, $parameters[0]);
-            
-            return $value === $other;
-        }
+        $other = Arr::get($this->data, $parameters[0]);
 
-        return true;
+        return $value === $other;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -439,14 +439,12 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'different');
 
         foreach ($parameters as $parameter) {
-            if (! Arr::has($this->data, $parameter)) {
-                return false;
-            }
-
-            $other = Arr::get($this->data, $parameter);
-
-            if ($value === $other) {
-                return false;
+            if (Arr::has($this->data, $parameter)) {
+                $other = Arr::get($this->data, $parameter);
+    
+                if ($value === $other) {
+                    return false;
+                }
             }
         }
 
@@ -1554,9 +1552,13 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'same');
 
-        $other = Arr::get($this->data, $parameters[0]);
+        if (Arr::has($this->data, $parameters[0])) {
+            $other = Arr::get($this->data, $parameters[0]);
+            
+            return $value === $other;
+        }
 
-        return $value === $other;
+        return true;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1153,7 +1153,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Same:baz']);
-        $this->assertTrue($v->passes());
+        $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'Same:baz']);
         $this->assertTrue($v->passes());

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1153,7 +1153,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Same:baz']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'Same:baz']);
         $this->assertTrue($v->passes());
@@ -1175,7 +1175,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'Different:baz']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'bar'], ['foo' => 'Different:baz']);
         $this->assertFalse($v->passes());
@@ -1187,7 +1187,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Different:fuu,baz']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'bar', 'fuu' => 'bar', 'baz' => 'boom'], ['foo' => 'Different:fuu,baz']);
         $this->assertFalse($v->passes());


### PR DESCRIPTION
That is my proposal to fix https://github.com/laravel/framework/issues/30944, if it was really intended as a bug (as I hope).

I'm sending to 7.x branch because I had to change two tests, which could means a "bc", but, my original intention was to send to 6.x as this is a bugfix.

These tests were asserting a wrong behavior according to https://github.com/laravel/framework/issues/30944