### PR TITLE
[7.x] Added the possibility to set a global Return-Path e-mail header

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -128,7 +128,7 @@ class MailManager implements FactoryContract
         // Next we will set all of the global addresses on this mailer, which allows
         // for easy unification of all "from" addresses as well as easy debugging
         // of sent messages since they get be sent into a single email address.
-        foreach (['from', 'reply_to', 'to'] as $type) {
+        foreach (['from', 'reply_to', 'to', 'return_path'] as $type) {
             $this->setGlobalAddress($mailer, $config, $type);
         }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -64,6 +64,13 @@ class Mailer implements MailerContract, MailQueueContract
     protected $replyTo;
 
     /**
+     * The global return path address.
+     *
+     * @var array
+     */
+    protected $returnPath;
+
+    /**
      * The global to address and name.
      *
      * @var array
@@ -123,6 +130,17 @@ class Mailer implements MailerContract, MailQueueContract
     public function alwaysReplyTo($address, $name = null)
     {
         $this->replyTo = compact('address', 'name');
+    }
+
+    /**
+     * Set the global return path address.
+     *
+     * @param  string  $address
+     * @return void
+     */
+    public function alwaysReturnPath($address)
+    {
+        $this->returnPath = compact('address');
     }
 
     /**
@@ -480,6 +498,13 @@ class Mailer implements MailerContract, MailQueueContract
         // they create a new message. We will just go ahead and push this address.
         if (! empty($this->replyTo['address'])) {
             $message->replyTo($this->replyTo['address'], $this->replyTo['name']);
+        }
+
+        // When a global return path address was specified we will set this on every message
+        // instance so the developer does not have to repeat themselves every time
+        // they create a new message. We will just go ahead and push this address.
+        if (! empty($this->returnPath['address'])) {
+            $message->returnPath($this->returnPath['address']);
         }
 
         return $message;

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -145,6 +145,23 @@ class MailMailerTest extends TestCase
         });
     }
 
+    public function testGlobalReturnPathIsRespectedOnAllMessages()
+    {
+        unset($_SERVER['__mailer.test']);
+        $mailer = $this->getMailer();
+        $view = m::mock(stdClass::class);
+        $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn('rendered.view');
+        $this->setSwiftMailer($mailer);
+        $mailer->alwaysReturnPath('taylorotwell@gmail.com');
+        $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
+            $this->assertEquals('taylorotwell@gmail.com', $message->getReturnPath());
+        });
+        $mailer->send('foo', ['data'], function ($m) {
+            //
+        });
+    }
+
     public function testFailedRecipientsAreAppendedAndCanBeRetrieved()
     {
         unset($_SERVER['__mailer.test']);


### PR DESCRIPTION
Made it possible to specify a `return_path` in the mail config file. Being able to set a global `Return-Path` email header can be important for DMARC alignment with transactional e-mail services when you have a strict policy. An example is Postmark, as is explained here: https://postmarkapp.com/support/article/910-how-do-i-add-a-custom-return-path. DMARC alignment is important if you want to prevent e-mail spoofing, and not have your real e-mails rejected by receiving mail servers.
