### PR TITLE
[6.x] Fix command return type for Symfony 4.4 compatibility

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -127,11 +127,11 @@ class Command extends SymfonyCommand
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return mixed
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        return $this->laravel->call([$this, 'handle']);
+        return (int) $this->laravel->call([$this, 'handle']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ClosureCommand.php
+++ b/src/Illuminate/Foundation/Console/ClosureCommand.php
@@ -37,7 +37,7 @@ class ClosureCommand extends Command
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input
      * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return mixed
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -51,7 +51,7 @@ class ClosureCommand extends Command
             }
         }
 
-        return $this->laravel->call(
+        return (int) $this->laravel->call(
             $this->callback->bindTo($this, $this), $parameters
         );
     }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31625. This is extracted from the Symfony 5 PR for 7.x which can be found [here](https://github.com/laravel/framework/pull/30610).