### PR TITLE
[6.x] Fixes response of collection using with

### DIFF
--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -79,6 +79,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }
+            $collection->with = (new static([]))->with(null);
         });
     }
 


### PR DESCRIPTION
When I search for 1 model the with is added to the response.
but when I search for a collection it's not added to the response.

It pull request should fix this.
