### PR TITLE
[7.x] Added firstWhereOrFail to Eloquent Builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -250,6 +250,20 @@ class Builder
     }
 
     /**
+     * Add a basic where clause to the query, and return the first result.
+     *
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstWhereOrFail($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->firstOrFail();
+    }
+    
+    /**
      * Add an "or where" clause to the query.
      *
      * @param  \Closure|array|string  $column

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -250,7 +250,7 @@ class Builder
     }
 
     /**
-     * Add a basic where clause to the query, and return the first result.
+     * Add a basic where clause to the query, and return the first result or throw an exception.
      *
      * @param  \Closure|string|array  $column
      * @param  mixed  $operator

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -262,7 +262,7 @@ class Builder
     {
         return $this->where($column, $operator, $value, $boolean)->firstOrFail();
     }
-    
+
     /**
      * Add an "or where" clause to the query.
      *

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -112,9 +112,15 @@ class EloquentWhereTest extends DatabaseTestCase
         $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail('name', '=', $firstUser->name)));
         $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail('name', $firstUser->name)));
         $this->assertTrue($firstUser->is(UserWhereTest::where('name', $firstUser->name)->firstWhereOrFail('email', $firstUser->email)));
+
         $this->expectException(ModelNotFoundException::class);
+        UserWhereTest::where('name', $firstUser->name)->firstWhereOrFail('email', $secondUser->email);
+
         $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail(['name' => 'test-name', 'email' => 'test-email'])));
+
         $this->expectException(ModelNotFoundException::class);
+        UserWhereTest::firstWhereOrFail(['name' => 'test-name', 'email' => 'test-email1']);
+
         $this->assertTrue($secondUser->is(
             UserWhereTest::firstWhereOrFail(['name' => 'wrong-name', 'email' => 'test-email1'], null, null, 'or'))
         );

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
@@ -89,6 +90,33 @@ class EloquentWhereTest extends DatabaseTestCase
         $this->assertNull(UserWhereTest::firstWhere(['name' => 'test-name', 'email' => 'test-email1']));
         $this->assertTrue($secondUser->is(
             UserWhereTest::firstWhere(['name' => 'wrong-name', 'email' => 'test-email1'], null, null, 'or'))
+        );
+    }
+
+    public function testFirstWhereOrFail()
+    {
+        /** @var UserWhereTest $firstUser */
+        $firstUser = UserWhereTest::create([
+            'name' => 'test-name',
+            'email' => 'test-email',
+            'address' => 'test-address',
+        ]);
+
+        /** @var UserWhereTest $secondUser */
+        $secondUser = UserWhereTest::create([
+            'name' => 'test-name1',
+            'email' => 'test-email1',
+            'address' => 'test-address1',
+        ]);
+
+        $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail('name', '=', $firstUser->name)));
+        $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail('name', $firstUser->name)));
+        $this->assertTrue($firstUser->is(UserWhereTest::where('name', $firstUser->name)->firstWhereOrFail('email', $firstUser->email)));
+        $this->expectException(ModelNotFoundException::class);
+        $this->assertTrue($firstUser->is(UserWhereTest::firstWhereOrFail(['name' => 'test-name', 'email' => 'test-email'])));
+        $this->expectException(ModelNotFoundException::class);
+        $this->assertTrue($secondUser->is(
+            UserWhereTest::firstWhereOrFail(['name' => 'wrong-name', 'email' => 'test-email1'], null, null, 'or'))
         );
     }
 }


### PR DESCRIPTION
Extend Eloquent Builder with method `firstWhereOrFail` to complement `firstWhere`.

A shortcut for `->where(...)->firstOrFail()`.

Example: I'm fetching a user by email address:

```php
// Before
User::where('email', 'foo@bar.com')->firstOrFail();

// After
User::firstWhereOrFail('email', 'foo@bar.com');
```

**Implementation Notes:**

I only added this to the Eloquent builder for now. As commented on https://github.com/laravel/framework/pull/31089 I have avoided to add this method on the Query builder due failed tests.

Thanks!