### PR TITLE
Adds an option to add strict_types in any artisan make command that creates a class

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -161,7 +161,34 @@ abstract class GeneratorCommand extends Command
     {
         $stub = $this->files->get($this->getStub());
 
-        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+        return $this->replaceStrictTypes($stub)->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+
+    /**
+     * Adds declare(strict_types = 1); or removes its placeholder
+     *
+     * @param  string  $stub
+     * @return $this
+     */
+    protected function replaceStrictTypes(&$stub)
+    {
+        $stub = str_replace('DummyStrictTypes', $this->getStrictTypes(), $stub);
+
+        return $this;
+    }
+
+    /**
+     * Gets the strict_types value according to 'strict' command option.
+     *
+     * @return string
+     */
+    protected function getStrictTypes()
+    {
+        if ($this->hasOption('strict') && $this->option('strict')) {
+            return "declare(strict_types = 1);\n";
+        }
+
+        return '';
     }
 
     /**

--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -89,6 +89,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         return [
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The name of the model'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
 use Faker\Generator as Faker;

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Console\Seeds;
 
+use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Composer;
@@ -92,5 +93,17 @@ class SeederMakeCommand extends GeneratorCommand
     protected function qualifyClass($name)
     {
         return $name;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
+++ b/src/Illuminate/Database/Console/Seeds/stubs/seeder.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 use Illuminate\Database\Seeder;
 
 class DummyClass extends Seeder

--- a/src/Illuminate/Database/Migrations/stubs/blank.stub
+++ b/src/Illuminate/Database/Migrations/stubs/blank.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/Illuminate/Database/Migrations/stubs/create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/create.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/Illuminate/Database/Migrations/stubs/update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/update.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ChannelMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class ChannelMakeCommand extends GeneratorCommand
 {
@@ -61,5 +62,17 @@ class ChannelMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Broadcasting';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php
@@ -85,6 +85,7 @@ class ConsoleMakeCommand extends GeneratorCommand
     {
         return [
             ['command', null, InputOption::VALUE_OPTIONAL, 'The terminal command that should be assigned', 'command:name'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/EventMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/EventMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class EventMakeCommand extends GeneratorCommand
 {
@@ -57,5 +58,17 @@ class EventMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Events';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
@@ -77,8 +77,8 @@ class ExceptionMakeCommand extends GeneratorCommand
     {
         return [
             ['render', null, InputOption::VALUE_NONE, 'Create the exception with an empty render method'],
-
             ['report', null, InputOption::VALUE_NONE, 'Create the exception with an empty report method'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/JobMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/JobMakeCommand.php
@@ -59,6 +59,7 @@ class JobMakeCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
             ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous'],
         ];
     }

--- a/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ListenerMakeCommand.php
@@ -105,8 +105,8 @@ class ListenerMakeCommand extends GeneratorCommand
     {
         return [
             ['event', 'e', InputOption::VALUE_OPTIONAL, 'The event class being listened for'],
-
             ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -109,8 +109,8 @@ class MailMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the mailable already exists'],
-
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the mailable'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -158,6 +158,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder file for the model'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
         ];

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -109,8 +109,8 @@ class NotificationMakeCommand extends GeneratorCommand
     {
         return [
             ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the notification already exists'],
-
             ['markdown', 'm', InputOption::VALUE_OPTIONAL, 'Create a new Markdown template for the notification'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ObserverMakeCommand.php
@@ -108,6 +108,7 @@ class ObserverMakeCommand extends GeneratorCommand
     {
         return [
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the observer applies to.'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -139,6 +139,7 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         return [
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ProviderMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class ProviderMakeCommand extends GeneratorCommand
 {
@@ -46,5 +47,17 @@ class ProviderMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Providers';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class RequestMakeCommand extends GeneratorCommand
 {
@@ -46,5 +47,17 @@ class RequestMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Http\Requests';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -86,6 +86,7 @@ class ResourceMakeCommand extends GeneratorCommand
     {
         return [
             ['collection', 'c', InputOption::VALUE_NONE, 'Create a resource collection'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class RuleMakeCommand extends GeneratorCommand
 {
@@ -46,5 +47,17 @@ class RuleMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Rules';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 
@@ -12,7 +13,7 @@ class TestMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $signature = 'make:test {name : The name of the class} {--unit : Create a unit test}';
+    protected $name = 'make:test';
 
     /**
      * The console command description.
@@ -78,5 +79,18 @@ class TestMakeCommand extends GeneratorCommand
     protected function rootNamespace()
     {
         return 'Tests';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+            ['unit', null, InputOption::VALUE_NONE, 'Create a unit test'],
+        ];
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/channel.stub
+++ b/src/Illuminate/Foundation/Console/stubs/channel.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use NamespacedDummyUserModel;

--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Console\Command;

--- a/src/Illuminate/Foundation/Console/stubs/event.stub
+++ b/src/Illuminate/Foundation/Console/stubs/event.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Broadcasting\Channel;

--- a/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render-report.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Exception;

--- a/src/Illuminate/Foundation/Console/stubs/exception-render.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-render.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Exception;

--- a/src/Illuminate/Foundation/Console/stubs/exception-report.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception-report.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Exception;

--- a/src/Illuminate/Foundation/Console/stubs/exception.stub
+++ b/src/Illuminate/Foundation/Console/stubs/exception.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Exception;

--- a/src/Illuminate/Foundation/Console/stubs/job-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job-queued.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/job.stub
+++ b/src/Illuminate/Foundation/Console/stubs/job.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-duck.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued-duck.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener-queued.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullEvent;

--- a/src/Illuminate/Foundation/Console/stubs/listener.stub
+++ b/src/Illuminate/Foundation/Console/stubs/listener.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullEvent;

--- a/src/Illuminate/Foundation/Console/stubs/mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/mail.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-mail.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/markdown-notification.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Database\Eloquent\Model;

--- a/src/Illuminate/Foundation/Console/stubs/notification.stub
+++ b/src/Illuminate/Foundation/Console/stubs/notification.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Bus\Queueable;

--- a/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.plain.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 class DummyClass

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use NamespacedDummyModel;

--- a/src/Illuminate/Foundation/Console/stubs/pivot.model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/pivot.model.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Auth\Access\HandlesAuthorization;

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Auth\Access\HandlesAuthorization;

--- a/src/Illuminate/Foundation/Console/stubs/provider.stub
+++ b/src/Illuminate/Foundation/Console/stubs/provider.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Support\ServiceProvider;

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource-collection.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Http\Resources\Json\ResourceCollection;

--- a/src/Illuminate/Foundation/Console/stubs/resource.stub
+++ b/src/Illuminate/Foundation/Console/stubs/resource.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Http\Resources\Json\JsonResource;

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Contracts\Validation\Rule;

--- a/src/Illuminate/Foundation/Console/stubs/test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Illuminate/Foundation/stubs/facade.stub
+++ b/src/Illuminate/Foundation/stubs/facade.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -182,6 +182,7 @@ class ControllerMakeCommand extends GeneratorCommand
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'Generate a resource controller for the given model.'],
             ['parent', 'p', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Generate a resource controller class.'],
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
         ];
     }
 }

--- a/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
+++ b/src/Illuminate/Routing/Console/MiddlewareMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Routing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
 
 class MiddlewareMakeCommand extends GeneratorCommand
 {
@@ -46,5 +47,17 @@ class MiddlewareMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         return $rootNamespace.'\Http\Middleware';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['strict', null, InputOption::VALUE_NONE, 'Add strict_types declaration to class'],
+        ];
     }
 }

--- a/src/Illuminate/Routing/Console/stubs/controller.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.api.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyRootNamespaceHttp\Controllers\Controller;

--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyRootNamespaceHttp\Controllers\Controller;

--- a/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.api.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullModelClass;

--- a/src/Illuminate/Routing/Console/stubs/controller.model.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.model.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullModelClass;

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.api.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullModelClass;

--- a/src/Illuminate/Routing/Console/stubs/controller.nested.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.nested.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyFullModelClass;

--- a/src/Illuminate/Routing/Console/stubs/controller.plain.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.plain.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyRootNamespaceHttp\Controllers\Controller;

--- a/src/Illuminate/Routing/Console/stubs/controller.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use DummyRootNamespaceHttp\Controllers\Controller;

--- a/src/Illuminate/Routing/Console/stubs/middleware.stub
+++ b/src/Illuminate/Routing/Console/stubs/middleware.stub
@@ -1,5 +1,5 @@
 <?php
-
+DummyStrictTypes
 namespace DummyNamespace;
 
 use Closure;


### PR DESCRIPTION
Using the option, the artisan commands that make classes will add declare(strict_types = 1); as the second line of the PHP file.

The changes alter some of the `--help` documentation for `make:` commands but all tests still pass.

Although Laravel as a framework refrains from adding strict types, developers find it helpful to enforce argument and/or return types. This new option allows them to choose strict types in an easier and more memorable way at the time they're most likely to be thinking about the design of their software design.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
