### PR TITLE
[6.x] Use SKIP LOCKED for mysql 8.1 and pgsql 9.5 queue workers

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -20,6 +20,18 @@ class SQLiteGrammar extends Grammar
     ];
 
     /**
+     * Compile the lock into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  bool|string  $value
+     * @return string
+     */
+    protected function compileLock(Builder $query, $value)
+    {
+        return '';
+    }
+
+    /**
      * Wrap a union subquery in parentheses.
      *
      * @param  string  $sql


### PR DESCRIPTION
Using `SKIP LOCKED` on MySQL 8.0.19 I was able to get 516,783 jobs processed by 50 workers in 25 minutes on a 3GB RAM - 1 CPU core DigitalOcean server. No deadlocks. 

Running the same test without `SKIP LOCKED` I started getting deadlocks after a few minutes.