### PR TITLE
[6.x] Use the current DB to create Doctrine Connections

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -904,7 +904,7 @@ class Connection implements ConnectionInterface
 
             $this->doctrineConnection = new DoctrineConnection(array_filter([
                 'pdo' => $this->getPdo(),
-                'dbname' => $this->getConfig('database'),
+                'dbname' => $this->getDatabaseName(),
                 'driver' => $driver->getName(),
                 'serverVersion' => $this->getConfig('server_version'),
             ]), $driver);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
If you change the configured DB via `$conn->setDatabaseName()`, then attempt to migrate an existing schema via `$conn->getSchemaBuilder->table('table', ...)`, the new Doctrine Connection uses the originally configured DB name, not the one set via the subsequent method call.

This conflicts with the behavior of `$conn->getSchemaBuilder()->create('table', ...)` which, correctly, creates the new tables in the currently selected DB.

My full use case is a console command which imports multiple MS Access DB files into MySQL.  The code imports each Access file to separate DB names in MySQL over the same connection and so doesn't know each DB name at configuration time.  The code which wraps each schema import looks like this:
```
        $mysqlConn->getPdo()->exec("CREATE DATABASE IF NOT EXISTS $schemaName;");
        $mysqlConn->getPdo()->exec("USE $schemaName;");
        $mysqlConn->setDatabaseName($schemaName);
        // Loop over the tables and create or update them in the new DB.
```
