### PR TITLE
[6.x] ManagesLayouts::yieldContent performance

### DIFF
--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -146,17 +146,10 @@ trait ManagesLayouts
      */
     public function yieldContent($section, $default = '')
     {
-        $sectionContent = $default instanceof View ? $default : e($default);
+        $sectionContent = $this->sections[$section] ?? ($default instanceof View ? $default : e($default));
 
-        if (isset($this->sections[$section])) {
-            $sectionContent = $this->sections[$section];
-        }
-
-        $sectionContent = str_replace('@@parent', '--parent--holder--', $sectionContent);
-
-        return str_replace(
-            '--parent--holder--', '@parent', str_replace(static::parentPlaceholder($section), '', $sectionContent)
-        );
+        return str_replace(['@@parent', static::parentPlaceholder($section), '--parent--holder--'],
+            ['--parent--holder--', '', '@parent'], $sectionContent);
     }
 
     /**


### PR DESCRIPTION
Optimize function yieldContent with single str_replace (3 calls before) and don't evaluate $sectionContent if `$this->sections[$section]` isset