### PR TITLE
[6.x] Optimize Service Provider registration

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -584,7 +584,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $providers = Collection::make($this->config['app.providers'])
                         ->partition(function ($provider) {
-                            return Str::startsWith($provider, 'Illuminate\\');
+                            return strpos($provider, 'Illuminate\\') === 0;
                         });
 
         $providers->splice(1, 0, [$this->make(PackageManifest::class)->providers()]);


### PR DESCRIPTION
As per the discussion in #30952 and according to my tests, `strpos` is considerably faster than calling startsWith for short haystacks. This function is called for every provider on boot.
A default laravel installation will load 25 service providers.

I adapted the benchmark to test checking the default laravel packages. Benchmark code and results here: https://gist.github.com/36864/4bc70175ad0bb60b3261d1100f249cf5

Class names are unlikely to be longer than 100 characters, so this change should not have a negative impact.

According to the same benchmarks, a direct substring comparison would also be faster than the current implementation, but slower than `strpos` for strings

Sample result, over 1000000 iterations, checking if the provider class name starts with `Illuminate\`:
```
Provider: Illuminate\Foundation\Providers\ConsoleSupportServiceProvider
Array
(
    [strpos] => 0.077999114990234
    [substr] => 0.13390588760376
    [startswith] => 0.28392887115479
)
```