### PR TITLE
[6.x] Add Macroable trait to the Dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -11,10 +11,13 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use ReflectionClass;
 
 class Dispatcher implements DispatcherContract
 {
+    use Macroable;
+
     /**
      * The IoC container instance.
      *


### PR DESCRIPTION
The reason behind this, is I've recently needed a way of getting all events. Rather than extending the register my own Dispatcher in place of the Illuminate one, I think this would be a cleaner approach.