### PR TITLE
[6.x] Support tiny, medium, and long blobs in MySQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1059,11 +1059,14 @@ class Blueprint
      * Create a new binary column on the table.
      *
      * @param  string  $column
+     * @param  int|null  $length
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function binary($column)
+    public function binary($column, $length = null)
     {
-        return $this->addColumn('binary', $column);
+        $length = $length ?: Builder::$defaultBinaryLength;
+
+        return $this->addColumn('binary', $column, compact('length'));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1064,8 +1064,6 @@ class Blueprint
      */
     public function binary($column, $length = null)
     {
-        $length = $length ?: Builder::$defaultBinaryLength;
-
         return $this->addColumn('binary', $column, compact('length'));
     }
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -39,6 +39,13 @@ class Builder
     public static $defaultStringLength = 255;
 
     /**
+     * The default binary length for migrations.
+     *
+     * @var int
+     */
+    public static $defaultBinaryLength = 65535;
+
+    /**
      * Create a new database Schema manager.
      *
      * @param  \Illuminate\Database\Connection  $connection

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -39,13 +39,6 @@ class Builder
     public static $defaultStringLength = 255;
 
     /**
-     * The default binary length for migrations.
-     *
-     * @var int
-     */
-    public static $defaultBinaryLength = 65535;
-
-    /**
      * Create a new database Schema manager.
      *
      * @param  \Illuminate\Database\Connection  $connection

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -9,6 +9,10 @@ use RuntimeException;
 
 class MySqlGrammar extends Grammar
 {
+    public const LENGTH_LIMIT_TINYBLOB   = 255;
+    public const LENGTH_LIMIT_BLOB       = 65535;
+    public const LENGTH_LIMIT_MEDIUMBLOB = 16777215;
+
     /**
      * The possible column modifiers.
      *
@@ -723,7 +727,16 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBinary(Fluent $column)
     {
-        return 'blob';
+        $length = $column->length ?? static::LENGTH_LIMIT_BLOB;
+        if ($length <= self::LENGTH_LIMIT_TINYBLOB) {
+            return 'tinyblob';
+        } else if ($length <= static::LENGTH_LIMIT_BLOB) {
+            return 'blob';
+        } else if ($length <= static::LENGTH_LIMIT_MEDIUMBLOB) {
+            return 'mediumblob';
+        } else {
+            return 'longblob';
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -730,9 +730,9 @@ class MySqlGrammar extends Grammar
         $length = $column->length ?? static::LENGTH_LIMIT_BLOB;
         if ($length <= self::LENGTH_LIMIT_TINYBLOB) {
             return 'tinyblob';
-        } else if ($length <= static::LENGTH_LIMIT_BLOB) {
+        } elseif ($length <= static::LENGTH_LIMIT_BLOB) {
             return 'blob';
-        } else if ($length <= static::LENGTH_LIMIT_MEDIUMBLOB) {
+        } elseif ($length <= static::LENGTH_LIMIT_MEDIUMBLOB) {
             return 'mediumblob';
         } else {
             return 'longblob';


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fixes bug #3544 by adding an optional $length argument to the Schema Builder's binary() argument.  This argument will currently be ignored by other grammars.