### PR TITLE
[6.x] Fix database url parsing for connections with no database specified

### DIFF
--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -95,7 +95,7 @@ class ConfigurationUrlParser
     {
         $path = $url['path'] ?? null;
 
-        return $path ? substr($path, 1) : null;
+        return $path && $path !== '/' ? substr($path, 1) : null;
     }
 
     /**

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -352,6 +352,23 @@ class ConfigurationUrlParserTest extends TestCase
                     'password' => 'asdfqwer1234asdf',
                 ],
             ],
+            'Redis example where URL ends with "/" and database is not present'  => [
+                [
+                    'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111/',
+                    'host' => '127.0.0.1',
+                    'password' =>  null,
+                    'port' =>  6379,
+                    'database' => 2,
+                ],
+                [
+                    'driver' => 'redis',
+                    'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
+                    'port' => 111,
+                    'database' => 2,
+                    'username' => 'h',
+                    'password' => 'asdfqwer1234asdf',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR fixes how a database URL is parsed when the URL does not specify the `database` bit but ends with an `/`. 

For example:
`REDIS_URL="redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111/"`

Before this fix the results from [getDatabase($url)](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/ConfigurationUrlParser.php#L94) would be `path=/`. Consequently, affecting how arrays are filtered on [RedisManager.php](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Redis/RedisManager.php#L186)

A test case has been added to cover this scenario.

This `REDIS_URL` format is very similar to what you can find when running applications on Heroku apart the addition of the `/` at the very end. Without this properly fixed, application developers will have to implement workarounds within the code base of their projects.
