### PR TITLE
[7.x] Add support for Arr::group

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -297,7 +297,7 @@ class BelongsToMany extends Relation
         // First we will build a dictionary of child models keyed by the foreign key
         // of the relation so that we will easily and quickly match them to their
         // parents without having a possibly slow inner loops for every models.
-        return Arr::group($results, $this->accessor . '.' . $this->foreignPivotKey);
+        return Arr::group($results, $this->accessor.'.'.$this->foreignPivotKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -296,13 +297,7 @@ class BelongsToMany extends Relation
         // First we will build a dictionary of child models keyed by the foreign key
         // of the relation so that we will easily and quickly match them to their
         // parents without having a possibly slow inner loops for every models.
-        $dictionary = [];
-
-        foreach ($results as $result) {
-            $dictionary[$result->{$this->accessor}->{$this->foreignPivotKey}][] = $result;
-        }
-
-        return $dictionary;
+        return Arr::group($results, $this->accessor . '.' . $this->foreignPivotKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
 
 class HasManyThrough extends Relation
 {
@@ -204,16 +205,10 @@ class HasManyThrough extends Relation
      */
     protected function buildDictionary(Collection $results)
     {
-        $dictionary = [];
-
         // First we will create a dictionary of models keyed by the foreign key of the
         // relationship as this will allow us to quickly access all of the related
         // models without having to do nested looping which will be quite slow.
-        foreach ($results as $result) {
-            $dictionary[$result->laravel_through_key][] = $result;
-        }
-
-        return $dictionary;
+        return Arr::group($results, 'laravel_through_key');
     }
 
     /**

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -309,6 +309,29 @@ class Arr
     }
 
     /**
+     * Group an associative array by a field or by using a callback.
+     *
+     * @param  array  $array
+     * @param  callable|string  $groupBy
+     * @param  string  $default
+     * @return array
+     */
+    public static function group($array, $groupBy, $default = '')
+    {
+        $results = [];
+
+        foreach ($array as $key => $item) {
+            if (is_callable($groupBy)) {
+                $results[$groupBy($item, $key)][$key] = $item;
+            } else {
+                $results[Arr::get($item, $groupBy, $default)][$key] = $item;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
      * Check if an item or items exist in an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -324,7 +324,7 @@ class Arr
             if (is_callable($groupBy)) {
                 $results[$groupBy($item, $key)][$key] = $item;
             } else {
-                $results[Arr::get($item, $groupBy, $default)][$key] = $item;
+                $results[self::get($item, $groupBy, $default)][$key] = $item;
             }
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -311,7 +311,7 @@ class Arr
     /**
      * Group an associative array by a field or by using a callback.
      *
-     * @param  array  $array
+     * @param  iterable  $array
      * @param  callable|string  $groupBy
      * @param  string  $default
      * @return array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -305,6 +305,63 @@ class SupportArrTest extends TestCase
         }));
     }
 
+    public function testGroupBy()
+    {
+        $array = [
+            'foo' => ['name' => 'Desk', 'type' => 'desk'],
+            'bar' => ['name' => 'Standing desk', 'type' => 'desk'],
+        ];
+
+        // Simple grouping by different values
+        $groupByName = Arr::group($array, 'name');
+        $this->assertSame([
+            'Desk' => ['foo' => ['name' => 'Desk', 'type' => 'desk']],
+            'Standing desk' => ['bar' => ['name' => 'Standing desk', 'type' => 'desk']],
+        ], $groupByName);
+
+        // Simple grouping by same value
+        $groupByType = Arr::group($array, 'type');
+        $this->assertSame([
+            'desk' => [
+                'foo' => ['name' => 'Desk', 'type' => 'desk'],
+                'bar' => ['name' => 'Standing desk', 'type' => 'desk'],
+            ],
+        ], $groupByType);
+
+        // Simple grouping by unknown values
+        $groupByUnknown = Arr::group($array, 'unknown');
+        $this->assertSame([
+            '' => [
+                'foo' => ['name' => 'Desk', 'type' => 'desk'],
+                'bar' => ['name' => 'Standing desk', 'type' => 'desk'],
+            ],
+        ], $groupByUnknown);
+
+        // Simple grouping by unknown values with fallback
+        $groupByFallback = Arr::group($array, 'unknown', 'fallback');
+        $this->assertSame([
+            'fallback' => [
+                'foo' => ['name' => 'Desk', 'type' => 'desk'],
+                'bar' => ['name' => 'Standing desk', 'type' => 'desk'],
+            ],
+        ], $groupByFallback);
+
+        // Custom grouping by callable
+        $groupByCallable = Arr::group($array, function ($value, $key) {
+            return $key . $value['type'];
+        });
+        $this->assertSame([
+            'foodesk' => ['foo' => ['name' => 'Desk', 'type' => 'desk']],
+            'bardesk' => ['bar' => ['name' => 'Standing desk', 'type' => 'desk']],
+        ], $groupByCallable);
+
+        // Non-associative array support, shouldn't be really useful but still, thanks Arr::get
+        $groupNonAssociative = Arr::group(['thats', 'all', 'folks'], '...');
+        $this->assertSame([
+            '' => ['thats', 'all', 'folks'],
+        ], $groupNonAssociative);
+    }
+
     public function testHas()
     {
         $array = ['products.desk' => ['price' => 100]];

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -348,7 +348,7 @@ class SupportArrTest extends TestCase
 
         // Custom grouping by callable
         $groupByCallable = Arr::group($array, function ($value, $key) {
-            return $key . $value['type'];
+            return $key.$value['type'];
         });
         $this->assertSame([
             'foodesk' => ['foo' => ['name' => 'Desk', 'type' => 'desk']],

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -305,7 +305,7 @@ class SupportArrTest extends TestCase
         }));
     }
 
-    public function testGroupBy()
+    public function testGroup()
     {
         $array = [
             'foo' => ['name' => 'Desk', 'type' => 'desk'],


### PR DESCRIPTION
Made the PR towards 7.x due to the release coming next week.

Was generally wondering why this wasn't added previously. :) Made a simple implementation for grouping array-like structures compared to the `Collection::groupBy` functionality but one which comes in handy when working with plain arrays. It differentiates by keeping everything array related instead of creating new Collection instances.

I found a couple of occurrences in the framework which could also use this method and added them to the pull request. If I've missed possible usages or missed any preferred functionality, let me know. Love to adjust it where needed.

Cheers,
L