### PR TITLE
[6.x] Fix database queue driver's locking on MariaDB

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -236,7 +236,7 @@ class DatabaseQueue extends Queue implements QueueContract
     }
 
     /**
-     * Check if the used database driver supports SKIP LOCKED
+     * Check if the used database driver supports SKIP LOCKED.
      *
      * @return bool
      */


### PR DESCRIPTION
Fixes #31536.

I verified that this change correctly identifies MariaDB and doesn't emit `FOR UPDATE SKIP LOCKED`. It would be nice if someone could additionally try actually running a queue on MariaDB using this fix.