### PR TITLE
[7.x] Add BaseNotification class

### DIFF
--- a/src/Illuminate/Contracts/Notifications/Notification.php
+++ b/src/Illuminate/Contracts/Notifications/Notification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Illuminate\Contracts\Notifications;
+
+interface Notification
+{
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn();
+
+    /**
+     * Set the locale to send this notification in.
+     *
+     * @param  string  $locale
+     * @return $this
+     */
+    public function locale($locale);
+}

--- a/src/Illuminate/Notifications/BaseNotification.php
+++ b/src/Illuminate/Notifications/BaseNotification.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Notifications;
+
+trait BaseNotification
+{
+    /**
+     * The unique identifier for the notification.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The locale to be used when sending the notification.
+     *
+     * @var string|null
+     */
+    public $locale;
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+
+    /**
+     * Set the locale to send this notification in.
+     *
+     * @param  string  $locale
+     * @return $this
+     */
+    public function locale($locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Notifications/Channels/BroadcastChannel.php
+++ b/src/Illuminate/Notifications/Channels/BroadcastChannel.php
@@ -3,9 +3,9 @@
 namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Notifications\Notification;
 use Illuminate\Notifications\Events\BroadcastNotificationCreated;
 use Illuminate\Notifications\Messages\BroadcastMessage;
-use Illuminate\Notifications\Notification;
 use RuntimeException;
 
 class BroadcastChannel
@@ -32,7 +32,7 @@ class BroadcastChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return array|null
      */
     public function send($notifiable, Notification $notification)
@@ -55,7 +55,7 @@ class BroadcastChannel
      * Get the data for the notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return mixed
      *
      * @throws \RuntimeException

--- a/src/Illuminate/Notifications/Channels/DatabaseChannel.php
+++ b/src/Illuminate/Notifications/Channels/DatabaseChannel.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Notifications\Channels;
 
-use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Notifications\Notification;
 use RuntimeException;
 
 class DatabaseChannel
@@ -11,7 +11,7 @@ class DatabaseChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return \Illuminate\Database\Eloquent\Model
      */
     public function send($notifiable, Notification $notification)
@@ -25,7 +25,7 @@ class DatabaseChannel
      * Get the data for the notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return array
      *
      * @throws \RuntimeException
@@ -48,7 +48,7 @@ class DatabaseChannel
      * Build an array payload for the DatabaseNotification Model.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return array
      */
     protected function buildPayload($notifiable, Notification $notification)

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -4,9 +4,9 @@ namespace Illuminate\Notifications\Channels;
 
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
+use Illuminate\Contracts\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Markdown;
-use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -43,7 +43,7 @@ class MailChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return void
      */
     public function send($notifiable, Notification $notification)
@@ -70,7 +70,7 @@ class MailChannel
      * Get the mailer Closure for the message.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return \Closure
      */
@@ -106,7 +106,7 @@ class MailChannel
     /**
      * Get additional meta-data to pass along with the view data.
      *
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @return array
      */
     protected function additionalMessageData($notification)
@@ -124,7 +124,7 @@ class MailChannel
      *
      * @param  \Illuminate\Mail\Message  $mailMessage
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return void
      */
@@ -150,7 +150,7 @@ class MailChannel
      *
      * @param  \Illuminate\Mail\Message  $mailMessage
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return void
      */
@@ -197,7 +197,7 @@ class MailChannel
      * Get the recipients of the given message.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  \Illuminate\Notifications\Messages\MailMessage  $message
      * @return mixed
      */

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -21,7 +21,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
     /**
      * The notification instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Contracts\Notifications\Notification
      */
     public $notification;
 
@@ -36,7 +36,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/Notifications/Events/NotificationFailed.php
+++ b/src/Illuminate/Notifications/Events/NotificationFailed.php
@@ -19,7 +19,7 @@ class NotificationFailed
     /**
      * The notification instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Contracts\Notifications\Notification
      */
     public $notification;
 
@@ -41,7 +41,7 @@ class NotificationFailed
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  string  $channel
      * @param  array  $data
      * @return void

--- a/src/Illuminate/Notifications/Events/NotificationSending.php
+++ b/src/Illuminate/Notifications/Events/NotificationSending.php
@@ -19,7 +19,7 @@ class NotificationSending
     /**
      * The notification instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Contracts\Notifications\Notification
      */
     public $notification;
 
@@ -34,7 +34,7 @@ class NotificationSending
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  string  $channel
      * @return void
      */

--- a/src/Illuminate/Notifications/Events/NotificationSent.php
+++ b/src/Illuminate/Notifications/Events/NotificationSent.php
@@ -19,7 +19,7 @@ class NotificationSent
     /**
      * The notification instance.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Contracts\Notifications\Notification
      */
     public $notification;
 
@@ -41,7 +41,7 @@ class NotificationSent
      * Create a new event instance.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification  $notification
      * @param  string  $channel
      * @param  mixed  $response
      * @return void

--- a/src/Illuminate/Notifications/Notification.php
+++ b/src/Illuminate/Notifications/Notification.php
@@ -2,46 +2,10 @@
 
 namespace Illuminate\Notifications;
 
+use Illuminate\Contracts\Notifications\Notification as NotificationContract;
 use Illuminate\Queue\SerializesModels;
 
-class Notification
+class Notification implements NotificationContract
 {
-    use SerializesModels;
-
-    /**
-     * The unique identifier for the notification.
-     *
-     * @var string
-     */
-    public $id;
-
-    /**
-     * The locale to be used when sending the notification.
-     *
-     * @var string|null
-     */
-    public $locale;
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return array
-     */
-    public function broadcastOn()
-    {
-        return [];
-    }
-
-    /**
-     * Set the locale to send this notification in.
-     *
-     * @param  string  $locale
-     * @return $this
-     */
-    public function locale($locale)
-    {
-        $this->locale = $locale;
-
-        return $this;
-    }
+    use SerializesModels, BaseNotification;
 }

--- a/src/Illuminate/Notifications/RoutesNotifications.php
+++ b/src/Illuminate/Notifications/RoutesNotifications.php
@@ -34,7 +34,7 @@ trait RoutesNotifications
      * Get the notification routing information for the given driver.
      *
      * @param  string  $driver
-     * @param  \Illuminate\Notifications\Notification|null  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification|null  $notification
      * @return mixed
      */
     public function routeNotificationFor($driver, $notification = null)

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -21,7 +21,7 @@ class SendQueuedNotifications implements ShouldQueue
     /**
      * The notification to be sent.
      *
-     * @var \Illuminate\Notifications\Notification
+     * @var \Illuminate\Contracts\Notifications\Notification
      */
     public $notification;
 
@@ -50,7 +50,7 @@ class SendQueuedNotifications implements ShouldQueue
      * Create a new job instance.
      *
      * @param  \Illuminate\Support\Collection  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
+     * @param  \Illuminate\Contracts\Notifications\Notification $notification
      * @param  array|null  $channels
      * @return void
      */

--- a/tests/Notifications/NotificationDatabaseChannelTest.php
+++ b/tests/Notifications/NotificationDatabaseChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Illuminate\Contracts\Notifications\Notification as NotificationContract;
 use Illuminate\Notifications\Channels\DatabaseChannel;
 use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Notification;
@@ -61,7 +62,7 @@ class NotificationDatabaseChannelTestNotification extends Notification
 
 class ExtendedDatabaseChannel extends DatabaseChannel
 {
-    protected function buildPayload($notifiable, Notification $notification)
+    protected function buildPayload($notifiable, NotificationContract $notification)
     {
         return array_merge(parent::buildPayload($notifiable, $notification), [
             'something' => 'else',


### PR DESCRIPTION
Because of the fact that `Illuminate\Notifications\Notification` class uses `Illuminate\Queue\SerializesModels` it is currently not possible to overwrite `__wakeup()` and at the same time use it from within the notification class.

Scenario where it would be useful:
```php

namespace App\Traits;

use Illuminate\Queue\SerializesModels;

trait TenantAwareJob
{
    use SerializesModels {
        __unserialize as __parentUnserialize;
    }

    /**
     * @var string
     */
    public string $host;

    /**
     * Reconnect database.
     *
     * @return void
     */
    protected function reconnect(): void
    {
        tenant()->setHost($this->host)->reconnect(app());
    }

    /**
     * Restore the model after serialization.
     *
     * @param  array  $values
     * @return array
     */
    public function __unserialize(array $values): array
    {
        $values = $this->__parentUnserialize($values);

        $this->reconnect();

        return $values;
    }
}
```

```php
namespace App\Notifications\Token;

use Illuminate\Bus\Queueable;
use Illuminate\Queue\SerializesModels;
use Illuminate\Contracts\Notifications\Notification
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Notifications\BaseNotification;

class TokenNotification implements Notification, ShouldQueue
{
    use Queueable, BaseNotification, TenantAwareJob;

    /**
     * @var string
     */
    public string $token;

    /**
     * @var array
     */
    public array $message;

    /**
     * Create a new notification instance.
     *
     * @param  string $host
     * @param  string $token
     * @param  array $message
     */
    public function __construct(string $host, string $token, array $message)
    {
        $this->host = $host;
        $this->message = $message;
        $this->token = encrypt($token);
    }

    // ...
}
```