### PR TITLE
[6.x] Add "optional" method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -220,9 +220,7 @@ trait InteractsWithInput
     public function input($key = null, $default = null)
     {
         return data_get(
-            $this->getInputSource()->all() + $this->query->all(),
-            $key,
-            $default
+            $this->getInputSource()->all() + $this->query->all(), $key, $default
         );
     }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -4,6 +4,7 @@ namespace Illuminate\Http\Concerns;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Optional;
 use Illuminate\Support\Str;
 use SplFileInfo;
 use stdClass;
@@ -219,7 +220,9 @@ trait InteractsWithInput
     public function input($key = null, $default = null)
     {
         return data_get(
-            $this->getInputSource()->all() + $this->query->all(), $key, $default
+            $this->getInputSource()->all() + $this->query->all(),
+            $key,
+            $default
         );
     }
 
@@ -235,6 +238,19 @@ trait InteractsWithInput
     public function boolean($key = null, $default = false)
     {
         return filter_var($this->input($key, $default), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Retrieve optional input.
+     *
+     * Returns value when value is non-empty. Otherwise, returns null.
+     *
+     * @param  string|null  $key
+     * @return mixed
+     */
+    public function optional($key = null)
+    {
+        return $this->filled($key) ? $this->input($key) : null;
     }
 
     /**

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -415,6 +415,16 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($request->boolean('some_undefined_key'));
     }
 
+    public function testOptionalMethod()
+    {
+        $request = Request::create('/', 'GET', ['is_string' => 'string', 'is_integer' => 123, 'is_empty_string' => '', 'is_null' => null]);
+        $this->assertSame('string', $request->optional('is_string'));
+        $this->assertSame(123, $request->optional('is_integer'));
+        $this->assertSame(null, $request->optional('is_empty_string'));
+        $this->assertSame(null, $request->optional('is_null'));
+        $this->assertSame(null, $request->optional('some_undefined_key'));
+    }
+
     public function testArrayAccess()
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);


### PR DESCRIPTION
This PR adds a new `optional()` method to the `Request` class.

Out of the box, `\Illuminate\Foundation\Http\Middleware\TrimStrings` is part of the base middleware group applied to all requests. It's a great tool, and cleans up a lot of junk in parameter values.

However, one side effect of this middleware is that it's impossible for a string value to reach a controller and contain a `null` value. Trimming a missing value will force it to become an empty string. This becomes problematic when using Request methods like `->get()` or `->has()` because there could be false-positives, so it requires first using `->filled()` to check if there is a value present.

For example:
```php
[
    'key' => '',
]

$value = request('key'); // ''
$has_value = request()->has('key'); // true
$has_filled_value = request()->filled('key'); // false

// Forced to do...
if(request()->filled('key')) {
    ... do stuff here
}
```

By providing an `->optional()` method we can make these checks much more trivial, and get a more intuitive output:
```php
$value = request()->optional('key'); // null
```