### PR TITLE
[6.x] Enforce usage of collect() helper

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Database\Console\Migrations;
 
 use Illuminate\Database\Migrations\Migrator;
-use Illuminate\Support\Collection;
 use Symfony\Component\Console\Input\InputOption;
 
 class StatusCommand extends BaseCommand

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -77,14 +77,14 @@ class StatusCommand extends BaseCommand
      */
     protected function getStatusFor(array $ran, array $batches)
     {
-        return Collection::make($this->getAllMigrationFiles())
-                    ->map(function ($migration) use ($ran, $batches) {
-                        $migrationName = $this->migrator->getMigrationName($migration);
+        return collect($this->getAllMigrationFiles())
+                ->map(function ($migration) use ($ran, $batches) {
+                    $migrationName = $this->migrator->getMigrationName($migration);
 
-                        return in_array($migrationName, $ran)
-                                ? ['<info>Yes</info>', $migrationName, $batches[$migrationName]]
-                                : ['<fg=red>No</fg=red>', $migrationName];
-                    });
+                    return in_array($migrationName, $ran)
+                            ? ['<info>Yes</info>', $migrationName, $batches[$migrationName]]
+                            : ['<fg=red>No</fg=red>', $migrationName];
+                });
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Events\MigrationStarted;
 use Illuminate\Database\Events\NoPendingMigrations;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class Migrator

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -121,7 +121,7 @@ class Migrator
      */
     protected function pendingMigrations($files, $ran)
     {
-        return Collection::make($files)
+        return collect($files)
                 ->reject(function ($file) use ($ran) {
                     return in_array($this->getMigrationName($file), $ran);
                 })->values()->all();
@@ -461,7 +461,7 @@ class Migrator
      */
     public function getMigrationFiles($paths)
     {
-        return Collection::make($paths)->flatMap(function ($path) {
+        return collect($paths)->flatMap(function ($path) {
             return Str::endsWith($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
         })->filter()->values()->keyBy(function ($file) {
             return $this->getMigrationName($file);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2015,7 +2015,7 @@ class Builder
      */
     protected function removeExistingOrdersFor($column)
     {
-        return Collection::make($this->orders)
+        return collect($this->orders)
                     ->reject(function ($order) use ($column) {
                         return isset($order['column'])
                                ? $order['column'] === $column : false;

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -701,7 +701,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function filterContentsByType($contents, $type)
     {
-        return Collection::make($contents)
+        return collect($contents)
             ->where('type', $type)
             ->pluck('path')
             ->values()

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
 use Illuminate\Http\File;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\Ftp;

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -582,7 +582,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function registerConfiguredProviders()
     {
-        $providers = Collection::make($this->config['app.providers'])
+        $providers = collect($this->config['app.providers'])
                         ->partition(function ($provider) {
                             return strpos($provider, 'Illuminate\\') === 0;
                         });

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -14,7 +14,6 @@ use Illuminate\Http\Request;
 use Illuminate\Log\LogServiceProvider;
 use Illuminate\Routing\RoutingServiceProvider;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -19,7 +19,7 @@ class Inspiring
      */
     public static function quote()
     {
-        return Collection::make([
+        return collect([
             'When there is no desire, all things are at peace. - Laozi',
             'Simplicity is the ultimate sophistication. - Leonardo da Vinci',
             'Simplicity is the essence of happiness. - Cedric Bledsoe',

--- a/src/Illuminate/Foundation/Inspiring.php
+++ b/src/Illuminate/Foundation/Inspiring.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Foundation;
 
-use Illuminate\Support\Collection;
-
 class Inspiring
 {
     /**

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -21,7 +21,7 @@ trait CollectsResources
         }
 
         if (is_array($resource)) {
-            $resource = new Collection($resource);
+            $resource = collect($resource);
         }
 
         $collects = $this->collects();

--- a/src/Illuminate/Mail/Transport/ArrayTransport.php
+++ b/src/Illuminate/Mail/Transport/ArrayTransport.php
@@ -21,7 +21,7 @@ class ArrayTransport extends Transport
      */
     public function __construct()
     {
-        $this->messages = new Collection;
+        $this->messages = collect();
     }
 
     /**
@@ -53,6 +53,6 @@ class ArrayTransport extends Transport
      */
     public function flush()
     {
-        return $this->messages = new Collection;
+        return $this->messages = collect();
     }
 }

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -7,7 +7,6 @@ use Countable;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginatorContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
 
@@ -50,7 +49,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         $this->lastPage = max((int) ceil($total / $perPage), 1);
         $this->path = $this->path !== '/' ? rtrim($this->path, '/') : $this->path;
         $this->currentPage = $this->setCurrentPage($currentPage, $this->pageName);
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->items = collect($items);
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -65,7 +65,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     protected function setItems($items)
     {
-        $this->items = $items instanceof Collection ? $items : Collection::make($items);
+        $this->items = collect($items);
 
         $this->hasMore = $this->items->count() > $this->perPage;
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -7,7 +7,6 @@ use Countable;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Collection;
 use IteratorAggregate;
 use JsonSerializable;
 

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -19,7 +19,7 @@ class SortedMiddleware extends Collection
             $middlewares = $middlewares->all();
         }
 
-        $this->items = $this->sortMiddleware($priorityMap, $middlewares);
+        parent::__construct($this->sortMiddleware($priorityMap, $middlewares));
     }
 
     /**

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -6,7 +6,6 @@ use Countable;
 use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Contracts\Translation\Translator as TranslatorContract;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\NamespacedItemResolver;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -235,7 +235,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function sortReplacements(array $replace)
     {
-        return (new Collection($replace))->sortBy(function ($value, $key) {
+        return collect($replace)->sortBy(function ($value, $key) {
             return mb_strlen($key) * -1;
         })->all();
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

`new Collection` and `Collection::make` have been replaced for some times already by `collect()`.

This PR enforces this choice for sake of consistancy.
