### PR TITLE
[6.x] Install Command Repository Check

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -52,25 +52,17 @@ class InstallCommand extends Command
         $this->repository->setSource($this->input->getOption('database'));
 
         if (true === (bool) $this->input->getOption('force')) {
-
             $this->repository->createRepository();
 
             $this->info('Migration table created successfully.');
-
         } else {
-
             if (false === $this->repository->repositoryExists()) {
-
                 $this->repository->createRepository();
 
                 $this->info('Migration table created successfully.');
-
             } else {
-
                 $this->info('Migration table already exists.');
-
             }
-
         }
     }
 

--- a/src/Illuminate/Database/Console/Migrations/InstallCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/InstallCommand.php
@@ -51,9 +51,27 @@ class InstallCommand extends Command
     {
         $this->repository->setSource($this->input->getOption('database'));
 
-        $this->repository->createRepository();
+        if (true === (bool) $this->input->getOption('force')) {
 
-        $this->info('Migration table created successfully.');
+            $this->repository->createRepository();
+
+            $this->info('Migration table created successfully.');
+
+        } else {
+
+            if (false === $this->repository->repositoryExists()) {
+
+                $this->repository->createRepository();
+
+                $this->info('Migration table created successfully.');
+
+            } else {
+
+                $this->info('Migration table already exists.');
+
+            }
+
+        }
     }
 
     /**
@@ -65,6 +83,7 @@ class InstallCommand extends Command
     {
         return [
             ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+            ['force', null, InputOption::VALUE_OPTIONAL, 'Force the operation to attempt to create the repository', true],
         ];
     }
 }

--- a/tests/Database/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Database/DatabaseMigrationInstallCommandTest.php
@@ -23,8 +23,31 @@ class DatabaseMigrationInstallCommandTest extends TestCase
         $command->setLaravel(new Application);
         $repo->shouldReceive('setSource')->once()->with('foo');
         $repo->shouldReceive('createRepository')->once();
+        $repo->shouldNotReceive('repositoryExists');
 
         $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    public function testFireCallsRepositoryToSkipInstallWhenExists()
+    {
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setLaravel(new Application);
+        $repo->shouldReceive('setSource')->once()->with('bar');
+        $repo->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $repo->shouldNotReceive('createRepository');
+
+        $this->runCommand($command, ['--database' => 'bar', '--force' => false]);
+    }
+
+    public function testFireCallsRepositoryToInstallWhenForcing()
+    {
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setLaravel(new Application);
+        $repo->shouldReceive('setSource')->once()->with('foo');
+        $repo->shouldReceive('createRepository')->once();
+        $repo->shouldNotReceive('repositoryExists');
+
+        $this->runCommand($command, ['--database' => 'foo', '--force' => true]);
     }
 
     protected function runCommand($command, $options = [])


### PR DESCRIPTION
This PR extends the default behaviour of the core Artisan Migrate Install command (`migrate:install`) to allow for the explicit checking of whether the repository already exists before trying to create it.

There's a new option within the above command, named `force`, which defaults to `true` - this is the current functionality and will maintain BC.

If this option is either ignored, or set to `true`, the command will attempt to create the repository regardless, throwing a SQL exception if the repository already exists.

If this option is set to `false`, then the command will run a check to see whether the repository already exists, if it does, it'll skip (With a helpful message), or it'll continue as normal and create.

The benefit of this is you're able to run the command, with the `force` flag set to `false`, without causing exceptions for repositories which have already been installed. This issue became apparent whilst I was developing a multi-tenancy, multi-database, application whereby migrations for each database were needed to be run programatically, ensuring that the repository was installed each time.

As explained above, the new options default value ensures that the command executes the same as it did prior to this PR being submitted, therefore maintaining BC. The additional test cases should verify this.