### PR TITLE
Revert "[6.x] Make Blueprint support Grammar's macro"

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -119,7 +119,7 @@ class Blueprint
         foreach ($this->commands as $command) {
             $method = 'compile'.ucfirst($command->name);
 
-            if (is_callable([$grammar, $method])) {
+            if (method_exists($grammar, $method)) {
                 if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -170,23 +170,4 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
-
-    public function testMacroable()
-    {
-        Blueprint::macro('foo', function () {
-            return $this->addCommand('foo');
-        });
-
-        MySqlGrammar::macro('compileFoo', function () {
-            return 'bar';
-        });
-
-        $blueprint = new Blueprint('users', function ($table) {
-            $table->foo();
-        });
-
-        $connection = m::mock(Connection::class);
-
-        $this->assertEquals(['bar'], $blueprint->toSql($connection, new MySqlGrammar));
-    }
 }


### PR DESCRIPTION
Reverts laravel/framework#31337