### PR TITLE
[7.x] Ensure that only Eloquent Collection can call loadMorph

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Pagination;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -283,9 +284,14 @@ abstract class AbstractPaginator implements Htmlable
      * @param  string  $relation
      * @param  array  $relations
      * @return $this
+     * @throws \Exception
      */
     public function loadMorph($relation, $relations)
     {
+        if (! method_exists($this->getCollection(), 'loadMorph')) {
+            throw new Exception('loadMorph method does not exist for this Collection.');
+        }
+
         $this->getCollection()->loadMorph($relation, $relations);
 
         return $this;

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -47,7 +47,7 @@ class PaginatorLoadMorphTest extends TestCase
         $this->expectExceptionMessage('loadMorph method does not exist for this Collection.');
 
         $items = m::mock(BaseCollection::class);
-        $items->shouldNotReceive('loadMorph')->once();
+        $items->shouldNotReceive('loadMorph');
 
         $p = (new class extends AbstractPaginator {
             //

--- a/tests/Pagination/PaginatorLoadMorphTest.php
+++ b/tests/Pagination/PaginatorLoadMorphTest.php
@@ -2,27 +2,57 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\AbstractPaginator;
+use Illuminate\Support\Collection as BaseCollection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class PaginatorLoadMorphTest extends TestCase
 {
-    public function testCollectionLoadMorphCanChainOnThePaginator()
-    {
-        $relations = [
-            'App\\User' => 'photos',
-            'App\\Company' => ['employees', 'calendars'],
-        ];
+    /**
+     * @var array
+     */
+    protected $relations;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->relations = [
+            'App\\User' => 'photos',
+            'App\\Company' => [
+                'employees',
+                'calendars',
+            ],
+        ];
+    }
+
+    public function testEloquentCollectionLoadMorphCanChainOnThePaginator()
+    {
         $items = m::mock(Collection::class);
-        $items->shouldReceive('loadMorph')->once()->with('parentable', $relations);
+        $items->shouldReceive('loadMorph')->once()->with('parentable', $this->relations);
 
         $p = (new class extends AbstractPaginator {
             //
         })->setCollection($items);
 
-        $this->assertSame($p, $p->loadMorph('parentable', $relations));
+        $this->assertSame($p, $p->loadMorph('parentable', $this->relations));
+    }
+
+    public function testSupportCollectionCannotLoadMorph()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('loadMorph method does not exist for this Collection.');
+
+        $items = m::mock(BaseCollection::class);
+        $items->shouldNotReceive('loadMorph')->once();
+
+        $p = (new class extends AbstractPaginator {
+            //
+        })->setCollection($items);
+
+        $p->loadMorph('parentable', $this->relations);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Ensure that only Eloquent Collection can call loadMorph.

I have no opinion on the type of property to throw. Maybe `\BadMethodCallException` would be better.
I let this be changed later, if this PR is merged. 