### PR TITLE
[6.x] Change MySql nullable modifier to allow generated columns to be not null

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -942,6 +942,10 @@ class MySqlGrammar extends Grammar
         if (is_null($column->virtualAs) && is_null($column->storedAs)) {
             return $column->nullable ? ' null' : ' not null';
         }
+
+        if ($column->nullable === false) {
+            return ' not null';
+        }
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -433,7 +433,6 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
 
-
         $blueprint = new Blueprint('products');
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5')->nullable(false);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -432,6 +432,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5), add `discounted_stored` int as (price - 5) stored', $statements[0]);
+
+
+        $blueprint = new Blueprint('products');
+        $blueprint->integer('price');
+        $blueprint->integer('discounted_virtual')->virtualAs('price - 5')->nullable(false);
+        $blueprint->integer('discounted_stored')->storedAs('price - 5')->nullable(false);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `products` add `price` int not null, add `discounted_virtual` int as (price - 5) not null, add `discounted_stored` int as (price - 5) stored not null', $statements[0]);
     }
 
     public function testAddingGeneratedColumnWithCharset()


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/laravel/ideas/issues/1211) where it is impossible to make a MySql generated column be `not null`. 
I ran into this issue when trying to run this migration:
```
class CreatePlacesTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create('places', function (Blueprint $table) {
            $table->bigIncrements('id');

            $table->string('name');
            $table->decimal('latitude', 8, 6);
            $table->decimal('longitude', 9, 6);
            $table->point('location', 4326)->storedAs('ST_SRID(Point(`longitude`, `latitude`), 4326)');
            $table->spatialIndex('location');

            $table->timestamps();
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists('places');
    }
}
```
which fails when trying to add the spatial index as it cannot be added to a 'nullable' column.

The change allows using the existing functionality of the `nullable()` method where you can pass false as the parameter to explictly mark the column as not null. This should hopefully limit the effect this change has on existing migrations by not changing the normal behaviour.

With this change, the migration would work by using this for the 'location' column
```
$table->point('location', 4326)->storedAs('ST_SRID(Point(`longitude`, `latitude`), 4326)')->nullable(false);
```
