### PR TITLE
[6.x] Docblock fix

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -54,7 +54,13 @@ class MailgunTransport extends Transport
     }
 
     /**
-     * {@inheritdoc}
+     * Send the given message.
+     *
+     * @param  Swift_Mime_SimpleMessage  $message
+     * @param  array  $failedRecipients
+     * @return int
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function send(Swift_Mime_SimpleMessage $message, &$failedRecipients = null)
     {


### PR DESCRIPTION
We are using Guzzle to send a post request to Mailgun.

The Guzzle client may throw a `GuzzleException`.