### PR TITLE
[7.x] Allow chaining jobs using bus facade

### DIFF
--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -7,9 +7,9 @@ class PendingChain
     /**
      * The class name of the job being dispatched.
      *
-     * @var string
+     * @var mixed
      */
-    public $class;
+    public $job;
 
     /**
      * The jobs to be chained.
@@ -21,13 +21,13 @@ class PendingChain
     /**
      * Create a new PendingChain instance.
      *
-     * @param  string  $class
+     * @param  mixed  $job
      * @param  array  $chain
      * @return void
      */
-    public function __construct($class, $chain)
+    public function __construct($job, $chain)
     {
-        $this->class = $class;
+        $this->job = $job;
         $this->chain = $chain;
     }
 
@@ -38,8 +38,10 @@ class PendingChain
      */
     public function dispatch()
     {
-        return (new PendingDispatch(
-            new $this->class(...func_get_args())
-        ))->chain($this->chain);
+        $firstJob = is_string($this->job)
+                    ? new $this->job(...func_get_args())
+                    : $this->job;
+
+        return (new PendingDispatch($firstJob))->chain($this->chain);
     }
 }

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -35,12 +35,12 @@ class Bus extends Facade
     }
 
     /**
-     * Chain the given jobs.
+     * Dispatch the given chain of jobs.
      *
      * @param  array|mixed  $jobs
      * @return \Illuminate\Foundation\Bus\PendingDispatch
      */
-    public static function chain($jobs)
+    public static function dispatchChain($jobs)
     {
         $jobs = is_array($jobs) ? $jobs : func_get_args();
 

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcherContract;
+use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Support\Testing\Fakes\BusFake;
 
 /**
@@ -31,6 +32,20 @@ class Bus extends Facade
         static::swap($fake = new BusFake(static::getFacadeRoot(), $jobsToFake));
 
         return $fake;
+    }
+
+    /**
+     * Chain the given jobs.
+     *
+     * @param  array|mixed  $jobs
+     * @return \Illuminate\Foundation\Bus\PendingDispatch
+     */
+    public static function chain($jobs)
+    {
+        $jobs = is_array($jobs) ? $jobs : func_get_args();
+
+        return (new PendingChain(array_shift($jobs), $jobs))
+                    ->dispatch();
     }
 
     /**

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -59,7 +59,7 @@ class JobChainingTest extends TestCase
 
     public function testJobsCanBeChainedOnSuccessUsingBusFacade()
     {
-        Bus::chain([
+        Bus::dispatchChain([
             new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob(),
         ]);
@@ -70,7 +70,7 @@ class JobChainingTest extends TestCase
 
     public function testJobsCanBeChainedOnSuccessUsingBusFacadeAsArguments()
     {
-        Bus::chain(
+        Bus::dispatchChain(
             new JobChainingTestFirstJob(),
             new JobChainingTestSecondJob()
         );

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\TestCase;
 
@@ -51,6 +52,28 @@ class JobChainingTest extends TestCase
         JobChainingTestFirstJob::withChain([
             new JobChainingTestSecondJob,
         ])->dispatch();
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testJobsCanBeChainedOnSuccessUsingBusFacade()
+    {
+        Bus::chain([
+            new JobChainingTestFirstJob(),
+            new JobChainingTestSecondJob(),
+        ]);
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(JobChainingTestSecondJob::$ran);
+    }
+
+    public function testJobsCanBeChainedOnSuccessUsingBusFacadeAsArguments()
+    {
+        Bus::chain(
+            new JobChainingTestFirstJob(),
+            new JobChainingTestSecondJob()
+        );
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
         $this->assertTrue(JobChainingTestSecondJob::$ran);


### PR DESCRIPTION
This PR allows the following:

```php
Bus::dispatchChain(
    new Download(),
    new RunTests(),
    new Deploy()
);
```