### PR TITLE
[6.x] Add URL::default(array $defaults, string $namePrefix = '') for named routes

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -54,6 +54,13 @@ class UrlGenerator implements UrlGeneratorContract
     protected $forceScheme;
 
     /**
+     * The default prefix for named routes.
+     *
+     * @var string
+     */
+    protected $defaultRouteNamePrefix = '';
+
+    /**
      * A cached copy of the URL root for the current request.
      *
      * @var string|null
@@ -413,6 +420,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
+        $name = $this->defaultNamePrefix.$name;
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
@@ -595,6 +603,17 @@ class UrlGenerator implements UrlGeneratorContract
     public function defaults(array $defaults)
     {
         $this->routeUrl()->defaults($defaults);
+    }
+
+    /**
+     * Set the default prefix of named routes used by the URL generator.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function defaultNamePrefix(string $prefix)
+    {
+        $this->defaultRouteNamePrefix = $prefix;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -599,13 +599,15 @@ class UrlGenerator implements UrlGeneratorContract
      * Set the default named parameters used by the URL generator.
      *
      * @param  array  $defaults
-     * @param  string  $namePrefix
+     * @param  string|null  $namePrefix
      * @return void
      */
-    public function defaults(array $defaults, $namePrefix = '')
+    public function defaults(array $defaults, $namePrefix = null)
     {
         $this->routeUrl()->defaults($defaults);
-        $this->defaultRouteNamePrefix = $namePrefix;
+        if(! is_null($namePrefix)){
+            $this->defaultRouteNamePrefix = $namePrefix;
+        }
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -605,7 +605,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function defaults(array $defaults, $namePrefix = null)
     {
         $this->routeUrl()->defaults($defaults);
-        if(! is_null($namePrefix)){
+        if (! is_null($namePrefix)){
             $this->defaultRouteNamePrefix = $namePrefix;
         }
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -422,7 +422,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
-        } elseif ($this->defaultRouteNamePrefix !== '' && ! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
+        } elseif (! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -599,6 +599,7 @@ class UrlGenerator implements UrlGeneratorContract
      * Set the default named parameters used by the URL generator.
      *
      * @param  array  $defaults
+     * @param  string  $namePrefix
      * @return void
      */
     public function defaults(array $defaults, string $namePrefix = '')

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -602,7 +602,7 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  string  $namePrefix
      * @return void
      */
-    public function defaults(array $defaults, string $namePrefix = '')
+    public function defaults(array $defaults, $namePrefix = '')
     {
         $this->routeUrl()->defaults($defaults);
         $this->defaultRouteNamePrefix = $namePrefix;

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -420,8 +420,9 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        $name = $this->defaultRouteNamePrefix.$name;
         if (! is_null($route = $this->routes->getByName($name))) {
+            return $this->toRoute($route, $parameters, $absolute);
+        } else if (! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -422,7 +422,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
-        } elseif (! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
+        } elseif ($this->defaultRouteNamePrefix !== '' && ! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -601,20 +601,10 @@ class UrlGenerator implements UrlGeneratorContract
      * @param  array  $defaults
      * @return void
      */
-    public function defaults(array $defaults)
+    public function defaults(array $defaults, string $namePrefix = '')
     {
         $this->routeUrl()->defaults($defaults);
-    }
-
-    /**
-     * Set the default prefix of named routes used by the URL generator.
-     *
-     * @param  string  $prefix
-     * @return void
-     */
-    public function defaultNamePrefix(string $prefix)
-    {
-        $this->defaultRouteNamePrefix = $prefix;
+        $this->defaultRouteNamePrefix = $namePrefix;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -422,7 +422,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
-        } else if (! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
+        } elseif (! is_null($route = $this->routes->getByName($this->defaultRouteNamePrefix.$name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -605,7 +605,7 @@ class UrlGenerator implements UrlGeneratorContract
     public function defaults(array $defaults, $namePrefix = null)
     {
         $this->routeUrl()->defaults($defaults);
-        if (! is_null($namePrefix)){
+        if (! is_null($namePrefix)) {
             $this->defaultRouteNamePrefix = $namePrefix;
         }
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -420,7 +420,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        $name = $this->defaultNamePrefix.$name;
+        $name = $this->defaultRouteNamePrefix.$name;
         if (! is_null($route = $this->routes->getByName($name))) {
             return $this->toRoute($route, $parameters, $absolute);
         }

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -15,7 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
  * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
- * @method static void defaults(array $defaults, string $namePrefix = '')
+ * @method static void defaults(array $defaults, string $namePrefix = null)
  *
  * @see \Illuminate\Routing\UrlGenerator
  */

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -15,7 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
  * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
- * @method static void defaults(array $defaults, string $namePrefix = null)
+ * @method static void defaults(array $defaults, string|null $namePrefix = null)
  *
  * @see \Illuminate\Routing\UrlGenerator
  */

--- a/src/Illuminate/Support/Facades/URL.php
+++ b/src/Illuminate/Support/Facades/URL.php
@@ -15,7 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static string signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, bool $absolute = true)
  * @method static string temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], bool $absolute = true)
  * @method static string hasValidSignature(\Illuminate\Http\Request $request, bool $absolute = true)
- * @method static void defaults(array $defaults)
+ * @method static void defaults(array $defaults, string $namePrefix = '')
  *
  * @see \Illuminate\Routing\UrlGenerator
  */


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Enables: [https://github.com/laravel/ideas/issues/2018](https://github.com/laravel/ideas/issues/2018)

Improves multilanguage-support for people who do not want to use **visible** language prefixes in their routes.

Example, defining routes like this:
```PHP
Route::name('en.')->group(function () {
    Route::get('/', 'HomeController@index')->name('home');
    Route::get('about', 'AboutController@index')->name('about');
    Route::get('register', 'AuthController@register')->name('register');
});
Route::name('nl.')->group(function () {
    Route::get('/', 'HomeController@index')->name('home');
    Route::get('over', 'AboutController@index')->name('about');
    Route::get('registreren', 'AuthController@register')->name('register');
});
```

Enables us to use the following middleware:
```PHP
namespace App\Http\Middleware;

use Closure;
use Illuminate\Support\Facades\URL;

class SetDefaultLocaleForUrls
{
    public function handle($request, Closure $next)
    {
        URL::defaultNamePrefix($request->user()->locale.".");

        return $next($request);
    }
}
```