### PR TITLE
[6.x] Consistently format factory stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,7 +1,6 @@
 <?php
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
-
 use Faker\Generator as Faker;
 use NamespacedDummyModel;
 


### PR DESCRIPTION
This pull request formats the docblock in the factory stub in the same way as in the `UserFactory` already present in a new Laravel project.

Related to https://github.com/laravel/laravel/pull/5006.