### PR TITLE
[6.x] Add assertion for empty job chain

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -95,6 +95,23 @@ class QueueFake extends QueueManager implements Queue
     }
 
     /**
+     * Assert if a job was pushed with empty chain based on a truth-test callback.
+     *
+     * @param  string  $job
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertPushedWithEmptyChain($job, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            $this->pushed($job, $callback)->isNotEmpty(),
+            "The expected [{$job}] job was not pushed."
+        );
+
+        $this->assertPushedWithChainOfClasses($job, [], $callback);
+    }
+
+    /**
      * Assert if a job was pushed with chained jobs based on a truth-test callback.
      *
      * @param  string  $job

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -138,6 +138,13 @@ class SupportTestingQueueFakeTest extends TestCase
         ]);
     }
 
+    public function testAssertPushedWithEmptyChain()
+    {
+        $this->fake->push(new JobWithChainStub([]));
+
+        $this->fake->assertPushedWithEmptyChain(JobWithChainStub::class);
+    }
+
     public function testAssertPushedWithChainSameJobDifferentChains()
     {
         $this->fake->push(new JobWithChainStub([


### PR DESCRIPTION
This PR introduces the `assertPushedWithEmptyChain` assertion.

-----

I found myself to implement conditional job chaining:

```php
MoveFile::withChain(
    $medium->isImage ? [new GenerateImages($medium)] : [],
)->dispatch($medium);
```
It's possible to pass an empty chain, but right now there is no way to test it.

The `assertPushedWithChain` does not accept an empty array for the expected chain and the `assertPushed` can't tell whether the chain is empty or not.

-----

I'm not sure, this is the cleanest approach, I'm up to any idea.
