### PR TITLE
[7.x] Give Stringable trim() function to default to native function

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -542,7 +542,7 @@ class Stringable
      */
     public function trim($characters = null)
     {
-        return new static(trim($this->value, $characters));
+        return new static(trim($this->value, $characters ?? " \t\n\r\0\x0B"));
     }
 
     /**


### PR DESCRIPTION
When using the new fluent string syntax, the documentation shows the ability to run code like this

~~~php
use Illuminate\Support\Str;

$string = Str::of('  Laravel  ')->trim();

// 'Laravel'
~~~

But the current behavior uses null and delegates to the default trim() php function. This function does not trim when null is passed to it. The default $characters should match that of the native PHP function.

This is a resubmission of #31650