### PR TITLE
[7.x] Custom component prefix

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -13,6 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static void if(string $name, callable $callback)
  * @method static bool check(string $name, array ...$parameters)
  * @method static void component(string $path, string|null $alias = null)
+ * @method static void prefix(string $prefix)
  * @method static void include(string $path, string|null $alias = null)
  * @method static void directive(string $name, callable $handler)
  * @method static array getCustomDirectives()

--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -13,7 +13,7 @@ namespace Illuminate\Support\Facades;
  * @method static void if(string $name, callable $callback)
  * @method static bool check(string $name, array ...$parameters)
  * @method static void component(string $path, string|null $alias = null)
- * @method static void prefix(string $prefix)
+ * @method static void componentPrefix(string $componentPrefix)
  * @method static void include(string $path, string|null $alias = null)
  * @method static void directive(string $name, callable $handler)
  * @method static array getCustomDirectives()

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -128,6 +128,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $compilesComponentTags = true;
 
     /**
+     * The default component prefix.
+     *
+     * @var string
+     */
+    public static $componentPrefix = 'x';
+
+    /**
      * Compile the view at the given path.
      *
      * @param  string|null  $path
@@ -569,6 +576,17 @@ class BladeCompiler extends Compiler implements CompilerInterface
                 static::component($key, $value, $prefix);
             }
         }
+    }
+
+    /**
+     * Set the default component prefix.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function prefix($prefix)
+    {
+        self::$componentPrefix = $prefix;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -581,12 +581,12 @@ class BladeCompiler extends Compiler implements CompilerInterface
     /**
      * Set the default component prefix.
      *
-     * @param  string  $prefix
+     * @param  string  $componentPrefix
      * @return void
      */
-    public function prefix($prefix)
+    public function componentPrefix($componentPrefix)
     {
-        self::$componentPrefix = $prefix;
+        self::$componentPrefix = $componentPrefix;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -68,10 +68,12 @@ class ComponentTagCompiler
      */
     protected function compileOpeningTags(string $value)
     {
+        $prefix = BladeCompiler::$componentPrefix;
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                {$prefix}[-\:]([\w\-\:\.]*)
                 (?<attributes>
                     (?:
                         \s+
@@ -108,10 +110,12 @@ class ComponentTagCompiler
      */
     protected function compileSelfClosingTags(string $value)
     {
+        $prefix = BladeCompiler::$componentPrefix;
+
         $pattern = "/
             <
                 \s*
-                x[-\:]([\w\-\:\.]*)
+                {$prefix}[-\:]([\w\-\:\.]*)
                 \s*
                 (?<attributes>
                     (?:
@@ -223,7 +227,9 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value)
     {
-        return preg_replace("/<\/\s*x[-\:][\w\-\:\.]*\s*>/", '@endcomponentClass', $value);
+        $prefix = BladeCompiler::$componentPrefix;
+
+        return preg_replace("/<\/\s*{$prefix}[-\:][\w\-\:\.]*\s*>/", '@endcomponentClass', $value);
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\View\Blade;
 
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;
 use Mockery;
@@ -122,6 +123,19 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?>
 @endcomponentClass", trim($result));
+    }
+
+    public function testCustomPrefixComponents()
+    {
+        BladeCompiler::$componentPrefix = 'z';
+
+        $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<z-alert></z-alert>');
+
+        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withAttributes([]); ?>@endcomponentClass", trim($result));
+
+        // Reset prefix back to default...
+        BladeCompiler::$componentPrefix = 'x';
     }
 }
 


### PR DESCRIPTION
Set a custom prefix for components.

```php
Blade::prefix('z');
```