### PR TITLE
[7.x] Default trim() in Stringable behavior to match the native function

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -540,7 +540,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function trim($characters = null)
+    public function trim($characters = ' ')
     {
         return new static(trim($this->value, $characters));
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -540,7 +540,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function trim($characters = ' ')
+    public function trim($characters = " \t\n\r\0\x0B")
     {
         return new static(trim($this->value, $characters));
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -23,5 +23,9 @@ class SupportStringableTest extends TestCase
 
         $this->assertEquals(['un', 'ly'], $string->matchAll('/f(\w*)/')->all());
         $this->assertTrue($string->matchAll('/nothing/')->isEmpty());
+
+        $string = new Stringable('  bar  ');
+
+        $this->assertEquals('bar', $string->trim());
     }
 }


### PR DESCRIPTION
When using the new fluent string syntax, the documentation shows the ability to run code like this

~~~php
use Illuminate\Support\Str;

$string = Str::of('  Laravel  ')->trim();

// 'Laravel'
~~~

But the current behavior uses null and delegates to the default trim() php function. This function does not trim when null is passed to it. The default $characters should match that of the native PHP function.