### PR TITLE
[6.x] Resolving further issues when testing Console command with table()

### DIFF
--- a/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
+++ b/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
@@ -42,6 +42,7 @@ class BufferedConsoleOutput extends Output
     {
         MockStream::register($this);
         $sections = [];
+
         return new ConsoleSectionOutput(MockStream::getStream(), $sections, $this->getVerbosity(), $this->isDecorated(), $this->getFormatter());
     }
 }

--- a/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
+++ b/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\Output;
+
+class BufferedConsoleOutput extends Output
+{
+    protected static $buffer = '';
+
+    /**
+     * Empties buffer and returns its content.
+     *
+     * @return string
+     */
+    public function fetch()
+    {
+        $content = self::$buffer;
+        self::$buffer = '';
+        MockStream::restore();
+
+        return $content;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function doWrite($message, $newline)
+    {
+        self::$buffer .= $message;
+
+        if ($newline) {
+            self::$buffer .= PHP_EOL;
+        }
+    }
+
+    /**
+     * Creates a new output section.
+     */
+    public function section()
+    {
+        MockStream::register($this);
+        $sections = [];
+        return new ConsoleSectionOutput(MockStream::getStream(), $sections, Output::VERBOSITY_NORMAL, false, new OutputFormatter);
+    }
+}

--- a/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
+++ b/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
@@ -43,6 +43,6 @@ class BufferedConsoleOutput extends Output
     {
         MockStream::register($this);
         $sections = [];
-        return new ConsoleSectionOutput(MockStream::getStream(), $sections, Output::VERBOSITY_NORMAL, false, new OutputFormatter);
+        return new ConsoleSectionOutput(MockStream::getStream(), $sections, $this->getVerbosity(), $this->isDecorated(), $this->getFormatter());
     }
 }

--- a/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
+++ b/src/Illuminate/Foundation/Testing/BufferedConsoleOutput.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Foundation\Testing;
 
-use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\Output;
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\BufferedConsoleOutput;
 use Illuminate\Foundation\Testing\PendingCommand;
 use Illuminate\Support\Arr;
 
@@ -40,7 +41,7 @@ trait InteractsWithConsole
     public function artisan($command, $parameters = [])
     {
         if (! $this->mockConsoleOutput) {
-            return $this->app[Kernel::class]->call($command, $parameters);
+            return $this->app[Kernel::class]->call($command, $parameters, new BufferedConsoleOutput);
         }
 
         $this->beforeApplicationDestroyed(function () {

--- a/src/Illuminate/Foundation/Testing/MockStream.php
+++ b/src/Illuminate/Foundation/Testing/MockStream.php
@@ -31,7 +31,7 @@ class MockStream
     }
 
     /**
-     * Return an opened resource of the captured stream
+     * Return an opened resource of the captured stream.
      *
      * @return false|resource
      */
@@ -55,7 +55,7 @@ class MockStream
     }
 
     /**
-     * Retrieve information about the resource
+     * Retrieve information about the resource.
      *
      * @return array
      */
@@ -65,7 +65,7 @@ class MockStream
     }
 
     /**
-     * Tests for end-of-file on the stream
+     * Tests for end-of-file on the stream.
      *
      * @return bool
      */
@@ -75,7 +75,7 @@ class MockStream
     }
 
     /**
-     * Read from the stream
+     * Read from the stream.
      *
      * @param $count
      * @return false|string
@@ -90,7 +90,7 @@ class MockStream
     }
 
     /**
-     * Seeks to specific location in the stream
+     * Seeks to specific location in the stream.
      *
      * @param     $offset
      * @param int $whence

--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -198,13 +198,11 @@ class PendingCommand
 
         MockStream::register($mock);
 
-        $stream = fopen('mock://stream', 'r+');
-
         $consoleOutputSections = [];
 
         $mock->shouldReceive('section')
             ->andReturn(new ConsoleSectionOutput(
-                $stream,
+                MockStream::getStream(),
                 $consoleOutputSections,
                 Output::VERBOSITY_NORMAL,
                 false,

--- a/tests/Foundation/Testing/MockStreamTest.php
+++ b/tests/Foundation/Testing/MockStreamTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation\Testing;
 
 use ErrorException;
+use Illuminate\Foundation\Testing\BufferedConsoleOutput;
 use Illuminate\Foundation\Testing\MockStream;
 use Mockery;
 use Orchestra\Testbench\TestCase;
@@ -17,7 +18,7 @@ class MockStreamTest extends TestCase
             ->shouldAllowMockingProtectedMethods();
 
         $mock->shouldReceive('doWrite')
-            ->with('Taylor', true)
+            ->with('Taylor', false)
             ->once();
 
         MockStream::register($mock);
@@ -40,5 +41,19 @@ class MockStreamTest extends TestCase
         }
 
         $this->assertTrue($failed);
+    }
+
+    public function testGetStreamReturnsAnOpenedResource()
+    {
+        MockStream::register(new BufferedConsoleOutput);
+        $stream = MockStream::getStream();
+
+        $this->assertIsResource($stream);
+
+        fputs($stream, 'Taylor');
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertEquals('Taylor', $contents);
     }
 }

--- a/tests/Foundation/Testing/MockStreamTest.php
+++ b/tests/Foundation/Testing/MockStreamTest.php
@@ -50,7 +50,7 @@ class MockStreamTest extends TestCase
 
         $this->assertIsResource($stream);
 
-        fputs($stream, 'Taylor');
+        fwrite($stream, 'Taylor');
         $contents = stream_get_contents($stream);
         fclose($stream);
 


### PR DESCRIPTION
Continuing on from #31447, it appears that there are further issues still when `$mockConsoleOutput` is set to false (https://github.com/laravel/framework/issues/31445#issuecomment-585635728)

This PR introduces a new `BufferedConsoleOutput` class to use within testing instead of the Symfony `BufferedOutput` class, implementing the `section()` method and still allowing the output to be captured and stored in `lastOutput` for comparison.