### PR TITLE
[6.x] Update symfony/http-kernel to Avoid CVE-2019-18887

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/debug": "^4.3.4",
         "symfony/finder": "^4.3.4",
         "symfony/http-foundation": "^4.3.4",
-        "symfony/http-kernel": "^4.3.4",
+        "symfony/http-kernel": "^4.3.8",
         "symfony/process": "^4.3.4",
         "symfony/routing": "^4.3.4",
         "symfony/var-dumper": "^4.3.4",


### PR DESCRIPTION
This is due to the vulnerability discovered in `symfony/http-kernel` 

which is now fixed in 4.3.8:

https://github.com/symfony/symfony/releases/tag/v4.3.8

https://symfony.com/blog/cve-2019-18887-use-constant-time-comparison-in-urisigner