### PR TITLE
[6.x] Add mailable names to assertion messages

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -86,7 +86,7 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNothingSent()
     {
-        $mailableNames = collect($this->mailables)->values()->map(function ($mailable) {
+        $mailableNames = collect($this->mailables)->map(function ($mailable) {
             return get_class($mailable);
         })->join(', ');
         PHPUnit::assertEmpty($this->mailables, 'The following Mailables were sent unexpectedly: ' . $mailableNames);
@@ -148,7 +148,10 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNothingQueued()
     {
-        PHPUnit::assertEmpty($this->queuedMailables, 'Mailables were queued unexpectedly.');
+        $mailableNames = collect($this->queuedMailables)->map(function ($mailable) {
+            return get_class($mailable);
+        })->join(', ');
+        PHPUnit::assertEmpty($this->queuedMailables, 'The following Mailables were queued unexpectedly: ' . $mailableNames);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -86,7 +86,10 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNothingSent()
     {
-        PHPUnit::assertEmpty($this->mailables, 'Mailables were sent unexpectedly.');
+        $mailableNames = collect($this->mailables)->values()->map(function ($mailable) {
+            return get_class($mailable);
+        })->join(', ');
+        PHPUnit::assertEmpty($this->mailables, 'The following Mailables were sent unexpectedly: ' . $mailableNames);
     }
 
     /**

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -137,7 +137,7 @@ class SupportTestingMailFakeTest extends TestCase
             $this->fake->assertNothingSent();
             $this->fail();
         } catch (ExpectationFailedException $e) {
-            $this->assertThat($e, new ExceptionMessage('Mailables were sent unexpectedly.'));
+            $this->assertThat($e, new ExceptionMessage('The following Mailables were sent unexpectedly: Illuminate\Tests\Support\MailableStub'));
         }
     }
 }

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -140,6 +140,20 @@ class SupportTestingMailFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The following Mailables were sent unexpectedly: Illuminate\Tests\Support\MailableStub'));
         }
     }
+
+    public function testAssertNothingQueued()
+    {
+        $this->fake->assertNothingQueued();
+
+        $this->fake->to('taylor@laravel.com')->queue($this->mailable);
+
+        try {
+            $this->fake->assertNothingQueued();
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The following Mailables were queued unexpectedly: Illuminate\Tests\Support\MailableStub'));
+        }
+    }
 }
 
 class MailableStub extends Mailable implements MailableContract


### PR DESCRIPTION
Hi,

This PR just adds the names of any mailables which _were_ sent or queued to the `assertNothingSent()` and `assertNothingQueued()` test methods.

My reason for wanting to add this in is previously you would get a message of 'Mailables were queued unexpectedly.' which left the question 'Well, what were they?'.  So I've made it print something a little more descriptive like 'The following Mailables were queued unexpectedly: Illuminate\Tests\Support\MailableStub'.

I've made it two commits as there wasn't originally a test for the `assertNothingQueued()` method so I've added that in with the change to the function itself.

