### PR TITLE
[7.x] Allow easier component prefixing

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -106,10 +106,10 @@ abstract class ServiceProvider
     }
 
     /**
-     * Load the given view components with the custom prefix.
+     * Register the given view components with a custom prefix.
      *
-     * @param $prefix
-     * @param array $components
+     * @param  string  $prefix
+     * @param  array  $components
      * @return void
      */
     protected function loadViewComponentsAs($prefix, array $components)

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Contracts\Foundation\CachesRoutes;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Eloquent\Factory as ModelFactory;
+use Illuminate\View\Compilers\BladeCompiler;
 
 abstract class ServiceProvider
 {
@@ -101,6 +102,22 @@ abstract class ServiceProvider
             }
 
             $view->addNamespace($namespace, $path);
+        });
+    }
+
+    /**
+     * Load the given view components with the custom prefix.
+     *
+     * @param $prefix
+     * @param array $components
+     * @return void
+     */
+    protected function loadViewComponentsAs($prefix, array $components)
+    {
+        $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
+            foreach ($components as $component) {
+                $blade->component($component, $prefix.'-'.Str::snake(class_basename($component), '-'));
+            }
         });
     }
 


### PR DESCRIPTION
This PR makes it easier to load components from within a service provider using a given prefix.

```php
// In a service provider
$this->loadViewComponentsAs('package-name', [
    Button::class,
    FormRow::class,
]);
```

The components will then be registered as:

```
package-name-button
package-name-form-row
```