### PR TITLE
[6.x] Fix can't insert float into MySQL with PHP 7.3

### DIFF
--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\MySqlBuilder;
-use PDO;
 
 class MySqlConnection extends Connection
 {
@@ -63,22 +62,5 @@ class MySqlConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new DoctrineDriver;
-    }
-
-    /**
-     * Bind values to their parameters in the given statement.
-     *
-     * @param  \PDOStatement  $statement
-     * @param  array  $bindings
-     * @return void
-     */
-    public function bindValues($statement, $bindings)
-    {
-        foreach ($bindings as $key => $value) {
-            $statement->bindValue(
-                is_string($key) ? $key : $key + 1, $value,
-                is_int($value) || is_float($value) ? PDO::PARAM_INT : PDO::PARAM_STR
-            );
-        }
     }
 }

--- a/tests/Integration/Database/EloquentMySqlConnectionTest.php
+++ b/tests/Integration/Database/EloquentMySqlConnectionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase;
+
+class EloquentMySqlConnectionTest extends TestCase
+{
+    const TABLE = 'player';
+    const FLOAT_COL = 'float_col';
+    const JSON_COL = 'json_col';
+
+    const FLOAT_VAL = 0.2;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        // Database configuration
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'username' => 'root',
+            'password' => '',
+            'database' => 'forge',
+            'prefix' => '',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table) {
+                $table->json(self::JSON_COL)->nullable();
+                $table->float(self::FLOAT_COL)->nullable();
+            });
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        DB::table(self::TABLE)->truncate();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @dataProvider floatComparisonsDataProvider
+     *
+     * @param float  $value       the value to compare against the JSON value
+     * @param string $operator    the comparison operator to use. e.g. '<', '>', '='
+     * @param bool   $shouldMatch true if the comparison should match, false if not
+     */
+    public function testJsonFloatComparison(float $value, string $operator, bool $shouldMatch): void
+    {
+        DB::table(self::TABLE)->insert([self::JSON_COL => '{"rank":'.self::FLOAT_VAL.'}']);
+        $this->assertSame(
+            $shouldMatch,
+            DB::table(self::TABLE)->where(self::JSON_COL.'->rank', $operator, $value)->exists(),
+            self::JSON_COL.'->rank should '.($shouldMatch ? '' : 'not ')."be $operator $value"
+        );
+    }
+
+    public function floatComparisonsDataProvider(): array
+    {
+        return [
+            [0.2, '=', true],
+            [0.2, '>', false],
+            [0.2, '<', false],
+            [0.1, '=', false],
+            [0.1, '<', false],
+            [0.1, '>', true],
+            [0.3, '=', false],
+            [0.3, '<', true],
+            [0.3, '>', false],
+        ];
+    }
+
+    public function testFloatValueStoredCorrectly(): void
+    {
+        DB::table(self::TABLE)->insert([self::FLOAT_COL => self::FLOAT_VAL]);
+        $this->assertEquals(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
+    }
+}


### PR DESCRIPTION
## Problem
When inserting a float value into MySQL via the Illuminate\Database package when using at least PHP 7.3, the value is converted to an int.

The bug has been reported a few times before:

* #30435 
* illuminate/database#246

## Cause
PR #16069 introduced logic to the MySQLConnection that cast floats to ints to address a comparison problem with JSON columns, which was reported in issue #16063. This does not seem to cause a problem with PHP 7.1 and below but causes the float to lose it's decimal places when using PHP 7.3. I have not tested with PHP 7.2.

## Bug Reproduction
Given we have the following MySQL table:

```
CREATE TABLE `zip_codes` (
  `zip_code` varchar(255) NOT NULL,
  `latitude` decimal(15,10) NOT NULL,
  `longitude` decimal(15,10) NOT NULL
)
```

When we execute the following using Artisan Tinker:

```php
DB::table('zip_codes')->delete();

// Using the same values
$lat = -0.2;
$lon = 0;
$sql = 'INSERT INTO zip_codes (latitude, longitude, zip_code) VALUES (:lat, :long, :zip)';

// We insert the first by using PDO directly
$values = [':lat' => $lat, ':long' => $lon, ':zip' => 1];
DB::connection()->getPdo()->prepare($sql)->execute($values);

// Then the second by using Eloquent
DB::table('zip_codes')->insert(['latitude' => $lat, 'longitude' => $lon, 'zip_code' => 2]);

// Then pull them both.
DB::table('zip_codes')->get();
```

Then we should see both records with -0.2 as the latitude. But only the first has the value, and the second row is zero.