### PR TITLE
[6.x] Make Blueprint support Grammar's macro

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -119,7 +119,7 @@ class Blueprint
         foreach ($this->commands as $command) {
             $method = 'compile'.ucfirst($command->name);
 
-            if (method_exists($grammar, $method)) {
+            if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
                 if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
                     $statements = array_merge($statements, (array) $sql);
                 }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -170,4 +170,23 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
         $this->assertEquals(['alter table `users` add `foo` varchar(255) not null'], $blueprint->toSql($connection, new MySqlGrammar));
     }
+
+    public function testMacroable()
+    {
+        Blueprint::macro('foo', function () {
+            return $this->addCommand('foo');
+        });
+
+        MySqlGrammar::macro('compileFoo', function () {
+            return 'bar';
+        });
+
+        $blueprint = new Blueprint('users', function ($table) {
+            $table->foo();
+        });
+
+        $connection = m::mock(Connection::class);
+
+        $this->assertEquals(['bar'], $blueprint->toSql($connection, new MySqlGrammar));
+    }
 }


### PR DESCRIPTION
According to #31296, this PR makes `Blueprint` support `Grammar`'s macro when building raw SQL statements from `Fluent` commands using `toSql()` method.

Note: I've used `hasMacro()` on this PR to check if the macro is registered on the `Grammar` class. I guessed the #31337 PR was reverted because it was wrongly using `is_callable()` which always returns `true` if the target class has `__call()` magic method.