### PR TITLE
[6.x] Fix testing with unencrypted cookies

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -26,6 +26,13 @@ trait MakesHttpRequests
     protected $defaultCookies = [];
 
     /**
+     * Additional cookies will be encrypted for the request.
+     *
+     * @var array
+     */
+    protected $encryptableCookies = [];
+
+    /**
      * Additional server variables for the request.
      *
      * @var array
@@ -168,6 +175,34 @@ trait MakesHttpRequests
     public function withCookie(string $name, string $value)
     {
         $this->defaultCookies[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Define additional cookies will be encrypted before sending with the request.
+     *
+     * @param  array  $cookies
+     * @return $this
+     */
+    public function withEncryptableCookies(array $cookies)
+    {
+        $this->encryptableCookies = array_merge($this->encryptableCookies, $cookies);
+
+        return $this;
+    }
+
+
+    /**
+     * Add a cookie will be encrypted before sending with the request.
+     *
+     * @param  string  $name
+     * @param  string  $value
+     * @return $this
+     */
+    public function withEncryptableCookie(string $name, string $value)
+    {
+        $this->encryptableCookies[$name] = $value;
 
         return $this;
     }
@@ -527,12 +562,12 @@ trait MakesHttpRequests
     protected function prepareCookiesForRequest()
     {
         if (! $this->encryptCookies) {
-            return $this->defaultCookies;
+            return array_merge($this->defaultCookies, $this->encryptableCookies);
         }
 
-        return collect($this->defaultCookies)->map(function ($value) {
+        return collect($this->encryptableCookies)->map(function ($value) {
             return encrypt($value, false);
-        })->all();
+        })->merge($this->defaultCookies)->all();
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -192,7 +192,6 @@ trait MakesHttpRequests
         return $this;
     }
 
-
     /**
      * Add a cookie will be encrypted before sending with the request.
      *

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -26,11 +26,11 @@ trait MakesHttpRequests
     protected $defaultCookies = [];
 
     /**
-     * Additional cookies will be encrypted for the request.
+     * Additional cookies will not be encrypted for the request.
      *
      * @var array
      */
-    protected $encryptableCookies = [];
+    protected $unencryptedCookies = [];
 
     /**
      * Additional server variables for the request.
@@ -180,28 +180,28 @@ trait MakesHttpRequests
     }
 
     /**
-     * Define additional cookies will be encrypted before sending with the request.
+     * Define additional cookies will not be encrypted before sending with the request.
      *
      * @param  array  $cookies
      * @return $this
      */
-    public function withEncryptableCookies(array $cookies)
+    public function withUnencryptedCookies(array $cookies)
     {
-        $this->encryptableCookies = array_merge($this->encryptableCookies, $cookies);
+        $this->unencryptedCookies = array_merge($this->unencryptedCookies, $cookies);
 
         return $this;
     }
 
     /**
-     * Add a cookie will be encrypted before sending with the request.
+     * Add a cookie will not be encrypted before sending with the request.
      *
      * @param  string  $name
      * @param  string  $value
      * @return $this
      */
-    public function withEncryptableCookie(string $name, string $value)
+    public function withUnencryptedCookie(string $name, string $value)
     {
-        $this->encryptableCookies[$name] = $value;
+        $this->unencryptedCookies[$name] = $value;
 
         return $this;
     }
@@ -561,12 +561,12 @@ trait MakesHttpRequests
     protected function prepareCookiesForRequest()
     {
         if (! $this->encryptCookies) {
-            return array_merge($this->defaultCookies, $this->encryptableCookies);
+            return array_merge($this->defaultCookies, $this->unencryptedCookies);
         }
 
-        return collect($this->encryptableCookies)->map(function ($value) {
+        return collect($this->defaultCookies)->map(function ($value) {
             return encrypt($value, false);
-        })->merge($this->defaultCookies)->all();
+        })->merge($this->unencryptedCookies)->all();
     }
 
     /**

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -73,6 +73,27 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('baz', $this->defaultCookies['foo']);
         $this->assertSame('new-value', $this->defaultCookies['new-cookie']);
     }
+
+    public function testWithEncryptableCookieSetCookie()
+    {
+        $this->withEncryptable('foo', 'bar');
+
+        $this->assertCount(1, $this->encryptableCookies);
+        $this->assertSame('bar', $this->encryptableCookies['foo']);
+    }
+
+    public function testWithEncryptableCookiesSetsCookiesAndOverwritesPreviousValues()
+    {
+        $this->withCookie('foo', 'bar');
+        $this->withCookies([
+            'foo' => 'baz',
+            'new-cookie' => 'new-value',
+        ]);
+
+        $this->assertCount(2, $this->encryptableCookies);
+        $this->assertSame('baz', $this->encryptableCookies['foo']);
+        $this->assertSame('new-value', $this->encryptableCookies['new-cookie']);
+    }
 }
 
 class MyMiddleware

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -76,7 +76,7 @@ class MakesHttpRequestsTest extends TestCase
 
     public function testWithEncryptableCookieSetCookie()
     {
-        $this->withEncryptable('foo', 'bar');
+        $this->withEncryptableCookie('foo', 'bar');
 
         $this->assertCount(1, $this->encryptableCookies);
         $this->assertSame('bar', $this->encryptableCookies['foo']);
@@ -84,8 +84,8 @@ class MakesHttpRequestsTest extends TestCase
 
     public function testWithEncryptableCookiesSetsCookiesAndOverwritesPreviousValues()
     {
-        $this->withCookie('foo', 'bar');
-        $this->withCookies([
+        $this->withEncryptableCookie('foo', 'bar');
+        $this->withEncryptableCookies([
             'foo' => 'baz',
             'new-cookie' => 'new-value',
         ]);

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -74,25 +74,25 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('new-value', $this->defaultCookies['new-cookie']);
     }
 
-    public function testWithEncryptableCookieSetCookie()
+    public function testWithUnencryptedCookieSetCookie()
     {
-        $this->withEncryptableCookie('foo', 'bar');
+        $this->withUnencryptedCookie('foo', 'bar');
 
-        $this->assertCount(1, $this->encryptableCookies);
-        $this->assertSame('bar', $this->encryptableCookies['foo']);
+        $this->assertCount(1, $this->unencryptedCookies);
+        $this->assertSame('bar', $this->unencryptedCookies['foo']);
     }
 
-    public function testWithEncryptableCookiesSetsCookiesAndOverwritesPreviousValues()
+    public function testWithUnencryptedCookiesSetsCookiesAndOverwritesPreviousValues()
     {
-        $this->withEncryptableCookie('foo', 'bar');
-        $this->withEncryptableCookies([
+        $this->withUnencryptedCookie('foo', 'bar');
+        $this->withUnencryptedCookies([
             'foo' => 'baz',
             'new-cookie' => 'new-value',
         ]);
 
-        $this->assertCount(2, $this->encryptableCookies);
-        $this->assertSame('baz', $this->encryptableCookies['foo']);
-        $this->assertSame('new-value', $this->encryptableCookies['new-cookie']);
+        $this->assertCount(2, $this->unencryptedCookies);
+        $this->assertSame('baz', $this->unencryptedCookies['foo']);
+        $this->assertSame('new-value', $this->unencryptedCookies['new-cookie']);
     }
 }
 


### PR DESCRIPTION
This PR provide a way to specify cookies will not be encrypted before sending with the request.

```php
$this->withCookie('bar', 'qux')
     ->withUnencryptedCookie('foo', 'bar')
     ->get('/');
```

```php
$this->withCookies($cookies) // cookies will be encrypted
     ->withUnencryptedCookies($unencryptedCookies) // cookies will not be encrypted
     ->get('/');
```

Fixes #31282