### PR TITLE
[7.x] Help Eloquent Collection work correctly when primary key is null

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -237,7 +237,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = $this->getDictionary();
 
         foreach ($items as $item) {
-            $dictionary[$item->getKey()] = $item;
+            if (is_null($key = $item->getKey())) {
+                $dictionary[] = $item;
+            } else {
+                $dictionary[$key] = $item;
+            }
         }
 
         return new static(array_values($dictionary));
@@ -399,7 +403,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get a dictionary keyed by primary keys.
+     * Get a dictionary keyed by primary keys if they exist.
      *
      * @param  \ArrayAccess|array|null  $items
      * @return array
@@ -411,7 +415,11 @@ class Collection extends BaseCollection implements QueueableCollection
         $dictionary = [];
 
         foreach ($items as $value) {
-            $dictionary[$value->getKey()] = $value;
+            if (is_null($key = $value->getKey())) {
+                $dictionary[] = $value;
+            } else {
+                $dictionary[$key] = $value;
+            }
         }
 
         return $dictionary;

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -179,9 +179,47 @@ class DatabaseEloquentCollectionTest extends TestCase
         $three = m::mock(Model::class);
         $three->shouldReceive('getKey')->andReturn(3);
 
+        $four = m::mock(Model::class);
+        $four->shouldReceive('getKey')->andReturnNull();
+
+        $five = m::mock(Model::class);
+        $five->shouldReceive('getKey')->andReturn('five');
+
+        $c = new Collection([$one, $two, $three, $four, $five]);
+
+        $this->assertEquals([1, 2, 3, null, 'five'], $c->modelKeys());
+    }
+
+    public function testCollectionReturnsDictionaryKeyedByPrimaryKey()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturn(3);
+
         $c = new Collection([$one, $two, $three]);
 
-        $this->assertEquals([1, 2, 3], $c->modelKeys());
+        $this->assertEquals([1 => $one, 2 => $two, 3 => $three], $c->getDictionary());
+    }
+
+    public function testCollectionReturnsDictionaryWhenKeysAreNull()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturnNull();
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturnNull();
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturnNull();
+
+        $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals([$one, $two, $three], $c->getDictionary());
     }
 
     public function testCollectionMergesWithGivenCollection()
@@ -199,6 +237,28 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c2 = new Collection([$two, $three]);
 
         $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
+    }
+
+    public function testCollectionElementsWithNullKeysMergesWithGivenCollection()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturnNull();
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturnNull();
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getKey')->andReturnNull();
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$three]);
+
+        $this->assertEquals(new Collection([$one, $two, $three]), $c1->merge($c2));
+
+        $c1 = new Collection([$one, $two]);
+        $c2 = new Collection([$two, $three]);
+
+        $this->assertEquals(new Collection([$one, $two, $two, $three]), $c1->merge($c2));
     }
 
     public function testMap()


### PR DESCRIPTION
When testing we often try to `make` models instead of `create`ing them so we can avoid DB calls. One downside to this is they do not receive a primary key.

```php
$user = factory(User::class)->make();
dd($user->id); // null
```

The `Eloquent\Collection` `merge()` and `getDictionary()` methods attempt to key the returned Collections by the primary key, but since all of the primary keys are `null`, they overwrite each other, and you end up with only 1 element in the resulting Collection.

```php
$users1 = factory(User::class, 2)->make();
$users2 = factory(User::class, 3)->make();

$users = $users1->merge($users2);

dd(count($users)); // 1
```

This PR updates the `merge()` and `getDictionary()` methods to *append* the element to the resulting array if the key is `null`.

This *feels* like a bug fix to me, but behavior is changing. It would be great to backport to 6.x, but I'll leave that decision up to you guys.

---

The current documentation for non-Eloquent Collections says:

> If a string key in the given items matches a string key in the original collection, the given items's value will overwrite the value in the original collection

> If the given items's keys are numeric, the values will be appended to the end of the collection

I don't think we want to match that behavior, since both string and integer keys are intended to be unique in the context of a Model.  If this PR is accepted I'll make the appropriate PR to the docs to explain this.