### PR TITLE
[6.x] Fix dropping columns with default value

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -211,7 +211,7 @@ class SqlServerGrammar extends Grammar
         $sql = "DECLARE @sql NVARCHAR(MAX) = '';";
         $sql .= "SELECT @sql += 'ALTER TABLE [dbo].[{$blueprint->getTable()}] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' ";
         $sql .= 'FROM SYS.COLUMNS ';
-        $sql .= "WHERE [object_id] = OBJECT_ID('[dbo].[{$blueprint->getTable()}]') AND [name] in ({$columns});";
+        $sql .= "WHERE [object_id] = OBJECT_ID('[dbo].[{$blueprint->getTable()}]') AND [name] in ({$columns}) AND [default_object_id] <> 0;";
         $sql .= 'EXEC(@sql)';
 
         return $sql;


### PR DESCRIPTION
<h1>Issue: #4402 </h1>

Select only rows where default_object_id is not 0.

A little modification of #31229 as fix from it did not work for a migration. 

It appears that SQL query generated by #31229 selects all columns and take their [default_object_id] field but columns without default value have [default_object_id] = 0. 
This pull request adds another condition to the query to take only fields where [default_object_id] !== 0.

<h1>End result</h1>
There in no need to specify dropping default constraints manually like proposed in issues like: #4402

<h1>Tests</h1>
Tests from original PR #31229 are suitable.