### PR TITLE
[7.x] Allow guessing of component names with namespaces

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -188,7 +188,11 @@ class ComponentTagCompiler
                     ->make(Application::class)
                     ->getNamespace();
 
-        return $namespace.'ViewComponents\\'.ucfirst(Str::camel($component));
+        $componentPieces = array_map(function ($componentPiece) {
+            return ucfirst(Str::camel($componentPiece));
+        }, explode(':', $component));
+
+        return $namespace.'ViewComponents\\'.implode('\\', $componentPieces);
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -46,6 +46,20 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         Container::setInstance(null);
     }
 
+    public function testClassNamesCanBeGuessedWithNamespaces()
+    {
+        $container = new Container;
+        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        Container::setInstance($container);
+
+        $result = (new ComponentTagCompiler([]))->guessClassName('base:alert');
+
+        $this->assertEquals("App\ViewComponents\Base\Alert", trim($result));
+
+        Container::setInstance(null);
+    }
+
     public function testComponentsCanBeCompiledWithHyphenAttributes()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');


### PR DESCRIPTION
This PR adds the ability to guess component class names that are in a separate namespace.

The convention is as follows:
`<x-namespace:componentClass />`

Examples:
`<x-forms:label />` becomes `App\ViewComponents\Forms\Label`
`<x-forms:buttons:primary />` becomes `App\ViewComponents\Forms\Buttons\Primary`