### PR TITLE
[6.x] Redis Broadcaster: Broadcast to multiple channels at once

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -113,7 +113,7 @@ class RedisBroadcaster extends Broadcaster
             'socket' => Arr::pull($payload, 'socket'),
         ]);
 
-        $connection->eval($this->broadcastMultipleChannelsScript(), 0, $payload, ...$channels);
+        $connection->eval($this->broadcastMultipleChannelsScript(), 0, $payload, ...$this->formatChannels($channels));
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -115,7 +115,7 @@ class RedisBroadcaster extends Broadcaster
 
         $connection->eval($this->broadcastMultipleChannelsScript(), 0, $payload, ...$channels);
     }
-    
+
     /**
      * Get the Lua script for broadcasting to multiple channels.
      *

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -114,10 +114,8 @@ class RedisBroadcaster extends Broadcaster
         ]);
 
         $connection->eval($this->broadcastMultipleChannelsScript(), 0, $payload, ...$channels);
-
     }
-
-
+    
     /**
      * Get the Lua script for broadcasting to multiple channels.
      *

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -101,6 +101,10 @@ class RedisBroadcaster extends Broadcaster
      */
     public function broadcast(array $channels, $event, array $payload = [])
     {
+        if (empty($channels)) {
+            return;
+        }
+
         $connection = $this->redis->connection($this->connection);
 
         $payload = json_encode([
@@ -109,8 +113,25 @@ class RedisBroadcaster extends Broadcaster
             'socket' => Arr::pull($payload, 'socket'),
         ]);
 
-        foreach ($this->formatChannels($channels) as $channel) {
-            $connection->publish($channel, $payload);
-        }
+        $connection->eval($this->broadcastMultipleChannelsScript(), 0, $payload, ...$channels);
+
+    }
+
+
+    /**
+     * Get the Lua script for broadcasting to multiple channels.
+     *
+     * ARGV[1] - The payload
+     * ARGV[2...] - The channels
+     *
+     * @return string
+     */
+    protected function broadcastMultipleChannelsScript()
+    {
+        return <<<'LUA'
+for i = 2, #ARGV do
+  redis.call('publish', ARGV[i], ARGV[1])
+end
+LUA;
     }
 }


### PR DESCRIPTION
This PR adds a Lua script to the `RedisBroadcaster` which allows to broadcast to multiple channels at once.

**Why?**
It is pretty common in Laravel to send events to multiple channels at once. Currently, this results in multiple `publish` commands, all sending the same payload to the Redis server. This causes unnecessary data transfer (costs), especially if the payload is rather big. 
