### PR TITLE
[6.x] SQLite JSON update support with json_patch

### DIFF
--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2557,13 +2557,14 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->getConnection()->shouldReceive('update')
             ->with('update "users" set "group_id" = 45, "created_at" = ?, "options" = json_patch(ifnull("options", json(\'{}\')), json(?))', [
                 new DateTime('2019-08-06'),
-                json_encode(['name' => 'Taylor', 'security' => ['2fa' => false, 'presets' => ['laravel', 'vue']]]),
+                json_encode(['name' => 'Taylor', 'security' => ['2fa' => false, 'presets' => ['laravel', 'vue']], 'sharing' => ['twitter' => 'username']]),
             ]);
 
         $builder->from('users')->update([
             'options->name' => 'Taylor',
-            'options->security' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
             'group_id' => new Raw('45'),
+            'options->security' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'options->sharing->twitter' => 'username',
             'created_at' => new DateTime('2019-08-06'),
         ]);
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2551,6 +2551,23 @@ class DatabaseQueryBuilderTest extends TestCase
         ]);
     }
 
+    public function testSQLiteUpdateWrappingNestedJsonArray()
+    {
+        $builder = $this->getSQLiteBuilder();
+        $builder->getConnection()->shouldReceive('update')
+            ->with('update "users" set "group_id" = 45, "created_at" = ?, "options" = json_patch(ifnull("options", json(\'{}\')), json(?))', [
+                new DateTime('2019-08-06'),
+                json_encode(['name' => 'Taylor', 'security' => ['2fa' => false, 'presets' => ['laravel', 'vue']]]),
+            ]);
+
+        $builder->from('users')->update([
+            'options->name' => 'Taylor',
+            'options->security' => ['2fa' => false, 'presets' => ['laravel', 'vue']],
+            'group_id' => new Raw('45'),
+            'created_at' => new DateTime('2019-08-06'),
+        ]);
+    }
+
     public function testMySqlWrappingJsonWithString()
     {
         $builder = $this->getMySqlBuilder();


### PR DESCRIPTION
This is a retry of #31472, but using `json_patch` instead of `json_set`.

------

- The currently compiled SQL is **invalid** when trying to update nested JSON fields (details in the previous PR).
- SQLite is a very nice solution when testing small packages or very light applications that may still use JSON columns. In those cases using SQLite for testing purposes is a huge time saver. 
- No one expects a robust JSON support for SQLite, but for smaller tests, this can serve perfectly and no need to set up a MySQL or a PostgreSQL database. So, it might be a good idea, supporting JSON column updates in SQLite's Grammar (especially, since there are native functions we can use, this is not a regex replacer or something like that).

------

By grouping the nested JSON updates (selectors using `->`), we can use a single [json_patch](https://www.sqlite.org/json1.html#jpatch) to update the JSON column. Also, filtering JSON selectors, prevents generating invalid SQL.

> The `json_patch` will merge the grouped attributes to the currently stored JSON in the database, so it updates only the values we want to update. Also, this approach guards the parameter order.

An Eloquent update query like the following will update the desired columns properly:

```php
Customer::whereIn('id', [1, 2, 3])->update([
    'meta->size' => 'L',
    'options->security' => ['2fa'],
    'group_id' => 30,
    'meta->color' => 'Yellow',
]);
```

------

This PR contains no beaking change as far as I know.