### PR TITLE
[6.x] Add php serialize cast to castAttribute in Eloquent model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -510,6 +510,8 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'timestamp':
                 return $this->asTimestamp($value);
+            case 'serialize':
+                return unserialize($value);
             default:
                 return $value;
         }
@@ -582,6 +584,10 @@ trait HasAttributes
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->castAttributeAsJson($key, $value);
+        }
+
+        if ($this->hasCast($key, ['serialize'])) {
+            $value = serialize($value);
         }
 
         // If this attribute contains a JSON ->, we'll set the proper value in the


### PR DESCRIPTION
when cast an object attribute to a native PHP type, php object converted to stdClass.
i added serialize to castAttribute . with this cast when cast an object to a native PHP type, use original php class

for example:

```php
class myModel extends Illuminate\Database\Eloquent\Model
{
     protected $casts = [
        'userObject' => 'object',
        'userSerializeObject' => 'serialize',
    ];
}
$model = new myModel();
$model->userObject               = new User();
$model->userSerializeObject = new User();
$model->save();

echo get_class($model->userObject) ; // stdClass 
echo get_class($model->userSerializeObject) ; // User 

```
