### PR TITLE
[7.x] Split The Authenticatable Contract

### DIFF
--- a/src/Illuminate/Contracts/Auth/Authenticatable.php
+++ b/src/Illuminate/Contracts/Auth/Authenticatable.php
@@ -24,26 +24,4 @@ interface Authenticatable
      * @return string
      */
     public function getAuthPassword();
-
-    /**
-     * Get the token value for the "remember me" session.
-     *
-     * @return string
-     */
-    public function getRememberToken();
-
-    /**
-     * Set the token value for the "remember me" session.
-     *
-     * @param  string  $value
-     * @return void
-     */
-    public function setRememberToken($value);
-
-    /**
-     * Get the column name for the "remember me" token.
-     *
-     * @return string
-     */
-    public function getRememberTokenName();
 }

--- a/src/Illuminate/Contracts/Auth/RememberMe.php
+++ b/src/Illuminate/Contracts/Auth/RememberMe.php
@@ -1,0 +1,29 @@
+
+<?php
+
+namespace Illuminate\Contracts\Auth;
+
+interface RememberMe
+{
+    /**
+     * Get the token value for the "remember me" session.
+     *
+     * @return string
+     */
+    public function getRememberToken();
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param  string  $value
+     * @return void
+     */
+    public function setRememberToken($value);
+
+    /**
+     * Get the column name for the "remember me" token.
+     *
+     * @return string
+     */
+    public function getRememberTokenName();
+}


### PR DESCRIPTION
The `Illuminate\Contracts\Auth\Authenticatable` interface forces to provide methods for the "remember me" session:

    public function getRememberToken();

    public function setRememberToken($value);

    public function getRememberTokenName();

Especially in `Lumen` apps we don't want to provide this functionality. I propose to split the Contract and add an optional `Illuminate\Contracts\Auth\RememberMe` interface.