### PR TITLE
[6.x] Added command for listing all commands and respective classes

### DIFF
--- a/src/Illuminate/Foundation/Console/CommandsListCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandsListCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+
+use Illuminate\Console\Command;
+
+
+class CommandsListCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'commands:list';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List all registered commands';
+
+    /**
+     * The table headers for the command.
+     *
+     * @var array
+     */
+    protected $headers = ['Signature', 'Class'];
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        
+        $commands = collect(Artisan::all())->map(function($command){
+            return $this->getCommandInformation($command);
+        })->toArray();
+
+        $this->table($this->getHeaders(), $commands);
+    }
+
+    /**
+     * Get the route information for a given command.
+     *
+     * @param  Symfony\Component\Console\Command\Command $command
+     * @return array
+     */
+    protected function getCommandInformation(SymfonyCommand $command)
+    {
+        return [
+            'signature' => $command->getName(),
+            'namespace' => get_class($command)
+        ];
+    }
+
+    /**
+     * Get the table headers for the visible columns.
+     *
+     * @return array
+     */
+    protected function getHeaders()
+    {
+        return $this->headers;
+    }
+}

--- a/src/Illuminate/Foundation/Console/CommandsListCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandsListCommand.php
@@ -4,6 +4,8 @@ namespace Illuminate\Foundation\Console;
 
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 
 class CommandsListCommand extends Command

--- a/src/Illuminate/Foundation/Console/CommandsListCommand.php
+++ b/src/Illuminate/Foundation/Console/CommandsListCommand.php
@@ -29,7 +29,7 @@ class CommandsListCommand extends Command
      *
      * @var array
      */
-    protected $headers = ['Signature', 'Class'];
+    protected $headers = ['Name', 'Class'];
 
     /**
      * Create a new command instance.
@@ -65,7 +65,7 @@ class CommandsListCommand extends Command
     protected function getCommandInformation(SymfonyCommand $command)
     {
         return [
-            'signature' => $command->getName(),
+            'name' => $command->getName(),
             'namespace' => get_class($command)
         ];
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently, there is no "easy" way to see the class responsible for handling the command. 
Many times I find myself ( maybe some other devs too ) inside `vendor` directory to find the class behind a command. This pull request can help us find the required command's class quickly. 

`php artisan commands:list` is inspired from `route:list` command. 
An option can be added to `php artisan list` command like `php artisan list --class` but I think it will make the existing output cluttered. 

A sample output of this command can be seen below:
![image](https://user-images.githubusercontent.com/29105478/74104033-ad0eba80-4b72-11ea-941f-03f68ea623e6.png)

Let me know your thoughts :) 

Thank you!