### PR TITLE
[6.x] Add boolean($key) method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -227,11 +227,12 @@ trait InteractsWithInput
      * Retrieve input as a boolean value.
      *
      * @param  string|null  $key
+     * @param  boolean  $default
      * @return bool
      */
-    public function boolean($key = null)
+    public function boolean($key = null, $default = false)
     {
-        return filter_var($this->input($key, false), FILTER_VALIDATE_BOOLEAN);
+        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -227,7 +227,7 @@ trait InteractsWithInput
      * Retrieve input as a boolean value.
      *
      * @param  string|null  $key
-     * @param  boolean  $default
+     * @param  bool  $default
      * @return bool
      */
     public function boolean($key = null, $default = false)

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -232,7 +232,7 @@ trait InteractsWithInput
      */
     public function boolean($key = null, $default = false)
     {
-        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
     }
 
     /**

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -224,6 +224,17 @@ trait InteractsWithInput
     }
 
     /**
+     * Retrieve input as a boolean value.
+     *
+     * @param  string|null  $key
+     * @return bool
+     */
+    public function boolean($key = null)
+    {
+        return filter_var($this->input($key, false), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
      * Get a subset containing the provided keys with values from the input data.
      *
      * @param  array|mixed  $keys

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -405,6 +405,16 @@ class HttpRequestTest extends TestCase
         $this->assertInstanceOf(SymfonyUploadedFile::class, $request['file']);
     }
 
+    public function testBooleanMethod()
+    {
+        $request = Request::create('/', 'GET', ['with_trashed' => 'false', 'download' => true, 'checked' => 1, 'unchecked' => '0']);
+        $this->assertTrue($request->boolean('checked'));
+        $this->assertTrue($request->boolean('download'));
+        $this->assertFalse($request->boolean('unchecked'));
+        $this->assertFalse($request->boolean('with_trashed'));
+        $this->assertFalse($request->boolean('some_undefined_key'));
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);


### PR DESCRIPTION
This PR introduces a new helper method to the `Illuminate\Http\Request`: `boolean($key)` which takes input using the `input()` method and filters it through [filter_var](https://www.php.net/manual/en/function.filter-var.php) and `FILTER_VALIDATE_BOOLEAN`

Brief about `FILTER_VALIDATE_BOOLEAN` from php.net: 

> Returns TRUE for "1", "true", "on" and "yes". Returns FALSE otherwise.

```php
// Before
$availableForHire = filter_var(Request::boolean('available_for_hire'), FILTER_VALIDATE_BOOLEAN);

// After
$availableForHire = Request::boolean('available_for_hire');
```

I set the default to be `false` so than an undefined variable (eg unchecked checkbox) would act as false.

Unsure how everyone feels about this and the naming of it though.

(edit: removed references to FILTER_NULL_ON_FAILURE as it was removed from the code)
