### PR TITLE
[6.x] Fixes issue for has_listeners method on dispatcher

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -104,7 +104,17 @@ class Dispatcher implements DispatcherContract
      */
     public function hasListeners($eventName)
     {
-        return isset($this->listeners[$eventName]) || isset($this->wildcards[$eventName]);
+        $hasWildcard = function ($eventName) {
+            foreach ($this->wildcards as $key => $listeners) {
+                if (Str::is($key, $eventName)) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        return isset($this->listeners[$eventName]) || isset($this->wildcards[$eventName]) || $hasWildcard($eventName);
     }
 
     /**

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -192,6 +192,7 @@ class EventsDispatcherTest extends TestCase
             //
         });
         $this->assertTrue($d->hasListeners('foo.*'));
+        $this->assertTrue($d->hasListeners('foo.bar'));
     }
 
     public function testEventPassedFirstToWildcards()


### PR DESCRIPTION
Currently the has_listeners method on the dispatcher class is not able to detect the listeners with wildcards, but getListeners() method can detect and return such listeners.
I also added test to cover that.

And of course because the || operator is lazy in php, it does not go for execution of the closure in cases, the first two conditions are true.

The below code demonstrates that :
```php
        Event::listen('foo.*', function () {
            //
        });
        Event::hasListeners('foo.bar'); // false
        Event::getListeners('foo.bar'); // returns closure !
```