### PR TITLE
[6.x] Allow formatting an implicit attribute using a closure

### DIFF
--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -250,6 +250,10 @@ trait FormatsMessages
         // an implicit attribute we will display the raw attribute's name and not
         // modify it with any of these replacements before we display the name.
         if (isset($this->implicitAttributes[$primaryAttribute])) {
+            if ($formatter = $this->implicitAttributeFormatter) {
+                return $formatter($attribute);
+            }
+
             return $attribute;
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -250,11 +250,9 @@ trait FormatsMessages
         // an implicit attribute we will display the raw attribute's name and not
         // modify it with any of these replacements before we display the name.
         if (isset($this->implicitAttributes[$primaryAttribute])) {
-            if ($formatter = $this->implicitAttributeFormatter) {
-                return $formatter($attribute);
-            }
-
-            return $attribute;
+            return ($formatter = $this->implicitAttributesFormatter)
+                            ? $formatter($attribute)
+                            : $attribute;
         }
 
         return str_replace('_', ' ', Str::snake($attribute));

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -98,6 +98,13 @@ class Validator implements ValidatorContract
     protected $implicitAttributes = [];
 
     /**
+     * The callback that should be used to format the attribute.
+     *
+     * @var callable
+     */
+    protected $implicitAttributeFormatter;
+
+    /**
      * The cached data for the "distinct" rule.
      *
      * @var array
@@ -1108,6 +1115,19 @@ class Validator implements ValidatorContract
     public function addCustomAttributes(array $customAttributes)
     {
         $this->customAttributes = array_merge($this->customAttributes, $customAttributes);
+
+        return $this;
+    }
+
+    /**
+     * Set the callback that used to format an implicit attribute..
+     *
+     * @param  callable  $formatter
+     * @return $this
+     */
+    public function setImplicitAttributeFormatter(callable $formatter)
+    {
+        $this->implicitAttributeFormatter = $formatter;
 
         return $this;
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -1125,7 +1125,7 @@ class Validator implements ValidatorContract
      * @param  callable|null  $formatter
      * @return $this
      */
-    public function setImplicitAttributesFormatter($formatter)
+    public function setImplicitAttributesFormatter(callable $formatter = null)
     {
         $this->implicitAttributesFormatter = $formatter;
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -102,7 +102,7 @@ class Validator implements ValidatorContract
      *
      * @var callable
      */
-    protected $implicitAttributeFormatter;
+    protected $implicitAttributesFormatter;
 
     /**
      * The cached data for the "distinct" rule.
@@ -1125,9 +1125,9 @@ class Validator implements ValidatorContract
      * @param  callable  $formatter
      * @return $this
      */
-    public function setImplicitAttributeFormatter(callable $formatter)
+    public function setImplicitAttributesFormatter(callable $formatter)
     {
-        $this->implicitAttributeFormatter = $formatter;
+        $this->implicitAttributesFormatter = $formatter;
 
         return $this;
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -100,7 +100,7 @@ class Validator implements ValidatorContract
     /**
      * The callback that should be used to format the attribute.
      *
-     * @var callable
+     * @var callable|null
      */
     protected $implicitAttributesFormatter;
 
@@ -1122,10 +1122,10 @@ class Validator implements ValidatorContract
     /**
      * Set the callback that used to format an implicit attribute..
      *
-     * @param  callable  $formatter
+     * @param  callable|null  $formatter
      * @return $this
      */
-    public function setImplicitAttributesFormatter(callable $formatter)
+    public function setImplicitAttributesFormatter($formatter)
     {
         $this->implicitAttributesFormatter = $formatter;
 

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -38,7 +38,7 @@ class ValidatorTest extends DatabaseTestCase
         $translator->addLines(['validation.string' => ':attribute must be a string!'], 'en');
         $validator = new Validator($translator, [['name' => 1]],  ['*.name' => 'string']);
 
-        $validator->setImplicitAttributeFormatter(function($attribute){
+        $validator->setImplicitAttributesFormatter(function($attribute){
             [$line, $attribute] = explode('.', $attribute);
 
             return sprintf('%s at line %d', $attribute, $line + 1);

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -38,7 +38,7 @@ class ValidatorTest extends DatabaseTestCase
         $translator->addLines(['validation.string' => ':attribute must be a string!'], 'en');
         $validator = new Validator($translator, [['name' => 1]], ['*.name' => 'string']);
 
-        $validator->setImplicitAttributesFormatter(function ($attribute){
+        $validator->setImplicitAttributesFormatter(function ($attribute) {
             [$line, $attribute] = explode('.', $attribute);
 
             return sprintf('%s at line %d', $attribute, $line + 1);

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -32,6 +32,23 @@ class ValidatorTest extends DatabaseTestCase
         $this->assertFalse($validator->passes());
     }
 
+    public function testImplicitAttributeFormatting()
+    {
+        $translator = new Translator(new ArrayLoader, 'en');
+        $translator->addLines(['validation.string' => ':attribute must be a string!'], 'en');
+        $validator = new Validator($translator, [['name' => 1]],  ['*.name' => 'string']);
+
+        $validator->setImplicitAttributeFormatter(function($attribute){
+            [$line, $attribute] = explode('.', $attribute);
+
+            return sprintf('%s at line %d', $attribute, $line + 1);
+        });
+
+        $validator->passes();
+
+        $this->assertEquals('name at line 1 must be a string!', $validator->getMessageBag()->all()[0]);
+    }
+
     protected function getValidator(array $data, array $rules)
     {
         $translator = new Translator(new ArrayLoader, 'en');

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -36,9 +36,9 @@ class ValidatorTest extends DatabaseTestCase
     {
         $translator = new Translator(new ArrayLoader, 'en');
         $translator->addLines(['validation.string' => ':attribute must be a string!'], 'en');
-        $validator = new Validator($translator, [['name' => 1]],  ['*.name' => 'string']);
+        $validator = new Validator($translator, [['name' => 1]], ['*.name' => 'string']);
 
-        $validator->setImplicitAttributesFormatter(function($attribute){
+        $validator->setImplicitAttributesFormatter(function ($attribute){
             [$line, $attribute] = explode('.', $attribute);
 
             return sprintf('%s at line %d', $attribute, $line + 1);


### PR DESCRIPTION
This PR adds a `setImplicitAttributesFormatter` method to the validator that allows the instance to output a message that says:

```
age at line 1 must be an integer
```

instead of 

```
0.age must be an integer
```

```php
validator(
    [['age' => 'thirty']],
    ['*.age' => 'integer']
)->setImplicitAttributesFormatter(function ($attribute) {
    [$line, $attribute] = explode('.', $attribute);

    return sprintf('%s at line %d', $attribute, $line + 1);
})->validate();
```