### PR TITLE
[7.x] Add withQueryString method to Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Pagination;
 
 use Closure;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -223,7 +223,7 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
-     * Add a set of query string values to the paginator.
+     * Add all query string values to the paginator.
      *
      * @return $this
      */

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,10 +3,10 @@
 namespace Illuminate\Pagination;
 
 use Closure;
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\ForwardsCalls;
 
 /**
@@ -99,6 +99,13 @@ abstract class AbstractPaginator implements Htmlable
      * @var \Closure
      */
     protected static $viewFactoryResolver;
+
+    /**
+     * The with query string resolver callback.
+     *
+     * @var \Closure
+     */
+    protected static $queryStringResolver;
 
     /**
      * The default pagination view.
@@ -213,6 +220,20 @@ abstract class AbstractPaginator implements Htmlable
         }
 
         return $this->addQuery($key, $value);
+    }
+
+    /**
+     * Add a set of query string values to the paginator.
+     *
+     * @return $this
+     */
+    public function withQueryString()
+    {
+        if (isset(static::$queryStringResolver)) {
+            return $this->appends(call_user_func(static::$queryStringResolver));
+        }
+
+        return $this;
     }
 
     /**
@@ -482,6 +503,17 @@ abstract class AbstractPaginator implements Htmlable
     public static function viewFactoryResolver(Closure $resolver)
     {
         static::$viewFactoryResolver = $resolver;
+    }
+
+    /**
+     * Set with query string resolver callback.
+     *
+     * @param  \Closure  $resolver
+     * @return void
+     */
+    public static function withQueryStringResolver(Closure $resolver)
+    {
+        static::$queryStringResolver = $resolver;
     }
 
     /**

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -46,5 +46,9 @@ class PaginationServiceProvider extends ServiceProvider
 
             return 1;
         });
+
+        Paginator::withQueryStringResolver(function () {
+            return $this->app['request']->query();
+        });
     }
 }


### PR DESCRIPTION
Another take at: https://github.com/laravel/framework/pull/31647

This PR adds a new method withQueryString to the Paginator class, which basically allows you to append all query strings to the paginator links, so instead of doing this:

```php
{{ $users->appends(request()->query())->links() }}
````

You can now do:
```php
{{ $users->withQueryString()->links() }}
```

I believe this is more readable and actually describes what you are doing better than ```appends(request()->query())```.