### PR TITLE
[6.x] Fix issue with Illuminate\Mail\Markdown parser

### DIFF
--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -108,6 +108,8 @@ class Markdown
             'allow_unsafe_links' => false,
         ], $environment);
 
+        $text = preg_replace("/^\\h+/m", '', $text->toHtml());
+
         return new HtmlString($converter->convertToHtml($text));
     }
 


### PR DESCRIPTION
My attempt to fix #31065 in a backward compatible manner. The recent change to CommonMark (9308a4e150e43c33eaf42ce4f631fb42d9ce8643) breaks different Blade mail components without this fix. See issue for details.
