### PR TITLE
[6.x] Adds missing options for PhpRedis - Part 2

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -304,8 +304,8 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     /**
      * Returns the score of member in the sorted set at key.
      *
-     * @param $key
-     * @param $member
+     * @param  string  $key
+     * @param  string  $member
      * @return int
      */
     public function zscore($key, $member)
@@ -448,6 +448,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
             while (! empty($parameters)) {
                 if ((in_array($parameters[0], ['NX', 'XX', 'CH', 'INCR']))) {
                     $args[] = array_shift($parameters);
+
                     continue;
                 }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -302,7 +302,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
-     * Returns the score of member in the sorted set at key
+     * Returns the score of member in the sorted set at key.
      *
      * @param $key
      * @param $member
@@ -445,13 +445,13 @@ class PhpRedisConnection extends Connection implements ConnectionContract
 
             $options = [];
             $args = [];
-            while (!empty($parameters)) {
-                if((in_array($parameters[0], ['NX', 'XX', 'CH', 'INCR']))){
+            while (! empty($parameters)) {
+                if ((in_array($parameters[0], ['NX', 'XX', 'CH', 'INCR']))) {
                     $args[] = array_shift($parameters);
                     continue;
                 }
 
-                if (!empty($args)) {
+                if (! empty($args)) {
                     $options[] = $args;
                     $args = [];
                 }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -98,8 +98,16 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
 
-            if (! empty($options['serializer'])) {
-                $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
+            if (! empty($config['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            }
+
+            if (! empty($config['compression'])) {
+                $client->setOption(Redis::OPT_COMPRESSION, $config['compression']);
+
+                if (! empty($config['compression_level'])) {
+                    $client->setOption(Redis::OPT_COMPRESSION_LEVEL, $config['compression_level']);
+                }
             }
 
             if (! empty($config['scan'])) {
@@ -162,6 +170,14 @@ class PhpRedisConnector implements Connector
 
             if (! empty($options['serializer'])) {
                 $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
+            }
+
+            if (! empty($options['compression'])) {
+                $client->setOption(RedisCluster::OPT_COMPRESSION, $options['compression']);
+
+                if (! empty($options['compression_level'])) {
+                    $client->setOption(RedisCluster::OPT_COMPRESSION_LEVEL, $options['compression_level']);
+                }
             }
 
             if (! empty($config['scan'])) {

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -676,6 +676,21 @@ class RedisConnectionTest extends TestCase
             ],
         ]);
 
+        if(defined('Redis::COMPRESSION_LZF')){
+            $withCompressionPhpRedis = new RedisManager(new Application, 'phpredis', [
+                'cluster' => false,
+                'default' => [
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 9,
+                    'options' => ['compression' => Redis::COMPRESSION_LZF],
+                    'timeout' => 0.5,
+                ],
+            ]);
+
+            $connections[] = $withCompressionPhpRedis->connection();
+        }
+
         $connections[] = $prefixedPhpredis->connection();
         $connections[] = $serializerPhpRedis->connection();
         $connections[] = $scanRetryPhpRedis->connection();

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -676,7 +676,7 @@ class RedisConnectionTest extends TestCase
             ],
         ]);
 
-        if(defined('Redis::COMPRESSION_LZF')){
+        if (defined('Redis::COMPRESSION_LZF')) {
             $withCompressionPhpRedis = new RedisManager(new Application, 'phpredis', [
                 'cluster' => false,
                 'default' => [


### PR DESCRIPTION
In extension of  #31182 we managed to find the issue with serializer tests failing once it was truly enabled. Turns out when using rawCommand in redis that it indeed does send commands in raw format and skips over the native serialiser.

So in order to utilise the serializer, we need to pass data through the native ->command() method.

And since special redis options (XX, NX...) need to be sent as an array, we need to cleanup parameters before passing data to command() method as per phpredis definitions.


We also added a new test for compression option (if compiled), which finally enabled native compression in redis.
