### PR TITLE
[6.x] Fix redis lock acquire

### DIFF
--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -29,14 +29,13 @@ class RedisLock extends Lock
 
     /**
      * Attempt to acquire the lock.
-     * use set Ex NX to make the operation atomic, to avoid deadlock
-     * Redis version >= 2.6.12.
      *
      * @return bool
      */
     public function acquire()
     {
         if ($this->seconds > 0) {
+            // Use the atomic operations EX NX to avoid deadlock (Redis version >= 2.6.12)
             $result = $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'NX');
 
             return $result == 'OK';

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -29,8 +29,6 @@ class RedisLock extends Lock
 
     /**
      * Attempt to acquire the lock.
-     * use set Ex NX to make the operation atomic, to avoid deadlock
-     * Redis version >= 2.6.12
      *
      * @return bool
      */
@@ -38,10 +36,13 @@ class RedisLock extends Lock
     {
         if ($this->seconds > 0)
         {
+            // Use the atomic operations EX NX to avoid deadlock (Redis version >= 2.6.12)
             $result = $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'NX');
+
             return $result == 'OK';
         } else {
             $result = $this->redis->setnx($this->name, $this->owner);
+
             return $result === 1;
         }
     }

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -34,8 +34,7 @@ class RedisLock extends Lock
      */
     public function acquire()
     {
-        if ($this->seconds > 0)
-        {
+        if ($this->seconds > 0) {
             // Use the atomic operations EX NX to avoid deadlock (Redis version >= 2.6.12)
             $result = $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'NX');
 

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -30,18 +30,19 @@ class RedisLock extends Lock
     /**
      * Attempt to acquire the lock.
      * use set Ex NX to make the operation atomic, to avoid deadlock
-     * Redis version >= 2.6.12
+     * Redis version >= 2.6.12.
      *
      * @return bool
      */
     public function acquire()
     {
-        if ($this->seconds > 0)
-        {
+        if ($this->seconds > 0) {
             $result = $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'NX');
+
             return $result == 'OK';
         } else {
             $result = $this->redis->setnx($this->name, $this->owner);
+
             return $result === 1;
         }
     }


### PR DESCRIPTION
Use set Ex NX to make the operation atomic, to avoid deadlock.