### PR TITLE
[6.x] Improve config cache by storing dot notation array

### DIFF
--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -57,8 +57,8 @@ class ConfigCacheCommand extends Command
         $this->call('config:clear');
 
         $freshConfig = $this->getFreshConfiguration();
-        $dotConfig   = Arr::dot($freshConfig);
-        $config      = $dotConfig + $freshConfig;
+        $dotConfig = Arr::dot($freshConfig);
+        $config = $dotConfig + $freshConfig;
 
         $configPath = $this->laravel->getCachedConfigPath();
 

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Console;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use LogicException;
 use Throwable;
 
@@ -55,7 +56,9 @@ class ConfigCacheCommand extends Command
     {
         $this->call('config:clear');
 
-        $config = $this->getFreshConfiguration();
+        $freshConfig = $this->getFreshConfiguration();
+        $dotConfig   = Arr::dot($freshConfig);
+        $config      = $dotConfig + $freshConfig;
 
         $configPath = $this->laravel->getCachedConfigPath();
 


### PR DESCRIPTION
**Change**
Update the artisan command for generating cached config so that it stores a dot-notation version of the config arrays. This provides a minor peformance improvement.

**Reasoning:**
When retrieving config from the cached config, the ```Arr::get``` function is able to use ```array_key_exists``` ([line 292](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/Arr.php#L292)) rather than triggering the ```foreach``` [loop](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Support/Arr.php#L300).

**Performance testing**
I tested this using a simple route & closure:

```php
Route::get('test', function() {

    $start = microtime(true);

    for ($i=0; $i<100000; $i++) {
        \Illuminate\Support\Facades\Config::get('database.connections.mysql.driver');
    }

    dd( microtime(true) - $start );
});
```

Whilst this is a unrealistic test, it was used provide a measurable performance change.

|       | Existing Code     | With dot cache        |
|-------|-------------|-------------|
|       | 1.15177083  | 0.499351978 |
|       | 1.134283066 | 0.501614094 |
|       | 1.15812397  | 0.495685101 |
|       | 1.1717031   | 0.499722958 |
|       | 1.133130789 | 0.496314049 |
| *Total* | *1.149802351* | *0.498537636* |

This gives a 0.6513 second saving.

There is also a measurable improvement in memory usage - from 6Mb to 2Mb.