### PR TITLE
[6.x] Add validatedExcept method for excluding unwanted data

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
@@ -186,6 +187,23 @@ class FormRequest extends Request implements ValidatesWhenResolved
     public function validated()
     {
         return $this->validator->validated();
+    }
+
+    /**
+     * Get the validated data except the given keys.
+     *
+     * @param  array|mixed  $keys
+     * @return array
+     */
+    public function validatedExcept($keys)
+    {
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        $results = $this->validated();
+
+        Arr::forget($results, $keys);
+
+        return $results;
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -123,7 +123,6 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertEquals(['name' => 'Rory'], $request->validatedExcept('unwanted'));
-
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -120,7 +120,7 @@ class FoundationFormRequestTest extends TestCase
     {
         $payload = ['name' => 'Rory', 'unwanted' => 'extras'];
 
-        $request = $this->createRequest($payload,FoundationTestFormRequestMultipleRulesStub::class);
+        $request = $this->createRequest($payload, FoundationTestFormRequestMultipleRulesStub::class);
 
         $request->validateResolved();
 

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -118,7 +118,9 @@ class FoundationFormRequestTest extends TestCase
 
     public function testValidatedExceptMethodReturnsTheValidatedDataWithoutTheSpecifiedKeys()
     {
-        $request = $this->createRequest(['name' => 'Rory', 'unwanted' => 'extras']);
+        $payload = ['name' => 'Rory', 'unwanted' => 'extras'];
+
+        $request = $this->createRequest($payload,FoundationTestFormRequestMultipleRulesStub::class);
 
         $request->validateResolved();
 
@@ -231,6 +233,19 @@ class FoundationTestFormRequestStub extends FormRequest
     public function rules()
     {
         return ['name' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestMultipleRulesStub extends FormRequest
+{
+    public function rules()
+    {
+        return ['name' => 'required', 'unwanted' => 'required'];
     }
 
     public function authorize()

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Validation\Factory as ValidationFactoryContract;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Validation\Factory as ValidationFactory;
@@ -113,6 +114,16 @@ class FoundationFormRequestTest extends TestCase
         $request->validateResolved();
 
         $this->assertEquals(['name' => 'Adam'], $request->all());
+    }
+
+    public function testValidatedExceptMethodReturnsTheValidatedDataWithoutTheSpecifiedKeys()
+    {
+        $request = $this->createRequest(['name' => 'Rory', 'unwanted' => 'extras']);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['name' => 'Rory'], $request->validatedExcept('unwanted'));
+
     }
 
     /**


### PR DESCRIPTION
I often find that I need to validate data, but them one or more pieces of it need to be removed in the controller to perform some sort of action, such as creating a model. This is most often the case when I'm using either the `sometimes` or `nullable` rules. I propose adding `validatedExcept` that would function exactly the same as `except` but would work from the validated data instead.

Before:
```
$input = $request->validated();
$thingId = $request->input('thing_id');
unset($input['thing_id']);
if(!$thingId){
    return DispositionReport::create($input);
 }
// do other things
```

After:
```
$thingId = $request->input('thing_id');
if(!$thingId){
    return Thing::create($request->validatedExcept('thing_id'));
}
 // do other things
```
Adding this method would improve developer experience and would mirror the functionality when not using validation.