### PR TITLE
[6.x] Do not call alias methods internally

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1947,7 +1947,7 @@ class Builder
      */
     public function forPage($page, $perPage = 15)
     {
-        return $this->skip(($page - 1) * $perPage)->take($perPage);
+        return $this->offset(($page - 1) * $perPage)->limit($perPage);
     }
 
     /**
@@ -1967,7 +1967,7 @@ class Builder
         }
 
         return $this->orderBy($column, 'desc')
-                    ->take($perPage);
+                    ->limit($perPage);
     }
 
     /**
@@ -1987,7 +1987,7 @@ class Builder
         }
 
         return $this->orderBy($column, 'asc')
-                    ->take($perPage);
+                    ->limit($perPage);
     }
 
     /**
@@ -2171,7 +2171,7 @@ class Builder
     {
         $page = $page ?: Paginator::resolveCurrentPage($pageName);
 
-        $this->skip(($page - 1) * $perPage)->take($perPage + 1);
+        $this->offset(($page - 1) * $perPage)->limit($perPage + 1);
 
         return $this->simplePaginator($this->get($columns), $perPage, $page, [
             'path' => Paginator::resolveCurrentPath(),
@@ -2721,7 +2721,7 @@ class Builder
             return true;
         }
 
-        return (bool) $this->take(1)->update($values);
+        return (bool) $this->limit(1)->update($values);
     }
 
     /**


### PR DESCRIPTION
in commit c92ec296897030cc4caae19c55d959c26c78eef2, the `skip()` and `take()` methods got turned into aliases.

internally it is not necessary to call the aliases, we can directly call the aliased method, and reduce the extra method call.