### PR TITLE
[6.x] Search for similar results

### DIFF
--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -77,13 +77,25 @@ class HasInDatabase extends Constraint
     {
         $query = $this->database->table($table);
 
-        $results = $query->limit($this->show)->get();
+        $key = array_key_first($this->data);
+        $value = $this->data[$key];
+        $similarResults = $query->where($key, $value)->limit($this->show)->get();
 
-        if ($results->isEmpty()) {
-            return 'The table is empty';
+        if ($similarResults->isNotEmpty()) {
+            $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
         }
 
-        $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+        else {
+            $query = $this->database->table($table);
+
+            $results = $query->limit($this->show)->get();
+
+            if ($results->isEmpty()) {
+                return 'The table is empty';
+            }
+
+            $description = 'Found: '.json_encode($results, JSON_PRETTY_PRINT);
+        }
 
         if ($query->count() > $this->show) {
             $description .= sprintf(' and %s others', $query->count() - $this->show);

--- a/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/HasInDatabase.php
@@ -83,9 +83,7 @@ class HasInDatabase extends Constraint
 
         if ($similarResults->isNotEmpty()) {
             $description = 'Found similar results: '.json_encode($similarResults, JSON_PRETTY_PRINT);
-        }
-
-        else {
+        } else {
             $query = $this->database->table($table);
 
             $results = $query->limit($this->show)->get();

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -17,7 +17,10 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
     protected $table = 'products';
 
-    protected $data = ['title' => 'Spark'];
+    protected $data = [
+        'title' => 'Spark',
+        'name' => 'Laravel',
+    ];
 
     protected $connection;
 
@@ -54,7 +57,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
 
-        $this->expectExceptionMessage('Found: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
+        $this->expectExceptionMessage('Found similar results: '.json_encode([['title' => 'Forge']], JSON_PRETTY_PRINT));
 
         $builder = $this->mockCountBuilder(0);
 
@@ -68,7 +71,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     {
         $this->expectException(ExpectationFailedException::class);
 
-        $this->expectExceptionMessage('Found: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
+        $this->expectExceptionMessage('Found similar results: '.json_encode(['data', 'data', 'data'], JSON_PRETTY_PRINT).' and 2 others.');
 
         $builder = $this->mockCountBuilder(0);
         $builder->shouldReceive('count')->andReturn(0, 5);
@@ -192,6 +195,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
     protected function mockCountBuilder($countResult, $deletedAtColumn = 'deleted_at')
     {
         $builder = m::mock(Builder::class);
+
+        $key = array_key_first($this->data);
+        $value = $this->data[$key];
+
+        $builder->shouldReceive('where')->with($key, $value)->andReturnSelf();
 
         $builder->shouldReceive('limit')->andReturnSelf();
 


### PR DESCRIPTION
This is a resubmission of #30886 with fixed tests.

When using the `assertDatabaseHas()` assertion, the failure method returns the first couple results out of the database.  This is not incredibly useful since those results are not guaranteed to contain the row of our expected data.

This PR allow the failure message to make an educated guess on the DB row we are most likely trying to compare to. It gives priority to the first key/value pair in our expected data, and performs a query based solely on that 1 piece of information.  If it finds rows matching this data, it will return them.  If it doesn't find any results from its educated guess, it will fallback to the current method of returning results.