### PR TITLE
[6.x] Add redis.connection aliases in container

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1185,6 +1185,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
             'queue.failer'         => [\Illuminate\Queue\Failed\FailedJobProviderInterface::class],
             'redirect'             => [\Illuminate\Routing\Redirector::class],
             'redis'                => [\Illuminate\Redis\RedisManager::class, \Illuminate\Contracts\Redis\Factory::class],
+            'redis.connection'     => [\Illuminate\Redis\Connections\Connection::class, \Illuminate\Contracts\Redis\Connection::class],
             'request'              => [\Illuminate\Http\Request::class, \Symfony\Component\HttpFoundation\Request::class],
             'router'               => [\Illuminate\Routing\Router::class, \Illuminate\Contracts\Routing\Registrar::class, \Illuminate\Contracts\Routing\BindingRegistrar::class],
             'session'              => [\Illuminate\Session\SessionManager::class],


### PR DESCRIPTION
In order to add on these improvements:

- laravel/framework#24142
- laravel/framework#17722

I've added two aliases to the `redis.connection` binding.

These aliases are:

- `\Illuminate\Redis\Connections\Connection::class`
- `\Illuminate\Contracts\Redis\Connection::class`

It will then allow anyone to type hint on the redis Connection class or Contract and let the container resolve the correct connection implementation.

This behavior will also be consistent with the database one.

One other advantage of doing this is that developers won't need to type hint on the lower level `RedisManager` class. This will result in code that is less coupled to the framework internals.