### PR TITLE
[7.x] Do not auto validate Form Requests

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -2,9 +2,10 @@
 
 namespace DummyNamespace;
 
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Foundation\Http\FormRequest;
 
-class DummyClass extends FormRequest
+class DummyClass extends FormRequest implements ValidatesWhenResolved
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -5,14 +5,13 @@ namespace Illuminate\Foundation\Http;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
-use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Validation\ValidatesWhenResolvedTrait;
 use Illuminate\Validation\ValidationException;
 
-class FormRequest extends Request implements ValidatesWhenResolved
+class FormRequest extends Request
 {
     use ValidatesWhenResolvedTrait;
 

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Routing;
 
+use Illuminate\Contracts\Validation\ValidatesWhenResolved;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Session\SessionServiceProvider;
 use Illuminate\Support\Facades\Route;
@@ -30,7 +31,7 @@ class PreviousUrlTest extends TestCase
     }
 }
 
-class DummyFormRequest extends FormRequest
+class DummyFormRequest extends FormRequest implements ValidatesWhenResolved
 {
     public function rules()
     {


### PR DESCRIPTION
By removing the `ValidatesWhenResolved` interface from the `FormRequest` object, we give the user control over deciding if they want the automatic validation to occur.

Occasionally I don't want automatic validation but still like using the Form Requests as a way to encapsulate the validation rules. By being able to manually check if it fails or passes, it also gives us a little more control on what happens than the traditional redirect or JSON response.

This is similar to how we add the `ShouldQueue` interface to Jobs to automatically queue them.

Since it is very common to automatically validate form requests, I've added it to the default stub so Form Requests generated through Artisan will still have this as their default behavior.