### PR TITLE
[6.x] Add a no migrations event

### DIFF
--- a/src/Illuminate/Database/Events/NoMigrations.php
+++ b/src/Illuminate/Database/Events/NoMigrations.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class NoMigrations
+{
+    /**
+     * The migration method that was called.
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $method
+     * @return void
+     */
+    public function __construct($method)
+    {
+        $this->method = $method;
+    }
+}

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Events\MigrationEnded;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\MigrationsStarted;
 use Illuminate\Database\Events\MigrationStarted;
+use Illuminate\Database\Events\NoMigrations;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -139,6 +140,8 @@ class Migrator
         // aren't, we will just make a note of it to the developer so they're aware
         // that all of the migrations have been run against this database system.
         if (count($migrations) === 0) {
+            $this->fireMigrationEvent(new NoMigrations('up'));
+
             $this->note('<info>Nothing to migrate.</info>');
 
             return;
@@ -221,6 +224,8 @@ class Migrator
         $migrations = $this->getMigrationsForRollback($options);
 
         if (count($migrations) === 0) {
+            $this->fireMigrationEvent(new NoMigrations('down'));
+
             $this->note('<info>Nothing to rollback.</info>');
 
             return [];

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -2,11 +2,6 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
-use Illuminate\Database\Events\MigrationEnded;
-use Illuminate\Database\Events\MigrationsEnded;
-use Illuminate\Database\Events\MigrationsStarted;
-use Illuminate\Database\Events\MigrationStarted;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 
 class MigrateWithRealpathTest extends DatabaseTestCase

--- a/tests/Integration/Database/MigrateWithRealpathTest.php
+++ b/tests/Integration/Database/MigrateWithRealpathTest.php
@@ -40,27 +40,4 @@ class MigrateWithRealpathTest extends DatabaseTestCase
             'batch' => 1,
         ]);
     }
-
-    public function testMigrationEventsAreFired()
-    {
-        Event::fake();
-
-        Event::listen(MigrationsStarted::class, function ($event) {
-            return $this->assertInstanceOf(MigrationsStarted::class, $event);
-        });
-
-        Event::listen(MigrationsEnded::class, function ($event) {
-            return $this->assertInstanceOf(MigrationsEnded::class, $event);
-        });
-
-        Event::listen(MigrationStarted::class, function ($event) {
-            return $this->assertInstanceOf(MigrationStarted::class, $event);
-        });
-
-        Event::listen(MigrationEnded::class, function ($event) {
-            return $this->assertInstanceOf(MigrationEnded::class, $event);
-        });
-
-        $this->artisan('migrate');
-    }
 }

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Events\MigrationEnded;
+use Illuminate\Database\Events\MigrationsEnded;
+use Illuminate\Database\Events\MigrationsStarted;
+use Illuminate\Database\Events\MigrationStarted;
+use Illuminate\Database\Events\NoMigrations;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Event;
+
+class MigratorEventsTest extends DatabaseTestCase
+{
+    protected function migrateOptions()
+    {
+        return [
+            '--path' => realpath(__DIR__.'/stubs/'),
+            '--realpath' => true,
+        ];
+    }
+
+    public function testMigrationEventsAreFired()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationsStarted::class, 2);
+        Event::assertDispatched(MigrationsEnded::class, 2);
+        Event::assertDispatched(MigrationStarted::class, 2);
+        Event::assertDispatched(MigrationEnded::class, 2);
+    }
+
+    public function testMigrationEventsContainTheMigrationAndMethod()
+    {
+        Event::fake();
+
+        $this->artisan('migrate', $this->migrateOptions());
+        $this->artisan('migrate:rollback', $this->migrateOptions());
+
+        Event::assertDispatched(MigrationStarted::class, function ($event) {
+            return $event->method == 'up' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationStarted::class, function ($event) {
+            return $event->method == 'down' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationEnded::class, function ($event) {
+            return $event->method == 'up' && $event->migration instanceof Migration;
+        });
+        Event::assertDispatched(MigrationEnded::class, function ($event) {
+            return $event->method == 'down' && $event->migration instanceof Migration;
+        });
+    }
+
+    public function testTheNoMigrationEventIsFiredWhenNothingToMigrate()
+    {
+        Event::fake();
+
+        $this->artisan('migrate');
+        $this->artisan('migrate:rollback');
+
+        Event::assertDispatched(NoMigrations::class, function ($event) {
+            return $event->method == 'up';
+        });
+        Event::assertDispatched(NoMigrations::class, function ($event) {
+            return $event->method == 'down';
+        });
+    }
+}


### PR DESCRIPTION
_This PR is a (much more) simplified version of https://github.com/laravel/framework/pull/29503_

**Reasoning:**
Currently, there are no migration events fired when there are no migrations to run or to rollback. However, there might be use cases (as described in the above PR) where events are still desirable.

The other PR refactored the `Migrator` quite a bit. And was also breaking because currently no events are fired, and with the update, the events would always be fired. So if your code expects the events to be only fired when migrations are available it would break.

The suggested change is a new event `NoMigrations` that will only be fired when no migrations will be executed. This is a new feature and does not break any code.