### PR TITLE
[6.x] Set MySQL charset

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -129,9 +129,15 @@ class MySqlConnector extends Connector implements ConnectorInterface
     {
         extract($config, EXTR_SKIP);
 
-        return isset($port)
-                    ? "mysql:host={$host};port={$port};dbname={$database}"
-                    : "mysql:host={$host};dbname={$database}";
+        $dsn = isset($port)
+            ? "mysql:host={$host};port={$port};dbname={$database}"
+            : "mysql:host={$host};dbname={$database}";
+
+        if (isset($charset)) {
+            $dsn .= ";charset={$charset}";
+        }
+
+        return $dsn;
     }
 
     /**


### PR DESCRIPTION
My database is `mysql8`.
And there's an exception when `$connection = $this->createConnection($dsn, $config, $options);`
so we need set charset befor create a connection.
*****
## The exception
`Uncaught PDOException: SQLSTATE[HY000] [1045] client charset is not supported`