### PR TITLE
[6.x] Fixes #31124

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1152,7 +1152,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         $actualRelations = collect();
         foreach ($this->relations as $key => $relation) {
-            if (!($relation instanceof Pivot)) {
+            if (! ($relation instanceof Pivot)) {
                 $actualRelations->put($key, $relation);
             }
         }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1150,7 +1150,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
         );
 
-        $this->load(collect($this->relations)->except('pivot')->keys()->toArray());
+        $actualRelations = collect();
+        foreach ($this->relations as $relation) {
+            if (!($relation instanceof Pivot)) {
+                $actualRelations->add($relation);
+            }
+        }
+
+        $this->load($actualRelations->keys()->toArray());
 
         $this->syncOriginal();
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1151,9 +1151,9 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         );
 
         $actualRelations = collect();
-        foreach ($this->relations as $relation) {
+        foreach ($this->relations as $key => $relation) {
             if (!($relation instanceof Pivot)) {
-                $actualRelations->add($relation);
+                $actualRelations->put($key, $relation);
             }
         }
 


### PR DESCRIPTION
This fixes the bug where pivot attribute name is customized. When customized, that attribute isn't "pivot" anymore (and doesn't get filtered out), and as a result of it remaining in the list of relationships to be loaded during ```refresh()```, model attempts to load these pivots as actual relationships, and this naturally fails.

Fixes #31124