### PR TITLE
[7.x] Add collection named explode constructor

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -84,6 +84,19 @@ trait EnumeratesValues
     }
 
     /**
+     * Create a new collection instance from an exploded string.
+     *
+     * @param  string  $delimiter
+     * @param  string  $string
+     * @param  int     $limit
+     * @return static
+     */
+    public static function explode($delimiter, $string, $limit = PHP_INT_MAX)
+    {
+        return new static(explode($delimiter, $string, $limit));
+    }
+
+    /**
      * Alias for the "avg" method.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1887,6 +1887,12 @@ class SupportCollectionTest extends TestCase
         $this->assertSame('foo', $collection::unwrap('foo'));
     }
 
+    public function testExplodeMethod()
+    {
+        $this->assertSame(['foo', 'bar', 'baz'], Collection::explode(' ', 'foo bar baz')->all());
+        $this->assertSame(['foo', 'bar baz'], Collection::explode(' ', 'foo bar baz', 2)->all());
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
This PR adds a new `Collection::explode()` named constructor. It's simply a proxy to the `explode()` method in PHP. I find myself converting exploded strings into collections more often, so this is a nice shortcut.

```php
// Before
Collection::make(explode(' ', $string))->map(...);

// After
Collection::explode(' ', $string)->map(...);
```