### PR TITLE
[7.x] Fix `artisan stub:publish` command

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -36,7 +36,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/job.queued.stub' => $stubsPath.'/job.queued.stub',
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
-            __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'stubs/model.pivot.stub',
+            __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'/model.pivot.stub',
             __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
             __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
             __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',


### PR DESCRIPTION
Bad path causing this issue:
![image](https://user-images.githubusercontent.com/3670578/73998658-54e87600-4930-11ea-8175-c25efd8c60d3.png)
