### PR TITLE
[6.x] Add method modelRouteKeys to Eloquent Collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -227,6 +227,18 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Get the array of model's route key.
+     *
+     * @return array
+     */
+    public function modelRouteKeys()
+    {
+        return array_map(function ($model) {
+            return $model->getRouteKey();
+        }, $this->items);
+    }
+
+    /**
      * Merge the collection with the given items.
      *
      * @param  \ArrayAccess|array  $items

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -184,6 +184,22 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([1, 2, 3], $c->modelKeys());
     }
 
+    public function testCollectionDictionaryReturnsModelRouteKeys()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getRouteKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getRouteKey')->andReturn(2);
+
+        $three = m::mock(Model::class);
+        $three->shouldReceive('getRouteKey')->andReturn(3);
+
+        $c = new Collection([$one, $two, $three]);
+
+        $this->assertEquals([1, 2, 3], $c->modelRouteKeys());
+    }
+
     public function testCollectionMergesWithGivenCollection()
     {
         $one = m::mock(Model::class);


### PR DESCRIPTION
This method used to get an array of model's route key. 
