### PR TITLE
[6.x] Iterable phpdoc param on iterable Arr methods

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -41,7 +41,7 @@ class Arr
     /**
      * Collapse an array of arrays into a single array.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @return array
      */
     public static function collapse($array)
@@ -64,7 +64,7 @@ class Arr
     /**
      * Cross join the given arrays, returning all possible permutations.
      *
-     * @param  array  ...$arrays
+     * @param  iterable  ...$arrays
      * @return array
      */
     public static function crossJoin(...$arrays)
@@ -102,7 +102,7 @@ class Arr
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @param  string  $prepend
      * @return array
      */
@@ -154,7 +154,7 @@ class Arr
     /**
      * Return the first element in an array passing a given truth test.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @param  callable|null  $callback
      * @param  mixed  $default
      * @return mixed
@@ -200,7 +200,7 @@ class Arr
     /**
      * Flatten a multi-dimensional array into a single level.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @param  int  $depth
      * @return array
      */
@@ -372,7 +372,7 @@ class Arr
     /**
      * Pluck an array of values from an array.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @param  string|array  $value
      * @param  string|array|null  $key
      * @return array


### PR DESCRIPTION
Changed function argument params to iterable instead of array.

Examples:

**collapse**
```php
$array1 = Arr::collapse([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
$array2 = Arr::collapse(collect([[1, 2, 3], [4, 5, 6], [7, 8, 9]]));

$array1 === $array2 // true
```

**crossJoin**
```php
$suites = ['Foo', 'Bar'];
$values = [1];

$array1 = Arr::crossJoin($suites, $values);
$array2 = Arr::crossJoin(collect($suites), collect($values));

$array1 === $array2; // true
```

**dot**
```php
$array = ['products' => ['desk' => ['price' => 100]]];

$array1 = Arr::dot($array);
$array2 = Arr::dot(collect($array));

$array1 == $array2; // true
```

**first**
```php
$values = ['Foo', 'Bar'];

$array1 = Arr::first($values);
$array2 = Arr::first(collect($values));

$array1 === $array2; // true
```

**flatten**
```php
$values = [[['Foo']]];

$array1 = Arr::flatten($values);
$array2 = Arr::flatten(collect($values));

$array1 === $array2; // true
```

**pluck**
```php
$values = [['foo' => 'bar']];

$array1 = Arr::pluck($values, 'foo');
$array2 = Arr::pluck(collect($values), 'foo');

$array1 === $array2; // true
```