### PR TITLE
[6.x] Improve ContainerTest

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -68,41 +68,40 @@ class ContainerTest extends TestCase
     public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
     {
         $container = new Container;
-        $class = new stdClass;
-        $container->singleton('class', function () use ($class) {
-            return $class;
+        $container->singleton('class', function () {
+            return new stdClass;
         });
-        $otherClass = new stdClass;
-        $container->singletonIf('class', function () use ($otherClass) {
-            return $otherClass;
+        $firstInstantiation = $container->make('class');
+        $container->singletonIf('class', function () {
+            return new ContainerConcreteStub;
         });
-
-        $this->assertSame($class, $container->make('class'));
+        $secondInstantiation = $container->make('class');
+        $this->assertSame($firstInstantiation, $secondInstantiation);
     }
 
     public function testSingletonIfDoesRegisterIfBindingNotRegisteredYet()
     {
         $container = new Container;
-        $class = new stdClass;
-        $container->singleton('class', function () use ($class) {
-            return $class;
+        $container->singleton('class', function () {
+            return new stdClass;
         });
-        $otherClass = new stdClass;
-        $container->singletonIf('otherClass', function () use ($otherClass) {
-            return $otherClass;
+        $container->singletonIf('otherClass', function () {
+            return new ContainerConcreteStub;
         });
-
-        $this->assertSame($otherClass, $container->make('otherClass'));
+        $firstInstantiation = $container->make('otherClass');
+        $secondInstantiation = $container->make('otherClass');
+        $this->assertSame($firstInstantiation, $secondInstantiation);
     }
 
     public function testSharedClosureResolution()
     {
         $container = new Container;
-        $class = new stdClass;
-        $container->singleton('class', function () use ($class) {
-            return $class;
+        $container->singleton('class', function () {
+            return new stdClass;
         });
-        $this->assertSame($class, $container->make('class'));
+        $firstInstantiation = $container->make('class');
+        $secondInstantiation = $container->make('class');
+        $this->assertSame($firstInstantiation, $secondInstantiation);
     }
 
     public function testAutoConcreteResolution()


### PR DESCRIPTION
This PR improves the unit tests for the `Singleton()` and `SingletonIf()` methods of the container class.

My reason for doing that is since the singleton pattern is meant for storing the _already computed value_ and always return that _already computed value_ for the subsequent calls **without** executing the given closure again.

The current test, for instance:

```php
public function testSharedClosureResolution()
{
  $container = new Container;
  $class = new stdClass;
  $container->singleton('class', function () use ($class) {
    return $class;
  });
  $this->assertSame($class, $container->make('class'));
}
```
While our assertion results in passed, we're not sure whether our closure is executed twice or not. In case our closure is executed more than one time, our assertion is still passed, because that closure always return the same _reference_ which refers to the same object stored in the memory.

---
By changing to this:
```php
public function testSharedClosureResolution()
{
  $container = new Container;
  $container->singleton('class', function () {
    return new stdClass;
  });
  $firstInstantiation = $container->make('class');
  $secondInstantiation = $container->make('class');
  $this->assertSame($firstInstantiation, $secondInstantiation);
}
```
We now can sure that our given closure is not executed the second time for the second call of `make()`.

The same reason for the unit tests of the `SingletonIf()` method.