### PR TITLE
[6.x] Split Console InteractsWithIO to external trait

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -2,21 +2,16 @@
 
 namespace Illuminate\Console;
 
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
-use Symfony\Component\Console\Formatter\OutputFormatterStyle;
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
-use Symfony\Component\Console\Question\Question;
 
 class Command extends SymfonyCommand
 {
     use Concerns\CallsCommands,
         Concerns\HasParameters,
+        Concerns\InteractsWithIO,
         Macroable;
 
     /**
@@ -25,20 +20,6 @@ class Command extends SymfonyCommand
      * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $laravel;
-
-    /**
-     * The input interface implementation.
-     *
-     * @var \Symfony\Component\Console\Input\InputInterface
-     */
-    protected $input;
-
-    /**
-     * The output interface implementation.
-     *
-     * @var \Illuminate\Console\OutputStyle
-     */
-    protected $output;
 
     /**
      * The name and signature of the console command.
@@ -74,26 +55,6 @@ class Command extends SymfonyCommand
      * @var bool
      */
     protected $hidden = false;
-
-    /**
-     * The default verbosity of output commands.
-     *
-     * @var int
-     */
-    protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
-
-    /**
-     * The mapping between human readable verbosity levels and Symfony's OutputInterface.
-     *
-     * @var array
-     */
-    protected $verbosityMap = [
-        'v' => OutputInterface::VERBOSITY_VERBOSE,
-        'vv' => OutputInterface::VERBOSITY_VERY_VERBOSE,
-        'vvv' => OutputInterface::VERBOSITY_DEBUG,
-        'quiet' => OutputInterface::VERBOSITY_QUIET,
-        'normal' => OutputInterface::VERBOSITY_NORMAL,
-    ];
 
     /**
      * Create a new console command instance.
@@ -199,343 +160,6 @@ class Command extends SymfonyCommand
     }
 
     /**
-     * Determine if the given argument is present.
-     *
-     * @param  string|int  $name
-     * @return bool
-     */
-    public function hasArgument($name)
-    {
-        return $this->input->hasArgument($name);
-    }
-
-    /**
-     * Get the value of a command argument.
-     *
-     * @param  string|null  $key
-     * @return string|array|null
-     */
-    public function argument($key = null)
-    {
-        if (is_null($key)) {
-            return $this->input->getArguments();
-        }
-
-        return $this->input->getArgument($key);
-    }
-
-    /**
-     * Get all of the arguments passed to the command.
-     *
-     * @return array
-     */
-    public function arguments()
-    {
-        return $this->argument();
-    }
-
-    /**
-     * Determine if the given option is present.
-     *
-     * @param  string  $name
-     * @return bool
-     */
-    public function hasOption($name)
-    {
-        return $this->input->hasOption($name);
-    }
-
-    /**
-     * Get the value of a command option.
-     *
-     * @param  string|null  $key
-     * @return string|array|bool|null
-     */
-    public function option($key = null)
-    {
-        if (is_null($key)) {
-            return $this->input->getOptions();
-        }
-
-        return $this->input->getOption($key);
-    }
-
-    /**
-     * Get all of the options passed to the command.
-     *
-     * @return array
-     */
-    public function options()
-    {
-        return $this->option();
-    }
-
-    /**
-     * Confirm a question with the user.
-     *
-     * @param  string  $question
-     * @param  bool  $default
-     * @return bool
-     */
-    public function confirm($question, $default = false)
-    {
-        return $this->output->confirm($question, $default);
-    }
-
-    /**
-     * Prompt the user for input.
-     *
-     * @param  string  $question
-     * @param  string|null  $default
-     * @return mixed
-     */
-    public function ask($question, $default = null)
-    {
-        return $this->output->ask($question, $default);
-    }
-
-    /**
-     * Prompt the user for input with auto completion.
-     *
-     * @param  string  $question
-     * @param  array|callable  $choices
-     * @param  string|null  $default
-     * @return mixed
-     */
-    public function anticipate($question, $choices, $default = null)
-    {
-        return $this->askWithCompletion($question, $choices, $default);
-    }
-
-    /**
-     * Prompt the user for input with auto completion.
-     *
-     * @param  string  $question
-     * @param  array|callable  $choices
-     * @param  string|null  $default
-     * @return mixed
-     */
-    public function askWithCompletion($question, $choices, $default = null)
-    {
-        $question = new Question($question, $default);
-
-        is_callable($choices)
-            ? $question->setAutocompleterCallback($choices)
-            : $question->setAutocompleterValues($choices);
-
-        return $this->output->askQuestion($question);
-    }
-
-    /**
-     * Prompt the user for input but hide the answer from the console.
-     *
-     * @param  string  $question
-     * @param  bool  $fallback
-     * @return mixed
-     */
-    public function secret($question, $fallback = true)
-    {
-        $question = new Question($question);
-
-        $question->setHidden(true)->setHiddenFallback($fallback);
-
-        return $this->output->askQuestion($question);
-    }
-
-    /**
-     * Give the user a single choice from an array of answers.
-     *
-     * @param  string  $question
-     * @param  array  $choices
-     * @param  string|null  $default
-     * @param  mixed|null  $attempts
-     * @param  bool|null  $multiple
-     * @return string
-     */
-    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
-    {
-        $question = new ChoiceQuestion($question, $choices, $default);
-
-        $question->setMaxAttempts($attempts)->setMultiselect($multiple);
-
-        return $this->output->askQuestion($question);
-    }
-
-    /**
-     * Format input to textual table.
-     *
-     * @param  array  $headers
-     * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
-     * @param  string  $tableStyle
-     * @param  array  $columnStyles
-     * @return void
-     */
-    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
-    {
-        $table = new Table($this->output);
-
-        if ($rows instanceof Arrayable) {
-            $rows = $rows->toArray();
-        }
-
-        $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
-
-        foreach ($columnStyles as $columnIndex => $columnStyle) {
-            $table->setColumnStyle($columnIndex, $columnStyle);
-        }
-
-        $table->render();
-    }
-
-    /**
-     * Write a string as information output.
-     *
-     * @param  string  $string
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function info($string, $verbosity = null)
-    {
-        $this->line($string, 'info', $verbosity);
-    }
-
-    /**
-     * Write a string as standard output.
-     *
-     * @param  string  $string
-     * @param  string|null  $style
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function line($string, $style = null, $verbosity = null)
-    {
-        $styled = $style ? "<$style>$string</$style>" : $string;
-
-        $this->output->writeln($styled, $this->parseVerbosity($verbosity));
-    }
-
-    /**
-     * Write a string as comment output.
-     *
-     * @param  string  $string
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function comment($string, $verbosity = null)
-    {
-        $this->line($string, 'comment', $verbosity);
-    }
-
-    /**
-     * Write a string as question output.
-     *
-     * @param  string  $string
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function question($string, $verbosity = null)
-    {
-        $this->line($string, 'question', $verbosity);
-    }
-
-    /**
-     * Write a string as error output.
-     *
-     * @param  string  $string
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function error($string, $verbosity = null)
-    {
-        $this->line($string, 'error', $verbosity);
-    }
-
-    /**
-     * Write a string as warning output.
-     *
-     * @param  string  $string
-     * @param  int|string|null  $verbosity
-     * @return void
-     */
-    public function warn($string, $verbosity = null)
-    {
-        if (! $this->output->getFormatter()->hasStyle('warning')) {
-            $style = new OutputFormatterStyle('yellow');
-
-            $this->output->getFormatter()->setStyle('warning', $style);
-        }
-
-        $this->line($string, 'warning', $verbosity);
-    }
-
-    /**
-     * Write a string in an alert box.
-     *
-     * @param  string  $string
-     * @return void
-     */
-    public function alert($string)
-    {
-        $length = Str::length(strip_tags($string)) + 12;
-
-        $this->comment(str_repeat('*', $length));
-        $this->comment('*     '.$string.'     *');
-        $this->comment(str_repeat('*', $length));
-
-        $this->output->newLine();
-    }
-
-    /**
-     * Set the input interface implementation.
-     *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @return void
-     */
-    public function setInput(InputInterface $input)
-    {
-        $this->input = $input;
-    }
-
-    /**
-     * Set the output interface implementation.
-     *
-     * @param  \Illuminate\Console\OutputStyle  $output
-     * @return void
-     */
-    public function setOutput(OutputStyle $output)
-    {
-        $this->output = $output;
-    }
-
-    /**
-     * Set the verbosity level.
-     *
-     * @param  string|int  $level
-     * @return void
-     */
-    protected function setVerbosity($level)
-    {
-        $this->verbosity = $this->parseVerbosity($level);
-    }
-
-    /**
-     * Get the verbosity level in terms of Symfony's OutputInterface level.
-     *
-     * @param  string|int|null  $level
-     * @return int
-     */
-    protected function parseVerbosity($level = null)
-    {
-        if (isset($this->verbosityMap[$level])) {
-            $level = $this->verbosityMap[$level];
-        } elseif (! is_int($level)) {
-            $level = $this->verbosity;
-        }
-
-        return $level;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isHidden()
@@ -551,16 +175,6 @@ class Command extends SymfonyCommand
         parent::setHidden($this->hidden = $hidden);
 
         return $this;
-    }
-
-    /**
-     * Get the output implementation.
-     *
-     * @return \Illuminate\Console\OutputStyle
-     */
-    public function getOutput()
-    {
-        return $this->output;
     }
 
     /**

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -1,0 +1,397 @@
+<?php
+
+namespace Illuminate\Console\Concerns;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
+
+trait InteractsWithIO
+{
+    /**
+     * The input interface implementation.
+     *
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected $input;
+
+    /**
+     * The output interface implementation.
+     *
+     * @var \Illuminate\Console\OutputStyle
+     */
+    protected $output;
+
+    /**
+     * The default verbosity of output commands.
+     *
+     * @var int
+     */
+    protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
+
+    /**
+     * The mapping between human readable verbosity levels and Symfony's OutputInterface.
+     *
+     * @var array
+     */
+    protected $verbosityMap = [
+        'v' => OutputInterface::VERBOSITY_VERBOSE,
+        'vv' => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        'vvv' => OutputInterface::VERBOSITY_DEBUG,
+        'quiet' => OutputInterface::VERBOSITY_QUIET,
+        'normal' => OutputInterface::VERBOSITY_NORMAL,
+    ];
+
+    /**
+     * Determine if the given argument is present.
+     *
+     * @param  string|int  $name
+     * @return bool
+     */
+    public function hasArgument($name)
+    {
+        return $this->input->hasArgument($name);
+    }
+
+    /**
+     * Get the value of a command argument.
+     *
+     * @param  string|null  $key
+     * @return string|array|null
+     */
+    public function argument($key = null)
+    {
+        if (is_null($key)) {
+            return $this->input->getArguments();
+        }
+
+        return $this->input->getArgument($key);
+    }
+
+    /**
+     * Get all of the arguments passed to the command.
+     *
+     * @return array
+     */
+    public function arguments()
+    {
+        return $this->argument();
+    }
+
+    /**
+     * Determine if the given option is present.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasOption($name)
+    {
+        return $this->input->hasOption($name);
+    }
+
+    /**
+     * Get the value of a command option.
+     *
+     * @param  string|null  $key
+     * @return string|array|bool|null
+     */
+    public function option($key = null)
+    {
+        if (is_null($key)) {
+            return $this->input->getOptions();
+        }
+
+        return $this->input->getOption($key);
+    }
+
+    /**
+     * Get all of the options passed to the command.
+     *
+     * @return array
+     */
+    public function options()
+    {
+        return $this->option();
+    }
+
+    /**
+     * Confirm a question with the user.
+     *
+     * @param  string  $question
+     * @param  bool  $default
+     * @return bool
+     */
+    public function confirm($question, $default = false)
+    {
+        return $this->output->confirm($question, $default);
+    }
+
+    /**
+     * Prompt the user for input.
+     *
+     * @param  string  $question
+     * @param  string|null  $default
+     * @return mixed
+     */
+    public function ask($question, $default = null)
+    {
+        return $this->output->ask($question, $default);
+    }
+
+    /**
+     * Prompt the user for input with auto completion.
+     *
+     * @param  string  $question
+     * @param  array|callable  $choices
+     * @param  string|null  $default
+     * @return mixed
+     */
+    public function anticipate($question, $choices, $default = null)
+    {
+        return $this->askWithCompletion($question, $choices, $default);
+    }
+
+    /**
+     * Prompt the user for input with auto completion.
+     *
+     * @param  string  $question
+     * @param  array|callable  $choices
+     * @param  string|null  $default
+     * @return mixed
+     */
+    public function askWithCompletion($question, $choices, $default = null)
+    {
+        $question = new Question($question, $default);
+
+        is_callable($choices)
+            ? $question->setAutocompleterCallback($choices)
+            : $question->setAutocompleterValues($choices);
+
+        return $this->output->askQuestion($question);
+    }
+
+    /**
+     * Prompt the user for input but hide the answer from the console.
+     *
+     * @param  string  $question
+     * @param  bool  $fallback
+     * @return mixed
+     */
+    public function secret($question, $fallback = true)
+    {
+        $question = new Question($question);
+
+        $question->setHidden(true)->setHiddenFallback($fallback);
+
+        return $this->output->askQuestion($question);
+    }
+
+    /**
+     * Give the user a single choice from an array of answers.
+     *
+     * @param  string  $question
+     * @param  array  $choices
+     * @param  string|null  $default
+     * @param  mixed|null  $attempts
+     * @param  bool|null  $multiple
+     * @return string
+     */
+    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
+    {
+        $question = new ChoiceQuestion($question, $choices, $default);
+
+        $question->setMaxAttempts($attempts)->setMultiselect($multiple);
+
+        return $this->output->askQuestion($question);
+    }
+
+    /**
+     * Format input to textual table.
+     *
+     * @param  array  $headers
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
+     * @param  string  $tableStyle
+     * @param  array  $columnStyles
+     * @return void
+     */
+    public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    {
+        $table = new Table($this->output);
+
+        if ($rows instanceof Arrayable) {
+            $rows = $rows->toArray();
+        }
+
+        $table->setHeaders((array) $headers)->setRows($rows)->setStyle($tableStyle);
+
+        foreach ($columnStyles as $columnIndex => $columnStyle) {
+            $table->setColumnStyle($columnIndex, $columnStyle);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * Write a string as information output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function info($string, $verbosity = null)
+    {
+        $this->line($string, 'info', $verbosity);
+    }
+
+    /**
+     * Write a string as standard output.
+     *
+     * @param  string  $string
+     * @param  string|null  $style
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function line($string, $style = null, $verbosity = null)
+    {
+        $styled = $style ? "<$style>$string</$style>" : $string;
+
+        $this->output->writeln($styled, $this->parseVerbosity($verbosity));
+    }
+
+    /**
+     * Write a string as comment output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function comment($string, $verbosity = null)
+    {
+        $this->line($string, 'comment', $verbosity);
+    }
+
+    /**
+     * Write a string as question output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function question($string, $verbosity = null)
+    {
+        $this->line($string, 'question', $verbosity);
+    }
+
+    /**
+     * Write a string as error output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function error($string, $verbosity = null)
+    {
+        $this->line($string, 'error', $verbosity);
+    }
+
+    /**
+     * Write a string as warning output.
+     *
+     * @param  string  $string
+     * @param  int|string|null  $verbosity
+     * @return void
+     */
+    public function warn($string, $verbosity = null)
+    {
+        if (! $this->output->getFormatter()->hasStyle('warning')) {
+            $style = new OutputFormatterStyle('yellow');
+
+            $this->output->getFormatter()->setStyle('warning', $style);
+        }
+
+        $this->line($string, 'warning', $verbosity);
+    }
+
+    /**
+     * Write a string in an alert box.
+     *
+     * @param  string  $string
+     * @return void
+     */
+    public function alert($string)
+    {
+        $length = Str::length(strip_tags($string)) + 12;
+
+        $this->comment(str_repeat('*', $length));
+        $this->comment('*     '.$string.'     *');
+        $this->comment(str_repeat('*', $length));
+
+        $this->output->newLine();
+    }
+
+    /**
+     * Set the input interface implementation.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @return void
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+
+    /**
+     * Set the output interface implementation.
+     *
+     * @param  \Illuminate\Console\OutputStyle  $output
+     * @return void
+     */
+    public function setOutput(OutputStyle $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Set the verbosity level.
+     *
+     * @param  string|int  $level
+     * @return void
+     */
+    protected function setVerbosity($level)
+    {
+        $this->verbosity = $this->parseVerbosity($level);
+    }
+
+    /**
+     * Get the verbosity level in terms of Symfony's OutputInterface level.
+     *
+     * @param  string|int|null  $level
+     * @return int
+     */
+    protected function parseVerbosity($level = null)
+    {
+        if (isset($this->verbosityMap[$level])) {
+            $level = $this->verbosityMap[$level];
+        } elseif (! is_int($level)) {
+            $level = $this->verbosity;
+        }
+
+        return $level;
+    }
+
+    /**
+     * Get the output implementation.
+     *
+     * @return \Illuminate\Console\OutputStyle
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
+}


### PR DESCRIPTION
This is the final part of moving `Illuminate\Console\Command` to traits that can be use by Symfony Console, and this allows developer to reuse all the available IO helpers such as `table`, `askQuestion`, `choice` or even output style based on Laravel.

#### Usages

```php
    // ...
    use \Illuminate\Console\Concerns\InteractsWithIO;

    /**
     * Execute the console command.
     *
     * @param  \Symfony\Component\Console\Input\InputInterface  $input
     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
     * @return mixed
     */
    protected function execute(InputInterface $input, OutputInterface $output)
    {
        $this->setOutput(new \Illuminate\Console\OutputStyle($input, $output));

         // you can now use any of the helper methods
    }
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
