### PR TITLE
[6.x] Add dispatchEventually()

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -185,6 +185,20 @@ class Dispatcher implements QueueingDispatcher
     }
 
     /**
+     * Dispatch a command to its appropriate handler after the current process.
+     *
+     * @param  mixed  $command
+     * @param  mixed  $handler
+     * @return void
+     */
+    public function dispatchEventually($command, $handler = null)
+    {
+        $this->container->terminating(function () use ($command, $handler) {
+            $this->dispatchNow($command, $handler);
+        });
+    }
+
+    /**
      * Set the pipes through which commands should be piped before dispatching.
      *
      * @param  array  $pipes

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -414,6 +414,20 @@ if (! function_exists('dispatch_now')) {
     }
 }
 
+if (! function_exists('dispatch_eventually')) {
+    /**
+     * Dispatch a command to its appropriate handler after the current process.
+     *
+     * @param  mixed  $job
+     * @param  mixed  $handler
+     * @return void
+     */
+    function dispatch_eventually($job, $handler = null)
+    {
+        return app(Dispatcher::class)->dispatchEventually($job, $handler);
+    }
+}
+
 if (! function_exists('elixir')) {
     /**
      * Get the path to a versioned Elixir file.


### PR DESCRIPTION
This method makes the job run after the response is sent and before closing the connection. It simply registers a terminating callback that the application runs before it's done with the request.

It can be useful to dispatch a short job instantly instead of sending it to a queue system.