### PR TITLE
[6.x] migrate --seed should seed the same database

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -77,7 +77,6 @@ class MigrateCommand extends BaseCommand
         if ($this->option('seed') && ! $this->option('pretend')) {
             $this->call('db:seed', array_filter([
                 '--database' => $this->option('database'),
-                '--class' => $this->option('seeder'),
                 '--force' => true,
             ]));
         }

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -75,7 +75,11 @@ class MigrateCommand extends BaseCommand
         // seed task to re-populate the database, which is convenient when adding
         // a migration and a seed at the same time, as it is only this command.
         if ($this->option('seed') && ! $this->option('pretend')) {
-            $this->call('db:seed', ['--force' => true]);
+            $this->call('db:seed', array_filter([
+                '--database' => $this->option('database'),
+                '--class' => $this->option('seeder'),
+                '--force' => true,
+            ]));
         }
     }
 


### PR DESCRIPTION
**TLDR**
This pull enables `php artisan migrate --seed --database=xxx` to seed the same database

**Current behaviour**
Currently if you run `php artisan migrate --seed --database=xxx`, the specified database will be migrated but seed will be run on default connection

**Expected behaviour**
`php artisan migrate --seed --database=xxx` should migrate and seed the same specified database

**Solution**
This pull passes the arguments of the MigrateCommand to the SeedCommand, so if --database is specified it will be used