### PR TITLE
[7.x] Specify dynamic attribute casts at query-time

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1271,6 +1271,19 @@ class Builder
     }
 
     /**
+     * Apply query-time casts to the model instance.
+     *
+     * @param  array  $casts
+     * @return $this
+     */
+    public function withCasts($casts)
+    {
+        $this->model->mergeCasts($casts);
+
+        return $this;
+    }
+
+    /**
      * Get the given macro by name.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -483,6 +483,17 @@ trait HasAttributes
     }
 
     /**
+     * Merge new casts with existing casts on the model.
+     *
+     * @param  array  $casts
+     * @return void
+     */
+    public function mergeCasts($casts)
+    {
+        $this->casts = array_merge($this->casts, $casts);
+    }
+
+    /**
      * Cast an attribute to a native PHP type.
      *
      * @param  string  $key

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -421,6 +421,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         $model->setTable($this->getTable());
 
+        $model->mergeCasts($this->casts);
+
         return $model;
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1240,6 +1240,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function testWithCastsMethod()
+    {
+        $builder = new Builder($this->getMockQueryBuilder());
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+
+        $model->shouldReceive('mergeCasts')->with(['foo' => 'bar'])->once();
+        $builder->withCasts(['foo' => 'bar']);
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -206,6 +206,16 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('test', $newInstance->getTable());
     }
 
+    public function testNewInstanceReturnsNewInstanceWithMergedCasts()
+    {
+        $model = new EloquentModelStub;
+        $model->mergeCasts(['foo' => 'date']);
+        $newInstance = $model->newInstance();
+
+        $this->assertArrayHasKey('foo', $newInstance->getCasts());
+        $this->assertEquals('date', $newInstance->getCasts()['foo']);
+    }
+
     public function testCreateMethodSavesNewModel()
     {
         $_SERVER['__eloquent.saved'] = false;
@@ -1768,6 +1778,18 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->floatAttribute = NAN;
         $this->assertNan($model->floatAttribute);
+    }
+
+    public function testMergeCastsMergesCasts()
+    {
+        $model = new EloquentModelCastingStub;
+
+        $castCount = count($model->getCasts());
+        $this->assertArrayNotHasKey('foo', $model->getCasts());
+
+        $model->mergeCasts(['foo' => 'date']);
+        $this->assertEquals($castCount + 1, count($model->getCasts()));
+        $this->assertArrayHasKey('foo', $model->getCasts());
     }
 
     public function testUpdatingNonExistentModelFails()


### PR DESCRIPTION
This pull request allows additional (or replacement) attribute casts to be specified on the Eloquent query builder, such that they apply only to the results of that query.

The primary use case for this functionality is to apply casts to columns resulting from subqueries or joins, that are not usually present on the model.

While adding the aliases for those columns to the `$casts` array on the model does work, I feel that polluting the model with columns that are simply not present most of the time is not ideal, especially when the actual definition of those column names are likely to be spread across many different files.

## Example Usage
Consider the following query selecting `User`s along with the date of their most recent `Post`:

```php
User
    ::select([
        'users.*',
        'last_posted_at' => Post::selectRaw('MAX(created_at)')
            ->whereColumn('user_id', 'users.id')
    ])
    ->get();
```

While `User`’s own timestamps will be cast to Carbon instances, `last_posted_at` will simply be a string. Currently, the only way to cast this would be to add `last_posted_at` to either `$casts` or `$dates` on `User`, despite the column only being present for this one specific query.

This PR allows the following:

```php
User
    ::select([
        'users.*',
        'last_posted_at' => Post::selectRaw('MAX(created_at)')
            ->whereColumn('user_id', 'users.id')
    ])
    ->withCasts(['last_posted_at' => 'date'])
    ->get();
```

where the array of casts will be merged into any existing casts specified on the model.

Naming-wise I’m not sure if “withCasts” is the best option; I’ve just gone along with the likes of “withCount”.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
