### PR TITLE
[7.x] Use valid methods when array value given for Query Builder where  method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -677,7 +677,7 @@ class Builder
         if (is_array($value)) {
             if ($operator === '=') {
                 return $this->whereIn($column, $value, $boolean);
-            } elseif ($operator === '<>' || $operator ===  '!=') {
+            } elseif ($operator === '<>' || $operator === '!=') {
                 return $this->whereNotIn($column, $value, $boolean);
             }
         }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -672,6 +672,16 @@ class Builder
             [$value, $operator] = [$operator, '='];
         }
 
+        // If the given value is array and operator is '=', '<>' or '!=' we will use valid methods instead
+        // to avoid running query with only first value from array
+        if (is_array($value)) {
+            if ($operator === '=') {
+                return $this->whereIn($column, $value, $boolean);
+            } elseif ($operator === '<>' || $operator ===  '!=') {
+                return $this->whereNotIn($column, $value, $boolean);
+            }
+        }
+
         // If the value is a Closure, it means the developer is performing an entire
         // sub-select within the query and we will need to compile the sub-select
         // within the where clause to get the appropriate query record results.

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -298,6 +298,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testWheresWithArrayValue()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', [12, 30]);
+        $this->assertSame('select * from "users" where "id" in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '=', [12, 30]);
+        $this->assertSame('select * from "users" where "id" in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '!=', [12, 30]);
+        $this->assertSame('select * from "users" where "id" not in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->where('id', '<>', [12, 30]);
+        $this->assertSame('select * from "users" where "id" not in (?, ?)', $builder->toSql());
+        $this->assertEquals([0 => 12, 1 => 30], $builder->getBindings());
+    }
+
     public function testMySqlWrappingProtectsQuotationMarks()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
It seems at the moment Query Builder silently chooses only 1st value from array when array value given. There is no exception thrown so this could lead to potential risky situations when code doesn't behave as it should if by mistake you pass array to `where` method.

For example at the moment when you use code like this:

```php
User::where('id', [5,2])->get();
User::where('id', '<>', [5,2])->get();
```

builder will generate queries like those:

```
select * from `users` where `id` = 5;
select * from `users` where `id` <> 5;
```

If this PR were accepted in case of developer error using such code, Builder would automatically fallback to `whereIn` and `whereNotIn` methods when possible.

I believe this change could potentially affect existing applications so it's better to target it to 7.x instead of 6.x
