### PR TITLE
Macroable for Paginator and LengthAwarePaginator

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -8,11 +8,14 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator as LengthAwarePaginator
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use JsonSerializable;
 
 class LengthAwarePaginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, LengthAwarePaginatorContract
 {
+    use Macroable;
+
     /**
      * The total number of items before slicing.
      *

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -8,11 +8,14 @@ use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 use JsonSerializable;
 
 class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Countable, IteratorAggregate, Jsonable, JsonSerializable, PaginatorContract
 {
+    use Macroable;
+
     /**
      * Determine if there are more items in the data source.
      *

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -111,4 +111,15 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertSame($this->options, $this->p->getOptions());
     }
+
+    public function testLengthAwarePaginatorIsMacroable()
+    {
+        $this->p->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertSame(
+            'bar', $this->p->foo()
+        );
+    }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -62,4 +62,17 @@ class PaginatorTest extends TestCase
 
         $this->assertSame($p->path(), 'http://website.com/test');
     }
+
+    public function testPaginatorIsMacroable()
+    {
+        $p = new Paginator([], 1);
+
+        $p->macro('foo', function () {
+            return 'bar';
+        });
+
+        $this->assertSame(
+            'bar', $p->foo()
+        );
+    }
 }


### PR DESCRIPTION
This adds `Macroable` to `Paginator` and `LengthAwarePaginator`. My use case is that I want to add a `present()` method so I can transform the paginator's items (because the `$items` property is private), like this:

```php
LengthAwarePaginator::macro('present', function ($presenter) {
    $this->items = $this->items()->map(function ($model) use ($presenter) {
        return new $presenter($model);
    });
});
```

Others may have other use cases for this. I can't think of any reason why this would break existing features. Tests are included.