### PR TITLE
[6.x] Fix a comment in Pipeline

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -147,7 +147,7 @@ class Pipeline implements PipelineContract
             return function ($passable) use ($stack, $pipe) {
                 try {
                     if (is_callable($pipe)) {
-                        // If the pipe is an instance of a Closure, we will just call it directly but
+                        // If the pipe is callable, we will just call it directly but
                         // otherwise we'll resolve the pipes out of the container and call it with
                         // the appropriate method and arguments, returning the results back out.
                         return $pipe($passable, $stack);
@@ -225,7 +225,7 @@ class Pipeline implements PipelineContract
     }
 
     /**
-     * Handles the value returned from each pipe before passing it to the next.
+     * Handle the value returned from each pipe before passing it to the next.
      *
      * @param  mixed  $carry
      * @return mixed

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -147,8 +147,8 @@ class Pipeline implements PipelineContract
             return function ($passable) use ($stack, $pipe) {
                 try {
                     if (is_callable($pipe)) {
-                        // If the pipe is callable, we will just call it directly but
-                        // otherwise we'll resolve the pipes out of the container and call it with
+                        // If the pipe is a callable, then we will call it directly, but otherwise we
+                        // will resolve the pipes out of the dependency container and call it with
                         // the appropriate method and arguments, returning the results back out.
                         return $pipe($passable, $stack);
                     } elseif (! is_object($pipe)) {


### PR DESCRIPTION
This PR fixs a comment in Pipeline.php
This [commit](https://github.com/illuminate/pipeline/commit/24ffb0ad13fe8246b47a9647f9f9e436bc668a92) changed the checking from `instance of Closure` to `is_callable`.