### PR TITLE
Allow FormRequest failedValidation override response

### DIFF
--- a/src/Illuminate/Foundation/Http/FormRequest.php
+++ b/src/Illuminate/Foundation/Http/FormRequest.php
@@ -121,13 +121,14 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * Handle a failed validation attempt.
      *
      * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     * @param  \Symfony\Component\HttpFoundation\Response|null  $response
      * @return void
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    protected function failedValidation(Validator $validator)
+    protected function failedValidation(Validator $validator, $response = null)
     {
-        throw (new ValidationException($validator))
+        throw (new ValidationException($validator, $response))
                     ->errorBag($this->errorBag)
                     ->redirectTo($this->getRedirectUrl());
     }


### PR DESCRIPTION
Since `ValidationException` accepts a second parameter for `response`, it'll be good to allow response override through there. This way we can do things like this without having to override the whole failedValidation method:

```php
<?php

namespace App\Http\Requests;

use Illuminate\Contracts\Validation\Validator;
use Illuminate\Foundation\Http\FormRequest;
use Symfony\Component\HttpFoundation\Response;

class CustomFormRequestResponse extends FormRequest
{
    // ...

    /**
     * Handle a failed validation attempt.
     *
     * @param  \Illuminate\Contracts\Validation\Validator  $validator
     * @param  \Symfony\Component\HttpFoundation\Response|null  $response
     * @return void
     *
     * @throws \Illuminate\Validation\
     */
    protected function failedValidation(Validator $validator, Response $response = null)
    {
        $response = back()
            ->with('custom_data', 'My custom data here');
        parent::failedValidation($validator, $response);
    }

    // ...
}
```

If that's not good, I'll be happy to learn a better way to pass custom data using FormRequests. Currently it seems hard to do that with FormRequests since there's no documented way for achieving this quickly.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
