### PR TITLE
[6.x] Ability to pass models to assertDatabaseHas, assertDatabaseMissing

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -37,13 +37,21 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition does not exist in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseMissing($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            $constraint = new ReverseConstraint(
+                new HasInDatabase($this->getConnection($table->getConnectionName()), $data)
+            );
+
+            return $this->assertThat($table->getTable(), $constraint);
+        }
+
         $constraint = new ReverseConstraint(
             new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -14,13 +14,19 @@ trait InteractsWithDatabase
     /**
      * Assert that a given where condition exists in the database.
      *
-     * @param  string  $table
+     * @param  \Illuminate\Database\Eloquent\Model|string  $table
      * @param  array  $data
      * @param  string|null  $connection
      * @return $this
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
+        if ($table instanceof Model) {
+            return $this->assertThat(
+                $table->getTable(), new HasInDatabase($this->getConnection($table->getConnectionName()), $data)
+            );
+        }
+
         $this->assertThat(
             $table, new HasInDatabase($this->getConnection($connection), $data)
         );

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -41,6 +41,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseHas($this->table, $this->data);
     }
 
+    public function testSeeInDatabaseModelFindsResults()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseHas(new ProductStub(), $this->data);
+    }
+
     public function testSeeInDatabaseDoesNotFindResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -51,6 +58,18 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertDatabaseHas($this->table, $this->data);
+    }
+
+    public function testSeeInDatabaseModelDoesNotFindResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('The table is empty.');
+
+        $builder = $this->mockCountBuilder(0);
+
+        $builder->shouldReceive('get')->andReturn(collect());
+
+        $this->assertDatabaseHas(new ProductStub(), $this->data);
     }
 
     public function testSeeInDatabaseFindsNotMatchingResults()

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -110,6 +110,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
+    public function testDontSeeInDatabaseModelDoesNotFindResults()
+    {
+        $this->mockCountBuilder(0);
+
+        $this->assertDatabaseMissing(new ProductStub(), $this->data);
+    }
+
     public function testDontSeeInDatabaseFindsResults()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -120,6 +127,18 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect([$this->data]));
 
         $this->assertDatabaseMissing($this->table, $this->data);
+    }
+
+    public function testDontSeeInDatabaseModelFindsResults()
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $builder = $this->mockCountBuilder(1);
+
+        $builder->shouldReceive('take')->andReturnSelf();
+        $builder->shouldReceive('get')->andReturn(collect([$this->data]));
+
+        $this->assertDatabaseMissing(new ProductStub(), $this->data);
     }
 
     public function testAssertDeletedPassesWhenDoesNotFindResults()


### PR DESCRIPTION
Currently, we explicitly define the table and connection strings when using `assertDatabaseHas` and `assertDatabaseMissing`. This PR creates the ability to pass eloquent models to each of the assertions.

**Before**
```
$this->assertDatabaseHas('users', [
    'email' => 'foo@bar.com'
], 'my-connection');
```

**After**
```
$this->assertDatabaseHas(User::class, [
    'email' => 'foo@bar.com'
]);
```

This is useful for testing across multiple database connections with similar table tables. 