### PR TITLE
[7.x] Drop quote removal from env function

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -93,13 +93,9 @@ class Env
                     case 'null':
                     case '(null)':
                         return;
+                    default:
+                        return $value;
                 }
-
-                if (preg_match('/\A([\'"])(.*)\1\z/', $value, $matches)) {
-                    return $matches[2];
-                }
-
-                return $value;
             })
             ->getOrCall(function () use ($default) {
                 return value($default);


### PR DESCRIPTION
### Why?

It's currently not possible to have quotes in environment variables in Laravel because Laravel deletes them. We should stop Laravel removing quotes. Quotes are already dealt with by phpdotenv (for a very long time).

### Wasn't this done before and reverted???

Yes... This was done in Laravel 5.8, and reverted soon after release because people complained it broke the "null" driver. Since then, Laravel's config has been setup so that if you leave the env variable empty, if there is a null driver, then you will get that, like with mail, so this argument is no longer relevant.

### Maybe we could stop "null" to null conversion?

Yes, maybe. Should we rip out the `"null"` to `null` conversion, and only have `null` coming from variables that are genuinely `null`? The way to do this in phpdotenv is to simply not set the variable:

```env
NULL=
```

The above will set the `NULL` variable to `null`, and not to the empty string. To get the empty string, you'd need to do:

```env
NULL=''
```
or:


```env
NULL=""
```

