### PR TITLE
[6.x] Use variadic parameters for factory() helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -487,14 +487,12 @@ if (! function_exists('factory')) {
     /**
      * Create a model factory builder for a given class, name, and amount.
      *
-     * @param  dynamic  class|class,name|class,amount|class,name,amount
+     * @param  string|array  ...$arguments class|class,name|class,amount|class,name,amount
      * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
-    function factory()
+    function factory(...$arguments)
     {
         $factory = app(EloquentFactory::class);
-
-        $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);


### PR DESCRIPTION
This prevents phpstan from complaining that you are passing parameters when it thinks it does not accept any parameters.

Note: I'm not totally sure what the PhpDoc would look like for a variadic function. 

