### PR TITLE
[6.x] Make newPivotQuery public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -532,7 +532,7 @@ trait InteractsWithPivotTable
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    public function newPivotQuery()
     {
         $query = $this->newPivotStatement();
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -120,7 +120,7 @@ class MorphToMany extends BelongsToMany
      *
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function newPivotQuery()
+    public function newPivotQuery()
     {
         return parent::newPivotQuery()->where($this->morphType, $this->morphClass);
     }


### PR DESCRIPTION
This pull request makes _newPivotQuery_ method as public. This is usefull for example: counting pivot table, getting information from pivot table etc. without querying related table.

Counting:
```php
$post->comments()->newPivotQuery()->count();
```

Counting with condition:
```php
$post->comments()->newPivotQuery()->whereIn('author_id', [1, 2])->count();
```

Checking if exists:
```php
$post->comments()->newPivotQuery()->where('created_at', '>=', Carbon::now()->subDay()->toDateTimeString())->exists();
```