### PR TITLE
[7.x] Automatically escape value on assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -416,10 +416,13 @@ class TestResponse implements ArrayAccess
      * Assert that the given string is contained within the response text.
      *
      * @param  string  $value
+     * @param  bool  $escaped
      * @return $this
      */
-    public function assertSeeText($value)
+    public function assertSeeText($value, $escaped = true)
     {
+        $value = $escaped ? e($value) : $value;
+
         PHPUnit::assertStringContainsString((string) $value, strip_tags($this->getContent()));
 
         return $this;

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -134,6 +134,15 @@ class TestResponseTest extends TestCase
         $response->assertSeeText('foobar');
     }
 
+    public function testAssertSeeTextEscaped()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'laravel &amp; php',
+        ]);
+
+        $response->assertSeeText('laravel & php');
+    }
+
     public function testAssertSeeTextInOrder()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
When we echo data in Blade, 99% of the time we are escaping output with `{{ $var }}`.  If there is a special character in `$var` our assertion will fail:

```php
$user = factory(User::class)->create([
    'favorite_colors' => 'red & green',
]);

$this->get('/endpoint')
    ->assertSee($user->favorite_colors);
```

because `red & green` will not match `red &amp; green`.

This **will be a breaking change**, but I've added a second parameter to the assertion so people can turn off this encoding.

Clearly there are other assertions that would benefit from this as well, but I wanted to throw this out there and get feedback before updating more.  I know the point of discussion will be whose responsibility is it to escape this data.  Is it on the user to do something like:

```php
$user = factory(User::class)->create([
    'favorite_colors' => 'red & green',
]);

$this->get('/endpoint')
    ->assertSee(e($user->favorite_colors));
```

or can we appeal to the majority use case here, and automatically do it for them?