### PR TITLE
[6.x] Allow fetching additional laravel extra sections from package composer.json files

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -61,7 +61,7 @@ class PackageManifest
     /**
      * Get all of the $name values for all packages.
      *
-     * @param string $name
+     * @param  string  $name
      * @return array
      */
     public function extra($name)

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -59,15 +59,26 @@ class PackageManifest
     }
 
     /**
+     * Get all of the $name values for all packages.
+     *
+     * @param string $name
+     * @return array
+     */
+    public function extra($name)
+    {
+        return collect($this->getManifest())->flatMap(function ($configuration) use ($name) {
+            return (array) ($configuration[$name] ?? []);
+        })->filter()->all();
+    }
+
+    /**
      * Get all of the service provider class names for all packages.
      *
      * @return array
      */
     public function providers()
     {
-        return collect($this->getManifest())->flatMap(function ($configuration) {
-            return (array) ($configuration['providers'] ?? []);
-        })->filter()->all();
+        return $this->extra('providers');
     }
 
     /**
@@ -77,9 +88,7 @@ class PackageManifest
      */
     public function aliases()
     {
-        return collect($this->getManifest())->flatMap(function ($configuration) {
-            return (array) ($configuration['aliases'] ?? []);
-        })->filter()->all();
+        return $this->extra('aliases');
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -64,7 +64,7 @@ class PackageManifest
      * @param  string  $name
      * @return array
      */
-    public function extra($name)
+    public function getRegisteredExtra($name)
     {
         return collect($this->getManifest())->flatMap(function ($configuration) use ($name) {
             return (array) ($configuration[$name] ?? []);
@@ -78,7 +78,7 @@ class PackageManifest
      */
     public function providers()
     {
-        return $this->extra('providers');
+        return $this->getRegisteredExtra('providers');
     }
 
     /**
@@ -88,7 +88,7 @@ class PackageManifest
      */
     public function aliases()
     {
-        return $this->extra('aliases');
+        return $this->getRegisteredExtra('aliases');
     }
 
     /**


### PR DESCRIPTION
This PR allows accessing other segments of the package `composer.json` extra.laravel block, not only providers and aliases.

The addition of extra method allows to fetch custom segments introduced by package developers. Currently it is only possible to access `providers` and `aliases` sections of the package composer.json files. With this package devlopers can easily access the manifests extra segmetns and use them as needed without the necessity of extending the class.
