### PR TITLE
[7.x] Don't force phpunit and mockery on people

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "email": "taylor@laravel.com"
         }
     ],
+    "conflict": {
+        "mockery/mockery": "<1.3.1|>=2.0",
+        "phpunit/phpunit": "<8.4|>=10",
+        "tightenco/collect": "<5.5.33"
+    },
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
@@ -75,9 +80,6 @@
         "illuminate/validation": "self.version",
         "illuminate/view": "self.version"
     },
-    "conflict": {
-        "tightenco/collect": "<5.5.33"
-    },
     "require-dev": {
         "aws/aws-sdk-php": "^3.0",
         "doctrine/dbal": "^2.6",
@@ -129,9 +131,11 @@
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
+        "mockery/mockery": "Required to use mocking (^1.3.1).",
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
+        "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.0).",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,6 @@
             "email": "taylor@laravel.com"
         }
     ],
-    "conflict": {
-        "mockery/mockery": "<1.3.1|>=2.0",
-        "phpunit/phpunit": "<8.4|>=10",
-        "tightenco/collect": "<5.5.33"
-    },
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
@@ -93,6 +88,9 @@
         "phpunit/phpunit": "^8.4|^9.0",
         "predis/predis": "^1.1.1",
         "symfony/cache": "^5.0"
+    },
+    "conflict": {
+        "tightenco/collect": "<5.5.33"
     },
     "autoload": {
         "files": [

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -13,6 +13,10 @@
             "email": "taylor@laravel.com"
         }
     ],
+    "conflict": {
+        "mockery/mockery": "<1.3.1|>=2.0",
+        "phpunit/phpunit": "<8.4|>=10"
+    },
     "require": {
         "php": "^7.2.5",
         "illuminate/contracts": "^7.0",
@@ -33,7 +37,9 @@
     "suggest": {
         "illuminate/console": "Required to assert console commands (^7.0).",
         "illuminate/database": "Required to assert databases (^7.0).",
-        "illuminate/http": "Required to assert responses (^7.0)."
+        "illuminate/http": "Required to assert responses (^7.0).",
+        "mockery/mockery": "Required to use mocking (^1.3.1).",
+        "phpunit/phpunit": "Required to use assertions and run tests (^8.4|^9.0)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -13,10 +13,6 @@
             "email": "taylor@laravel.com"
         }
     ],
-    "conflict": {
-        "mockery/mockery": "<1.3.1|>=2.0",
-        "phpunit/phpunit": "<8.4|>=10"
-    },
     "require": {
         "php": "^7.2.5",
         "illuminate/contracts": "^7.0",

--- a/src/Illuminate/Testing/composer.json
+++ b/src/Illuminate/Testing/composer.json
@@ -16,9 +16,7 @@
     "require": {
         "php": "^7.2.5",
         "illuminate/contracts": "^7.0",
-        "illuminate/support": "^7.0",
-        "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "illuminate/support": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Requiring phpunit is a very aggressive thing to do. People might want to use the phar version of phpunit, or something else. Instead, I propose we suggest it, and conflict ourselves with versions we don't support. This has the same effect of not letting people install bad versions, but is weaker in the sense that people don't have to install them.

EDIT: Decided to remove the conflicts stuff.