### PR TITLE
[6.x] Add assertJsonEmpty to TestResponse

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -702,6 +702,18 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response JSON has zero number of items at the given key.
+     *
+     * @param  int  $count
+     * @param  string|null  $key
+     * @return $this
+     */
+    public function assertJsonEmpty($key = null)
+    {
+        return $this->assertJsonCount(0, $key);
+    }
+
+    /**
      * Assert that the response has the given JSON validation errors.
      *
      * @param  string|array  $errors

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -504,7 +504,7 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonEmpty('empty_bars');
 
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableEmptyResourcesStub));
-        
+
         $response->assertJsonEmpty();
     }
 
@@ -949,7 +949,7 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
                 3 => ['bar' => 'foo 1', 'foo' => 'bar 1'],
                 4 => ['bar' => 'foo 2', 'foo' => 'bar 2'],
             ],
-            'empty_bars' => []
+            'empty_bars' => [],
         ];
     }
 }

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -486,6 +486,7 @@ class FoundationTestResponseTest extends TestCase
 
         // With simple key
         $response->assertJsonCount(3, 'bars');
+        $response->assertJsonCount(0, 'empty_bars');
 
         // With nested key
         $response->assertJsonCount(1, 'barfoo.0.bar');
@@ -494,6 +495,17 @@ class FoundationTestResponseTest extends TestCase
         // Without structure
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));
         $response->assertJsonCount(4);
+    }
+
+    public function testAssertJsonEmpty()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $response->assertJsonEmpty('empty_bars');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableEmptyResourcesStub));
+        
+        $response->assertJsonEmpty();
     }
 
     public function testAssertJsonMissing()
@@ -937,6 +949,7 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
                 3 => ['bar' => 'foo 1', 'foo' => 'bar 1'],
                 4 => ['bar' => 'foo 2', 'foo' => 'bar 2'],
             ],
+            'empty_bars' => []
         ];
     }
 }
@@ -963,5 +976,13 @@ class JsonSerializableSingleResourceWithIntegersStub implements JsonSerializable
             ['id' => 20, 'foo' => 'bar'],
             ['id' => 30, 'foo' => 'bar'],
         ];
+    }
+}
+
+class JsonSerializableEmptyResourcesStub implements JsonSerializable
+{
+    public function jsonSerialize()
+    {
+        return [];
     }
 }


### PR DESCRIPTION
I want to add to Illuminate\Foundation\Testing\TestResponse class a new method named assertJsonEmpty. This method is gonna assert that a specific key in a json response contains ZERO number of items.

A real scenario that I have worked with recently is like this:
```php
test_filtering_payment_methods_returning_empty_response()
{
    $this->get('/api/payment_methods?status=disabled')
        ->assertJsonCount(0, 'data.payment_methods');
}
```

It could be a bit nicer to just say:
```php
test_filtering_payment_methods_returning_empty_response()
{
    $this->get('/api/payment_methods?status=disabled')
        ->assertJsonEmpty('data.payment_methods');
}
```

I reckon scenarios like this are quite common.