### PR TITLE
[6.x] Dont merge middleware from method and property

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -127,7 +127,7 @@ trait Queueable
      */
     public function middleware()
     {
-        return $this->middleware ?: [];
+        return [];
     }
 
     /**


### PR DESCRIPTION
Since already merge middleware from the method and from the property when sending a job through the pipeline, we don't need to make the `middleware()` method return the values of the `middleware` property.

This leads to middleware duplication in case there are middleware in the property but the method wasn't added to the job, as reported in https://github.com/laravel/framework/issues/31192.