### PR TITLE
[6.x] Fix docblocks of dispatch method return type

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -165,7 +165,7 @@ class Dispatcher implements DispatcherContract
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return array|null
+     * @return mixed
      */
     public function until($event, $payload = [])
     {
@@ -178,7 +178,7 @@ class Dispatcher implements DispatcherContract
      * @param  string|object  $event
      * @param  mixed  $payload
      * @param  bool  $halt
-     * @return array|null
+     * @return mixed
      */
     public function dispatch($event, $payload = [], $halt = false)
     {

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -189,7 +189,7 @@ class EventFake implements Dispatcher
      * @param  string|object  $event
      * @param  mixed  $payload
      * @param  bool  $halt
-     * @return array|null
+     * @return mixed
      */
     public function dispatch($event, $payload = [], $halt = false)
     {
@@ -250,7 +250,7 @@ class EventFake implements Dispatcher
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return void
+     * @return mixed
      */
     public function until($event, $payload = [])
     {


### PR DESCRIPTION
It seems that it is perfectly possible to return any value from the dispatch method, when the $halt is true. The same is also true for until. 
The sample below:
```
$t = function () {
    return 'hello';
};
Event::listen('a', $t);
$resp = Event::dispatch('a', [], true);
dd(is_string($resp) and $resp === 'hello');  // true

```
I did not touched the interface doc blocks.
You may change them yourself later on or I can force push a commit for that if needed.


