### PR TITLE
[6.x] phpdoc hints for Request class

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -12,6 +12,11 @@ use RuntimeException;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+/**
+ * @method array validate(array $rules, ...$params)
+ * @method array validateWithBag(array $rules, ...$params)
+ * @method string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
+ */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
     use Concerns\InteractsWithContentTypes,


### PR DESCRIPTION
According to issue #22474, the `Request#validate` method  is not recognized by the IDE because this is implemented as a macro in the [FoundationServiceProvider](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php).

With this phpdoc the IDE will recognize the macro's