### PR TITLE
Allow to translate the default unauthorized action message

### DIFF
--- a/src/Illuminate/Auth/Access/AuthorizationException.php
+++ b/src/Illuminate/Auth/Access/AuthorizationException.php
@@ -23,7 +23,7 @@ class AuthorizationException extends Exception
      */
     public function __construct($message = null, $code = null, Exception $previous = null)
     {
-        parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
+        parent::__construct($message ?? __('This action is unauthorized.'), 0, $previous);
 
         $this->code = $code ?: 0;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Add json translation support for the unauthorized message in the `AuthorizationException` wrapping the message into the `__()` function.

That way we can use translation strings as keys to translate that default message to any language, for example:

In the file `resources/lang/es.json`
```
{
    "This action is unauthorized.": "Esta acción no está autorizada."
}
```