### PR TITLE
[6.x] File facade ensureDirectoryExists hint

### DIFF
--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -34,6 +34,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Symfony\Component\Finder\SplFileInfo[] files(string $directory, bool $hidden = false)
  * @method static \Symfony\Component\Finder\SplFileInfo[] allFiles(string $directory, bool $hidden = false)
  * @method static array directories(string $directory)
+ * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
  * @method static bool makeDirectory(string $path, int $mode = 0755, bool $recursive = false, bool $force = false)
  * @method static bool moveDirectory(string $from, string $to, bool $overwrite = false)
  * @method static bool copyDirectory(string $directory, string $destination, int|null $options = null)


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Newly added ensureDirectoryExists method doesn't have hint in File facade