### PR TITLE
Revert "[6.x] Simplify check for wildcard listeners"

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -117,7 +117,13 @@ class Dispatcher implements DispatcherContract
      */
     public function hasWildcardListeners($eventName)
     {
-        return Str::is(array_keys($this->wildcards), $eventName);
+        foreach ($this->wildcards as $key => $listeners) {
+            if (Str::is($key, $eventName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Reverts laravel/framework#31436 because it does not fix "don't need to iterate through the wildcards". The new code actually iterates through them twice instead of once...