### PR TITLE
[6.x] Clean up some methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -384,7 +384,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function updateGroupStack(array $attributes)
     {
-        if (! empty($this->groupStack)) {
+        if ($this->hasGroupStack()) {
             $attributes = $this->mergeWithLastGroup($attributes);
         }
 
@@ -509,7 +509,7 @@ class Router implements BindingRegistrar, RegistrarContract
         // Here we'll merge any group "uses" statement if necessary so that the action
         // has the proper clause for this property. Then we can simply set the name
         // of the controller on the action and return the action array for usage.
-        if (! empty($this->groupStack)) {
+        if ($this->hasGroupStack()) {
             $action['uses'] = $this->prependGroupNamespace($action['uses']);
         }
 


### PR DESCRIPTION
I saw these two are missing from the [Clean up some methods](https://github.com/laravel/framework/commit/4c0600ce19d706ccce74df9b25c469948b23c92d#diff-66c4eb54eb5af7de5e493b416e13991dR393) commit of @taylorotwell , so I sent this PR to complete it.

@driesvints There are two more. I did force push in the last commit but it got merged immediately, so..