### PR TITLE
[7.x] Use variable value instead of invoking method

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -61,9 +61,7 @@ abstract class Component
 
         $factory = Container::getInstance()->make('view');
 
-        return $factory->exists($this->render())
-                    ? $this->render()
-                    : $this->createBladeViewFromString($factory, $this->render());
+        return $factory->exists($view) ? $view : $this->createBladeViewFromString($factory, $view);
     }
 
     /**


### PR DESCRIPTION
I did not see any reason to call the method multiple times when the $view variable is already available,
so I suggested this little change.
And if there is a reason, it means that a test is missing.