### PR TITLE
[6.x] Add whereNull and whereNotNull to Collection

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -493,7 +493,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is null.
+     * Filter items where the given key is not null.
      *
      * @param  string  $key
      * @return static
@@ -504,7 +504,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is not null.
+     * Filter items where the given key is null.
      *
      * @param  string  $key
      * @return static

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -498,7 +498,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @return static
      */
-    public function whereNull($key)
+    public function whereNull($key = null)
     {
         return $this->whereStrict($key, null);
     }
@@ -509,7 +509,7 @@ trait EnumeratesValues
      * @param  string  $key
      * @return static
      */
-    public function whereNotNull($key)
+    public function whereNotNull($key = null)
     {
         return $this->where($key, '!==', null);
     }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -493,6 +493,28 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items where the given key is null.
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public function whereNull($key)
+    {
+        return $this->where($key, null);
+    }
+
+    /**
+     * Filter items where the given key is not null.
+     *
+     * @param  string  $key
+     * @return static
+     */
+    public function whereNotNull($key)
+    {
+        return $this->where($key, '!=', null);
+    }
+
+    /**
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -500,7 +500,7 @@ trait EnumeratesValues
      */
     public function whereNull($key)
     {
-        return $this->where($key, null);
+        return $this->whereStrict($key, null);
     }
 
     /**
@@ -511,7 +511,7 @@ trait EnumeratesValues
      */
     public function whereNotNull($key)
     {
-        return $this->where($key, '!=', null);
+        return $this->where($key, '!==', null);
     }
 
     /**

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -495,7 +495,7 @@ trait EnumeratesValues
     /**
      * Filter items where the given key is not null.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @return static
      */
     public function whereNull($key = null)
@@ -506,7 +506,7 @@ trait EnumeratesValues
     /**
      * Filter items where the given key is null.
      *
-     * @param  string  $key
+     * @param  string|null  $key
      * @return static
      */
     public function whereNotNull($key = null)

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3917,6 +3917,8 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Taylor'],
             ['name' => null],
             ['name' => 'Bert'],
+            ['name' => false],
+            ['name' => ''],
         ]);
 
         $this->assertSame([
@@ -3933,11 +3935,15 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Taylor'],
             ['name' => null],
             ['name' => 'Bert'],
+            ['name' => false],
+            ['name' => ''],
         ]);
 
         $this->assertSame([
             0 => ['name' => 'Taylor'],
             2 => ['name' => 'Bert'],
+            3 => ['name' => false],
+            4 => ['name' => ''],
         ], $data->whereNotNull('name')->all());
     }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3911,6 +3911,39 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhereNull($collection)
+    {
+        $data = new $collection([
+            ['name' => 'Taylor'],
+            ['name' => null],
+            ['name' => 'Bert'],
+        ]);
+
+        $this->assertSame([
+            1 => ['name' => null],
+        ], $data->whereNull('name')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNotNull($collection)
+    {
+        $data = new $collection([
+            ['name' => 'Taylor'],
+            ['name' => null],
+            ['name' => 'Bert'],
+        ]);
+
+        $this->assertSame([
+            0 => ['name' => 'Taylor'],
+            2 => ['name' => 'Bert'],
+        ], $data->whereNotNull('name')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCollect($collection)
     {
         $data = $collection::make([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3924,6 +3924,19 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([
             1 => ['name' => null],
         ], $data->whereNull('name')->all());
+
+        $this->assertSame([], $data->whereNull()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNullWithoutKey($collection)
+    {
+        $collection = new $collection([1, null, 3, 'null', false, true]);
+        $this->assertSame([
+            1 => null,
+        ], $collection->whereNull()->all());
     }
 
     /**
@@ -3931,7 +3944,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testWhereNotNull($collection)
     {
-        $data = new $collection([
+        $data = new $collection($originalData = [
             ['name' => 'Taylor'],
             ['name' => null],
             ['name' => 'Bert'],
@@ -3945,6 +3958,24 @@ class SupportCollectionTest extends TestCase
             3 => ['name' => false],
             4 => ['name' => ''],
         ], $data->whereNotNull('name')->all());
+
+        $this->assertSame($originalData, $data->whereNotNull()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testWhereNotNullWithoutKey($collection)
+    {
+        $data = new $collection([1, null, 3, 'null', false, true]);
+
+        $this->assertSame([
+            0 => 1,
+            2 => 3,
+            3 => 'null',
+            4 => false,
+            5 => true,
+        ], $data->whereNotNull()->all());
     }
 
     /**


### PR DESCRIPTION
This PR adds `whereNull` and `whereNotNull` methods to the Collection class.

These methods are already available when building a query:
```php
$users = User::whereNotNull('email_verified_at')->get();
```

But as soon as you have a collection, you need to do this instead:
```php
$users = User::all();

$unverifiedUsers = $users->whereStrict('is_verified_at', null);

$verifiedUsers = $users->where('is_verified_at', '!==', null);
```

With this PR, you can do this instead:
```php
$users = User::all();

$unverifiedUsers = $users->whereNull('is_verified_at');

$verifiedUsers = $users->whereNotNull('is_verified_at');
```