### PR TITLE
[7.x] Ability to extend validation rules with Rule references

### DIFF
--- a/src/Illuminate/Contracts/Validation/Factory.php
+++ b/src/Illuminate/Contracts/Validation/Factory.php
@@ -19,7 +19,7 @@ interface Factory
      * Register a custom validator extension.
      *
      * @param  string  $rule
-     * @param  \Closure|string  $extension
+     * @param  \Closure|\Illuminate\Contracts\Validation\Rule|string  $extension
      * @param  string|null  $message
      * @return void
      */

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -180,7 +180,7 @@ class Factory implements FactoryContract
      * Register a custom validator extension.
      *
      * @param  string  $rule
-     * @param  \Closure|string  $extension
+     * @param  \Closure|\Illuminate\Contracts\Validation\Rule|string  $extension
      * @param  string|null  $message
      * @return void
      */


### PR DESCRIPTION
I [have an array of objects](https://github.com/andrey-helldar/strong-password/blob/master/src/Rules/Rules.php#L7-L14) that need to expand validation rules:
```php
const ALL = [
    'case_diff'  => CaseDiffRule::class,
    'letters'    => LettersRule::class,
    'min_length' => MinLengthRule::class,
    'numbers'    => NumbersRule::class,
    'strong'     => StrongRule::class,
    'symbols'    => SymbolsRule::class,
];
```

Since I don’t want to initialize the class instance when forming the list of validator extensions, I had to write static methods:

```php
use Helldar\StrongPassword\Contracts\Rule;

class CaseDiffRule implements Rule
{
    public static function passes($value = null): bool
    {
        return (bool) preg_match('/(\p{Ll}+.*\p{Lu})|(\p{Lu}+.*\p{Ll})/u', $value);
    }

    public static function message(): string
    {
        return trans('strong-password::validation.case_diff');
    }
}
```

and ServiceProvider:
```php
class ServiceProvider extends IlluminateServiceProvider
{
    public function boot(Factory $validator)
    {
        $this->validation($validator);
    }

    protected function validation(Factory $validator)
    {
        array_map(function ($name) use ($validator) {
            /** @var \Helldar\StrongPassword\Contracts\Rule $rule */
            $rule = Rules::get($name);

            $validator->extend(Rules::name($name), function ($_, $value) use ($rule) {
                return $rule::passes($value);
            }, $rule::message());
        }, Rules::names());
    }
}
```

The proposed changes allow me to pass a reference to an instance of the rule inherited from `Illuminate\Contracts\Validation\Rule` into the extend method.

Thus, it will be possible to easily form extensions. For example:
```php
foreach (Rules::ALL as $name => $rule) {
  $validator->extend($name, $rule);
}

// or
$validator->extend('case_diff', CaseDiffRule::class);
$validator->extend('letters', LettersRule::class);
$validator->extend('min_length', MinLengthRule::class);
$validator->extend('numbers', NumbersRule::class);
$validator->extend('strong', StrongRule::class);
$validator->extend('symbols', SymbolsRule::class);
```

I believe that these changes will allow the use of objects inherited from `Illuminate\Contracts\Validation\Rule` when expanding the rules, thereby making the application code cleaner.

I find it especially useful when `*Rule` are in other packages.