### PR TITLE
[6.x] MySQL Aurora failover - DetectsLostConnections

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -40,6 +40,8 @@ trait DetectsLostConnections
             'Communication link failure',
             'connection is no longer usable',
             'Login timeout expired',
+            'Connection refused',
+            'running with the --read-only option so it cannot execute this statement',
         ]);
     }
 }


### PR DESCRIPTION
We recently experienced a MySQL Aurora failover on production and noticed that our queue workers didn't restart.

When running the following code inside a Laravel command and then starting a failover inside RDS dashboard we see these exception messages:

- SQLSTATE[HY000] [2002] Connection refused
- SQLSTATE[HY000]: General error: 1290 The MySQL server is running with the --read-only option so it cannot execute this statement (SQL: update `brand_daily_summary` set `deposit_count` = 23 where `id` = 1)

```
    public static function testConnection($attemptReconnect = true)
    {
        $end = Carbon::now()->copy()->addSeconds(120);

        $lastSecondRun = null;
        $count = 0;

        while (Carbon::now()->lessThan($end)) {
            $now = Carbon::now();

            if ($lastSecondRun === null || $lastSecondRun !== $now->second) {

                \Log::debug('second: ' . $now->second);

                $count++;

                try {
                    
                    $affected = \DB::table(DailySummary::TABLE)
                        ->where('id', 1)
                        ->update(['deposit_count' => $count]);

                    \Log::debug('affected: ' . $affected);

                } catch (\Exception $e) {
                    \Log::debug('Exception');
                    \Log::debug($e->getMessage());

                    if ($attemptReconnect) {
                        if (Str::contains($e->getMessage(), ['--read-only'])) {
                            \Log::debug('attempting to reconnect');
                            \DB::reconnect();
                        }
                    }
                }

            }

            $lastSecondRun = $now->second;
        }
    }
```

Maybe `protected function causedByLostConnection` is not the correct place to be handling the `--read-only option` exception message though as it is quite general?

Any thoughts on this?