### PR TITLE
[6.x] Remove duplicate output when publishing tags

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -165,9 +165,7 @@ class VendorPublishCommand extends Command
             $published = true;
         }
 
-        if ($published) {
-            $this->info('Publishing complete.');
-        } else {
+        if ($published === false) {
             $this->error('Unable to locate publishable resources.');
         }
     }


### PR DESCRIPTION
<img width="840" alt="Screenshot 2020-02-03 at 10 55 09" src="https://user-images.githubusercontent.com/38881834/73649378-8e428c80-4677-11ea-91ed-f905a9194cd1.png">

When using the `vendor:publish` to publish a specific tag (either via the prompt or providing a --tag option) the "Publish Complete." line was duplicated - it's output at the end of the handle method and during the publish tag method. This initially caused me some confusion as I thought the process was being duplicated.

This PR removes the output from the publishTag method and allows the handle method to output a single instance when the process is complete.