### PR TITLE
[6.x] fix sqlserver drop column

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -191,8 +191,29 @@ class SqlServerGrammar extends Grammar
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
         $columns = $this->wrapArray($command->columns);
+		$dropExistingConstraintsSql = $this->compileDropDefaultConstraint($blueprint, $command).';';
 
-        return 'alter table '.$this->wrapTable($blueprint).' drop column '.implode(', ', $columns);
+        return $dropExistingConstraintsSql.'alter table '.$this->wrapTable($blueprint).' drop column '.implode(', ', $columns);
+    }
+	
+	/**
+     * Compile a drop default constraint command.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $command
+     * @return string
+     */
+	public function compileDropDefaultConstraint(Blueprint $blueprint, Fluent $command)
+    {
+        $tableName = $blueprint->getTable();
+        $columnSql = "'" . implode("','", $command->columns) . "'";
+        $sql = "DECLARE @sql NVARCHAR(MAX) = '';";
+        $sql .= "SELECT @sql += 'ALTER TABLE [dbo].[$tableName] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' ";
+        $sql .= 'FROM SYS.COLUMNS ';
+        $sql .= "WHERE [object_id] = OBJECT_ID('[dbo].[$tableName]') AND [name] in ($columnSql);";
+        $sql .= 'EXEC(@sql)';
+
+        return $sql;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -191,11 +191,11 @@ class SqlServerGrammar extends Grammar
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
         $columns = $this->wrapArray($command->columns);
-		$dropExistingConstraintsSql = $this->compileDropDefaultConstraint($blueprint, $command).';';
+        $dropExistingConstraintsSql = $this->compileDropDefaultConstraint($blueprint, $command).';';
 
         return $dropExistingConstraintsSql.'alter table '.$this->wrapTable($blueprint).' drop column '.implode(', ', $columns);
     }
-	
+
 	/**
      * Compile a drop default constraint command.
      *
@@ -203,10 +203,10 @@ class SqlServerGrammar extends Grammar
      * @param  \Illuminate\Support\Fluent  $command
      * @return string
      */
-	public function compileDropDefaultConstraint(Blueprint $blueprint, Fluent $command)
+    public function compileDropDefaultConstraint(Blueprint $blueprint, Fluent $command)
     {
         $tableName = $blueprint->getTable();
-        $columnSql = "'" . implode("','", $command->columns) . "'";
+        $columnSql = "'".implode("','", $command->columns)."'";
         $sql = "DECLARE @sql NVARCHAR(MAX) = '';";
         $sql .= "SELECT @sql += 'ALTER TABLE [dbo].[$tableName] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' ";
         $sql .= 'FROM SYS.COLUMNS ';

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -196,7 +196,7 @@ class SqlServerGrammar extends Grammar
         return $dropExistingConstraintsSql.'alter table '.$this->wrapTable($blueprint).' drop column '.implode(', ', $columns);
     }
 
-	/**
+    /**
      * Compile a drop default constraint command.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint


### PR DESCRIPTION
Answer for sql server dropColumn migrations not working because of default constraints:

Now default constraints get deleted first:

Read here the whole issue: https://github.com/laravel/framework/issues/4402