### PR TITLE
HasAttributes: Stricter versions of isDirty and wasChanged

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1074,6 +1074,19 @@ trait HasAttributes
     }
 
     /**
+     * Determine if only given attribute(s) have been modified.
+     *
+     * @param  array|string  $attributes
+     * @return bool
+     */
+    public function isOnlyDirtyFor($attributes)
+    {
+        return $this->hasChangesOnly(
+            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
+        );
+    }
+
+    /**
      * Determine if the model and all the given attribute(s) have remained the same.
      *
      * @param  array|string|null  $attributes
@@ -1085,7 +1098,7 @@ trait HasAttributes
     }
 
     /**
-     * Determine if the model or any of the given attribute(s) have been modified.
+     * Determine if the model or any of the given attribute(s) have been changed.
      *
      * @param  array|string|null  $attributes
      * @return bool
@@ -1093,6 +1106,19 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
+            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
+        );
+    }
+
+    /**
+     * Determine if only the given attribute(s) have been changed.
+     *
+     * @param  array|string  $attributes
+     * @return bool
+     */
+    public function wasOnlyChangedFor($attributes)
+    {
+        return $this->hasChangesOnly(
             $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
         );
     }
@@ -1123,6 +1149,18 @@ trait HasAttributes
         }
 
         return false;
+    }
+
+    /**
+     * Determine if only the given attributes were changed.
+     *
+     * @param  array  $changes
+     * @param  array|string  $attributes
+     * @return bool
+     */
+    protected function hasChangesOnly($changes, $attributes)
+    {
+        return Arr::wrap($attributes) == array_keys($changes);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -89,6 +89,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->isDirty('bar'));
         $this->assertTrue($model->isDirty('foo', 'bar'));
         $this->assertTrue($model->isDirty(['foo', 'bar']));
+
+        $this->assertTrue($model->isOnlyDirtyFor(['bar', 'baz']));
+        $this->assertTrue($model->isOnlyDirtyFor('bar', 'baz'));
+        $this->assertFalse($model->isOnlyDirtyFor(['foo', 'bar', 'baz']));
+        $this->assertFalse($model->isOnlyDirtyFor('foo', 'bar', 'baz'));
+        $this->assertFalse($model->isOnlyDirtyFor(['foo']));
+        $this->assertFalse($model->isOnlyDirtyFor('foo'));
     }
 
     public function testDirtyOnCastOrDateAttributes()
@@ -114,6 +121,13 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty('boolAttribute'));
         $this->assertFalse($model->isDirty('dateAttribute'));
         $this->assertTrue($model->isDirty('datetimeAttribute'));
+
+        $this->assertTrue($model->isOnlyDirtyFor(['foo', 'bar', 'datetimeAttribute']));
+        $this->assertTrue($model->isOnlyDirtyFor('foo', 'bar', 'datetimeAttribute'));
+        $this->assertFalse($model->isOnlyDirtyFor('foo'));
+        $this->assertFalse($model->isOnlyDirtyFor('foo', 'bar'));
+        $this->assertFalse($model->isOnlyDirtyFor('foo', 'boolAttribute'));
+        $this->assertFalse($model->isOnlyDirtyFor(['boolAttribute', 'dateAttribute', 'datetimeAttribute']));
     }
 
     public function testDirtyOnCastedObjects()
@@ -131,6 +145,11 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isDirty());
         $this->assertFalse($model->isDirty('objectAttribute'));
         $this->assertFalse($model->isDirty('collectionAttribute'));
+        $this->assertFalse($model->isDirty(['objectAttribute', 'collectionAttribute']));
+
+        $this->assertFalse($model->isOnlyDirtyFor('objectAttribute'));
+        $this->assertFalse($model->isOnlyDirtyFor('collectionAttribute'));
+        $this->assertFalse($model->isOnlyDirtyFor(['objectAttribute', 'collectionAttribute']));
     }
 
     public function testCleanAttributes()

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -61,6 +61,11 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEmpty($user->getChanges());
         $this->assertTrue($user->isDirty());
         $this->assertFalse($user->wasChanged());
+        $this->assertTrue($user->isOnlyDirtyFor('name'));
+        $this->assertFalse($user->isOnlyDirtyFor('name', 'title'));
+        $this->assertFalse($user->wasChanged());
+        $this->assertFalse($user->wasOnlyChangedFor('name'));
+        $this->assertFalse($user->wasOnlyChangedFor('name', 'title'));
 
         $user->save();
 
@@ -68,6 +73,8 @@ class EloquentModelTest extends DatabaseTestCase
         $this->assertEquals(['name' => $name], $user->getChanges());
         $this->assertTrue($user->wasChanged());
         $this->assertTrue($user->wasChanged('name'));
+        $this->assertTrue($user->wasOnlyChangedFor('name'));
+        $this->assertFalse($user->wasOnlyChangedFor('name', 'title'));
     }
 }
 


### PR DESCRIPTION
# HasAttributes: Stricter versions of isDirty and wasChanged

When using `isDirty()` or `wasChanged()` with attributes, the current implementation will look for **at least** one among the dirty or changed attributes on a model. I don't think there is a way to strictly verify that one or multiple attributes are **the only ones** dirty or changed.

This is a draft in order to add support for the following methods:
- `isOnlyDirtyFor($attributes)`
- `wasOnlyChangedFor($attributes)`

## Basic Usage

```php
$post->title = 'Foo Bar';
$post->slug = 'foo-bar';

$post->isOnlyDirtyFor('title'); // true
```

### With more than one attribute

```php
$post->title = 'Foo Bar';
$post->slug = 'foo-bar';

$post->isOnlyDirtyFor('title'); // false
$post->isOnlyDirtyFor('title', 'slug'); // true
$post->isOnlyDirtyFor(['title', 'slug']); // true
```

### isDirty() still behaves as usual

```php
$post->title = 'Foo Bar';

$post->isDirty(); // true
$post->isDirty('name'); // true
$post->isDirty('name', 'slug'); // true
$post->isDirty(['name', 'slug']); // true

$post->isOnlyDirtyFor('title'); // true
$post->isOnlyDirtyFor('title', 'slug'); // false
$post->isOnlyDirtyFor(['title', 'slug']); // false
```

The same logic applies for the couple `wasChanged()` / `wasOnlyChangedFor()`.