### PR TITLE
[6.x] Clean up a method

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -424,7 +424,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function getLastGroupPrefix()
     {
-        if (! empty($this->groupStack)) {
+        if ($this->hasGroupStack()) {
             $last = end($this->groupStack);
 
             return $last['prefix'] ?? '';


### PR DESCRIPTION
I saw this one is missing from the [Clean up some methods](https://github.com/laravel/framework/commit/4c0600ce19d706ccce74df9b25c469948b23c92d#diff-66c4eb54eb5af7de5e493b416e13991dR393) commit of @taylorotwell , so I sent this PR to complete it.