### PR TITLE
[6.x] Optional methods for delayed listeners to get queue name and connection

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -463,15 +463,24 @@ class Dispatcher implements DispatcherContract
     {
         [$listener, $job] = $this->createListenerAndJob($class, $method, $arguments);
 
+        if (method_exists($listener, 'getConnection')) {
+            $connectionName = $listener->getConnection();
+        } else {
+            $connectionName = $listener->connection ?? null;
+        }
         $connection = $this->resolveQueue()->connection(
-            $listener->connection ?? null
+            $connectionName
         );
 
-        $queue = $listener->queue ?? null;
+        if (method_exists($listener, 'getQueue')) {
+            $queue = $listener->getQueue();
+        } else {
+            $queue = $listener->queue ?? null;
+        }
 
         isset($listener->delay)
-                    ? $connection->laterOn($queue, $listener->delay, $job)
-                    : $connection->pushOn($queue, $job);
+                ? $connection->laterOn($queue, $listener->delay, $job)
+                : $connection->pushOn($queue, $job);
     }
 
     /**


### PR DESCRIPTION
The main idea of PR is to add ability to set queue name and connection name for delayed listeners via get methods, to be able to use config helper function or smth else.

Currently we can set these settings only with public properties, like:
```php
   /**
     * The name of the connection the job should be sent to.
     *
     * @var string|null
     */
    public $connection = 'some_conn_name';

    /**
     * The name of the queue the job should be sent to.
     *
     * @var string|null
     */
    public $queue = 'some_queue_name';
```

But with this approach we are not able to configure these parameters through config or some other function. Only hardcoded string.
Thats because in Dispatcher listener is created without calling constructor:
```php
    protected function createListenerAndJob($class, $method, $arguments)
    {
        $listener = (new ReflectionClass($class))->newInstanceWithoutConstructor();

        return [$listener, $this->propagateListenerOptions(
            $listener, new CallQueuedListener($class, $method, $arguments)
        )];
    }
```
