### PR TITLE
[7.x] Illuminate\Database\Query\Builder: added support to groupByRaw($sql, array $bindings = []) [fixes #1112].

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -53,13 +53,14 @@ class Builder
      * @var array
      */
     public $bindings = [
-        'select' => [],
-        'from'   => [],
-        'join'   => [],
-        'where'  => [],
-        'having' => [],
-        'order'  => [],
-        'union'  => [],
+        'select'     => [],
+        'from'       => [],
+        'join'       => [],
+        'where'      => [],
+        'groupBy'    => [],
+        'having'     => [],
+        'order'      => [],
+        'union'      => [],
         'unionOrder' => [],
     ];
 
@@ -1691,6 +1692,21 @@ class Builder
                 Arr::wrap($group)
             );
         }
+
+        return $this;
+    }
+
+    /**
+     * Add a raw groupBy clause to the query.
+     *
+     * @param  string  $sql
+     * @param  array   $bindings
+     */
+    public function groupByRaw($sql, array $bindings = []): self
+    {
+        $this->groups[] = new Expression($sql);
+
+        $this->addBinding($bindings, 'groupBy');
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -53,14 +53,14 @@ class Builder
      * @var array
      */
     public $bindings = [
-        'select'  => [],
-        'from'    => [],
-        'join'    => [],
-        'where'   => [],
-        'groupBy' => [],
-        'having'  => [],
-        'order'   => [],
-        'union'   => [],
+        'select'     => [],
+        'from'       => [],
+        'join'       => [],
+        'where'      => [],
+        'groupBy'    => [],
+        'having'     => [],
+        'order'      => [],
+        'union'      => [],
         'unionOrder' => [],
     ];
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -53,14 +53,14 @@ class Builder
      * @var array
      */
     public $bindings = [
-        'select'     => [],
-        'from'       => [],
-        'join'       => [],
-        'where'      => [],
-        'groupBy'    => [],
-        'having'     => [],
-        'order'      => [],
-        'union'      => [],
+        'select'  => [],
+        'from'    => [],
+        'join'    => [],
+        'where'   => [],
+        'groupBy' => [],
+        'having'  => [],
+        'order'   => [],
+        'union'   => [],
         'unionOrder' => [],
     ];
 
@@ -1700,9 +1700,10 @@ class Builder
      * Add a raw groupBy clause to the query.
      *
      * @param  string  $sql
-     * @param  array   $bindings
+     * @param  array  $bindings
+     * @return $this
      */
-    public function groupByRaw($sql, array $bindings = []): self
+    public function groupByRaw($sql, array $bindings = [])
     {
         $this->groups[] = new Expression($sql);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1068,6 +1068,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder = $this->getBuilder();
         $builder->select('*')->from('users')->groupBy(new Raw('DATE(created_at)'));
         $this->assertSame('select * from "users" group by DATE(created_at)', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->groupByRaw('DATE(created_at), ? DESC', ['foo']);
+        $this->assertSame('select * from "users" group by DATE(created_at), ? DESC', $builder->toSql());
+        $this->assertEquals(['foo'], $builder->getBindings());
+
+        $builder = $this->getBuilder();
+        $builder->havingRaw('?', ['havingRawBinding'])->groupByRaw('?', ['groupByRawBinding'])->whereRaw('?', ['whereRawBinding']);
+        $this->assertEquals(['whereRawBinding', 'groupByRawBinding', 'havingRawBinding'], $builder->getBindings());
     }
 
     public function testOrderBys()


### PR DESCRIPTION
- [x] **Tests added**: 2;
  - [x] Test SQL generated for `groupByRaw()` with bindings;
  - [x] Test SQL generated for `groupbyRaw()` with mixed binding types to ensure that bindings order is respected;
- [x] Tested in a real project;
- [x] Based at **v7.x** (_master_);

Fixes https://github.com/laravel/ideas/issues/1112.