### PR TITLE
[7.x] Allow disabling check for expired views

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -23,14 +23,23 @@ class CompilerEngine extends PhpEngine
     protected $lastCompiled = [];
 
     /**
+     * Flag to check expired views.
+     *
+     * @var bool
+     */
+    protected $checkExpiredViews;
+
+    /**
      * Create a new Blade view engine instance.
      *
      * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
+     * @param  bool  $checkExpiredViews
      * @return void
      */
-    public function __construct(CompilerInterface $compiler)
+    public function __construct(CompilerInterface $compiler, $checkExpiredViews = true)
     {
         $this->compiler = $compiler;
+        $this->checkExpiredViews = $checkExpiredViews;
     }
 
     /**
@@ -47,7 +56,7 @@ class CompilerEngine extends PhpEngine
         // If this given view has expired, which means it has simply been edited since
         // it was last compiled, we will re-compile the views so we can evaluate a
         // fresh copy of the view. We'll pass the compiler the path of the view.
-        if ($this->compiler->isExpired($path)) {
+        if ($this->checkExpiredViews && $this->compiler->isExpired($path)) {
             $this->compiler->compile($path);
         }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -150,7 +150,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler']);
+            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled']);
         });
     }
 }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -150,7 +150,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled']);
+            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled'] ?? true);
         });
     }
 }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -38,8 +38,20 @@ class ViewCompilerEngineTest extends TestCase
 ', $results);
     }
 
-    protected function getEngine()
+    public function testViewsAreNotRecompiledIfWeDoNotWantThemRecompiled()
     {
-        return new CompilerEngine(m::mock(CompilerInterface::class));
+        $engine = $this->getEngine(false);
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');
+        $engine->getCompiler()->shouldReceive('isExpired')->never();
+        $engine->getCompiler()->shouldReceive('compile')->never();
+        $results = $engine->get(__DIR__.'/fixtures/foo.php');
+
+        $this->assertSame('Hello World
+', $results);
+    }
+
+    protected function getEngine($checkExpiredViews = true)
+    {
+        return new CompilerEngine(m::mock(CompilerInterface::class), $checkExpiredViews);
     }
 }


### PR DESCRIPTION
currently every time a view is rendered we first check to see if the compiled view has "expired", which means it doesn't exist or the pre-compiled view was modified after the compiled view.  this is good for performance, because it means we don't spend time compiling views on every request.

however, we can take it a step further and avoid making the filesystem calls in `isExpired` completely. On production environments, we can make the assumption that compiled views will **never** be expired.  We control this with a boolean config value, and we default it to `true` to maintain the current behavior.

If your page contains a lot of rendered Blade files, this will cause a decent decrease in unnecessary calls to `file_exists()` and `filemtime()`.

In order to use this feature, you **must** run `php artisan view:cache` in your deployment.

If this PR is accepted, I will make the appropriate changes to `laravel/laravel` and the docs.

There is no breaking change, so I probably could have sent it to 6.x, but I figured we're so close to release.