### PR TITLE
[6.x] Prevent asterisks from being used as data keys

### DIFF
--- a/src/Illuminate/Validation/InvalidDataException.php
+++ b/src/Illuminate/Validation/InvalidDataException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Exception;
+
+class InvalidDataException extends Exception
+{
+    public static function asteriskUsage()
+    {
+        return new static('Asterisks are not allowed as keys in validation data.');
+    }
+}

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -240,12 +240,18 @@ class Validator implements ValidatorContract
      *
      * @param  array  $data
      * @return array
+     *
+     * @throws \Illuminate\Validation\InvalidDataException
      */
     public function parseData(array $data)
     {
         $newData = [];
 
         foreach ($data as $key => $value) {
+            if ($key === '*') {
+                throw InvalidDataException::asteriskUsage();
+            }
+
             if (is_array($value)) {
                 $value = $this->parseData($value);
             }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
+use Illuminate\Validation\InvalidDataException;
 use Illuminate\Validation\PresenceVerifierInterface;
 use Illuminate\Validation\Rules\Exists;
 use Illuminate\Validation\Rules\Unique;
@@ -5174,6 +5175,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($validator->fails());
         $this->assertSame(['cat' => 'Tom'], $validator->valid());
         $this->assertSame(['mouse' => null], $validator->invalid());
+    }
+
+    public function testValidateFailsWithAsterisksAsDataKeys()
+    {
+        $post = ['data' => [0 => ['date' => '2019-01-24'], 1 => ['date' => 'blah'], '*' => ['date' => 'blah']]];
+
+        $rules = [['data.*.date' => 'required|date']];
+
+        $this->expectException(InvalidDataException::class);
+
+        new Validator($this->getIlluminateArrayTranslator(), $post, $rules);
     }
 
     protected function getTranslator()


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31228