### PR TITLE
[7.x] Cache forgotten properties on route object

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -142,6 +142,9 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'methods' => $route->methods(),
                 'uri' => $route->uri(),
                 'action' => $route->getAction(),
+                'fallback' => $route->isFallback,
+                'defaults' => $route->defaults,
+                'wheres' => $route->wheres,
             ];
         }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -65,6 +65,9 @@ class CompiledRouteCollection extends AbstractRouteCollection
             'methods' => $route->methods(),
             'uri' => $route->uri(),
             'action' => $route->getAction() + ['as' => $name],
+            'fallback' => $route->isFallback,
+            'defaults' => $route->defaults,
+            'wheres' => $route->wheres,
         ];
 
         $this->compiled = [];
@@ -219,6 +222,9 @@ class CompiledRouteCollection extends AbstractRouteCollection
     protected function newRoute(array $attributes)
     {
         return (new Route($attributes['methods'], $attributes['uri'], $attributes['action']))
+            ->setFallback($attributes['fallback'])
+            ->setDefaults($attributes['defaults'])
+            ->setWheres($attributes['wheres'])
             ->setRouter($this->router)
             ->setContainer($this->container);
     }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -603,7 +603,7 @@ class Route
     }
 
     /**
-     * Set the fallback value
+     * Set the fallback value.
      *
      * @param  bool  $isFallback
      * @return $this

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -535,6 +535,19 @@ class Route
     }
 
     /**
+     * Set the default values for the route.
+     *
+     * @param  array  $defaults
+     * @return $this
+     */
+    public function setDefaults(array $defaults)
+    {
+        $this->defaults = $defaults;
+
+        return $this;
+    }
+
+    /**
      * Set a regular expression requirement on the route.
      *
      * @param  array|string  $name
@@ -568,7 +581,7 @@ class Route
      * @param  array  $wheres
      * @return $this
      */
-    protected function whereArray(array $wheres)
+    public function setWheres(array $wheres)
     {
         foreach ($wheres as $name => $expression) {
             $this->where($name, $expression);
@@ -585,6 +598,19 @@ class Route
     public function fallback()
     {
         $this->isFallback = true;
+
+        return $this;
+    }
+
+    /**
+     * Set the fallback value
+     *
+     * @param  bool  $isFallback
+     * @return $this
+     */
+    public function setFallback($isFallback)
+    {
+        $this->isFallback = $isFallback;
 
         return $this;
     }


### PR DESCRIPTION
These properties also need to be restored properly in order to make `Route::view` and `Route::redirect` work.

Fixes https://github.com/laravel/framework/issues/31567