### PR TITLE
[6x] Optimize Str PHPDoc for array usage

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -149,7 +149,7 @@ class Str
      * Determine if a given string contains a given substring.
      *
      * @param  string  $haystack
-     * @param  string|array  $needles
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function contains($haystack, $needles)
@@ -167,7 +167,7 @@ class Str
      * Determine if a given string contains all array values.
      *
      * @param  string  $haystack
-     * @param  array  $needles
+     * @param  string[]  $needles
      * @return bool
      */
     public static function containsAll($haystack, array $needles)
@@ -185,7 +185,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|array  $needles
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function endsWith($haystack, $needles)
@@ -345,7 +345,7 @@ class Str
      *
      * @param  string  $callback
      * @param  string|null  $default
-     * @return array
+     * @return array<int, string|null>
      */
     public static function parseCallback($callback, $default = null)
     {
@@ -405,7 +405,7 @@ class Str
      * Replace a given value in the string sequentially with an array.
      *
      * @param  string  $search
-     * @param  array  $replace
+     * @param  array<int|string, string>  $replace
      * @param  string  $subject
      * @return string
      */
@@ -568,7 +568,7 @@ class Str
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack
-     * @param  string|array  $needles
+     * @param  string|string[]  $needles
      * @return bool
      */
     public static function startsWith($haystack, $needles)

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -167,6 +167,7 @@ class SupportStrTest extends TestCase
     {
         $this->assertEquals(['Class', 'method'], Str::parseCallback('Class@method', 'foo'));
         $this->assertEquals(['Class', 'foo'], Str::parseCallback('Class', 'foo'));
+        $this->assertEquals(['Class', null], Str::parseCallback('Class'));
     }
 
     public function testSlug()


### PR DESCRIPTION
This is a simple example for optimized PHPDocs: https://github.com/laravel/ideas/issues/2057

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/framework/31388)
<!-- Reviewable:end -->
