### PR TITLE
[6.x] Utilize Symfony’s PSR Factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,7 @@
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
+        "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -8,10 +8,10 @@ use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\ServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Nyholm\Psr7\Response as PsrResponse;
 
 class RoutingServiceProvider extends ServiceProvider
 {

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -143,7 +143,7 @@ class RoutingServiceProvider extends ServiceProvider
                 return (new DiactorosFactory)->createRequest($app->make('request'));
             }
 
-            throw new Exception('Unable to resolve PSR request. Please install nyholm/psr7 or laminas/laminas-diactoros.');
+            throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
         });
     }
 
@@ -163,7 +163,7 @@ class RoutingServiceProvider extends ServiceProvider
                 return new ZendPsrResponse;
             }
 
-            throw new Exception('Unable to resolve PSR response. Please install nyholm/psr7 or laminas/laminas-diactoros.');
+            throw new Exception('Unable to resolve PSR response. Please install nyholm/psr7.');
         });
     }
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -7,10 +7,11 @@ use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\ServiceProvider;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
-use Zend\Diactoros\Response as PsrResponse;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Nyholm\Psr7\Response as PsrResponse;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -128,7 +129,9 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerPsrRequest()
     {
         $this->app->bind(ServerRequestInterface::class, function ($app) {
-            return (new DiactorosFactory)->createRequest($app->make('request'));
+            $psr17Factory = new Psr17Factory;
+            return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
+                ->createRequest($app->make('request'));
         });
     }
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Exception;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
@@ -137,9 +138,12 @@ class RoutingServiceProvider extends ServiceProvider
                 return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
                     ->createRequest($app->make('request'));
             }
+
             if (class_exists(DiactorosFactory::class)) {
                 return (new DiactorosFactory)->createRequest($app->make('request'));
             }
+
+            throw new Exception('Unable to resolve PSR request. Please install nyholm/psr7 or laminas/laminas-diactoros.');
         });
     }
 
@@ -154,9 +158,12 @@ class RoutingServiceProvider extends ServiceProvider
             if (class_exists(NyholmPsrResponse::class)) {
                 return new NyholmPsrResponse;
             }
+
             if (class_exists(ZendPsrResponse::class)) {
                 return new ZendPsrResponse;
             }
+
+            throw new Exception('Unable to resolve PSR response. Please install nyholm/psr7 or laminas/laminas-diactoros.');
         });
     }
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -130,6 +130,7 @@ class RoutingServiceProvider extends ServiceProvider
     {
         $this->app->bind(ServerRequestInterface::class, function ($app) {
             $psr17Factory = new Psr17Factory;
+
             return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
                 ->createRequest($app->make('request'));
         });

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -39,7 +39,8 @@
     },
     "suggest": {
         "illuminate/console": "Required to use the make commands (^6.0).",
-        "symfony/psr-http-message-bridge": "Required to psr7 bridging features (^1.2)."
+        "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
- replace DiactorosFactory with Symfony’s PSR Factory and recommended implementation
- replace Diactoros Response with Nyholm’s Response per [Symfony docs](https://symfony.com/doc/current/components/psr7.html) recommendation

---

Closes #31017.