### PR TITLE
[7.x] Remove the addHidden method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -42,19 +42,6 @@ trait HidesAttributes
     }
 
     /**
-     * Add hidden attributes for the model.
-     *
-     * @param  array|string|null  $attributes
-     * @return void
-     */
-    public function addHidden($attributes = null)
-    {
-        $this->hidden = array_merge(
-            $this->hidden, is_array($attributes) ? $attributes : func_get_args()
-        );
-    }
-
-    /**
      * Get the visible attributes for the model.
      *
      * @return array


### PR DESCRIPTION
This change was advertised in #30348 however I had forgotten to commit this particular change.

I noticed this change has even gotten into the new upgrade guide and this PR aims to actually do the change.

![image](https://user-images.githubusercontent.com/16481303/74472009-e4020a80-4ea9-11ea-82ed-756337c7d3fb.png)


As before - this method is not documented, is not tested and is no longer used in the codebase. `makeHidden` provides the same functionality and it is tested, used and documented.