### PR TITLE
[6.x] Fix command execute deprecated warning

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -198,7 +198,7 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        return $this->laravel->call([$this, 'handle']);
+        return $this->laravel->call([$this, 'handle']) ?? 0;
     }
 
     /**


### PR DESCRIPTION
When executing a command with no status code returned, a warning is generated:

> Return value of "App/Console/Commands/Command::execute()" should always be of the type int since Symfony 4.4, NULL returned.

Instead of adding a `return 0;` to all commands, we could return `0` by default if `null` is returned from the command's `handle` function.