### PR TITLE
[7.x] Add optional parameter $key to validated() methods

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -16,9 +16,10 @@ interface Validator extends MessageProvider
     /**
      * Get the attributes and values that were validated.
      *
+     * @param string|null $key
      * @return array
      */
-    public function validated();
+    public function validated($key = null);
 
     /**
      * Determine if the data fails the validation rules.

--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -16,10 +16,10 @@ interface Validator extends MessageProvider
     /**
      * Get the attributes and values that were validated.
      *
-     * @param string|null $key
+     * @param string|array|null $query
      * @return array
      */
-    public function validated($key = null);
+    public function validated($query = null);
 
     /**
      * Determine if the data fails the validation rules.

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -181,11 +181,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
+     * @param string|null $key
      * @return array
      */
-    public function validated()
+    public function validated($key = null)
     {
-        return $this->validator->validated();
+        return $this->validator->validated($key);
     }
 
     /**

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -181,12 +181,12 @@ class FormRequest extends Request implements ValidatesWhenResolved
     /**
      * Get the validated data from the request.
      *
-     * @param string|null $key
+     * @param string|array|null $query
      * @return array
      */
-    public function validated($key = null)
+    public function validated($query = null)
     {
-        return $this->validator->validated($key);
+        return $this->validator->validated($query);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -399,12 +399,12 @@ class Validator implements ValidatorContract
     /**
      * Get the attributes and values that were validated.
      *
-     * @param string|null $key
+     * @param string|array|null $query
      * @return array
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validated($key = null)
+    public function validated($query = null)
     {
         if ($this->invalid()) {
             throw new ValidationException($this);
@@ -422,7 +422,15 @@ class Validator implements ValidatorContract
             }
         }
 
-        return data_get($results, $key);
+        if (is_array($query)) {
+            return array_reduce($query, function ($carry, $selector) use ($results) {
+                $carry[$selector] = data_get($results, $selector);
+
+                return $carry;
+            }, []);
+        }
+
+        return data_get($results, $query);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -399,11 +399,12 @@ class Validator implements ValidatorContract
     /**
      * Get the attributes and values that were validated.
      *
+     * @param string|null $key
      * @return array
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function validated()
+    public function validated($key = null)
     {
         if ($this->invalid()) {
             throw new ValidationException($this);
@@ -413,15 +414,15 @@ class Validator implements ValidatorContract
 
         $missingValue = Str::random(10);
 
-        foreach (array_keys($this->getRules()) as $key) {
-            $value = data_get($this->getData(), $key, $missingValue);
+        foreach (array_keys($this->getRules()) as $ruleName) {
+            $value = data_get($this->getData(), $ruleName, $missingValue);
 
             if ($value !== $missingValue) {
-                Arr::set($results, $key, $value);
+                Arr::set($results, $ruleName, $value);
             }
         }
 
-        return $results;
+        return data_get($results, $key);
     }
 
     /**

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -70,6 +70,16 @@ class FoundationFormRequestTest extends TestCase
         $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated());
     }
 
+    public function testValidatedMethodReturnsTheValidatedDataWithKey()
+    {
+        $payload = ['object' => ['first' => 'foo', 'second' => 'bar']];
+        $request = $this->createRequest($payload, FoundationTestFormRequestValidatedWithKey::class);
+
+        $request->validateResolved();
+
+        $this->assertEquals(['first' => 'foo'], $request->validated('object'));
+    }
+
     public function testValidatedMethodNotValidateTwice()
     {
         $payload = ['name' => 'specified', 'with' => 'extras'];
@@ -260,6 +270,19 @@ class FoundationTestFormRequestNestedArrayStub extends FormRequest
     public function rules()
     {
         return ['nested.*.bar' => 'required'];
+    }
+
+    public function authorize()
+    {
+        return true;
+    }
+}
+
+class FoundationTestFormRequestValidatedWithKey extends FormRequest
+{
+    public function rules()
+    {
+        return ['object.first' => 'required'];
     }
 
     public function authorize()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4760,6 +4760,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(['first' => 'foo'], $v->validated('object'));
     }
 
+    public function testValidatedWithArrayAsKey()
+    {
+        $post = ['first' => 'foo', 'second' => 'bar'];
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'second' => 'required']);
+        $this->assertEquals(['first' => 'foo', 'second' => 'bar'], $v->validated(['first', 'second']));
+    }
+
     public function testMultiplePassesCalls()
     {
         $trans = $this->getIlluminateArrayTranslator();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4753,6 +4753,13 @@ class ValidationValidatorTest extends TestCase
         $this->assertEquals(1, $validateCount);
     }
 
+    public function testValidatedWithKey()
+    {
+        $post = ['object' => ['first' => 'foo', 'second' => 'bar']];
+        $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['object.first' => 'required']);
+        $this->assertEquals(['first' => 'foo'], $v->validated('object'));
+    }
+
     public function testMultiplePassesCalls()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
Right now, it is possible to do this:
```PHP
$model->update($request->input('foo.bar.baz'))
```
but not this:
```PHP
$model->update($request->validated('foo.bar.baz'))
```

I think using `validated()` is better than using `input()`, because it filters out any data that is not explicitly allowed by the validator. This provides a (very) small security benefit, for example during mass assignment. Right now, the `validated()` method does not allow for any querying and therefore is less ergonomic when working with nested forms, which means I personally just don't bother very often.

This PR adds an optional parameter to `Validator::validated()` and `FormRequest::validated()` so that they work the same way as `Request::input()`.

Example usage:

Form:
```HTML
<input type="text" name="pet[owner][name]" required>
```

FormRequest:
```PHP
class UpdatePetRequest extends FormRequest {
    public function rules() {
        return ['pet.owner.name' => 'required'];
    }
}
```

Controller:
```PHP
public function update(UpdatePetRequest $request, Pet $pet) {
    // currently
    $pet->update(data_get($request->validated(), 'pet.owner'));

    // would be nicer as
    $pet->update($request->validated('pet.owner'));
}
```

As far as I can tell, this PR does not contain any breaking changes. I created some tests that are passing, and all existing tests are also still passing. Since this is my first PR to this project, I might be missing something in this regard. I would be happy to fix any issues that might arise.