### PR TITLE
[7.x] Update ViewComponents to a subdirectory

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -104,7 +104,7 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\ViewComponents';
+        return $rootNamespace.'\View\Components';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -525,8 +525,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function component($class, $alias = null, $prefix = '')
     {
         if (is_null($alias)) {
-            $alias = Str::contains($class, '\\ViewComponents\\')
-                            ? collect(explode('\\', Str::after($class, '\\ViewComponents\\')))->map(function ($segment) {
+            $alias = Str::contains($class, '\\View\\Components\\')
+                            ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(function ($segment) {
                                 return Str::kebab($segment);
                             })->implode(':')
                             : Str::kebab(class_basename($class));

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -192,7 +192,7 @@ class ComponentTagCompiler
             return ucfirst(Str::camel($componentPiece));
         }, explode(':', $component));
 
-        return $namespace.'ViewComponents\\'.implode('\\', $componentPieces);
+        return $namespace.'View\\Components\\'.implode('\\', $componentPieces);
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -41,7 +41,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->guessClassName('alert');
 
-        $this->assertEquals("App\ViewComponents\Alert", trim($result));
+        $this->assertEquals("App\View\Components\Alert", trim($result));
 
         Container::setInstance(null);
     }
@@ -55,7 +55,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->guessClassName('base:alert');
 
-        $this->assertEquals("App\ViewComponents\Base\Alert", trim($result));
+        $this->assertEquals("App\View\Components\Base\Alert", trim($result));
 
         Container::setInstance(null);
     }

--- a/tests/View/ViewBladeCompilerTest.php
+++ b/tests/View/ViewBladeCompilerTest.php
@@ -193,13 +193,13 @@ class ViewBladeCompilerTest extends TestCase
 
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->component('App\ViewComponents\Forms\Input');
-        $this->assertEquals(['forms:input' => 'App\ViewComponents\Forms\Input'], $compiler->getClassComponentAliases());
+        $compiler->component('App\View\Components\Forms\Input');
+        $this->assertEquals(['forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());
 
         $compiler = new BladeCompiler($files = $this->getFiles(), __DIR__);
 
-        $compiler->component('App\ViewComponents\Forms\Input', null, 'prefix');
-        $this->assertEquals(['prefix-forms:input' => 'App\ViewComponents\Forms\Input'], $compiler->getClassComponentAliases());
+        $compiler->component('App\View\Components\Forms\Input', null, 'prefix');
+        $this->assertEquals(['prefix-forms:input' => 'App\View\Components\Forms\Input'], $compiler->getClassComponentAliases());
     }
 
     protected function getFiles()


### PR DESCRIPTION
This updates the default view components directory from `App\ViewComponents` to `App\View\Components`. The reason for this is that "View" is a very common directory name and namespace across the Laravel ecosystem. This will cause one sub directory though but allows for other packages to also group any "View" related classes under this namespace (think Spatie's ViewModels). I believe this is a sensible default to have in the framework. Console commands are handled in the same fashion atm.