### PR TITLE
[5.8] Code style fixes

### DIFF
--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -194,7 +194,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
         });
     }
 
@@ -233,7 +234,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
         }
     }
 
@@ -252,7 +254,8 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
                 'email',
                 'created_at',
                 'updated_at',
-                'laravel_through_key', ], array_keys($post->getAttributes()));
+                'laravel_through_key',
+            ], array_keys($post->getAttributes()));
         });
     }
 
@@ -285,9 +288,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         HasManyThroughTestCountry::create(['id' => 1, 'name' => 'United States of America', 'shortname' => 'us'])
                                  ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com', 'country_short' => 'us'])
                                  ->posts()->createMany([
-                ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
-                ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
-            ]);
+                                     ['title' => 'A title', 'body' => 'A body', 'email' => 'taylorotwell@gmail.com'],
+                                     ['title' => 'Another title', 'body' => 'Another body', 'email' => 'taylorotwell@gmail.com'],
+                                 ]);
     }
 
     protected function seedDataExtended()
@@ -316,11 +319,11 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     protected function seedDefaultData()
     {
         HasManyThroughDefaultTestCountry::create(['id' => 1, 'name' => 'United States of America'])
-                                 ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
-                                 ->posts()->createMany([
-                ['title' => 'A title', 'body' => 'A body'],
-                ['title' => 'Another title', 'body' => 'Another body'],
-            ]);
+                                        ->users()->create(['id' => 1, 'email' => 'taylorotwell@gmail.com'])
+                                        ->posts()->createMany([
+                                            ['title' => 'A title', 'body' => 'A body'],
+                                            ['title' => 'Another title', 'body' => 'Another body'],
+                                        ]);
     }
 
     /**

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -573,10 +573,9 @@ class FoundationTestResponseTest extends TestCase
     {
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
-                    'foo' => [],
-                    'bar' => ['one', 'two'],
-                ]]
-            ));
+                'foo' => [],
+                'bar' => ['one', 'two'],
+            ]]));
         });
 
         $response = TestResponse::fromBaseResponse($baseResponse);
@@ -597,10 +596,9 @@ class FoundationTestResponseTest extends TestCase
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
-                    'foo' => [],
-                    'bar' => ['one', 'two'],
-                ]]
-            ));
+                'foo' => [],
+                'bar' => ['one', 'two'],
+            ]]));
         });
 
         $response = TestResponse::fromBaseResponse($baseResponse);
@@ -614,10 +612,9 @@ class FoundationTestResponseTest extends TestCase
 
         $baseResponse = tap(new Response, function ($response) {
             $response->setContent(json_encode(['errors' => [
-                    'foo' => [],
-                    'bar' => ['one', 'two'],
-                ]]
-            ));
+                'foo' => [],
+                'bar' => ['one', 'two'],
+            ]]));
         });
 
         $response = TestResponse::fromBaseResponse($baseResponse);


### PR DESCRIPTION
## What

This PR applies the CS fixes for the proposed new `laravel` preset for StyleCI, which adds the `array_indentation`, `compact_nullable_typehint`, `no_unneeded_curly_braces` fixers, and disables the `phpdoc_to_comment` fixer.

## Why this branch?

StyleCI is currently enabled on the 5.5, 5.8, 6.x and master branches, since they are all still maintained in some way (security fixes (5.5, 5.8), active support (6.x), upcoming release (master)).