### PR TITLE
[6.x] Introduce BeforeQueryExecuted event

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -620,6 +620,10 @@ class Connection implements ConnectionInterface
     {
         $this->reconnectIfMissingConnection();
 
+        // allow raw SQL query to be modified before it's prepared and executed
+        // for instance you can prepend a comment to it with some helpful context information
+        $this->event(new Events\BeforeQueryExecuted($query, $this));
+
         $start = microtime(true);
 
         // Here we will run this query. If an exception occurs we'll determine if it was

--- a/src/Illuminate/Database/Events/BeforeQueryExecuted.php
+++ b/src/Illuminate/Database/Events/BeforeQueryExecuted.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Database\Events;
+
+class BeforeQueryExecuted
+{
+    /**
+     * The SQL query that was executed.
+     *
+     * @var string
+     */
+    public $sql;
+
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    public $connection;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  string  $sql
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return void
+     */
+    public function __construct(&$sql, $connection)
+    {
+        $this->sql = &$sql;
+        $this->connection = $connection;
+    }
+}


### PR DESCRIPTION
This is a follow-up of b8ecedacce80ccfe5c2f44c51c35954d836df413 that introduced `StatementPrepared` event. However, it did not provide an ease way to modify the raw SQL query before it's prepared and executed by the database server. Further more, only `SELECT` queries trigger this event.

This PR introduces `BeforeQueryExecuted` event that is provided with a raw SQL query and connection instance. SQL query string is passed as a reference, so it can be modified by whatever binds to this event.

Use? A comment can be prepended to the query to ease debugging of performance issues as these comments will show up in MySQL's `SHOW PROCESSLIST` and in slow query log.

An example of a modified query:

```sql
/* UserQuizResultsApiController.php:96 POST /papi/v2/quiz_results */ insert into `user_quiz_results` (`created_at`, `quiz_answer_id`, `quiz_question_id`, `user_id`) values (?, ?, ?, ?)
```

> We will publish a composer package providing the above SQL commenting feature for Laravel shortly.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
