### PR TITLE
[7.0] Improve performance Str::startsWith

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -551,7 +551,8 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+            $needle = (string) $needle;
+            if ($needle !== '' && strpos($haystack, $needle) === 0) {
                 return true;
             }
         }


### PR DESCRIPTION
In my case startsWith function calls 37 times at the framework starts, so this PR improve speed of that to 30-50%.
Avg benchmarks of running script 10 times * 1000000 calls like this
```
// $i - range from 0 to 1000000
$str = 'longsamplestringlongsamplestringlongsamplestringlongsamplestring';
Str::startsWith($str, [$i, $i])
```
Before: 1.5312407016754 sec
After: 1.0467435836792 sec