### PR TITLE
[7.x] Register bindings consistently

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -39,12 +39,12 @@ class FilesystemServiceProvider extends ServiceProvider
     {
         $this->registerManager();
 
-        $this->app->singleton('filesystem.disk', function () {
-            return $this->app['filesystem']->disk($this->getDefaultDriver());
+        $this->app->singleton('filesystem.disk', function ($app) {
+            return $app['filesystem']->disk($this->getDefaultDriver());
         });
 
-        $this->app->singleton('filesystem.cloud', function () {
-            return $this->app['filesystem']->disk($this->getCloudDriver());
+        $this->app->singleton('filesystem.cloud', function ($app) {
+            return $app['filesystem']->disk($this->getCloudDriver());
         });
     }
 
@@ -55,8 +55,8 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerManager()
     {
-        $this->app->singleton('filesystem', function () {
-            return new FilesystemManager($this->app);
+        $this->app->singleton('filesystem', function ($app) {
+            return new FilesystemManager($app);
         });
     }
 

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -13,8 +13,8 @@ class LogServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('log', function () {
-            return new LogManager($this->app);
+        $this->app->singleton('log', function ($app) {
+            return new LogManager($app);
         });
     }
 }

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -163,15 +163,15 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerWorker()
     {
-        $this->app->singleton('queue.worker', function () {
+        $this->app->singleton('queue.worker', function ($app) {
             $isDownForMaintenance = function () {
                 return $this->app->isDownForMaintenance();
             };
 
             return new Worker(
-                $this->app['queue'],
-                $this->app['events'],
-                $this->app[ExceptionHandler::class],
+                $app['queue'],
+                $app['events'],
+                $app[ExceptionHandler::class],
                 $isDownForMaintenance
             );
         });
@@ -184,8 +184,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerListener()
     {
-        $this->app->singleton('queue.listener', function () {
-            return new Listener($this->app->basePath());
+        $this->app->singleton('queue.listener', function ($app) {
+            return new Listener($app->basePath());
         });
     }
 
@@ -196,8 +196,8 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerFailedJobServices()
     {
-        $this->app->singleton('queue.failer', function () {
-            $config = $this->app['config']['queue.failed'];
+        $this->app->singleton('queue.failer', function ($app) {
+            $config = $app['config']['queue.failed'];
 
             if (isset($config['driver']) && $config['driver'] === 'dynamodb') {
                 return $this->dynamoFailedJobProvider($config);

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -87,10 +87,8 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeCompiler()
     {
-        $this->app->singleton('blade.compiler', function () {
-            return new BladeCompiler(
-                $this->app['files'], $this->app['config']['view.compiled']
-            );
+        $this->app->singleton('blade.compiler', function ($app) {
+            return new BladeCompiler($app['files'], $app['config']['view.compiled']);
         });
     }
 


### PR DESCRIPTION
currently there are 2 different ways core files are registering bindings. 

```php
$this->app->singleton('binding', function() {
    return new SomeClass($this->app['other-binding']);
});
```

vs

```php
$this->app->singleton('binding', function($app) {
    return new SomeClass($app['other-binding']);
});
```


they both accomplish the same result, but I think it is important to try and be consistent where possible.

the second pattern was far more prevalent, so I've updated them all to follow that pattern.