### PR TITLE
[6.x] Custom Migration Table with Prefix Error

### DIFF
--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -165,8 +165,14 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     public function repositoryExists()
     {
         $schema = $this->getConnection()->getSchemaBuilder();
-
-        return $schema->hasTable($this->table);
+    
+        $table = $this->table;
+        if (strstr($table, '.') !== false) {
+            $arrTable = explode('.', $table);
+            $table = end($arrTable);
+        }
+        
+        return $schema->hasTable($table);
     }
 
     /**


### PR DESCRIPTION
If you need to use a prefix to access the migrations table (ie. SQL Server), the migration fails to find the table in the schema.

The schema just stores the table name, so it doesn't think the migrations table exists.

Steps to reproduce:
In `config/database.php`:
Change `'migrations' => 'migrations',` to `'migrations' => '[Database/Schema Name].migrations',`

Try to run migrations or just do: `php artisan migrate:status`

This (terrible) fix, is to highlight that the table name is not directly found in the schema when using a schema prefix.

My SQL Server is not using `dbo` as the table schema prefix.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
