### PR TITLE
[6.x] Fix plucking column name containing a space

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2314,9 +2314,9 @@ class Builder
             return $column;
         }
 
-        $seperator = strpos($column, ' as ') !== false ? ' as ' : '\.';
+        $seperator = strpos(strtolower($column), ' as ') !== false ? ' as ' : '\.';
 
-        return last(preg_split('~'.$seperator.'~', $column));
+        return last(preg_split('~'.$seperator.'~i', $column));
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2310,7 +2310,13 @@ class Builder
      */
     protected function stripTableForPluck($column)
     {
-        return is_null($column) ? $column : last(preg_split('~\.| ~', $column));
+        if (is_null($column)) {
+            return $column;
+        }
+
+        $seperator = strpos($column, ' as ') !== false ? ' as ' : '\.';
+
+        return last(preg_split('~'.$seperator.'~', $column));
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -69,6 +69,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
             $table->timestamps();
         });
 
+        $this->schema('default')->create('users_with_space_in_colum_name', function ($table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email address');
+            $table->timestamps();
+        });
+
         foreach (['default', 'second_connection'] as $connection) {
             $this->schema($connection)->create('users', function ($table) {
                 $table->increments('id');
@@ -441,6 +448,18 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertEquals([1 => 'First post', 2 => 'Second post'], $query->pluck('posts.name', 'posts.id')->all());
         $this->assertEquals([2 => 'First post', 1 => 'Second post'], $query->pluck('posts.name', 'users.id')->all());
         $this->assertEquals(['abigailotwell@gmail.com' => 'First post', 'taylorotwell@gmail.com' => 'Second post'], $query->pluck('posts.name', 'users.email as user_email')->all());
+    }
+
+    public function testPluckWithColumnNameContainingASpace()
+    {
+        EloquentTestUserWithSpaceInColumnName::create(['id' => 1, 'email address' => 'taylorotwell@gmail.com']);
+        EloquentTestUserWithSpaceInColumnName::create(['id' => 2, 'email address' => 'abigailotwell@gmail.com']);
+
+        $simple = EloquentTestUserWithSpaceInColumnName::oldest('id')->pluck('users_with_space_in_colum_name.email address')->all();
+        $keyed = EloquentTestUserWithSpaceInColumnName::oldest('id')->pluck('email address', 'id')->all();
+
+        $this->assertEquals(['taylorotwell@gmail.com', 'abigailotwell@gmail.com'], $simple);
+        $this->assertEquals([1 => 'taylorotwell@gmail.com', 2 => 'abigailotwell@gmail.com'], $keyed);
     }
 
     public function testFindOrFail()
@@ -1671,6 +1690,11 @@ class EloquentTestUserWithCustomFriendPivot extends EloquentTestUser
         return $this->belongsToMany(EloquentTestUser::class, 'friends', 'user_id', 'friend_id')
                         ->using(EloquentTestFriendPivot::class)->withPivot('user_id', 'friend_id', 'friend_level_id');
     }
+}
+
+class EloquentTestUserWithSpaceInColumnName extends EloquentTestUser
+{
+    protected $table = 'users_with_space_in_colum_name';
 }
 
 class EloquentTestNonIncrementing extends Eloquent

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -447,7 +447,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         $this->assertEquals([1 => 'First post', 2 => 'Second post'], $query->pluck('posts.name', 'posts.id')->all());
         $this->assertEquals([2 => 'First post', 1 => 'Second post'], $query->pluck('posts.name', 'users.id')->all());
-        $this->assertEquals(['abigailotwell@gmail.com' => 'First post', 'taylorotwell@gmail.com' => 'Second post'], $query->pluck('posts.name', 'users.email as user_email')->all());
+        $this->assertEquals(['abigailotwell@gmail.com' => 'First post', 'taylorotwell@gmail.com' => 'Second post'], $query->pluck('posts.name', 'users.email AS user_email')->all());
     }
 
     public function testPluckWithColumnNameContainingASpace()


### PR DESCRIPTION
This PR fixes this https://github.com/laravel/framework/issues/31298

Plucking a column that contains a space in it's name will fail

```php
NoteRow::pluck('Identifiant groupe');
```
Will give this error
```
ErrorException : Undefined property: stdClass::$groupe`
 W:\projects\exam-laravel\src\exam-laravel\vendor\laravel\framework\src\Illuminate\Database\Query\Builder.php:2330
 W:\projects\exam-laravel\src\exam-laravel\vendor\laravel\framework\src\Illuminate\Database\Query\Builder.php:2302
 W:\projects\exam-laravel\src\exam-laravel\vendor\laravel\framework\src\Illuminate\Database\Eloquent\Builder.php:687
```

As you can see in the error the First word of the column name is striped `Identifiant` and only the second word `groupe` is being used.
The problem is that the `Illuminate\Database\Query\Builder::stripTableForPluck()` is splitting the column name by space to allow for plucking while using column alias.
This behavior was introduced in this commit https://github.com/laravel/framework/commit/4fd6db18d1586eeb8f12424394f143e465015bbc

The PR preserves the alias behavior and fixes column names with a space.
This PR changes the alias behavior from splitting by space to splitting by ` as ` keyword. It also takes into consideration that the developper could write `AS` in uppercase. 
Existing tests are passing a new test was added to confirm that plucking columns with a space in the name works as well.

As for why i have space in the column names; It's due to me developing a new application based on a legacy app database and both should exist at the same time until porting the features of the legacy one is over.