### PR TITLE
[6.x] Allow to specify an array of conditions and callbacks in when()

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -154,12 +154,12 @@ trait BuildsQueries
     public function when($value, $callback = null, $default = null)
     {
         if (is_array($value)) {
-           $result = $this;
-           foreach ($value as $subWhen) {
-               $result = $result->when($subWhen[0], $subWhen[1]);
-           }
+            $result = $this;
+            foreach ($value as $subWhen) {
+                $result = $result->when($subWhen[0], $subWhen[1]);
+            }
 
-           return $result;
+            return $result;
         } elseif ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -158,6 +158,7 @@ trait BuildsQueries
            foreach ($value as $subWhen) {
                $result = $result->when($subWhen[0], $subWhen[1]);
            }
+
            return $result;
         } elseif ($value) {
             return $callback($this, $value) ?: $this;

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -151,9 +151,15 @@ trait BuildsQueries
      * @param  callable|null  $default
      * @return mixed|$this
      */
-    public function when($value, $callback, $default = null)
+    public function when($value, $callback = null, $default = null)
     {
-        if ($value) {
+        if (is_array($value)) {
+           $result = $this;
+           foreach ($value as $subWhen) {
+               $result = $result->when($subWhen[0], $subWhen[1]);
+           }
+           return $result;
+        } elseif ($value) {
             return $callback($this, $value) ?: $this;
         } elseif ($default) {
             return $default($this, $value) ?: $this;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -237,7 +237,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->when([
             [true, $callback],
-            [true, $callback2]
+            [true, $callback2],
         ])->where('email', 'foo');
         $this->assertSame('select * from "users" where "id" = ? and "id" = ? and "email" = ?', $builder->toSql());
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -220,6 +220,32 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 2, 1 => 'foo'], $builder->getBindings());
     }
 
+    public function testWhenCallbackArray()
+    {
+        $callback = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 1);
+        };
+
+        $callback2 = function ($query, $condition) {
+            $this->assertTrue($condition);
+
+            $query->where('id', '=', 2);
+        };
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when([
+            [true, $callback],
+            [true, $callback2]
+        ])->where('email', 'foo');
+        $this->assertSame('select * from "users" where "id" = ? and "id" = ? and "email" = ?', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->when(false, $callback)->where('email', 'foo');
+        $this->assertSame('select * from "users" where "email" = ?', $builder->toSql());
+    }
+
     public function testUnlessCallback()
     {
         $callback = function ($query, $condition) {


### PR DESCRIPTION
This PR allows to use an array of conditions and callbacks inside the `when()` method of `BuildQueries` trait.

Example:
```
$builder->select('*')->from('users')->when([
    [true, $callback],
    [true, $callback2]
])->where('email', 'foo');
```