### PR TITLE
[6.x] Throw exception on empty collection

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Exception;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -35,10 +36,16 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * @param  string  $notification
      * @param  callable|null  $callback
      * @return void
+     *
+     * @throws \Exception
      */
     public function assertSentTo($notifiable, $notification, $callback = null)
     {
         if (is_array($notifiable) || $notifiable instanceof Collection) {
+            if (count($notifiable) === 0) {
+                throw new Exception('No notifiable given.');
+            }
+
             foreach ($notifiable as $singleNotifiable) {
                 $this->assertSentTo($singleNotifiable, $notification, $callback);
             }
@@ -79,10 +86,16 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * @param  string  $notification
      * @param  callable|null  $callback
      * @return void
+     *
+     * @throws \Exception
      */
     public function assertNotSentTo($notifiable, $notification, $callback = null)
     {
         if (is_array($notifiable) || $notifiable instanceof Collection) {
+            if (count($notifiable) === 0) {
+                throw new Exception('No notifiable given.');
+            }
+
             foreach ($notifiable as $singleNotifiable) {
                 $this->assertNotSentTo($singleNotifiable, $notification, $callback);
             }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -2,9 +2,11 @@
 
 namespace Illuminate\Tests\Support;
 
+use Exception;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Testing\Fakes\NotificationFake;
 use PHPUnit\Framework\Constraint\ExceptionMessage;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -61,6 +63,20 @@ class SupportTestingNotificationFakeTest extends TestCase
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.'));
         }
+    }
+
+    public function testAssertSentToFailsForEmptyArray()
+    {
+        $this->expectException(Exception::class);
+
+        $this->fake->assertSentTo([], NotificationStub::class);
+    }
+
+    public function testAssertSentToFailsForEmptyCollection()
+    {
+        $this->expectException(Exception::class);
+
+        $this->fake->assertSentTo(new Collection, NotificationStub::class);
     }
 
     public function testResettingNotificationId()


### PR DESCRIPTION
When someone passes an empty collection of notifiables to the `assertSentTo` or `assertNotSentTo` methods of a `NotificationFake` then the test will be marked as risky because no assertions were made. It seems to me that if you want to perform the assertion that you'd always want to make sure that you're passing at least one notifiable. Throwing an exception on an empty collection will make it more obvious why the test isn't run.

Fixes https://github.com/laravel/framework/issues/31459