### PR TITLE
[6.x] Better docblocks for Event::listen

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -68,7 +68,7 @@ class Dispatcher implements DispatcherContract
      * Register an event listener with the dispatcher.
      *
      * @param  string|array  $events
-     * @param  mixed  $listener
+     * @param  \Closure|string  $listener
      * @return void
      */
     public function listen($events, $listener)
@@ -86,7 +86,7 @@ class Dispatcher implements DispatcherContract
      * Setup a wildcard listener callback.
      *
      * @param  string  $event
-     * @param  mixed  $listener
+     * @param  \Closure|string  $listener
      * @return void
      */
     protected function setupWildcardListen($event, $listener)

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Testing\Fakes\EventFake;
 
 /**
- * @method static void listen(string|array $events, mixed $listener)
+ * @method static void listen(string|array $events, \Closure|string $listener)
  * @method static bool hasListeners(string $eventName)
  * @method static void push(string $event, array $payload = [])
  * @method static void flush(string $event)


### PR DESCRIPTION
This makes sense since the 'setupWildcardListen' method is documented like this.
Which we directly forward the $listener to it.
```
/**
 * Setup a wildcard listener callback.
 *
 * @param  string  $event
 * @param  \Closure|string  $listener
 * @return void
 */
protected function setupWildcardListen($event, $listener)
{
    $this->wildcards[$event][] = $this->makeListener($listener, true);

    $this->wildcardsCache = [];
}
```