### PR TITLE
[6.x] Adds composer scripts for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ install:
   - if [[ $SETUP = 'lowest' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-lowest --prefer-stable --no-suggest; fi
 
 script:
-  - vendor/bin/phpunit
+  - composer test

--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "test:unit": "phpunit -d memory_limit=512M",
+        "test:unit": "phpunit -d memory_limit=512M --colors=always",
         "test": [
             "@test:unit"
         ]

--- a/composer.json
+++ b/composer.json
@@ -139,5 +139,11 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "test:unit": "phpunit -d memory_limit=512M",
+        "test": [
+            "@test:unit"
+        ]
+    }
 }


### PR DESCRIPTION
This pull request adds composer scripts for launching the tests of the framework. This is beneficial to new and returning contributors alike, as they don't need to know about specifics of our testing suite such as `memory_limit`.

With this change, to launch the test suite, we just need to do: `composer test`.