### PR TITLE
[6.x] Size Validation Rule - Allows to use other fields

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1631,7 +1631,11 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(1, $parameters, 'size');
 
-        return $this->getSize($attribute, $value) == $parameters[0];
+        $comparedToValue = is_numeric($parameters[0])
+            ? $parameters[0]
+            : $this->getSize($parameters[0], $this->getValue($parameters[0]));
+
+        return $this->getSize($attribute, $value) == $comparedToValue;
     }
 
     /**


### PR DESCRIPTION
# Before 

Currently, the **size:value** rule allows you to validate size of a field. In this rule the `value` corresponds to a **given value**

Example: 
```
$data  = ['ids' => ['12', '15']];
$rules = ['ids' => 'size:2'];
```

# After

This PR adds the ability to make this `value` a bit more dynamic by allowing the user to provide the name of another field

Example:
```
$data  = [
    'types' => ['App\User', 'App\Team'],
    'ids' => ['12', '15']
];
$rules = ['ids' => 'size:types'];
```

## It already exists in other rules

Something similar already happens with the rules `after:date`, `after_or_equal:date`, `before:date` and `before_or_equal:date`, In these rules you can put a string *date* or the *name of another field*

## Why

I needed this when I was working with something similar to the previous example, this example uses *arrays*, but it also works with *string data*, *numeric data* and *files*

## Just in case

Do you like it? 
Do you prefer this as another rule? `same_size_as` `size_as` ?
