### PR TITLE
[6.x] Use correct locale when resolving Faker from the container

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -74,8 +74,8 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerEloquentFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function ($app) {
-            return FakerFactory::create($app['config']->get('app.faker_locale', 'en_US'));
+        $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
+            return FakerFactory::create($parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -46,7 +46,7 @@ trait WithFaker
         $locale = $locale ?? config('app.faker_locale', Factory::DEFAULT_LOCALE);
 
         if (isset($this->app) && $this->app->bound(Generator::class)) {
-            return $this->app->make(Generator::class, [$locale]);
+            return $this->app->make(Generator::class, ['locale' => $locale]);
         }
 
         return Factory::create($locale);


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31614 by using the provided locale even when resolving the Generator from the container.