### PR TITLE
[6.x] Resolve issue with tests using table()

### DIFF
--- a/src/Illuminate/Foundation/Testing/MockStream.php
+++ b/src/Illuminate/Foundation/Testing/MockStream.php
@@ -44,7 +44,7 @@ class MockStream
     }
 
     /**
-     * Unregister the mock:// stream wrapper
+     * Unregister the mock:// stream wrapper.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Testing/MockStream.php
+++ b/src/Illuminate/Foundation/Testing/MockStream.php
@@ -18,7 +18,7 @@ class MockStream
     protected static $existed = false;
 
     /**
-     * Register a new Stream wrapper using the protocol mock://
+     * Register a new Stream wrapper using the protocol mock://.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
@@ -36,7 +36,7 @@ class MockStream
     }
 
     /**
-     * Attempt to restore the stream wrapper to the previous state, if it existed
+     * Attempt to restore the stream wrapper to the previous state, if it existed.
      *
      * @return void
      */

--- a/src/Illuminate/Foundation/Testing/MockStream.php
+++ b/src/Illuminate/Foundation/Testing/MockStream.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use ErrorException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MockStream
+{
+    /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected static $output;
+
+    /**
+     * @var bool
+     */
+    protected static $existed = false;
+
+    /**
+     * Register a new Stream wrapper using the protocol mock://
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return void
+     */
+    public static function register(OutputInterface $output)
+    {
+        if (in_array('mock', stream_get_wrappers())) {
+            stream_wrapper_unregister('mock');
+            self::$existed = true;
+        }
+
+        self::$output = $output;
+
+        stream_wrapper_register('mock', self::class);
+    }
+
+    /**
+     * Attempt to restore the stream wrapper to the previous state, if it existed
+     *
+     * @return void
+     */
+    public static function deregister()
+    {
+        try {
+            stream_wrapper_restore('mock');
+        } catch (ErrorException $e) {
+            //
+        }
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        return true;
+    }
+
+    public function stream_write($data)
+    {
+        self::$output->doWrite($data, true);
+
+        return strlen($data);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/MockStream.php
+++ b/src/Illuminate/Foundation/Testing/MockStream.php
@@ -13,22 +13,14 @@ class MockStream
     protected static $output;
 
     /**
-     * @var bool
-     */
-    protected static $existed = false;
-
-    /**
-     * Register a new Stream wrapper using the protocol mock://.
+     * Register a new stream wrapper using the protocol mock://.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     public static function register(OutputInterface $output)
     {
-        if (in_array('mock', stream_get_wrappers())) {
-            stream_wrapper_unregister('mock');
-            self::$existed = true;
-        }
+        self::unregister();
 
         self::$output = $output;
 
@@ -40,12 +32,26 @@ class MockStream
      *
      * @return void
      */
-    public static function deregister()
+    public static function restore()
     {
+        self::unregister();
+
         try {
             stream_wrapper_restore('mock');
         } catch (ErrorException $e) {
             //
+        }
+    }
+
+    /**
+     * Unregister the mock:// stream wrapper
+     *
+     * @return void
+     */
+    protected static function unregister()
+    {
+        if (in_array('mock', stream_get_wrappers())) {
+            stream_wrapper_unregister('mock');
         }
     }
 

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -7,8 +7,11 @@ use Illuminate\Contracts\Console\Kernel;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\Output;
 
 class PendingCommand
 {
@@ -193,6 +196,19 @@ class PendingCommand
                 ->shouldAllowMockingProtectedMethods()
                 ->shouldIgnoreMissing();
 
+        MockStream::register($mock);
+        $stream = fopen('mock://stream', 'r+');
+        $consoleOutputSections = [];
+
+        $mock->shouldReceive('section')
+            ->andReturn(new ConsoleSectionOutput(
+                $stream,
+                $consoleOutputSections,
+                Output::VERBOSITY_NORMAL,
+                false,
+                new OutputFormatter)
+            );
+
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')
                 ->once()
@@ -218,5 +234,7 @@ class PendingCommand
         }
 
         $this->run();
+
+        MockStream::deregister();
     }
 }

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -235,6 +235,6 @@ class PendingCommand
 
         $this->run();
 
-        MockStream::deregister();
+        MockStream::restore();
     }
 }

--- a/tests/Foundation/Testing/MockStreamTest.php
+++ b/tests/Foundation/Testing/MockStreamTest.php
@@ -13,7 +13,7 @@ class MockStreamTest extends TestCase
 {
     public function testMockStreamWritesToOutputInterface()
     {
-        $mock = Mockery::mock(BufferedOutput::class . '[doWrite]')
+        $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive('doWrite')

--- a/tests/Foundation/Testing/MockStreamTest.php
+++ b/tests/Foundation/Testing/MockStreamTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Testing;
+
+use ErrorException;
+use Illuminate\Foundation\Testing\MockStream;
+use Mockery;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class MockStreamTest extends TestCase
+{
+    public function testMockStreamWritesToOutputInterface()
+    {
+        $mock = Mockery::mock(BufferedOutput::class . '[doWrite]')
+            ->shouldAllowMockingProtectedMethods();
+
+        $mock->shouldReceive('doWrite')
+            ->with('Taylor', true)
+            ->once();
+
+        MockStream::register($mock);
+        $stream = fopen('mock://stream', 'r+');
+        $output = new StreamOutput($stream);
+        $output->write('Taylor');
+        MockStream::restore();
+    }
+
+    public function testMockStreamIsUnregisteredOnRestore()
+    {
+        MockStream::register(new BufferedOutput);
+        MockStream::restore();
+
+        $failed = false;
+        try {
+            fopen('mock://test', 'r+');
+        } catch (ErrorException $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed);
+    }
+}


### PR DESCRIPTION
As mentioned in #31445, my latest PR adding support for `appendRow()` when using `table()` in an Artisan command caused tests on commands using `table()` to fail due to the use of `ConsoleSectionOutput`

This PR attempts to resolve those issues by adding `section()` to the `BufferedOutput` mock, returning a `ConsoleSectionOutput` instance with a mocked stream puching back to the `BufferedOutput`
