### PR TITLE
[6.x] Use Model connection if set on Model when validating with exists:Model

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -819,8 +819,9 @@ trait ValidatesAttributes
         [$connection, $table] = Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
 
         if (Str::contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
-            $connection = $connection ?? (new $table)->getConnectionName();
-            $table = (new $table)->getTable();
+            $model = new $table;
+            $table = $model->getTable();
+            $connection = $connection ?? $model->getConnectionName();
         }
 
         return [$connection, $table];

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -819,6 +819,7 @@ trait ValidatesAttributes
         [$connection, $table] = Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
 
         if (Str::contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
+            $connection = $connection ?? (new $table)->getConnectionName();
             $table = (new $table)->getTable();
         }
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4323,6 +4323,10 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals('connection', $explicit_connection[0]);
         $this->assertEquals('explicits', $explicit_connection[1]);
 
+        $explicit_model_implicit_connection = $v->parseTable(ExplicitTableAndConnectionModel::class);
+        $this->assertEquals('connection', $explicit_model_implicit_connection[0]);
+        $this->assertEquals('explicits', $explicit_model_implicit_connection[1]);
+
         $noneloquent_connection = $v->parseTable('connection.'.NonEloquentModel::class);
         $this->assertEquals('connection', $noneloquent_connection[0]);
         $this->assertEquals(NonEloquentModel::class, $noneloquent_connection[1]);
@@ -5194,6 +5198,14 @@ class ImplicitTableModel extends Model
 class ExplicitTableModel extends Model
 {
     protected $table = 'explicits';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+class ExplicitTableAndConnectionModel extends Model
+{
+    protected $table = 'explicits';
+    protected $connection = 'connection';
     protected $guarded = [];
     public $timestamps = false;
 }


### PR DESCRIPTION
This PR allows you to use the `'exists:App\Model'` rule for validation even if it has a custom connection property set.

Prior to this PR, the only way to use a custom connection on a Model in the exists validation rule is to call the `getConnectionName()` on the model itself, which seems messy since we have to pass it for the table name anyway:
`'exists:' . (new Model())->getConnectionName() . '.App\Model`