### PR TITLE
[7.x] Add validation rule presets

### DIFF
--- a/src/Illuminate/Validation/RulesPreset.php
+++ b/src/Illuminate/Validation/RulesPreset.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use BadMethodCallException;
+use Illuminate\Support\Str;
+
+abstract class RulesPreset
+{
+    protected $preset;
+
+    public static function make()
+    {
+        return app()->make(static::class);
+    }
+
+    public function rules($overrides = [])
+    {
+        $rules = $this->{$this->preset}();
+
+        foreach ($overrides as $field => $fieldRules) {
+            $rules[$field] = array_merge(
+                isset($rules[$field]) ? $this->normalizeRules($rules[$field]) : [],
+                $this->normalizeRules($fieldRules)
+            );
+        }
+
+        return $rules;
+    }
+
+    protected function normalizeRules($rules)
+    {
+        return is_array($rules) ? $rules : [$rules];
+    }
+
+    /**
+     * Selects a preset.
+     *
+     * @param $preset
+     *
+     * @return $this
+     */
+    public function preset($preset)
+    {
+        $presetMethod = Str::camel("preset-{$preset}");
+
+        if (! method_exists($this, $presetMethod)) {
+            throw new BadMethodCallException(sprintf(
+                'Method %s::%s does not exist.', static::class, $presetMethod
+            ));
+        }
+
+        $this->preset = $presetMethod;
+
+        return $this;
+    }
+
+    public static function __callStatic($method, $parameters)
+    {
+        return static::make()->preset($method);
+    }
+}

--- a/tests/Validation/ValidationRulesPresetTest.php
+++ b/tests/Validation/ValidationRulesPresetTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use BadMethodCallException;
+use Illuminate\Validation\RulesPreset;
+use PHPUnit\Framework\TestCase;
+
+class ValidationRulesPresetTest extends TestCase
+{
+    public function testMakeMethodCreatesARulesPreset()
+    {
+        $this->assertInstanceOf(UserRulesPreset::class, UserRulesPreset::make());
+    }
+
+    public function testInvokingPresetNameWillInstanciateAnObjectAndSelectsThePreset()
+    {
+        $this->assertEquals(['foo' => ['required']], DummyPreset::foo()->rules());
+        $this->assertEquals(['bar' => ['required']], DummyPreset::bar()->rules());
+
+        try {
+            DummyPreset::baz()->rules();
+        } catch (BadMethodCallException $e) {
+            $this->assertEquals("Method Illuminate\Tests\Validation\DummyPreset::presetBaz does not exist.", $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected BadMethodCallException to be thrown, because there is no baz preset !');
+    }
+
+    public function testSelectingPresets()
+    {
+        $instance = DummyPreset::foo();
+        $this->assertEquals(['foo' => ['required']], DummyPreset::foo()->rules());
+        $this->assertEquals(['bar' => ['required']], $instance->preset('bar')->rules());
+        $this->assertEquals(['foo' => ['required']], $instance->preset('foo')->rules());
+
+        $this->assertSame($instance, $instance->preset('foo'));
+    }
+
+    public function testRulesMethod()
+    {
+        $this->assertEquals(
+            [
+                'name' => ['required', 'max:191'],
+                'username' => ['required', 'unique:users,username'],
+                'password' => ['required', 'confirmed', 'min:8'],
+                'email' => ['email', 'confirmed'],
+            ],
+            UserRulesPreset::create()->rules([
+                'name' => 'max:191',
+                'password' => ['confirmed', 'min:8'],
+                'email' => ['email', 'confirmed'],
+            ])
+        );
+
+        $this->assertEquals(
+            [
+                'name' => ['required'],
+                'username' => ['required', 'unique:users,username'],
+                'password' => 'required',
+            ],
+            UserRulesPreset::create()->rules()
+        );
+    }
+}
+
+class DummyPreset extends RulesPreset
+{
+    public function presetFoo()
+    {
+        return [
+            'foo' => ['required'],
+        ];
+    }
+
+    public function presetBar()
+    {
+        return [
+            'bar' => ['required'],
+        ];
+    }
+}
+
+class UserRulesPreset extends RulesPreset
+{
+    public function presetCreate()
+    {
+        return [
+            'name' => ['required'],
+            'username' => ['required', 'unique:users,username'],
+            'password' => 'required',
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces validation rule presets which allows to group validation rules in single place and avoid repeating defining them.
Please note that this serves a different purpose from the `rules()` method of the form requests.
Consider the following example:

A user can be :
- Created by an administrator.
- Created via account registration.
- Updated by an administrator.
- Updated via the user itself (Profile update)

These four actions validates the input in a very similar way but with some differences.

```php

// For creating a user by an admin
[
	'first_name' => ['required', 'max:191'],
	'last_name' => ['required', 'max:191'],
	'email' => ['required', 'email', 'confirmed', Rule::unique(User::class, 'email')],
	'password' => ['required', 'confirmed', 'min:8'],
        'roles' => ['required', 'array'],
        'roles.*' => Rule::exists(Role::class, 'id'),
];

// For creating a user via account registration
[
	'first_name' => ['required', 'max:191'],
	'last_name' => ['required', 'max:191'],
	'email' => ['required', 'email', 'confirmed', Rule::unique(User::class, 'email')],
	'password' => ['required', 'confirmed', 'min:8'],
];

// For updating a user by an admin
[
	'first_name' => ['required', 'max:191'],
	'last_name' => ['required', 'max:191'],
	'email' => ['nullable', 'email', 'confirmed', Rule::unique(User::class, 'email')->ignore($id, 'id')],
	'password' => ['nullable', 'confirmed', 'min:8'],
        'roles' => ['required', 'array'],
        'roles.*' => Rule::exists(Role::class, 'id'),
];

// For updating a user by the user himself (Profile update)
[
	'first_name' => ['required', 'max:191'],
	'last_name' => ['required', 'max:191'],
	'email' => ['nullable', 'email', 'confirmed', Rule::unique(User::class, 'email')->ignore($id, 'id')],
	'password' => ['nullable', 'confirmed', 'min:8']
];
```

The following rules are all different but have a lot in common.
- Create a user by admin have the same rules as the registration with the addition that and admin can choose different roles for the user.
- Creating and updating rules are almost the same with the difference that when updating the person is not required to provide an email or password, also the unique validation ignores the id of the user that is being updated.
- Update a user by admin have the same rules as the profile update with the addition that and admin can choose different roles for the user.

Before the PR the developper must write these rules in 4 different places, so if a new validation rule for an existing field is added or a new field is added the developper must update the 4 places.
If the developper forgets one place that will allow for invalid data to be persisted in the database.
Also having a single place for my user rules is way better then have them scattered in 4 form requests or controllers.

Please keep in mind that the example i used is very simple. Imagine what would happen when working with large forms, it will get ugly very easy (from experience).

Validation rule sets allows to eliminate all these problems.
Basic usage

```php
class UserRulesPreset extends RulesPreset
{
	public function presetCreate()
	{
		return [
			// Validation rules for creating a user
		];
	}

	public function presetUpdate()
	{
		return [
			// Validation rules for updating a user
		];
	}
}

// Use the create preset
UserRulesPreset::create()->rules();

// Use the update preset
UserRulesPreset::update()->rules();

// Use the update preset with some overrides
UserRulesPreset::update()->rules([
	'foo' => 'required',
	'bar' => 'confirmed',
]);

// Choose the preset depeding on some condition
$rulesPreset = UserRulesPreset::make();

if($foo == $bar)
    $rulesPreset->preset('create')->rules();
else
    $rulesPreset->preset('update')->rules();
```

Since this is a simple php class the developper can add his own methods and call them to pass in some data.
```php
class UserRulesPreset extends RulesPreset
{
        protected $user;

	public function presetUpdate()
	{
               // Use the user 
		return [
                        'email' => Rule::unique(User::class, 'email')->ignore($this->user->id, 'id')
			// ...
		];
	}

	public function user($user)
	{
                $this->user = $user;
		return $this;
	}
}

UserRulesPreset::update()->user($user)->rules();
```

As an example implementation for the 4 actions that i mentioned
```php
<?php

class UserRulesPreset extends RulesPreset
{
	protected $user;
	protected $enableAdminRules;

	public function presetCreate()
	{
		$rules = $this->commonRules();

		$rules['email'][] = 'required';
		$rules['email'][] = Rule::unique(User::class, 'email');
		$rules['password'][] = 'required';

		return $rules;
	}

	public function presetUpdate()
	{
		$rules = $this->commonRules();

		$rules['email'][] = 'nullable';
		$rules['email'][] = Rule::unique(User::class, 'email')->ignore($this->user->id, 'id');
		$rules['password'][] = 'nullable';

		return $rules;
	}

	protected function commonRules()
	{
		$rules = [
			'first_name' => ['required', 'max:191'],
			'last_name' => ['required', 'max:191'],
			'email' => ['email', 'confirmed'],
			'password' => ['confirmed', 'min:8'],
		];

		if($this->enableAdminRules) {
			$rules = array_merge($rules, [
		        'roles' => ['required', 'array'],
		        'roles.*' => Rule::exists(Role::class, 'id'),
			]);
		}

		return $rules;
	}

	public function enableAdminRules($enable = true)
	{
		$this->enableAdminRules = $enable;

		return $this;
	}

	public function user($user)
	{
		$this->user = $user;

		return $this;
	}
}

// Create by admin
UserRulesPreset::create()->enableAdminRules()->rules();

// Account registration
UserRulesPreset::create()->rules();

// Update by admin
UserRulesPreset::update()->user($user)->enableAdminRules()->rules();

// Update profile
UserRulesPreset::update()->user($user)->rules();
```

Important: This PR was submitted as a draft for two reasons :
- If Taylor is going to accept it then i must add command for generating the rules preset class.
- Giving the community a chance to discuss this and see if there is some suggestions.

I really hope that this gets accepted, because for me in my projects using the rules preset has significantly helped me and cleaned up my form requests.