### PR TITLE
[6.x] Dispatch MessageProcessing event before the message is sent

### DIFF
--- a/src/Illuminate/Mail/Events/MessageProcessing.php
+++ b/src/Illuminate/Mail/Events/MessageProcessing.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Mail\Events;
+
+class MessageProcessing
+{
+    /**
+     * The Swift message instance.
+     *
+     * @var \Swift_Message
+     */
+    public $message;
+
+    /**
+     * The message data.
+     *
+     * @var array
+     */
+    public $data;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  \Swift_Message  $message
+     * @param  array  $data
+     * @return void
+     */
+    public function __construct($message, $data = [])
+    {
+        $this->data = $data;
+        $this->message = $message;
+    }
+}

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Mail;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Events\MessageProcessing;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailer;
@@ -170,6 +171,7 @@ class MailMailerTest extends TestCase
         $events = m::mock(Dispatcher::class);
         $events->shouldReceive('until')->once()->with(m::type(MessageSending::class));
         $events->shouldReceive('dispatch')->once()->with(m::type(MessageSent::class));
+        $events->shouldReceive('dispatch')->once()->with(m::type(MessageProcessing::class));
         $mailer = $this->getMailer($events);
         $view = m::mock(stdClass::class);
         $mailer->getViewFactory()->shouldReceive('make')->once()->andReturn($view);


### PR DESCRIPTION
This PR dispatches a new `Illuminate\Mail\Events\MessageProcessing` event to add an opportunity to change the message just before it is sent.

A use case for this is when there are global changes that need to be applied to all messages.
In my case, I needed to add a BCC address to all outgoing emails, and I couldn't find a way to do it except extending the mailer class. But with this new event, it will be much easier:
```php
class EventServiceProvider extends ServiceProvider
{
    ...
    public function boot()
    {
        parent::boot();

        Event::listen(MessageProcessing::class, function($event) {
            $event->message->addBcc('test@example.com');
        });
    }
}
```
Note: There's a `MessageSending` event but it's for `shouldSendMessage` method, and it's dispatched using `$this->events->until`, so it means that some listeners may be skipped.

