### PR TITLE
After user verified their email return to the intended url

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -23,7 +23,7 @@ class EnsureEmailIsVerified
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
-                    : Redirect::route($redirectToRoute ?: 'verification.notice');
+                    : Redirect::guest($redirectToRoute ?: route('verification.notice'));
         }
 
         return $next($request);

--- a/src/Illuminate/Foundation/Auth/VerifiesEmails.php
+++ b/src/Illuminate/Foundation/Auth/VerifiesEmails.php
@@ -42,14 +42,14 @@ trait VerifiesEmails
         }
 
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect($this->redirectPath());
+            return redirect()->intended($this->redirectPath());
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect($this->redirectPath())->with('verified', true);
+        return redirect()->intended($this->redirectPath())->with('verified', true);
     }
 
     /**


### PR DESCRIPTION
Currently, after user verified their email, they are going to be redirected to '/home'(default) where I think it should be the intended url they were previously trying to access. This PR just makes that happen.