### PR TITLE
[6.x] Add TestResponse::assertJsonPathFragment()

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -562,6 +562,34 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the given path in the response contains the given JSON fragment.
+     *
+     * @param  string $path
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertJsonPathFragment($path, array $data)
+    {
+        $actual = json_encode(Arr::sortRecursive(
+            $this->json($path)
+        ));
+
+        foreach (Arr::sortRecursive($data) as $key => $value) {
+            $expected = $this->jsonSearchStrings($key, $value);
+
+            PHPUnit::assertTrue(
+                Str::contains($actual, $expected),
+                'Unable to find JSON fragment: '.PHP_EOL.PHP_EOL.
+                '['.json_encode([$key => $value]).']'.PHP_EOL.PHP_EOL.
+                'within'.PHP_EOL.PHP_EOL.
+                "[{$actual}]."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
      * Assert that the response does not contain the given JSON fragment.
      *
      * @param  array  $data

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -564,7 +564,7 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the given path in the response contains the given JSON fragment.
      *
-     * @param  string $path
+     * @param  string  $path
      * @param  array  $data
      * @return $this
      */

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -452,6 +452,54 @@ class FoundationTestResponseTest extends TestCase
         $response->assertJsonFragment(['id' => 1]);
     }
 
+    public function testAssertJsonPathFragment()
+    {
+        $response = TestResponse::fromBaseResponse(new Response([
+            [
+                'author' => [
+                    'name' => 'Taylor Otwell',
+                ],
+                'title' => 'Laravel: From Apprentice To Artisan',
+            ],
+            [
+                'author' => [
+                    'name' => 'Jeffrey Way',
+                ],
+                'title' => 'Laravel Testing Decoded',
+            ],
+        ]));
+
+        $response->assertJsonPathFragment('0', [
+            'name' => 'Taylor Otwell',
+            'title' => 'Laravel: From Apprentice To Artisan',
+        ]);
+    }
+
+    public function testAssertJsonPathFragmentCanFail()
+    {
+        $this->expectException(AssertionFailedError::class);
+
+        $response = TestResponse::fromBaseResponse(new Response([
+            [
+                'author' => [
+                    'name' => 'Taylor Otwell',
+                ],
+                'title' => 'Laravel: From Apprentice To Artisan',
+            ],
+            [
+                'author' => [
+                    'name' => 'Jeffrey Way',
+                ],
+                'title' => 'Laravel Testing Decoded',
+            ],
+        ]));
+
+        $response->assertJsonPathFragment('0', [
+            'name' => 'Taylor Otwell',
+            'title' => 'Laravel Testing Decoded',
+        ]);
+    }
+
     public function testAssertJsonStructure()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));


### PR DESCRIPTION
This PR adds a new assertion `assertJsonPathFragment($path, $fragment)` to the TestResponse class.
The new assertion allows to check for a json fragment but within a path instead of the whole response.

```php
[
	'reviewers' => [
		[
			'name' => 'Taylor',
		],
		[
			'name' => 'Jeff',
		],
	],
	'potential_reviewers' => [
		[
			'name' => 'Mohamed'
		],
		[
			'name' => 'Dries'
		],
	]
]
```

In this example response, i want to assert that `Taylor` is in the `reviewers` array and that `Mohamed` is in the `potential_reviewers` array.

```php
$response->assertJsonPathFragment('reviewers', ['name' => 'Taylor']);
$response->assertJsonPathFragment('potential_reviewers', ['name' => 'Mohamed']);
```

The new assertion can also be used to group multiple `assertJsonPath` assertions into one

```php
// From
$response->->assertJsonPath('data.0.table_exists', true);
$response->assertJsonPath('data.0.id', $firstAssignment->id);
$response->->assertJsonPath('data.0.group_ids', ['01', '02']);

// To
$response->->assertJsonPathFragment('data.0', [
	'table_exists' => true,
	'id' => $firstAssignment->id,
	'group_ids' => ['01', '02']
]);
```