### PR TITLE
[6.x] Fix postgres grammar for nested json arrays

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -380,6 +380,10 @@ class PostgresGrammar extends Grammar
     protected function wrapJsonPathAttributes($path)
     {
         return array_map(function ($attribute) {
+            if (\strval(\intval($attribute)) === $attribute) {
+                return $attribute;
+            }
+
             return "'$attribute'";
         }, $path);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2626,6 +2626,10 @@ SQL;
         $this->assertSame('select * from "users" where "items"->\'price\'->>\'in_usd\' = ? and "items"->>\'age\' = ?', $builder->toSql());
 
         $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('items->prices->0', '=', 1)->where('items->age', '=', 2);
+        $this->assertSame('select * from "users" where "items"->\'prices\'->>0 = ? and "items"->>\'age\' = ?', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
         $builder->select('*')->from('users')->where('items->available', '=', true);
         $this->assertSame('select * from "users" where ("items"->\'available\')::jsonb = \'true\'::jsonb', $builder->toSql());
     }


### PR DESCRIPTION
Hi, 
This PR fix a bug when quering postgres json field.

I have a json `details` field which contains : 
```json
{"firstName": "John", "lastName": "Doe", "phones": ["+33123456789", "+44123456789"]}
```

With this Eloquent query:
```php
Contact::where([
    'details->firstName' => 'John',
    'details->lastName' => 'Doe',
    'details->phones->0' => '+33123456789',
])->firstOrFail();
```

The builder should return the row.


The problem is that the Postgres query generated is : 
```sql
"select * from "contacts" where ("details"->>'firstName' = 'John' and "details"->>'lastName' = 'Doe' and "details"->'phones'->>'0' = '+33123456789') limit 1"
```
which return no result, and fail.

The working query is: 
```sql
"select * from "contacts" where ("details"->>'firstName' = 'John' and "details"->>'lastName' = 'Doe' and "details"->'phones'->>0 = '+33123456789') limit 1"
```

See the difference:
```diff
- "details"->'phones'->>'0'
+ "details"->'phones'->>0
```


This PR fix this issue, by omitting the quote if the attribute is a integer.

A test was added.

Thanks.
Matt'