### PR TITLE
[7.x] Allow disabling checks for expired views

### DIFF
--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -23,14 +23,23 @@ class CompilerEngine extends PhpEngine
     protected $lastCompiled = [];
 
     /**
+     * Flag to check expired views.
+     *
+     * @var bool
+     */
+    protected $checkExpiredViews;
+
+    /**
      * Create a new Blade view engine instance.
      *
      * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
+     * @param  bool  $checkExpiredViews
      * @return void
      */
-    public function __construct(CompilerInterface $compiler)
+    public function __construct(CompilerInterface $compiler, $checkExpiredViews = true)
     {
         $this->compiler = $compiler;
+        $this->checkExpiredViews = $checkExpiredViews;
     }
 
     /**
@@ -47,7 +56,7 @@ class CompilerEngine extends PhpEngine
         // If this given view has expired, which means it has simply been edited since
         // it was last compiled, we will re-compile the views so we can evaluate a
         // fresh copy of the view. We'll pass the compiler the path of the view.
-        if ($this->compiler->isExpired($path)) {
+        if ($this->checkExpiredViews && $this->compiler->isExpired($path)) {
             $this->compiler->compile($path);
         }
 

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -150,7 +150,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler']);
+            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled']);
         });
     }
 }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -150,7 +150,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled']);
+            return new CompilerEngine($this->app['blade.compiler'], $this->app['config']['view.check_compiled'] ?? true);
         });
     }
 }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -38,8 +38,20 @@ class ViewCompilerEngineTest extends TestCase
 ', $results);
     }
 
-    protected function getEngine()
+    public function testViewsAreNotRecompiledIfWeDoNotWantThemRecompiled()
     {
-        return new CompilerEngine(m::mock(CompilerInterface::class));
+        $engine = $this->getEngine(false);
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->with(__DIR__.'/fixtures/foo.php')->andReturn(__DIR__.'/fixtures/basic.php');
+        $engine->getCompiler()->shouldReceive('isExpired')->never();
+        $engine->getCompiler()->shouldReceive('compile')->never();
+        $results = $engine->get(__DIR__.'/fixtures/foo.php');
+
+        $this->assertSame('Hello World
+', $results);
+    }
+
+    protected function getEngine($checkExpiredViews = true)
+    {
+        return new CompilerEngine(m::mock(CompilerInterface::class), $checkExpiredViews);
     }
 }


### PR DESCRIPTION
 This is a resubmission of #31195 with some performance results.

I did my best to isolate this change, so we could see the performance impact specifically from this change, so I kept the request as simple as possible.

Route:
```php
Route::get('/', 'MainController@index');
```

Controller:
```php
class MainController
{
    public function index(Request $request)
    {
        return view ('parent');
    }
}
```

Parent View:
```blade
@for($a=1; $a<=50; $a++)
    @include('child');
@endfor
```

Child View:
```blade
dummy content
```

The execution savings are entirely dependent on how many views need to be rendered for a given request. In the example above it is set at 51 (1 parent + 50 children).  I varied this number to see savings for different scenarios.

---

The following is the **inclusive time** of the `isExpired()` method:

| View Count    | Sample 1 | Sample 2 | Sample 3 | Average |
| ------------- | --------- | ---------- | --------- | -------- |
| 10 | 7.95 ms | 7.34 ms | 7.36 ms | 7.55 ms |
| 25  | 17 ms | 20 ms | 18.5 | 18.50 ms |
| 50  | 35.5 ms | 38.5 ms | 33.3 ms | 35.77 ms |
| 100 | 73.6 ms | 80.3 ms | 62.8 ms | 72.23 ms |

---

The following are the **total times** of the request:

| View Count    | Sample 1 | Sample 2 | Sample 3 | Average |
| ------------- | --------- | ---------- | --------- | -------- |
| 10 | 410 ms | 346 ms | 331 ms | 362 ms |
| 25  | 343 ms | 382 ms | 375 ms | 367 ms |
| 50  | 398 ms | 414 ms | 387 ms | 400 ms |
| 100 | 478 ms | 489 ms | 408 ms | 458 ms |

---

Based on these numbers our average savings per request by implementing this feature are:

| View Count | Inclusive Time | Total Time | Savings |
| ------------- | --------- | ---------- | --------- |
| 10 | 7.55 ms | 362 ms | 2.08% |
| 25 | 18.50 ms | 367 ms | 5.05% |
| 50 | 35.77 ms | 400 ms | 8.95% |
| 100 | 72.23 ms | 458 ms | 15.76% |

---

So we see, as expected, the more views that need to be rendered, the bigger percentage it takes up of your request.  Looking through some of our sites, it's not uncommon to see some pages with 40-50 views rendered.

---

Here is a screenshot of Blackfire comparing a 100 view run with the new feature disabled to with it enabled.

![Screen Shot 2020-01-22 at 4 21 31 PM](https://user-images.githubusercontent.com/5232313/72939916-798afe00-3d33-11ea-870b-4bf46deb74c5.png)

![Screen Shot 2020-01-22 at 4 22 30 PM](https://user-images.githubusercontent.com/5232313/72939965-8e679180-3d33-11ea-8e84-a1d2cc5dc46e.png)

We can see the calls are identical, except we drop a large number of calls to `isExpired()` and the filesystem functions it calls.
