### PR TITLE
[6.x] Changed version range of symfony/debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "ramsey/uuid": "^3.7",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/console": "^4.3.4",
-        "symfony/debug": "^4.3.4",
+        "symfony/debug": "~4.3.4",
         "symfony/finder": "^4.3.4",
         "symfony/http-foundation": "^4.3.4",
         "symfony/http-kernel": "^4.3.4",


### PR DESCRIPTION
Hello! This is my first PR, so please don't swear if I'm contributing any kind of nonsence.
So, in symfony/debug since 4.4 class FatalThrowableError is being deprecated. In my project after composer update and having an exception in custom handler I've got not my exception, but message about FatalThrowableError being deprecated. Moreover, this class is used in 6.x branch. 

Therefore, this is the way not to have such problems - not to update to symfony/debug 4.4 and later versions in 6.x versions of Laravel.