### PR TITLE
[7.x] Add class component alias getter

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -546,6 +546,16 @@ class BladeCompiler extends Compiler implements CompilerInterface
     }
 
     /**
+     * Get the registered class component aliases.
+     *
+     * @return array
+     */
+    public function getClassComponentAliases()
+    {
+        return $this->classComponentAliases;
+    }
+
+    /**
      * Register a component alias directive.
      *
      * @param  string  $path


### PR DESCRIPTION
This PR adds a `getClassComponentAliases` so that you can retrieve all registered component aliases.