### PR TITLE
[6.x] Fix model restoring right after soft deleting it

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -92,6 +92,8 @@ trait SoftDeletes
         }
 
         $query->update($columns);
+
+        $this->syncOriginal();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -285,7 +285,6 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         /** @var SoftDeletesTestUser $userModel */
         $userModel = SoftDeletesTestUser::find(2);
         $userModel->delete();
-        $userModel->syncOriginal();
         $userModel->restore();
 
         $this->assertEquals($userModel->id, SoftDeletesTestUser::find(2)->id);

--- a/tests/Database/DatabaseSoftDeletingTraitTest.php
+++ b/tests/Database/DatabaseSoftDeletingTraitTest.php
@@ -24,6 +24,7 @@ class DatabaseSoftDeletingTraitTest extends TestCase
             'deleted_at' => 'date-time',
             'updated_at' => 'date-time',
         ]);
+        $model->shouldReceive('syncOriginal')->once();
         $model->delete();
 
         $this->assertInstanceOf(Carbon::class, $model->deleted_at);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Relates to #31527

When we soft delete a model it becomes dirty, so if we try to restore it after deletion, the deleted_at column is not cleared. We need to sync the model, setting dirty to false, then the restore works.


