### PR TITLE
[6.x] Fix bug with wildcard caching in event dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -522,6 +522,12 @@ class Dispatcher implements DispatcherContract
         } else {
             unset($this->listeners[$event]);
         }
+
+        foreach ($this->wildcardsCache as $key => $listeners) {
+            if (Str::is($event, $key)) {
+                unset($this->wildcardsCache[$key]);
+            }
+        }
     }
 
     /**

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -152,6 +152,26 @@ class EventsDispatcherTest extends TestCase
         $this->assertFalse(isset($_SERVER['__event.test']));
     }
 
+    public function testWildcardCacheIsClearedWhenListenersAreRemoved()
+    {
+        unset($_SERVER['__event.test']);
+
+        $d = new Dispatcher;
+        $d->listen('foo*', function () {
+            $_SERVER['__event.test'] = 'foo';
+        });
+        $d->dispatch('foo');
+
+        $this->assertSame('foo', $_SERVER['__event.test']);
+
+        unset($_SERVER['__event.test']);
+
+        $d->forget('foo*');
+        $d->dispatch('foo');
+
+        $this->assertFalse(isset($_SERVER['__event.test']));
+    }
+
     public function testListenersCanBeFound()
     {
         $d = new Dispatcher;


### PR DESCRIPTION
```php
    Event::listen('foo', fn () => dump('foo listener'));
    Event::listen('foo*', fn () => dump('foo* listener'));
    Event::dispatch('foo');

    Event::forget('foo');
    Event::forget('foo*');
    Event::dispatch('foo');
```

The above code would still execute the `foo*` listener because it will still be cached. We'll need to clear the cache when we forget the given (wildcard) key.

Fixes https://github.com/laravel/framework/issues/31307