### PR TITLE
[6.x] Add @includeOnce() Blade directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesIncludes.php
@@ -79,4 +79,17 @@ trait CompilesIncludes
 
         return "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
     }
+
+    /**
+     * Compile the include statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileIncludeOnce($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        return "<?php echo \$__env->renderOnce($expression, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path'])); ?>";
+    }
 }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -84,6 +84,13 @@ class Factory implements FactoryContract
     protected $renderCount = 0;
 
     /**
+     * List of views that have been rendered.
+     *
+     * @var array
+     */
+    protected $renderedViews = [];
+
+    /**
      * Create a new view factory instance.
      *
      * @param  \Illuminate\View\Engines\EngineResolver  $engines
@@ -131,6 +138,8 @@ class Factory implements FactoryContract
             $view = $this->normalizeName($view)
         );
 
+        $this->renderedViews[$view] = true;
+
         // Next, we will create the view instance and call the view creator for the view
         // which can set any data, etc. Then we will return the view instance back to
         // the caller for rendering or performing other view manipulations on this.
@@ -176,6 +185,24 @@ class Factory implements FactoryContract
     public function renderWhen($condition, $view, $data = [], $mergeData = [])
     {
         if (! $condition) {
+            return '';
+        }
+
+        return $this->make($view, $this->parseData($data), $mergeData)->render();
+    }
+
+    /**
+     * Get the rendered content of the view, unless
+     * it has already been rendered previously.
+     *
+     * @param  string  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
+     * @return string
+     */
+    public function renderOnce($view, $data = [], $mergeData = [])
+    {
+        if (isset($this->renderedViews[$view])) {
             return '';
         }
 

--- a/tests/View/Blade/BladeIncludesTest.php
+++ b/tests/View/Blade/BladeIncludesTest.php
@@ -33,4 +33,9 @@ class BladeIncludesTest extends AbstractBladeTestCase
         $this->assertSame('<?php echo $__env->first(["one", "two"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"])'));
         $this->assertSame('<?php echo $__env->first(["one", "two"], ["foo" => "bar"], \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>', $this->compiler->compileString('@includeFirst(["one", "two"], ["foo" => "bar"])'));
     }
+
+    public function testIncludeOncesAreCompiled()
+    {
+        $this->assertSame('<?php echo $__env->renderOnce(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\'])); ?>', $this->compiler->compileString('@includeOnce(\'foo\')'));
+    }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -252,6 +252,17 @@ class ViewFactoryTest extends TestCase
         $this->assertTrue($factory->doneRendering());
     }
 
+    public function testRenderOnce()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/basic.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine);
+        $factory->getDispatcher()->shouldReceive('dispatch');
+        $this->assertSame('Hello World' . PHP_EOL, $factory->renderOnce('foo'));
+        $this->assertSame('', $factory->renderOnce('foo'));
+        $this->assertSame('Hello World' . PHP_EOL, $factory->renderOnce('bar'));
+    }
+
     public function testYieldDefault()
     {
         $factory = $this->getFactory();

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -258,9 +258,9 @@ class ViewFactoryTest extends TestCase
         $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/basic.php');
         $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine);
         $factory->getDispatcher()->shouldReceive('dispatch');
-        $this->assertSame('Hello World' . PHP_EOL, $factory->renderOnce('foo'));
+        $this->assertSame('Hello World'.PHP_EOL, $factory->renderOnce('foo'));
         $this->assertSame('', $factory->renderOnce('foo'));
-        $this->assertSame('Hello World' . PHP_EOL, $factory->renderOnce('bar'));
+        $this->assertSame('Hello World'.PHP_EOL, $factory->renderOnce('bar'));
     }
 
     public function testYieldDefault()


### PR DESCRIPTION
This PR adds a single new Blade directive: `@includeOnce($view, $params)`

The intention of this directive is to behave the same as PHP's [`include_once` statement](https://www.php.net/manual/en/function.include-once.php), where a file will only be included if it hasn't already been.

Of course, it is up to the developer how they wish to use this, but here is an example scenario that it could be useful in:

* An included view does something like rendering a `<style>` or `<script>` tag, but only ever needs to be included in the page once. For example, a script tag may initiate a WYSIWYG editor on certain textareas in the frontend, but shouldn't be included if no such textareas are on the page -so the developer can just use the `@includeOnce` directive wherever these textareas are.