### PR TITLE
[6.x] Allow private-encrypted pusher channels

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
@@ -14,7 +14,7 @@ trait UsePusherChannelConventions
      */
     public function isGuardedChannel($channel)
     {
-        return Str::startsWith($channel, ['private-', 'presence-', 'private-encrypted-']);
+        return Str::startsWith($channel, ['private-', 'presence-']);
     }
 
     /**
@@ -25,10 +25,11 @@ trait UsePusherChannelConventions
      */
     public function normalizeChannelName($channel)
     {
-        if ($this->isGuardedChannel($channel)) {
-            return Str::startsWith($channel, 'private-')
-                ? Str::replaceFirst('private-', '', Str::replaceFirst('private-encrypted-', '', $channel))
-                : Str::replaceFirst('presence-', '', $channel);
+        foreach (['private-encrypted-', 'private-', 'presence-'] as $prefix) {
+            $replacement = Str::replaceFirst($prefix, '', $channel);
+            if ($replacement !== $channel) {
+                return $replacement;
+            }
         }
 
         return $channel;

--- a/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
@@ -26,9 +26,8 @@ trait UsePusherChannelConventions
     public function normalizeChannelName($channel)
     {
         foreach (['private-encrypted-', 'private-', 'presence-'] as $prefix) {
-            $replacement = Str::replaceFirst($prefix, '', $channel);
-            if ($replacement !== $channel) {
-                return $replacement;
+            if (Str::startsWith($channel, $prefix)) {
+                return Str::replaceFirst($prefix, '', $channel);
             }
         }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/UsePusherChannelConventions.php
@@ -14,7 +14,7 @@ trait UsePusherChannelConventions
      */
     public function isGuardedChannel($channel)
     {
-        return Str::startsWith($channel, ['private-', 'presence-']);
+        return Str::startsWith($channel, ['private-', 'presence-', 'private-encrypted-']);
     }
 
     /**
@@ -27,7 +27,7 @@ trait UsePusherChannelConventions
     {
         if ($this->isGuardedChannel($channel)) {
             return Str::startsWith($channel, 'private-')
-                ? Str::replaceFirst('private-', '', $channel)
+                ? Str::replaceFirst('private-', '', Str::replaceFirst('private-encrypted-', '', $channel))
                 : Str::replaceFirst('presence-', '', $channel);
         }
 

--- a/src/Illuminate/Broadcasting/PrivateEncryptedChannel.php
+++ b/src/Illuminate/Broadcasting/PrivateEncryptedChannel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Broadcasting;
+
+class PrivateEncryptedChannel extends Channel
+{
+    /**
+     * Create a new channel instance.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function __construct($name)
+    {
+        parent::__construct('private-encrypted-'.$name);
+    }
+}

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -21,6 +21,16 @@ class UsePusherChannelConventionsTest extends TestCase
         );
     }
 
+    public function testChannelNameNormalizationSpecialCase()
+    {
+        $broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
+
+        $this->assertSame(
+            'private-123',
+            $broadcaster->normalizeChannelName('private-encrypted-private-123')
+        );
+    }
+
     /**
      * @dataProvider channelsProvider
      */
@@ -48,7 +58,6 @@ class UsePusherChannelConventionsTest extends TestCase
             'test-channel',
             'test-private-channel',
             'test-presence-channel',
-            'private-123',
             'abcd.efgh',
             'abcd.efgh.ijkl',
             'test.{param}',

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -4,36 +4,20 @@ namespace Illuminate\Tests\Broadcasting;
 
 use Illuminate\Broadcasting\Broadcasters\Broadcaster;
 use Illuminate\Broadcasting\Broadcasters\UsePusherChannelConventions;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class UsePusherChannelConventionsTest extends TestCase
 {
     /**
-     * @var \Illuminate\Broadcasting\Broadcasters\RedisBroadcaster
-     */
-    public $broadcaster;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
-    }
-
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
-    /**
      * @dataProvider channelsProvider
      */
     public function testChannelNameNormalization($requestChannelName, $normalizedName)
     {
-        $this->assertEquals(
+        $broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
+
+        $this->assertSame(
             $normalizedName,
-            $this->broadcaster->normalizeChannelName($requestChannelName)
+            $broadcaster->normalizeChannelName($requestChannelName)
         );
     }
 
@@ -42,9 +26,11 @@ class UsePusherChannelConventionsTest extends TestCase
      */
     public function testIsGuardedChannel($requestChannelName, $_, $guarded)
     {
-        $this->assertEquals(
+        $broadcaster = new FakeBroadcasterUsingPusherChannelsNames();
+
+        $this->assertSame(
             $guarded,
-            $this->broadcaster->isGuardedChannel($requestChannelName)
+            $broadcaster->isGuardedChannel($requestChannelName)
         );
     }
 
@@ -52,6 +38,7 @@ class UsePusherChannelConventionsTest extends TestCase
     {
         $prefixesInfos = [
             ['prefix' => 'private-', 'guarded' => true],
+            ['prefix' => 'private-encrypted-', 'guarded' => true],
             ['prefix' => 'presence-', 'guarded' => true],
             ['prefix' => '', 'guarded' => false],
         ];
@@ -61,6 +48,7 @@ class UsePusherChannelConventionsTest extends TestCase
             'test-channel',
             'test-private-channel',
             'test-presence-channel',
+            'private-123',
             'abcd.efgh',
             'abcd.efgh.ijkl',
             'test.{param}',


### PR DESCRIPTION
pusher/pusher-php-server allows private-encrypted channels but broadcaster implementation missing the definitions so it couldn't pass the broadcasting/auth guard.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
