### PR TITLE
[7.x] Method contains() should only have needles

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -148,7 +148,7 @@ class Stringable
      * @param  string|array  $needles
      * @return bool
      */
-    public function contains($haystack, $needles)
+    public function contains($needles)
     {
         return Str::contains($this->value, $needles);
     }


### PR DESCRIPTION
The method contains() had an extra parameter in the signature that would cause the documented behavior to fail. 

Solution:
Remove the haystack requirement in the signature as it is not used or needed.

Documentation example
~~~php
use Illuminate\Support\Str;

$contains = Str::of('This is my name')->contains('my');

// true
~~~