### PR TITLE
[6.x] Add `dumpSession` method to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1169,6 +1169,23 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the session from the response.
+     *
+     * @param  array  $keys
+     * @return $this
+     */
+    public function dumpSession($keys = null)
+    {
+        if (is_array($keys)) {
+            dump($this->session()->only($keys));
+        } else {
+            dump($this->session()->all());
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the streamed content from the response.
      *
      * @return string


### PR DESCRIPTION
similar to `dumpHeaders` this dumps either all or selected keys from the session.  useful for debugging tests.