### PR TITLE
[7.x] Fix not being able to set component attributes from inside class

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -214,7 +214,7 @@ abstract class Component
     {
         $this->attributes = $this->attributes ?: new ComponentAttributeBag;
 
-        $this->attributes->setAttributes($attributes);
+        $this->attributes = $this->attributes->merge($attributes);
 
         return $this;
     }

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -45,6 +45,17 @@ class ViewComponentTest extends TestCase
         $component->data();
         $this->assertEquals(3, $component->counter);
     }
+
+    public function testAttributesAreMergedNotOverwritten()
+    {
+        $component = new TestDefaultAttributesComponent;
+
+        $this->assertEquals('text-red-500', $component->attributes->get('class'));
+
+        $component->withAttributes(['class' => 'bg-blue-100']);
+
+        $this->assertEquals('bg-blue-100 text-red-500', $component->attributes->get('class'));
+    }
 }
 
 class TestViewComponent extends Component
@@ -97,5 +108,18 @@ class TestSampleViewComponent extends Component
     private function privateHello()
     {
         $this->counter++;
+    }
+}
+
+class TestDefaultAttributesComponent extends Component
+{
+    public function __construct()
+    {
+        $this->withAttributes(['class' => 'text-red-500']);
+    }
+
+    public function render()
+    {
+        return $this->attributes->get('id');
     }
 }


### PR DESCRIPTION
This pull request should fix #31653 . There were a couple of routes that could have been taken which I detailed in the issue, but I chose to go down the merging route, instead of conditional setting.

There is a very simple test provided too, not sure if this could be expanded.