### PR TITLE
[6.x] Add file permission config option for the File cache store

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -153,7 +153,7 @@ class CacheManager implements FactoryContract
      */
     protected function createFileDriver(array $config)
     {
-        return $this->repository(new FileStore($this->app['files'], $config['path']));
+        return $this->repository(new FileStore($this->app['files'], $config['path'], $config['permission'] ?? null));
     }
 
     /**

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Cache;
 
+use Exception;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\InteractsWithTime;
-use Throwable;
 
 class FileStore implements Store
 {
@@ -40,7 +40,7 @@ class FileStore implements Store
      * @param  int|null  $filePermission
      * @return void
      */
-    public function __construct(Filesystem $files, $directory, ?int $filePermission = null)
+    public function __construct(Filesystem $files, $directory, $filePermission = null)
     {
         $this->files = $files;
         $this->directory = $directory;
@@ -188,7 +188,7 @@ class FileStore implements Store
             $expire = substr(
                 $contents = $this->files->get($path, true), 0, 10
             );
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             return $this->emptyPayload();
         }
 
@@ -203,7 +203,7 @@ class FileStore implements Store
 
         try {
             $data = unserialize(substr($contents, 10));
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $this->forget($key);
 
             return $this->emptyPayload();

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -26,7 +26,7 @@ class FileStore implements Store
     protected $directory;
 
     /**
-     * Cache file access permissions in octal.
+     * Octal representation of the cache file permissions.
      *
      * @var int
      */


### PR DESCRIPTION
Adds 'permission' configuration option for the File cache store.

At the present state file cache writes files with the default umask, which is usually allows writing (deleting) only for the owner.

This creates trouble in some environments, when cache is written by web-server (e.g. nginx) and then accessed from the artisan console.

In particular this make `php artisan cache:clear` command to silently fail to remove file cache created by web-server.

This PR adds 'permission' config option for the `FileStore`, in the same manner as for Stream Logger.