### PR TITLE
[6.x] View Bindings Assessor Object

### DIFF
--- a/src/Illuminate/View/ViewBindingsAssessor.php
+++ b/src/Illuminate/View/ViewBindingsAssessor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\View;
+
+class BindingsAssessor
+{
+    public const VIEW = 'view';
+    public const PHP_ENGINE = 'php';
+    public const FILE_ENGINE = 'file';
+    public const BLADE_ENGINE = 'blade';
+    public const VIEW_FINDER = 'view.finder';
+    public const BLADE_COMPILER = 'blade.compiler';
+    public const VIEW_ENGINE_RESOLVER = 'view.engine.resolver';
+}

--- a/src/Illuminate/View/ViewBindingsAssessor.php
+++ b/src/Illuminate/View/ViewBindingsAssessor.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\View;
 
-class BindingsAssessor
+class ViewBindingsAssessor
 {
     public const VIEW = 'view';
     public const PHP_ENGINE = 'php';

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -34,7 +34,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFactory()
     {
-        $this->app->singleton('view', function ($app) {
+        $this->app->singleton(ViewBindingsAssessor::VIEW, function ($app) {
             // Next we need to grab the engine resolver instance that will be used by the
             // environment. The resolver will be used by an environment to get each of
             // the various engine implementations such as plain PHP or Blade engine.
@@ -75,7 +75,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerViewFinder()
     {
-        $this->app->bind('view.finder', function ($app) {
+        $this->app->bind(ViewBindingsAssessor::VIEW_FINDER, function ($app) {
             return new FileViewFinder($app['files'], $app['config']['view.paths']);
         });
     }
@@ -87,7 +87,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeCompiler()
     {
-        $this->app->singleton('blade.compiler', function () {
+        $this->app->singleton(ViewBindingsAssessor::BLADE_COMPILER, function () {
             return new BladeCompiler(
                 $this->app['files'], $this->app['config']['view.compiled']
             );
@@ -101,7 +101,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerEngineResolver()
     {
-        $this->app->singleton('view.engine.resolver', function () {
+        $this->app->singleton(ViewBindingsAssessor::VIEW_ENGINE_RESOLVER, function () {
             $resolver = new EngineResolver;
 
             // Next, we will register the various view engines with the resolver so that the
@@ -123,7 +123,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFileEngine($resolver)
     {
-        $resolver->register('file', function () {
+        $resolver->register(ViewBindingsAssessor::FILE_ENGINE, function () {
             return new FileEngine;
         });
     }
@@ -136,7 +136,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerPhpEngine($resolver)
     {
-        $resolver->register('php', function () {
+        $resolver->register(ViewBindingsAssessor::PHP_ENGINE, function () {
             return new PhpEngine;
         });
     }
@@ -149,7 +149,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeEngine($resolver)
     {
-        $resolver->register('blade', function () {
+        $resolver->register(ViewBindingsAssessor::BLADE_ENGINE, function () {
             return new CompilerEngine($this->app['blade.compiler']);
         });
     }


### PR DESCRIPTION
Hi, this PR is a proof of concept that aims for better naming encapsulation.

The idea behind it is to remove the magic strings that are bound in the container to refer to the various components within the framework. Also, it will allow us to use the proper object names in the long future.  For instance, we could use `ViewInterface::class` instead `view`. This will lead us to remove this configurations object in the future avoiding breaking people code. 

If approved, I will be able to start working on replacing these strings by their references within this proposed object. 

> Naming and conventions can be improved, but you get the idea.

There is not breaking change and do not need tests before approving. But, we can add some tests for these constant's names in order for us to keep the wanted names once merged.

> The long run goal is to do this same process with all the strings bound in the container.

Thanks