### PR TITLE
[6.x] Fix Unit Test Generator Command

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/unit-test.stub
+++ b/src/Illuminate/Foundation/Console/stubs/unit-test.stub
@@ -2,7 +2,7 @@
 
 namespace DummyNamespace;
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class DummyClass extends TestCase
 {


### PR DESCRIPTION
When using
```bash
php artisan make:test --unit
```
The stub file seemingly incorrectly pulls in PHPUnit's TestCase instead of the framework's TestCase. I've seen this cause the following separate exceptions in tests:
```
ReflectionException: Class config does not exist
```
```
InvalidArgumentException: Unable to locate factory with name [default]
```