### PR TITLE
[6.x] Added creation of custom Cast classes for Eloquent

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Castable.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Castable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface Castable
+{
+    /**
+     * Get the mutated value.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function handle($value = null);
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -5,11 +5,9 @@ namespace Illuminate\Database\Eloquent\Concerns;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use LogicException;
@@ -36,13 +34,6 @@ trait HasAttributes
      * @var array
      */
     protected $changes = [];
-
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [];
 
     /**
      * The attributes that should be mutated to dates.
@@ -158,47 +149,6 @@ trait HasAttributes
             $attributes[$key] = $this->mutateAttributeForArray(
                 $key, $attributes[$key]
             );
-        }
-
-        return $attributes;
-    }
-
-    /**
-     * Add the casted attributes to the attributes array.
-     *
-     * @param  array  $attributes
-     * @param  array  $mutatedAttributes
-     * @return array
-     */
-    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
-    {
-        foreach ($this->getCasts() as $key => $value) {
-            if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes)) {
-                continue;
-            }
-
-            // Here we will cast the attribute. Then, if the cast is a date or datetime cast
-            // then we will serialize the date for the array. This will convert the dates
-            // to strings based on the date format specified for these Eloquent models.
-            $attributes[$key] = $this->castAttribute(
-                $key, $attributes[$key]
-            );
-
-            // If the attribute cast was a date or a datetime, we will serialize the date as
-            // a string. This allows the developers to customize how dates are serialized
-            // into an array without affecting how they are persisted into the storage.
-            if ($attributes[$key] &&
-                ($value === 'date' || $value === 'datetime')) {
-                $attributes[$key] = $this->serializeDate($attributes[$key]);
-            }
-
-            if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
-                $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
-            }
-
-            if ($attributes[$key] instanceof Arrayable) {
-                $attributes[$key] = $attributes[$key]->toArray();
-            }
         }
 
         return $attributes;
@@ -469,95 +419,6 @@ trait HasAttributes
     }
 
     /**
-     * Cast an attribute to a native PHP type.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return mixed
-     */
-    protected function castAttribute($key, $value)
-    {
-        if (is_null($value)) {
-            return $value;
-        }
-
-        switch ($this->getCastType($key)) {
-            case 'int':
-            case 'integer':
-                return (int) $value;
-            case 'real':
-            case 'float':
-            case 'double':
-                return $this->fromFloat($value);
-            case 'decimal':
-                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
-            case 'string':
-                return (string) $value;
-            case 'bool':
-            case 'boolean':
-                return (bool) $value;
-            case 'object':
-                return $this->fromJson($value, true);
-            case 'array':
-            case 'json':
-                return $this->fromJson($value);
-            case 'collection':
-                return new BaseCollection($this->fromJson($value));
-            case 'date':
-                return $this->asDate($value);
-            case 'datetime':
-            case 'custom_datetime':
-                return $this->asDateTime($value);
-            case 'timestamp':
-                return $this->asTimestamp($value);
-            default:
-                return $value;
-        }
-    }
-
-    /**
-     * Get the type of cast for a model attribute.
-     *
-     * @param  string  $key
-     * @return string
-     */
-    protected function getCastType($key)
-    {
-        if ($this->isCustomDateTimeCast($this->getCasts()[$key])) {
-            return 'custom_datetime';
-        }
-
-        if ($this->isDecimalCast($this->getCasts()[$key])) {
-            return 'decimal';
-        }
-
-        return trim(strtolower($this->getCasts()[$key]));
-    }
-
-    /**
-     * Determine if the cast type is a custom date time cast.
-     *
-     * @param  string  $cast
-     * @return bool
-     */
-    protected function isCustomDateTimeCast($cast)
-    {
-        return strncmp($cast, 'date:', 5) === 0 ||
-               strncmp($cast, 'datetime:', 9) === 0;
-    }
-
-    /**
-     * Determine if the cast type is a decimal cast.
-     *
-     * @param  string  $cast
-     * @return bool
-     */
-    protected function isDecimalCast($cast)
-    {
-        return strncmp($cast, 'decimal:', 8) === 0;
-    }
-
-    /**
      * Set a given attribute on the model.
      *
      * @param  string  $key
@@ -620,18 +481,6 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the given attribute is a date or date castable.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isDateAttribute($key)
-    {
-        return in_array($key, $this->getDates(), true) ||
-                                    $this->isDateCastable($key);
-    }
-
-    /**
      * Set a given JSON attribute on the model.
      *
      * @param  string  $key
@@ -674,26 +523,6 @@ trait HasAttributes
     {
         return isset($this->attributes[$key]) ?
                     $this->fromJson($this->attributes[$key]) : [];
-    }
-
-    /**
-     * Cast the given attribute to JSON.
-     *
-     * @param  string  $key
-     * @param  mixed  $value
-     * @return string
-     */
-    protected function castAttributeAsJson($key, $value)
-    {
-        $value = $this->asJson($value);
-
-        if ($value === false) {
-            throw JsonEncodingException::forAttribute(
-                $this, $key, json_last_error_msg()
-            );
-        }
-
-        return $value;
     }
 
     /**
@@ -900,58 +729,6 @@ trait HasAttributes
     }
 
     /**
-     * Determine whether an attribute should be cast to a native type.
-     *
-     * @param  string  $key
-     * @param  array|string|null  $types
-     * @return bool
-     */
-    public function hasCast($key, $types = null)
-    {
-        if (array_key_exists($key, $this->getCasts())) {
-            return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the casts array.
-     *
-     * @return array
-     */
-    public function getCasts()
-    {
-        if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
-        }
-
-        return $this->casts;
-    }
-
-    /**
-     * Determine whether a value is Date / DateTime castable for inbound manipulation.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isDateCastable($key)
-    {
-        return $this->hasCast($key, ['date', 'datetime']);
-    }
-
-    /**
-     * Determine whether a value is JSON castable for inbound manipulation.
-     *
-     * @param  string  $key
-     * @return bool
-     */
-    protected function isJsonCastable($key)
-    {
-        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
-    }
-
-    /**
      * Get all of the current attributes on the model.
      *
      * @return array
@@ -1151,40 +928,6 @@ trait HasAttributes
     public function getChanges()
     {
         return $this->changes;
-    }
-
-    /**
-     * Determine if the new and old values for a given key are equivalent.
-     *
-     * @param  string  $key
-     * @param  mixed  $current
-     * @return bool
-     */
-    public function originalIsEquivalent($key, $current)
-    {
-        if (! array_key_exists($key, $this->original)) {
-            return false;
-        }
-
-        $original = $this->getOriginal($key);
-
-        if ($current === $original) {
-            return true;
-        } elseif (is_null($current)) {
-            return false;
-        } elseif ($this->isDateAttribute($key)) {
-            return $this->fromDateTime($current) ===
-                   $this->fromDateTime($original);
-        } elseif ($this->hasCast($key, ['object', 'collection'])) {
-            return $this->castAttribute($key, $current) ==
-                $this->castAttribute($key, $original);
-        } elseif ($this->hasCast($key)) {
-            return $this->castAttribute($key, $current) ===
-                   $this->castAttribute($key, $original);
-        }
-
-        return is_numeric($current) && is_numeric($original)
-                && strcmp((string) $current, (string) $original) === 0;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCasts.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCasts.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Support\Collection;
+
+trait HasCasts
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [];
+
+    /**
+     * Determine whether an attribute should be cast to a native type.
+     *
+     * @param string $key
+     * @param array|string|null $types
+     *
+     * @return bool
+     */
+    public function hasCast($key, $types = null)
+    {
+        if (array_key_exists($key, $this->getCasts())) {
+            return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the casts array.
+     *
+     * @return array
+     */
+    public function getCasts()
+    {
+        if ($this->getIncrementing()) {
+            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
+        }
+
+        return $this->casts;
+    }
+
+    /**
+     * Determine if the new and old values for a given key are equivalent.
+     *
+     * @param string $key
+     * @param mixed $current
+     *
+     * @return bool
+     */
+    public function originalIsEquivalent($key, $current)
+    {
+        if (! array_key_exists($key, $this->original)) {
+            return false;
+        }
+
+        $original = $this->getOriginal($key);
+
+        if ($current === $original) {
+            return true;
+        } elseif (is_null($current)) {
+            return false;
+        } elseif ($this->isDateAttribute($key)) {
+            return $this->fromDateTime($current) ===
+                $this->fromDateTime($original);
+        } elseif ($this->hasCast($key, ['object', 'collection'])) {
+            return $this->castAttribute($key, $current) ==
+                $this->castAttribute($key, $original);
+        } elseif ($this->hasCast($key)) {
+            return $this->castAttribute($key, $current) ===
+                $this->castAttribute($key, $original);
+        }
+
+        return is_numeric($current) && is_numeric($original)
+            && strcmp((string) $current, (string) $original) === 0;
+    }
+
+    /**
+     * Add the casted attributes to the attributes array.
+     *
+     * @param array $attributes
+     * @param array $mutatedAttributes
+     *
+     * @return array
+     */
+    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
+    {
+        foreach ($this->getCasts() as $key => $value) {
+            if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes)) {
+                continue;
+            }
+
+            // Here we will cast the attribute. Then, if the cast is a date or datetime cast
+            // then we will serialize the date for the array. This will convert the dates
+            // to strings based on the date format specified for these Eloquent models.
+            $attributes[$key] = $this->castAttribute(
+                $key, $attributes[$key]
+            );
+
+            // If the attribute cast was a date or a datetime, we will serialize the date as
+            // a string. This allows the developers to customize how dates are serialized
+            // into an array without affecting how they are persisted into the storage.
+            if ($attributes[$key] &&
+                ($value === 'date' || $value === 'datetime')) {
+                $attributes[$key] = $this->serializeDate($attributes[$key]);
+            }
+
+            if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
+                $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
+            }
+
+            if ($attributes[$key] instanceof Arrayable) {
+                $attributes[$key] = $attributes[$key]->toArray();
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Cast an attribute to a native PHP type.
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    protected function castAttribute($key, $value)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        switch ($this->getCastType($key)) {
+            case 'int':
+            case 'integer':
+                return (int) $value;
+            case 'real':
+            case 'float':
+            case 'double':
+                return $this->fromFloat($value);
+            case 'decimal':
+                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
+            case 'string':
+                return (string) $value;
+            case 'bool':
+            case 'boolean':
+                return (bool) $value;
+            case 'object':
+                return $this->fromJson($value, true);
+            case 'array':
+            case 'json':
+                return $this->fromJson($value);
+            case 'collection':
+                return new Collection($this->fromJson($value));
+            case 'date':
+                return $this->asDate($value);
+            case 'datetime':
+            case 'custom_datetime':
+                return $this->asDateTime($value);
+            case 'timestamp':
+                return $this->asTimestamp($value);
+            default:
+                return $value;
+        }
+    }
+
+    /**
+     * Get the type of cast for a model attribute.
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    protected function getCastType($key)
+    {
+        if ($this->isCustomDateTimeCast($this->getCasts()[$key])) {
+            return 'custom_datetime';
+        }
+
+        if ($this->isDecimalCast($this->getCasts()[$key])) {
+            return 'decimal';
+        }
+
+        return trim(strtolower($this->getCasts()[$key]));
+    }
+
+    /**
+     * Cast the given attribute to JSON.
+     *
+     * @param string $key
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function castAttributeAsJson($key, $value)
+    {
+        $value = $this->asJson($value);
+
+        if ($value === false) {
+            throw JsonEncodingException::forAttribute(
+                $this, $key, json_last_error_msg()
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * Determine if the cast type is a custom date time cast.
+     *
+     * @param string $cast
+     *
+     * @return bool
+     */
+    protected function isCustomDateTimeCast($cast)
+    {
+        return strncmp($cast, 'date:', 5) === 0 ||
+            strncmp($cast, 'datetime:', 9) === 0;
+    }
+
+    /**
+     * Determine if the cast type is a decimal cast.
+     *
+     * @param string $cast
+     *
+     * @return bool
+     */
+    protected function isDecimalCast($cast)
+    {
+        return strncmp($cast, 'decimal:', 8) === 0;
+    }
+
+    /**
+     * Determine if the given attribute is a date or date castable.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function isDateAttribute($key)
+    {
+        return in_array($key, $this->getDates(), true) ||
+            $this->isDateCastable($key);
+    }
+
+    /**
+     * Determine whether a value is Date / DateTime castable for inbound manipulation.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function isDateCastable($key)
+    {
+        return $this->hasCast($key, ['date', 'datetime']);
+    }
+
+    /**
+     * Determine whether a value is JSON castable for inbound manipulation.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function isJsonCastable($key)
+    {
+        return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasCasts.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasCasts.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Support\Collection;
@@ -25,11 +28,13 @@ trait HasCasts
      */
     public function hasCast($key, $types = null)
     {
-        if (array_key_exists($key, $this->getCasts())) {
-            return $types ? in_array($this->getCastType($key), (array) $types, true) : true;
+        if (! array_key_exists($key, $this->getCasts())) {
+            return false;
         }
 
-        return false;
+        return $types
+            ? in_array($this->getCastType($key), (array) $types, true)
+            : true;
     }
 
     /**
@@ -39,11 +44,14 @@ trait HasCasts
      */
     public function getCasts()
     {
-        if ($this->getIncrementing()) {
-            return array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts);
-        }
+        return $this->getIncrementing()
+            ? array_merge([$this->getKeyName() => $this->getKeyType()], $this->casts)
+            : $this->casts;
+    }
 
-        return $this->casts;
+    public function getCast($key)
+    {
+        return $this->getCasts()[$key];
     }
 
     /**
@@ -51,6 +59,8 @@ trait HasCasts
      *
      * @param string $key
      * @param mixed $current
+     *
+     * @throws BindingResolutionException
      *
      * @return bool
      */
@@ -87,6 +97,8 @@ trait HasCasts
      * @param array $attributes
      * @param array $mutatedAttributes
      *
+     * @throws BindingResolutionException
+     *
      * @return array
      */
     protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
@@ -106,12 +118,11 @@ trait HasCasts
             // If the attribute cast was a date or a datetime, we will serialize the date as
             // a string. This allows the developers to customize how dates are serialized
             // into an array without affecting how they are persisted into the storage.
-            if ($attributes[$key] &&
-                ($value === 'date' || $value === 'datetime')) {
+            if (($value === 'date' || $value === 'datetime')) {
                 $attributes[$key] = $this->serializeDate($attributes[$key]);
             }
 
-            if ($attributes[$key] && $this->isCustomDateTimeCast($value)) {
+            if ($this->isCustomDateTimeCast($value)) {
                 $attributes[$key] = $attributes[$key]->format(explode(':', $value, 2)[1]);
             }
 
@@ -129,9 +140,11 @@ trait HasCasts
      * @param string $key
      * @param mixed $value
      *
+     * @throws BindingResolutionException
+     *
      * @return mixed
      */
-    protected function castAttribute($key, $value)
+    protected function castAttribute($key, $value = null)
     {
         if (is_null($value)) {
             return $value;
@@ -146,7 +159,7 @@ trait HasCasts
             case 'double':
                 return $this->fromFloat($value);
             case 'decimal':
-                return $this->asDecimal($value, explode(':', $this->getCasts()[$key], 2)[1]);
+                return $this->asDecimal($value, explode(':', $this->getCast($key), 2)[1]);
             case 'string':
                 return (string) $value;
             case 'bool':
@@ -167,7 +180,9 @@ trait HasCasts
             case 'timestamp':
                 return $this->asTimestamp($value);
             default:
-                return $value;
+                return $this->isCustomCastable($key)
+                    ? $this->fromCustomCastable($key, $value)
+                    : $value;
         }
     }
 
@@ -180,15 +195,17 @@ trait HasCasts
      */
     protected function getCastType($key)
     {
-        if ($this->isCustomDateTimeCast($this->getCasts()[$key])) {
+        $cast = $this->getCast($key);
+
+        if ($this->isCustomDateTimeCast($cast)) {
             return 'custom_datetime';
         }
 
-        if ($this->isDecimalCast($this->getCasts()[$key])) {
+        if ($this->isDecimalCast($cast)) {
             return 'decimal';
         }
 
-        return trim(strtolower($this->getCasts()[$key]));
+        return trim(strtolower($cast));
     }
 
     /**
@@ -251,6 +268,21 @@ trait HasCasts
     }
 
     /**
+     * Is the checked value a custom Cast.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    protected function isCustomCastable($key)
+    {
+        return is_subclass_of(
+            $this->getCast($key),
+            Castable::class
+        );
+    }
+
+    /**
      * Determine whether a value is Date / DateTime castable for inbound manipulation.
      *
      * @param string $key
@@ -272,5 +304,35 @@ trait HasCasts
     protected function isJsonCastable($key)
     {
         return $this->hasCast($key, ['array', 'json', 'object', 'collection']);
+    }
+
+    /**
+     * Getting the execution result from a user Cast object.
+     *
+     * @param string $key
+     * @param null $value
+     *
+     * @throws BindingResolutionException
+     *
+     * @return mixed
+     */
+    protected function fromCustomCastable($key, $value = null)
+    {
+        return $this
+            ->normalizeHandlerToCallable($key)
+            ->handle($value);
+    }
+
+    /**
+     * @param string $key
+     *
+     * @throws BindingResolutionException
+     *
+     * @return Castable
+     */
+    protected function normalizeHandlerToCallable($key)
+    {
+        return Container::getInstance()
+            ->make($this->getCast($key));
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -20,6 +20,7 @@ use JsonSerializable;
 abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializable, QueueableEntity, UrlRoutable
 {
     use Concerns\HasAttributes,
+        Concerns\HasCasts,
         Concerns\HasEvents,
         Concerns\HasGlobalScopes,
         Concerns\HasRelationships,

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class CastMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:cast';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new cast mutator';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Cast';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/cast.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Http\Casts';
+    }
+}

--- a/src/Illuminate/Foundation/Console/stubs/cast.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+
+class DummyClass implements Castable
+{
+    /**
+     * Get the mutated value.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public function handle($value = null)
+    {
+        return $value;
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ConfigCacheCommand;
@@ -130,6 +131,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'MailMake' => 'command.mail.make',
         'MiddlewareMake' => 'command.middleware.make',
         'ModelMake' => 'command.model.make',
+        'CastMake' => 'command.cast.make',
         'NotificationMake' => 'command.notification.make',
         'NotificationTable' => 'command.notification.table',
         'ObserverMake' => 'command.observer.make',
@@ -483,6 +485,13 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.model.make', function ($app) {
             return new ModelMakeCommand($app['files']);
+        });
+    }
+
+    protected function registerCastMakeCommand()
+    {
+        $this->app->singleton('command.cast.make', function ($app) {
+            return new CastMakeCommand($app['files']);
         });
     }
 

--- a/tests/Integration/Database/EloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/EloquentModelCustomCastingTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EloquentModelCustomCastingTest extends DatabaseTestCase
+{
+    public function testFoo()
+    {
+        $item = TestModel::create([
+            'field_1' => 'foobar',
+            'field_2' => 20,
+            'field_3' => '08:19:12',
+        ]);
+
+        $this->assertSame(['f', 'o', 'o', 'b', 'a', 'r'], $item->toArray()['field_1']);
+
+        $this->assertSame(0.2, $item->toArray()['field_2']);
+
+        $this->assertIsArray($item->toArray()['field_3']);
+
+        $this->assertSame(
+            [
+                'year'          => false,
+                'month'         => false,
+                'day'           => false,
+                'hour'          => 8,
+                'minute'        => 19,
+                'second'        => 12,
+                'fraction'      => 0.0,
+                'warning_count' => 0,
+                'warnings'      => [],
+                'error_count'   => 0,
+                'errors'        => [],
+                'is_localtime'  => false,
+            ],
+            $item->toArray()['field_3']
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('test_model1', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('field_1')->nullable();
+            $table->integer('field_2')->nullable();
+            $table->time('field_3')->nullable();
+        });
+    }
+}
+
+class TestModel extends Model
+{
+    public $table = 'test_model1';
+
+    public $timestamps = false;
+
+public $casts = [
+    'field_1' => StringCast::class,
+    'field_2' => NumberCast::class,
+    'field_3' => TimeCast::class,
+];
+
+    protected $guarded = ['id'];
+}
+
+class TimeCast implements Castable
+{
+    public function handle($value = null)
+    {
+        return date_parse($value);
+    }
+}
+
+class StringCast implements Castable
+{
+    public function handle($value = null)
+    {
+        return mb_str_split($value);
+    }
+}
+
+class NumberCast implements Castable
+{
+    public function handle($value = null)
+    {
+        return $value / 100;
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Recently, my #30931 PR was rejected and I understand the reason, since my proposal implies an increase in the amount of processed code. This is not entirely good.

In exchange, I suggest introducing a new type of object - custom Cast objects that allow developers to choose how to handle their values.

The application process is as follows:

1. Using the `php artisan make:cast` command, the developer creates a cast file.
2. Inside the created file (by default in the `app/Http/Casts` directory), the developer himself determines the behavior of the `handle` method:
```php
use Illuminate\Contracts\Database\Eloquent\Castable;

class MyCast implements Castable
{
    public function handle($value = null)
    {
        return $value % 10;
    }
}
```

3. In the model, you need to specify the created caste:
```php
use App\Http\Casts\MyCast;

public $casts = [
    'user_field' => MyCast::class,
];
```
4. Profit :)

In my opinion, this approach will not only save the amount of code for the “box” of the framework, but also significantly expand its functionality.

In addition, I removed the methods for working with castes from the `hasAttributes` trait, which allowed me to keep the code cleaner.