### PR TITLE
[6.x] Simplify check for wildcard listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -117,13 +117,7 @@ class Dispatcher implements DispatcherContract
      */
     public function hasWildcardListeners($eventName)
     {
-        foreach ($this->wildcards as $key => $listeners) {
-            if (Str::is($key, $eventName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return Str::is(array_keys($this->wildcards), $eventName);
     }
 
     /**


### PR DESCRIPTION
`Str::is()` can handle an array of patterns, so we don't need to iterate through the wildcards.