### PR TITLE
[7.x] Add Http::fakeSequence()

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -110,12 +110,12 @@ class Factory
     }
 
     /**
-     * Register a response sequence for the given url pattern.
+     * Register a response sequence for the given URL pattern.
      *
-     * @param  string  $urlPattern
-     * @return ResponseSequence
+     * @param  string  $url
+     * @return \Illuminate\Http\Client\ResponseSequence
      */
-    public function fakeSequence($urlPattern = '*')
+    public function fakeSequence($url = '*')
     {
         $responseSequence = $this->sequence();
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -110,6 +110,21 @@ class Factory
     }
 
     /**
+     * Register a response sequence for the given url pattern.
+     *
+     * @param  string  $urlPattern
+     * @return ResponseSequence
+     */
+    public function fakeSequence($urlPattern = '*')
+    {
+        $responseSequence = $this->sequence();
+
+        $this->fake([$urlPattern => $responseSequence]);
+
+        return $responseSequence;
+    }
+
+    /**
      * Stub the given URL using the given callback.
      *
      * @param  string  $url

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -119,7 +119,7 @@ class Factory
     {
         $responseSequence = $this->sequence();
 
-        $this->fake([$urlPattern => $responseSequence]);
+        $this->fake([$url => $responseSequence]);
 
         return $responseSequence;
     }

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -30,6 +30,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response delete(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
  * @method static \Illuminate\Http\Client\PendingRequest stub(callable $callback)
+ * @method static \Illuminate\Http\Client\ResponseSequence fakeSequence(string $urlPattern = '*')
  *
  * @see \Illuminate\Http\Client\Factory
  */

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -190,4 +190,17 @@ class HttpClientTest extends TestCase
 
         $factory->assertSequencesAreEmpty();
     }
+
+    public function testFakeSequence()
+    {
+        $factory = new Factory;
+
+        $factory->fakeSequence()
+            ->pushStatus(201)
+            ->pushStatus(301);
+
+        /** @var PendingRequest $factory */
+        $this->assertSame(201, $factory->get('https://example.com')->status());
+        $this->assertSame(301, $factory->get('https://example.com')->status());
+    }
 }


### PR DESCRIPTION
This PR adds a `fakeSequence()` method to the new http client:
```php
// Before
Http::fake([
    '*' => Http::sequence()
        ->push('first')
        ->push('second'),
]);

// After
Http::fakeSequence()
    ->push('first')
    ->push('second');
```

A big advantage with this new method is that IDEs will provide convenient autocompletion:
![image](https://user-images.githubusercontent.com/7202674/74867533-24073880-5355-11ea-84c2-31f2dc4162e5.png)

![image](https://user-images.githubusercontent.com/7202674/74867582-37b29f00-5355-11ea-9f72-b96bcd731d00.png)

-----

Slightly unrelated, but based on my experience in the last two years working with my package Gobble, I think it is a better idea that `fake()` would return a `ResponseSequence`, and a new method, something like `fakeForUrl('github.com/*')` could be used for faking specific requests to urls.

In my opinion, specifying url patterns is overkill for 95%+ of tests. Most tests, especially in "normal" applications, only make 1 Guzzle request. Some will make 2 or more, but even then, almost always to the same external api. Even if one test makes multiple requests to different apis, you will most likely know the order of the requests, so you can still use a response sequence.

The goal of the new http client was to improve the developer experience in 80% of Guzzle use-cases (in my case it actually improves everything I use Guzzle for). I think making `fake()` return a `ResponseSequence` that provides simple response builder methods that an IDE can autocomplete is a great developer experience in 80% (or in my case 99%) of tests.
