### PR TITLE
[7.x] Add withQueryString method to Paginator

### DIFF
--- a/src/Illuminate/Contracts/Pagination/Paginator.php
+++ b/src/Illuminate/Contracts/Pagination/Paginator.php
@@ -22,6 +22,13 @@ interface Paginator
     public function appends($key, $value = null);
 
     /**
+     * Add all query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString();
+
+    /**
      * Get / set the URL fragment to be appended to URLs.
      *
      * @param  string|null  $fragment

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Pagination;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
@@ -216,7 +216,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Add a set of query string values to the paginator.
+     * Add all query string values to the paginator.
      *
      * @return $this
      */

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Pagination;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
@@ -213,6 +213,16 @@ abstract class AbstractPaginator implements Htmlable
         }
 
         return $this->addQuery($key, $value);
+    }
+
+    /**
+     * Add a set of query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString()
+    {
+        return $this->appends(request()->query());
     }
 
     /**


### PR DESCRIPTION
This PR adds a new method `withQueryString` to the Paginator class, which basically allows you to append **all** query strings to the paginator links, so instead of doing this:

```php
{{ $users->appends(request()->query())->links() }}
```
You can now do:

```php
{{ $users->withQueryString()->links() }}
```

I believe this is more readable and actually describes what you are doing better than `appends(request()->query())`.