### PR TITLE
[6.x] add dumpErrors() method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1159,7 +1159,7 @@ class TestResponse implements ArrayAccess
     /**
      * Dump the session errors from the response.
      *
-     * @param string $errorBag
+     * @param  string  $errorBag
      * @return $this
      */
     public function dumpErrors($errorBag = 'default')

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1157,6 +1157,21 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the session errors from the response.
+     *
+     * @param string $errorBag
+     * @return $this
+     */
+    public function dumpErrors($errorBag = 'default')
+    {
+        if ($errors = $this->session()->get('errors')) {
+            dump($errors->getBag($errorBag)->getMessages());
+        }
+
+        return $this;
+    }
+
+    /**
      * Dump the headers from the response.
      *
      * @return $this


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When writing tests and an unintended ValidationException is thrown I would like to be able to inspect the error, but with `$response->dump()` I only get the HTML rendered error page. With `$response->dumpErrors()` I can instantly see which errors occurred and fix them.

Another solution could be to check inside of the existing `dump()` method whether we have errors in the session and dump them out as well.