### PR TITLE
[6.x] Add tests for preg_replace_array, remove foreach

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -362,9 +362,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject)
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $key => $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -665,6 +665,18 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testPregReplaceArrayIgnoresInternalArrayPointer()
+    {
+        $pointerArray = ['Taylor', 'Otwell'];
+
+        next($pointerArray);
+
+        $this->assertSame(
+            'Hi, Taylor Otwell',
+            preg_replace_array('/%s/', $pointerArray, 'Hi, %s %s')
+        );
+    }
 }
 
 trait SupportTestTraitOne

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -643,6 +643,28 @@ class SupportHelpersTest extends TestCase
         $_SERVER['foo'] = 'From $_SERVER';
         $this->assertSame('From $_ENV', env('foo'));
     }
+
+    public function providesPregReplaceArrayData()
+    {
+        return [
+            ['/:[a-z_]+/', ['8:30', '9:00'], 'The event will take place between :start and :end', 'The event will take place between 8:30 and 9:00'],
+            ['/%s/', ['Taylor'], 'Hi, %s', 'Hi, Taylor'],
+            ['/%s/', ['Taylor', 'Otwell'], 'Hi, %s %s', 'Hi, Taylor Otwell'],
+            ['/%s/', [], 'Hi, %s %s', 'Hi,  '],
+            ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
+            ['//', [], '', ''],
+            ['/%s/', ['a'], '', ''],
+        ];
+    }
+
+    /** @dataProvider providesPregReplaceArrayData */
+    public function testPregReplaceArray($pattern, $replacements, $subject, $expectedOutput)
+    {
+        $this->assertSame(
+            $expectedOutput,
+            preg_replace_array($pattern, $replacements, $subject)
+        );
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
This PR is the same as PR https://github.com/laravel/framework/pull/31499, but it also adds tests.

The `foreach` in `preg_replace_array` is unnecessary, the tests in this PR work also work when the `foreach` is present.

@GrahamCampbell Could you double-check if  I'm missing any test cases? I've included the ones you mentioned in [your comment](https://github.com/laravel/framework/pull/31499#issuecomment-586882307).