### PR TITLE
[7.x] Automatically `setUp` traits in test classes

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -135,7 +135,7 @@ abstract class TestCase extends BaseTestCase
             $this->setUpFaker();
         }
 
-        foreach($uses as $trait) {
+        foreach ($uses as $trait) {
             $bootMethod = $method = 'setUp'.class_basename($trait);
 
             if (method_exists(static::class, $bootMethod)) {

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -135,6 +135,14 @@ abstract class TestCase extends BaseTestCase
             $this->setUpFaker();
         }
 
+        foreach($uses as $trait) {
+            $bootMethod = $method = 'setUp'.class_basename($trait);
+
+            if (method_exists(static::class, $bootMethod)) {
+                $this->{$method}();
+            }
+        }
+
         return $uses;
     }
 

--- a/tests/Foundation/Testing/TestCaseSetUpTraitTest.php
+++ b/tests/Foundation/Testing/TestCaseSetUpTraitTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\TestCase;
+
+class TestCaseSetUpTraitTest extends TestCase
+{
+    use TestTrait;
+
+    public $setUpTraitWasCalled = false;
+
+    public function createApplication()
+    {
+        return new Application();
+    }
+
+    public function testSetUpTrait()
+    {
+        $this->assertTrue($this->setUpTraitWasCalled);
+    }
+}
+
+trait TestTrait
+{
+    public function setUpTestTrait()
+    {
+        $this->setUpTraitWasCalled = true;
+    }
+}


### PR DESCRIPTION
> This is the minimal version of https://github.com/laravel/framework/pull/31136 with only additive changes, leaving the existing test traits as they are, as their order was deliberately chosen.

When organizing my tests, i frequently found myself adding small bits of functionality that set up the environment in some specific way, e.g. logging in as a test user, binding certain mock interfaces. I really enjoy the elegance of Laravel's bootable Model traits and how they allow horizontal inheritance without any definition overhead, so i looked for similarly elegant mechanism for hooking into the `setUp` method.

This feature will allow adding such functionality to test classes without having to manually call `setUp()`. By following a simple naming convention in the trait and using it in the test class, it is automatically called. This is particularly useful for Laravel packages, they can provide custom test helpers that can be easily integrated within test classes without explicit setup.

In the *highly* unlikely case that a user already defined and used a trait that coincidentally follows the naming convention, this method would now be called. Because of this slim potential for breakage, this PR is targeting `master`.