### PR TITLE
[7.x] Remember the intended URL if the user's email has not been verified.

### DIFF
--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -23,7 +23,7 @@ class EnsureEmailIsVerified
             ! $request->user()->hasVerifiedEmail())) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
-                    : Redirect::route($redirectToRoute ?: 'verification.notice');
+                    : Redirect::guest($redirectToRoute ?: route('verification.notice'));
         }
 
         return $next($request);


### PR DESCRIPTION
Remember the intended url if the user's email has not been verified, so that they can resume the operation once they have verified the email.

Related to : https://github.com/laravel/ui/pull/57