### PR TITLE
[7.x] Remove magic View `with...()` method

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -402,13 +402,9 @@ class View implements ArrayAccess, Htmlable, ViewContract
             return $this->macroCall($method, $parameters);
         }
 
-        if (! Str::startsWith($method, 'with')) {
-            throw new BadMethodCallException(sprintf(
-                'Method %s::%s does not exist.', static::class, $method
-            ));
-        }
-
-        return $this->with(Str::camel(substr($method, 4)), $parameters[0]);
+        throw new BadMethodCallException(sprintf(
+            'Method %s::%s does not exist.', static::class, $method
+        ));
     }
 
     /**

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -11,7 +11,6 @@ use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\MessageBag;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Throwable;
 

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -27,10 +27,6 @@ class ViewTest extends TestCase
         $view->with('foo', 'bar');
         $view->with(['baz' => 'boom']);
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
-
-        $view = $this->getView();
-        $view->withFoo('bar')->withBaz('boom');
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
     }
 
     public function testRenderProperlyRendersView()


### PR DESCRIPTION
🔥 🔥 🔥 

Currently you can pass data to a View using a magic `with...()` method.

```php
$view = view('greeting')->withName('Victoria');
```

This feature was removed from the documentation back in May 2015 in v5.1, so it has been undocumented for almost 5 years and **9 major versions**.

https://github.com/laravel/docs/commit/f02dc44b1bb8591da506ac3013eaaea3cf2115ac#diff-26ec5f5c36efaeaee4a3ac86cdec358eL43

There are more than enough other documented ways to pass data to views, so I would propose getting rid of this code, and promoting the use of the currently documented ways.

```php
$view = view('greeting', ['name' => 'Victoria']);
$view = view('greeting')->with('name', 'Victoria');
```