### PR TITLE
[6.x] Fix implied middleware when using custom guards in tests (#31506)

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithAuthentication.php
@@ -33,8 +33,6 @@ trait InteractsWithAuthentication
 
         $this->app['auth']->guard($driver)->setUser($user);
 
-        $this->app['auth']->shouldUse($driver);
-
         return $this;
     }
 


### PR DESCRIPTION
This pull request is meant to fix issue #31506 - although it seems pretty concerning to me that the solution was literally _taking a line out_. It feels that I'm missing something, although the tests do not point out any issues in particular.

I've checked it in my only reference project where I'm using custom guard for admin authentication, and it causes quite some issues across the board, so some more digging is needed. For that reason, this PR stays a draft...