### PR TITLE
[7.x] Fix default multi-select argument to match symfony/console 5

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -377,10 +377,10 @@ class Command extends SymfonyCommand
      * @param  array  $choices
      * @param  string|null  $default
      * @param  mixed|null  $attempts
-     * @param  bool|null  $multiple
+     * @param  bool  $multiple
      * @return string
      */
-    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
+    public function choice($question, array $choices, $default = null, $attempts = null, bool $multiple = false)
     {
         $question = new ChoiceQuestion($question, $choices, $default);
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -380,7 +380,7 @@ class Command extends SymfonyCommand
      * @param  bool  $multiple
      * @return string
      */
-    public function choice($question, array $choices, $default = null, $attempts = null, bool $multiple = false)
+    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = false)
     {
         $question = new ChoiceQuestion($question, $choices, $default);
 

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class CommandTest extends TestCase
 {
@@ -111,5 +112,31 @@ class CommandTest extends TestCase
         $command->setOutput($output);
 
         $command->info('foo');
+    }
+
+    public function testChoiceIsSingleSelectByDefault()
+    {
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
+            return $question->isMultiselect() === false;
+        });
+
+        $command = new Command;
+        $command->setOutput($output);
+
+        $command->choice('Do you need further help?', ['yes', 'no']);
+    }
+
+    public function testChoiceWithMultiselect()
+    {
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
+            return $question->isMultiselect() === true;
+        });
+
+        $command = new Command;
+        $command->setOutput($output);
+
+        $command->choice('Select all that apply.', ['option-1', 'option-2', 'option-3'], null, null, true);
     }
 }


### PR DESCRIPTION
Because:
- In symfony/console v5.x the ChoiceQuestion::setMultiselect() has a bool type-hint

This PR:
- Changes the default multiple parameter to false to match the default behavior in Symfony 4.x
- Adds regression tests to test default multi-select

**Notes**

Symfony 5.x changed `ChoiceQuestion::setMultiselect()` to include a `bool` typehint in symfony/console@d17cbb5f2cdaf7ec42199f6645035f5c7118e73d.

The Symfony 5.x change breaks `Illuminate\Console\Command::choice()` due to a `null` value by default.

You can reproduce by running `php artisan vendor:publish` in a 7.x version of Laravel:

```
TypeError

  Argument 1 passed to Symfony\Component\Console\Question\ChoiceQuestion::setMultiselect() must be of the type bool, null given, called in /Users/predmond/code/sandbox/airlock-demo/vendor/laravel/framework/src/Illuminate/Console/Command.php on line 387

  at /Users/predmond/code/sandbox/airlock-demo/vendor/symfony/console/Question/ChoiceQuestion.php:63
    59|      * When multiselect is set to true, multiple choices can be answered.
    60|      *
    61|      * @return $this
    62|      */
  > 63|     public function setMultiselect(bool $multiselect)
    64|     {
    65|         $this->multiselect = $multiselect;
    66|         $this->setValidator($this->getDefaultValidator());
    67|

      +18 vendor frames
  19  /Users/predmond/code/sandbox/airlock-demo/artisan:37
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```


