### PR TITLE
[7.x] Conditional rendering for view components

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -219,7 +219,7 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value)
     {
-        return preg_replace("/<\/\s*x-[\w\-]*\s*>/", '@endcomponent', $value);
+        return preg_replace("/<\/\s*x-[\w\-]*\s*>/", '@endcomponentClass', $value);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -92,9 +92,9 @@ trait CompilesComponents
      */
     public function compileEndComponentClass()
     {
-        return static::compileEndComponent() . PHP_EOL . implode(PHP_EOL, [
-                '<?php endif; ?>',
-            ]);
+        return static::compileEndComponent().PHP_EOL.implode(PHP_EOL, [
+            '<?php endif; ?>',
+        ]);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -74,16 +74,6 @@ trait CompilesComponents
      */
     protected function compileEndComponent()
     {
-        return static::compileClassComponentClosing();
-    }
-
-    /**
-     * Compile the end-component statements into valid PHP.
-     *
-     * @return string
-     */
-    public function compileClassComponentClosing()
-    {
         $hash = array_pop(static::$componentHashStack);
 
         return implode(PHP_EOL, [
@@ -92,8 +82,19 @@ trait CompilesComponents
             '<?php unset($__componentOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
             '<?php echo $__env->renderComponent(); ?>',
-            '<?php endif; ?>',
         ]);
+    }
+
+    /**
+     * Compile the end-component statements into valid PHP.
+     *
+     * @return string
+     */
+    public function compileEndComponentClass()
+    {
+        return static::compileEndComponent() . PHP_EOL . implode(PHP_EOL, [
+                '<?php endif; ?>',
+            ]);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -62,6 +62,7 @@ trait CompilesComponents
         return implode(PHP_EOL, [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
             '<?php $component = app()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
+            '<?php if ($component->shouldRender()): ?>',
             '<?php $__env->startComponent($component->view(), $component->data()); ?>',
         ]);
     }
@@ -91,6 +92,7 @@ trait CompilesComponents
             '<?php unset($__componentOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
             '<?php echo $__env->renderComponent(); ?>',
+            '<?php endif; ?>',
         ]);
     }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -118,7 +118,18 @@ abstract class Component implements Renderable
             'data',
             'withAttributes',
             'render',
+            'shouldRender',
         ], $this->except);
+    }
+
+    /**
+     * Determine if the component should be rendered.
+     *
+     * @return bool
+     */
+    public function shouldRender()
+    {
+        return true;
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -80,7 +80,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?>
-@endcomponent", trim($result));
+@endcomponentClass", trim($result));
     }
 }
 

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -31,8 +31,19 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
 <?php endif; ?>
+<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
+    }
+
+    public function testEndComponentClassesAreCompiled()
+    {
+        $this->compiler->newComponentHash('foo');
+
+        $this->assertSame('<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
+<?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
+<?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
+<?php endif; ?>
 <?php echo $__env->renderComponent(); ?>
-<?php endif; ?>', $this->compiler->compileString('@endcomponent'));
+<?php endif; ?>', $this->compiler->compileString('@endcomponentClass'));
     }
 
     public function testSlotsAreCompiled()

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -19,6 +19,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
 <?php $component = app()->make(Test::class, ["foo" => "bar"]); ?>
+<?php if ($component->shouldRender()): ?>
 <?php $__env->startComponent($component->view(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
     }
 
@@ -30,7 +31,8 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
 <?php endif; ?>
-<?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
+<?php echo $__env->renderComponent(); ?>
+<?php endif; ?>', $this->compiler->compileString('@endcomponent'));
     }
 
     public function testSlotsAreCompiled()


### PR DESCRIPTION
This PR adds the ability to make the upcoming view components decide whether or not the component should be rendered.
The component class has a `shouldRender` method, that always returns true by default.

When using class-based components, the view component class already has all the information available to how it should render itself.
By adding the ability to decide if the component should render itself, composing your views can become even easier since you do not need to worry about when to display the component to the user.