### PR TITLE
[6.x] Set model's attributes using a fluent syntax

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1256,4 +1256,22 @@ trait HasAttributes
 
         return $matches[1];
     }
+
+    /**
+     * Dynamic setter for attributes.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return $this
+     */
+    protected function dynamicSet($method, $parameters)
+    {
+        $attribute = Str::snake(
+            substr($method, 3)
+        );
+
+        $this->{$attribute} = $parameters[0];
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1617,6 +1617,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
+        if (Str::startsWith($method, 'set')) {
+            return $this->dynamicSet($method, $parameters);
+        }
+
         return $this->forwardCallTo($this->newQuery(), $method, $parameters);
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1592,6 +1592,21 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertFalse(Model::isIgnoringTouch());
     }
 
+    public function testDynamicSet()
+    {
+        $model = new EloquentTestUser;
+
+        $model->setEmail('taylorotwell@gmail.com');
+        $this->assertSame('taylorotwell@gmail.com', $model->email);
+
+        $model->setFullName('taylor otwell');
+        $this->assertSame('taylor otwell', $model->full_name);
+        $this->assertNull($model->fullname);
+
+        $model->setFullname('taylor otwell');
+        $this->assertSame('taylor otwell', $model->fullname);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
This PR adds a dynamic setter that allows setting attributes using a fluent syntax.

The motivation is to simplify this
```php
$user = User::find(1);
$user->name = 'example';
$user->save();
```

To a fluent syntax like this
```php
User::find(1)->setName('example')->save();
```
`setName()` is a dynamic method which sets the `name' attribute to the given value and then returns the instance allowing it to be chained.

I was inspired by the dynamic "where" clauses functionality
```php
$user = User::whereName('example')->first();
```