### PR TITLE
[6.x] Change File cache store permission to not chmod if not set.

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -44,7 +44,7 @@ class FileStore implements Store
     {
         $this->files = $files;
         $this->directory = $directory;
-        $this->filePermission = $filePermission ?? 0775;
+        $this->filePermission = $filePermission;
     }
 
     /**
@@ -75,7 +75,9 @@ class FileStore implements Store
         );
 
         if ($result !== false && $result > 0) {
-            $this->files->chmod($path, $this->filePermission);
+            if (! is_null($this->filePermission)) {
+                $this->files->chmod($path, $this->filePermission);
+            }
 
             return true;
         }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -28,7 +28,7 @@ class FileStore implements Store
     /**
      * Octal representation of the cache file permissions.
      *
-     * @var int
+     * @var int|null
      */
     protected $filePermission;
 


### PR DESCRIPTION
This reverts some of the behavior in 61b5aa1895dd4eab26c7e45fcc8e69f0c408cbab
From pull request #31579

With that change, if you did not set a permission in your config file ( a new feature not yet in https://github.com/laravel/laravel ) it would now default to `0775` for the permission.
The previous behavior was to use whatever was the system default, which on most Linux systems would actually be `0644` instead of `0775`.

In addition an additional `chmod` system call would be issued after every file write.

This change restores the previous behavior while still allowing you to set the config to override the permission to whatever you like.