### PR TITLE
[7.x] Use the request method instead of dynamic get

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -561,7 +561,7 @@ class Event
     {
         return function (Container $container, HttpClient $http) use ($url) {
             try {
-                $http->get($url);
+                $http->request('GET', $url);
             } catch (TransferException $e) {
                 $container->make(ExceptionHandler::class)->report($e);
             }


### PR DESCRIPTION
Just like in the mail transport, we should really be calling `request(...)` on the Guzzle client.