### PR TITLE
[6.x] Extract CallOtherCommands feature from Illuminate\Console\Command

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -8,18 +8,17 @@ use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 
 class Command extends SymfonyCommand
 {
-    use Macroable;
+    use Concerns\CallOtherCommands,
+        Macroable;
 
     /**
      * The Laravel application instance.
@@ -203,47 +202,6 @@ class Command extends SymfonyCommand
     }
 
     /**
-     * Call another console command.
-     *
-     * @param  \Symfony\Component\Console\Command\Command|string  $command
-     * @param  array  $arguments
-     * @return int
-     */
-    public function call($command, array $arguments = [])
-    {
-        return $this->runCommand($command, $arguments, $this->output);
-    }
-
-    /**
-     * Call another console command silently.
-     *
-     * @param  \Symfony\Component\Console\Command\Command|string  $command
-     * @param  array  $arguments
-     * @return int
-     */
-    public function callSilent($command, array $arguments = [])
-    {
-        return $this->runCommand($command, $arguments, new NullOutput);
-    }
-
-    /**
-     * Run the given the console command.
-     *
-     * @param  \Symfony\Component\Console\Command\Command|string  $command
-     * @param  array  $arguments
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return int
-     */
-    protected function runCommand($command, array $arguments, OutputInterface $output)
-    {
-        $arguments['command'] = $command;
-
-        return $this->resolveCommand($command)->run(
-            $this->createInputFromArguments($arguments), $output
-        );
-    }
-
-    /**
      * Resolve the console command instance for the given command.
      *
      * @param  \Symfony\Component\Console\Command\Command|string  $command
@@ -266,39 +224,6 @@ class Command extends SymfonyCommand
         }
 
         return $command;
-    }
-
-    /**
-     * Create an input instance from the given arguments.
-     *
-     * @param  array  $arguments
-     * @return \Symfony\Component\Console\Input\ArrayInput
-     */
-    protected function createInputFromArguments(array $arguments)
-    {
-        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
-            if ($input->hasParameterOption(['--no-interaction'], true)) {
-                $input->setInteractive(false);
-            }
-        });
-    }
-
-    /**
-     * Get all of the context passed to the command.
-     *
-     * @return array
-     */
-    protected function context()
-    {
-        return collect($this->option())->only([
-            'ansi',
-            'no-ansi',
-            'no-interaction',
-            'quiet',
-            'verbose',
-        ])->filter()->mapWithKeys(function ($value, $key) {
-            return ["--{$key}" => $value];
-        })->all();
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/CallOtherCommands.php
+++ b/src/Illuminate/Console/Concerns/CallOtherCommands.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait CallOtherCommands
+{
+    /**
+     * Call another console command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  array  $arguments
+     * @return int
+     */
+    public function call($command, array $arguments = [])
+    {
+        return $this->runCommand($command, $arguments, $this->output);
+    }
+
+    /**
+     * Call another console command silently.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  array  $arguments
+     * @return int
+     */
+    public function callSilent($command, array $arguments = [])
+    {
+        return $this->runCommand($command, $arguments, new NullOutput);
+    }
+
+    /**
+     * Run the given the console command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @param  array  $arguments
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function runCommand($command, array $arguments, OutputInterface $output)
+    {
+        $arguments['command'] = $command;
+
+        return $this->resolveCommand($command)->run(
+            $this->createInputFromArguments($arguments), $output
+        );
+    }
+
+    /**
+     * Create an input instance from the given arguments.
+     *
+     * @param  array  $arguments
+     * @return \Symfony\Component\Console\Input\ArrayInput
+     */
+    protected function createInputFromArguments(array $arguments)
+    {
+        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
+            if ($input->hasParameterOption(['--no-interaction'], true)) {
+                $input->setInteractive(false);
+            }
+        });
+    }
+
+    /**
+     * Get all of the context passed to the command.
+     *
+     * @return array
+     */
+    protected function context()
+    {
+        return collect($this->option())->only([
+            'ansi',
+            'no-ansi',
+            'no-interaction',
+            'quiet',
+            'verbose',
+        ])->filter()->mapWithKeys(function ($value, $key) {
+            return ["--{$key}" => $value];
+        })->all();
+    }
+
+    /**
+     * Resolve the console command instance for the given command.
+     *
+     * @param  \Symfony\Component\Console\Command\Command|string  $command
+     * @return \Symfony\Component\Console\Command\Command
+     */
+    abstract protected function resolveCommand($command);
+}


### PR DESCRIPTION
At the moment Illuminate\Console\Command is tightly couple with Laravel
via `$this->laravel->make()` usage, this changes make it possible to reuse
`CallOtherCommands` feature available for Laravel commands to standalone
Symfony commands.

```php
<?php
namespace Foo\Commands;

use Illuminate\Console\Concerns\CallOtherCommands;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;

abstract class Command extends \Symfony\Component\Console\Command\Command
{
    use CallOtherCommands;

    /**
     * Resolve the console command instance for the given command.
     *
     * @param  string  $command
     * @return \Symfony\Component\Console\Command\Command
     */
    protected function resolveCommand($command)
    {
        return $this->getApplication()->find($command);
    }
}
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
