### PR TITLE
[6.x] Fix undefined property in WithFaker

### DIFF
--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -45,7 +45,7 @@ trait WithFaker
     {
         $locale = $locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE);
 
-        if ($this->app->bound(Generator::class)) {
+        if (isset($this->app) && $this->app->bound(Generator::class)) {
             return $this->app->make(Generator::class, [$locale]);
         }
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/30992 introduced a side effect where resolving faker would fail if the trait was implemented on a class that hasn't set the framework as a property. 

Fixes https://github.com/laravel/framework/issues/31071