### PR TITLE
[6.x] Allow arrays for keyBy method in collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -484,7 +484,13 @@ class Collection implements ArrayAccess, Enumerable
                 $resolvedKey = (string) $resolvedKey;
             }
 
-            $results[$resolvedKey] = $item;
+            if (is_array($resolvedKey)) {
+                foreach ($resolvedKey as $resolvedKeyItem) {
+                    $results[$resolvedKeyItem][$key] = $item;
+                }
+            } else {
+                $results[$resolvedKey] = $item;
+            }
         }
 
         return new static($results);

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -483,7 +483,13 @@ class LazyCollection implements Enumerable
                     $resolvedKey = (string) $resolvedKey;
                 }
 
-                yield $resolvedKey => $item;
+                if (is_array($resolvedKey)) {
+                    foreach ($resolvedKey as $resolvedKeyItem) {
+                        yield $resolvedKeyItem => [$key => $item];
+                    }
+                } else {
+                    yield $resolvedKey => $item;
+                }
             }
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2477,6 +2477,26 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testKeyByArray($collection)
+    {
+        $data = new $collection([
+            'foo' => ['method' => ['GET', 'HEAD']],
+            'bar' => ['method' => ['GET']],
+            'baz' => ['method' => ['POST']],
+        ]);
+
+        $result = $data->keyBy('method');
+
+        $this->assertEquals([
+            'GET' => ['foo' => ['method' => ['GET', 'HEAD']], 'bar' => ['method' => ['GET']]],
+            'HEAD' => ['foo' => ['method' => ['GET', 'HEAD']]],
+            'POST' => ['baz' => ['method' => ['POST']]],
+        ], $result->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testContains($collection)
     {
         $c = new $collection([1, 3, 5]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2480,17 +2480,17 @@ class SupportCollectionTest extends TestCase
     public function testKeyByArray($collection)
     {
         $data = new $collection([
-            'foo' => ['method' => ['GET', 'HEAD']],
-            'bar' => ['method' => ['GET']],
-            'baz' => ['method' => ['POST']],
+            'foo' => ['methods' => ['GET', 'HEAD']],
+            'bar' => ['methods' => ['GET']],
+            'baz' => ['methods' => ['POST']],
         ]);
 
-        $result = $data->keyBy('method');
+        $result = $data->keyBy('methods');
 
         $this->assertEquals([
-            'GET' => ['foo' => ['method' => ['GET', 'HEAD']], 'bar' => ['method' => ['GET']]],
-            'HEAD' => ['foo' => ['method' => ['GET', 'HEAD']]],
-            'POST' => ['baz' => ['method' => ['POST']]],
+            'GET' => ['foo' => ['methods' => ['GET', 'HEAD']], 'bar' => ['method' => ['GET']]],
+            'HEAD' => ['foo' => ['methods' => ['GET', 'HEAD']]],
+            'POST' => ['baz' => ['methods' => ['POST']]],
         ], $result->all());
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2488,7 +2488,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->keyBy('methods');
 
         $this->assertEquals([
-            'GET' => ['foo' => ['methods' => ['GET', 'HEAD']], 'bar' => ['method' => ['GET']]],
+            'GET' => ['foo' => ['methods' => ['GET', 'HEAD']], 'bar' => ['methods' => ['GET']]],
             'HEAD' => ['foo' => ['methods' => ['GET', 'HEAD']]],
             'POST' => ['baz' => ['methods' => ['POST']]],
         ], $result->all());


### PR DESCRIPTION
These changes allow the `keyBy` method to be used in combination with arrays. So for example you can go from:

```php
[
    'foo' => ['methods' => ['GET', 'HEAD']],
    'bar' => ['methods' => ['GET']],
    'baz' => ['methods' => ['POST']],
]
```

With `->keyBy('methods')` to:

```php
[
    'GET' => ['foo' => ['methods' => ['GET', 'HEAD']], 'bar' => ['method' => ['GET']]],
    'HEAD' => ['foo' => ['methods' => ['GET', 'HEAD']]],
    'POST' => ['baz' => ['methods' => ['POST']]],
]
```

I do have one failing test however with the LazyCollection. I suspect I need to refactor the `foreach ($resolvedKey as $resolvedKeyItem) {` to a callable but not sure how exactly. Anyone who has any ideas? @JosephSilber maybe?