### PR TITLE
[7.x] Removed legacy HTTP PSR code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,7 @@
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.0).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2).",
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },
     "config": {

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -9,13 +9,10 @@ use Illuminate\Contracts\View\Factory as ViewFactoryContract;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Support\ServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Nyholm\Psr7\Response as NyholmPsrResponse;
+use Nyholm\Psr7\Response as PsrResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
-use Zend\Diactoros\Response as ZendPsrResponse;
-use Zend\Diactoros\ServerRequestFactory;
 
 class RoutingServiceProvider extends ServiceProvider
 {
@@ -140,10 +137,6 @@ class RoutingServiceProvider extends ServiceProvider
                     ->createRequest($app->make('request'));
             }
 
-            if (class_exists(ServerRequestFactory::class) && class_exists(DiactorosFactory::class)) {
-                return (new DiactorosFactory)->createRequest($app->make('request'));
-            }
-
             throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
         });
     }
@@ -156,12 +149,8 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerPsrResponse()
     {
         $this->app->bind(ResponseInterface::class, function () {
-            if (class_exists(NyholmPsrResponse::class)) {
-                return new NyholmPsrResponse;
-            }
-
-            if (class_exists(ZendPsrResponse::class)) {
-                return new ZendPsrResponse;
+            if (class_exists(PsrResponse::class)) {
+                return new PsrResponse;
             }
 
             throw new Exception('Unable to resolve PSR response. Please install nyholm/psr7.');

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -39,7 +39,7 @@
     "suggest": {
         "illuminate/console": "Required to use the make commands (^7.0).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
-        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^1.2)."
+        "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Previous versions of Laravel (up until 6.10.0), used the Zend Diactoros PSR implementations. This package was abandoned a few days ago, and Symfony now recommend to use the `nyholm/psr7` package. Laravel 6.11.0 and upwards will now first look for this new package first, and fall back to Zend if not available. In Laravel 7, we can remove this fallback code, which we couldn't do in 6.x, without it being a breaking change.