### PR TITLE
[6.x] Add Str::isUuid() helper

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -252,6 +252,21 @@ class Str
     }
 
     /**
+     * Determine if a given string matches a valid UUID
+     *
+     * @param  string  $value
+     * @return bool
+     */
+    public static function isUuid($value)
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
+    }
+
+    /**
      * Convert a string to kebab case.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -252,7 +252,7 @@ class Str
     }
 
     /**
-     * Determine if a given string matches a valid UUID.
+     * Determine if a given string is a valid UUID.
      *
      * @param  string  $value
      * @return bool

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -252,7 +252,7 @@ class Str
     }
 
     /**
-     * Determine if a given string matches a valid UUID
+     * Determine if a given string matches a valid UUID.
      *
      * @param  string  $value
      * @return bool

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1750,11 +1750,7 @@ trait ValidatesAttributes
      */
     public function validateUuid($attribute, $value)
     {
-        if (! is_string($value)) {
-            return false;
-        }
-
-        return preg_match('/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iD', $value) > 0;
+        return Str::isUuid($value);
     }
 
     /**

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -230,6 +230,22 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::is([], 'test'));
     }
 
+    /**
+     * @dataProvider validUuidList
+     */
+    public function testIsUuidWithValidUuid($uuid)
+    {
+        $this->assertTrue(Str::isUuid($uuid));
+    }
+
+    /**
+     * @dataProvider invalidUuidList
+     */
+    public function testIsUuidWithInvalidUuid($uuid)
+    {
+        $this->assertFalse(Str::isUuid($uuid));
+    }
+
     public function testKebab()
     {
         $this->assertSame('laravel-php-framework', Str::kebab('LaravelPhpFramework'));
@@ -387,6 +403,38 @@ class SupportStrTest extends TestCase
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());
         $this->assertInstanceOf(UuidInterface::class, Str::orderedUuid());
+    }
+
+    public function validUuidList()
+    {
+        return [
+            ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
+            ['00000000-0000-0000-0000-000000000000'],
+            ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'],
+            ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'],
+            ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'],
+            ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'],
+        ];
+    }
+
+    public function invalidUuidList()
+    {
+        return [
+            ['not a valid uuid so we can test this'],
+            ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL],
+            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
+            [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
+            ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
+            ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'],
+            ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
+            ['af6f8cb0c57d11e19b210800200c9a66'],
+            ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
+        ];
     }
 }
 


### PR DESCRIPTION
It was already possible to validate uuid's using the Validator class. This PR extracts the validation logic for the `uuid` rule and puts it into the Str::isUuid() helper. 

Usage:
```php
Str::isUuid('a0a2a2d2-0b87-4a18-83f2-2529882be2de'); // Returns true
Str::isUuid('laravel'); // Returns false
```