### PR TITLE
[6.x] Test for pushed events

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -132,14 +132,20 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->push('update', ['name' => 'taylor']);
         $d->listen('update', function ($name) {
             $_SERVER['__event.test'] = $name;
+        });
+        $d->push('update', ['name' => 'taylor']);
+        $d->listen('update', function ($name) {
+            $_SERVER['__event.test'] .= '_'.$name;
         });
 
         $this->assertFalse(isset($_SERVER['__event.test']));
         $d->flush('update');
-        $this->assertSame('taylor', $_SERVER['__event.test']);
+        $d->listen('update', function ($name) {
+            $_SERVER['__event.test'] .= $name;
+        });
+        $this->assertSame('taylor_taylor', $_SERVER['__event.test']);
     }
 
     public function testQueuedEventsCanBeForgotten()

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -156,6 +156,20 @@ class EventsDispatcherTest extends TestCase
         $this->assertSame('unset', $_SERVER['__event.test']);
     }
 
+    public function testMultiplePushedEventsWillGetFlushed()
+    {
+        $_SERVER['__event.test'] = '';
+        $d = new Dispatcher;
+        $d->push('update', ['name' => 'taylor ']);
+        $d->push('update', ['name' => 'otwell']);
+        $d->listen('update', function ($name) {
+            $_SERVER['__event.test'] .= $name;
+        });
+
+        $d->flush('update');
+        $this->assertSame('taylor otwell', $_SERVER['__event.test']);
+    }
+
     public function testWildcardListeners()
     {
         unset($_SERVER['__event.test']);


### PR DESCRIPTION
This PR adds more tests for the pushed (queued) events.

As the name of the commits say:
1. Adds a test to check that a single flush($event), fires all queued events with same name but different payloads.
(which a lot of applications may already depend on this, so we should be careful not to break it.)

2. Strengthen the test to be sure that (unlike regular event dispatching) listeners can be set both "before" and "after" we push the event, but Not after we flush it.