### PR TITLE
[8.x] Adds view testing in isolation

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Testing\Concerns;
+
+use Illuminate\Testing\TestView;
+
+trait InteractsWithViews
+{
+    /**
+     * Create a new TestView from the given view.
+     *
+     * @param  string  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @param  array  $mergeData
+     * @return \Illuminate\Testing\TestView
+     */
+    protected function view($view, $data = [], $mergeData = [])
+    {
+        $view = view($view, $data, $mergeData);
+
+        return new TestView($view);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -18,6 +18,7 @@ abstract class TestCase extends BaseTestCase
     use Concerns\InteractsWithContainer,
         Concerns\MakesHttpRequests,
         Concerns\InteractsWithAuthentication,
+        Concerns\InteractsWithViews,
         Concerns\InteractsWithConsole,
         Concerns\InteractsWithDatabase,
         Concerns\InteractsWithExceptionHandling,

--- a/src/Illuminate/Testing/TestView.php
+++ b/src/Illuminate/Testing/TestView.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Illuminate\Testing\Assert as PHPUnit;
+use Illuminate\View\View;
+
+class TestView
+{
+    /**
+     * The original view.
+     *
+     * @var \Illuminate\View\View
+     */
+    protected $view;
+
+    /**
+     * Create a new test view instance.
+     *
+     * @param  \Illuminate\View\View  $view
+     * @return void
+     */
+    public function __construct(View $view)
+    {
+        $this->view = $view;
+    }
+
+    /**
+     * Assert that the given string is contained within the view.
+     *
+     * @param  string  $value
+     * @param  bool  $escaped
+     * @return $this
+     */
+    public function assertSee($value, $escaped = true)
+    {
+        $value = $escaped ? e($value) : $value;
+
+        PHPUnit::assertStringContainsString((string) $value, $this->view->render());
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This pull request adds the ability of **testing views in isolation** without the need of using the http layer - and it looks like this:

```php
class WelcomeTest extends TestCase
{
    /**
     * Asserts welcome view.
     *
     * @return void
     */
    public function testWelcomeView()
    {
        $contents = $this->view('welcome');

        $contents->assertSee('Laravel');
    }
}
```

Of course, just like the `view` helper, you can pass arguments:

```php
class ButtonTest extends TestCase
{
    /**
     * Tests the button partial
     *
     * @return void
     */
    public function testButton()
    {
        $contents = $this->view('partials.button', [
             'name' => 'Send',
        ]);

        $contents->assertSee('Send');
    }
}
```

**Note**: This pull request don't contain tests yet - I will add them if people want this on the framework.