### PR TITLE
[6.x] Resolve Faker\Generator out of the container if it is bound

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Testing;
 
 use Faker\Factory;
+use Faker\Generator;
 
 trait WithFaker
 {
@@ -42,6 +43,12 @@ trait WithFaker
      */
     protected function makeFaker($locale = null)
     {
-        return Factory::create($locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE));
+        $locale = $locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE);
+
+        if ($this->app->bound(Generator::class)) {
+            return $this->app->make(Generator::class, [$locale]);
+        }
+
+        return Factory::create($locale);
     }
 }


### PR DESCRIPTION
If Faker\Generator is bound in the container then use that instance instead of creating a default version. This allows you to bind your own custom Faker\Generator and add custom faker providers which will be available when using WithFaker

For example, you can create a FakerServiceProvider that can bind it like this:
```php
        $this->app->singleton(Generator::class, function () {
            $faker = Factory::create();
            $faker->addProvider(new CompanyNameGenerator\FakerProvider($faker));

            return $faker;
        });
```

The code is adding the custom CompanyNameGenerator faker provider. Since it is bound in the container then it will be used and the custom company name provider will be available to be used. Without this change then the CompanyNameGenerator provider would not be available and would have to be manually added everytime you wanted to use it.