### PR TITLE
[6.x] Fix exclude validation rules for nested data

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -182,6 +182,7 @@ class Validator implements ValidatorContract
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
         'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'Gt', 'Lt', 'Gte', 'Lte',
+        'ExcludeIf', 'ExcludeUnless',
     ];
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4953,8 +4953,8 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
                             ['color' => 'red', 'shape' => 'square'],
-                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat'],
@@ -4962,12 +4962,12 @@ class ValidationValidatorTest extends TestCase
                 ], [
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
-                            ['color' => 'red', 'shape' => 'square'],
-                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             // The shape field for these blue wheels were correctly excluded (if they weren't, they would
                             // fail the validation). They still appear in the validated data. This behaviour is unrelated
                             // to the "exclude" type rules.
+                            ['color' => 'red', 'shape' => 'square'],
                             ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat'],
@@ -5076,15 +5076,15 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
                             ['color' => 'red', 'shape' => 'square'],
-                            ['color' => 'red', 'shape' => 'hexagon'],
                             ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'red', 'shape' => 'hexagon'],
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat', 'wheels' => 'should be excluded'],
                     ],
                 ], [
                     // The blue wheels are excluded and are therefor not validated against the "in:square,round" rule
-                    'vehicles.0.wheels.1.shape' => ['validation.in'],
+                    'vehicles.0.wheels.2.shape' => ['validation.in'],
                 ],
             ],
         ];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4910,6 +4910,70 @@ class ValidationValidatorTest extends TestCase
                     'has_appointments' => false,
                 ],
             ],
+            'nested-05' => [
+                [
+                    'vehicles.*.type' => 'required|in:car,boat',
+                    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|numeric',
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => 4],
+                        ['type' => 'boat', 'wheels' => 'should be excluded'],
+                    ]
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => 4],
+                        ['type' => 'boat'],
+                    ]
+                ],
+            ],
+            'nested-06' => [
+                [
+                    'vehicles.*.type' => 'required|in:car,boat',
+                    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|numeric',
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => 4],
+                        ['type' => 'boat'],
+                    ]
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => 4],
+                        ['type' => 'boat'],
+                    ]
+                ],
+            ],
+            'nested-07' => [
+                [
+                    'vehicles.*.type' => 'required|in:car,boat',
+                    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|array',
+                    'vehicles.*.wheels.*.color' => 'required|in:red,blue',
+                    // In this bizzaro world example you can choose a custom shape for your wheels if they are red
+                    'vehicles.*.wheels.*.shape' => 'exclude_unless:vehicles.*.wheels.*.color,red|required|in:square,round',
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => [
+                            ['color' => 'red', 'shape' => 'square'],
+                            ['color' => 'red', 'shape' => 'round'],
+                            ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'blue', 'shape' => 'triangle'],
+                        ]],
+                        ['type' => 'boat'],
+                    ]
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => [
+                            ['color' => 'red', 'shape' => 'square'],
+                            ['color' => 'red', 'shape' => 'round'],
+                            // The shape field for these blue wheels were correctly excluded (if they weren't, they would
+                            // fail the validation). They still appear in the validated data. This behaviour is unrelated
+                            // to the "exclude" type rules.
+                            ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'blue', 'shape' => 'triangle'],
+                        ]],
+                        ['type' => 'boat'],
+                    ]
+                ],
+            ],
         ];
     }
 
@@ -4978,6 +5042,49 @@ class ValidationValidatorTest extends TestCase
                 ], [
                     'appointments.0.date' => ['validation.date'],
                     'appointments.1.name' => ['validation.required'],
+                ],
+            ],
+            [
+                [
+                    'vehicles.*.price' => 'required|numeric',
+                    'vehicles.*.type' => 'required|in:car,boat',
+                    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|numeric',
+                ], [
+                    'vehicles' => [
+                        [
+                            'price' => 100,
+                            'type' => 'car',
+                        ],
+                        [
+                            'price' => 500,
+                            'type' => 'boat',
+                        ],
+                    ]
+                ], [
+                    'vehicles.0.wheels' => ['validation.required'],
+                    // vehicles.1.wheels is not required, because type is not "car"
+                ],
+            ],
+            'exclude-validation-error-01' => [
+                [
+                    'vehicles.*.type' => 'required|in:car,boat',
+                    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|array',
+                    'vehicles.*.wheels.*.color' => 'required|in:red,blue',
+                    // In this bizzaro world example you can choose a custom shape for your wheels if they are red
+                    'vehicles.*.wheels.*.shape' => 'exclude_unless:vehicles.*.wheels.*.color,red|required|in:square,round',
+                ], [
+                    'vehicles' => [
+                        ['type' => 'car', 'wheels' => [
+                            ['color' => 'red', 'shape' => 'square'],
+                            ['color' => 'red', 'shape' => 'hexagon'],
+                            ['color' => 'blue', 'shape' => 'hexagon'],
+                            ['color' => 'blue', 'shape' => 'triangle'],
+                        ]],
+                        ['type' => 'boat', 'wheels' => 'should be excluded'],
+                    ]
+                ], [
+                    // The blue wheels are excluded and are therefor not validated against the "in:square,round" rule
+                    'vehicles.0.wheels.1.shape' => ['validation.in'],
                 ],
             ],
         ];

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4953,7 +4953,7 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
                             ['color' => 'red', 'shape' => 'square'],
-                            ['color' => 'red', 'shape' => 'round'],
+                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             ['color' => 'blue', 'shape' => 'hexagon'],
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
@@ -4963,7 +4963,7 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
                             ['color' => 'red', 'shape' => 'square'],
-                            ['color' => 'red', 'shape' => 'round'],
+                            ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
                             // The shape field for these blue wheels were correctly excluded (if they weren't, they would
                             // fail the validation). They still appear in the validated data. This behaviour is unrelated
                             // to the "exclude" type rules.

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4918,12 +4918,12 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => 4],
                         ['type' => 'boat', 'wheels' => 'should be excluded'],
-                    ]
+                    ],
                 ], [
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => 4],
                         ['type' => 'boat'],
-                    ]
+                    ],
                 ],
             ],
             'nested-06' => [
@@ -4934,12 +4934,12 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => 4],
                         ['type' => 'boat'],
-                    ]
+                    ],
                 ], [
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => 4],
                         ['type' => 'boat'],
-                    ]
+                    ],
                 ],
             ],
             'nested-07' => [
@@ -4958,7 +4958,7 @@ class ValidationValidatorTest extends TestCase
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat'],
-                    ]
+                    ],
                 ], [
                     'vehicles' => [
                         ['type' => 'car', 'wheels' => [
@@ -4971,7 +4971,7 @@ class ValidationValidatorTest extends TestCase
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat'],
-                    ]
+                    ],
                 ],
             ],
         ];
@@ -5059,7 +5059,7 @@ class ValidationValidatorTest extends TestCase
                             'price' => 500,
                             'type' => 'boat',
                         ],
-                    ]
+                    ],
                 ], [
                     'vehicles.0.wheels' => ['validation.required'],
                     // vehicles.1.wheels is not required, because type is not "car"
@@ -5081,7 +5081,7 @@ class ValidationValidatorTest extends TestCase
                             ['color' => 'blue', 'shape' => 'triangle'],
                         ]],
                         ['type' => 'boat', 'wheels' => 'should be excluded'],
-                    ]
+                    ],
                 ], [
                     // The blue wheels are excluded and are therefor not validated against the "in:square,round" rule
                     'vehicles.0.wheels.1.shape' => ['validation.in'],


### PR DESCRIPTION
PR https://github.com/laravel/framework/pull/30835 added the `exclude_if` and `exclude_unless` validation rules. The following example currently doesn't work, this PR fixes that:
```php
$request->validate([
    'vehicles.*.type' => 'required|in:car,boat',
    'vehicles.*.wheels' => 'exclude_if:vehicles.*.type,boat|required|numeric',
]);
```

---

The tests in this PR also [contains an example](https://github.com/laravel/framework/compare/6.x...SjorsO:tests-for-validation-nesting?expand=1#diff-577188511192a5e66c2bd31cb84d38c2R4967) of fields nested 2 levels deep getting included in the validated data, even though they don't have a validation rule. There has been discussion about this bug/feature in the past: https://github.com/laravel/ideas/issues/1993#27205. This is unrelated to the `exclude` validation rules, but I ran into it and thought it would be a useful addition to the test suite.

---

This PR came from trying to replicate the weird behavior I encountered while making the original PR (see: https://github.com/laravel/framework/pull/30835#issuecomment-569402694). I couldn't replicate it, I must have been doing something wrong.
