### PR TITLE
[7.x] Allow including a closure in a queued chain

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -122,7 +122,7 @@ class QueueFake extends QueueManager implements Queue
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
     {
         $chain = collect($expectedChain)->map(function ($job) {
-            return serialize($job);
+            return $job;
         })->all();
 
         PHPUnit::assertTrue(

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -145,7 +145,7 @@ class QueueFake extends QueueManager implements Queue
     {
         $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
             return collect($chain)->map(function ($job) {
-                return get_class(unserialize($job));
+                return get_class($job);
             });
         })->filter(function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -122,7 +122,7 @@ class QueueFake extends QueueManager implements Queue
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
     {
         $chain = collect($expectedChain)->map(function ($job) {
-            return $job;
+            return serialize($job);
         })->all();
 
         PHPUnit::assertTrue(
@@ -145,7 +145,7 @@ class QueueFake extends QueueManager implements Queue
     {
         $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
             return collect($chain)->map(function ($job) {
-                return get_class($job);
+                return get_class(unserialize($job));
             });
         })->filter(function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;


### PR DESCRIPTION
This PR allows including a closure in a chain.

```php
Download::withChain([
    new RunTests(),
    new Deploy(),
    function(){
        Deployment::update(....);
    }
])
```

Also I've removed the serialization and deserialization of chained jobs since it'll be serialized deserialized along with the main job being dispatched anyway.