### PR TITLE
[7.x] Nested Eager Load Columns Usage

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1058,6 +1058,25 @@ class Builder
     {
         $eagerLoad = $this->parseWithRelations(is_string($relations) ? func_get_args() : $relations);
 
+        $segmentsToIgnore = [];
+        foreach ($eagerLoad as $name => $constraints) {
+            $segments = explode('.', $name);
+            if (count($segments) > 1) {
+                // Last Segment is the Current Definition
+                $currentDefinition = array_pop($segments);
+                foreach ($segments as $segment) {
+                    // Already Defined?
+                    if (isset($this->eagerLoad[$segment])) {
+                        // Mark to Ignore!
+                        $segmentsToIgnore[$segment] = true;
+                    }
+                }
+            }
+        }
+
+        // Remove Duplicated Eager @see PR #31616
+        $eagerLoad = array_diff_key($eagerLoad, $segmentsToIgnore);
+
         $this->eagerLoad = array_merge($this->eagerLoad, $eagerLoad);
 
         return $this;

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -563,6 +563,14 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('books:id')
             ->with('books.chapters:id,book_id');
 
+        // Inverse Fluent Interface
+
+        $builderFluentInverse = $this->getBuilder();
+
+        $builderFluentInverse
+            ->with('books.chapters:id,book_id')
+            ->with('books:id');
+
         // Array Configuration
 
         $builderArray = $this->getBuilder();
@@ -572,9 +580,20 @@ class DatabaseEloquentBuilderTest extends TestCase
             'books.chapters:id,book_id',
         ]);
 
+        // Inverse Array Configuration
+
+        $builderArrayInverse = $this->getBuilder();
+
+        $builderArrayInverse->with([
+            'books.chapters:id,book_id',
+            'books:id',
+        ]);
+
         return [
             [$builderFluent],
+            [$builderFluentInverse],
             [$builderArray],
+            [$builderArrayInverse],
         ];
     }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -553,21 +553,24 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getRelation('invalid');
     }
 
-    public function testEagerLoadSelectColumns()
+    public function eagerLoadSelectColumnsProvider()
     {
-        $builder = $this->getBuilder();
+        $builderFluent = $this->getBuilder();
 
-        // IT WORKS
-        // $builder->with([
-        //     'books:id',
-        //     'books.chapters:id,book_id',
-        // ]);
-
-        // IT DOESN'T
-        $builder
+        $builderFluent
             ->with('books:id')
             ->with('books.chapters:id,book_id');
 
+        return [
+            [$builderFluent],
+        ];
+    }
+
+    /**
+     * @dataProvider eagerLoadSelectColumnsProvider
+     */
+    public function testEagerLoadSelectColumns($builder)
+    {
         // Base Tests
 
         $eagers = $builder->getEagerLoads();

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -571,6 +571,15 @@ class DatabaseEloquentBuilderTest extends TestCase
             ->with('books.chapters:id,book_id')
             ->with('books:id');
 
+        // Fluent Interface Duplicated
+
+        $builderFluentDuplicate = $this->getBuilder();
+
+        $builderFluentDuplicate
+            ->with('books')
+            ->with('books.chapters:id,book_id')
+            ->with('books:id');
+
         // Array Configuration
 
         $builderArray = $this->getBuilder();
@@ -592,6 +601,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         return [
             [$builderFluent],
             [$builderFluentInverse],
+            [$builderFluentDuplicate],
             [$builderArray],
             [$builderArrayInverse],
         ];

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -555,14 +555,26 @@ class DatabaseEloquentBuilderTest extends TestCase
 
     public function eagerLoadSelectColumnsProvider()
     {
+        // Fluent Interface
+
         $builderFluent = $this->getBuilder();
 
         $builderFluent
             ->with('books:id')
             ->with('books.chapters:id,book_id');
 
+        // Array Configuration
+
+        $builderArray = $this->getBuilder();
+
+        $builderArray->with([
+            'books:id',
+            'books.chapters:id,book_id',
+        ]);
+
         return [
             [$builderFluent],
+            [$builderArray],
         ];
     }
 


### PR DESCRIPTION
I am using eager load to select dependencies.

I select _books_ and require only `id` column. After, I select _chapters_ from _books_ and require only `id` and `book_id` columns.

```php
$builder
    ->with('books:id')
    ->with('books.chapters:id,book_id');
```

If I analyze database queries, it will generate:

```sql
SELECT * FROM `books`;
SELECT `id`, `book_id` FROM `chapters`;
```

Note that `*` from _books_ was used instead of `id`.

I created a simple test to simulate the problem.

That was caused because `Illuminate\Database\Eloquent\Builder::with` method use `array_merge` to join eager loads: if we call _books_ twice, second call (without columns) will be used.

But, the question is: how to fix that? Or, it _must_ be fixed?