### PR TITLE
[7.x] Use ViewErrorBag instead of MessageBag

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\ViewErrorBag;
 use Throwable;
 
 class View implements ArrayAccess, Htmlable, ViewContract
@@ -207,23 +208,30 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
      * @return $this
      */
-    public function withErrors($provider)
+    public function withErrors($provider, $key = 'default')
     {
-        $this->with('errors', $this->formatErrors($provider));
+        $value = $this->parseErrors($provider);
+
+        $errors = new ViewErrorBag;
+
+        $this->with('errors', $errors->put($key, $value));
 
         return $this;
     }
 
     /**
-     * Format the given message provider into a MessageBag.
+     * Parse the given errors into an appropriate value.
      *
-     * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
+     * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider
      * @return \Illuminate\Support\MessageBag
      */
-    protected function formatErrors($provider)
+    protected function parseErrors($provider)
     {
-        return $provider instanceof MessageProvider
-                        ? $provider->getMessageBag() : new MessageBag((array) $provider);
+        if ($provider instanceof MessageProvider) {
+            return $provider->getMessageBag();
+        }
+
+        return new MessageBag((array) $provider);
     }
 
     /**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
 use Mockery as m;
@@ -216,7 +217,7 @@ class ViewTest extends TestCase
         $view = $this->getView();
         $errors = ['foo' => 'bar', 'qu' => 'ux'];
         $this->assertSame($view, $view->withErrors($errors));
-        $this->assertInstanceOf(MessageBag::class, $view->errors);
+        $this->assertInstanceOf(ViewErrorBag::class, $view->errors);
         $foo = $view->errors->get('foo');
         $this->assertEquals($foo[0], 'bar');
         $qu = $view->errors->get('qu');
@@ -224,6 +225,11 @@ class ViewTest extends TestCase
         $data = ['foo' => 'baz'];
         $this->assertSame($view, $view->withErrors(new MessageBag($data)));
         $foo = $view->errors->get('foo');
+        $this->assertEquals($foo[0], 'baz');
+        $foo = $view->errors->getBag('default')->get('foo');
+        $this->assertEquals($foo[0], 'baz');
+        $this->assertSame($view, $view->withErrors(new MessageBag($data), 'login'));
+        $foo = $view->errors->getBag('login')->get('foo');
         $this->assertEquals($foo[0], 'baz');
     }
 


### PR DESCRIPTION
This adds the ability to set the error bag to which errors are added to when adding errors to a view response.

```php
return view('login')->withErrors($errors, 'login');
```

In addition, you can now use the `@error` Blade directive when passing errors to the view. https://github.com/laravel/framework/pull/29750 changed the behavior (for the better!) with the assumption that `$errors` is an instance of `\Illuminate\Support\ViewErrorBag` rather than a more generic `\Illuminate\Support\MessageBag` by using `getBag()`. [CompilesErrors.php#L18](https://github.com/laravel/framework/blob/65705e0a8f0fffdf9784a32d864198ece4a3de23/src/Illuminate/View/Compilers/Concerns/CompilesErrors.php#L18)

This also brings closer parity to the `withErrors()` method in `\Illuminate\View\View` and `\Illuminate\Http\RedirectResponse`. See: [RedirectResponse.php#L124-L161](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Http/RedirectResponse.php#L124-L161)

With the pending release of 7.x, I made this a breaking change by changing `formatErrors()` to `parseErrors()` to match the similar implementation in `RedirectResponse`. Without that change, I don't believe this would be breaking. `formatErrors()` was already casting `$provider` to an array, so the docblock could have been updated to hint `$provider` could be a string. Assumed it would be better to mirror implementations, but happy to revert back to `formatErrors()`.
