### PR TITLE
[6.x] Fix handleBeginTransactionException method calling pdo property instead of getPdo() method

### DIFF
--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -34,9 +34,7 @@ trait ManagesTransactions
             // exception back out and let the developer handle an uncaught exceptions.
             catch (Exception $e) {
                 $this->handleTransactionException(
-                    $e,
-                    $currentAttempt,
-                    $attempts
+                    $e, $currentAttempt, $attempts
                 );
 
                 continue;
@@ -50,9 +48,7 @@ trait ManagesTransactions
                 $this->commit();
             } catch (Exception $e) {
                 $this->handleCommitTransactionException(
-                    $e,
-                    $currentAttempt,
-                    $attempts
+                    $e, $currentAttempt, $attempts
                 );
 
                 continue;

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -34,7 +34,9 @@ trait ManagesTransactions
             // exception back out and let the developer handle an uncaught exceptions.
             catch (Exception $e) {
                 $this->handleTransactionException(
-                    $e, $currentAttempt, $attempts
+                    $e,
+                    $currentAttempt,
+                    $attempts
                 );
 
                 continue;
@@ -48,7 +50,9 @@ trait ManagesTransactions
                 $this->commit();
             } catch (Exception $e) {
                 $this->handleCommitTransactionException(
-                    $e, $currentAttempt, $attempts
+                    $e,
+                    $currentAttempt,
+                    $attempts
                 );
 
                 continue;
@@ -154,7 +158,7 @@ trait ManagesTransactions
         if ($this->causedByLostConnection($e)) {
             $this->reconnect();
 
-            $this->pdo->beginTransaction();
+            $this->getPdo()->beginTransaction();
         } else {
             throw $e;
         }


### PR DESCRIPTION
Fix handleBeginTransactionException method calling pdo property instead of getPdo() method (#31230)

### Description:

When connection to database is lost and transaction is retried, an exception is thrown.

```text
[2020-01-24 15:00:16] production.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Closure::beginTransaction() in /var/www/html/vendor/illuminate/database/Concerns/ManagesTransactions.php:157
Stack trace:
#0 /var/www/html/vendor/illuminate/database/Concerns/ManagesTransactions.php(125): Illuminate\Database\Connection->handleBeginTransactionException(Object(PDOException))
#1 /var/www/html/vendor/illuminate/database/Concerns/ManagesTransactions.php(105): Illuminate\Database\Connection->createTransaction()
#2 /var/www/html/vendor/illuminate/database/Concerns/ManagesTransactions.php(23): Illuminate\Database\Connection->beginTransaction()
#3 /var/www/html/vendor/illuminate/database/DatabaseManager.php(349): Illuminate\Database\Connection->transaction(Object(Closure))
#4 /var/www/html/vendor/illuminate/support/Facades/Facade.php(261): Illuminate\Database\DatabaseManager->__call('transaction', Array)
#5 /var/www/html/app/Services/PriceService.php(55): Illuminate\Support\Facades\Facade::__callStatic('transaction', Array)
```

The exception is thrown because of line 157 calling $this->pdo instead of $this->getPdo()

Same bug was detected in Laravel 5.3 but was not linked to the same file.

https://github.com/laravel/framework/issues/15927

### Steps To Reproduce:

Lose connection to database during transaction creation (hard to reproduce but easy to fix)