### PR TITLE
[6.x] Add an `--api` option to the `make:model` command to generate an API Controller

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -60,7 +60,7 @@ class ModelMakeCommand extends GeneratorCommand
             $this->createSeeder();
         }
 
-        if ($this->option('controller') || $this->option('resource')) {
+        if ($this->option('controller') || $this->option('resource') || $this->option('api')) {
             $this->createController();
         }
     }
@@ -124,10 +124,11 @@ class ModelMakeCommand extends GeneratorCommand
 
         $modelName = $this->qualifyClass($this->getNameInput());
 
-        $this->call('make:controller', [
-            'name' => "{$controller}Controller",
+        $this->call('make:controller', array_filter([
+            'name'    => "{$controller}Controller",
             '--model' => $this->option('resource') ? $modelName : null,
-        ]);
+            '--api'   => $this->option('api'),
+        ]));
     }
 
     /**
@@ -160,6 +161,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder file for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an api controller'],
         ];
     }
 }


### PR DESCRIPTION
With this PR we can generate an API controller for a model while creating the model using the command:

```bash
php artisan make:model Order --api
```

Or we can generate a factory, seeder, migration, resource, and  **API controller** all in the same command:

```bash
php artisan make:model Order --all --api
```

Generating resourceful controller works too:

```bash
php artisan make:model Order --resource --api
```

**Breaking Changes**

There should be no breaking change since the `make:model` command already using `make:controller` command in the background.