### PR TITLE
[6.x] support pulling decay minutes from the user instance for throttle

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -46,7 +46,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
      * @param  int|string  $maxAttempts
-     * @param  float|int  $decayMinutes
+     * @param  float|int|string  $decayMinutes
      * @param  string  $prefix
      * @return mixed
      *
@@ -57,6 +57,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
         $key = $prefix.$this->resolveRequestSignature($request);
 
         $maxAttempts = $this->resolveMaxAttempts($request, $maxAttempts);
+        $decayMinutes = $this->resolveDecayMinutes($request, $decayMinutes);
 
         if ($this->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
             throw $this->buildException($key, $maxAttempts);


### PR DESCRIPTION
Using the same logic of `resolveMaxAttempts()` I added a `resolveDecayMinutes()`

This change allow to users have different decay minutes for the rate limit.

For example in an API we can have:

- A user limited with 60 requests per minute.
- Another user limited with 20.000 requests per day.

The configuration in the middleware is analog to the max attempts. An example with the configuration for the throttle middleware:

`throttle:60|api_rate_limit,1|api_rate_time`

Where `api_rate_limit` and `api_rate_time` are attributtes of the user model (with that name or any other).
