### PR TITLE
[6.x] Allow easier customization of the queued mailable job

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -177,7 +177,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->pushOn(
-            $queueName ?: null, $this->makeQueuedJob()
+            $queueName ?: null, $this->newQueuedJob()
         );
     }
 
@@ -195,7 +195,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->laterOn(
-            $queueName ?: null, $delay, $this->makeQueuedJob()
+            $queueName ?: null, $delay, $this->newQueuedJob()
         );
     }
 
@@ -204,7 +204,7 @@ class Mailable implements MailableContract, Renderable
      *
      * @return mixed
      */
-    protected function makeQueuedJob()
+    protected function newQueuedJob()
     {
         return new SendQueuedMailable($this);
     }

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -177,7 +177,7 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->pushOn(
-            $queueName ?: null, new SendQueuedMailable($this)
+            $queueName ?: null, $this->makeQueuedJob()
         );
     }
 
@@ -195,8 +195,18 @@ class Mailable implements MailableContract, Renderable
         $queueName = property_exists($this, 'queue') ? $this->queue : null;
 
         return $queue->connection($connection)->laterOn(
-            $queueName ?: null, $delay, new SendQueuedMailable($this)
+            $queueName ?: null, $delay, $this->makeQueuedJob()
         );
+    }
+
+    /**
+     * Make the queued mailable job instance.
+     *
+     * @return mixed
+     */
+    protected function makeQueuedJob()
+    {
+        return new SendQueuedMailable($this);
     }
 
     /**


### PR DESCRIPTION
This will allow developers to override `newQueuedJob` method in their mailables and return their own job which would enable being able to e.g: add job middlewares to rate limit emails, define a time limit on when a mailable is timed out etc.