### PR TITLE
[6.x] Adds missing options for PhpRedis

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -97,6 +97,14 @@ class PhpRedisConnector implements Connector
             if (! empty($config['read_timeout'])) {
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
+
+            if (! empty($options['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
+            }
+
+            if (! empty($config['scan'])) {
+                $client->setOption(Redis::OPT_SCAN, $config['scan']);
+            }
         });
     }
 
@@ -150,6 +158,18 @@ class PhpRedisConnector implements Connector
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
             if (! empty($options['prefix'])) {
                 $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
+            }
+
+            if (! empty($options['serializer'])) {
+                $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
+            }
+
+            if (! empty($config['scan'])) {
+                $client->setOption(RedisCluster::OPT_SCAN, $config['scan']);
+            }
+
+            if (! empty($config['failover'])) {
+                $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $config['failover']);
             }
         });
     }

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -557,10 +557,17 @@ class RedisConnectionTest extends TestCase
                 $redis->set($key, 'test');
             }
 
+            // keys coming out of scan include any prefix so we'll need to expect that
+            if (! empty($prefix = $redis->getOption(Redis::OPT_PREFIX))) {
+                foreach ($initialKeys as $k => $initialKey) {
+                    $initialKeys[$k] = $prefix.$initialKey;
+                }
+            }
+
             $iterator = null;
 
             do {
-                list($cursor, $returnedKeys) = $redis->scan($iterator);
+                [$cursor, $returnedKeys] = $redis->scan($iterator);
 
                 $this->assertEquals($initialKeys, $returnedKeys);
             } while ($iterator > 0);
@@ -570,7 +577,7 @@ class RedisConnectionTest extends TestCase
             $iterator = null;
 
             do {
-                list($cursor, $returnedKeys) = $redis->scan($iterator);
+                [$cursor, $returnedKeys] = $redis->scan($iterator);
 
                 if ($redis->getOption(Redis::OPT_SCAN) === Redis::SCAN_RETRY) {
                     $this->assertNotFalse($returnedKeys);
@@ -624,7 +631,7 @@ class RedisConnectionTest extends TestCase
                 'database' => 7,
                 'options' => ['serializer' => Redis::SERIALIZER_JSON],
                 'timeout' => 0.5,
-           ],
+            ],
         ]);
 
         $scanRetryPhpRedis = new RedisManager(new Application, 'phpredis', [

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -9,6 +9,7 @@ use Illuminate\Redis\Connections\Connection;
 use Illuminate\Redis\RedisManager;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Predis\Client;
 use Redis;
 
 class RedisConnectionTest extends TestCase
@@ -555,7 +556,7 @@ class RedisConnectionTest extends TestCase
 
             foreach ($initialKeys as $k => $key) {
                 $redis->set($key, 'test');
-                $initialKeys[$k] = $this->getPrefix($redis->client()).$key;
+                $initialKeys[$k] = $this->getPrefix($redis->client()) . $key;
             }
 
             $iterator = null;
@@ -569,6 +570,15 @@ class RedisConnectionTest extends TestCase
             } while ($iterator > 0);
 
             $redis->flushAll();
+        }
+    }
+
+    public function testPhpRedisScanOption()
+    {
+        foreach ($this->connections() as $redis) {
+            if ($redis->client() instanceof Client) {
+                continue;
+            }
 
             $iterator = null;
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -560,7 +560,9 @@ class RedisConnectionTest extends TestCase
             $iterator = null;
 
             do {
-                $this->assertEquals($initialKeys, $redis->scan($iterator));
+                list($cursor, $returnedKeys) = $redis->scan($iterator);
+
+                $this->assertEquals($initialKeys, $returnedKeys);
             } while ($iterator > 0);
 
             $redis->flushAll();
@@ -568,7 +570,7 @@ class RedisConnectionTest extends TestCase
             $iterator = null;
 
             do {
-                $returnedKeys = $redis->scan($iterator);
+                list($cursor, $returnedKeys) = $redis->scan($iterator);
 
                 if ($redis->getOption(Redis::OPT_SCAN) === Redis::SCAN_RETRY) {
                     $this->assertNotFalse($returnedKeys);
@@ -615,13 +617,13 @@ class RedisConnectionTest extends TestCase
         ]);
 
         $serializerPhpRedis = new RedisManager(new Application, 'phpredis', [
-           'cluster' => false,
-           'default' => [
-               'host' => $host,
-               'port' => $port,
-               'database' => 7,
-               'options' => ['serializer' => Redis::SERIALIZER_JSON],
-               'timeout' => 0.5,
+            'cluster' => false,
+            'default' => [
+                'host' => $host,
+                'port' => $port,
+                'database' => 7,
+                'options' => ['serializer' => Redis::SERIALIZER_JSON],
+                'timeout' => 0.5,
            ],
         ]);
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -622,7 +622,7 @@ class RedisConnectionTest extends TestCase
                'database' => 7,
                'options' => ['serializer' => Redis::SERIALIZER_JSON],
                'timeout' => 0.5,
-           ]
+           ],
         ]);
 
         $scanRetryPhpRedis = new RedisManager(new Application, 'phpredis', [
@@ -633,7 +633,7 @@ class RedisConnectionTest extends TestCase
                 'database' => 7,
                 'options' => ['scan' => Redis::SCAN_RETRY],
                 'timeout' => 0.5,
-            ]
+            ],
         ]);
 
         $connections[] = $prefixedPhpredis->connection();


### PR DESCRIPTION
This PR adds support for options on PhpRedis connections that were not allowed before. This includes specifying a `serializer`, `scan` option, and `failover` behavior for cluster connections.

The `serializer` option allows for using `igbinary` which can use significantly less storage space as documented [here](https://medium.com/@akalongman/phpredis-vs-predis-comparison-on-real-production-data-a819b48cbadb).

The `scan` option allows for customizing the behavior of scan commands as described [here](https://github.com/phpredis/phpredis#setoption).

The `failover` option allows for customizing the behavior of a cluster connection as described [here](https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#automatic-slave-failover--distribution).