### PR TITLE
[6.x] Use "$ php artisan serve --host=network" to serve on local internet for team collabs

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -77,7 +77,17 @@ class ServeCommand extends Command
      */
     protected function host()
     {
-        return $this->input->getOption('host');
+        return $this->input->getOption('host') === 'network' ? $this->getLocalIp() : $this->input->getOption('host');
+    }
+
+    /**
+     * Get the user's local IP address to serve on the network.
+     *
+     * @return string
+     */
+    protected function getLocalIp()
+    {
+        return exec('ipconfig getifaddr en1') ?: '127.0.0.1';
     }
 
     /**
@@ -100,7 +110,7 @@ class ServeCommand extends Command
     protected function canTryAnotherPort()
     {
         return is_null($this->input->getOption('port')) &&
-               ($this->input->getOption('tries') > $this->portOffset);
+            ($this->input->getOption('tries') > $this->portOffset);
     }
 
     /**


### PR DESCRIPTION
This option will allow users to serve their app on their local internet so that they can easily collaborate with team members who are sharing the same internet connection.

This is sometimes preferable versus other options like ngrok (app tunneling) which can have serious lag time, especially for front-end developers who are running `npm run watch`. From my own testing on a high-speed connection, there can be latency of anywhere from 20 - 60 seconds when using a service like ngrok on a non-production build of a large JS file.

It basically just gets the user's computer's local IP address and uses that as the hostname.

I opted to use the existing `host` option instead of creating a new `network` option because a user who specified both in the command would be confused when one option overrides the other.

We get the local IP address like this. It fallsback to localhost if for some reason the former fails (perhaps if there is no local IP address for a machine).
```
/**
     * Get the user's local IP address to serve on the network.
     *
     * @return string
     */
    protected function getLocalIp()
    {
        return exec('ipconfig getifaddr en1') ?: '127.0.0.1';
    }
```

And the host function has been extended to include the new option:
```
/**
     * Get the host for the command.
     *
     * @return string
     */
    protected function host()
    {
        return $this->input->getOption('host') === 'network' ? $this->getLocalIp() : $this->input->getOption('host');
    }
```

The result is that the app will now serve on an address like this `http://192.168.1.10:8000`.

You can provide that address to your team members so they can view your front-end changes live without having to waste time tunneling.

Of course it is already possible prior to this pull request to just do this:
```
php artisan serve --host=192.168.1.10
```

However the problem with this is that most users will not know their local IP address off-hand or how to find it easily.

And additionally, the local IP address changes unpredictably on reboot for most network configurations.

This pull fixes those issues by handling the retrieval of the local IP address without the headache.