### PR TITLE
[6.x] Using the improper URL in UrlGenerator::hasCorrectSignature()

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -377,7 +377,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function hasCorrectSignature(Request $request, $absolute = true)
     {
-        $url = $absolute ? $request->url() : '/'.$request->path();
+        $url = $absolute ? $this->current() : '/'.$request->path();
 
         $original = rtrim($url.'?'.Arr::query(
             Arr::except($request->query(), 'signature')


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Problem
The `hasCorrectSignature()` function in the `src/Illuminate/Routing/UrlGenerator.php` is using the incorrect function for getting the current URL.

`$request->url()` is getting the URL specified by the Request.
`$this->current()` is getting the URL specified by the Application.

Getting the URL specified by the application is the expected behavior, getting the URL in the request only adds the possibility of it having inconsistencies. If you are checking the url generated by the application, you should compare it with a URL generated by the application not supplied through the request. This issue specifically comes up when doing a `\URL::forceScheme("https")` in the `AppServiceProvider`, the URL becomes different on Laravel's end when doing this, without using `\URL::forceScheme("https")` the function works as intended.

Any attempt at configuration of TrustProxies was unsuccessful, as well as any attempt at changing the `APP_URL` specified in the .ENV. This is what resulted in me creating this Pull Request.

This issue has been mentioned before in many GitHub issues but was closed due to "Almost all of the previous reports for this were caused by improper configured trusted proxies." and similar reasons, which were not the case. Hopefully this pull request will solve this issue.

### Related Issues & Pull Requests
https://github.com/laravel/framework/issues/31430
https://github.com/laravel/framework/issues/28941
https://github.com/laravel/framework/issues/26834
https://github.com/laravel/framework/pull/27699

## Solution
As I mentioned above just replacing line 380 of `src/Illuminate/Routing/UrlGenerator.php`,
instead of
```php
$url = $absolute ? $request->url() : '/'.$request->path();
```
We need
```php
$url = $absolute ? $this->current() : '/'.$request->path();
```

## Tests
As outlined here (https://laravel.com/docs/4.2/contributions) I should provide some sort of test for this pull request but I was not sure how to run a Unit Test on this specific issue, since its an issue because of the hasCorrectSignature() function.