### PR TITLE
[6.x] Improve container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -196,7 +196,7 @@ class Container implements ArrayAccess, ContainerContract
     public function isShared($abstract)
     {
         return isset($this->instances[$abstract]) ||
-               (isset($this->bindings[$abstract]['shared']) &&
+               (isset($this->bindings[$abstract]) &&
                $this->bindings[$abstract]['shared'] === true);
     }
 
@@ -726,11 +726,7 @@ class Container implements ArrayAccess, ContainerContract
         // If we don't have a registered resolver or concrete for the type, we'll just
         // assume each type is a concrete name and will attempt to resolve it as is
         // since the container should be able to resolve concretes automatically.
-        if (isset($this->bindings[$abstract])) {
-            return $this->bindings[$abstract]['concrete'];
-        }
-
-        return $abstract;
+        return $this->bindings[$abstract]['concrete'] ?? $abstract;
     }
 
     /**


### PR DESCRIPTION
This PR improves the `isShared()` and `getConcrete()` methods of the container class.

---

The current `isShared()` method:
```php
public function isShared($abstract)
{
  return isset($this->instances[$abstract]) ||
         (isset($this->bindings[$abstract]['shared']) &&
         $this->bindings[$abstract]['shared'] === true);
}
```

We don't need to go one level deeper to check the existence of the `shared` value because that value _always_ exist as long as the corresponding `$abstract` key exists. The `shared` parameter is set a default value as false. 

Changing to this would be better:

```php
public function isShared($abstract)
{
  return isset($this->instances[$abstract]) ||
         (isset($this->bindings[$abstract]) &&
         $this->bindings[$abstract]['shared'] === true);
}
```
Just like what we did with the _current_ [getConcrete()](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Container/Container.php#L729) method.

```php
...
if (isset($this->bindings[$abstract])) {
  return $this->bindings[$abstract]['concrete'];
}
...
```
---
The current `getConcrete()` method:

```php
protected function getConcrete($abstract)
{
  if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
    return $concrete;
  }
  if (isset($this->bindings[$abstract])) {
    return $this->bindings[$abstract]['concrete'];
  }
  return $abstract;
}
```
It would be cleaner when utilizing the [Null coalescing operator](https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op)

```php
protected function getConcrete($abstract)
{
  if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
    return $concrete;
  }

  return $this->bindings[$abstract]['concrete'] ?? $abstract
}
```