### PR TITLE
[7.x] Serialize values in array cache store

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -45,7 +45,7 @@ class ArrayStore extends TaggableStore implements LockProvider
             return;
         }
 
-        return $item['value'];
+        return unserialize($item['value']);
     }
 
     /**
@@ -59,7 +59,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     public function put($key, $value, $seconds)
     {
         $this->storage[$key] = [
-            'value' => $value,
+            'value' => serialize($value),
             'expiresAt' => $this->calculateExpiration($seconds),
         ];
 
@@ -77,7 +77,7 @@ class ArrayStore extends TaggableStore implements LockProvider
     {
         if ($existing = $this->get($key)) {
             return tap(((int) $existing) + $value, function ($incremented) use ($key) {
-                $this->storage[$key]['value'] = $incremented;
+                $this->storage[$key]['value'] = serialize($incremented);
             });
         }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -138,11 +138,12 @@ class CacheManager implements FactoryContract
     /**
      * Create an instance of the array cache driver.
      *
+     * @param  array  $config
      * @return \Illuminate\Cache\Repository
      */
-    protected function createArrayDriver()
+    protected function createArrayDriver(array $config)
     {
-        return $this->repository(new ArrayStore);
+        return $this->repository(new ArrayStore($config['serialize'] ?? true));
     }
 
     /**

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -194,4 +194,16 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertTrue($wannabeOwner->acquire());
     }
+
+    public function testValuesAreNotStoredByReference()
+    {
+        $store = new ArrayStore;
+        $object = new \stdClass;
+        $object->foo = true;
+
+        $store->put('object', $object, 10);
+        $object->bar = true;
+
+        $this->assertObjectNotHasAttribute('bar', $store->get('object'));
+    }
 }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -206,4 +206,16 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertObjectNotHasAttribute('bar', $store->get('object'));
     }
+
+    public function testValuesAreStoredByReferenceIfSerializationIsDisabled()
+    {
+        $store = new ArrayStore(false);
+        $object = new \stdClass;
+        $object->foo = true;
+
+        $store->put('object', $object, 10);
+        $object->bar = true;
+
+        $this->assertObjectHasAttribute('bar', $store->get('object'));
+    }
 }


### PR DESCRIPTION
Follow up from #31251.

I've called the configuration key `serialize` and the default is true, an example configuration would look like this:

```php
'array' => [
    'driver' => 'array',
    'serialize' => false,
],
```

I thought about calling it `store_by_reference` but it is too verbose, I'm open to suggestions with the naming.