### PR TITLE
get auth guard  without  passing name to guard

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -63,9 +63,39 @@ class AuthManager implements FactoryContract
      */
     public function guard($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = $name ?: $this->getAuthGaurd();
+        return $this->getGaurd($name);
+    }
+     /**
+     * Attempt to get gaurd
+     *
+     * @param  string  $name
+     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     */
+
+
+    public function getGaurd($name)
+    {
 
         return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
+    }
+
+
+    /**
+     * Attempt to get the auth guard  name from the local cache.
+     *
+     * @return string $name
+     */
+    public function getAuthGaurd()
+    {
+        $guards = $this->app['config']['auth']['guards'];
+
+        foreach($guards as $name=>$guard){
+            if($this->getGaurd($name)) return $name;
+
+        }
+
+        return $this->getDefaultDriver();
     }
 
     /**


### PR DESCRIPTION
Hi developers 
while i am coding on project using auth guard  sometimes i fond myself coding same thing for tow guards.
why we use name of the guard to get auth user ?? why not auto get auth guard  ??
that why i have contribute to our popular  laravel framework
feel free to add this function.

thanks (*-*)

