### PR TITLE
[6.x] Simplify string modification

### DIFF
--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -21,12 +21,10 @@ class Mix
     {
         static $manifests = [];
 
-        if (! Str::startsWith($path, '/')) {
-            $path = "/{$path}";
-        }
+        $path = Str::start($path, '/');
 
-        if ($manifestDirectory && ! Str::startsWith($manifestDirectory, '/')) {
-            $manifestDirectory = "/{$manifestDirectory}";
+        if ($manifestDirectory) {
+            $manifestDirectory = Str::start($manifestDirectory, '/');
         }
 
         if (file_exists(public_path($manifestDirectory.'/hot'))) {


### PR DESCRIPTION
`Str::start` adds the prefix only if it's not present. Using that can simplify the code a bit.