### PR TITLE
[6.x] Allow appending of rows to Artisan tables

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -218,11 +218,11 @@ trait InteractsWithIO
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
      * @param  string  $tableStyle
      * @param  array  $columnStyles
-     * @return void
+     * @return \Symfony\Component\Console\Helper\Table
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
     {
-        $table = new Table($this->output);
+        $table = new Table($this->output->getOutput()->section());
 
         if ($rows instanceof Arrayable) {
             $rows = $rows->toArray();
@@ -235,6 +235,8 @@ trait InteractsWithIO
         }
 
         $table->render();
+
+        return $table;
     }
 
     /**

--- a/src/Illuminate/Console/OutputStyle.php
+++ b/src/Illuminate/Console/OutputStyle.php
@@ -68,4 +68,14 @@ class OutputStyle extends SymfonyStyle
     {
         return $this->output->isDebug();
     }
+
+    /**
+     * Get the underlying Symfony output implementation.
+     *
+     * @return \Symfony\Component\Console\Output\OutputInterface
+     */
+    public function getOutput()
+    {
+        return $this->output;
+    }
 }


### PR DESCRIPTION
As a fix to the issue @freekmurze raised (https://github.com/laravel/ideas/issues/2064) on using `appendRow()` on a Table within Artisan commands, this PR enables that feature by passing a `ConsoleSectionOutput` to the `Table` constructor, thus creating a new section.

The `Table` instance is also now returned following render, which allows `appendRow()` to be called on the rendered table.

Example:
```php
public function handle()
{
    $table = $this->table(
        ['Column', 'Another column'],
        []
    );

    $table->appendRow(['Value', 'Another Value']);
    $table->appendRow(['Value', 'Another Value']);
}
```

Output:
```
+--------+----------------+
| Column | Another column |
+--------+----------------+
| Value  | Another Value  |
| Value  | Another Value  |
+--------+----------------+
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
