### PR TITLE
[6.x] Prevent ambiguous column with table name prefix

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -222,7 +222,7 @@ trait QueriesRelationships
                         };
                     }
 
-                    $query->where($relation->getMorphType(), '=', (new $type)->getMorphClass())
+                    $query->where($this->query->from.'.'.$relation->getMorphType(), '=', (new $type)->getMorphClass())
                         ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }


### PR DESCRIPTION
## Description
When fetching a multi polymorphic relationships, the query builder is creating the query without inject the table name prefix in the query, throwing a MySQL ambiguous column error.

With this fix `QueriesRelationships` will automatically add the `table name` before the column definition preventing this kind of errors.

## Test case

```php
class Model_1 extends Model
{
    protected $table = 'model_1';

    /**
     * @return MorphToMany
     */
    public function models()
    {
        return $this->morphedByMany(Model_2::class, 'model', 'model_1_relationships');
    }

    /**
     * Filtered models
     *
     * @return MorphToMany
     */
    public function filteredModels()
    {
        return $this->models()
            ->whereHasMorph('model', Model_3::class, function ($model) {
                $model->where(with(new Model_3)->getTable() .'.model_type', Model_4::class);
            });
    }
}

class Model_2 extends Model
{
    protected $table = 'model_2';

    /**
     * @return MorphTo
     */
    public function model()
    {
        return $this->morphTo();
    }
}

class Model_3 extends Model
{
    protected $table = 'model_3';

    /**
     * @return MorphTo
     */
    public function model()
    {
        return $this->morphTo();
    }
}

class Model_4 extends Model
{
}
```

### Error
Fetching `Model_1::filteredModels()` the query builder return ambiguous column error.
```
Illuminate\Database\QueryException : SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'model_type' in where clause is ambiguous 
```

### Returned query
```sql
SELECT
    `model_2`.*,
    `model_1_relationships`.`model_1_id` AS `pivot_model_1_id`,
    `model_1_relationships`.`model_id` AS `pivot_model_id`,
    `model_1_relationships`.`model_type` AS `pivot_model_type`,
    `model_1_relationships`.`created_at` AS `pivot_created_at`,
    `model_1_relationships`.`updated_at` AS `pivot_updated_at`
FROM
    `model_2`
    INNER JOIN `model_1_relationships` ON `model_2`.`id` = `model_1_relationships`.`model_id`
WHERE
    `model_1_relationships`.`model_1_id` = 1
    AND `model_1_relationships`.`model_type` = 'App\Models\Model_2'
    and((`model_type` = 'App\Models\Model_3'
        AND EXISTS (
            SELECT
                * FROM `model_3`
            WHERE
                `model_2`.`model_id` = `model_3`.`id`
                AND `model_3`.`model_type` = 'App\Models\Model_4'
                AND `model_3`.`deleted_at` IS NULL)))
    AND `model_2`.`deleted_at` IS NULL
ORDER BY
    `position` ASC, `model_2`.`created_at` DESC
```

### Expected query
```sql
SELECT
    `model_2`.*,
    `model_1_relationships`.`model_1_id` AS `pivot_model_1_id`,
    `model_1_relationships`.`model_id` AS `pivot_model_id`,
    `model_1_relationships`.`model_type` AS `pivot_model_type`,
    `model_1_relationships`.`created_at` AS `pivot_created_at`,
    `model_1_relationships`.`updated_at` AS `pivot_updated_at`
FROM
    `model_2`
    INNER JOIN `model_1_relationships` ON `model_2`.`id` = `model_1_relationships`.`model_id`
WHERE
    `model_1_relationships`.`model_1_id` = 1
    AND `model_1_relationships`.`model_type` = 'App\Models\Model_2'
    and((`model_2`.`model_type` = 'App\Models\Model_3' # <= Here the FIX
        AND EXISTS (
            SELECT
                * FROM `model_3`
            WHERE
                `model_2`.`model_id` = `model_3`.`id`
                AND `model_3`.`model_type` = 'App\Models\Model_4'
                AND `model_3`.`deleted_at` IS NULL)))
    AND `model_2`.`deleted_at` IS NULL
ORDER BY
    `position` ASC, `model_2`.`created_at` DESC
```