### PR TITLE
[6.x] Limited properties returned by morph type

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -43,7 +43,7 @@ class MorphTo extends BelongsTo
      * @var array
      */
     protected $morphableEagerLoads = [];
-    
+
     /**
      * A map of model type properties to show on individual morph type.
      *
@@ -131,8 +131,8 @@ class MorphTo extends BelongsTo
                             ));
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
-        
-        if(!empty($this->morphableProperties[get_class($instance)])) {
+
+        if (! empty($this->morphableProperties[get_class($instance)])) {
             $query->select($this->morphableProperties[get_class($instance)]);
         }
 
@@ -288,7 +288,7 @@ class MorphTo extends BelongsTo
 
         return $this;
     }
-    
+
     /**
      * Specify which properties to load for a given morph type.
      *

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -43,6 +43,13 @@ class MorphTo extends BelongsTo
      * @var array
      */
     protected $morphableEagerLoads = [];
+    
+    /**
+     * A map of model type properties to show on individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableProperties = [];
 
     /**
      * Create a new morph to relationship instance.
@@ -124,6 +131,10 @@ class MorphTo extends BelongsTo
                             ));
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
+        
+        if(!empty($this->morphableProperties[get_class($instance)])) {
+            $query->select($this->morphableProperties[get_class($instance)]);
+        }
 
         return $query->{$whereIn}(
             $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
@@ -273,6 +284,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoads = array_merge(
             $this->morphableEagerLoads, $with
+        );
+
+        return $this;
+    }
+    
+    /**
+     * Specify which properties to load for a given morph type.
+     *
+     * @param  array  $properties
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function morphProperties(array $properties)
+    {
+        $this->morphableProperties = array_merge(
+            $this->morphableProperties, $properties
         );
 
         return $this;


### PR DESCRIPTION
This is a functionality to allow a query like "morphWith" but named "morphProperties" to limit the properties of morph by type.
