### PR TITLE
[6.x] Allow cache helper to have an optional expiration parameter (syntactic sugar for forever)

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -250,13 +250,7 @@ if (! function_exists('cache')) {
             );
         }
 
-        if (! isset($arguments[1])) {
-            throw new Exception(
-                'You must specify an expiration time when setting a value in the cache.'
-            );
-        }
-
-        return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1]);
+        return app('cache')->put(key($arguments[0]), reset($arguments[0]), $arguments[1] ?? null);
     }
 }
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -43,14 +43,6 @@ class FoundationHelpersTest extends TestCase
         $this->assertSame('default', cache('baz', 'default'));
     }
 
-    public function testCacheThrowsAnExceptionIfAnExpirationIsNotProvided()
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('You must specify an expiration time when setting a value in the cache.');
-
-        cache(['foo' => 'bar']);
-    }
-
     public function testUnversionedElixir()
     {
         $file = 'unversioned.css';


### PR DESCRIPTION
I believe this is a minor change that's completely backwards compatible.

This change will also make it match the facade usage.

![image](https://user-images.githubusercontent.com/1296882/75065187-5c725800-54b6-11ea-8116-0a07ec3e311c.png)
