### PR TITLE
[6.x] Add support for Storage::url() for the Ftp driver

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
+use League\Flysystem\Adapter\Ftp;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\AwsS3v3\AwsS3Adapter;
@@ -435,6 +436,8 @@ class FilesystemAdapter implements CloudFilesystemContract
             return $this->driver->getUrl($path);
         } elseif ($adapter instanceof AwsS3Adapter) {
             return $this->getAwsUrl($adapter, $path);
+        } elseif ($adapter instanceof Ftp) {
+            return $this->getFtpUrl($path);
         } elseif ($adapter instanceof LocalAdapter) {
             return $this->getLocalUrl($path);
         } else {
@@ -485,6 +488,23 @@ class FilesystemAdapter implements CloudFilesystemContract
         return $adapter->getClient()->getObjectUrl(
             $adapter->getBucket(), $adapter->getPathPrefix().$path
         );
+    }
+
+    /**
+     * Get the URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function getFtpUrl($path)
+    {
+        $config = $this->driver->getConfig();
+
+        if ($config->has('url')) {
+            return $this->concatPathToUrl($config->get('url'), $path);
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
Currently it's not possible to generate an url for files that are stored on a `ftp` disk using the `Storage::url()`
This PR allows to generate an url by adding a `url` key  in the configuration of the disk the same way `local` and `s3` do.

## Motiviation

I have an application that is running in production for years since laravel 5.2 and i'm using the local driver to store files on the server. This app has taken a lot of space and i need to move the files to a remote ftp server.
Adding support for url generation with `Storage::url()` for the `ftp` driver will allow me to keep my code as is and not change a single line of code.
I just need to move the files to the new ftp server and everything will work the same, i don't even need to update the database since i'm storing only relative paths in the db.

Other then my use case this will allow to be consistent and allow for url generation using the `Storage::url()` no matter what driver the developper is using.