### PR TITLE
[7.x] Add requeue function to jobs

### DIFF
--- a/src/Illuminate/Contracts/Queue/Job.php
+++ b/src/Illuminate/Contracts/Queue/Job.php
@@ -43,6 +43,23 @@ interface Job
     public function isReleased();
 
     /**
+     * Requeue the job back into the queue.
+     *
+     * Accepts a delay specified in seconds.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0);
+
+    /**
+     * Determine if the job was requeued back into the queue.
+     *
+     * @return bool
+     */
+    public function isRequeued();
+
+    /**
      * Delete the job from the queue.
      *
      * @return void

--- a/src/Illuminate/Queue/InteractsWithQueue.php
+++ b/src/Illuminate/Queue/InteractsWithQueue.php
@@ -62,6 +62,19 @@ trait InteractsWithQueue
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        if ($this->job) {
+            return $this->job->requeue($delay);
+        }
+    }
+
+    /**
      * Set the base queue job instance.
      *
      * @param  \Illuminate\Contracts\Queue\Job  $job

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -57,6 +57,23 @@ class DatabaseJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        parent::requeue($delay);
+
+        $this->delete();
+
+        $this->job->decrement();
+
+        return $this->database->release($this->queue, $this->job, $delay);
+    }
+
+    /**
      * Delete the job from the queue.
      *
      * @return void

--- a/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJobRecord.php
@@ -39,6 +39,18 @@ class DatabaseJobRecord
     }
 
     /**
+     * Decrement the number of times the job has been attempted.
+     *
+     * @return int
+     */
+    public function decrement()
+    {
+        $this->record->attempts--;
+
+        return $this->record->attempts;
+    }
+
+    /**
      * Update the "reserved at" timestamp of the job.
      *
      * @return int

--- a/src/Illuminate/Queue/Jobs/Job.php
+++ b/src/Illuminate/Queue/Jobs/Job.php
@@ -40,6 +40,13 @@ abstract class Job
     protected $released = false;
 
     /**
+     * Indicates if the job has been requeued.
+     *
+     * @var bool
+     */
+    protected $requeued = false;
+
+    /**
      * Indicates if the job has failed.
      *
      * @var bool
@@ -120,6 +127,17 @@ abstract class Job
     }
 
     /**
+     * Requeue the job back into the queue.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        $this->requeued = true;
+    }
+
+    /**
      * Determine if the job was released back into the queue.
      *
      * @return bool
@@ -130,13 +148,23 @@ abstract class Job
     }
 
     /**
+     * Determine if the job was requeued back into the queue.
+     *
+     * @return bool
+     */
+    public function isRequeued()
+    {
+        return $this->requeued;
+    }
+
+    /**
      * Determine if the job has been deleted or released.
      *
      * @return bool
      */
     public function isDeletedOrReleased()
     {
-        return $this->isDeleted() || $this->isReleased();
+        return $this->isDeleted() || $this->isReleased() || $this->isRequeued();
     }
 
     /**

--- a/src/Illuminate/Queue/Jobs/RedisJob.php
+++ b/src/Illuminate/Queue/Jobs/RedisJob.php
@@ -98,6 +98,19 @@ class RedisJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        parent::requeue($delay);
+
+        $this->redis->deleteAndRequeue($this->queue, $this, $delay);
+    }
+
+    /**
      * Get the number of times the job has been attempted.
      *
      * @return int

--- a/src/Illuminate/Queue/Jobs/SyncJob.php
+++ b/src/Illuminate/Queue/Jobs/SyncJob.php
@@ -50,6 +50,17 @@ class SyncJob extends Job implements JobContract
     }
 
     /**
+     * Requeue the job back.
+     *
+     * @param  int  $delay
+     * @return void
+     */
+    public function requeue($delay = 0)
+    {
+        $this->release($delay);
+    }
+
+    /**
      * Get the number of times the job has been attempted.
      *
      * @return int

--- a/tests/Integration/Queue/CallQueuedHandlerTest.php
+++ b/tests/Integration/Queue/CallQueuedHandlerTest.php
@@ -35,6 +35,7 @@ class CallQueuedHandlerTest extends TestCase
         $job->shouldReceive('hasFailed')->andReturn(false);
         $job->shouldReceive('isDeleted')->andReturn(false);
         $job->shouldReceive('isReleased')->andReturn(false);
+        $job->shouldReceive('isRequeued')->andReturn(false);
         $job->shouldReceive('isDeletedOrReleased')->andReturn(false);
         $job->shouldReceive('delete')->once();
 

--- a/tests/Queue/QueueRedisJobTest.php
+++ b/tests/Queue/QueueRedisJobTest.php
@@ -43,6 +43,15 @@ class QueueRedisJobTest extends TestCase
         $job->release(1);
     }
 
+    public function testRequeueProperlyReleasesJobOntoRedis()
+    {
+        $job = $this->getJob();
+        $job->getRedisQueue()->shouldReceive('deleteAndRequeue')->once()
+            ->with('default', $job, 1);
+
+        $job->requeue(1);
+    }
+
     protected function getJob()
     {
         return new RedisJob(

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -421,6 +421,7 @@ class WorkerFakeJob implements QueueJobContract
     public $deleted = false;
     public $releaseAfter;
     public $released = false;
+    public $requeued = false;
     public $maxTries;
     public $delaySeconds;
     public $timeoutAt;
@@ -491,9 +492,21 @@ class WorkerFakeJob implements QueueJobContract
         return $this->released;
     }
 
+    public function requeue($delay = 0)
+    {
+        $this->requeued = true;
+
+        $this->releaseAfter = $delay;
+    }
+
+    public function isRequeued()
+    {
+        return $this->requeued;
+    }
+
     public function isDeletedOrReleased()
     {
-        return $this->deleted || $this->released;
+        return $this->isDeleted() || $this->isReleased() || $this->isRequeued();
     }
 
     public function attempts()


### PR DESCRIPTION
This is a re-creation of #31537 due to GitHub not liking my rebase and closing the PR permanently (which is in turn a re-creation of #30342). Sorry about that! Anyway, this new PR is now based against the latest 7.x branch, so we can see how the tests perform.

---

#### ORIGINAL PR:

This pull requests adds a `requeue` method to database and Redis jobs. The idea comes from https://github.com/laravel/ideas/issues/1381

The method does the same as the `release` method, but before putting the job back into queue, it decrements the attempts attribute.

This handles an issue like this, where the job could fail, because the attempts attribute had exceeded the tries attribute.

```php
Redis::throttle('key')->allow(10)->every(60)->then(function () {
    try {
        // API logic
    }
    catch (Exception) {
        // Release the job back into the queue
        return $this->release(10);
    }
}, function () {
    // Could not obtain lock...
    return $this->requeue(10);
});
```

I think we possibly need to rename this method to something more suited. Maybe `isDeletable` ?
https://github.com/laravel/framework/blob/641a7cda8280ecd3035616d4ce6434434b116624/src/Illuminate/Contracts/Queue/Job.php#L64