### PR TITLE
[7.x ] Add view components tests

### DIFF
--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -45,6 +45,31 @@ class ViewComponentTest extends TestCase
         $component->data();
         $this->assertEquals(3, $component->counter);
     }
+
+    public function testItIgnoresExceptedMethodsAndProperties()
+    {
+        $component = new TestExceptedViewComponent();
+        $variables = $component->data();
+
+        // Ignored methods (with no args) are not invoked behind the scenes.
+        $this->assertEquals('Otwell', $component->taylor);
+
+        $this->assertArrayNotHasKey('hello', $variables);
+        $this->assertArrayNotHasKey('hello2', $variables);
+        $this->assertArrayNotHasKey('taylor', $variables);
+    }
+
+    public function testMethodsOverridePropertyValues()
+    {
+        $component = new TestHelloPropertyHelloMethodComponent();
+        $variables = $component->data();
+        $this->assertArrayHasKey('hello', $variables);
+        $this->assertEquals('world', $variables['hello']());
+
+        // protected methods do not override public properties.
+        $this->assertArrayHasKey('world', $variables);
+        $this->assertEquals('world property', $variables['world']);
+    }
 }
 
 class TestViewComponent extends Component
@@ -97,5 +122,49 @@ class TestSampleViewComponent extends Component
     private function privateHello()
     {
         $this->counter++;
+    }
+}
+
+class TestExceptedViewComponent extends Component
+{
+    protected $except = ['hello', 'hello2', 'taylor'];
+
+    public $taylor = 'Otwell';
+
+    public function hello($string = 'world')
+    {
+        return $string;
+    }
+
+    public function hello2()
+    {
+        return $this->taylor = '';
+    }
+
+    public function render()
+    {
+        return 'test';
+    }
+}
+
+class TestHelloPropertyHelloMethodComponent extends Component
+{
+    public $hello = 'hello property';
+
+    public $world = 'world property';
+
+    public function hello($string = 'world')
+    {
+        return $string;
+    }
+
+    protected function world($string = 'world')
+    {
+        return $string;
+    }
+
+    public function render()
+    {
+        return 'test';
     }
 }

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -46,7 +46,6 @@ class ViewComponentTest extends TestCase
         $this->assertEquals(3, $component->counter);
     }
 
-
     public function testItIgnoresExceptedMethodsAndProperties()
     {
         $component = new TestExceptedViewComponent();
@@ -70,6 +69,7 @@ class ViewComponentTest extends TestCase
         // protected methods do not override public properties.
         $this->assertArrayHasKey('world', $variables);
         $this->assertEquals('world property', $variables['world']);
+    }
 
     public function testAttributesAreMergedNotOverwritten()
     {
@@ -80,7 +80,6 @@ class ViewComponentTest extends TestCase
         $component->withAttributes(['class' => 'bg-blue-100']);
 
         $this->assertEquals('bg-blue-100 text-red-500', $component->attributes->get('class'));
-
     }
 }
 
@@ -161,6 +160,11 @@ class TestExceptedViewComponent extends Component
 
 class TestHelloPropertyHelloMethodComponent extends Component
 {
+    public function render()
+    {
+        return 'test';
+    }
+
     public $hello = 'hello property';
 
     public $world = 'world property';


### PR DESCRIPTION
This PR covers two cases:
1 - When there is conflict between method names and property names.
2 - Ignoring custom method and property names with $except property.
