### PR TITLE
[6.x] JSON update for SQLite

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2528,6 +2528,22 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
     }
 
+    public function testSQLiteUpdateWrappingNestedJsonArray()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "options" = (select json_set(ifnull("options", json(\'{}\')), \'$."security"\', ?)), "group_id" = 45, "created_at" = ?', [
+                json_encode(['2fa' => false, 'presets' => ['laravel', 'vue']]),
+                new DateTime('2019-08-06'),
+            ]);
+
+        $builder->from('users')->update([
+            'options->security' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'group_id' => new Raw('45'),
+            'created_at' => new DateTime('2019-08-06'),
+        ]);
+    }
+
     public function testMySqlWrappingJsonWithString()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
This PR implements an SQLite specific update for nested JSON columns and paths.

-----

When using SQLite, an Eloquent update like this:

```php
Customer::whereIn('id', [1, 2, 3])->update([
    'meta->size' => 'L',
]);
```
Compiles to an SQL like this:

```sql
update "customers" set json_extract("meta", '$."size"') = 'L' where "id" in (1, 2, 3)
```
This is not a valid update query. This happens only when trying to update multiple models at the same time.

----

By checking if the column is JSON when compiling update queries, it's possible to fix this and update the value that belongs to the JSON path. The update statement for a JSON column should look like this:

```sql
update "customers" set "meta" = (select json_set(ifnull("meta", json('{}')), '$."size"', 'L'));
```

> The JSON column can be `null`. If it is, the update query won't affect the column. By adding an empty JSON object as a fallback, `json_set` can put the value in the desired path.

----

**Unfortunately, this approach has some pitfalls as well**. For example:

```php
Customer::whereIn('id', [1, 2, 3])->update([
    'meta->size' => 'L',
    'meta->color' => 'yellow',
    'options->security' => ['2fa'],
]);
```

In this case, the `meta->color` update will override the `meta->size` update, which means it will keep its original value.

-----

Adding JSON update support to SQLite (even partially) would be a great help when using test environments.

As far as I know, this is not a breaking change.