### PR TITLE
[6.x] Fix Str::afterLast

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -61,7 +61,17 @@ class Str
      */
     public static function afterLast($subject, $search)
     {
-        return $search === '' ? $subject : array_reverse(explode($search, $subject))[0];
+        if ($search === '') {
+            return $subject;
+        }
+
+        $position = strrpos($subject, (string) $search);
+
+        if ($position === false) {
+            return $subject;
+        }
+
+        return substr($subject, $position + strlen($search));
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -142,6 +142,7 @@ class SupportStrTest extends TestCase
         $this->assertSame('te', Str::afterLast('yv0et0te', '0'));
         $this->assertSame('te', Str::afterLast('yv0et0te', 0));
         $this->assertSame('te', Str::afterLast('yv2et2te', 2));
+        $this->assertSame('foo', Str::afterLast('----foo', '---'));
     }
 
     public function testStrContains()


### PR DESCRIPTION
There was a problem where a subject of `----foo` wouldn't return `foo` when `---` was passed as the search parameter for `Str::afterLast`.

Fixes https://github.com/laravel/framework/issues/31085