### PR TITLE
Add validateDomainName to ValidatesAttributes

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1764,8 +1764,8 @@ trait ValidatesAttributes
         }
 
         // ToDo get TLDs from https://data.iana.org/TLD/tlds-alpha-by-domain.txt and compare first label with them
-        foreach ($labels as $l) {
-            if (! preg_match("/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]|)$/D", $l)) {
+        foreach ($labels as $label) {
+            if (! preg_match("/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]|)$/D", $label)) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1754,7 +1754,7 @@ trait ValidatesAttributes
             return false;
         }
 
-        if (strlen($value) > 256) {
+        if (strlen($value) > 254) {
             return false;
         }
 
@@ -1765,7 +1765,7 @@ trait ValidatesAttributes
 
         // ToDo get TLDs from https://data.iana.org/TLD/tlds-alpha-by-domain.txt and compare first label with them
         foreach ($labels as $l) {
-            if (!preg_match("/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]|)$/D", $l)) {
+            if (! preg_match("/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]|)$/D", $l)) {
                 return false;
             }
         }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1742,6 +1742,38 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is a valid URL.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateDomainName($attribute, $value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        if (strlen($value) > 256) {
+            return false;
+        }
+
+        $labels = explode(".", $value);
+        if (count($labels) < 2) {
+            return false;
+        }
+
+        // ToDo get TLDs from https://data.iana.org/TLD/tlds-alpha-by-domain.txt and compare first label with them
+        foreach ($labels as $l) {
+            if (!preg_match("/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9]|)$/D", $l)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is a valid UUID.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1742,7 +1742,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute is a valid URL.
+     * Validate that an attribute is a valid Domain Name according to RFC1035.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2269,6 +2269,50 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->fails());
     }
 
+    /** @dataProvider validDomainNames */
+    public function testValidateDomainNameWithValidDomainNames($validDomainName)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['domain' =>  $validDomainName], ['domain' => 'domain_name']);
+        $this->assertTrue($v->passes());
+    }
+
+    /** @dataProvider invalidDomainNames */
+    public function testValidateDomainNameWithInvalidDomainNames($invalidDomainName)
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['domain' =>  $invalidDomainName], ['domain' => 'domain_name']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function validDomainNames()
+    {
+        return [
+            ['example.com'],
+            ['sub.example.com'],
+            ['a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.com'],
+            ['1-1.com'],
+            ['labels-with-less-than-sixty-four-64-characters-considered-valid.com'],
+            [str_repeat(str_repeat('a', 62).".", 4) . 'com'],
+            ['xn--mnich-kva.com']
+        ];
+    }
+
+    public function invalidDomainNames()
+    {
+        return [
+            ['com'],
+            ['.com'],
+            ['.a.com'],
+            ['-1.com'],
+            ['1-.com'],
+            ['1_1.com'],
+            ['1&1.com'],
+            ['labels-with-more-than-sixty-four-64-characters-considered-invalid.com'],
+            [str_repeat(str_repeat('a', 62).".", 4) . 'co.uk'], // more than 256chars
+        ];
+    }
+
     public function testValidateEmail()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2293,7 +2293,7 @@ class ValidationValidatorTest extends TestCase
             ['a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.com'],
             ['1-1.com'],
             ['labels-with-less-than-sixty-four-64-characters-considered-valid.com'],
-            [str_repeat(str_repeat('a', 62).".", 4) . 'com'],
+            [str_repeat(str_repeat('a', 61).".", 4) . 'co.uk'],   // 254 characters
             ['xn--mnich-kva.com']
         ];
     }


### PR DESCRIPTION
There were no validation rules for [domain names](https://en.wikipedia.org/wiki/Domain_name) in the framework. This simple method validates an input against [rfc1035](https://tools.ietf.org/html/rfc1035).