### PR TITLE
[7.x] Rename CastsAttributes contract methods

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -13,7 +13,7 @@ interface CastsAttributes
      * @param  array  $attributes
      * @return mixed
      */
-    public function get($model, string $key, $value, array $attributes);
+    public function fromDatabase($model, string $key, $value, array $attributes);
 
     /**
      * Transform the attribute to its underlying model values.
@@ -24,5 +24,5 @@ interface CastsAttributes
      * @param  array  $attributes
      * @return array
      */
-    public function set($model, string $key, $value, array $attributes);
+    public function toDatabase($model, string $key, $value, array $attributes);
 }

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
@@ -13,5 +13,5 @@ interface CastsInboundAttributes
      * @param  array  $attributes
      * @return array
      */
-    public function set($model, string $key, $value, array $attributes);
+    public function toDatabase($model, string $key, $value, array $attributes);
 }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -133,7 +133,7 @@ class HashCaster implements CastsInboundAttributes
         $this->algorithm = $algorithm;
     }
 
-    public function set($model, $key, $value, $attributes)
+    public function toDatabase($model, $key, $value, $attributes)
     {
         return [$key => hash($this->algorithm, $value)];
     }

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -141,12 +141,12 @@ class HashCaster implements CastsInboundAttributes
 
 class ReverseCaster implements CastsAttributes
 {
-    public function get($model, $key, $value, $attributes)
+    public function fromDatabase($model, $key, $value, $attributes)
     {
         return strrev($value);
     }
 
-    public function set($model, $key, $value, $attributes)
+    public function toDatabase($model, $key, $value, $attributes)
     {
         return [$key => strrev($value)];
     }
@@ -154,12 +154,12 @@ class ReverseCaster implements CastsAttributes
 
 class AddressCaster implements CastsAttributes
 {
-    public function get($model, $key, $value, $attributes)
+    public function fromDatabase($model, $key, $value, $attributes)
     {
         return new Address($attributes['address_line_one'], $attributes['address_line_two']);
     }
 
-    public function set($model, $key, $value, $attributes)
+    public function toDatabase($model, $key, $value, $attributes)
     {
         return ['address_line_one' => $value->lineOne, 'address_line_two' => $value->lineTwo];
     }
@@ -167,12 +167,12 @@ class AddressCaster implements CastsAttributes
 
 class JsonCaster implements CastsAttributes
 {
-    public function get($model, $key, $value, $attributes)
+    public function fromDatabase($model, $key, $value, $attributes)
     {
         return json_decode($value, true);
     }
 
-    public function set($model, $key, $value, $attributes)
+    public function toDatabase($model, $key, $value, $attributes)
     {
         return json_encode($value);
     }


### PR DESCRIPTION
This PR is proposal to rename methods introduced in PR #31035 by @taylorotwell 

From my point of view `get` & `set` methods are too common and doesn't expose their meaning enough.

This question was raised many times before in different discussion threads. Here is one of the explanations from @sisve https://github.com/laravel/framework/pull/30958#issuecomment-569503992

I propose to rename them to `fromDatabase` and `toDatabase` respectively.
