### PR TITLE
[6.x] Fix infinite value for RedisStore

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return is_numeric($value) && ! in_array($value, [INF, -INF]) ? $value : serialize($value);
+        return is_numeric($value) && ! in_array($value, [INF, -INF]) && ! is_nan($value) ? $value : serialize($value);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -292,7 +292,7 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     protected function serialize($value)
     {
-        return is_numeric($value) ? $value : serialize($value);
+        return is_numeric($value) && ! in_array($value, [INF, -INF]) ? $value : serialize($value);
     }
 
     /**

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Cache;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Tests\Integration\IntegrationTest;
+
+/**
+ * @group integration
+ */
+class RedisStoreTest extends IntegrationTest
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+    }
+
+    public function testItCanStoreInfinite()
+    {
+        $result = Cache::store('redis')->put('foo', INF);
+        $this->assertTrue($result);
+        $this->assertSame(INF, Cache::store('redis')->get('foo'));
+
+        $result = Cache::store('redis')->put('bar', -INF);
+        $this->assertTrue($result);
+        $this->assertSame(-INF, Cache::store('redis')->get('bar'));
+    }
+}

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -29,6 +29,8 @@ class RedisStoreTest extends IntegrationTest
 
     public function testItCanStoreInfinite()
     {
+        Cache::store('redis')->clear();
+
         $result = Cache::store('redis')->put('foo', INF);
         $this->assertTrue($result);
         $this->assertSame(INF, Cache::store('redis')->get('foo'));
@@ -36,5 +38,14 @@ class RedisStoreTest extends IntegrationTest
         $result = Cache::store('redis')->put('bar', -INF);
         $this->assertTrue($result);
         $this->assertSame(-INF, Cache::store('redis')->get('bar'));
+    }
+
+    public function testItCanStoreNan()
+    {
+        Cache::store('redis')->clear();
+
+        $result = Cache::store('redis')->put('foo', NAN);
+        $this->assertTrue($result);
+        $this->assertNan(Cache::store('redis')->get('foo'));
     }
 }


### PR DESCRIPTION
This PR fixes storing infinite values for the Redis cache store. Since INF values will be converted to strings upon storing in Redis we'll need to serialize them.

Fixes https://github.com/laravel/framework/issues/31345