### PR TITLE
[6.x] Allow passing of strings to dumpSession method

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1171,15 +1171,17 @@ class TestResponse implements ArrayAccess
     /**
      * Dump the session from the response.
      *
-     * @param  array  $keys
+     * @param  string|array  $keys
      * @return $this
      */
-    public function dumpSession($keys = null)
+    public function dumpSession($keys = [])
     {
-        if (is_array($keys)) {
-            dump($this->session()->only($keys));
-        } else {
+        $keys = (array) $keys;
+
+        if (empty($keys)) {
             dump($this->session()->all());
+        } else {
+            dump($this->session()->only($keys));
         }
 
         return $this;


### PR DESCRIPTION
This PR is a minor improvement to the `dumpSession` method in the `TestResponse` class, which was recently added via https://github.com/laravel/framework/pull/31131.

While debugging, I usually want to dump a single key from the session but end up getting the full session output because I passed a string to `dumpSession` instead of an array.

This PR simply casts `$keys` to an array allowing passing of strings. There are no breaking changes as the previous array-only implementation will continue to work as expected.

Let me know if there's any feedback!