### PR TITLE
[6.x] Support dispatchAfterResponse in BusFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -178,7 +178,8 @@ class BusFake implements Dispatcher
      * @param  callable|null  $callback
      * @return \Illuminate\Support\Collection
      */
-    public function dispatchedAfterResponse(string $command, $callback = null) {
+    public function dispatchedAfterResponse(string $command, $callback = null)
+    {
         if (! $this->hasDispatchedAfterResponse($command)) {
             return collect();
         }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -31,6 +31,13 @@ class BusFake implements Dispatcher
     protected $commands = [];
 
     /**
+     * The commands that have been dispatched after the response has been sent.
+     *
+     * @var array
+     */
+    protected $commandsAfterResponse = [];
+
+    /**
      * Create a new bus fake instance.
      *
      * @param  \Illuminate\Contracts\Bus\Dispatcher  $dispatcher
@@ -79,6 +86,21 @@ class BusFake implements Dispatcher
     }
 
     /**
+     * Assert if a job was pushed after the response was sent a number of times.
+     *
+     * @param  string  $command
+     * @param  int  $times
+     * @return void
+     */
+    public function assertDispatchedAfterResponseTimes($command, $times = 1)
+    {
+        PHPUnit::assertTrue(
+            ($count = $this->dispatchedAfterResponse($command)->count()) === $times,
+            "The expected [{$command}] job was pushed {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
      * Determine if a job was dispatched based on a truth-test callback.
      *
      * @param  string  $command
@@ -90,6 +112,40 @@ class BusFake implements Dispatcher
         PHPUnit::assertTrue(
             $this->dispatched($command, $callback)->count() === 0,
             "The unexpected [{$command}] job was dispatched."
+        );
+    }
+
+    /**
+     * Determine if a job was dispatched based on a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|null  $callback
+     * @return void
+     */
+    public function assertNotDispatchedAfterResponse($command, $callback = null)
+    {
+        PHPUnit::assertTrue(
+            $this->dispatchedAfterResponse($command, $callback)->count() === 0,
+            "The unexpected [{$command}] job was dispatched for after sending the response."
+        );
+    }
+
+    /**
+     * Assert if a job was dispatched after the response was sent based on a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|int|null  $callback
+     * @return void
+     */
+    public function assertDispatchedAfterResponse($command, $callback = null)
+    {
+        if (is_numeric($callback)) {
+            return $this->assertDispatchedAfterResponseTimes($command, $callback);
+        }
+
+        PHPUnit::assertTrue(
+            $this->dispatchedAfterResponse($command, $callback)->count() > 0,
+            "The expected [{$command}] job was not dispatched for after sending the response."
         );
     }
 
@@ -116,6 +172,27 @@ class BusFake implements Dispatcher
     }
 
     /**
+     * Get all of the jobs dispatched after the response was sent matching a truth-test callback.
+     *
+     * @param  string  $command
+     * @param  callable|null  $callback
+     * @return \Illuminate\Support\Collection
+     */
+    public function dispatchedAfterResponse(string $command, $callback = null) {
+        if (! $this->hasDispatchedAfterResponse($command)) {
+            return collect();
+        }
+
+        $callback = $callback ?: function () {
+            return true;
+        };
+
+        return collect($this->commandsAfterResponse[$command])->filter(function ($command) use ($callback) {
+            return $callback($command);
+        });
+    }
+
+    /**
      * Determine if there are any stored commands for a given class.
      *
      * @param  string  $command
@@ -124,6 +201,17 @@ class BusFake implements Dispatcher
     public function hasDispatched($command)
     {
         return isset($this->commands[$command]) && ! empty($this->commands[$command]);
+    }
+
+    /**
+     * Determine if there are any stored commands for a given class.
+     *
+     * @param  string  $command
+     * @return bool
+     */
+    public function hasDispatchedAfterResponse($command)
+    {
+        return isset($this->commandsAfterResponse[$command]) && ! empty($this->commandsAfterResponse[$command]);
     }
 
     /**
@@ -154,6 +242,21 @@ class BusFake implements Dispatcher
             $this->commands[get_class($command)][] = $command;
         } else {
             return $this->dispatcher->dispatchNow($command, $handler);
+        }
+    }
+
+    /**
+     * Dispatch a command to its appropriate handler.
+     *
+     * @param  mixed  $command
+     * @return mixed
+     */
+    public function dispatchAfterResponse($command)
+    {
+        if ($this->shouldFakeJob($command)) {
+            $this->commandsAfterResponse[get_class($command)][] = $command;
+        } else {
+            return $this->dispatcher->dispatch($command);
         }
     }
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -40,6 +40,20 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertDispatched(BusJobStub::class);
     }
 
+    public function testAssertDispatchedAfterResponse()
+    {
+        try {
+            $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched for after sending the response.'));
+        }
+
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
+    }
+
     public function testAssertDispatchedNow()
     {
         $this->fake->dispatchNow(new BusJobStub);
@@ -60,6 +74,21 @@ class SupportTestingBusFakeTest extends TestCase
         }
 
         $this->fake->assertDispatched(BusJobStub::class, 2);
+    }
+
+    public function testAssertDispatchedAfterResponseWithCallbackInt()
+    {
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedAfterResponse(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatchedAfterResponse(BusJobStub::class, 2);
     }
 
     public function testAssertDispatchedWithCallbackFunction()
@@ -85,6 +114,29 @@ class SupportTestingBusFakeTest extends TestCase
         });
     }
 
+    public function testAssertDispatchedAfterResponseWithCallbackFunction()
+    {
+        $this->fake->dispatchAfterResponse(new OtherBusJobStub);
+        $this->fake->dispatchAfterResponse(new OtherBusJobStub(1));
+
+        try {
+            $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+                return $job->id === 0;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\OtherBusJobStub] job was not dispatched for after sending the response.'));
+        }
+
+        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+            return $job->id === null;
+        });
+
+        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+            return $job->id === 1;
+        });
+    }
+
     public function testAssertDispatchedTimes()
     {
         $this->fake->dispatch(new BusJobStub);
@@ -100,6 +152,21 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertDispatchedTimes(BusJobStub::class, 2);
     }
 
+    public function testAssertDispatchedAfterResponseTimes()
+    {
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        try {
+            $this->fake->assertDispatchedAfterResponseTimes(BusJobStub::class, 1);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was pushed 2 times instead of 1 times.'));
+        }
+
+        $this->fake->assertDispatchedAfterResponseTimes(BusJobStub::class, 2);
+    }
+
     public function testAssertNotDispatched()
     {
         $this->fake->assertNotDispatched(BusJobStub::class);
@@ -112,6 +179,20 @@ class SupportTestingBusFakeTest extends TestCase
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched.'));
+        }
+    }
+
+    public function testAssertNotDispatchedAfterResponse()
+    {
+        $this->fake->assertNotDispatchedAfterResponse(BusJobStub::class);
+
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatchedAfterResponse(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched for after sending the response.'));
         }
     }
 


### PR DESCRIPTION
This PR aims to solve the issue I reported in #31416 by adding the required methods to the `BusFake`

I'm not sure wether separating them into a different array of commands was necessary, but I felt like you should be able to assert that a job will be executed _after_ teminating the request instead of whenever.