### PR TITLE
[6.x] Fixes appendRow on console table

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
@@ -222,7 +223,9 @@ trait InteractsWithIO
      */
     public function table($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
     {
-        $table = new Table($this->output->getOutput()->section());
+        $output = $this->output->getOutput();
+
+        $table = new Table($output instanceof ConsoleOutput ? $output->section() : $output);
 
         if ($rows instanceof Arrayable) {
             $rows = $rows->toArray();

--- a/tests/Integration/Console/CommandWithTableTest.php
+++ b/tests/Integration/Console/CommandWithTableTest.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
-use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase;
 use Symfony\Component\Console\Exception\RuntimeException;
 
@@ -22,7 +21,6 @@ class CommandWithTableTest extends TestCase
 
         $this->artisan('command:table');
     }
-
 
     public function testItCantExecuteCommandWithTableAndAppendRowDueToBufferedOutput()
     {
@@ -63,4 +61,3 @@ class CommandWithTableTest extends TestCase
         });
     }
 }
-

--- a/tests/Integration/Console/CommandWithTableTest.php
+++ b/tests/Integration/Console/CommandWithTableTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Console;
+
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Console\Command;
+use Orchestra\Testbench\TestCase;
+
+class CommandWithTableTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->mockConsoleOutput = true;
+    }
+
+    public function testItCanExecuteCommandWithTable()
+    {
+        $this->mockConsoleOutput = false;
+
+        $this->artisan('command:table');
+    }
+
+
+    public function testItCantExecuteCommandWithTableAndAppendRowDueToBufferedOutput()
+    {
+        $this->mockConsoleOutput = false;
+
+        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectExceptionMessage('Output should be an instance of "Symfony\Component\Console\Output\ConsoleSectionOutput" when calling "Symfony\Component\Console\Helper\Table::appendRow');
+
+        $this->app[ConsoleKernel::class]->command('command:table-with-append', function () {
+            $table = $this->table([
+                'name',
+            ], [
+                ['Taylor Otwell'],
+            ]);
+
+            $table->appendRow(['Mohamed Said']);
+        });
+
+        $this->artisan('command:table-with-append');
+    }
+
+    public function testItCanExecuteMockedCommandWithTable()
+    {
+        $this->mockConsoleOutput = true;
+
+        $this->artisan('command:table')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app[ConsoleKernel::class]->command('command:table', function () {
+            $this->table([
+                'name',
+            ], [
+                ['Taylor Otwell'],
+            ]);
+        });
+    }
+}
+

--- a/tests/Integration/Console/CommandWithTableTest.php
+++ b/tests/Integration/Console/CommandWithTableTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Console;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Console\Command;
 use Orchestra\Testbench\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
 
 class CommandWithTableTest extends TestCase
 {
@@ -27,7 +28,7 @@ class CommandWithTableTest extends TestCase
     {
         $this->mockConsoleOutput = false;
 
-        $this->expectException('Symfony\Component\Console\Exception\RuntimeException');
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Output should be an instance of "Symfony\Component\Console\Output\ConsoleSectionOutput" when calling "Symfony\Component\Console\Helper\Table::appendRow');
 
         $this->app[ConsoleKernel::class]->command('command:table-with-append', function () {
@@ -51,12 +52,6 @@ class CommandWithTableTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
     protected function getEnvironmentSetUp($app)
     {
         $app[ConsoleKernel::class]->command('command:table', function () {


### PR DESCRIPTION
There's some limitation with the new implementation.

- You can't call command with table from another command (the request to command will use `BufferedOutput`).
- You can't call command with table from a controller.

------- 

IMHO if developer want to use Table with `appendRow()` capability they should manually execute it inside `Command` instead of `table()` because the usage of `ConsoleOutput` on CLI usage while `BufferedOutput` when calling other commands or from a controller.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
