### PR TITLE
[6.x] Remove unused variable

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -157,7 +157,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function getOpenAndClosingPhpTokens($contents)
     {
         return collect(token_get_all($contents))
-            ->pluck($tokenNumber = 0)
+            ->pluck(0)
             ->filter(function ($token) {
                 return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
             });


### PR DESCRIPTION
for the life of me I can't see that this variable assignment does anything.  I'm guessing it was maybe just put in for readability?

https://github.com/laravel/framework/commit/6be12dd818ed15c01ba28b2bbfd3bcadf0955da3