### PR TITLE
[7.x] Refactor component

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -112,15 +112,8 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$propertyCache[$class])) {
-            $reflection = new ReflectionClass($this);
-
-            static::$propertyCache[$class] = collect($reflection->getProperties(ReflectionProperty::IS_PUBLIC))
-                ->reject(function (ReflectionProperty $property) {
-                    return $this->shouldIgnore($property->getName());
-                })
-                ->map(function (ReflectionProperty $property) {
-                    return $property->getName();
-                })->all();
+            $publicProperties = (new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC);
+            static::$propertyCache[$class] = $this->getNames($publicProperties)->all();
         }
 
         $values = [];
@@ -142,15 +135,8 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$methodCache[$class])) {
-            $reflection = new ReflectionClass($this);
-
-            static::$methodCache[$class] = collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))
-                ->reject(function (ReflectionMethod $method) {
-                    return $this->shouldIgnore($method->getName());
-                })
-                ->map(function (ReflectionMethod $method) {
-                    return $method->getName();
-                });
+            $publicMethods = (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC);
+            static::$methodCache[$class] = $this->getNames($publicMethods);
         }
 
         $values = [];
@@ -227,5 +213,20 @@ abstract class Component
     public function shouldRender()
     {
         return true;
+    }
+
+    /**
+     * @param  array  $reflections
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getNames(array $reflections)
+    {
+        return collect($reflections)->reject(function ($reflection) {
+            return $this->shouldIgnore($reflection->getName());
+        })
+        ->map(function ($reflection) {
+            return $reflection->getName();
+        });
     }
 }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -112,8 +112,9 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$propertyCache[$class])) {
-            $properties = (new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC);
-            static::$propertyCache[$class] = $this->getNames($properties);
+            static::$propertyCache[$class] = $this->getNames(
+                (new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC)
+            );
         }
 
         $values = [];
@@ -135,8 +136,9 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$methodCache[$class])) {
-            $methods = (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC);
-            static::$methodCache[$class] = $this->getNames($methods);
+            static::$methodCache[$class] = $this->getNames(
+                (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC)
+            );
         }
 
         $values = [];

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -112,8 +112,8 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$propertyCache[$class])) {
-            $publicProperties = (new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC);
-            static::$propertyCache[$class] = $this->getNames($publicProperties)->all();
+            $properties = (new ReflectionClass($this))->getProperties(ReflectionProperty::IS_PUBLIC);
+            static::$propertyCache[$class] = $this->getNames($properties);
         }
 
         $values = [];
@@ -135,8 +135,8 @@ abstract class Component
         $class = get_class($this);
 
         if (! isset(static::$methodCache[$class])) {
-            $publicMethods = (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC);
-            static::$methodCache[$class] = $this->getNames($publicMethods);
+            $methods = (new ReflectionClass($this))->getMethods(ReflectionMethod::IS_PUBLIC);
+            static::$methodCache[$class] = $this->getNames($methods);
         }
 
         $values = [];
@@ -216,17 +216,15 @@ abstract class Component
     }
 
     /**
-     * @param  array  $reflections
+     * Get the non-ignored names of the given methods.
      *
-     * @return \Illuminate\Support\Collection
+     * @param  array  $reflections
+     * @return string[]
      */
     protected function getNames(array $reflections)
     {
-        return collect($reflections)->reject(function ($reflection) {
-            return $this->shouldIgnore($reflection->getName());
-        })
-        ->map(function ($reflection) {
+        return collect($reflections)->map(function ($reflection) {
             return $reflection->getName();
-        });
+        })->reject([$this, 'shouldIgnore'])->all();
     }
 }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -117,13 +117,9 @@ abstract class Component
             );
         }
 
-        $values = [];
-
-        foreach (static::$propertyCache[$class] as $property) {
-            $values[$property] = $this->{$property};
-        }
-
-        return $values;
+        return $this->collectAttributes(static::$propertyCache[$class], function ($property) {
+            return $this->{$property};
+        });
     }
 
     /**
@@ -141,13 +137,9 @@ abstract class Component
             );
         }
 
-        $values = [];
-
-        foreach (static::$methodCache[$class] as $method) {
-            $values[$method] = $this->createVariableFromMethod(new ReflectionMethod($this, $method));
-        }
-
-        return $values;
+        return $this->collectAttributes(static::$methodCache[$class], function ($method) {
+            return $this->createVariableFromMethod(new ReflectionMethod($this, $method));
+        });
     }
 
     /**
@@ -230,5 +222,22 @@ abstract class Component
         })->reject(function ($item) {
             return $this->shouldIgnore($item);
         })->all();
+    }
+
+    /**
+     * @param  array  $items
+     * @param  \Closure  $callable
+     *
+     * @return array
+     */
+    protected function collectAttributes($items, Closure $callable)
+    {
+        $values = [];
+
+        foreach ($items as $name) {
+            $values[$name] = $callable($name);
+        }
+
+        return $values;
     }
 }

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -227,6 +227,8 @@ abstract class Component
     {
         return collect($reflections)->map(function ($reflection) {
             return $reflection->getName();
-        })->reject([$this, 'shouldIgnore'])->all();
+        })->reject(function ($item) {
+            return $this->shouldIgnore($item);
+        })->all();
     }
 }


### PR DESCRIPTION
It refactors a little bit of duplicated logic into a method with a readable name.

@GrahamCampbell the reject method on the collection class does not work properly with this syntax:
`->reject([$this, 'methodName'])` if the 'methodName' is a protected one.

but this will work :
`->reject(\Closure::fromCallable([$this, 'methodName']))`
