### PR TITLE
[6.x] Prevent making actual pdo connections while reconnecting

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -928,6 +928,16 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Get the raw current PDO connection parameter.
+     *
+     * @return \PDO
+     */
+    public function getRawPdo()
+    {
+        return $this->pdo;
+    }
+
+    /**
      * Get the current PDO connection used for reading.
      *
      * @return \PDO
@@ -947,6 +957,16 @@ class Connection implements ConnectionInterface
         }
 
         return $this->readPdo ?: $this->getPdo();
+    }
+
+    /**
+     * Get the raw current read PDO connection parameter.
+     *
+     * @return \PDO
+     */
+    public function getRawReadPdo()
+    {
+        return $this->readPdo;
     }
 
     /**

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -930,7 +930,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the raw current PDO connection parameter.
      *
-     * @return \PDO
+     * @return \PDO|\Closure|null
      */
     public function getRawPdo()
     {
@@ -962,7 +962,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the raw current read PDO connection parameter.
      *
-     * @return \PDO
+     * @return \PDO|\Closure|null
      */
     public function getRawReadPdo()
     {

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -256,8 +256,8 @@ class DatabaseManager implements ConnectionResolverInterface
         $fresh = $this->makeConnection($name);
 
         return $this->connections[$name]
-                                ->setPdo($fresh->getPdo())
-                                ->setReadPdo($fresh->getReadPdo());
+                                ->setPdo($fresh->getRawPdo())
+                                ->setReadPdo($fresh->getRawReadPdo());
     }
 
     /**


### PR DESCRIPTION
Calling `$connection->getPdo()` or `$connection->getReadPdo()` starts an actual connection with the database:

- https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Connection.php#L924
- https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Connection.php#L946

Problems appear when the connection we are using is a read-only or write-only connection, in that case we don't want to make the other PDO connection while it won't be used as seen in this issue(https://github.com/laravel/framework/issues/30957).

I went for `readRawPdo` and `readWritePdo` for method names as we have the same in Query\Builder.php where we have a getter `getBidnings` and another method `getRawBindings`. That way we won't have to break the interface.