### PR TITLE
[7.x] Model getKeyType discrepancy

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -284,7 +284,7 @@ class BelongsTo extends Relation
     protected function relationHasIncrementingId()
     {
         return $this->related->getIncrementing() &&
-                                $this->related->getKeyType() === 'int';
+            in_array($this->related->getKeyType(), ['int', 'integer']);
     }
 
     /**


### PR DESCRIPTION
This is just something that I noticed while examining how `Model::getKeyType()` is utilized.

It seems that almost all cases where the value of `getKeyType()` is used, it will allow the value to be either `int` or `integer` ( among others, obviously ). Examples:

https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php#L656
https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#L485
https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Eloquent/Relations/Relation.php#L320

However in the `relationHasIncrementingId()` method, it would only allow that value to be set to `int` but not `integer`

This pull request would fix that issue.