### PR TITLE
[6.x] Use CommonMark For Mailable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
         "dragonmantank/cron-expression": "^2.0",
         "egulias/email-validator": "^2.1.10",
         "erusev/parsedown": "^1.7",
+        "league/commonmark": "^1.1",
+        "league/commonmark-ext-table": "^2.1",
         "league/flysystem": "^1.0.8",
         "monolog/monolog": "^1.12|^2.0",
         "nesbot/carbon": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "doctrine/inflector": "^1.1",
         "dragonmantank/cron-expression": "^2.0",
         "egulias/email-validator": "^2.1.10",
-        "erusev/parsedown": "^1.7",
         "league/commonmark": "^1.1",
         "league/commonmark-ext-table": "^2.1",
         "league/flysystem": "^1.0.8",

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -5,6 +5,9 @@ namespace Illuminate\Mail;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment;
+use League\CommonMark\Ext\Table\TableExtension;
 use Parsedown;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
@@ -98,9 +101,15 @@ class Markdown
      */
     public static function parse($text)
     {
-        $parsedown = new Parsedown;
+        $environment = Environment::createCommonMarkEnvironment();
 
-        return new HtmlString($parsedown->text($text));
+        $environment->addExtension(new TableExtension);
+
+        $converter = new CommonMarkConverter([
+            'allow_unsafe_links' => false,
+        ], $environment);
+
+        return new HtmlString($converter->convertToHtml($text));
     }
 
     /**

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Str;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Ext\Table\TableExtension;
-use Parsedown;
 use TijsVerkoyen\CssToInlineStyles\CssToInlineStyles;
 
 class Markdown

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "erusev/parsedown": "^1.7",
+        "league/commonmark": "^1.1",
+        "league/commonmark-ext-table": "^2.1",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -66,6 +66,7 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->parse('# Something')->toHtml();
 
-        $this->assertSame('<h1>Something</h1>', $result);
+        $this->assertSame('<h1>Something</h1>
+', $result);
     }
 }

--- a/tests/Mail/MailMarkdownTest.php
+++ b/tests/Mail/MailMarkdownTest.php
@@ -66,7 +66,6 @@ class MailMarkdownTest extends TestCase
 
         $result = $markdown->parse('# Something')->toHtml();
 
-        $this->assertSame('<h1>Something</h1>
-', $result);
+        $this->assertSame("<h1>Something</h1>\n", $result);
     }
 }


### PR DESCRIPTION
This switches Markdown Mailable parsing to CommonMark instead of Parsedown. The main reason for this is better granularity of security related features in CommonMark, which allows us to prevent unsafe links in user input (a user input with the content: "[a](javascript:alert(1))") without needing to prevent all HTML tags in general which would break our current mailable system.

I think it would be good to do this basically security related change on 6.x because it is an LTS. 