### PR TITLE
Add \App\User to auth()->user() phpDoc

### DIFF
--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -21,7 +21,7 @@ interface Guard
     /**
      * Get the currently authenticated user.
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     * @return \Illuminate\Contracts\Auth\Authenticatable|\App\User|null
      */
     public function user();
 


### PR DESCRIPTION
One-line-change PR to remove the need for...
```
/**
 * @var \App\User $user 
 */
```
...every time when utilizing user from `auth` guard.

![image](https://user-images.githubusercontent.com/23461412/72804890-e1691800-3c51-11ea-9a7d-0e36f1f863b0.png)
