### PR TITLE
[6.x] Adds lcfirst helper in Str class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -251,7 +251,7 @@ class Str
     {
         return static::snake($value, '-');
     }
-    
+
     /**
      * Make a string's first character lowercase.
      *

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -132,7 +132,7 @@ class Str
             return static::$camelCache[$value];
         }
 
-        return static::$camelCache[$value] = lcfirst(static::studly($value));
+        return static::$camelCache[$value] = static::lcfirst(static::studly($value));
     }
 
     /**
@@ -250,6 +250,17 @@ class Str
     public static function kebab($value)
     {
         return static::snake($value, '-');
+    }
+    
+    /**
+     * Make a string's first character lowercase.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function lcfirst($string)
+    {
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -234,6 +234,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
     }
 
+    public function testLcfirst()
+    {
+        $this->assertSame('laravel', Str::lcfirst('Laravel'));
+        $this->assertSame('laravel framework', Str::lcfirst('Laravel framework'));
+        $this->assertSame('мама', Str::lcfirst('Мама'));
+        $this->assertSame('мама мыла раму', Str::lcfirst('Мама мыла раму'));
+    }
+
     public function testLower()
     {
         $this->assertSame('foo bar baz', Str::lower('FOO BAR BAZ'));


### PR DESCRIPTION
Adds a `lcfirst` helper in `Str` class that mirrors the existing `ucfirst`.

Adds a `testLcfirst` test for the helper.

The helper makes a string first character lowercase.
