### PR TITLE
[6.x] Add loadFactoriesFrom method

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Database\Eloquent\Factory as ModelFactory;
 
 abstract class ServiceProvider
 {
@@ -139,6 +140,21 @@ abstract class ServiceProvider
         $this->callAfterResolving('migrator', function ($migrator) use ($paths) {
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
+            }
+        });
+    }
+
+    /**
+     * Register an Eloquent model factory path.
+     *
+     * @param  array|string  $paths
+     * @return void
+     */
+    protected function loadFactoriesFrom($paths)
+    {
+        $this->callAfterResolving(ModelFactory::class, function ($factory) use ($paths) {
+            foreach ((array) $paths as $path) {
+                $factory->load($path);
             }
         });
     }


### PR DESCRIPTION
This PR implements a new `loadFactoriesFrom` method in the service providers.
This method works like `loadRoutesFrom` or `loadMigrationsFrom` methods.

-----
Usage:

```php
$this->loadFactoriesFrom('source/database/factories');

$this->loadFactoriesFrom([
    'source_one/database/factories', 
    'source_two/database/factories',
]);
```
-----

Right now, there is no way to use a package's factories that are using models provided by the package itself. For testing the package and the application integration, it's easier to use the package's factories if there is any, instead of rewrite the factories.

Right now, packages can't load their own factories like migrations, views or routes, however it may be a help to the developers to use the package factories easily as well.

[orchestral/testbench](https://github.com/orchestral/testbench) offers something similar to solve this for package testing:

```php
$this->withFactories(__DIR__.'/../database/factories');
```

-----

I did not find any tests for the route or migration loading from the provider and right now I don't see how to test this easily. This is why I skipped tests.