### PR TITLE
[7.x] Add a sequence builder to the new HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -62,7 +62,7 @@ class Factory
      * @param  array  $responses
      * @return \Illuminate\Http\Client\ResponseSequence
      */
-    public static function sequence(array $responses)
+    public static function sequence(array $responses = [])
     {
         return new ResponseSequence($responses);
     }

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -23,6 +23,80 @@ class ResponseSequence
     }
 
     /**
+     * Push a response to the sequence.
+     *
+     * @param  mixed $response
+     * @return $this
+     */
+    public function pushResponse($response)
+    {
+        $this->responses[] = $response;
+
+        return $this;
+    }
+
+    /**
+     * Push an empty response to the sequence.
+     *
+     * @param  int  $status
+     * @param  array  $headers
+     * @return $this
+     */
+    public function pushEmptyResponse($status = 200, $headers = [])
+    {
+        return $this->pushResponse(
+            Factory::response('', $status, $headers)
+        );
+    }
+
+    /**
+     * Push response with a string body to the sequence.
+     *
+     * @param  string  $string
+     * @param  int  $status
+     * @param  array  $headers
+     * @return $this
+     */
+    public function pushString($string, $status = 200, $headers = [])
+    {
+        return $this->pushResponse(
+            Factory::response($string, $status, $headers)
+        );
+    }
+
+    /**
+     * Push response with a json body to the sequence.
+     *
+     * @param  array  $data
+     * @param  int  $status
+     * @param  array  $headers
+     * @return $this
+     */
+    public function pushJson(array $data, $status = 200, $headers = [])
+    {
+        return $this->pushResponse(
+            Factory::response(json_encode($data), $status, $headers)
+        );
+    }
+
+    /**
+     * Push response with the contents of a file as the body to the sequence.
+     *
+     * @param  string  $filePath
+     * @param  int  $status
+     * @param  array  $headers
+     * @return $this
+     */
+    public function pushFile($filePath, $status = 200, $headers = [])
+    {
+        $string = file_get_contents($filePath);
+
+        return $this->pushResponse(
+            Factory::response($string, $status, $headers)
+        );
+    }
+
+    /**
      * Get the next response in the sequence.
      *
      * @return mixed

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -146,7 +146,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $response->status());
 
         $response = $factory->get('https://example.com');
-        $this->assertSame("", $response->body());
+        $this->assertSame('', $response->body());
         $this->assertSame(403, $response->status());
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Http;
 
 use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Str;
 use PHPUnit\Framework\TestCase;
 
@@ -117,5 +118,35 @@ class HttpClientTest extends TestCase
                    $request[0]['name'] == 'foo' &&
                    $request->hasFile('foo', 'data', 'file.txt');
         });
+    }
+
+    public function testSequenceBuilder()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            '*' => Factory::sequence()
+                ->pushString('Ok', 201)
+                ->pushJson(['fact' => 'Cats are great!'])
+                ->pushFile(__DIR__.'/fixtures/test.txt')
+                ->pushEmptyResponse(403),
+        ]);
+
+        /** @var PendingRequest $factory */
+        $response = $factory->get('https://example.com');
+        $this->assertSame('Ok', $response->body());
+        $this->assertSame(201, $response->status());
+
+        $response = $factory->get('https://example.com');
+        $this->assertSame(['fact' => 'Cats are great!'], $response->json());
+        $this->assertSame(200, $response->status());
+
+        $response = $factory->get('https://example.com');
+        $this->assertSame("This is a story about something that happened long ago when your grandfather was a child.\n", $response->body());
+        $this->assertSame(200, $response->status());
+
+        $response = $factory->get('https://example.com');
+        $this->assertSame("", $response->body());
+        $this->assertSame(403, $response->status());
     }
 }


### PR DESCRIPTION
As briefly discussed in https://github.com/laravel/framework/pull/31449#issuecomment-585429177, this PR adds a simple sequence builder to the new HTTP client.

```php
// Before
Http::fake([
    '*' => Http::sequence([
        Http::response(['fact' => 'Cats are great!'], 200),
        Http::response([file_get_contents('tests/Fixtures/huge-google-maps-api-response.json'), 200),
        Http::response('', 403),
    ]),
]);

// After
Http::fake([
    '*' => Factory::sequence()
        ->pushJson(['fact' => 'Cats are great!'])
        ->pushFile('tests/Fixtures/huge-google-maps-api-response.json')
        ->pushEmptyResponse(403),
]);
```

A big advantage over this approach is that any good IDE will provide convenient autocompletion:
![image](https://user-images.githubusercontent.com/7202674/74771196-fa370e80-528d-11ea-9d78-024905bd8f73.png)