### PR TITLE
[6.x] Clarify invalid connection message

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -149,7 +149,7 @@ class DatabaseManager implements ConnectionResolverInterface
         $connections = $this->app['config']['database.connections'];
 
         if (is_null($config = Arr::get($connections, $name))) {
-            throw new InvalidArgumentException("Database [{$name}] not configured.");
+            throw new InvalidArgumentException("Database connection [{$name}] not configured.");
         }
 
         return (new ConfigurationUrlParser)


### PR DESCRIPTION
Currently if Laravel attempts to fetch configuration for an undefined connection it will throw an `InvalidArgumentException` with the message "Database [x] not configured." which can be a little confusing when debugging. This PR simply adds the word "connection" to the message to read "Database connection [x] not configured." 