### PR TITLE
Revert "[6.x] Fix error with set serializer for createClient"

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -98,8 +98,8 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
 
-            if (! empty($config['serializer'])) {
-                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            if (! empty($options['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $options['serializer']);
             }
 
             if (! empty($config['scan'])) {


### PR DESCRIPTION
The other PR broke the tests:

```
There were 7 failures:

1) Illuminate\Tests\Redis\RedisConnectionTest::testItAddsMembersToSortedSet

Failed asserting that false matches expected 100.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:165

2) Illuminate\Tests\Redis\RedisConnectionTest::testItIncrementsScoreOfSortedSet

Failed asserting that 2.0 matches expected 3.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:189

3) Illuminate\Tests\Redis\RedisConnectionTest::testItCalculatesIntersectionOfSortedSetsAndStores

Failed asserting that false matches expected 3.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:233

4) Illuminate\Tests\Redis\RedisConnectionTest::testItCalculatesUnionOfSortedSetsAndStores

Failed asserting that false matches expected 3.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:262

5) Illuminate\Tests\Redis\RedisConnectionTest::testItReturnsRankInSortedSet

Failed asserting that false matches expected 2.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:360

6) Illuminate\Tests\Redis\RedisConnectionTest::testItReturnsScoreInSortedSet

Failed asserting that false matches expected 1.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:371

7) Illuminate\Tests\Redis\RedisConnectionTest::testItRemovesMembersInSortedSet

Failed asserting that 4 matches expected 3.

/home/travis/build/laravel/framework/tests/Redis/RedisConnectionTest.php:384
```


---

Reverts laravel/framework#31393