### PR TITLE
[7.x] Serialize values in array cache store

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -45,7 +45,7 @@ class ArrayStore extends TaggableStore implements LockProvider
             return;
         }
 
-        return $item['value'];
+        return unserialize($item['value']);
     }
 
     /**
@@ -59,7 +59,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function put($key, $value, $seconds)
     {
         $this->storage[$key] = [
-            'value' => $value,
+            'value' => serialize($value),
             'expiresAt' => $this->calculateExpiration($seconds),
         ];
 
@@ -77,7 +77,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     {
         if ($existing = $this->get($key)) {
             return tap(((int) $existing) + $value, function ($incremented) use ($key) {
-                $this->storage[$key]['value'] = $incremented;
+                $this->storage[$key]['value'] = serialize($incremented);
             });
         }
 

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -194,4 +194,16 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertTrue($wannabeOwner->acquire());
     }
+
+    public function testValuesAreNotStoredByReference()
+    {
+        $store = new ArrayStore;
+        $object = new \stdClass;
+        $object->foo = true;
+
+        $store->put('object', $object, 10);
+        $object->bar = true;
+
+        $this->assertObjectNotHasAttribute('bar', $store->get('object'));
+    }
 }


### PR DESCRIPTION
As discussed in #23079, values stored by reference with the array store can cause behaviour that isn't consistent with other drivers.