### PR TITLE
[6.x] Replace Event Dispatcher in resolved cache repositories when `Event::fake()` is used

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -268,7 +268,7 @@ class CacheManager implements FactoryContract
      */
     protected function addEventDispatcher(Repository $repository)
     {
-        if (!$this->app->bound(DispatcherContract::class)) {
+        if (! $this->app->bound(DispatcherContract::class)) {
             return;
         }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -258,15 +258,23 @@ class CacheManager implements FactoryContract
      */
     public function repository(Store $store)
     {
-        $repository = new Repository($store);
+        return tap(new Repository($store), function ($repository) {
+            $this->setEventDispatcher($repository);
+        });
+    }
 
-        if ($this->app->bound(DispatcherContract::class)) {
-            $repository->setEventDispatcher(
-                $this->app[DispatcherContract::class]
-            );
+    /**
+     * @param Repository $repository
+     */
+    protected function setEventDispatcher(Repository $repository): void
+    {
+        if (!$this->app->bound(DispatcherContract::class)) {
+            return;
         }
 
-        return $repository;
+        $repository->setEventDispatcher(
+            $this->app[DispatcherContract::class]
+        );
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -259,14 +259,14 @@ class CacheManager implements FactoryContract
     public function repository(Store $store)
     {
         return tap(new Repository($store), function ($repository) {
-            $this->setEventDispatcher($repository);
+            $this->addEventDispatcher($repository);
         });
     }
 
     /**
      * @param Repository $repository
      */
-    protected function setEventDispatcher(Repository $repository): void
+    protected function addEventDispatcher(Repository $repository)
     {
         if (!$this->app->bound(DispatcherContract::class)) {
             return;
@@ -283,7 +283,7 @@ class CacheManager implements FactoryContract
      */
     public function refreshEventDispatcher()
     {
-        array_map([$this, 'setEventDispatcher'], $this->stores);
+        array_map([$this, 'addEventDispatcher'], $this->stores);
     }
 
     /**

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -278,6 +278,15 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Refreshes the event dispatcher of all resolved repositories
+     * with the currently bound event dispatcher implementation.
+     */
+    public function refreshEventDispatcher()
+    {
+        array_map([$this, 'setEventDispatcher'], $this->stores);
+    }
+
+    /**
      * Get the cache prefix.
      *
      * @param  array  $config

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -559,6 +559,16 @@ class Repository implements ArrayAccess, CacheContract
     }
 
     /**
+     * Get the event dispatcher instance.
+     *
+     * @return  \Illuminate\Contracts\Events\Dispatcher  $events
+     */
+    public function getEventDispatcher()
+    {
+        return $this->events;
+    }
+
+    /**
      * Determine if a cached value exists.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -60,6 +60,7 @@ class Event extends Facade
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);
+            Cache::refreshEventDispatcher();
         });
     }
 

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -38,6 +38,7 @@ class Event extends Facade
         static::swap($fake = new EventFake(static::getFacadeRoot(), $eventsToFake));
 
         Model::setEventDispatcher($fake);
+        Cache::refreshEventDispatcher();
 
         return $fake;
     }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -57,13 +57,17 @@ class SupportFacadesEventTest extends TestCase
 
     public function testFakeForSwapsDispatchers()
     {
-        Event::fakeFor(function () {
+        $arrayRepository = Cache::store('array');
+
+        Event::fakeFor(function () use ($arrayRepository) {
             $this->assertInstanceOf(EventFake::class, Event::getFacadeRoot());
             $this->assertInstanceOf(EventFake::class, Model::getEventDispatcher());
+            $this->assertInstanceOf(EventFake::class, $arrayRepository->getEventDispatcher());
         });
 
         $this->assertSame($this->events, Event::getFacadeRoot());
         $this->assertSame($this->events, Model::getEventDispatcher());
+        $this->assertSame($this->events, $arrayRepository->getEventDispatcher());
     }
 
     public function testFakeSwapsDispatchersInResolvedCacheRepositories()

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -90,10 +90,10 @@ class SupportFacadesEventTest extends TestCase
             'cache' => [
                 'stores' => [
                     'array' => [
-                        'driver' => 'array'
-                    ]
-                ]
-            ]
+                        'driver' => 'array',
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -2,9 +2,14 @@
 
 namespace Illuminate\Tests\Support;
 
+use Illuminate\Cache\CacheManager;
+use Illuminate\Cache\Events\CacheMissed;
+use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Testing\Fakes\EventFake;
@@ -23,6 +28,9 @@ class SupportFacadesEventTest extends TestCase
 
         $container = new Container;
         $container->instance('events', $this->events);
+        $container->alias('events', DispatcherContract::class);
+        $container->instance('cache', new CacheManager($container));
+        $container->instance('config', new ConfigRepository($this->getCacheConfig()));
 
         Facade::setFacadeApplication($container);
     }
@@ -56,6 +64,33 @@ class SupportFacadesEventTest extends TestCase
 
         $this->assertSame($this->events, Event::getFacadeRoot());
         $this->assertSame($this->events, Model::getEventDispatcher());
+    }
+
+    public function testFakeSwapsDispatchersInResolvedCacheRepositories()
+    {
+        $arrayRepository = Cache::store('array');
+
+        $this->events->shouldReceive('dispatch')->once();
+        $arrayRepository->get('foo');
+
+        Event::fake();
+
+        $arrayRepository->get('bar');
+
+        Event::assertDispatched(CacheMissed::class);
+    }
+
+    protected function getCacheConfig()
+    {
+        return [
+            'cache' => [
+                'stores' => [
+                    'array' => [
+                        'driver' => 'array'
+                    ]
+                ]
+            ]
+        ];
     }
 }
 


### PR DESCRIPTION
The `fake` and `fakeFor` method of the `Event` facade currently fails to replace the existing Event Dispatcher with the faked dispatcher in resolved cache repositories.

I've found that making assertions on cache events is a pretty useful way of testing code that uses the cache under the hood. For instance:

```php

class Calculator {

    public function add($operand1, $operand2)
    {
        $cacheKey = sprintf("%s+%s", $operand1, $operand2);

        if (Cache::has($cacheKey)) {
            return Cache::get($cacheKey);
        }

        $result = $operand1 + $operand2;

        Cache::put($cacheKey, $result);

        return $result;
    }
}

class CalculatorTest {

    public function test_it_returns_calculations_from_cache()
    {
        Cache::put('1+1', 3);
        Event::fake();

        $calculator = new Calculator;

        $this->assertEquals(3, $calculator->add(1, 1));

        Event::assertDispatched(CacheHit::class, function ($hit) {
            return $hit->key == '1+1' && $hit->value == 3;
        });
    }
}
``` 

This PR adds a public method to the `CacheManager` used to refresh each cache repositories  to which it holds a reference to with the event dispatcher that is currently bound in the service container.

The method is called in the `Event::fake` and `Event::fakeFor` methods.

A `getEventDispatcher` method was added to the cache `Repository` class to make testing a little easier.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
