### PR TITLE
[6.x] Don't replicate timestamp fields only when timestamps are enabled

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1165,11 +1165,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function replicate(array $except = null)
     {
-        $defaults = [
-            $this->getKeyName(),
-            $this->getCreatedAtColumn(),
-            $this->getUpdatedAtColumn(),
-        ];
+        $defaults = [$this->getKeyName()];
+
+        if ($this->usesTimestamps()) {
+            $defaults = array_merge($defaults, [
+                $this->getCreatedAtColumn(),
+                $this->getUpdatedAtColumn(),
+            ]);
+        }
 
         $attributes = Arr::except(
             $this->attributes, $except ? array_unique(array_merge($except, $defaults)) : $defaults

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1322,6 +1322,32 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['bar'], $clone->foo);
     }
 
+    public function testCloneModelMakesAFreshCopyOfTheModelIncludingTimestampFieldsWhenTimestampsDisabled()
+    {
+        $class = new EloquentModelStub;
+        $class->timestamps = false;
+
+        $class->id = 1;
+        $class->exists = true;
+        $class->first = 'taylor';
+        $class->last = 'otwell';
+        $class->created_at = $class->freshTimestamp();
+        $class->updated_at = $class->freshTimestamp();
+        $class->setRelation('foo', ['bar']);
+
+        $clone = $class->replicate();
+
+        $this->assertNull($clone->id);
+        $this->assertFalse($clone->exists);
+        $this->assertSame('taylor', $clone->first);
+        $this->assertSame('otwell', $clone->last);
+        $this->assertArrayHasKey('created_at', $clone->getAttributes());
+        $this->assertArrayHasKey('updated_at', $clone->getAttributes());
+        $this->assertSame($class->created_at->toDateTimeString(), $clone->created_at->toDateTimeString());
+        $this->assertSame($class->updated_at->toDateTimeString(), $clone->updated_at->toDateTimeString());
+        $this->assertEquals(['bar'], $clone->foo);
+    }
+
     public function testModelObserversCanBeAttachedToModels()
     {
         EloquentModelStub::setEventDispatcher($events = m::mock(Dispatcher::class));

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1317,8 +1317,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($clone->exists);
         $this->assertSame('taylor', $clone->first);
         $this->assertSame('otwell', $clone->last);
-        $this->assertObjectNotHasAttribute('created_at', $clone);
-        $this->assertObjectNotHasAttribute('updated_at', $clone);
+        $this->assertArrayNotHasKey('created_at', $clone->getAttributes());
+        $this->assertArrayNotHasKey('updated_at', $clone->getAttributes());
         $this->assertEquals(['bar'], $clone->foo);
     }
 


### PR DESCRIPTION
At the moment `created_at` and `updated_at` are always not replicated but in fact they should not be replicated only when model has timestamps enabled. 

It's possible that they are managed manually or they contain completely different values than timestamps so they should not be excluded when replicating in such case

Moved to 6.x branch as requested in https://github.com/laravel/framework/pull/30994