### PR TITLE
[5.5] Code style fixes

### DIFF
--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -126,7 +126,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testFirstOrFailThrowsAnException()
     {
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
-            ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
+                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us']);
 
         HasManyThroughTestCountry::first()->posts()->firstOrFail();
     }
@@ -210,9 +210,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
                                  ->posts()->createMany([
-                ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-            ]);
+                                     ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                                     ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+                                 ]);
     }
 
     /**
@@ -221,11 +221,11 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     protected function seedDefaultData()
     {
         HasManyThroughDefaultTestCountry::create(['id' => 1, 'name' => 'United States of America'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
-                                 ->posts()->createMany([
-                ['title' => 'A title', 'body' => 'A body'],
-                ['title' => 'Another title', 'body' => 'Another body'],
-            ]);
+                                        ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
+                                        ->posts()->createMany([
+                                            ['title' => 'A title', 'body' => 'A body'],
+                                            ['title' => 'Another title', 'body' => 'Another body'],
+                                        ]);
     }
 
     /**

--- a/tests/Notifications/NotificationSlackChannelTest.php
+++ b/tests/Notifications/NotificationSlackChannelTest.php
@@ -185,8 +185,8 @@ class NotificationSlackChannelTestNotification extends Notification
                                    ->content('Attachment Content')
                                    ->fallback('Attachment Fallback')
                                    ->fields([
-                                        'Project' => 'Laravel',
-                                    ])
+                                       'Project' => 'Laravel',
+                                   ])
                                     ->footer('Laravel')
                                     ->footerIcon('https://laravel.com/fake.png')
                                     ->markdown(['text'])
@@ -212,8 +212,8 @@ class NotificationSlackChannelTestNotificationWithImageIcon extends Notification
                                    ->content('Attachment Content')
                                    ->fallback('Attachment Fallback')
                                    ->fields([
-                                        'Project' => 'Laravel',
-                                    ])
+                                       'Project' => 'Laravel',
+                                   ])
                                     ->footer('Laravel')
                                     ->footerIcon('https://laravel.com/fake.png')
                                     ->markdown(['text'])
@@ -232,8 +232,8 @@ class NotificationSlackChannelWithoutOptionalFieldsTestNotification extends Noti
                         $attachment->title('Laravel', 'https://laravel.com')
                                    ->content('Attachment Content')
                                    ->fields([
-                                        'Project' => 'Laravel',
-                                    ]);
+                                       'Project' => 'Laravel',
+                                   ]);
                     });
     }
 }


### PR DESCRIPTION
## What

This PR applies the CS fixes for the proposed new `laravel` preset for StyleCI, which adds the `array_indentation`, `compact_nullable_typehint`, `no_unneeded_curly_braces` fixers, and disables the `phpdoc_to_comment` fixer.

## Why this branch?

StyleCI is currently enabled on the 5.5, 5.8, 6.x and master branches, since they are all still maintained in some way (security fixes (5.5, 5.8), active support (6.x), upcoming release (master)).