### PR TITLE
[6.x] Reset timeout handler after worker loop

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -122,7 +122,6 @@ class Worker
             $job = $this->getNextJob(
                 $this->manager->connection($connectionName), $queue
             );
-            sleep(5);
 
             if ($this->supportsAsyncSignals()) {
                 $this->registerTimeoutHandler($job, $options);

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -122,6 +122,7 @@ class Worker
             $job = $this->getNextJob(
                 $this->manager->connection($connectionName), $queue
             );
+            sleep(5);
 
             if ($this->supportsAsyncSignals()) {
                 $this->registerTimeoutHandler($job, $options);
@@ -135,6 +136,8 @@ class Worker
             } else {
                 $this->sleep($options->sleep);
             }
+
+            $this->resetTimeoutHandler();
 
             // Finally, we will check to see if we have exceeded our memory limits or if
             // the queue should restart based on other indications. If so, we'll stop
@@ -168,6 +171,16 @@ class Worker
         pcntl_alarm(
             max($this->timeoutForJob($job, $options), 0)
         );
+    }
+
+    /**
+     * Reset the worker timeout handler.
+     *
+     * @return void
+     */
+    protected function resetTimeoutHandler()
+    {
+        pcntl_alarm(0);
     }
 
     /**


### PR DESCRIPTION
If we have a timeout of 5 seconds, and a job took 4 seconds to run. On the next loop if `getNextJob()` took 1 second or more to run, the worker will exit before the script reaches `registerTimeoutHandler()` due to timeout. This will cause the job to not run, yet the attempt will count.

In this PR, we reset the alarm so it doesn't kill the process before the new loop sets a new value for the alarm.