### PR TITLE
[6.x] Consider mailto: and tel: links in the subcopy actionUrl label. #31522

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -219,6 +219,7 @@ class SimpleMessage
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,
             'actionUrl' => $this->actionUrl,
+            'actionUrlReadable' => str_replace(['mailto:', 'tel:'], '', $this->actionUrl),
         ];
     }
 }

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,9 +52,10 @@
 @slot('subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:actionURL](:actionURL)',
+    'into your web browser: [:actionUrlReadable](:actionURL)',
     [
         'actionText' => $actionText,
+        'actionUrlReadable' => $actionUrlReadable,
         'actionURL' => $actionUrl,
     ]
 )


### PR DESCRIPTION
As mentioned in #31522 this PR removes the `mailto:` and `tel:` from the Notification subcopy `$actionUrl` label in an attempt to make the label more readable and to allow users to copy and paste the link.