### PR TITLE
[6.x] Add shallow option for resource routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -154,6 +154,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Set the shallow option for a resource.
+     *
+     * @param  boolean  $shallow
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function shallow($shallow = true)
+    {
+        $this->options['shallow'] = $shallow;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -156,7 +156,7 @@ class PendingResourceRegistration
     /**
      * Set the shallow option for a resource.
      *
-     * @param  boolean  $shallow
+     * @param  bool  $shallow
      * @return \Illuminate\Routing\PendingResourceRegistration
      */
     public function shallow($shallow = true)

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -420,7 +420,7 @@ class ResourceRegistrar
     protected function getNameWithShallowness($name, $options)
     {
         if (isset($options['shallow']) && $options['shallow']) {
-            return last(explode(".", $name));
+            return last(explode('.', $name));
         } else {
             return $name;
         }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -230,6 +230,9 @@ class ResourceRegistrar
      */
     protected function addResourceShow($name, $base, $controller, $options)
     {
+
+        $name = $this->getNameWithShallowness($name, $options);
+
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'show', $options);
@@ -248,6 +251,8 @@ class ResourceRegistrar
      */
     protected function addResourceEdit($name, $base, $controller, $options)
     {
+        $name = $this->getNameWithShallowness($name, $options);
+
         $uri = $this->getResourceUri($name).'/{'.$base.'}/'.static::$verbs['edit'];
 
         $action = $this->getResourceAction($name, $controller, 'edit', $options);
@@ -266,6 +271,8 @@ class ResourceRegistrar
      */
     protected function addResourceUpdate($name, $base, $controller, $options)
     {
+        $name = $this->getNameWithShallowness($name, $options);
+
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'update', $options);
@@ -284,6 +291,8 @@ class ResourceRegistrar
      */
     protected function addResourceDestroy($name, $base, $controller, $options)
     {
+        $name = $this->getNameWithShallowness($name, $options);
+
         $uri = $this->getResourceUri($name).'/{'.$base.'}';
 
         $action = $this->getResourceAction($name, $controller, 'destroy', $options);
@@ -399,6 +408,22 @@ class ResourceRegistrar
         $prefix = isset($options['as']) ? $options['as'].'.' : '';
 
         return trim(sprintf('%s%s.%s', $prefix, $name, $method), '.');
+    }
+
+    /**
+     * Get the name for a given resource with shallowness applied when needed.
+     *
+     * @param  string  $name
+     * @param  array  $options
+     * @return string
+     */
+    protected function getNameWithShallowness($name, $options)
+    {
+        if (isset($options['shallow']) && $options['shallow']) {
+            return last(explode(".", $name));
+        } else {
+            return $name;
+        }
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -230,7 +230,6 @@ class ResourceRegistrar
      */
     protected function addResourceShow($name, $base, $controller, $options)
     {
-
         $name = $this->getNameWithShallowness($name, $options);
 
         $uri = $this->getResourceUri($name).'/{'.$base.'}';

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -345,7 +345,7 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('tasks.show'));
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.tasks.show'));
     }
-    
+
     public function testCanExcludeMethodsOnRegisteredApiResource()
     {
         $this->router->apiResource('users', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -335,6 +335,17 @@ class RouteRegistrarTest extends TestCase
         $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.destroy'));
     }
 
+    public function testCanSetShallowOptionOnRegisteredResource()
+    {
+        $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->shallow();
+
+        $this->assertCount(7, $this->router->getRoutes());
+
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('users.tasks.index'));
+        $this->assertTrue($this->router->getRoutes()->hasNamedRoute('tasks.show'));
+        $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.tasks.show'));
+    }
+    
     public function testCanExcludeMethodsOnRegisteredApiResource()
     {
         $this->router->apiResource('users', RouteRegistrarControllerStub::class)

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1182,6 +1182,41 @@ class RoutingRouteTest extends TestCase
         $router->dispatch(Request::create('/'));
     }
 
+    public function testShallowResourceRouting()
+    {
+        $router = $this->getRouter();
+        $router->resource('foo.bar', 'FooController', ['shallow' => true]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertSame('foo/{foo}/bar', $routes[0]->uri());
+        $this->assertSame('foo/{foo}/bar/create', $routes[1]->uri());
+        $this->assertSame('foo/{foo}/bar', $routes[2]->uri());
+
+        $this->assertSame('bar/{bar}', $routes[3]->uri());
+        $this->assertSame('bar/{bar}/edit', $routes[4]->uri());
+        $this->assertSame('bar/{bar}', $routes[5]->uri());
+        $this->assertSame('bar/{bar}', $routes[6]->uri());
+
+        $router = $this->getRouter();
+        $router->resource('foo', 'FooController');
+        $router->resource('foo.bar.baz', 'FooController', ['shallow' => true]);
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+
+        $this->assertSame('foo', $routes[0]->uri());
+        $this->assertSame('foo/create', $routes[1]->uri());
+        $this->assertSame('foo', $routes[2]->uri());
+        $this->assertSame('foo/{foo}', $routes[3]->uri());
+        $this->assertSame('foo/{foo}/edit', $routes[4]->uri());
+        $this->assertSame('foo/{foo}', $routes[5]->uri());
+        $this->assertSame('foo/{foo}', $routes[6]->uri());
+
+        $this->assertSame('foo/{foo}/bar/{bar}/baz', $routes[7]->uri());
+        $this->assertSame('foo/{foo}/bar/{bar}/baz/create', $routes[8]->uri());
+        $this->assertSame('foo/{foo}/bar/{bar}/baz', $routes[9]->uri());
+    }
+
     public function testResourceRouting()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
It's a good practice not to nest resources too much. Routes and their url helpers quickly get unwieldy. Shallow nesting is a way to prevent deep nesting of resources. Collection actions (index, new, create) are scoped to the parent to provide context, while member actions (show, edit, update, destroy) are placed in the root or namespace when provided. This strikes a nice balance between being descriptive and being compact. An additional advantage is that resource members have a single canonical route. 

Instead of typing:
```php
Route::resource('foo.bar', 'BarController')->only(['index', 'create', 'store']);
Route::resource('bar', 'BarController')->only(['show', 'edit', 'update', 'destroy']);
```

We can simply type:
```php
Route::resource('foo.bar', 'BarController')->shallow();
```

And have the following routes generated for us:

```
| PUT|PATCH | bar/{bar}            | bar.update     | App\Http\Controllers\BarController@update  | web,auth |
| DELETE    | bar/{bar}            | bar.destroy    | App\Http\Controllers\BarController@destroy | web,auth |
| GET|HEAD  | bar/{bar}            | bar.show       | App\Http\Controllers\BarController@show    | web,auth |
| GET|HEAD  | bar/{bar}/edit       | bar.edit       | App\Http\Controllers\BarController@edit    | web,auth |
| POST      | foo/{foo}/bar        | foo.bar.store  | App\Http\Controllers\BarController@store   | web,auth |
| GET|HEAD  | foo/{foo}/bar        | foo.bar.index  | App\Http\Controllers\BarController@index   | web,auth |
| GET|HEAD  | foo/{foo}/bar/create | foo.bar.create | App\Http\Controllers\BarController@create  | web,auth |
```


