### PR TITLE
[7.x] Add conditional component rendering

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -62,6 +62,7 @@ trait CompilesComponents
         return implode(PHP_EOL, [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
             '<?php $component = app()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
+            '<?php if ($component->shouldRender()): ?>',
             '<?php $__env->startComponent($component->view(), $component->data()); ?>',
         ]);
     }
@@ -91,6 +92,7 @@ trait CompilesComponents
             '<?php unset($__componentOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
             '<?php echo $__env->renderComponent(); ?>',
+            '<?php endif; ?>',
         ]);
     }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -118,7 +118,18 @@ abstract class Component implements Renderable
             'data',
             'withAttributes',
             'render',
+            'shouldRender',
         ], $this->except);
+    }
+
+    /**
+     * Determine if the component should be rendered.
+     *
+     * @return bool
+     */
+    public function shouldRender()
+    {
+        return true;
     }
 
     /**

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -19,6 +19,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
 <?php $component = app()->make(Test::class, ["foo" => "bar"]); ?>
+<?php if ($component->shouldRender()): ?>
 <?php $__env->startComponent($component->view(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
     }
 
@@ -30,7 +31,8 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
 <?php endif; ?>
-<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>', $this->compiler->compileString('@endcomponent'));
     }
 
     public function testSlotsAreCompiled()


### PR DESCRIPTION
This PR adds the ability to make the upcoming view components decide whether or not the component should be rendered.
The component class has a `shouldRender` method, that always returns `true` by default.

When using class-based components, the view component class already has all the information available to _how_ it should render itself.
By adding the ability to decide _if_ the component should render itself, composing your views can become even easier since you do not need to worry about when to display the component to the user.