### PR TITLE
[7.x] Allow queueing closures using Queue::push()

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -78,7 +78,7 @@ abstract class Queue
     /**
      * Create a payload string from the given job and data.
      *
-     * @param  string|\Closure|object  $job
+     * @param  \Closure|string|object  $job
      * @param  string  $queue
      * @param  mixed  $data
      * @return string

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -80,7 +80,7 @@ abstract class Queue
     /**
      * Create a payload string from the given job and data.
      *
-     * @param  string|object  $job
+     * @param  string|\Closure|object  $job
      * @param  string  $queue
      * @param  mixed  $data
      * @return string

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -6,6 +6,9 @@ use DateTimeInterface;
 use Illuminate\Container\Container;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
+use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\SerializableClosure;
+use Closure;
 
 abstract class Queue
 {
@@ -86,6 +89,10 @@ abstract class Queue
      */
     protected function createPayload($job, $queue, $data = '')
     {
+        if ($job instanceof Closure) {
+            $job = new CallQueuedClosure(new SerializableClosure($job));
+        }
+
         $payload = json_encode($this->createPayloadArray($job, $queue, $data));
 
         if (JSON_ERROR_NONE !== json_last_error()) {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -2,13 +2,11 @@
 
 namespace Illuminate\Queue;
 
+use Closure;
 use DateTimeInterface;
 use Illuminate\Container\Container;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
-use Illuminate\Queue\CallQueuedClosure;
-use Illuminate\Queue\SerializableClosure;
-use Closure;
 
 abstract class Queue
 {


### PR DESCRIPTION
After @themsaid's changes to support Closure based, chained jobs I noticed a problem that somebody had reported regarding pushing Closure based jobs via the `Queue::push()` method (see [here](https://github.com/laravel/framework/pull/31488#issuecomment-586614665)).

This is a fix for that problem, inline with the changes that @themsaid made, as well as how the `dispatch()` helper function supports queueing Closure based jobs.

Not sure about the best way to test for this support though without adding the test method to each of the supported drivers test cases. Ideas please 😃 

Prior to the fix, it would throw a fatal error due to properties being accessed on the `$job` variable. There might actually be a better place to put this logic too, but I figured this would not introduce a breaking change and was the fastest change, so could possibly be backed into the 6.x branch too, however this PR is aimed for 7.x