### PR TITLE
[6.x] Generalize Filesystem hashing while preserving backwards compatibility

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -113,11 +113,12 @@ class Filesystem
      * Get the hash of the file at the given path.
      *
      * @param  string  $path
+     * @param  string|null  $algo
      * @return string
      */
-    public function hash(string $path, string $algo = 'md5'): string
+    public function hash($path, $algo = null)
     {
-        return hash_file($algo, $path);
+        return hash_file($algo ?? 'md5', $path);
     }
 
     /**
@@ -125,13 +126,15 @@ class Filesystem
      *
      * @param  string  $path
      * @param  string  $hash
-     * @param  string  $algo
+     * @param  string|null  $algo
      * @return bool
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function check(string $path, string $hash, string $algo = 'md5'): bool
+    public function check($path, $hash, $algo = null)
     {
         if ($this->exists($path)) {
-            return hash_file($algo, $path) === $hash;
+            return $this->hash($algo, $path) === $hash;
         }
 
         throw new FileNotFoundException("File does not exist at path {$path}");

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -110,14 +110,14 @@ class Filesystem
     }
 
     /**
-     * Get the MD5 hash of the file at the given path.
+     * Get the hash of the file at the given path.
      *
      * @param  string  $path
      * @return string
      */
-    public function hash($path)
+    public function hash(string $path, string $algo = 'md5'): string
     {
-        return md5_file($path);
+        return hash_file($algo, $path);
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -121,6 +121,23 @@ class Filesystem
     }
 
     /**
+     * Verify if the file at the given path matches the hash given
+     *
+     * @param  string  $path
+     * @param  string  $hash
+     * @param  string  $algo
+     * @return bool
+     */
+    public function check(string $path, string $hash, string $algo = 'md5'): bool
+    {
+        if($this->exists($path)) {
+            return hash_file($algo, $path) === $hash;
+        }
+
+        throw new FileNotFoundException("File does not exist at path {$path}");
+    }
+
+    /**
      * Write the contents of a file.
      *
      * @param  string  $path

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -121,7 +121,7 @@ class Filesystem
     }
 
     /**
-     * Verify if the file at the given path matches the hash given
+     * Verify if the file at the given path matches the hash given.
      *
      * @param  string  $path
      * @param  string  $hash
@@ -130,7 +130,7 @@ class Filesystem
      */
     public function check(string $path, string $hash, string $algo = 'md5'): bool
     {
-        if($this->exists($path)) {
+        if ($this->exists($path)) {
             return hash_file($algo, $path) === $hash;
         }
 

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -550,6 +550,25 @@ class FilesystemTest extends TestCase
         $this->assertSame($filesystem->hash($this->tempDir.'/foo.txt', 'md5'), $filesystem->hash($this->tempDir.'/foo.txt'));
     }
 
+    public function testCheck()
+    {
+        file_put_contents($this->tempDir.'/foo.txt', 'foo');
+        $filesystem = new Filesystem;
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'acbd18db4cc2f85cedef654fccc4a4d8'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'acbd18db4cc2f85cedef654fccc4a4d8', 'md5'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'sha1'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', 'sha256'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7', 'sha512'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'a5c4fe49','crc32'));
+
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'md5'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha1'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha256'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha512'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid','crc32'));
+    }
+
     /**
      * @param string $file
      * @return int

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -542,6 +542,12 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo.txt', 'foo');
         $filesystem = new Filesystem;
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
+        $this->assertSame('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', $filesystem->hash($this->tempDir.'/foo.txt', 'sha1'));
+        $this->assertSame('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',  $filesystem->hash($this->tempDir.'/foo.txt', 'sha256'));
+        $this->assertSame('f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7',  $filesystem->hash($this->tempDir.'/foo.txt', 'sha512'));
+        $this->assertSame('a5c4fe49',  $filesystem->hash($this->tempDir.'/foo.txt', 'crc32'));
+
+        $this->assertSame($filesystem->hash($this->tempDir.'/foo.txt', 'md5'), $filesystem->hash($this->tempDir.'/foo.txt'));
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -543,9 +543,9 @@ class FilesystemTest extends TestCase
         $filesystem = new Filesystem;
         $this->assertSame('acbd18db4cc2f85cedef654fccc4a4d8', $filesystem->hash($this->tempDir.'/foo.txt'));
         $this->assertSame('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', $filesystem->hash($this->tempDir.'/foo.txt', 'sha1'));
-        $this->assertSame('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',  $filesystem->hash($this->tempDir.'/foo.txt', 'sha256'));
-        $this->assertSame('f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7',  $filesystem->hash($this->tempDir.'/foo.txt', 'sha512'));
-        $this->assertSame('a5c4fe49',  $filesystem->hash($this->tempDir.'/foo.txt', 'crc32'));
+        $this->assertSame('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', $filesystem->hash($this->tempDir.'/foo.txt', 'sha256'));
+        $this->assertSame('f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7', $filesystem->hash($this->tempDir.'/foo.txt', 'sha512'));
+        $this->assertSame('a5c4fe49', $filesystem->hash($this->tempDir.'/foo.txt', 'crc32'));
 
         $this->assertSame($filesystem->hash($this->tempDir.'/foo.txt', 'md5'), $filesystem->hash($this->tempDir.'/foo.txt'));
     }
@@ -566,7 +566,7 @@ class FilesystemTest extends TestCase
         $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha1'));
         $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha256'));
         $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'sha512'));
-        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid','crc32'));
+        $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'crc32'));
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -559,7 +559,7 @@ class FilesystemTest extends TestCase
         $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'sha1'));
         $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', 'sha256'));
         $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7', 'sha512'));
-        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'a5c4fe49','crc32'));
+        $this->assertTrue($filesystem->check($this->tempDir.'/foo.txt', 'a5c4fe49', 'crc32'));
 
         $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid'));
         $this->assertFalse($filesystem->check($this->tempDir.'/foo.txt', 'invalid', 'md5'));


### PR DESCRIPTION
with Laravel 5

The Filesystem::hash() function only allows for md5 hashes, which is
prone to collision attacks.  The PHP builtin function hash_file() allows
for more algorithms.  By default we select the md5 algorithm because the
users of this method likely can't afford to have all their hashes be
invalid all of the sudden.

In the future it will be beneficial to select a different hashing method
as the internet is moving away from md5 and to more modern hashing
standards.

This comment on php.net:
https://www.php.net/manual/en/function.hash.php#89574 outlines all of
the methods allowed by the $algo parameter and we must consider adding
it/linking it in the docs or in the docblock.  For now, I have left this
out because there is no rule in the styleguide to link to this kind of
user-contributed documentation.

Signed-off-by: Rudolf R Ford <60923682+r32rf@users.noreply.github.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
