### PR TITLE
[6.x] Change docblock type dynamic to mixed in variadic

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -227,14 +227,13 @@ if (! function_exists('cache')) {
      *
      * If an array is passed, we'll assume you want to put to the cache.
      *
-     * @param  dynamic  key|key,default|data,expiration|null
+     * @param  mixed  ...$arguments  key|key,default|data,expiration|null
      * @return mixed|\Illuminate\Cache\CacheManager
      *
      * @throws \Exception
      */
-    function cache()
+    function cache(...$arguments)
     {
-        $arguments = func_get_args();
 
         if (empty($arguments)) {
             return app('cache');
@@ -487,14 +486,12 @@ if (! function_exists('factory')) {
     /**
      * Create a model factory builder for a given class, name, and amount.
      *
-     * @param  dynamic  class|class,name|class,amount|class,name,amount
+     * @param  mixed  ...$arguments  class|class,name|class,amount|class,name,amount
      * @return \Illuminate\Database\Eloquent\FactoryBuilder
      */
-    function factory()
+    function factory(...$arguments)
     {
         $factory = app(EloquentFactory::class);
-
-        $arguments = func_get_args();
 
         if (isset($arguments[1]) && is_string($arguments[1])) {
             return $factory->of($arguments[0], $arguments[1])->times($arguments[2] ?? null);

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -234,7 +234,6 @@ if (! function_exists('cache')) {
      */
     function cache(...$arguments)
     {
-
         if (empty($arguments)) {
             return app('cache');
         }


### PR DESCRIPTION
I think dynamic type should be changed to mixed because dynamic is not supported and we should follow the phpdoc on variadic arguments
``@param type ...$parameter``
