### PR TITLE
[6.x] Add createMany to factoryBuilder

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -191,6 +191,20 @@ class FactoryBuilder
     }
 
     /**
+     * Create a collection of models and persist them to the database.
+     *
+     * @param iterable  $records
+     * @return mixed
+     */
+    public function createMany(iterable $records)
+    {
+        $instances = array_map(function ($attribute) {
+            return $this->create($attribute);
+        }, $records);
+        return new Collection($instances);
+    }
+
+    /**
      * Set the connection name on the results and store them.
      *
      * @param  \Illuminate\Support\Collection  $results

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -201,6 +201,7 @@ class FactoryBuilder
         $instances = array_map(function ($attribute) {
             return $this->create($attribute);
         }, $records);
+
         return new Collection($instances);
     }
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -176,6 +176,25 @@ class EloquentFactoryBuilderTest extends TestCase
         $this->assertCount(0, FactoryBuildableUser::find($instances->pluck('id')->toArray()));
     }
 
+    public function testCreateManyCollectionOfModels()
+    {
+        $users = factory(FactoryBuildableUser::class)->createMany([
+            [
+                'name' => 'Taylor',
+            ],
+            [
+                'name' => 'John'
+            ],
+            [
+                'name' => 'Doe'
+            ],
+        ]);
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(3, $users);
+        $this->assertCount(3, FactoryBuildableUser::find($users->pluck('id')->toArray()));
+        $this->assertEquals(['Taylor', 'John', 'Doe'], $users->pluck('name')->toArray());
+    }
+
     public function testCreatingModelsWithCallableState()
     {
         $server = factory(FactoryBuildableServer::class)->create();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -183,10 +183,10 @@ class EloquentFactoryBuilderTest extends TestCase
                 'name' => 'Taylor',
             ],
             [
-                'name' => 'John'
+                'name' => 'John',
             ],
             [
-                'name' => 'Doe'
+                'name' => 'Doe',
             ],
         ]);
         $this->assertInstanceOf(Collection::class, $users);


### PR DESCRIPTION
Create multiple records with custom data ! 

Before
```php
factory(User::class)->create([
    'name' => 'Taylor',
]);
factory(User::class)->create([
    'name' => 'John',
]);
factory(User::class)->create([
    'name' => 'Doe',
]);
```

After
```php
factory(User::class)->createMany([
    [
        'name' => 'Taylor',
    ],
    [
        'name' => 'John'
    ],
    [
        'name' => 'Doe'
    ],
]);
```

**Implementation Notes:**
I added `createMany` method to `FactoryBuilder`, it loops over `create` and return an eloquent collection at the end.

Thanks!