### PR TITLE
[7.x] Artisan `stub:publish` command improvements

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -63,7 +63,7 @@ class StubPublishCommand extends Command
 
         if ($stubs = $this->option('stubs')) {
             $files = $files->filter(function ($destination) use ($stubs, $stubsPath) {
-                return ! in_array(Str::between($destination, $stubsPath . '/', '.stub'), $stubs);
+                return ! in_array(Str::between($destination, $stubsPath.'/', '.stub'), $stubs);
             });
         }
 

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Foundation\Console;
 
-use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 
 class StubPublishCommand extends Command
 {

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -58,7 +58,7 @@ class StubPublishCommand extends Command
 
         if ($stubs = $this->option('stubs')) {
             $files->filter(function ($destination) use ($stubs, $stubsPath) {
-                return ! in_array(Str::between($destination, $stubsPath, '.stub'), $stubs);
+                return ! in_array(Str::between($destination, $stubsPath . '/', '.stub'), $stubs);
             });
         }
 

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -62,6 +62,8 @@ class StubPublishCommand extends Command
         }
 
         if ($stubs = $this->option('stubs')) {
+            $stubs = explode(',', $stubs);
+
             $files = $files->filter(function ($destination) use ($stubs, $stubsPath) {
                 return ! in_array(Str::between($destination, $stubsPath.'/', '.stub'), $stubs);
             });

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -13,7 +13,7 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish {--stubs= : The stubs to publish}
+    protected $signature = 'stub:publish {--stubs= : Comma-separated list of the stubs to publish}
                     {--force : Overwrite any existing files}';
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -52,7 +52,9 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $stubsPath.'/controller.nested.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $stubsPath.'/controller.plain.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
-        ]);
+        ])->filter(function ($destination) {
+            return ! file_exists($destination);
+        });
 
         if ($stubs = $this->option('stubs')) {
             $files->filter(function ($destination) use ($stubs, $stubsPath) {

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -13,7 +13,8 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish {--stubs= : The stubs to publish}';
+    protected $signature = 'stub:publish {--stubs= : The stubs to publish}
+                    {--force : Overwrite any existing files}';
 
     /**
      * The console command description.
@@ -52,12 +53,16 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $stubsPath.'/controller.nested.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $stubsPath.'/controller.plain.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
-        ])->filter(function ($destination) {
-            return ! file_exists($destination);
-        });
+        ]);
+
+        if (! $this->option('force')) {
+            $files = $files->filter(function ($destination) {
+                return ! file_exists($destination);
+            });
+        }
 
         if ($stubs = $this->option('stubs')) {
-            $files->filter(function ($destination) use ($stubs, $stubsPath) {
+            $files = $files->filter(function ($destination) use ($stubs, $stubsPath) {
                 return ! in_array(Str::between($destination, $stubsPath . '/', '.stub'), $stubs);
             });
         }

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 
@@ -12,14 +13,14 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish';
+    protected $signature = 'stub:publish {--stubs= : The stubs to publish}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Publish all stubs that are available for customization';
+    protected $description = 'Publish the stubs that are available for customization';
 
     /**
      * Execute the console command.
@@ -32,7 +33,7 @@ class StubPublishCommand extends Command
             (new Filesystem)->makeDirectory($stubsPath);
         }
 
-        $files = [
+        $files = collect([
             __DIR__.'/stubs/job.queued.stub' => $stubsPath.'/job.queued.stub',
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
@@ -51,7 +52,13 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.nested.stub') => $stubsPath.'/controller.nested.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.plain.stub') => $stubsPath.'/controller.plain.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.stub') => $stubsPath.'/controller.stub',
-        ];
+        ]);
+
+        if ($stubs = $this->option('stubs')) {
+            $files->filter(function ($destination) use ($stubs, $stubsPath) {
+                return ! in_array(Str::between($destination, $stubsPath, '.stub'), $stubs);
+            });
+        }
 
         foreach ($files as $from => $to) {
             file_put_contents($to, file_get_contents($from));


### PR DESCRIPTION
This pull request only contains a couple of changes. I think that by default, the `stub:publish` command should publish **all** stubs, but there should also be an option to only publish the ones that are wanted.

I've added a new `--stubs` option that takes in a comma-separated list of stubs, e.g. `php artisan stub:publish --stubs=model,job.queued`. The only problem I can see here is that people will need to know the name of the stub file, so it might be worth adding some info in the docs about those names.

The other change is to prevent stub files being overwritten. For example, if I have published the `model.pivot` stub and made changes and then decide I want the rest of them too, running the current command would overwrite all of my changes, which I definitely wouldn't want.

The final change is adding a new `--force` flag that will overwrite any existing files.