### PR TITLE
[7.x] [Testing] add query params support to request maker

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -213,11 +213,11 @@ trait MakesHttpRequests
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
-     * @param  array  $parameters
      * @param  array  $headers
+     * @param  array  $parameters
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function get($uri, array $parameters = [], array $headers = [])
+    public function get($uri, array $headers = [], array $parameters = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -213,15 +213,16 @@ trait MakesHttpRequests
      * Visit the given URI with a GET request.
      *
      * @param  string  $uri
+     * @param  array  $parameters
      * @param  array  $headers
      * @return \Illuminate\Foundation\Testing\TestResponse
      */
-    public function get($uri, array $headers = [])
+    public function get($uri, array $parameters = [], array $headers = [])
     {
         $server = $this->transformHeadersToServerVars($headers);
         $cookies = $this->prepareCookiesForRequest();
 
-        return $this->call('GET', $uri, [], $cookies, [], $server);
+        return $this->call('GET', $uri, $parameters, $cookies, [], $server);
     }
 
     /**


### PR DESCRIPTION
This PR targets Laravel testing component. with `->get` there is no way to set the query parameters. 
 despite SymfonyRequest has the parameter already. so instead of 
```php
$params = ['key' => 'value'];
$response = $this->get('/test?'.http_build_query($params),[]);
```
this PR makes it
```php
$headers = [];
$params = ['key' => 'value'];
$response = $this->get('/test',$headers,$params);
```

and Symfony request maker will handle it himself.

I've no idea why it's an empty array without any way to set it. also, I didn't find any PR discuss this before. but I think it would be good to have it simple. 

**NOTE** this is a breaking change as the method signature has changed

also if it gets merged. should I add it to the changelog?