### PR TITLE
[7.x] Make response sequences fail by default when they are out of responses

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -28,6 +28,13 @@ class Factory
     protected $recording = false;
 
     /**
+     * All created response sequences.
+     *
+     * @var array
+     */
+    protected static $responseSequences = [];
+
+    /**
      * Create a new factory instance.
      *
      * @return void
@@ -64,7 +71,7 @@ class Factory
      */
     public static function sequence(array $responses = [])
     {
-        return new ResponseSequence($responses);
+        return static::$responseSequences[] = new ResponseSequence($responses);
     }
 
     /**
@@ -160,6 +167,21 @@ class Factory
             $this->recorded($callback)->count() > 0,
             'An expected request was not recorded.'
         );
+    }
+
+    /**
+     * Assert that every created response sequence is empty.
+     *
+     * @return void
+     */
+    public static function assertSequencesAreEmpty()
+    {
+        foreach (static::$responseSequences as $responseSequence) {
+            PHPUnit::assertTrue(
+                $responseSequence->isEmpty(),
+                'Not all response sequences are empty.'
+            );
+        }
     }
 
     /**

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -109,6 +109,16 @@ class ResponseSequence
     }
 
     /**
+     * Indicate that this sequence has depleted all of its responses.
+     *
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return count($this->responses) === 0;
+    }
+
+    /**
      * Get the next response in the sequence.
      *
      * @return mixed
@@ -116,7 +126,7 @@ class ResponseSequence
     public function __invoke()
     {
         if ($this->failWhenEmpty && count($this->responses) === 0) {
-            throw new OutOfBoundsException('A request was made, but the response sequence is empty.');
+            throw new OutOfBoundsException('A request was made, but the response sequence is empty');
         }
 
         return array_shift($this->responses);

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Http\Client;
 
+use OutOfBoundsException;
+
 class ResponseSequence
 {
     /**
@@ -10,6 +12,13 @@ class ResponseSequence
      * @var array
      */
     protected $responses;
+
+    /**
+     * Indicates that invoking this sequence when it is empty should throw an exception.
+     *
+     * @var bool
+     */
+    protected $failWhenEmpty = true;
 
     /**
      * Create a new response sequence.
@@ -88,12 +97,28 @@ class ResponseSequence
     }
 
     /**
+     * Make the sequence return a default response when it is empty.
+     *
+     * @return $this
+     */
+    public function dontFailWhenEmpty()
+    {
+        $this->failWhenEmpty = false;
+
+        return $this;
+    }
+
+    /**
      * Get the next response in the sequence.
      *
      * @return mixed
      */
     public function __invoke()
     {
+        if ($this->failWhenEmpty && count($this->responses) === 0) {
+            throw new OutOfBoundsException('A request was made, but the response sequence is empty.');
+        }
+
         return array_shift($this->responses);
     }
 }

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -111,7 +111,7 @@ class ResponseSequence
     /**
      * Indicate that this sequence has depleted all of its responses.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEmpty()
     {

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -173,4 +173,21 @@ class HttpClientTest extends TestCase
         // The sequence is empty, but it should not fail.
         $factory->get('https://example.com');
     }
+
+    public function testAssertSequencesAreEmpty()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            '*' => Factory::sequence()
+                ->push('1')
+                ->push('2')
+        ]);
+
+        /** @var PendingRequest $factory */
+        $factory->get('https://example.com');
+        $factory->get('https://example.com');
+
+        Factory::assertSequencesAreEmpty();
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -181,7 +181,7 @@ class HttpClientTest extends TestCase
         $factory->fake([
             '*' => Factory::sequence()
                 ->push('1')
-                ->push('2')
+                ->push('2'),
         ]);
 
         /** @var PendingRequest $factory */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Http;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Str;
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
 class HttpClientTest extends TestCase
@@ -148,5 +149,28 @@ class HttpClientTest extends TestCase
         $response = $factory->get('https://example.com');
         $this->assertSame('', $response->body());
         $this->assertSame(403, $response->status());
+
+        $this->expectException(OutOfBoundsException::class);
+
+        // The sequence is empty, it should throw an exception.
+        $factory->get('https://example.com');
+    }
+
+    public function testSequenceBuilderCanKeepGoingWhenEmpty()
+    {
+        $factory = new Factory;
+
+        $factory->fake([
+            '*' => Factory::sequence()
+                ->dontFailWhenEmpty()
+                ->push('Ok'),
+        ]);
+
+        /** @var PendingRequest $factory */
+        $response = $factory->get('https://example.com');
+        $this->assertSame('Ok', $response->body());
+
+        // The sequence is empty, but it should not fail.
+        $factory->get('https://example.com');
     }
 }


### PR DESCRIPTION
Currently, if a response sequence has no more queued responses, it will return a default 200 response. This PR changes that behavior to make it throw an exception instead. This PR also adds an assertion to make sure all the pushed responses have been used.

The idea is that if I give my test a sequence of 3 responses, I want my test to make exactly 3 requests. More or less should fail my test immediately.

Example:
```php
public function test_it_does_some_business_logic()
{
    Http::fake([
        '*' => Factory::sequence()
            ->push('some specific response'),
            ->push('another specific response'),
            ->push('yet another specific response'),
    ]);

    // Make a request to a controller...

    Http::assertSequencesAreEmpty();

    // Assert business logic did its thing
}
```

The test above will fail as soon as an unexpected 4th request is made. If it would have returned a default 200 response, it would probably have failed further along in the business logic. If the business logic is making POST requests and only checks status codes, it probably wouldn't fail at all.

It will also fail if less than 3 requests are made. Without the `Http::assertSequencesAreEmpty()` assertion you'd most likely get a `Failed asserting that 2 is identical to 3` error later on in the test, which doesn't directly indicate what the problem is.

----

The normal Guzzle mock handler also doesn't use a default response. It throws an exception when it has run out of queued responses. 
In my experience, when mocking Guzzle, a default response is almost never what you want. It might be a good idea to make the entire http client fail by default, and to add a `->defaultResponse($response)` method instead.

