### PR TITLE
[6.x] Controller stub from make:model --api missing model typehint

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -126,7 +126,7 @@ class ModelMakeCommand extends GeneratorCommand
 
         $this->call('make:controller', array_filter([
             'name'  => "{$controller}Controller",
-            '--model' => $this->option('resource') ? $modelName : null,
+            '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
         ]));
     }


### PR DESCRIPTION
Discovered based on code replication https://github.com/orchestral/canvas/commit/dc4fd9ff72dcd6799d9ebb10a511d682383b3463
