### PR TITLE
[7.x] Let the MassAssignmentException handle many keys.

### DIFF
--- a/src/Illuminate/Database/Eloquent/MassAssignmentException.php
+++ b/src/Illuminate/Database/Eloquent/MassAssignmentException.php
@@ -3,8 +3,63 @@
 namespace Illuminate\Database\Eloquent;
 
 use RuntimeException;
+use Throwable;
 
 class MassAssignmentException extends RuntimeException
 {
-    //
+    /**
+     * The attributes.
+     *
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * The model.
+     *
+     * @var string
+     */
+    protected $model;
+
+    /**
+     * MassAssignmentException constructor.
+     *
+     * @param  mixed  $attributes
+     * @param  string  $model
+     * @param  int  $code
+     * @param  \Throwable|null  $previous
+     * @return void
+     */
+    public function __construct($attributes, $model, $code = 0, Throwable $previous = null)
+    {
+        $this->attributes = is_array($attributes) ? $attributes : [$attributes];
+        $this->model = $model;
+
+        $message = sprintf(
+            'Add [%s] to fillable property to allow mass assignment on [%s].',
+            implode(', ', $this->attributes), $this->model
+        );
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Get the attributes.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Get the model.
+     *
+     * @return string
+     */
+    public function model()
+    {
+        return $this->model;
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -341,6 +341,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $totallyGuarded = $this->totallyGuarded();
 
+        $guarded = [];
+
         foreach ($this->fillableFromArray($attributes) as $key => $value) {
             $key = $this->removeTableFromKey($key);
 
@@ -350,11 +352,12 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             if ($this->isFillable($key)) {
                 $this->setAttribute($key, $value);
             } elseif ($totallyGuarded) {
-                throw new MassAssignmentException(sprintf(
-                    'Add [%s] to fillable property to allow mass assignment on [%s].',
-                    $key, get_class($this)
-                ));
+                $guarded[] = $key;
             }
+        }
+
+        if (count($guarded) > 0) {
+            throw new MassAssignmentException($guarded, get_class($this));
         }
 
         return $this;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1020,12 +1020,26 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testGlobalGuarded()
     {
-        $this->expectException(MassAssignmentException::class);
-        $this->expectExceptionMessage('name');
-
-        $model = new EloquentModelStub;
-        $model->guard(['*']);
-        $model->fill(['name' => 'foo', 'age' => 'bar', 'votes' => 'baz']);
+        try {
+            $model = new EloquentModelStub;
+            $model->guard(['*']);
+            $model->fill([
+                'age' => 'bar',
+                'name' => 'foo',
+                'votes' => 'baz',
+            ]);
+        } catch (MassAssignmentException $exception) {
+            $this->assertSame(
+                'Add [age, name, votes] to fillable property to allow mass assignment on [Illuminate\Tests\Database\EloquentModelStub].',
+                $exception->getMessage()
+            );
+            $this->assertSame([
+                'age',
+                'name',
+                'votes',
+            ], $exception->attributes());
+            $this->assertSame(EloquentModelStub::class, $exception->model());
+        }
     }
 
     public function testUnguardedRunsCallbackWhileBeingUnguarded()


### PR DESCRIPTION
This PR let the `MassAssignmentException` handle many keys.

---

This is particularly beneficial to quickly figure out, what are ALL the unassignable fields.