### PR TITLE
[7.x] Fix SendQueuedNotifications notifiables property type

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 
 class SendQueuedNotifications implements ShouldQueue
 {
@@ -57,7 +58,7 @@ class SendQueuedNotifications implements ShouldQueue
     public function __construct($notifiables, $notification, array $channels = null)
     {
         $this->channels = $channels;
-        $this->notifiables = $notifiables;
+        $this->notifiables = Collection::wrap($notifiables);
         $this->notification = $notification;
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -58,8 +58,8 @@ class SendQueuedNotifications implements ShouldQueue
     public function __construct($notifiables, $notification, array $channels = null)
     {
         $this->channels = $channels;
-        $this->notifiables = Collection::wrap($notifiables);
         $this->notification = $notification;
+        $this->notifiables = Collection::wrap($notifiables);
         $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
         $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
     }

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Notifications;
 
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,11 @@ class NotificationSendQueuedNotificationTest extends TestCase
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
         $manager = m::mock(ChannelManager::class);
-        $manager->shouldReceive('sendNow')->once()->with('notifiables', 'notification', null);
+        $manager->shouldReceive('sendNow')->once()->withArgs(function ($notifiables, $notification, $channels) {
+            return $notifiables instanceof Collection && $notifiables->toArray() === ['notifiables']
+                && $notification === 'notification'
+                && $channels === null;
+        });
         $job->handle($manager);
     }
 }


### PR DESCRIPTION
Currently the `notifiables` property is typehinted as a collection, but it isn't actually (always) one. For instance when doing `$request->user()->notify(new MyNotification)`, the `notifiables` property will be set to an instance of `App\User`.

For the sending of the notifications it does not seem to matter if its actually a collection or not, so I opted to always wrap a collection around the given notifiable(s); this allows for collection operations in notification middleware without having to do type checks.

For example:
```php
public function handle($job, $next)
{
    if ($job->notifiables->isNotEmpty()) {
        // do something...
    }
}
```

Side note: I didn't know which version to target this to, because technically it's not working correctly at the moment, but I can also see this breaking people's code if they are using notification middleware.