### PR TITLE
[7.x] Override custom error view more easily

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -401,7 +401,7 @@ class Handler implements ExceptionHandlerContract
     {
         $this->registerErrorViewPaths();
 
-        if (view()->exists($view = "errors::{$e->getStatusCode()}")) {
+        if (view()->exists($view = $this->getHttpExceptionView($e))) {
             return response()->view($view, [
                 'errors' => new ViewErrorBag,
                 'exception' => $e,
@@ -409,6 +409,17 @@ class Handler implements ExceptionHandlerContract
         }
 
         return $this->convertExceptionToResponse($e);
+    }
+
+    /**
+     * Get the view used to render HTTP exceptions.
+     *
+     * @param  \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface  $e
+     * @return string
+     */
+    protected function getHttpExceptionView(HttpExceptionInterface $e)
+    {
+        return "errors::{$e->getStatusCode()}";
     }
 
     /**


### PR DESCRIPTION
At the moment I have to override the `renderHttpException` method to use a custom error view. Maybe it's a idea to have something like this that will make it easy to override the new `getHttpExceptionView` method.

Would love to get some feedback 🙏