### PR TITLE
[6.x] [Testing] add query params support to request maker

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -214,14 +214,15 @@ trait MakesHttpRequests
      *
      * @param  string  $uri
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $headers = [],$parameters = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        return $this->call('GET', $uri, $parameters, $cookies, [], $server);
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -217,7 +217,7 @@ trait MakesHttpRequests
      * @param  array  $parameters
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function get($uri, array $headers = [],$parameters = [])
+    public function get($uri, array $headers = [], $parameters = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();


### PR DESCRIPTION
This PR targets Laravel testing component. with `->get` there is no way to set the query parameters. 
 despite SymfonyRequest has the parameter already. so instead of 
```php
$params = ['key' => 'value'];
$response = $this->get('/test?'.http_build_query($params),[]);
```
this PR makes it
```php
$params = ['key' => 'value'];
$response = $this->get('/test',[],$params);
```

and Symfony request maker will handle it himself.

I've no idea why it's an empty array without any way to set it. also, I didn't find any PR discuss this before. but I think it would be good to have it simple. 

I've put the parameter at the end, to make it backward compatible.

