### PR TITLE
[6.x] Expose Notification Id within Message Data

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -112,6 +112,7 @@ class MailChannel
     protected function additionalMessageData($notification)
     {
         return [
+            '__laravel_notification_id' => $notification->id,
             '__laravel_notification' => get_class($notification),
             '__laravel_notification_queued' => in_array(
                 ShouldQueue::class, class_implements($notification)

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -13,6 +13,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 
@@ -69,6 +70,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSent()
     {
         $notification = new TestMailNotification;
+        $notification->id = Str::uuid();
 
         $user = NotifiableUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -80,6 +82,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -112,6 +115,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentToNamedAddress()
     {
         $notification = new TestMailNotification;
+        $notification->id = Str::uuid();
 
         $user = NotifiableUserWithNamedAddress::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -124,6 +128,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -156,6 +161,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentWithSubject()
     {
         $notification = new TestMailNotificationWithSubject;
+        $notification->id = Str::uuid();
 
         $user = NotifiableUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -167,6 +173,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -189,6 +196,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentToMultipleAdresses()
     {
         $notification = new TestMailNotificationWithSubject;
+        $notification->id = Str::uuid();
 
         $user = NotifiableUserWithMultipleAddreses::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -200,6 +208,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -80,6 +80,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -124,6 +125,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -167,6 +169,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
@@ -200,6 +203,7 @@ class SendingMailNotificationsTest extends TestCase
         $this->mailer->shouldReceive('send')->once()->with(
             ['html' => 'htmlContent', 'text' => 'textContent'],
             array_merge($notification->toMail($user)->toArray(), [
+                '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -70,7 +70,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSent()
     {
         $notification = new TestMailNotification;
-        $notification->id = Str::uuid();
+        $notification->id = Str::uuid()->toString();
 
         $user = NotifiableUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -115,7 +115,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentToNamedAddress()
     {
         $notification = new TestMailNotification;
-        $notification->id = Str::uuid();
+        $notification->id = Str::uuid()->toString();
 
         $user = NotifiableUserWithNamedAddress::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -161,7 +161,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentWithSubject()
     {
         $notification = new TestMailNotificationWithSubject;
-        $notification->id = Str::uuid();
+        $notification->id = Str::uuid()->toString();
 
         $user = NotifiableUser::forceCreate([
             'email' => 'taylor@laravel.com',
@@ -196,7 +196,7 @@ class SendingMailNotificationsTest extends TestCase
     public function testMailIsSentToMultipleAdresses()
     {
         $notification = new TestMailNotificationWithSubject;
-        $notification->id = Str::uuid();
+        $notification->id = Str::uuid()->toString();
 
         $user = NotifiableUserWithMultipleAddreses::forceCreate([
             'email' => 'taylor@laravel.com',


### PR DESCRIPTION
This is a pretty edge case scenario so i'll start with what i'm trying to do.

I'm logging all notifications that the application is sending (similar to Telescope), and i'd like to setup webhooks with my providers (mailgun, twilio, etc) so I can mark off notifications statuses as well as opens, clicks, etc. Currently these are implemented using the`Illuminate\Notifications\Events\*` events

```php
public function handle(NotificationSending $event)
    {
        Notification::forceCreate([
            'notification_id' => $event->notification->id,
            'status' => Notification::STATUS_SENDING,
            'channel' => $event->channel,
            'notifiable_id' => $event->notifiable->getKey(),
            'to' => $event->notifiable->routeNotificationFor($event->channel)
        ]);
    }
```

Starting with the mail implementation, within the context of the two Mail Events: `Illuminate\Mail\Events\MessageSent` and `Illuminate\Mail\Events\MessageSending`, there is no way of referencing exactly which instance of a Notification class has sent it. For my implementation to work I need the message id so I can match them up with the webhook calls.

```php
public function handle(MessageSent $event)
    {
        // find the notification for the given id and set the message id
        Notification::where('notification_id', $event->data['__laravel_notification_id'])
                ->update(['message_id' => $event->message->getId()]);
    }
```

Hopefully this makes sense, i'm sure there's other use cases for exposing the id beyond my own.