### PR TITLE
[7.x] Allow component classes to return their view content directly

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -63,7 +63,7 @@ trait CompilesComponents
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
             '<?php $component = app()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->view(), $component->data()); ?>',
+            '<?php $__env->startComponent($component->viewFile(), $component->data()); ?>',
         ]);
     }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -157,7 +157,7 @@ abstract class Component implements Renderable
             file_put_contents($viewFile, $contents);
         }
 
-        return '__components::'.basename($viewFile,'.blade.php');
+        return '__components::'.basename($viewFile, '.blade.php');
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -28,7 +28,7 @@ abstract class Component implements Renderable
     public $attributes;
 
     /**
-     * Get the view/view contents that represents the component.
+     * Get the view / view contents that represent the component.
      *
      * @return string
      */

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -20,7 +20,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
 <?php $component = app()->make(Test::class, ["foo" => "bar"]); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->view(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
+<?php $__env->startComponent($component->viewFile(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Illuminate\Tests\View;
+
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\View\Component;
+use Illuminate\View\Factory;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class ComponentTest extends TestCase
+{
+    protected $viewFactory;
+    protected $config;
+
+    public function setUp(): void
+    {
+        $this->config = m::mock(Config::class);
+
+        $container = new Container;
+
+        $this->viewFactory = m::mock(Factory::class);
+
+        $container->instance('view', $this->viewFactory);
+        $container->instance('config', $this->config);
+
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+        Container::setInstance(null);
+    }
+
+    public function testInlineViewsGetCreated()
+    {
+        $this->config->shouldReceive('get')->once()->with('view.compiled')->andReturn('/tmp');
+        $this->viewFactory->shouldReceive('exists')->once()->andReturn(false);
+        $this->viewFactory->shouldReceive('addNamespace')->once()->with('__components', '/tmp');
+
+        $component = new TestInlineViewComponent();
+        $this->assertSame('__components::c6327913fef3fca4518bcd7df1d0ff630758e241', $component->viewFile());
+    }
+
+    public function testRegularViewsGetReturned()
+    {
+        $this->viewFactory->shouldReceive('exists')->once()->andReturn(true);
+        $this->viewFactory->shouldReceive('addNamespace')->never();
+
+        $component = new TestRegularViewComponent();
+
+        $this->assertSame('alert', $component->viewFile());
+    }
+}
+
+class TestInlineViewComponent extends Component
+{
+    public $title;
+
+    public function __construct($title = 'foo')
+    {
+        $this->title = $title;
+    }
+
+    public function view()
+    {
+        return 'Hello {{ $title }}';
+    }
+}
+
+
+class TestRegularViewComponent extends Component
+{
+    public $title;
+
+    public function __construct($title = 'foo')
+    {
+        $this->title = $title;
+    }
+
+    public function view()
+    {
+        return 'alert';
+    }
+}

--- a/tests/View/ComponentTest.php
+++ b/tests/View/ComponentTest.php
@@ -77,7 +77,6 @@ class TestInlineViewComponent extends Component
     }
 }
 
-
 class TestRegularViewComponent extends Component
 {
     public $title;


### PR DESCRIPTION
This PR allows components to return their view contents directly, without having the need for a dedicated blade view. This is extremely handy for smaller components, like form buttons or labels.