### PR TITLE
[7.x] getting  auth guard  without passing name to guard method

### DIFF
--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -88,7 +88,7 @@ class AuthManager implements FactoryContract
     {
         $guards = $this->app['config']['auth']['guards'];
 
-        foreach($guards as $name=>$guard){
+        foreach(array_keys($guards) as $name){
             if($this->getGuard($name)) return $name;
 
         }

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -54,8 +54,7 @@ class AuthManager implements FactoryContract
             return $this->guard($guard)->user();
         };
     }
-
-    /**
+     /**
      * Attempt to get the guard from the local cache.
      *
      * @param  string|null  $name
@@ -63,9 +62,38 @@ class AuthManager implements FactoryContract
      */
     public function guard($name = null)
     {
-        $name = $name ?: $this->getDefaultDriver();
+        $name = $name ?: $this->getAuthGaurd();
+        return $this->getGuard($name);
+    }
+     /**
+     * Attempt to get guard
+     *
+     * @param  string  $name
+     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     */
+
+
+    public function getGuard($name)
+    {
 
         return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
+    }
+    /**
+     * Attempt to get the auth guard  name from the local cache.
+     *
+     * @return string $name
+     */
+    
+    public function getAuthGuard()
+    {
+        $guards = $this->app['config']['auth']['guards'];
+
+        foreach($guards as $name=>$guard){
+            if($this->getGuard($name)) return $name;
+
+        }
+
+        return $this->getDefaultDriver();
     }
 
     /**

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -88,7 +88,7 @@ class AuthManager implements FactoryContract
         $guards = $this->app['config']['auth']['guards'];
 
         foreach (array_keys($guards) as $name) {
-            if ($this->getGuard($name)) {
+            if ($this->getGuard($name)->check()) {
 
                 return $name;
             }

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -54,7 +54,7 @@ class AuthManager implements FactoryContract
             return $this->guard($guard)->user();
         };
     }
-     /**
+    /**
      * Attempt to get the guard from the local cache.
      *
      * @param  string|null  $name
@@ -65,37 +65,37 @@ class AuthManager implements FactoryContract
         $name = $name ?: $this->getAuthGaurd();
         return $this->getGuard($name);
     }
-     /**
+
+    /**
      * Attempt to get guard
      *
      * @param  string  $name
      * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
-
-
-    public function getGuard($name)
+    protected function getGuard($name)
     {
 
         return $this->guards[$name] ?? $this->guards[$name] = $this->resolve($name);
     }
+
     /**
      * Attempt to get the auth guard  name from the local cache.
      *
      * @return string $name
      */
-    
-    public function getAuthGuard()
+    protected function getAuthGuard()
     {
         $guards = $this->app['config']['auth']['guards'];
 
-        foreach(array_keys($guards) as $name){
-            if($this->getGuard($name)) return $name;
+        foreach (array_keys($guards) as $name) {
+            if ($this->getGuard($name)) {
 
+                return $name;
+            }
         }
 
         return $this->getDefaultDriver();
     }
-
     /**
      * Resolve the given guard.
      *
@@ -116,7 +116,7 @@ class AuthManager implements FactoryContract
             return $this->callCustomCreator($name, $config);
         }
 
-        $driverMethod = 'create'.ucfirst($config['driver']).'Driver';
+        $driverMethod = 'create' . ucfirst($config['driver']) . 'Driver';
 
         if (method_exists($this, $driverMethod)) {
             return $this->{$driverMethod}($name, $config);


### PR DESCRIPTION
Hi developers
while i am coding on a project using auth guard sometimes i found myself coding the same thing for tow guards.

why we use the name of the guard to get auth guard ?? why not auto get auth guard from laravel ??

- before
```
          auth()->guard() // return default guard
          auth()->guard($name) // return guard
  ```
- now
```
          auth()->guard($name) // return guard
          auth()->guard() // return guard if auth guard else return default guard
```
thanks (*_*)