### PR TITLE
[6.x] Create `AppendsToJson` Model Trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/AppendsToJson.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/AppendsToJson.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+trait AppendsToJson
+{
+    /**
+     * @param  string  $field
+     * @param  string  $key
+     * @param  mixed   $value
+     */
+    public function appendToArray($field, $key, $value)
+    {
+        $temp = $this->{$field};
+        $temp[$key] = $value;
+
+        $this->{$field} = $temp;
+    }
+
+    /**
+     * @param  string  $field
+     * @param  string  $key
+     * @param  mixed   $value
+     */
+    public function appendToCollection($field, $key, $value)
+    {
+        $this->appendToArray($field, $key, $value);
+    }
+
+    /**
+     * @param  string  $field
+     * @param  string  $key
+     * @param  mixed   $value
+     */
+    public function appendToObject($field, $key, $value)
+    {
+        $temp = $this->{$field};
+
+        if (is_null($temp)) {
+            $temp = new \stdClass;
+        }
+
+        $temp->{$key} = $value;
+
+        $this->{$field} = $temp;
+    }
+}

--- a/tests/Database/DatabaseEloquentAppendsToJsonTest.php
+++ b/tests/Database/DatabaseEloquentAppendsToJsonTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Concerns\AppendsToJson;
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+
+class AppendsToJsonTest extends TestCase
+{
+    public function test_can_append_to_array()
+    {
+        $user = new UserStub;
+
+        $user->appendToArray('first', 'sport', 'soccer');
+        $this->assertEquals($user->first, ['sport' => 'soccer']);
+
+        $user->appendToArray('first', 'subject', 'math');
+        $this->assertEquals($user->first, ['sport' => 'soccer', 'subject' => 'math']);
+
+        $user->appendToArray('first', 'sport', 'football');
+        $this->assertEquals($user->first, ['sport' => 'football', 'subject' => 'math']);
+    }
+
+    public function test_can_append_to_collection()
+    {
+        $user = new UserStub;
+
+        $user->appendToCollection('second', 'sport', 'soccer');
+        $this->assertEquals($user->second->toArray(), ['sport' => 'soccer']);
+
+        $user->appendToCollection('second', 'subject', 'math');
+        $this->assertEquals($user->second->toArray(), ['sport' => 'soccer', 'subject' => 'math']);
+
+        $user->appendToCollection('second', 'sport', 'football');
+        $this->assertEquals($user->second->toArray(), ['sport' => 'football', 'subject' => 'math']);
+    }
+
+    public function test_can_append_to_object()
+    {
+        $user = new UserStub;
+
+        $user->appendToObject('third', 'sport', 'soccer');
+        $this->assertEquals($user->third->sport, 'soccer');
+
+        $user->appendToObject('third', 'subject', 'math');
+        $this->assertEquals($user->third->sport, 'soccer');
+        $this->assertEquals($user->third->subject, 'math');
+
+        $user->appendToObject('third', 'sport', 'football');
+        $this->assertEquals($user->third->sport, 'football');
+        $this->assertEquals($user->third->subject, 'math');
+    }
+}
+
+class UserStub extends Model
+{
+    use AppendsToJson;
+
+    protected $casts = [
+        'first'  => 'array',
+        'second' => 'collection',
+        'third'  => 'object',
+    ];
+}


### PR DESCRIPTION
As I've been using JSON castable fields more and more, I've found myself come across the need to add or manipulate a single key/value pair to the property, rather than overriding the entire property.  Due to Laravel's use of magic getters, we cannot directly manipulate the property.  Instead, we need to create a temporary variable, which is then manipulated, and re-assigned to the property.  This makes for verbose code, so I use a method to isolate it. I thought I'd create this PR to see if this is of general interest.

---

You might think you could run the following code:

```php
class User extends Model
{
    $casts = [
        'favorites' => 'collection',
    ];
}

$user = new User;
$user->favorites['sport'] = 'soccer';
$user->favorites['color'] = 'red';
$user->favorites['food'] = 'pizza';
$user->save();
```

but this will not actually update the `favorites` property.

Using this new *optional* Trait this behavior can be accomplished with the provided methods:

```php
class User extends Model
{
    use AppendsToJson;

    $casts = [
        'favorites' => 'collection',
    ];
}

$user = new User;
$user->appendToCollection('favorites', 'sport', 'soccer');
$user->appendToCollection('favorites', 'color', 'red');
$user->appendToCollection('favorites', 'food', 'pizza');
$user->save();
```