### PR TITLE
[6.x] Ensure Application::$terminatingCallbacks are reset on Application::flush()

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1217,9 +1217,9 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->reboundCallbacks = [];
         $this->serviceProviders = [];
         $this->resolvingCallbacks = [];
+        $this->terminatingCallbacks = [];
         $this->afterResolvingCallbacks = [];
         $this->globalResolvingCallbacks = [];
-        $this->terminatingCallbacks = [];
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1219,6 +1219,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
         $this->resolvingCallbacks = [];
         $this->afterResolvingCallbacks = [];
         $this->globalResolvingCallbacks = [];
+        $this->terminatingCallbacks = [];
     }
 
     /**


### PR DESCRIPTION
I recently registered a terminating callback in the constructor of one of my services e.g. 

```php
$this->container->terminating(function () {
    $this->doSomething();
});
```

When I ran my application test suite, the memory usage went crazy. Turns out the event listeners for $terminatingCallbacks weren't being cleared out between tests, causing a memory leak.

This change clears out the $terminatingCallbacks array in the Application::flush() method.