### PR TITLE
[6.x] Fix for issue Content Type not specified

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -746,7 +746,7 @@ class Router implements BindingRegistrar, RegistrarContract
                     is_array($response))) {
             $response = new JsonResponse($response);
         } elseif (! $response instanceof SymfonyResponse) {
-            $response = new Response($response);
+            $response = new Response($response, 200, ['Content-Type' => 'text/html']);
         }
 
         if ($response->getStatusCode() === Response::HTTP_NOT_MODIFIED) {


### PR DESCRIPTION
This fixes issue https://github.com/laravel/framework/issues/31518 where Laravel isn't setting a Content-Type and so Symfony is just setting it to whatever the request is asking for.  This is poisoning our cache, randomly serving up our website HTML pages as "text/xml" (which causes Chrome rendering errors).

This is a regression caused by a recent update to the underlying Symfony framework, but affects Laravel because we chose not to specify the default Content-Type.
