### PR TITLE
[6.x] Deprecate $factory variable and replace with Factory Facade

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -1,11 +1,10 @@
 <?php
 
-/** @var \Illuminate\Database\Eloquent\Factory $factory */
-
 use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Factory;
 use NamespacedDummyModel;
 
-$factory->define(DummyModel::class, function (Faker $faker) {
+Factory::define(DummyModel::class, function (Faker $faker) {
     return [
         //
     ];

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -79,8 +79,15 @@ class DatabaseServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {
-            return EloquentFactory::construct(
-                $app->make(FakerGenerator::class), $this->app->databasePath('factories')
+            return new EloquentFactory(
+                $app->make(FakerGenerator::class)
+            );
+        });
+
+        /* Unable to use `$this->loadFactoriesFrom()` as database path may be changed at runtime (e.g. tests) */
+        $this->app->afterResolving(EloquentFactory::class, function ($factory) {
+            $factory->load(
+                $this->app->databasePath('factories')
             );
         });
     }

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -60,6 +60,8 @@ class Factory implements ArrayAccess
      * @param  \Faker\Generator  $faker
      * @param  string|null  $pathToFactories
      * @return static
+     *
+     * @deprecated Construct using new keyword as this approach is incompatible with the Factory facade
      */
     public static function construct(Faker $faker, $pathToFactories = null)
     {

--- a/src/Illuminate/Support/Facades/Factory.php
+++ b/src/Illuminate/Support/Facades/Factory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+use Illuminate\Database\Eloquent\Factory as EloquentFactory;
+
+/**
+ * @method static EloquentFactory defineAs($class, $name, callable $attributes)
+ * @method static EloquentFactory define($class, callable $attributes, $name = 'default')
+ * @method static EloquentFactory state($class, $state, $attributes)
+ * @method static EloquentFactory afterMaking($class, callable $callback, $name = 'default')
+ * @method static EloquentFactory afterMakingState($class, $state, callable $callback)
+ * @method static EloquentFactory afterCreating($class, callable $callback, $name = 'default')
+ * @method static EloquentFactory afterCreatingState($class, $state, callable $callback)
+ * @method static mixed create($class, array $attributes = [])
+ * @method static mixed createAs($class, $name, array $attributes = [])
+ * @method static mixed make($class, array $attributes = [])
+ * @method static mixed makeAs($class, $name, array $attributes = [])
+ * @method static array rawOf($class, $name, array $attributes = [])
+ * @method static array raw($class, array $attributes = [], $name = 'default')
+ * @method static \Illuminate\Database\Eloquent\FactoryBuilder of($class, $name = 'default')
+ * @method static EloquentFactory load($path)
+ *
+ * @see EloquentFactory
+ */
+class Factory extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return EloquentFactory::class;
+    }
+}

--- a/tests/Integration/Database/EloquentFactoryTest.php
+++ b/tests/Integration/Database/EloquentFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Database\Eloquent\Model;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * @group integration
+ */
+class EloquentFactoryTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+        $app->useDatabasePath(__DIR__);
+    }
+
+    public function testLoad()
+    {
+        /** @var Factory $factory */
+        $factory = app(Factory::class);
+
+        $this->assertTrue($factory->offsetExists(FactoryViaVariable::class));
+        $this->assertTrue($factory->offsetExists(FactoryViaFacade::class));
+        $this->assertTrue($factory->offsetExists(FactoryViaExtension::class));
+        $this->assertFalse($factory->offsetExists(FactoryNotDefined::class));
+
+        $this->assertEquals(['name' => 'variable'], $factory->raw(FactoryViaVariable::class));
+        $this->assertEquals(['name' => 'facade'], $factory->raw(FactoryViaFacade::class));
+        $this->assertEquals(['name' => 'facade', 'extends' => FactoryViaFacade::class], $factory->raw(FactoryViaExtension::class));
+
+        // These tests should fail but pass due to how factories are loaded.
+        $this->assertTrue($factory->offsetExists(FactoryViaThis::class));
+        $this->assertEquals(['name' => 'this', 'protected' => 4], $factory->raw(FactoryViaThis::class));
+    }
+}
+
+class FactoryViaVariable extends Model
+{
+
+}
+
+class FactoryViaFacade extends Model
+{
+
+}
+
+class FactoryViaExtension extends Model
+{
+
+}
+
+class FactoryViaThis extends Model
+{
+
+}
+
+class FactoryNotDefined extends Model
+{
+
+}

--- a/tests/Integration/Database/EloquentFactoryTest.php
+++ b/tests/Integration/Database/EloquentFactoryTest.php
@@ -39,25 +39,20 @@ class EloquentFactoryTest extends TestCase
 
 class FactoryViaVariable extends Model
 {
-
 }
 
 class FactoryViaFacade extends Model
 {
-
 }
 
 class FactoryViaExtension extends Model
 {
-
 }
 
 class FactoryViaThis extends Model
 {
-
 }
 
 class FactoryNotDefined extends Model
 {
-
 }

--- a/tests/Integration/Database/factories/FactoryViaExtension.php
+++ b/tests/Integration/Database/factories/FactoryViaExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Factory;
+use Illuminate\Tests\Integration\Database\FactoryViaExtension;
+use Illuminate\Tests\Integration\Database\FactoryViaFacade;
+
+Factory::define(FactoryViaExtension::class, function (Faker $faker) {
+    return array_merge(
+        factory(FactoryViaFacade::class)->raw(),
+        ['extends' => FactoryViaFacade::class]
+    );
+});

--- a/tests/Integration/Database/factories/FactoryViaFacade.php
+++ b/tests/Integration/Database/factories/FactoryViaFacade.php
@@ -1,0 +1,11 @@
+<?php
+
+use Faker\Generator as Faker;
+use Illuminate\Support\Facades\Factory;
+use Illuminate\Tests\Integration\Database\FactoryViaFacade;
+
+Factory::define(FactoryViaFacade::class, function (Faker $faker) {
+    return [
+        'name' => 'facade',
+    ];
+});

--- a/tests/Integration/Database/factories/FactoryViaThis.php
+++ b/tests/Integration/Database/factories/FactoryViaThis.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is able to access the factory in a protected state as
+ * it is being required from within the factory. Ideally this file should
+ * be loaded from a safe instance (e.g. separate object or function) that
+ * can only access public properties and methods of the factory.
+ *
+ * @see \Illuminate\Database\Eloquent\Factory::load()
+ */
+
+/** @var \Illuminate\Database\Eloquent\Factory $this */
+
+use Faker\Generator as Faker;
+use Illuminate\Tests\Integration\Database\FactoryViaThis;
+
+$this->define(FactoryViaThis::class, function (Faker $faker) {
+    return [
+        'name' => 'this',
+        'protected' => count($this->definitions), /* proof that factories are accessing protected state */
+    ];
+});

--- a/tests/Integration/Database/factories/FactoryViaVariable.php
+++ b/tests/Integration/Database/factories/FactoryViaVariable.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator as Faker;
+use Illuminate\Tests\Integration\Database\FactoryViaVariable;
+
+$factory->define(FactoryViaVariable::class, function (Faker $faker) {
+    return [
+        'name' => 'variable',
+    ];
+});


### PR DESCRIPTION
Brings model factories inline with other procedural files (e.g. routes) by defining factories via a `Factory` Facade rather than using the `$factory` variable.

Accomplished in a backwards-compatible way by ensuring the factory instance has been resolved within the service container before loading the files. The `factory()` function has a dependency on this service so there should only be one instance of the factory service.

As a Facade is used there is native IDE auto-completion without the need for a docblock.

Change is backwards compatible as the `$factory` variable remains in an undocumented state. No impact to the `factory()` function. Existing factory files can be incrementally updated to use the Facade by:

* Removing `/** @var \Illuminate\Database\Eloquent\Factory $factory */`
* Adding `use Illuminate\Support\Factory;`
* Replacing `$factory->` with `Factory::`

Here is an updated example taken from the official 6.x documentation:

```php
use Faker\Generator as Faker;
use Illuminate\Support\Factory;
use Illuminate\Support\Str;

Factory::define(App\User::class, function (Faker $faker) {
    return [
        'name' => $faker->name,
        'email' => $faker->unique()->safeEmail,
        'email_verified_at' => now(),
        'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
        'remember_token' => Str::random(10),
    ];
});

Factory::define(App\Admin::class, function (Faker\Generator $faker) {
    return factory(App\User::class)->raw([
        // ...
    ]);
});
```