### PR TITLE
[6.x] Add missing parameter to annotation

### DIFF
--- a/src/Illuminate/Support/Facades/Notification.php
+++ b/src/Illuminate/Support/Facades/Notification.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Testing\Fakes\NotificationFake;
 
 /**
  * @method static void send(\Illuminate\Support\Collection|array|mixed $notifiables, $notification)
- * @method static void sendNow(\Illuminate\Support\Collection|array|mixed $notifiables, $notification)
+ * @method static void sendNow(\Illuminate\Support\Collection|array|mixed $notifiables, $notification, array $channels = null)
  * @method static mixed channel(string|null $name = null)
  * @method static \Illuminate\Notifications\ChannelManager locale(string|null $locale)
  * @method static void assertSentTo(mixed $notifiable, string $notification, callable $callback = null)


### PR DESCRIPTION
The `sendNow()` method can have a third parameter `$channels` that is not considered in the annotation of the Notification Facade. This PR is adding the missing parameter.