### PR TITLE
[6.x] Make sure changing a database field to json does not include charset

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -124,6 +124,7 @@ class ChangeColumn
         if (in_array($fluent['type'], ['json', 'binary'])) {
             $options['customSchemaOptions'] = [
                 'collation' => '',
+                'charset' => '',
             ];
         }
 


### PR DESCRIPTION
This PR will fix an issue very close to #25735 (comment). It will fix pretty much the same error but related to charset parameter.