### PR TITLE
[6.x] Added Macroable trait to Illuminate\Console\Scheduling\Schedule class

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -7,9 +7,12 @@ use Illuminate\Console\Application;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\ProcessUtils;
+use Illuminate\Support\Traits\Macroable;
 
 class Schedule
 {
+    use Macroable;
+
     /**
      * All of the events on the schedule.
      *


### PR DESCRIPTION
This PR simply adds the `Macroable` trait to the `Illuminate\Console\Scheduling\Schedule` class, allowing developers, both application and package, to add custom methods to the Schedule class.

The main benefit I see here is that third-party package developers can add methods to the Schedule class that will schedule commands / closures from their package, letting the package-user to optionally enable those scheduled commands by calling the macro'd function. This would act in the same way as many packages create Route macros to register routes.

There won't be any breaking changes here, or any conflicts that I can see as the Schedule class did not have any magic `__call()` or `__callStatic()` methods to begin with.

This trait has already been added to the `Illuminate\Console\Scheduling\Event` class, can't see any reason why it can't be added to the scheduler.
