### PR TITLE
[6.x] Make the Redis Connection macroable

### DIFF
--- a/src/Illuminate/Redis/Connections/Connection.php
+++ b/src/Illuminate/Redis/Connections/Connection.php
@@ -7,9 +7,14 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Redis\Events\CommandExecuted;
 use Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder;
 use Illuminate\Redis\Limiters\DurationLimiterBuilder;
+use Illuminate\Support\Traits\Macroable;
 
 abstract class Connection
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * The Redis client.
      *
@@ -208,6 +213,10 @@ abstract class Connection
      */
     public function __call($method, $parameters)
     {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
         return $this->command($method, $parameters);
     }
 }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -547,6 +547,20 @@ class RedisConnectionTest extends TestCase
         );
     }
 
+    public function testMacroable()
+    {
+        Connection::macro('foo', function () {
+            return 'foo';
+        });
+
+        foreach ($this->connections() as $redis) {
+            $this->assertSame(
+                'foo',
+                $redis->foo()
+            );
+        }
+    }
+
     public function connections()
     {
         $connections = [


### PR DESCRIPTION
This PR makes the Redis connection macroable.

I personally need this because I wrote a [circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html) and I would like to be able to use it in a similar manner to `Redis::throttle` and `Redis::funnel`.

I imagine macros would also be helpful for registering custom Lua scripts as commands, overriding `funnel` with an implementation using [the RedLock algorithm](https://redis.io/topics/distlock), adding a [SCAN](https://redis.io/commands/scan) abstraction that works the same across predis and phpredis, etc.

If a macro is not registered we fallback to executing a command on the client so this should not be a breaking change.