### PR TITLE
[7.x] Custom Cast Types + Object / Value Object Casts

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface CastsAttributes
+{
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes);
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, string $key, $value, array $attributes);
+}

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface CastsInboundAttributes
+{
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, string $key, $value, array $attributes);
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -536,11 +536,11 @@ trait HasAttributes
     }
 
     /**
-      * Cast the given attribute using a custom cast class.
-      *
-      * @param  string  $key
-      * @return mixed
-      */
+     * Cast the given attribute using a custom cast class.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
     protected function getClassCastableAttribute($key)
     {
         if (isset($this->classCastCache[$key])) {
@@ -705,7 +705,8 @@ trait HasAttributes
     {
         if (is_null($value)) {
             $this->attributes = array_merge($this->attributes, array_map(
-                function () { return null; },
+                function () {
+                },
                 $this->normalizeCastClassResponse($key, $this->resolveCasterClass($key)->set(
                     $this, $key, $this->{$key}, $this->attributes
                 ))
@@ -719,7 +720,7 @@ trait HasAttributes
             );
         }
 
-       unset($this->classCastCache[$key]);
+        unset($this->classCastCache[$key]);
     }
 
     /**
@@ -1031,7 +1032,7 @@ trait HasAttributes
      */
     protected function isClassCastable($key)
     {
-         return array_key_exists($key, $this->getCasts()) &&
+        return array_key_exists($key, $this->getCasts()) &&
                 class_exists($class = $this->getCasts()[$key]) &&
                 ! in_array($class, static::$primitiveCastTypes);
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -546,7 +546,7 @@ trait HasAttributes
              return $this->classCastCache[$key];
          } else {
              return $this->classCastCache[$key] = forward_static_call(
-                 [$this->getCasts()[$key], 'fromModelAttributes'], $this, $key, $this->attributes
+                 [$this->getCasts()[$key], 'fromModelAttributes'], $this, $key, $this->attributes[$key] ?? null, $this->attributes
              );
          }
      }
@@ -702,7 +702,11 @@ trait HasAttributes
      {
          if (is_null($value)) {
              $this->attributes = array_merge($this->attributes, array_map(
-                 function () { return null; }, $this->castToClass($key)->toModelAttributes($this)
+                 function () { return null; },
+                 forward_static_call(
+                    [$this->getCasts()[$key], 'toModelAttributes'],
+                    $this, $key, $this->{$key}, $this->attributes
+                )
              ));
 
              unset($this->classCastCache[$key]);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -476,7 +476,7 @@ trait HasAttributes
     protected function mutateAttributeForArray($key, $value)
     {
         $value = $this->isClassCastable($key)
-                    ? $this->getClassCastableAttribute($key)
+                    ? $this->getClassCastableAttributeValue($key)
                     : $this->mutateAttribute($key, $value);
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
@@ -529,7 +529,7 @@ trait HasAttributes
         }
 
         if ($this->isClassCastable($key)) {
-            return $this->getClassCastableAttribute($key);
+            return $this->getClassCastableAttributeValue($key);
         }
 
         return $value;
@@ -541,7 +541,7 @@ trait HasAttributes
       * @param  string  $key
       * @return mixed
       */
-    protected function getClassCastableAttribute($key)
+    protected function getClassCastableAttributeValue($key)
     {
         if (isset($this->classCastCache[$key])) {
             return $this->classCastCache[$key];

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1040,9 +1040,7 @@ trait HasAttributes
      */
     protected function resolveCasterClass($key)
     {
-        $castType = $this->getCasts()[$key];
-
-        if (strpos($castType, ':') === false) {
+        if (strpos($castType = $this->getCasts()[$key], ':') === false) {
             return new $castType;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1027,13 +1027,9 @@ trait HasAttributes
      */
     protected function isClassCastable($key)
     {
-        if (! array_key_exists($key, $this->getCasts())) {
-             return false;
-         }
-
-         $class = $this->getCasts()[$key];
-
-         return class_exists($class) && ! in_array($class, static::$primitiveCastTypes);
+         return array_key_exists($key, $this->getCasts()) &&
+                class_exists($class = $this->getCasts()[$key]) &&
+                ! in_array($class, static::$primitiveCastTypes);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -45,6 +45,38 @@ trait HasAttributes
     protected $casts = [];
 
     /**
+     * The attributes that have been cast using custom classes.
+     *
+     * @var array
+     */
+    protected $classCastCache = [];
+
+    /**
+     * The built-in, primitive cast types supported by Eloquent.
+     *
+     * @var array
+     */
+    protected static $primitiveCastTypes = [
+        'array',
+        'bool',
+        'boolean',
+        'collection',
+        'custom_datetime',
+        'date',
+        'datetime',
+        'decimal',
+        'double',
+        'float',
+        'int',
+        'integer',
+        'json',
+        'object',
+        'real',
+        'string',
+        'timestamp',
+    ];
+
+    /**
      * The attributes that should be mutated to dates.
      *
      * @var array
@@ -173,7 +205,9 @@ trait HasAttributes
     protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
     {
         foreach ($this->getCasts() as $key => $value) {
-            if (! array_key_exists($key, $attributes) || in_array($key, $mutatedAttributes)) {
+            if (! array_key_exists($key, $attributes) ||
+                in_array($key, $mutatedAttributes) ||
+                $this->isClassCastable($key)) {
                 continue;
             }
 
@@ -211,7 +245,7 @@ trait HasAttributes
      */
     protected function getArrayableAttributes()
     {
-        return $this->getArrayableItems($this->attributes);
+        return $this->getArrayableItems($this->getAttributes());
     }
 
     /**
@@ -318,8 +352,9 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            $this->hasGetMutator($key)) {
+        if (array_key_exists($key, $this->getAttributes()) ||
+            $this->hasGetMutator($key) ||
+            $this->isClassCastable($key)) {
             return $this->getAttributeValue($key);
         }
 
@@ -352,7 +387,7 @@ trait HasAttributes
      */
     protected function getAttributeFromArray($key)
     {
-        return $this->attributes[$key] ?? null;
+        return $this->getAttributes()[$key] ?? null;
     }
 
     /**
@@ -439,7 +474,9 @@ trait HasAttributes
      */
     protected function mutateAttributeForArray($key, $value)
     {
-        $value = $this->mutateAttribute($key, $value);
+        $value = $this->isClassCastable($key)
+                    ? $this->castUsingClass($key)
+                    : $this->mutateAttribute($key, $value);
 
         return $value instanceof Arrayable ? $value->toArray() : $value;
     }
@@ -453,11 +490,13 @@ trait HasAttributes
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        $castType = $this->getCastType($key);
+
+        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -486,10 +525,31 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
-            default:
-                return $value;
         }
+
+        if ($this->isClassCastable($key)) {
+            return $this->castUsingClass($key);
+        }
+
+        return $value;
     }
+
+    /**
+      * Cast the given attribute using a custom cast class.
+      *
+      * @param  string  $key
+      * @return mixed
+      */
+     protected function castUsingClass($key)
+     {
+         if (isset($this->classCastCache[$key])) {
+             return $this->classCastCache[$key];
+         } else {
+             return $this->classCastCache[$key] = forward_static_call(
+                 [$this->getCasts()[$key], 'fromModelAttributes'], $this, $key, $this->attributes
+             );
+         }
+     }
 
     /**
      * Get the type of cast for a model attribute.
@@ -554,6 +614,12 @@ trait HasAttributes
         // the connection grammar's date format. We will auto set the values.
         elseif ($value && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
+        }
+
+        if ($this->isClassCastable($key)) {
+            $this->setClassCastableAttribute($key, $value);
+
+            return $this;
         }
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {
@@ -624,6 +690,26 @@ trait HasAttributes
 
         return $this;
     }
+
+    /**
+      * Set the value of a class castable attribute.
+      *
+      * @param  string  $key
+      * @param  mixed  $value
+      * @return void
+      */
+     protected function setClassCastableAttribute($key, $value)
+     {
+         if (is_null($value)) {
+             $this->attributes = array_merge($this->attributes, array_map(
+                 function () { return null; }, $this->castToClass($key)->toModelAttributes($this)
+             ));
+
+             unset($this->classCastCache[$key]);
+         } else {
+             $this->classCastCache[$key] = $value;
+         }
+     }
 
     /**
      * Get an array attribute with the given key and value set.
@@ -927,12 +1013,49 @@ trait HasAttributes
     }
 
     /**
+     * Determine if the given key is cast using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassCastable($key)
+    {
+        if (! array_key_exists($key, $this->getCasts())) {
+             return false;
+         }
+
+         $class = $this->getCasts()[$key];
+
+         return class_exists($class) && ! in_array($class, static::$primitiveCastTypes);
+    }
+
+    /**
+      * Merge the cast class attributes back into the model.
+      *
+      * @return void
+      */
+     protected function mergeAttributesFromClassCasts()
+     {
+         foreach ($this->classCastCache as $key => $value) {
+             $this->attributes = array_merge(
+                $this->attributes,
+                forward_static_call(
+                    [$this->getCasts()[$key], 'toModelAttributes'],
+                    $this, $key, $value, $this->attributes
+                )
+             );
+         }
+     }
+
+    /**
      * Get all of the current attributes on the model.
      *
      * @return array
      */
     public function getAttributes()
     {
+        $this->mergeAttributesFromClassCasts();
+
         return $this->attributes;
     }
 
@@ -998,7 +1121,7 @@ trait HasAttributes
      */
     public function syncOriginal()
     {
-        $this->original = $this->attributes;
+        $this->original = $this->getAttributes();
 
         return $this;
     }
@@ -1024,8 +1147,10 @@ trait HasAttributes
     {
         $attributes = is_array($attributes) ? $attributes : func_get_args();
 
+        $modelAttributes = $this->getAttributes();
+
         foreach ($attributes as $attribute) {
-            $this->original[$attribute] = $this->attributes[$attribute];
+            $this->original[$attribute] = $modelAttributes[$attribute];
         }
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1681,18 +1681,18 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-      * Prepare the object for serialization.
-      *
-      * @return array
-      */
-     public function __sleep()
-     {
-         $this->mergeAttributesFromClassCasts();
+     * Prepare the object for serialization.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $this->mergeAttributesFromClassCasts();
 
-         $this->classCastCache = [];
+        $this->classCastCache = [];
 
-         return array_keys(get_object_vars($this));
-     }
+        return array_keys(get_object_vars($this));
+    }
 
     /**
      * When a model is being unserialized, check if it needs to be booted.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -665,6 +665,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function save(array $options = [])
     {
+        $this->mergeAttributesFromClassCasts();
+
         $query = $this->newModelQuery();
 
         // If the "saving" event returns false we'll bail out of the save and return
@@ -905,6 +907,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function delete()
     {
+        $this->mergeAttributesFromClassCasts();
+
         if (is_null($this->getKeyName())) {
             throw new Exception('No primary key defined on model.');
         }
@@ -1194,7 +1198,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         ];
 
         $attributes = Arr::except(
-            $this->attributes, $except ? array_unique(array_merge($except, $defaults)) : $defaults
+            $this->getAttributes(), $except ? array_unique(array_merge($except, $defaults)) : $defaults
         );
 
         return tap(new static, function ($instance) use ($attributes) {
@@ -1675,6 +1679,18 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         return $this->toJson();
     }
+
+    /**
+      * Prepare the object for serialization.
+      *
+      * @return array
+      */
+     public function __sleep()
+     {
+         $this->mergeAttributesFromClassCasts();
+
+         return array_keys(get_object_vars($this));
+     }
 
     /**
      * When a model is being unserialized, check if it needs to be booted.

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1689,6 +1689,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      {
          $this->mergeAttributesFromClassCasts();
 
+         $this->classCastCache = [];
+
          return array_keys(get_object_vars($this));
      }
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -41,6 +41,11 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $this->assertEquals('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
         $this->assertEquals('My House', json_decode($model->toJson(), true)['address_line_two']);
+
+        $model->address = null;
+
+        $this->assertNull($model->toArray()['address_line_one']);
+        $this->assertNull($model->toArray()['address_line_two']);
     }
 }
 
@@ -72,7 +77,7 @@ class EncryptCaster
 
 class AddressCaster
 {
-    public static function fromModelAttributes($model, $key, $attributes)
+    public static function fromModelAttributes($model, $key, $value, $attributes)
     {
         return new Address($attributes['address_line_one'], $attributes['address_line_two']);
     }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * @group integration
+ */
+class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
+{
+    public function testBasicCustomCasting()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+        $model->encrypted = 'taylor';
+
+        $this->assertEquals('taylor', $model->encrypted);
+        $this->assertEquals('rolyat', $model->getAttributes()['encrypted']);
+        $this->assertEquals('rolyat', $model->toArray()['encrypted']);
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My House',
+        ]);
+
+        $this->assertEquals('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertEquals('My House', $model->address->lineTwo);
+
+        $this->assertEquals('110 Kingsbrook St.', $model->toArray()['address_line_one']);
+        $this->assertEquals('My House', $model->toArray()['address_line_two']);
+
+        $model->address->lineOne = '117 Spencer St.';
+
+        $this->assertFalse(isset($model->toArray()['address']));
+        $this->assertEquals('117 Spencer St.', $model->toArray()['address_line_one']);
+        $this->assertEquals('My House', $model->toArray()['address_line_two']);
+
+        $this->assertEquals('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
+        $this->assertEquals('My House', json_decode($model->toJson(), true)['address_line_two']);
+    }
+}
+
+class TestEloquentModelWithCustomCast extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'address' => AddressCaster::class,
+        'encrypted' => EncryptCaster::class,
+    ];
+}
+
+class EncryptCaster
+{
+    public static function fromModelAttributes($model, $key, $attributes)
+    {
+        return strrev($attributes[$key]);
+    }
+
+    public static function toModelAttributes($model, $key, $value, $attributes)
+    {
+        return [$key => strrev($value)];
+    }
+}
+
+class AddressCaster
+{
+    public static function fromModelAttributes($model, $key, $attributes)
+    {
+        return new Address($attributes['address_line_one'], $attributes['address_line_two']);
+    }
+
+    public static function toModelAttributes($model, $key, $value, $attributes)
+    {
+        return ['address_line_one' => $value->lineOne, 'address_line_two' => $value->lineTwo];
+    }
+}
+
+class Address
+{
+    public $lineOne;
+    public $lineTwo;
+
+    public function __construct($lineOne, $lineTwo)
+    {
+        $this->lineOne = $lineOne;
+        $this->lineTwo = $lineTwo;
+    }
+}

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -24,6 +24,12 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $this->assertEquals('rolyat', $model->getAttributes()['reversed']);
         $this->assertEquals('rolyat', $model->toArray()['reversed']);
 
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertEquals('taylor', $unserializedModel->reversed);
+        $this->assertEquals('rolyat', $unserializedModel->getAttributes()['reversed']);
+        $this->assertEquals('rolyat', $unserializedModel->toArray()['reversed']);
+
         $model->setRawAttributes([
             'address_line_one' => '110 Kingsbrook St.',
             'address_line_two' => 'My House',

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -5,10 +5,6 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 
 /**
  * @group integration

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -170,7 +170,7 @@ class JsonCaster implements CastsAttributes
 
     public function set($model, $key, $value, $attributes)
     {
-        return [$key => json_encode($value)];
+        return json_encode($value);
     }
 }
 


### PR DESCRIPTION
This adds the ability to write your own custom casts. These can cast to simple primitive values like strings (like an encrypted string) or to objects. When casting to objects, you have the opportunity to sync the object's values back into the model before saving. 

Objects that cast attributes must implement the `Illuminate\Contracts\Database\Eloquent\CastsAttributes` contract or `CastsInboundAttributes`. This `CastsAttributes` interface defines a `get` and `set` method. 

For example, a JSON caster that replicates the built-in JSON casting offered by Laravel would look like the following:

```php
<?php

use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

class JsonCaster implements CastsAttributes
{
    public function get($model, $key, $value, $attributes)
    {
        return json_decode($value, true);
    }

    public function set($model, $key, $value, $attributes)
    {
        return json_encode($value);
    }
}
```

A caster that casts to a value object with multiple properties may look like the following:

```php
<?php

use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

class AddressCaster implements CastsAttributes
{
    public function get($model, $key, $value, $attributes)
    {
        return new Address(
            $attributes['address_line_one'], 
            $attributes['address_line_two']
        );
    }

    public function set($model, $key, $value, $attributes)
    {
        return [
            'address_line_one' => $value->lineOne, 
            'address_line_two' => $value->lineTwo
        ];
    }
}
```

When defined this way, you may update the address object properties and then save the model. The object's properties will be synced back to the model before saving:

```php
$user->address->lineOne = 'New Line 1';
$user->save();
```