### PR TITLE
[6.x] Limited properties returned by morph type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -43,6 +43,13 @@ class MorphTo extends BelongsTo
      * @var array
      */
     protected $morphableEagerLoads = [];
+    
+    /**
+     * A map of model type properties to show on individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableProperties = [];
 
     /**
      * Create a new morph to relationship instance.
@@ -124,6 +131,10 @@ class MorphTo extends BelongsTo
                             ));
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
+        
+        if(!empty($this->morphableProperties[get_class($instance)])) {
+            $query->select($this->morphableProperties[get_class($instance)]);
+        }
 
         return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
@@ -273,6 +284,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoads = array_merge(
             $this->morphableEagerLoads, $with
+        );
+
+        return $this;
+    }
+    
+    /**
+     * Specify which properties to load for a given morph type.
+     *
+     * @param  array  $properties
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function morphProperties(array $properties)
+    {
+        $this->morphableProperties = array_merge(
+            $this->morphableProperties, $properties
         );
 
         return $this;


### PR DESCRIPTION
This is a functionality to allow a query like "morphWith" but named "morphProperties" to limit the properties of morph by type.

```
$recommendations = Recommendation::with(['recommendable' => function (MorphTo $morphTo) {
    // This limit the properties showed for morph type
    $morphTo->morphProperties([
        User::class => ['id', 'username'],
        UserVacantion::class => ['id', 'user_id'],
    ]);

    // This eager load some relationships for morph type
    $morphTo->morphWith([
        User::class => [],
        UserVacantion::class => ['user:id,username'],
    ]);
}])->get();
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
