### PR TITLE
[7.x] Make `StorageLinkCommand` dynamic

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -28,7 +28,6 @@ class StorageLinkCommand extends Command
     public function handle()
     {
         foreach ($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
-
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -18,7 +18,7 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Create a symbolic link from "public/storage" to "storage/app/public"';
+    protected $description = 'Create symbolic links';
 
     /**
      * Execute the console command.
@@ -27,14 +27,17 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
-        if (file_exists(public_path('storage'))) {
-            return $this->error('The "public/storage" directory already exists.');
+        foreach($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
+
+            if (file_exists($link)) {
+                $this->error('The [$link] directory already exists.');
+            } else {
+                $this->laravel->make('files')->link($target, $link);
+
+                $this->info("The [$link] directory has been linked to [$target].");
+            }
         }
 
-        $this->laravel->make('files')->link(
-            storage_path('app/public'), public_path('storage')
-        );
-
-        $this->info('The [public/storage] directory has been linked.');
+        $this->info('The links have been created.');
     }
 }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -27,7 +27,7 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
-        foreach($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
+        foreach ($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
 
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -27,7 +27,7 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
-        foreach ($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
+        foreach ($this->laravel['config']['filesystems.links'] ?? [public_path('storage') => storage_path('app/public')] as $link => $target) {
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -30,11 +30,11 @@ class StorageLinkCommand extends Command
         foreach($this->laravel['config']['filesystems.links'] ?? [] as $link => $target) {
 
             if (file_exists($link)) {
-                $this->error('The [$link] directory already exists.');
+                $this->error("The [$link] link already exists.");
             } else {
                 $this->laravel->make('files')->link($target, $link);
 
-                $this->info("The [$link] directory has been linked to [$target].");
+                $this->info("The [$link] link has been connected to [$target].");
             }
         }
 


### PR DESCRIPTION
This PR gives the programmer the ability to define all the links they would like created in their application programmatically. Links and their targets are defined in the `config/filesystems.php` file.

```php
'links' => [
    public_path('storage') => storage_path('app/public'),
    public_path('images') => storage_path('app/images'),
],
```

If this PR is accepted I will make necessary changes in `laravel/laravel`.