### PR TITLE
[6.x] Remove serializer option for now

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -98,10 +98,6 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
 
-            if (! empty($config['serializer'])) {
-                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
-            }
-
             if (! empty($config['scan'])) {
                 $client->setOption(Redis::OPT_SCAN, $config['scan']);
             }
@@ -160,16 +156,12 @@ class PhpRedisConnector implements Connector
                 $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
             }
 
-            if (! empty($options['serializer'])) {
-                $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
+            if (! empty($options['scan'])) {
+                $client->setOption(RedisCluster::OPT_SCAN, $options['scan']);
             }
 
-            if (! empty($config['scan'])) {
-                $client->setOption(RedisCluster::OPT_SCAN, $config['scan']);
-            }
-
-            if (! empty($config['failover'])) {
-                $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $config['failover']);
+            if (! empty($options['failover'])) {
+                $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
             }
         });
     }


### PR DESCRIPTION
Apparently when https://github.com/laravel/framework/pull/31393 was merged it broke the test suite because the test suite was now actually running with the proper tests to verify the serializer behavior. This actually showed that the serializer option never worked in the first place. 

This PR will remove the broken serializer option for now. If anyone wants to tackle implementing it again with passing tests they can attempt a new PR.

I also fixed two incorrect variable names.