### PR TITLE
[6.x] Add tests for preg_replace_array

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -362,9 +362,7 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject)
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            foreach ($replacements as $key => $value) {
-                return array_shift($replacements);
-            }
+            return array_shift($replacements);
         }, $subject);
     }
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -362,7 +362,9 @@ if (! function_exists('preg_replace_array')) {
     function preg_replace_array($pattern, array $replacements, $subject)
     {
         return preg_replace_callback($pattern, function () use (&$replacements) {
-            return array_shift($replacements);
+            foreach ($replacements as $key => $value) {
+                return array_shift($replacements);
+            }
         }, $subject);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -665,6 +665,18 @@ class SupportHelpersTest extends TestCase
             preg_replace_array($pattern, $replacements, $subject)
         );
     }
+
+    public function testPregReplaceArrayIgnoresInternalArrayPointer()
+    {
+        $pointerArray = ['Taylor', 'Otwell'];
+
+        next($pointerArray);
+
+        $this->assertSame(
+            'Hi, Taylor Otwell',
+            preg_replace_array('/%s/', $pointerArray, 'Hi, %s %s')
+        );
+    }
 }
 
 trait SupportTestTraitOne

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -646,6 +646,10 @@ class SupportHelpersTest extends TestCase
 
     public function providesPregReplaceArrayData()
     {
+        $pointerArray = ['Taylor', 'Otwell'];
+
+        next($pointerArray);
+
         return [
             ['/:[a-z_]+/', ['8:30', '9:00'], 'The event will take place between :start and :end', 'The event will take place between 8:30 and 9:00'],
             ['/%s/', ['Taylor'], 'Hi, %s', 'Hi, Taylor'],
@@ -654,6 +658,8 @@ class SupportHelpersTest extends TestCase
             ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
             ['//', [], '', ''],
             ['/%s/', ['a'], '', ''],
+            // The internal pointer of this array is not at the beginning
+            ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'],
         ];
     }
 
@@ -663,18 +669,6 @@ class SupportHelpersTest extends TestCase
         $this->assertSame(
             $expectedOutput,
             preg_replace_array($pattern, $replacements, $subject)
-        );
-    }
-
-    public function testPregReplaceArrayIgnoresInternalArrayPointer()
-    {
-        $pointerArray = ['Taylor', 'Otwell'];
-
-        next($pointerArray);
-
-        $this->assertSame(
-            'Hi, Taylor Otwell',
-            preg_replace_array('/%s/', $pointerArray, 'Hi, %s %s')
         );
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -643,6 +643,28 @@ class SupportHelpersTest extends TestCase
         $_SERVER['foo'] = 'From $_SERVER';
         $this->assertSame('From $_ENV', env('foo'));
     }
+
+    public function providesPregReplaceArrayData()
+    {
+        return [
+            ['/:[a-z_]+/', ['8:30', '9:00'], 'The event will take place between :start and :end', 'The event will take place between 8:30 and 9:00'],
+            ['/%s/', ['Taylor'], 'Hi, %s', 'Hi, Taylor'],
+            ['/%s/', ['Taylor', 'Otwell'], 'Hi, %s %s', 'Hi, Taylor Otwell'],
+            ['/%s/', [], 'Hi, %s %s', 'Hi,  '],
+            ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
+            ['//', [], '', ''],
+            ['/%s/', ['a'], '', ''],
+        ];
+    }
+
+    /** @dataProvider providesPregReplaceArrayData */
+    public function testPregReplaceArray($pattern, $replacements, $subject, $expectedOutput)
+    {
+        $this->assertSame(
+            $expectedOutput,
+            preg_replace_array($pattern, $replacements, $subject)
+        );
+    }
 }
 
 trait SupportTestTraitOne


### PR DESCRIPTION
This PR adds tests for the currently untested `preg_replace_array` helper.