### PR TITLE
[6.x] Add default request rules

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -187,6 +187,16 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return $this->validator->validated();
     }
+    
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [];
+    }
 
     /**
      * Get custom messages for validator errors.

--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -187,7 +187,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
     {
         return $this->validator->validated();
     }
-    
+
     /**
      * Get the validation rules that apply to the request.
      *


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The proposed change allows custom requests classes to not require the `rules` method for cases when only the `authorized` method is needed. 

It would be nice to remove the rules method from a custom request class without `Method App\Http\Requests\CustomRequest::rules() does not exist` exception firing.

It makes sense to do it this way as `messages` and `attributes` methods are here too.


