### PR TITLE
[7.x] Stubs follow up

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -89,7 +89,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
     protected function registerCreator()
     {
         $this->app->singleton('migration.creator', function ($app) {
-            return new MigrationCreator($app['files']);
+            return new MigrationCreator($app['files'], $app->basePath('stubs'));
         });
     }
 

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -17,6 +17,13 @@ class MigrationCreator
     protected $files;
 
     /**
+     * The custom app stubs directory.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $customStubs;
+
+    /**
      * The registered post create hooks.
      *
      * @var array
@@ -27,11 +34,13 @@ class MigrationCreator
      * Create a new migration creator instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  string  $customStubs
      * @return void
      */
-    public function __construct(Filesystem $files)
+    public function __construct(Filesystem $files, $customStubs)
     {
         $this->files = $files;
+        $this->customStubs = $customStubs;
     }
 
     /**
@@ -101,15 +110,15 @@ class MigrationCreator
     protected function getStub($table, $create)
     {
         if (is_null($table)) {
-            $stub = file_exists($customPath = base_path('stubs/migration.stub'))
+            $stub = $this->files->exists($customPath = $this->customStubs.'/migration.stub')
                             ? $customPath
                             : $this->stubPath().'/migration.stub';
         } elseif ($create) {
-            $stub = file_exists($customPath = base_path('stubs/migration.create.stub'))
+            $stub = $this->files->exists($customPath = $this->customStubs.'/migration.create.stub')
                             ? $customPath
                             : $this->stubPath().'/migration.create.stub';
         } else {
-            $stub = file_exists($customPath = base_path('stubs/migration.update.stub'))
+            $stub = $this->files->exists($customPath = $this->customStubs.'/migration.update.stub')
                             ? $customPath
                             : $this->stubPath().'/migration.update.stub';
         }

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -48,7 +48,7 @@ class JobMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = base_path(trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
                         ? $customPath
                         : __DIR__.$stub;
     }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -150,7 +150,7 @@ class ModelMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = base_path(trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
                         ? $customPath
                         : __DIR__.$stub;
     }

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -28,30 +28,30 @@ class StubPublishCommand extends Command
      */
     public function handle()
     {
-        $files = [
-            __DIR__.'/stubs/job.queued.stub' => base_path('stubs/job.queued.stub'),
-            __DIR__.'/stubs/job.stub' => base_path('stubs/job.stub'),
-            __DIR__.'/stubs/job.stub' => base_path('stubs/job.stub'),
-            __DIR__.'/stubs/model.pivot.stub' => base_path('stubs/model.pivot.stub'),
-            __DIR__.'/stubs/model.stub' => base_path('stubs/model.stub'),
-            __DIR__.'/stubs/test.stub' => base_path('stubs/test.stub'),
-            __DIR__.'/stubs/test.unit.stub' => base_path('stubs/test.unit.stub'),
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => base_path('stubs/migration.create.stub'),
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => base_path('stubs/migration.stub'),
-            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => base_path('stubs/migration.update.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => base_path('stubs/controller.api.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => base_path('stubs/controller.invokable.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => base_path('stubs/controller.model.api.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => base_path('stubs/controller.model.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => base_path('stubs/controller.nested.api.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => base_path('stubs/controller.nested.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => base_path('stubs/controller.plain.stub'),
-            realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => base_path('stubs/controller.stub'),
-        ];
-
-        if (! is_dir(base_path('stubs'))) {
-            (new Filesystem)->makeDirectory(base_path('stubs'));
+        if (! is_dir($stubsPath = $this->laravel->basePath('stubs'))) {
+            (new Filesystem)->makeDirectory($stubsPath);
         }
+
+        $files = [
+            __DIR__.'/stubs/job.queued.stub' => $stubsPath.'/job.queued.stub',
+            __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
+            __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
+            __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'stubs/model.pivot.stub',
+            __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
+            __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
+            __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => $stubsPath.'/migration.stub',
+            realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => $stubsPath.'/migration.update.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => $stubsPath.'/controller.api.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => $stubsPath.'/controller.invokable.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => $stubsPath.'/controller.model.api.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.stub') => $stubsPath.'/controller.model.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.api.stub') => $stubsPath.'/controller.nested.api.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $stubsPath.'/controller.nested.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $stubsPath.'/controller.plain.stub',
+            realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
+        ];
 
         foreach ($files as $from => $to) {
             file_put_contents($to, file_get_contents($from));

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -48,7 +48,7 @@ class TestMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = base_path(trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
                         ? $customPath
                         : __DIR__.$stub;
     }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -68,7 +68,7 @@ class ControllerMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = base_path(trim($stub, '/')))
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
                         ? $customPath
                         : __DIR__.$stub;
     }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -20,7 +20,8 @@ class DatabaseMigrationCreatorTest extends TestCase
         $creator = $this->getCreator();
 
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/blank.stub')->andReturn('DummyClass');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.stub')->andReturn('DummyClass');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
@@ -39,7 +40,8 @@ class DatabaseMigrationCreatorTest extends TestCase
         });
 
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
@@ -55,7 +57,8 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/update.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.update.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.update.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
@@ -67,7 +70,8 @@ class DatabaseMigrationCreatorTest extends TestCase
     {
         $creator = $this->getCreator();
         $creator->expects($this->any())->method('getDatePrefix')->willReturn('foo');
-        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/create.stub')->andReturn('DummyClass DummyTable');
+        $creator->getFilesystem()->shouldReceive('exists')->once()->with('stubs/migration.create.stub')->andReturn(false);
+        $creator->getFilesystem()->shouldReceive('get')->once()->with($creator->stubPath().'/migration.create.stub')->andReturn('DummyClass DummyTable');
         $creator->getFilesystem()->shouldReceive('put')->once()->with('foo/foo_create_bar.php', 'CreateBar baz');
         $creator->getFilesystem()->shouldReceive('glob')->once()->with('foo/*.php')->andReturn(['foo/foo_create_bar.php']);
         $creator->getFilesystem()->shouldReceive('requireOnce')->once()->with('foo/foo_create_bar.php');
@@ -91,7 +95,11 @@ class DatabaseMigrationCreatorTest extends TestCase
     protected function getCreator()
     {
         $files = m::mock(Filesystem::class);
+        $customStubs = 'stubs';
 
-        return $this->getMockBuilder(MigrationCreator::class)->setMethods(['getDatePrefix'])->setConstructorArgs([$files])->getMock();
+        return $this->getMockBuilder(MigrationCreator::class)
+            ->setMethods(['getDatePrefix'])
+            ->setConstructorArgs([$files, $customStubs])
+            ->getMock();
     }
 }


### PR DESCRIPTION
This is a follow-up for https://github.com/laravel/framework/pull/31052. It fixes the tests and replaces the used helpers by the already resolved Laravel instance. I had to update the `MigrationCreator` to make the tests pass. 