### PR TITLE
[6.x] Fix event:list shows non-registered events

### DIFF
--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -48,7 +48,7 @@ class EventListCommand extends Command
         $events = [];
 
         foreach ($this->laravel->getProviders(EventServiceProvider::class) as $provider) {
-            $providerEvents = array_merge_recursive($provider->discoverEvents(), $provider->listens());
+            $providerEvents = array_merge_recursive($provider->shouldDiscoverEvents() ? $provider->discoverEvents() : [], $provider->listens());
 
             $events = array_merge_recursive($events, $providerEvents);
         }


### PR DESCRIPTION
The command `event:list` auto-discovers events even if auto-discovery is disabled. This PR fixes this.