### PR TITLE
[6.X] Make paginator per_page always return an int

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -307,7 +307,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function perPage()
     {
-        return $this->perPage;
+        return (int) $this->perPage;
     }
 
     /**

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -31,6 +31,15 @@ class PaginatorTest extends TestCase
         $this->assertEquals($pageInfo, $p->toArray());
     }
 
+    public function testPerPageShouldAlwaysReturnAnInt()
+    {
+        $perPageOptions = [2, '2'];
+        foreach ($perPageOptions as $perPage) {
+            $p = new Paginator($array = ['item3', 'item4', 'item5'], $perPage, 2);
+            $this->assertTrue(is_int($p->toArray()["per_page"]));
+        }
+    }
+
     public function testPaginatorRemovesTrailingSlashes()
     {
         $p = new Paginator($array = ['item1', 'item2', 'item3'], 2, 2,


### PR DESCRIPTION
Paginator will happily accept a string for the `perPage` option. This works, but may cause confusion when `toArray()` will then return a string for `per_page`. This P/R ensures that it will only ever return an `int`.

```
...
$numPerPage = $request->input('per_page')
return $query->paginate($numPerPage)
```

