### PR TITLE
[7.x] Update "subquery value" where statement support to allow builder instance

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -655,9 +655,9 @@ class Builder
             return $this->whereNested($column, $boolean);
         }
 
-        // If the column is a Closure instance and there is an operator value, we will
-        // assume the developer wants to run a subquery and then compare the result
-        // of that subquery with the given value that was provided to the method.
+        // If the column is a Closure or Builder instance, and there is an operator value,
+        // we will assume the developer wants to run the subquery and then compare the
+        // result of the subquery with the value that was provided to the method.
         if ($this->isQueryable($column) && ! is_null($operator)) {
             [$sub, $bindings] = $this->createSub($column);
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -658,7 +658,7 @@ class Builder
         // If the column is a Closure instance and there is an operator value, we will
         // assume the developer wants to run a subquery and then compare the result
         // of that subquery with the given value that was provided to the method.
-        if ($column instanceof Closure && ! is_null($operator)) {
+        if ($this->isQueryable($column) && ! is_null($operator)) {
             [$sub, $bindings] = $this->createSub($column);
 
             return $this->addBinding($bindings, 'where')

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration\Database\EloquentBelongsToManyTest;
+namespace Illuminate\Tests\Integration\Database;
 
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Schema\Blueprint;
@@ -96,6 +96,15 @@ class QueryBuilderTest extends DatabaseTestCase
         $subQuery = function ($query) {
             $query->selectRaw("'Sub query value'");
         };
+
+        $this->assertTrue(DB::table('posts')->where($subQuery, 'Sub query value')->exists());
+        $this->assertFalse(DB::table('posts')->where($subQuery, 'Does not match')->exists());
+        $this->assertTrue(DB::table('posts')->where($subQuery, '!=', 'Does not match')->exists());
+    }
+
+    public function testWhereValueSubQueryBuilder()
+    {
+        $subQuery = DB::table('posts')->selectRaw("'Sub query value'");
 
         $this->assertTrue(DB::table('posts')->where($subQuery, 'Sub query value')->exists());
         $this->assertFalse(DB::table('posts')->where($subQuery, 'Does not match')->exists());

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Tests\Integration\Database\DatabaseTestCase;
 
 /**
  * @group integration


### PR DESCRIPTION
 The ability to add "where subquery value" clauses to the query builder was added in PR #30934.

Currently only a closure can be provided as a subquery. This PR makes it possible to provide a builder instance as a subquery. This allows you to use an Eloquent model's query (and its scopes, relations, ...).

This behavior is already supported by other methods with subquery-support (`addSelect`, `orderBy`)

This example is an updated version of the initial PR's example:

```php
$athletes = Athlete::query()
    ->where(
        Medal::query()
            ->whereColumn('athlete_id', 'athletes.id')
            ->orderByDesc('awarded_date')
            ->limit(1),
       'Gold'
    )
    ->get();
```
