### PR TITLE
[6.x] Fix channel names when broadcasting via redis

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -233,12 +233,13 @@ abstract class Broadcaster implements BroadcasterContract
      * Format the channel array into an array of strings.
      *
      * @param  array  $channels
+     * @param  string $prefix
      * @return array
      */
-    protected function formatChannels(array $channels)
+    protected function formatChannels(array $channels, string $prefix = '')
     {
-        return array_map(function ($channel) {
-            return (string) $channel;
+        return array_map(function ($channel) use ($prefix) {
+            return $prefix . (string) $channel;
         }, $channels);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -233,13 +233,12 @@ abstract class Broadcaster implements BroadcasterContract
      * Format the channel array into an array of strings.
      *
      * @param  array  $channels
-     * @param  string  $prefix
      * @return array
      */
-    protected function formatChannels(array $channels, $prefix = '')
+    protected function formatChannels(array $channels)
     {
-        return array_map(function ($channel) use ($prefix) {
-            return $prefix.(string) $channel;
+        return array_map(function ($channel) {
+            return (string) $channel;
         }, $channels);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -239,7 +239,7 @@ abstract class Broadcaster implements BroadcasterContract
     protected function formatChannels(array $channels, string $prefix = '')
     {
         return array_map(function ($channel) use ($prefix) {
-            return $prefix . (string) $channel;
+            return $prefix.(string) $channel;
         }, $channels);
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -233,10 +233,10 @@ abstract class Broadcaster implements BroadcasterContract
      * Format the channel array into an array of strings.
      *
      * @param  array  $channels
-     * @param  string $prefix
+     * @param  string  $prefix
      * @return array
      */
-    protected function formatChannels(array $channels, string $prefix = '')
+    protected function formatChannels(array $channels, $prefix = '')
     {
         return array_map(function ($channel) use ($prefix) {
             return $prefix.(string) $channel;

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -115,8 +115,19 @@ class RedisBroadcaster extends Broadcaster
 
         $connection->eval(
             $this->broadcastMultipleChannelsScript(),
-            0, $payload, ...$this->formatChannels($channels, $this->prefix)
+            0, $payload, ...$this->formatChannels($channels)
         );
+    }
+
+    /**
+     * @param  array  $channels
+     * @return array
+     */
+    protected function formatChannels(array $channels)
+    {
+        return array_map(function ($channel) {
+            return $this->prefix.$channel;
+        }, parent::formatChannels($channels));
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -115,7 +115,7 @@ class RedisBroadcaster extends Broadcaster
 
         $connection->eval(
             $this->broadcastMultipleChannelsScript(),
-            0, $payload, ...$this->formatChannels($channels)
+            0, $payload, ...$this->formatChannels($channels, $this->prefix)
         );
     }
 


### PR DESCRIPTION
#31108 introduced publishing events to multiple channels at once using a Lua script. When publishing events through the Lua script, the `Redis::OPT_PREFIX` option does not apply and needs to be prepended manually.

Fixes in external projects:
Fixes https://github.com/tlaverdure/laravel-echo-server/issues/477
Fixes https://github.com/tlaverdure/laravel-echo-server/issues/407