### PR TITLE
[6.x] Fix PHPDoc for Redirector::intended()

### DIFF
--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -7,7 +7,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Http\RedirectResponse back(int $status = 302, array $headers = [], $fallback = false)
  * @method static \Illuminate\Http\RedirectResponse refresh(int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse guest(string $path, int $status = 302, array $headers = [], bool $secure = null)
- * @method static intended(string $default = '/', int $status = 302, array $headers = [], bool $secure = null)
+ * @method static \Illuminate\Http\RedirectResponse intended(string $default = '/', int $status = 302, array $headers = [], bool $secure = null)
  * @method static \Illuminate\Http\RedirectResponse to(string $path, int $status = 302, array $headers = [], bool $secure = null)
  * @method static \Illuminate\Http\RedirectResponse away(string $path, int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse secure(string $path, int $status = 302, array $headers = [])


### PR DESCRIPTION
The missing return type confuses PHPStan which reports the error:

```
Static call to instance method Illuminate\Support\Facades\Redirect::intended()
```

for calls such as:

```
Illuminate\Support\Facades\Redirect::intended();
```

This minor fix resolves the issue and PHPStan no longer complains.

The newly added return type is consistent with the return value of `Illuminate\Routing\Redirector::intended()`.