### PR TITLE
[6.x] Deprecate sendNow and remove unneeded check

### DIFF
--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -132,6 +132,7 @@ class PendingMail
      *
      * @param  \Illuminate\Contracts\Mail\Mailable  $mailable
      * @return mixed
+     * @deprecated Use send() instead.
      */
     public function sendNow(MailableContract $mailable)
     {
@@ -146,13 +147,7 @@ class PendingMail
      */
     public function queue(MailableContract $mailable)
     {
-        $mailable = $this->fill($mailable);
-
-        if (isset($mailable->delay)) {
-            return $this->mailer->later($mailable->delay, $mailable);
-        }
-
-        return $this->mailer->queue($mailable);
+        return $this->mailer->queue($this->fill($mailable));
     }
 
     /**

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -4,7 +4,6 @@ namespace Illuminate\Mail;
 
 use Illuminate\Contracts\Mail\Mailable as MailableContract;
 use Illuminate\Contracts\Mail\Mailer as MailerContract;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 
 class PendingMail

--- a/src/Illuminate/Mail/PendingMail.php
+++ b/src/Illuminate/Mail/PendingMail.php
@@ -120,10 +120,6 @@ class PendingMail
      */
     public function send(MailableContract $mailable)
     {
-        if ($mailable instanceof ShouldQueue) {
-            return $this->queue($mailable);
-        }
-
         return $this->mailer->send($this->fill($mailable));
     }
 


### PR DESCRIPTION
This PR removes `PendingMail::sendNow` since it won't actually send the mail `now` if the mailable implements `ShouldQueue`. It works same as `send`.

It Also removes the `ShouldQueue` check from `PendingMail::send` since the check will happen in `Mailer::sendMailable` anyway.

Finally, it removes the `$mailable->delay` check since it'll be checked in `Mailable::queue` anyway.