### PR TITLE
[6.x] Revert work around for StyleCI lack of PHP 7.4 support

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,8 +1,5 @@
 php:
   preset: laravel
-  finder:
-    not-name:
-      - typed-properties.php
 js:
   finder:
     not-name:


### PR DESCRIPTION
StyleCI now supports PHP 7.4, so we don't need to ignore that file anymore.