### PR TITLE
[6.x] Possibly fixed a logical error

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -77,7 +77,7 @@ trait ConditionallyLoadsAttributes
             if (($value instanceof PotentiallyMissing && $value->isMissing()) ||
                 ($value instanceof self &&
                 $value->resource instanceof PotentiallyMissing &&
-                $value->isMissing())) {
+                $value->resource->isMissing())) {
                 unset($data[$key]);
             } else {
                 $numericKeys = $numericKeys && is_numeric($key);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I think there might have been a mistake in the second group of if checks, you seem to be checking if the *resource* of the value is an instance of `PotentiallyMissing` but try to get the `isMissing()` method from the value, instead of its *resource*