### PR TITLE
[6.x] Fixed "Str::parseCallback()" PHPDoc

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -341,7 +341,7 @@ class Str
     }
 
     /**
-     * Parse a Class@method style callback into class and method.
+     * Parse a Class[@]method style callback into class and method.
      *
      * @param  string  $callback
      * @param  string|null  $default


### PR DESCRIPTION
-> was broken for e.g. PhpStorm

![Bildschirmfoto vom 2020-02-07 00-44-55](https://user-images.githubusercontent.com/264695/73988478-21fbad80-4943-11ea-9f2d-84115faf3f82.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/framework/31387)
<!-- Reviewable:end -->
