### PR TITLE
[6.x] Use native array_reduce

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -201,7 +201,7 @@ abstract class ServiceProvider
             return $paths;
         }
 
-        return collect(static::$publishes)->reduce(function ($paths, $p) {
+        return array_reduce(static::$publishes, function ($paths, $p) {
             return array_merge($paths, $p);
         }, []);
     }


### PR DESCRIPTION
This PR replaces the unnecessary use of collections with a native function.