### PR TITLE
[6.x] PhpStorm fixes + improvments

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -450,8 +450,17 @@ class Gate implements GateContract
      */
     protected function parameterAllowsGuests($parameter)
     {
-        return ($parameter->getClass() && $parameter->allowsNull()) ||
-               ($parameter->isDefaultValueAvailable() && is_null($parameter->getDefaultValue()));
+        return (
+                   $parameter->getClass()
+                   &&
+                   $parameter->allowsNull()
+               )
+               ||
+               (
+                   $parameter->isDefaultValueAvailable()
+                   &&
+                   is_null($parameter->getDefaultValue())
+               );
     }
 
     /**
@@ -524,9 +533,13 @@ class Gate implements GateContract
      */
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
-        if (isset($arguments[0]) &&
-            ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
-            $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
+        if (
+            isset($arguments[0])
+            &&
+            ! is_null($policy = $this->getPolicyFor($arguments[0]))
+            &&
+            $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)
+        ) {
             return $callback;
         }
 
@@ -538,12 +551,15 @@ class Gate implements GateContract
             }
         }
 
-        if (isset($this->abilities[$ability]) &&
-            $this->canBeCalledWithUser($user, $this->abilities[$ability])) {
+        if (
+            isset($this->abilities[$ability])
+            &&
+            $this->canBeCalledWithUser($user, $this->abilities[$ability])
+        ) {
             return $this->abilities[$ability];
         }
 
-        return function () {
+        return static function () {
             //
         };
     }
@@ -726,7 +742,7 @@ class Gate implements GateContract
      */
     public function forUser($user)
     {
-        $callback = function () use ($user) {
+        $callback = static function () use ($user) {
             return $user;
         };
 

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -30,7 +30,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthenticator()
     {
-        $this->app->singleton('auth', function ($app) {
+        $this->app->singleton('auth', static function ($app) {
             // Once the authentication service has actually been requested by the developer
             // we will set a variable in the application indicating such. This helps us
             // know that we need to set any queued cookies in the after event later.
@@ -39,7 +39,7 @@ class AuthServiceProvider extends ServiceProvider
             return new AuthManager($app);
         });
 
-        $this->app->singleton('auth.driver', function ($app) {
+        $this->app->singleton('auth.driver', static function ($app) {
             return $app['auth']->guard();
         });
     }
@@ -52,7 +52,7 @@ class AuthServiceProvider extends ServiceProvider
     protected function registerUserResolver()
     {
         $this->app->bind(
-            AuthenticatableContract::class, function ($app) {
+            AuthenticatableContract::class, static function ($app) {
                 return call_user_func($app['auth']->userResolver());
             }
         );
@@ -65,8 +65,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAccessGate()
     {
-        $this->app->singleton(GateContract::class, function ($app) {
-            return new Gate($app, function () use ($app) {
+        $this->app->singleton(GateContract::class, static function ($app) {
+            return new Gate($app, static function () use ($app) {
                 return call_user_func($app['auth']->userResolver());
             });
         });
@@ -79,8 +79,9 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerRequestRebindHandler()
     {
-        $this->app->rebinding('request', function ($app, $request) {
-            $request->setUserResolver(function ($guard = null) use ($app) {
+        $this->app->rebinding('request', static function ($app, $request) {
+            /** @var $request \Illuminate\Http\Request */
+            $request->setUserResolver(static function ($guard = null) use ($app) {
                 return call_user_func($app['auth']->userResolver(), $guard);
             });
         });
@@ -93,7 +94,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerEventRebindHandler()
     {
-        $this->app->rebinding('events', function ($app, $dispatcher) {
+        $this->app->rebinding('events', static function ($app, $dispatcher) {
+            /** @var $app \Illuminate\Container\Container */
             if (! $app->resolved('auth')) {
                 return;
             }
@@ -103,6 +105,7 @@ class AuthServiceProvider extends ServiceProvider
             }
 
             if (method_exists($guard = $app['auth']->guard(), 'setDispatcher')) {
+                /** @var \Illuminate\Contracts\Auth\Guard $guard */
                 $guard->setDispatcher($dispatcher);
             }
         });

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -99,9 +99,14 @@ class DatabaseUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if (empty($credentials) ||
-           (count($credentials) === 1 &&
-            array_key_exists('password', $credentials))) {
+        if (
+            empty($credentials)
+            ||
+            (
+                count($credentials) === 1
+                &&
+                array_key_exists('password', $credentials))
+        ) {
             return;
         }
 

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -105,9 +105,14 @@ class EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if (empty($credentials) ||
-           (count($credentials) === 1 &&
-            Str::contains($this->firstCredentialKey($credentials), 'password'))) {
+        if (
+            empty($credentials)
+            ||
+            (
+                count($credentials) === 1
+                &&
+                Str::contains($this->firstCredentialKey($credentials), 'password'))
+        ) {
             return;
         }
 

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -73,12 +73,14 @@ trait GuardHelpers
     /**
      * Get the ID for the currently authenticated user.
      *
-     * @return int|null
+     * @return int|null|void
      */
     public function id()
     {
-        if ($this->user()) {
-            return $this->user()->getAuthIdentifier();
+        /** @var \Illuminate\Contracts\Auth\Authenticatable|null $user */
+        $user = $this->user();
+        if ($user) {
+            return $user->getAuthIdentifier();
         }
     }
 

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -68,16 +68,19 @@ class Authorize
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $model
-     * @return \Illuminate\Database\Eloquent\Model|string
+     * @return \Illuminate\Database\Eloquent\Model|string|null
      */
     protected function getModel($request, $model)
     {
         if ($this->isClassName($model)) {
             return trim($model);
-        } else {
-            return $request->route($model, null) ?:
-                ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
         }
+
+        if ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches))) {
+            return $request->route($model, null) ?: $matches[1];
+        }
+
+        return $request->route($model, null) ?: null;
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
+++ b/src/Illuminate/Auth/Middleware/EnsureEmailIsVerified.php
@@ -18,9 +18,14 @@ class EnsureEmailIsVerified
      */
     public function handle($request, Closure $next, $redirectToRoute = null)
     {
-        if (! $request->user() ||
-            ($request->user() instanceof MustVerifyEmail &&
-            ! $request->user()->hasVerifiedEmail())) {
+        if (
+            ! $request->user()
+            ||
+            (
+                $request->user() instanceof MustVerifyEmail
+                &&
+                ! $request->user()->hasVerifiedEmail())
+        ) {
             return $request->expectsJson()
                     ? abort(403, 'Your email address is not verified.')
                     : Redirect::route($redirectToRoute ?: 'verification.notice');

--- a/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
+++ b/src/Illuminate/Auth/Passwords/DatabaseTokenRepository.php
@@ -133,9 +133,11 @@ class DatabaseTokenRepository implements TokenRepositoryInterface
             'email', $user->getEmailForPasswordReset()
         )->first();
 
-        return $record &&
-               ! $this->tokenExpired($record['created_at']) &&
-                 $this->hasher->check($token, $record['token']);
+        return $record
+               &&
+               ! $this->tokenExpired($record['created_at'])
+               &&
+               $this->hasher->check($token, $record['token']);
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -55,8 +55,11 @@ class PasswordBroker implements PasswordBrokerContract
             return static::INVALID_USER;
         }
 
-        if (method_exists($this->tokens, 'recentlyCreatedToken') &&
-            $this->tokens->recentlyCreatedToken($user)) {
+        if (
+            method_exists($this->tokens, 'recentlyCreatedToken')
+            &&
+            $this->tokens->recentlyCreatedToken($user)
+        ) {
             return static::RESET_THROTTLED;
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -24,11 +24,12 @@ class PasswordResetServiceProvider extends ServiceProvider implements Deferrable
      */
     protected function registerPasswordBroker()
     {
-        $this->app->singleton('auth.password', function ($app) {
+        $this->app->singleton('auth.password', static function ($app) {
             return new PasswordBrokerManager($app);
         });
 
-        $this->app->bind('auth.password.broker', function ($app) {
+        $this->app->bind('auth.password.broker', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
             return $app->make('auth.password')->broker();
         });
     }

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -65,7 +65,8 @@ class BroadcastManager implements FactoryContract
 
         $attributes = $attributes ?: ['middleware' => ['web']];
 
-        $this->app['router']->group($attributes, function ($router) {
+        $this->app['router']->group($attributes, static function ($router) {
+            /** @var \Illuminate\Routing\Router $router */
             $router->match(
                 ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -16,11 +16,12 @@ class BroadcastServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function register()
     {
-        $this->app->singleton(BroadcastManager::class, function ($app) {
+        $this->app->singleton(BroadcastManager::class, static function ($app) {
             return new BroadcastManager($app);
         });
 
-        $this->app->singleton(BroadcasterContract::class, function ($app) {
+        $this->app->singleton(BroadcasterContract::class, static function ($app) {
+            /** @var \Illuminate\Contracts\Container\Container $app */
             return $app->make(BroadcastManager::class)->connection();
         });
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -42,8 +42,11 @@ class PusherBroadcaster extends Broadcaster
     {
         $channelName = $this->normalizeChannelName($request->channel_name);
 
-        if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName)) {
+        if (
+            $this->isGuardedChannel($request->channel_name)
+            &&
+            ! $this->retrieveUser($request, $channelName)
+        ) {
             throw new AccessDeniedHttpException;
         }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -60,8 +60,11 @@ class RedisBroadcaster extends Broadcaster
             str_replace($this->prefix, '', $request->channel_name)
         );
 
-        if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName)) {
+        if (
+            $this->isGuardedChannel($request->channel_name)
+            &&
+            ! $this->retrieveUser($request, $channelName)
+        ) {
             throw new AccessDeniedHttpException;
         }
 

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -17,8 +17,8 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton(Dispatcher::class, function ($app) {
-            return new Dispatcher($app, function ($connection = null) use ($app) {
+        $this->app->singleton(Dispatcher::class, static function ($app) {
+            return new Dispatcher($app, static function ($connection = null) use ($app) {
                 return $app[QueueFactoryContract::class]->connection($connection);
             });
         });

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -86,7 +86,7 @@ class Dispatcher implements QueueingDispatcher
     public function dispatchNow($command, $handler = null)
     {
         if ($handler || $handler = $this->getCommandHandler($command)) {
-            $callback = function ($command) use ($handler) {
+            $callback = static function ($command) use ($handler) {
                 return $handler->handle($command);
             };
         } else {

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -151,7 +151,7 @@ trait Queueable
      */
     public function chain($chain)
     {
-        $this->chained = collect($chain)->map(function ($job) {
+        $this->chained = collect($chain)->map(static function ($job) {
             return serialize($job);
         })->all();
 

--- a/src/Illuminate/Cache/ApcStore.php
+++ b/src/Illuminate/Cache/ApcStore.php
@@ -37,7 +37,7 @@ class ApcStore extends TaggableStore
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key
-     * @return mixed
+     * @return mixed|void
      */
     public function get($key)
     {

--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -27,7 +27,7 @@ class ArrayStore extends TaggableStore implements LockProvider
      * Retrieve an item from the cache by key.
      *
      * @param  string|array  $key
-     * @return mixed
+     * @return mixed|void
      */
     public function get($key)
     {

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -15,19 +15,19 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('cache', function ($app) {
+        $this->app->singleton('cache', static function ($app) {
             return new CacheManager($app);
         });
 
-        $this->app->singleton('cache.store', function ($app) {
+        $this->app->singleton('cache.store', static function ($app) {
             return $app['cache']->driver();
         });
 
-        $this->app->singleton('cache.psr6', function ($app) {
-            return new Psr16Adapter($app['cache.store']);
+        $this->app->singleton('cache.psr6', static function ($app) {
+            return new Psr16Adapter($app['cache.store'] );
         });
 
-        $this->app->singleton('memcached.connector', function () {
+        $this->app->singleton('memcached.connector', static function () {
             return new MemcachedConnector;
         });
     }

--- a/src/Illuminate/Cache/Console/ClearCommand.php
+++ b/src/Illuminate/Cache/Console/ClearCommand.php
@@ -100,7 +100,7 @@ class ClearCommand extends Command
     /**
      * Get the cache instance for the command.
      *
-     * @return \Illuminate\Cache\Repository
+     * @return \Illuminate\Contracts\Cache\Repository
      */
     protected function cache()
     {

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -117,7 +117,7 @@ class DatabaseStore implements Store
      */
     public function increment($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current + $value;
         });
     }
@@ -131,7 +131,7 @@ class DatabaseStore implements Store
      */
     public function decrement($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current - $value;
         });
     }

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -150,7 +150,7 @@ class DynamoDbStore implements LockProvider, Store
 
         $now = Carbon::now();
 
-        return array_merge(collect(array_flip($keys))->map(function () {
+        return array_merge(collect(array_flip($keys))->map(static function () {
             //
         })->all(), collect($response['Responses'][$this->table])->mapWithKeys(function ($response) use ($now) {
             if ($this->isExpired($response, $now)) {
@@ -178,7 +178,8 @@ class DynamoDbStore implements LockProvider, Store
     {
         $expiration = $expiration ?: Carbon::now();
 
-        return isset($item[$this->expirationAttribute]) &&
+        return isset($item[$this->expirationAttribute])
+               &&
                $expiration->getTimestamp() >= $item[$this->expirationAttribute]['N'];
     }
 
@@ -442,7 +443,7 @@ class DynamoDbStore implements LockProvider, Store
     /**
      * Remove all items from the cache.
      *
-     * @return bool
+     * @return void
      *
      * @throws \RuntimeException
      */

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -120,7 +120,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function many(array $keys)
     {
-        $values = $this->store->many(collect($keys)->map(function ($value, $key) {
+        $values = $this->store->many(collect($keys)->map(static function ($value, $key) {
             return is_string($key) ? $key : $value;
         })->values()->all());
 

--- a/src/Illuminate/Console/Application.php
+++ b/src/Illuminate/Console/Application.php
@@ -288,6 +288,7 @@ class Application extends SymfonyApplication implements ApplicationContract
     protected function getDefaultInputDefinition()
     {
         return tap(parent::getDefaultInputDefinition(), function ($definition) {
+            /** @var \Symfony\Component\Console\Input\InputDefinition $definition */
             $definition->addOption($this->getEnvironmentOption());
         });
     }

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -65,7 +65,8 @@ trait CallsCommands
      */
     protected function createInputFromArguments(array $arguments)
     {
-        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
+        return tap(new ArrayInput(array_merge($this->context(), $arguments)), static function ($input) {
+            /** @var ArrayInput $input */
             if ($input->hasParameterOption(['--no-interaction'], true)) {
                 $input->setInteractive(false);
             }
@@ -85,7 +86,7 @@ trait CallsCommands
             'no-interaction',
             'quiet',
             'verbose',
-        ])->filter()->mapWithKeys(function ($value, $key) {
+        ])->filter()->mapWithKeys(static function ($value, $key) {
             return ["--{$key}" => $value];
         })->all();
     }

--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -58,9 +58,15 @@ abstract class GeneratorCommand extends Command
         // First we will check to see if the class already exists. If it does, we don't want
         // to create the class and overwrite the user's code. So, we will bail out so the
         // code is untouched. Otherwise, we will continue generating this class' files.
-        if ((! $this->hasOption('force') ||
-             ! $this->option('force')) &&
-             $this->alreadyExists($this->getNameInput())) {
+        if (
+            (
+                ! $this->hasOption('force')
+                ||
+                ! $this->option('force')
+            )
+            &&
+            $this->alreadyExists($this->getNameInput())
+        ) {
             $this->error($this->type.' already exists!');
 
             return false;

--- a/src/Illuminate/Console/Parser.php
+++ b/src/Illuminate/Console/Parser.php
@@ -21,10 +21,16 @@ class Parser
     {
         $name = static::name($expression);
 
-        if (preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches)) {
-            if (count($matches[1])) {
-                return array_merge([$name], static::parameters($matches[1]));
-            }
+        if (
+            strpos($expression, '{') !== false
+            &&
+            strpos($expression, '}') !== false
+            &&
+            preg_match_all('/\{\s*(.*?)\s*\}/', $expression, $matches)
+            &&
+            count($matches[1])
+        ) {
+            return array_merge([$name], static::parameters($matches[1]));
         }
 
         return [$name, [], []];

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -284,7 +284,8 @@ class Event
             return false;
         }
 
-        return $this->expressionPasses() &&
+        return $this->expressionPasses()
+               &&
                $this->runsInEnvironment($app->environment());
     }
 
@@ -560,7 +561,7 @@ class Event
      */
     protected function pingCallback($url)
     {
-        return function (Container $container, HttpClient $http) use ($url) {
+        return static function (Container $container, HttpClient $http) use ($url) {
             try {
                 $http->get($url);
             } catch (ClientExceptionInterface | TransferException $e) {

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -66,7 +66,7 @@ trait ManagesFrequencies
             }
         }
 
-        return function () use ($now, $startTime, $endTime) {
+        return static function () use ($now, $startTime, $endTime) {
             return $now->between($startTime, $endTime);
         };
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -106,7 +106,7 @@ class Schedule
      */
     public function job($job, $queue = null, $connection = null)
     {
-        return $this->call(function () use ($job, $queue, $connection) {
+        return $this->call(static function () use ($job, $queue, $connection) {
             $job = is_string($job) ? resolve($job) : $job;
 
             if ($job instanceof ShouldQueue) {
@@ -145,12 +145,12 @@ class Schedule
      */
     protected function compileParameters(array $parameters)
     {
-        return collect($parameters)->map(function ($value, $key) {
+        return collect($parameters)->map(static function ($value, $key) {
             if (is_array($value)) {
-                $value = collect($value)->map(function ($value) {
+                $value = collect($value)->map(static function ($value) {
                     return ProcessUtils::escapeArgument($value);
                 })->implode(' ');
-            } elseif (! is_numeric($value) && ! preg_match('/^(-.$|--.*)/i', $value)) {
+            } elseif (! is_numeric($value) && ! preg_match('/^(-.$|--.*)/', $value)) {
                 $value = ProcessUtils::escapeArgument($value);
             }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -27,7 +27,7 @@ class BoundMethod
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }
 
-        return static::callBoundMethod($container, $callback, function () use ($container, $callback, $parameters) {
+        return static::callBoundMethod($container, $callback, static function () use ($container, $callback, $parameters) {
             return call_user_func_array(
                 $callback, static::getMethodDependencies($container, $callback, $parameters)
             );

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -158,8 +158,10 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function bound($abstract)
     {
-        return isset($this->bindings[$abstract]) ||
-               isset($this->instances[$abstract]) ||
+        return isset($this->bindings[$abstract])
+               ||
+               isset($this->instances[$abstract])
+               ||
                $this->isAlias($abstract);
     }
 
@@ -183,7 +185,8 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        return isset($this->resolved[$abstract]) ||
+        return isset($this->resolved[$abstract])
+               ||
                isset($this->instances[$abstract]);
     }
 
@@ -195,9 +198,13 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function isShared($abstract)
     {
-        return isset($this->instances[$abstract]) ||
-               (isset($this->bindings[$abstract]['shared']) &&
-               $this->bindings[$abstract]['shared'] === true);
+        return isset($this->instances[$abstract])
+               ||
+               (
+                   isset($this->bindings[$abstract]['shared'])
+                   &&
+                   $this->bindings[$abstract]['shared'] === true
+               );
     }
 
     /**
@@ -256,7 +263,9 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClosure($abstract, $concrete)
     {
-        return function ($container, $parameters = []) use ($abstract, $concrete) {
+        return static function ($container, $parameters = []) use ($abstract, $concrete) {
+            /** @var Container $container */
+
             if ($abstract == $concrete) {
                 return $container->build($concrete);
             }
@@ -532,7 +541,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function refresh($abstract, $target, $method)
     {
-        return $this->rebinding($abstract, function ($app, $instance) use ($target, $method) {
+        return $this->rebinding($abstract, static function ($app, $instance) use ($target, $method) {
             $target->{$method}($instance);
         });
     }
@@ -548,7 +557,7 @@ class Container implements ArrayAccess, ContainerContract
         $instance = $this->make($abstract);
 
         foreach ($this->getReboundCallbacks($abstract) as $callback) {
-            call_user_func($callback, $this, $instance);
+            $callback($this, $instance);
         }
     }
 
@@ -1082,8 +1091,12 @@ class Container implements ArrayAccess, ContainerContract
 
         foreach ($callbacksPerType as $type => $callbacks) {
             if ($type === $abstract || $object instanceof $type) {
-                $results = array_merge($results, $callbacks);
+                $results[] = $callbacks;
             }
+        }
+
+        if ($results !== []) {
+            $results = array_merge([], ...$results);
         }
 
         return $results;
@@ -1254,7 +1267,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetSet($key, $value)
     {
-        $this->bind($key, $value instanceof Closure ? $value : function () use ($value) {
+        $this->bind($key, $value instanceof Closure ? $value : static function () use ($value) {
             return $value;
         });
     }

--- a/src/Illuminate/Contracts/Foundation/Application.php
+++ b/src/Illuminate/Contracts/Foundation/Application.php
@@ -5,6 +5,9 @@ namespace Illuminate\Contracts\Foundation;
 use Closure;
 use Illuminate\Contracts\Container\Container;
 
+/**
+ * @property-read array $config
+ */
 interface Application extends Container
 {
     /**

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -13,7 +13,8 @@ class CookieServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('cookie', function ($app) {
+        $this->app->singleton('cookie', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
             $config = $app->make('config')->get('session');
 
             return (new CookieJar)->setDefaultPathAndDomain(

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -57,7 +57,7 @@ trait BuildsQueries
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;
@@ -123,7 +123,7 @@ trait BuildsQueries
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results) use ($callback) {
+        return $this->chunkById($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -73,8 +73,11 @@ trait ManagesTransactions
         // On a deadlock, MySQL rolls back the entire transaction so we can't just
         // retry the query. We have to throw this exception all the way out and
         // let the developer handle it in another way. We will decrement too.
-        if ($this->causedByConcurrencyError($e) &&
-            $this->transactions > 1) {
+        if (
+            $this->causedByConcurrencyError($e)
+            &&
+            $this->transactions > 1
+        ) {
             $this->transactions--;
 
             throw $e;
@@ -85,8 +88,11 @@ trait ManagesTransactions
         // if we haven't we will return and try this query again in our loop.
         $this->rollBack();
 
-        if ($this->causedByConcurrencyError($e) &&
-            $currentAttempt < $maxAttempts) {
+        if (
+            $this->causedByConcurrencyError($e)
+            &&
+            $currentAttempt < $maxAttempts
+        ) {
             return;
         }
 
@@ -188,8 +194,11 @@ trait ManagesTransactions
     {
         $this->transactions--;
 
-        if ($this->causedByConcurrencyError($e) &&
-            $currentAttempt < $maxAttempts) {
+        if (
+            $this->causedByConcurrencyError($e)
+            &&
+            $currentAttempt < $maxAttempts
+        ) {
             return;
         }
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -217,7 +217,7 @@ class Connection implements ConnectionInterface
     /**
      * Get the default schema grammar instance.
      *
-     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     * @return \Illuminate\Database\Schema\Grammars\Grammar|void
      */
     protected function getDefaultSchemaGrammar()
     {

--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -78,7 +78,8 @@ class Connector
      */
     protected function isPersistentConnection($options)
     {
-        return isset($options[PDO::ATTR_PERSISTENT]) &&
+        return isset($options[PDO::ATTR_PERSISTENT])
+               &&
                $options[PDO::ATTR_PERSISTENT];
     }
 

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -44,7 +44,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      *
      * @param  \PDO  $connection
      * @param  array  $config
-     * @return void
+     * @return \PDO|void
      */
     protected function configureEncoding($connection, array $config)
     {

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -62,7 +62,8 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function prefersOdbc(array $config)
     {
-        return in_array('odbc', $this->getAvailableDrivers()) &&
+        return in_array('odbc', $this->getAvailableDrivers())
+               &&
                ($config['odbc'] ?? null) === true;
     }
 
@@ -168,7 +169,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function buildConnectString($driver, array $arguments)
     {
-        return $driver.':'.implode(';', array_map(function ($key) use ($arguments) {
+        return $driver.':'.implode(';', array_map(static function ($key) use ($arguments) {
             return sprintf('%s=%s', $key, $arguments[$key]);
         }, array_keys($arguments)));
     }

--- a/src/Illuminate/Database/Console/Migrations/StatusCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/StatusCommand.php
@@ -45,7 +45,7 @@ class StatusCommand extends BaseCommand
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return void|int
      */
     public function handle()
     {

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -51,18 +51,18 @@ class DatabaseServiceProvider extends ServiceProvider
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->singleton('db.factory', function ($app) {
+        $this->app->singleton('db.factory', static function ($app) {
             return new ConnectionFactory($app);
         });
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->singleton('db', function ($app) {
+        $this->app->singleton('db', static function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
 
-        $this->app->bind('db.connection', function ($app) {
+        $this->app->bind('db.connection', static function ($app) {
             return $app['db']->connection();
         });
     }
@@ -74,11 +74,12 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerEloquentFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function ($app) {
+        $this->app->singleton(FakerGenerator::class, static function ($app) {
             return FakerFactory::create($app['config']->get('app.faker_locale', 'en_US'));
         });
 
         $this->app->singleton(EloquentFactory::class, function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
             return EloquentFactory::construct(
                 $app->make(FakerGenerator::class), $this->app->databasePath('factories')
             );
@@ -92,7 +93,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton(EntityResolver::class, function () {
+        $this->app->singleton(EntityResolver::class, static function () {
             return new QueueEntityResolver;
         });
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -310,7 +310,7 @@ class Builder
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($instance) {
+        return $instance->newCollection(array_map(static function ($item) use ($instance) {
             return $instance->newFromBuilder($item);
         }, $items));
     }
@@ -434,7 +434,8 @@ class Builder
             return $instance;
         }
 
-        return tap($this->newModelInstance($attributes + $values), function ($instance) {
+        return tap($this->newModelInstance($attributes + $values), static function ($instance) {
+            /** @var Model $instance */
             $instance->save();
         });
     }
@@ -448,7 +449,8 @@ class Builder
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
+        return tap($this->firstOrNew($attributes), static function ($instance) use ($values) {
+            /** @var Model $instance */
             $instance->fill($values)->save();
         });
     }
@@ -541,8 +543,8 @@ class Builder
     /**
      * Eager load the relationships for the models.
      *
-     * @param  array  $models
-     * @return array
+     * @param  Model[]  $models
+     * @return Model[]
      */
     public function eagerLoadRelations(array $models)
     {
@@ -561,7 +563,7 @@ class Builder
     /**
      * Eagerly load the relationship on a set of models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  string  $name
      * @param  \Closure  $constraints
      * @return array
@@ -689,9 +691,13 @@ class Builder
         // If the model has a mutator for the requested column, we will spin through
         // the results and mutate the values so that the mutated version of these
         // columns are returned as you would expect from these Eloquent models.
-        if (! $this->model->hasGetMutator($column) &&
-            ! $this->model->hasCast($column) &&
-            ! in_array($column, $this->model->getDates())) {
+        if (
+            ! $this->model->hasGetMutator($column)
+            &&
+            ! $this->model->hasCast($column)
+            &&
+            ! in_array($column, $this->model->getDates())
+        ) {
             return $results;
         }
 
@@ -761,7 +767,8 @@ class Builder
      */
     public function create(array $attributes = [])
     {
-        return tap($this->newModelInstance($attributes), function ($instance) {
+        return tap($this->newModelInstance($attributes), static function ($instance) {
+            /** @var Model $instance */
             $instance->save();
         });
     }
@@ -774,7 +781,7 @@ class Builder
      */
     public function forceCreate(array $attributes)
     {
-        return $this->model->unguarded(function () use ($attributes) {
+        return $this->model::unguarded(function () use ($attributes) {
             return $this->newModelInstance()->create($attributes);
         });
     }
@@ -828,8 +835,11 @@ class Builder
      */
     protected function addUpdatedAtColumn(array $values)
     {
-        if (! $this->model->usesTimestamps() ||
-            is_null($this->model->getUpdatedAtColumn())) {
+        if (
+            ! $this->model->usesTimestamps()
+            ||
+            is_null($this->model->getUpdatedAtColumn())
+        ) {
             return $values;
         }
 
@@ -1135,6 +1145,7 @@ class Builder
     protected function createSelectWithConstraint($name)
     {
         return [explode(':', $name)[0], static function ($query) use ($name) {
+            /** @var QueryBuilder $query */
             $query->select(explode(',', explode(':', $name)[1]));
         }];
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -151,8 +151,9 @@ trait GuardsAttributes
             return false;
         }
 
-        return empty($this->getFillable()) &&
-            ! Str::startsWith($key, '_');
+        return empty($this->getFillable())
+               &&
+               ! Str::startsWith($key, '_');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -318,8 +318,11 @@ trait HasAttributes
         // If the attribute exists in the attribute array or has a "get" mutator we will
         // get the attribute's value. Otherwise, we will proceed as if the developers
         // are asking for a relationship's value. This covers both types of values.
-        if (array_key_exists($key, $this->attributes) ||
-            $this->hasGetMutator($key)) {
+        if (
+            array_key_exists($key, $this->attributes)
+            ||
+            $this->hasGetMutator($key)
+        ) {
             return $this->getAttributeValue($key);
         }
 
@@ -360,8 +363,11 @@ trait HasAttributes
         // If the attribute is listed as a date, we will convert it to a DateTime
         // instance on retrieval, which makes it quite convenient to work with
         // date fields without having to create a mutator for each property.
-        if (in_array($key, $this->getDates()) &&
-            ! is_null($value)) {
+        if (
+            ! is_null($value)
+            &&
+            in_array($key, $this->getDates())
+        ) {
             return $this->asDateTime($value);
         }
 
@@ -531,7 +537,7 @@ trait HasAttributes
             return 'decimal';
         }
 
-        return trim(strtolower($this->getCasts()[$key]));
+        return strtolower(trim($this->getCasts()[$key]));
     }
 
     /**
@@ -627,8 +633,9 @@ trait HasAttributes
      */
     protected function isDateAttribute($key)
     {
-        return in_array($key, $this->getDates(), true) ||
-                                    $this->isDateCastable($key);
+        return in_array($key, $this->getDates(), true)
+               ||
+               $this->isDateCastable($key);
     }
 
     /**
@@ -659,7 +666,7 @@ trait HasAttributes
      */
     protected function getArrayAttributeWithValue($path, $key, $value)
     {
-        return tap($this->getArrayAttributeByKey($key), function (&$array) use ($path, $value) {
+        return tap($this->getArrayAttributeByKey($key), static function (&$array) use ($path, $value) {
             Arr::set($array, str_replace('->', '.', $path), $value);
         });
     }
@@ -1239,7 +1246,7 @@ trait HasAttributes
      */
     public static function cacheMutatedAttributes($class)
     {
-        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))->map(function ($match) {
+        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))->map(static function ($match) {
             return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -218,7 +218,7 @@ trait HasEvents
     protected function filterModelEventResults($result)
     {
         if (is_array($result)) {
-            $result = array_filter($result, function ($response) {
+            $result = array_filter($result, static function ($response) {
                 return ! is_null($response);
             });
         }
@@ -353,7 +353,7 @@ trait HasEvents
             static::$dispatcher->forget("eloquent.{$event}: ".static::class);
         }
 
-        foreach (array_values($instance->dispatchesEvents) as $event) {
+        foreach ($instance->dispatchesEvents as $event) {
             static::$dispatcher->forget($event);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -86,6 +86,8 @@ trait QueriesRelationships
         }
 
         $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
+            /** @var Builder $q */
+
             // In order to nest "has", we need to add count relation constraints on the
             // callback Closure. We'll do this by simply passing the Closure its own
             // reference to itself so it calls itself recursively on each segment.
@@ -212,8 +214,12 @@ trait QueriesRelationships
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {
+            /** @var Builder $query */
+
             foreach ($types as $type) {
                 $query->orWhere(function ($query) use ($relation, $callback, $operator, $count, $type) {
+                    /** @var Builder $query */
+
                     $belongsTo = $this->getBelongsToRelation($relation, $type);
 
                     if ($callback) {

--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -272,6 +272,7 @@ class Factory implements ArrayAccess
 
         if (is_dir($path)) {
             foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
+                /** @var \SplFileInfo $file */
                 require $file->getRealPath();
             }
         }

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -452,7 +452,8 @@ class FactoryBuilder
      */
     protected function stateHasAfterCallback($state)
     {
-        return isset($this->afterMaking[$this->class][$state]) ||
+        return isset($this->afterMaking[$this->class][$state])
+               ||
                isset($this->afterCreating[$this->class][$state]);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -121,8 +121,8 @@ class BelongsTo extends Relation
     /**
      * Gather the keys from an array of related models.
      *
-     * @param  array  $models
-     * @return array
+     * @param  Model[]  $models
+     * @return string[]
      */
     protected function getEagerModelKeys(array $models)
     {
@@ -145,9 +145,9 @@ class BelongsTo extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  string  $relation
-     * @return array
+     * @return Model[]
      */
     public function initRelation(array $models, $relation)
     {
@@ -161,10 +161,10 @@ class BelongsTo extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
-     * @return array
+     * @return Model[]
      */
     public function match(array $models, Collection $results, $relation)
     {
@@ -283,8 +283,9 @@ class BelongsTo extends Relation
      */
     protected function relationHasIncrementingId()
     {
-        return $this->related->getIncrementing() &&
-                                $this->related->getKeyType() === 'int';
+        return $this->related->getIncrementing()
+               &&
+               $this->related->getKeyType() === 'int';
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -229,7 +229,7 @@ class BelongsToMany extends Relation
     /**
      * Set the constraints for an eager load of the relation.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @return void
      */
     public function addEagerConstraints(array $models)
@@ -245,9 +245,9 @@ class BelongsToMany extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  string  $relation
-     * @return array
+     * @return Model[]
      */
     public function initRelation(array $models, $relation)
     {
@@ -261,10 +261,10 @@ class BelongsToMany extends Relation
     /**
      * Match the eagerly loaded results to their parents.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  \Illuminate\Database\Eloquent\Collection  $results
      * @param  string  $relation
-     * @return array
+     * @return Model[]
      */
     public function match(array $models, Collection $results, $relation)
     {
@@ -692,6 +692,7 @@ class BelongsToMany extends Relation
         $this->query->addSelect($this->shouldSelect($columns));
 
         return tap($this->query->paginate($perPage, $columns, $pageName, $page), function ($paginator) {
+            /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator $paginator */
             $this->hydratePivotRelation($paginator->items());
         });
     }
@@ -710,6 +711,7 @@ class BelongsToMany extends Relation
         $this->query->addSelect($this->shouldSelect($columns));
 
         return tap($this->query->simplePaginate($perPage, $columns, $pageName, $page), function ($paginator) {
+            /** @var \Illuminate\Contracts\Pagination\LengthAwarePaginator $paginator */
             $this->hydratePivotRelation($paginator->items());
         });
     }
@@ -726,6 +728,7 @@ class BelongsToMany extends Relation
         $this->query->addSelect($this->shouldSelect());
 
         return $this->query->chunk($count, function ($results) use ($callback) {
+            /** @var Collection|Model[] $results */
             $this->hydratePivotRelation($results->all());
 
             return $callback($results);
@@ -795,7 +798,7 @@ class BelongsToMany extends Relation
     /**
      * Hydrate the pivot table relationship on the models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @return void
      */
     protected function hydratePivotRelation(array $models)

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -289,11 +289,13 @@ trait AsPivot
         }
 
         $query = $this->newQueryWithoutScopes();
+        /** @var Builder $query */
 
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
+                /** @var Builder $query */
                 return $query->where($segments[0], $segments[1])
                     ->where($segments[2], $segments[3]);
             });

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -54,8 +54,15 @@ trait InteractsWithPivotTable
         // Once we have finished attaching or detaching the records, we will see if we
         // have done any attaching or detaching, and if we have we will touch these
         // relationships if they are configured to touch on any database updates.
-        if ($touch && (count($changes['attached']) ||
-                       count($changes['detached']))) {
+        if (
+            $touch
+            &&
+            (
+                count($changes['attached'])
+                ||
+                count($changes['detached'])
+            )
+        ) {
             $this->touchIfTouching();
         }
 
@@ -115,8 +122,11 @@ trait InteractsWithPivotTable
         // Once we have finished attaching or detaching the records, we will see if we
         // have done any attaching or detaching, and if we have we will touch these
         // relationships if they are configured to touch on any database updates.
-        if (count($changes['attached']) ||
-            count($changes['updated'])) {
+        if (
+            count($changes['attached'])
+            ||
+            count($changes['updated'])
+        ) {
             $this->touchIfTouching();
         }
 
@@ -131,7 +141,7 @@ trait InteractsWithPivotTable
      */
     protected function formatRecordsList(array $records)
     {
-        return collect($records)->mapWithKeys(function ($attributes, $id) {
+        return collect($records)->mapWithKeys(static function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }
@@ -291,8 +301,11 @@ trait InteractsWithPivotTable
     {
         $records = [];
 
-        $hasTimestamps = ($this->hasPivotColumn($this->createdAt()) ||
-                  $this->hasPivotColumn($this->updatedAt()));
+        $hasTimestamps = (
+            $this->hasPivotColumn($this->createdAt())
+            ||
+            $this->hasPivotColumn($this->updatedAt())
+        );
 
         // To create the attachment records, we will simply spin through the IDs given
         // and create a new record to insert for each ID. Each ID may actually be a

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -156,7 +156,7 @@ class HasManyThrough extends Relation
     /**
      * Initialize the relation on a set of models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  string  $relation
      * @return array
      */

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -166,7 +166,7 @@ abstract class HasOneOrMany extends Relation
     {
         $foreign = $this->getForeignKeyName();
 
-        return $results->mapToDictionary(function ($result) use ($foreign) {
+        return $results->mapToDictionary(static function ($result) use ($foreign) {
             return [$result->{$foreign} => $result];
         })->all();
     }
@@ -232,7 +232,9 @@ abstract class HasOneOrMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
+        return tap($this->firstOrNew($attributes), static function ($instance) use ($values) {
+            /** @var Model $instance */
+
             $instance->fill($values);
 
             $instance->save();
@@ -276,6 +278,8 @@ abstract class HasOneOrMany extends Relation
     public function create(array $attributes = [])
     {
         return tap($this->related->newInstance($attributes), function ($instance) {
+            /** @var Model $instance */
+
             $this->setForeignAttributesForCreate($instance);
 
             $instance->save();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -144,7 +144,8 @@ class MorphPivot extends Pivot
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
+                /** @var \Illuminate\Database\Eloquent\Builder $query */
                 return $query->where($segments[0], $segments[1])
                              ->where($segments[2], $segments[3])
                              ->where($segments[4], $segments[5]);

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -103,7 +103,7 @@ abstract class Relation
     /**
      * Set the constraints for an eager load of the relation.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @return void
      */
     abstract public function addEagerConstraints(array $models);
@@ -216,13 +216,14 @@ abstract class Relation
     /**
      * Get all of the primary keys for an array of models.
      *
-     * @param  array  $models
+     * @param  Model[]  $models
      * @param  string  $key
      * @return array
      */
     protected function getKeys(array $models, $key = null)
     {
-        return collect($models)->map(function ($value) use ($key) {
+        return collect($models)->map(static function ($value) use ($key) {
+            /** @var Model $value */
             return $key ? $value->getAttribute($key) : $value->getKey();
         })->values()->unique(null, true)->sort()->all();
     }
@@ -345,7 +346,7 @@ abstract class Relation
      * Builds a table-keyed array from model class names.
      *
      * @param  string[]|null  $models
-     * @return array|null
+     * @return string[]|null
      */
     protected static function buildMorphMapFromModels(array $models = null)
     {
@@ -353,8 +354,10 @@ abstract class Relation
             return $models;
         }
 
-        return array_combine(array_map(function ($model) {
-            return (new $model)->getTable();
+        return array_combine(array_map(static function ($model) {
+            /** @var Model $model */
+            $model = new $model();
+            return $model->getTable();
         }, $models), $models);
     }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -67,7 +67,7 @@ class SoftDeletingScope implements Scope
      */
     protected function addRestore(Builder $builder)
     {
-        $builder->macro('restore', function (Builder $builder) {
+        $builder->macro('restore', static function (Builder $builder) {
             $builder->withTrashed();
 
             return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -57,7 +57,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerRepository()
     {
-        $this->app->singleton('migration.repository', function ($app) {
+        $this->app->singleton('migration.repository', static function ($app) {
             $table = $app['config']['database.migrations'];
 
             return new DatabaseMigrationRepository($app['db'], $table);
@@ -74,7 +74,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
+        $this->app->singleton('migrator', static function ($app) {
             $repository = $app['migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
@@ -88,7 +88,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerCreator()
     {
-        $this->app->singleton('migration.creator', function ($app) {
+        $this->app->singleton('migration.creator', static function ($app) {
             return new MigrationCreator($app['files']);
         });
     }
@@ -115,7 +115,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton('command.migrate', function ($app) {
+        $this->app->singleton('command.migrate', static function ($app) {
             return new MigrateCommand($app['migrator']);
         });
     }
@@ -127,7 +127,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton('command.migrate.fresh', function () {
+        $this->app->singleton('command.migrate.fresh', static function () {
             return new FreshCommand;
         });
     }
@@ -139,7 +139,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton('command.migrate.install', function ($app) {
+        $this->app->singleton('command.migrate.install', static function ($app) {
             return new InstallCommand($app['migration.repository']);
         });
     }
@@ -151,7 +151,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton('command.migrate.make', function ($app) {
+        $this->app->singleton('command.migrate.make', static function ($app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.
@@ -170,7 +170,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->singleton('command.migrate.refresh', function () {
+        $this->app->singleton('command.migrate.refresh', static function () {
             return new RefreshCommand;
         });
     }
@@ -182,7 +182,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton('command.migrate.reset', function ($app) {
+        $this->app->singleton('command.migrate.reset', static function ($app) {
             return new ResetCommand($app['migrator']);
         });
     }
@@ -194,7 +194,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton('command.migrate.rollback', function ($app) {
+        $this->app->singleton('command.migrate.rollback', static function ($app) {
             return new RollbackCommand($app['migrator']);
         });
     }
@@ -206,7 +206,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton('command.migrate.status', function ($app) {
+        $this->app->singleton('command.migrate.status', static function ($app) {
             return new StatusCommand($app['migrator']);
         });
     }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -147,7 +147,9 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->getConnection()->getSchemaBuilder();
 
-        $schema->create($this->table, function ($table) {
+        $schema->create($this->table, static function ($table) {
+            /** @var \Illuminate\Database\Schema\Blueprint $table */
+
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
             // table to hold the migration file's path as well as the batch ID.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -326,7 +326,7 @@ class Migrator
         // Since the getRan method that retrieves the migration name just gives us the
         // migration name, we will format the names into objects with the name as a
         // property on the objects so that we can pass it to the rollback method.
-        $migrations = collect($migrations)->map(function ($m) {
+        $migrations = collect($migrations)->map(static function ($m) {
             return (object) ['migration' => $m];
         })->all();
 
@@ -433,7 +433,7 @@ class Migrator
             $migration->getConnection()
         );
 
-        return $db->pretend(function () use ($migration, $method) {
+        return $db->pretend(static function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
                 $migration->{$method}();
             }
@@ -465,7 +465,7 @@ class Migrator
             return Str::endsWith($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
         })->filter()->values()->keyBy(function ($file) {
             return $this->getMigrationName($file);
-        })->sortBy(function ($file, $key) {
+        })->sortBy(static function ($file, $key) {
             return $key;
         })->all();
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -714,7 +714,7 @@ class Builder
      */
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
+        return $this->whereNested(static function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
@@ -757,8 +757,11 @@ class Builder
      */
     protected function invalidOperatorAndValue($operator, $value)
     {
-        return is_null($value) && in_array($operator, $this->operators) &&
-             ! in_array($operator, ['=', '<>', '!=']);
+        return is_null($value)
+               &&
+               in_array($operator, $this->operators)
+               &&
+               ! in_array($operator, ['=', '<>', '!=']);
     }
 
     /**
@@ -769,7 +772,8 @@ class Builder
      */
     protected function invalidOperator($operator)
     {
-        return ! in_array(strtolower($operator), $this->operators, true) &&
+        return ! in_array(strtolower($operator), $this->operators, true)
+               &&
                ! in_array(strtolower($operator), $this->grammar->getOperators(), true);
     }
 
@@ -1329,7 +1333,7 @@ class Builder
      */
     public function whereNested(Closure $callback, $boolean = 'and')
     {
-        call_user_func($callback, $query = $this->forNestedWhere());
+        $callback($query = $this->forNestedWhere());
 
         return $this->addNestedWhereQuery($query, $boolean);
     }
@@ -1380,7 +1384,7 @@ class Builder
         // Once we have the query instance we can simply execute it so it can add all
         // of the sub-select's conditions to itself, and then we can cache it off
         // in the array of where clauses for the "main" parent query instance.
-        call_user_func($callback, $query = $this->forSubQuery());
+        $callback($query = $this->forSubQuery());
 
         $this->wheres[] = compact(
             'type', 'column', 'operator', 'query', 'boolean'
@@ -1406,7 +1410,7 @@ class Builder
         // Similar to the sub-select clause, we will create a new query instance so
         // the developer may cleanly specify the entire exists query and we will
         // compile the whole thing in the grammar and insert it into the SQL.
-        call_user_func($callback, $query);
+        $callback($query);
 
         return $this->addWhereExistsQuery($query, $boolean, $not);
     }
@@ -2016,9 +2020,10 @@ class Builder
     protected function removeExistingOrdersFor($column)
     {
         return Collection::make($this->orders)
-                    ->reject(function ($order) use ($column) {
+                    ->reject(static function ($order) use ($column) {
                         return isset($order['column'])
-                               ? $order['column'] === $column : false;
+                               ? $order['column'] === $column
+                               : false;
                     })->values()->all();
     }
 
@@ -2032,7 +2037,7 @@ class Builder
     public function union($query, $all = false)
     {
         if ($query instanceof Closure) {
-            call_user_func($query, $query = $this->newQuery());
+            $query($query = $this->newQuery());
         }
 
         $this->unions[] = compact('query', 'all');
@@ -2244,9 +2249,10 @@ class Builder
      */
     protected function withoutSelectAliases(array $columns)
     {
-        return array_map(function ($column) {
+        return array_map(static function ($column) {
             return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
-                    ? substr($column, 0, $aliasPosition) : $column;
+                    ? substr($column, 0, $aliasPosition)
+                    : $column;
         }, $columns);
     }
 
@@ -2331,7 +2337,7 @@ class Builder
             return $column;
         }
 
-        $seperator = strpos(strtolower($column), ' as ') !== false ? ' as ' : '\.';
+        $seperator = stripos($column, ' as ') !== false ? ' as ' : '\.';
 
         return last(preg_split('~'.$seperator.'~i', $column));
     }
@@ -2943,7 +2949,7 @@ class Builder
      */
     protected function cleanBindings(array $bindings)
     {
-        return array_values(array_filter($bindings, function ($binding) {
+        return array_values(array_filter($bindings, static function ($binding) {
             return ! $binding instanceof Expression;
         }));
     }
@@ -3021,7 +3027,7 @@ class Builder
      */
     public function cloneWithout(array $properties)
     {
-        return tap(clone $this, function ($clone) use ($properties) {
+        return tap(clone $this, static function ($clone) use ($properties) {
             foreach ($properties as $property) {
                 $clone->{$property} = null;
             }
@@ -3036,7 +3042,7 @@ class Builder
      */
     public function cloneWithoutBindings(array $except)
     {
-        return tap(clone $this, function ($clone) use ($except) {
+        return tap(clone $this, static function ($clone) use ($except) {
             foreach ($except as $type) {
                 $clone->bindings[$type] = [];
             }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -718,7 +718,7 @@ class Grammar extends BaseGrammar
     protected function compileOrdersToArray(Builder $query, $orders)
     {
         return array_map(function ($order) {
-            return $order['sql'] ?? $this->wrap($order['column']).' '.$order['direction'];
+            return $order['sql'] ?? ($this->wrap($order['column']).' '.$order['direction']);
         }, $orders);
     }
 
@@ -1226,7 +1226,7 @@ class Grammar extends BaseGrammar
      */
     protected function concatenate($segments)
     {
-        return implode(' ', array_filter($segments, function ($value) {
+        return implode(' ', array_filter($segments, static function ($value) {
             return (string) $value !== '';
         }));
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -175,7 +175,7 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) && is_bool($value);
-        })->map(function ($value) {
+        })->map(static function ($value) {
             return is_array($value) ? json_encode($value) : $value;
         })->all();
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -379,7 +379,7 @@ class PostgresGrammar extends Grammar
      */
     protected function wrapJsonPathAttributes($path)
     {
-        return array_map(function ($attribute) {
+        return array_map(static function ($attribute) {
             return filter_var($attribute, FILTER_VALIDATE_INT) !== false
                         ? $attribute
                         : "'$attribute'";

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -246,7 +246,7 @@ class SQLiteGrammar extends Grammar
 
         $values = collect($values)->reject(function ($value, $key) {
             return $this->isJsonSelector($key);
-        })->merge($groups)->map(function ($value) {
+        })->merge($groups)->map(static function ($value) {
             return is_array($value) ? json_encode($value) : $value;
         })->all();
 

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -12,7 +12,7 @@ class MySqlProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->column_name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -34,7 +34,7 @@ class PostgresProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->column_name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -12,7 +12,7 @@ class SQLiteProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -63,7 +63,7 @@ class SqlServerProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->name;
         }, $results);
     }

--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -51,7 +51,9 @@ $results = Capsule::select('select * from users where id = ?', [1]);
 **Using The Schema Builder**
 
 ```PHP
-Capsule::schema()->create('users', function ($table) {
+Capsule::schema()->create('users', static function ($table) {
+    /** @var \Illuminate\Database\Schema\Blueprint $table */
+
     $table->increments('id');
     $table->string('email')->unique();
     $table->timestamps();

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -121,9 +121,13 @@ class Blueprint
 
             if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
                 if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
-                    $statements = array_merge($statements, (array) $sql);
+                    $statements[] = (array) $sql;
                 }
             }
+        }
+
+        if ($statements !== []) {
+            $statements = array_merge([], ...$statements);
         }
 
         return $statements;
@@ -162,7 +166,7 @@ class Blueprint
      */
     protected function commandsNamed(array $names)
     {
-        return collect($this->commands)->filter(function ($command) use ($names) {
+        return collect($this->commands)->filter(static function ($command) use ($names) {
             return in_array($command->name, $names);
         });
     }
@@ -252,7 +256,7 @@ class Blueprint
      */
     protected function creating()
     {
-        return collect($this->commands)->contains(function ($command) {
+        return collect($this->commands)->contains(static function ($command) {
             return $command->name === 'create';
         });
     }
@@ -1369,7 +1373,7 @@ class Blueprint
      */
     public function removeColumn($name)
     {
-        $this->columns = array_values(array_filter($this->columns, function ($c) use ($name) {
+        $this->columns = array_values(array_filter($this->columns, static function ($c) use ($name) {
             return $c['name'] != $name;
         }));
 
@@ -1439,7 +1443,7 @@ class Blueprint
      */
     public function getAddedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return ! $column->change;
         });
     }
@@ -1451,7 +1455,7 @@ class Blueprint
      */
     public function getChangedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return (bool) $column->change;
         });
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -160,7 +160,8 @@ class Builder
      */
     public function create($table, Closure $callback)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) use ($callback) {
+            /** @var Blueprint $blueprint */
             $blueprint->create();
 
             $callback($blueprint);
@@ -175,7 +176,8 @@ class Builder
      */
     public function drop($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
+            /** @var Blueprint $blueprint */
             $blueprint->drop();
         }));
     }
@@ -188,7 +190,8 @@ class Builder
      */
     public function dropIfExists($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
+            /** @var Blueprint $blueprint */
             $blueprint->dropIfExists();
         }));
     }
@@ -250,7 +253,8 @@ class Builder
      */
     public function rename($from, $to)
     {
-        $this->build(tap($this->createBlueprint($from), function ($blueprint) use ($to) {
+        $this->build(tap($this->createBlueprint($from), static function ($blueprint) use ($to) {
+            /** @var Blueprint $blueprint */
             $blueprint->rename($to);
         }));
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -185,7 +185,7 @@ abstract class Grammar extends BaseGrammar
      */
     protected function getCommandsByName(Blueprint $blueprint, $name)
     {
-        return array_filter($blueprint->getCommands(), function ($value) use ($name) {
+        return array_filter($blueprint->getCommands(), static function ($value) use ($name) {
             return $value->name == $name;
         });
     }
@@ -199,7 +199,7 @@ abstract class Grammar extends BaseGrammar
      */
     public function prefixArray($prefix, array $values)
     {
-        return array_map(function ($value) use ($prefix) {
+        return array_map(static function ($value) use ($prefix) {
             return $prefix.' '.$value;
         }, $values);
     }
@@ -259,7 +259,7 @@ abstract class Grammar extends BaseGrammar
     {
         $table = $this->getTablePrefix().$blueprint->getTable();
 
-        return tap(new TableDiff($table), function ($tableDiff) use ($schema, $table) {
+        return tap(new TableDiff($table), static function ($tableDiff) use ($schema, $table) {
             $tableDiff->fromTable = $schema->listTableDetails($table);
         });
     }

--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -55,8 +55,17 @@ class Encrypter implements EncrypterContract
     {
         $length = mb_strlen($key, '8bit');
 
-        return ($cipher === 'AES-128-CBC' && $length === 16) ||
-               ($cipher === 'AES-256-CBC' && $length === 32);
+        return (
+                   $cipher === 'AES-128-CBC'
+                   &&
+                   $length === 16
+               )
+               ||
+               (
+                   $cipher === 'AES-256-CBC'
+                   &&
+                   $length === 32
+               );
     }
 
     /**
@@ -210,7 +219,8 @@ class Encrypter implements EncrypterContract
      */
     protected function validPayload($payload)
     {
-        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac']) &&
+        return is_array($payload) && isset($payload['iv'], $payload['value'], $payload['mac'])
+               &&
                strlen(base64_decode($payload['iv'], true)) === openssl_cipher_iv_length($this->cipher);
     }
 

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -39,7 +39,7 @@ class EncryptionServiceProvider extends ServiceProvider
      */
     protected function key(array $config)
     {
-        return tap($config['key'], function ($key) {
+        return tap($config['key'], static function ($key) {
             if (empty($key)) {
                 throw new RuntimeException(
                     'No application encryption key has been specified.'

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -160,7 +160,7 @@ class CallQueuedListener implements ShouldQueue
      */
     public function __clone()
     {
-        $this->data = array_map(function ($data) {
+        $this->data = array_map(static function ($data) {
             return is_object($data) ? clone $data : $data;
         }, $this->data);
     }

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -14,8 +14,9 @@ class EventServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('events', function ($app) {
-            return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
+        $this->app->singleton('events', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+            return (new Dispatcher($app))->setQueueResolver(static function () use ($app) {
                 return $app->make(QueueFactoryContract::class);
             });
         });

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -255,7 +255,7 @@ class Filesystem
      *
      * @param  string  $target
      * @param  string  $link
-     * @return void
+     * @return void|bool
      */
     public function link($target, $link)
     {
@@ -453,6 +453,7 @@ class Filesystem
         $directories = [];
 
         foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
+            /** @var \SplFileInfo $dir */
             $directories[] = $dir->getPathname();
         }
 
@@ -551,10 +552,8 @@ class Filesystem
             // If the current items is just a regular file, we will just copy this to the new
             // location and keep looping. If for some reason the copy fails we'll bail out
             // and return false, so the developer is aware that the copy process failed.
-            else {
-                if (! $this->copy($item->getPathname(), $target)) {
-                    return false;
-                }
+            else if (! $this->copy($item->getPathname(), $target)) {
+                return false;
             }
         }
 

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -25,7 +25,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerNativeFilesystem()
     {
-        $this->app->singleton('files', function () {
+        $this->app->singleton('files', static function () {
             return new Filesystem;
         });
     }

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -79,6 +79,8 @@ class AliasLoader
         if (isset($this->aliases[$alias])) {
             return class_alias($this->aliases[$alias], $alias);
         }
+
+        return null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -583,7 +583,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     public function registerConfiguredProviders()
     {
         $providers = Collection::make($this->config['app.providers'])
-                        ->partition(function ($provider) {
+                        ->partition(static function ($provider) {
                             return strpos($provider, 'Illuminate\\') === 0;
                         });
 
@@ -663,7 +663,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
     {
         $name = is_string($provider) ? $provider : get_class($provider);
 
-        return Arr::where($this->serviceProviders, function ($value) use ($name) {
+        return Arr::where($this->serviceProviders, static function ($value) use ($name) {
             return $value instanceof $name;
         });
     }
@@ -828,7 +828,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      * Boot the given service provider.
      *
      * @param  \Illuminate\Support\ServiceProvider  $provider
-     * @return mixed
+     * @return mixed|void
      */
     protected function bootProvider(ServiceProvider $provider)
     {
@@ -891,7 +891,8 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      */
     public function shouldSkipMiddleware()
     {
-        return $this->bound('middleware.disable') &&
+        return $this->bound('middleware.disable')
+               &&
                $this->make('middleware.disable') === true;
     }
 

--- a/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
+++ b/src/Illuminate/Foundation/Auth/AuthenticatesUsers.php
@@ -35,8 +35,11 @@ trait AuthenticatesUsers
         // If the class is using the ThrottlesLogins trait, we can automatically throttle
         // the login attempts for this application. We'll key this by the username and
         // the IP address of the client making these requests into this application.
-        if (method_exists($this, 'hasTooManyLoginAttempts') &&
-            $this->hasTooManyLoginAttempts($request)) {
+        if (
+            method_exists($this, 'hasTooManyLoginAttempts')
+            &&
+            $this->hasTooManyLoginAttempts($request)
+        ) {
             $this->fireLockoutEvent($request);
 
             return $this->sendLockoutResponse($request);
@@ -115,7 +118,7 @@ trait AuthenticatesUsers
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  mixed  $user
-     * @return mixed
+     * @return mixed|void
      */
     protected function authenticated(Request $request, $user)
     {
@@ -126,7 +129,6 @@ trait AuthenticatesUsers
      * Get the failed login response instance.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -168,7 +170,7 @@ trait AuthenticatesUsers
      * The user has logged out of the application.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return mixed
+     * @return mixed|void
      */
     protected function loggedOut(Request $request)
     {

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -42,7 +42,7 @@ class LoadConfiguration
         // Finally, we will set the application's environment based on the configuration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
-        $app->detectEnvironment(function () use ($config) {
+        $app->detectEnvironment(static function () use ($config) {
             return $config->get('app.env', 'production');
         });
 
@@ -86,9 +86,11 @@ class LoadConfiguration
         $configPath = realpath($app->configPath());
 
         foreach (Finder::create()->files()->name('*.php')->in($configPath) as $file) {
+            /** @var SplFileInfo $file */
             $directory = $this->getNestedDirectory($file, $configPath);
+            $path = $file->getRealPath();
 
-            $files[$directory.basename($file->getRealPath(), '.php')] = $file->getRealPath();
+            $files[$directory.basename($path, '.php')] = $path;
         }
 
         ksort($files, SORT_NATURAL);
@@ -107,7 +109,8 @@ class LoadConfiguration
     {
         $directory = $file->getPath();
 
-        if ($nested = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR)) {
+        $nested = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR);
+        if ($nested) {
             $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested).'.';
         }
 

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -40,12 +40,14 @@ class LoadEnvironmentVariables
      */
     protected function checkForSpecificEnvironmentFile($app)
     {
-        if ($app->runningInConsole() && ($input = new ArgvInput)->hasParameterOption('--env')) {
-            if ($this->setEnvironmentFilePath(
-                $app, $app->environmentFile().'.'.$input->getParameterOption('--env')
-            )) {
-                return;
-            }
+        if (
+            $app->runningInConsole()
+            &&
+            ($input = new ArgvInput)->hasParameterOption('--env')
+            &&
+            $this->setEnvironmentFilePath($app, $app->environmentFile() . '.' . $input->getParameterOption('--env'))
+        ) {
+            return;
         }
 
         $environment = Env::get('APP_ENV');

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -57,7 +57,7 @@ class EventListCommand extends Command
             $events = $this->filterEvents($events);
         }
 
-        return collect($events)->map(function ($listeners, $event) {
+        return collect($events)->map(static function ($listeners, $event) {
             return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
         })->sortBy('Event')->values()->toArray();
     }
@@ -74,7 +74,7 @@ class EventListCommand extends Command
             return $events;
         }
 
-        return collect($events)->filter(function ($listeners, $event) use ($eventName) {
+        return collect($events)->filter(static function ($listeners, $event) use ($eventName) {
             return Str::contains($event, $eventName);
         })->toArray();
     }

--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -73,7 +73,7 @@ class KeyGenerateCommand extends Command
     {
         $currentKey = $this->laravel['config']['app.key'];
 
-        if (strlen($currentKey) !== 0 && (! $this->confirmToProceed())) {
+        if ($currentKey != '' && (! $this->confirmToProceed())) {
             return false;
         }
 

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -32,7 +32,7 @@ class ModelMakeCommand extends GeneratorCommand
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return void|false
      */
     public function handle()
     {

--- a/src/Illuminate/Foundation/Console/Presets/None.php
+++ b/src/Illuminate/Foundation/Console/Presets/None.php
@@ -17,7 +17,9 @@ class None extends Preset
         static::updateBootstrapping();
         static::updateWebpackConfiguration();
 
-        tap(new Filesystem, function ($filesystem) {
+        tap(new Filesystem, static function ($filesystem) {
+            /** @var Filesystem $filesystem */
+
             $filesystem->deleteDirectory(resource_path('js/components'));
             $filesystem->delete(resource_path('sass/_variables.scss'));
             $filesystem->deleteDirectory(base_path('node_modules'));

--- a/src/Illuminate/Foundation/Console/Presets/Preset.php
+++ b/src/Illuminate/Foundation/Console/Presets/Preset.php
@@ -55,7 +55,9 @@ class Preset
      */
     protected static function removeNodeModules()
     {
-        tap(new Filesystem, function ($files) {
+        tap(new Filesystem, static function ($files) {
+            /** @var Filesystem $files */
+
             $files->deleteDirectory(base_path('node_modules'));
 
             $files->delete(base_path('yarn.lock'));

--- a/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
@@ -62,7 +62,8 @@ class ResourceMakeCommand extends GeneratorCommand
      */
     protected function collection()
     {
-        return $this->option('collection') ||
+        return $this->option('collection')
+               ||
                Str::endsWith($this->argument('name'), 'Collection');
     }
 

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -76,7 +76,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplicationRoutes()
     {
-        return tap($this->getFreshApplication()['router']->getRoutes(), function ($routes) {
+        return tap($this->getFreshApplication()['router']->getRoutes(), static function ($routes) {
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
         });
@@ -89,7 +89,9 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplication()
     {
-        return tap(require $this->laravel->bootstrapPath().'/app.php', function ($app) {
+        return tap(require $this->laravel->bootstrapPath().'/app.php', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             $app->make(ConsoleKernelContract::class)->bootstrap();
         });
     }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -127,7 +127,7 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-        return Arr::sort($routes, function ($route) use ($sort) {
+        return Arr::sort($routes, static function ($route) use ($sort) {
             return $route[$sort];
         });
     }
@@ -170,7 +170,7 @@ class RouteListCommand extends Command
      */
     protected function getMiddleware($route)
     {
-        return collect($route->gatherMiddleware())->map(function ($middleware) {
+        return collect($route->gatherMiddleware())->map(static function ($middleware) {
             return $middleware instanceof Closure ? 'Closure' : $middleware;
         })->implode(',');
     }
@@ -183,9 +183,25 @@ class RouteListCommand extends Command
      */
     protected function filterRoute(array $route)
     {
-        if (($this->option('name') && ! Str::contains($route['name'], $this->option('name'))) ||
-             $this->option('path') && ! Str::contains($route['uri'], $this->option('path')) ||
-             $this->option('method') && ! Str::contains($route['method'], strtoupper($this->option('method')))) {
+        if (
+            (
+                $this->option('name')
+                &&
+                ! Str::contains($route['name'], $this->option('name'))
+            )
+            ||
+            (
+                $this->option('path')
+                &&
+                ! Str::contains($route['uri'], $this->option('path'))
+            )
+            ||
+            (
+                $this->option('method')
+                &&
+                ! Str::contains($route['method'], strtoupper($this->option('method')))
+            )
+        ) {
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -99,8 +99,9 @@ class ServeCommand extends Command
      */
     protected function canTryAnotherPort()
     {
-        return is_null($this->input->getOption('port')) &&
-               ($this->input->getOption('tries') > $this->portOffset);
+        return is_null($this->input->getOption('port'))
+               &&
+               $this->input->getOption('tries') > $this->portOffset;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -47,9 +47,10 @@ class ViewCacheCommand extends Command
      */
     protected function compileViews(Collection $views)
     {
+        /** @var \Illuminate\View\Compilers\Compiler $compiler */
         $compiler = $this->laravel['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
-        $views->map(function (SplFileInfo $file) use ($compiler) {
+        $views->map(static function (SplFileInfo $file) use ($compiler) {
             $compiler->compile($file->getRealPath());
         });
     }
@@ -78,6 +79,7 @@ class ViewCacheCommand extends Command
      */
     protected function paths()
     {
+        /** @var \Illuminate\View\ViewFinderInterface $finder */
         $finder = $this->laravel['view']->getFinder();
 
         return collect($finder->getPaths())->merge(

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -22,7 +22,7 @@ class DiscoverEvents
     {
         return collect(static::getListenerEvents(
             (new Finder)->files()->in($listenerPath), $basePath
-        ))->mapToDictionary(function ($event, $listener) {
+        ))->mapToDictionary(static function ($event, $listener) {
             return [$event => $listener];
         })->all();
     }
@@ -52,8 +52,11 @@ class DiscoverEvents
             }
 
             foreach ($listener->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-                if (! Str::is('handle*', $method->name) ||
-                    ! isset($method->getParameters()[0])) {
+                if (
+                    ! Str::is('handle*', $method->name)
+                    ||
+                    ! isset($method->getParameters()[0])
+                ) {
                     continue;
                 }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -144,7 +144,7 @@ class Handler implements ExceptionHandlerContract
     {
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
+        return ! is_null(Arr::first($dontReport, static function ($type) use ($e) {
             return $e instanceof $type;
         }));
     }
@@ -354,6 +354,8 @@ class Handler implements ExceptionHandlerContract
     protected function renderExceptionWithWhoops(Exception $e)
     {
         return tap(new Whoops, function ($whoops) {
+            /** @var Whoops $whoops */
+
             $whoops->appendHandler($this->whoopsHandler());
 
             $whoops->writeToOutput(false);
@@ -419,7 +421,7 @@ class Handler implements ExceptionHandlerContract
     {
         $paths = collect(config('view.paths'));
 
-        View::replaceNamespace('errors', $paths->map(function ($path) {
+        View::replaceNamespace('errors', $paths->map(static function ($path) {
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
     }
@@ -487,7 +489,7 @@ class Handler implements ExceptionHandlerContract
             'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
-            'trace' => collect($e->getTrace())->map(function ($trace) {
+            'trace' => collect($e->getTrace())->map(static function ($trace) {
                 return Arr::except($trace, ['args']);
             })->all(),
         ] : [

--- a/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
+++ b/src/Illuminate/Foundation/Exceptions/WhoopsHandler.php
@@ -16,6 +16,7 @@ class WhoopsHandler
     public function forDebug()
     {
         return tap(new PrettyPageHandler, function ($handler) {
+            /** @var PrettyPageHandler $handler */
             $handler->handleUnconditionally(true);
 
             $this->registerApplicationPaths($handler)

--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -265,7 +265,7 @@ class Kernel implements KernelContract
      */
     public function prependMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (!in_array($middleware, $this->middleware)) {
             array_unshift($this->middleware, $middleware);
         }
 
@@ -280,7 +280,7 @@ class Kernel implements KernelContract
      */
     public function pushMiddleware($middleware)
     {
-        if (array_search($middleware, $this->middleware) === false) {
+        if (!in_array($middleware, $this->middleware)) {
             $this->middleware[] = $middleware;
         }
 
@@ -302,7 +302,7 @@ class Kernel implements KernelContract
             throw new InvalidArgumentException("The [{$group}] middleware group has not been defined.");
         }
 
-        if (array_search($middleware, $this->middlewareGroups[$group]) === false) {
+        if (!in_array($middleware, $this->middlewareGroups[$group])) {
             array_unshift($this->middlewareGroups[$group], $middleware);
         }
 
@@ -326,7 +326,7 @@ class Kernel implements KernelContract
             throw new InvalidArgumentException("The [{$group}] middleware group has not been defined.");
         }
 
-        if (array_search($middleware, $this->middlewareGroups[$group]) === false) {
+        if (!in_array($middleware, $this->middlewareGroups[$group])) {
             $this->middlewareGroups[$group][] = $middleware;
         }
 

--- a/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
+++ b/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php
@@ -68,9 +68,12 @@ class VerifyCsrfToken
     public function handle($request, Closure $next)
     {
         if (
-            $this->isReading($request) ||
-            $this->runningUnitTests() ||
-            $this->inExceptArray($request) ||
+            $this->isReading($request)
+            ||
+            $this->runningUnitTests()
+            ||
+            $this->inExceptArray($request)
+            ||
             $this->tokensMatch($request)
         ) {
             return tap($next($request), function ($response) use ($request) {
@@ -135,8 +138,10 @@ class VerifyCsrfToken
     {
         $token = $this->getTokenFromRequest($request);
 
-        return is_string($request->session()->token()) &&
-               is_string($token) &&
+        return is_string($request->session()->token())
+               &&
+               is_string($token)
+               &&
                hash_equals($request->session()->token(), $token);
     }
 

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -86,7 +86,7 @@ class PackageManifest
      */
     public function config($key)
     {
-        return collect($this->getManifest())->flatMap(function ($configuration) use ($key) {
+        return collect($this->getManifest())->flatMap(static function ($configuration) use ($key) {
             return (array) ($configuration[$key] ?? []);
         })->filter()->all();
     }
@@ -129,9 +129,9 @@ class PackageManifest
 
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
-        })->each(function ($configuration) use (&$ignore) {
+        })->each(static function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
-        })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
+        })->reject(static function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
         })->filter()->all());
     }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -181,7 +181,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheClearCommand()
     {
-        $this->app->singleton('command.cache.clear', function ($app) {
+        $this->app->singleton('command.cache.clear', static function ($app) {
             return new CacheClearCommand($app['cache'], $app['files']);
         });
     }
@@ -193,7 +193,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheForgetCommand()
     {
-        $this->app->singleton('command.cache.forget', function ($app) {
+        $this->app->singleton('command.cache.forget', static function ($app) {
             return new CacheForgetCommand($app['cache']);
         });
     }
@@ -205,7 +205,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheTableCommand()
     {
-        $this->app->singleton('command.cache.table', function ($app) {
+        $this->app->singleton('command.cache.table', static function ($app) {
             return new CacheTableCommand($app['files'], $app['composer']);
         });
     }
@@ -217,7 +217,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerChannelMakeCommand()
     {
-        $this->app->singleton('command.channel.make', function ($app) {
+        $this->app->singleton('command.channel.make', static function ($app) {
             return new ChannelMakeCommand($app['files']);
         });
     }
@@ -229,7 +229,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearCompiledCommand()
     {
-        $this->app->singleton('command.clear-compiled', function () {
+        $this->app->singleton('command.clear-compiled', static function () {
             return new ClearCompiledCommand;
         });
     }
@@ -241,7 +241,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearResetsCommand()
     {
-        $this->app->singleton('command.auth.resets.clear', function () {
+        $this->app->singleton('command.auth.resets.clear', static function () {
             return new ClearResetsCommand;
         });
     }
@@ -253,7 +253,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigCacheCommand()
     {
-        $this->app->singleton('command.config.cache', function ($app) {
+        $this->app->singleton('command.config.cache', static function ($app) {
             return new ConfigCacheCommand($app['files']);
         });
     }
@@ -265,7 +265,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigClearCommand()
     {
-        $this->app->singleton('command.config.clear', function ($app) {
+        $this->app->singleton('command.config.clear', static function ($app) {
             return new ConfigClearCommand($app['files']);
         });
     }
@@ -277,7 +277,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConsoleMakeCommand()
     {
-        $this->app->singleton('command.console.make', function ($app) {
+        $this->app->singleton('command.console.make', static function ($app) {
             return new ConsoleMakeCommand($app['files']);
         });
     }
@@ -289,7 +289,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerControllerMakeCommand()
     {
-        $this->app->singleton('command.controller.make', function ($app) {
+        $this->app->singleton('command.controller.make', static function ($app) {
             return new ControllerMakeCommand($app['files']);
         });
     }
@@ -301,7 +301,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDbWipeCommand()
     {
-        $this->app->singleton('command.db.wipe', function () {
+        $this->app->singleton('command.db.wipe', static function () {
             return new WipeCommand;
         });
     }
@@ -313,7 +313,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventGenerateCommand()
     {
-        $this->app->singleton('command.event.generate', function () {
+        $this->app->singleton('command.event.generate', static function () {
             return new EventGenerateCommand;
         });
     }
@@ -325,7 +325,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventMakeCommand()
     {
-        $this->app->singleton('command.event.make', function ($app) {
+        $this->app->singleton('command.event.make', static function ($app) {
             return new EventMakeCommand($app['files']);
         });
     }
@@ -337,7 +337,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerExceptionMakeCommand()
     {
-        $this->app->singleton('command.exception.make', function ($app) {
+        $this->app->singleton('command.exception.make', static function ($app) {
             return new ExceptionMakeCommand($app['files']);
         });
     }
@@ -349,7 +349,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerFactoryMakeCommand()
     {
-        $this->app->singleton('command.factory.make', function ($app) {
+        $this->app->singleton('command.factory.make', static function ($app) {
             return new FactoryMakeCommand($app['files']);
         });
     }
@@ -361,7 +361,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDownCommand()
     {
-        $this->app->singleton('command.down', function () {
+        $this->app->singleton('command.down', static function () {
             return new DownCommand;
         });
     }
@@ -373,7 +373,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEnvironmentCommand()
     {
-        $this->app->singleton('command.environment', function () {
+        $this->app->singleton('command.environment', static function () {
             return new EnvironmentCommand;
         });
     }
@@ -385,7 +385,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventCacheCommand()
     {
-        $this->app->singleton('command.event.cache', function () {
+        $this->app->singleton('command.event.cache', static function () {
             return new EventCacheCommand;
         });
     }
@@ -397,7 +397,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventClearCommand()
     {
-        $this->app->singleton('command.event.clear', function ($app) {
+        $this->app->singleton('command.event.clear', static function ($app) {
             return new EventClearCommand($app['files']);
         });
     }
@@ -409,7 +409,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventListCommand()
     {
-        $this->app->singleton('command.event.list', function () {
+        $this->app->singleton('command.event.list', static function () {
             return new EventListCommand();
         });
     }
@@ -421,7 +421,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerJobMakeCommand()
     {
-        $this->app->singleton('command.job.make', function ($app) {
+        $this->app->singleton('command.job.make', static function ($app) {
             return new JobMakeCommand($app['files']);
         });
     }
@@ -433,7 +433,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerKeyGenerateCommand()
     {
-        $this->app->singleton('command.key.generate', function () {
+        $this->app->singleton('command.key.generate', static function () {
             return new KeyGenerateCommand;
         });
     }
@@ -445,7 +445,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerListenerMakeCommand()
     {
-        $this->app->singleton('command.listener.make', function ($app) {
+        $this->app->singleton('command.listener.make', static function ($app) {
             return new ListenerMakeCommand($app['files']);
         });
     }
@@ -457,7 +457,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMailMakeCommand()
     {
-        $this->app->singleton('command.mail.make', function ($app) {
+        $this->app->singleton('command.mail.make', static function ($app) {
             return new MailMakeCommand($app['files']);
         });
     }
@@ -469,7 +469,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMiddlewareMakeCommand()
     {
-        $this->app->singleton('command.middleware.make', function ($app) {
+        $this->app->singleton('command.middleware.make', static function ($app) {
             return new MiddlewareMakeCommand($app['files']);
         });
     }
@@ -481,7 +481,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerModelMakeCommand()
     {
-        $this->app->singleton('command.model.make', function ($app) {
+        $this->app->singleton('command.model.make', static function ($app) {
             return new ModelMakeCommand($app['files']);
         });
     }
@@ -493,7 +493,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationMakeCommand()
     {
-        $this->app->singleton('command.notification.make', function ($app) {
+        $this->app->singleton('command.notification.make', static function ($app) {
             return new NotificationMakeCommand($app['files']);
         });
     }
@@ -505,7 +505,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationTableCommand()
     {
-        $this->app->singleton('command.notification.table', function ($app) {
+        $this->app->singleton('command.notification.table', static function ($app) {
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
@@ -517,7 +517,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeCommand()
     {
-        $this->app->singleton('command.optimize', function () {
+        $this->app->singleton('command.optimize', static function () {
             return new OptimizeCommand;
         });
     }
@@ -529,7 +529,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerObserverMakeCommand()
     {
-        $this->app->singleton('command.observer.make', function ($app) {
+        $this->app->singleton('command.observer.make', static function ($app) {
             return new ObserverMakeCommand($app['files']);
         });
     }
@@ -541,7 +541,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeClearCommand()
     {
-        $this->app->singleton('command.optimize.clear', function () {
+        $this->app->singleton('command.optimize.clear', static function () {
             return new OptimizeClearCommand;
         });
     }
@@ -553,7 +553,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPackageDiscoverCommand()
     {
-        $this->app->singleton('command.package.discover', function () {
+        $this->app->singleton('command.package.discover', static function () {
             return new PackageDiscoverCommand;
         });
     }
@@ -565,7 +565,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPolicyMakeCommand()
     {
-        $this->app->singleton('command.policy.make', function ($app) {
+        $this->app->singleton('command.policy.make', static function ($app) {
             return new PolicyMakeCommand($app['files']);
         });
     }
@@ -577,7 +577,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPresetCommand()
     {
-        $this->app->singleton('command.preset', function () {
+        $this->app->singleton('command.preset', static function () {
             return new PresetCommand;
         });
     }
@@ -589,7 +589,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerProviderMakeCommand()
     {
-        $this->app->singleton('command.provider.make', function ($app) {
+        $this->app->singleton('command.provider.make', static function ($app) {
             return new ProviderMakeCommand($app['files']);
         });
     }
@@ -601,7 +601,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedCommand()
     {
-        $this->app->singleton('command.queue.failed', function () {
+        $this->app->singleton('command.queue.failed', static function () {
             return new ListFailedQueueCommand;
         });
     }
@@ -613,7 +613,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueForgetCommand()
     {
-        $this->app->singleton('command.queue.forget', function () {
+        $this->app->singleton('command.queue.forget', static function () {
             return new ForgetFailedQueueCommand;
         });
     }
@@ -625,7 +625,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFlushCommand()
     {
-        $this->app->singleton('command.queue.flush', function () {
+        $this->app->singleton('command.queue.flush', static function () {
             return new FlushFailedQueueCommand;
         });
     }
@@ -637,7 +637,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueListenCommand()
     {
-        $this->app->singleton('command.queue.listen', function ($app) {
+        $this->app->singleton('command.queue.listen', static function ($app) {
             return new QueueListenCommand($app['queue.listener']);
         });
     }
@@ -649,7 +649,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function ($app) {
+        $this->app->singleton('command.queue.restart', static function ($app) {
             return new QueueRestartCommand($app['cache.store']);
         });
     }
@@ -661,7 +661,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRetryCommand()
     {
-        $this->app->singleton('command.queue.retry', function () {
+        $this->app->singleton('command.queue.retry', static function () {
             return new QueueRetryCommand;
         });
     }
@@ -673,7 +673,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueWorkCommand()
     {
-        $this->app->singleton('command.queue.work', function ($app) {
+        $this->app->singleton('command.queue.work', static function ($app) {
             return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
@@ -685,7 +685,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedTableCommand()
     {
-        $this->app->singleton('command.queue.failed-table', function ($app) {
+        $this->app->singleton('command.queue.failed-table', static function ($app) {
             return new FailedTableCommand($app['files'], $app['composer']);
         });
     }
@@ -697,7 +697,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueTableCommand()
     {
-        $this->app->singleton('command.queue.table', function ($app) {
+        $this->app->singleton('command.queue.table', static function ($app) {
             return new TableCommand($app['files'], $app['composer']);
         });
     }
@@ -709,7 +709,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRequestMakeCommand()
     {
-        $this->app->singleton('command.request.make', function ($app) {
+        $this->app->singleton('command.request.make', static function ($app) {
             return new RequestMakeCommand($app['files']);
         });
     }
@@ -721,7 +721,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerResourceMakeCommand()
     {
-        $this->app->singleton('command.resource.make', function ($app) {
+        $this->app->singleton('command.resource.make', static function ($app) {
             return new ResourceMakeCommand($app['files']);
         });
     }
@@ -733,7 +733,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRuleMakeCommand()
     {
-        $this->app->singleton('command.rule.make', function ($app) {
+        $this->app->singleton('command.rule.make', static function ($app) {
             return new RuleMakeCommand($app['files']);
         });
     }
@@ -745,7 +745,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeederMakeCommand()
     {
-        $this->app->singleton('command.seeder.make', function ($app) {
+        $this->app->singleton('command.seeder.make', static function ($app) {
             return new SeederMakeCommand($app['files'], $app['composer']);
         });
     }
@@ -757,7 +757,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSessionTableCommand()
     {
-        $this->app->singleton('command.session.table', function ($app) {
+        $this->app->singleton('command.session.table', static function ($app) {
             return new SessionTableCommand($app['files'], $app['composer']);
         });
     }
@@ -769,7 +769,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerStorageLinkCommand()
     {
-        $this->app->singleton('command.storage.link', function () {
+        $this->app->singleton('command.storage.link', static function () {
             return new StorageLinkCommand;
         });
     }
@@ -781,7 +781,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteCacheCommand()
     {
-        $this->app->singleton('command.route.cache', function ($app) {
+        $this->app->singleton('command.route.cache', static function ($app) {
             return new RouteCacheCommand($app['files']);
         });
     }
@@ -793,7 +793,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteClearCommand()
     {
-        $this->app->singleton('command.route.clear', function ($app) {
+        $this->app->singleton('command.route.clear', static function ($app) {
             return new RouteClearCommand($app['files']);
         });
     }
@@ -805,7 +805,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteListCommand()
     {
-        $this->app->singleton('command.route.list', function ($app) {
+        $this->app->singleton('command.route.list', static function ($app) {
             return new RouteListCommand($app['router']);
         });
     }
@@ -817,7 +817,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeedCommand()
     {
-        $this->app->singleton('command.seed', function ($app) {
+        $this->app->singleton('command.seed', static function ($app) {
             return new SeedCommand($app['db']);
         });
     }
@@ -849,7 +849,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerServeCommand()
     {
-        $this->app->singleton('command.serve', function () {
+        $this->app->singleton('command.serve', static function () {
             return new ServeCommand;
         });
     }
@@ -861,7 +861,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerTestMakeCommand()
     {
-        $this->app->singleton('command.test.make', function ($app) {
+        $this->app->singleton('command.test.make', static function ($app) {
             return new TestMakeCommand($app['files']);
         });
     }
@@ -873,7 +873,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerUpCommand()
     {
-        $this->app->singleton('command.up', function () {
+        $this->app->singleton('command.up', static function () {
             return new UpCommand;
         });
     }
@@ -885,7 +885,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerVendorPublishCommand()
     {
-        $this->app->singleton('command.vendor.publish', function ($app) {
+        $this->app->singleton('command.vendor.publish', static function ($app) {
             return new VendorPublishCommand($app['files']);
         });
     }
@@ -897,7 +897,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewCacheCommand()
     {
-        $this->app->singleton('command.view.cache', function () {
+        $this->app->singleton('command.view.cache', static function () {
             return new ViewCacheCommand;
         });
     }
@@ -909,7 +909,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewClearCommand()
     {
-        $this->app->singleton('command.view.clear', function ($app) {
+        $this->app->singleton('command.view.clear', static function ($app) {
             return new ViewClearCommand($app['files']);
         });
     }

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -15,7 +15,8 @@ class ComposerServiceProvider extends ServiceProvider implements DeferrableProvi
      */
     public function register()
     {
-        $this->app->singleton('composer', function ($app) {
+        $this->app->singleton('composer', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
             return new Composer($app['files'], $app->basePath());
         });
     }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -26,11 +26,14 @@ class FormRequestServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
+        $this->app->afterResolving(ValidatesWhenResolved::class, static function ($resolved) {
+            /** @var ValidatesWhenResolved $resolved */
             $resolved->validateResolved();
         });
 
-        $this->app->resolving(FormRequest::class, function ($request, $app) {
+        $this->app->resolving(FormRequest::class, static function ($request, $app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             $request = FormRequest::createFrom($app['request'], $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -101,10 +101,10 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return collect($this->discoverEventsWithin())
-                    ->reject(function ($directory) {
+                    ->reject(static function ($directory) {
                         return ! is_dir($directory);
                     })
-                    ->reduce(function ($discovered, $directory) {
+                    ->reduce(static function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,
                             DiscoverEvents::within($directory, base_path())

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -88,7 +88,7 @@ trait InteractsWithContainer
             $this->originalMix = app(Mix::class);
         }
 
-        $this->swap(Mix::class, function () {
+        $this->swap(Mix::class, static function () {
             return '';
         });
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
+/**
+ * @property \Illuminate\Foundation\Application $app
+ */
 trait MakesHttpRequests
 {
     /**
@@ -121,6 +124,12 @@ trait MakesHttpRequests
 
         foreach ((array) $middleware as $abstract) {
             $this->app->instance($abstract, new class {
+                /**
+                 * @param Request $request
+                 * @param \Closure $next
+                 *
+                 * @return mixed
+                 */
                 public function handle($request, $next)
                 {
                     return $next($request);
@@ -505,7 +514,7 @@ trait MakesHttpRequests
     protected function transformHeadersToServerVars(array $headers)
     {
         return collect(array_merge($this->defaultHeaders, $headers))->mapWithKeys(function ($value, $name) {
-            $name = strtr(strtoupper($name), '-', '_');
+            $name = str_replace('-', '_', strtoupper($name));
 
             return [$this->formatServerHeaderKey($name) => $value];
         })->all();
@@ -564,7 +573,7 @@ trait MakesHttpRequests
             return array_merge($this->defaultCookies, $this->unencryptedCookies);
         }
 
-        return collect($this->defaultCookies)->map(function ($value) {
+        return collect($this->defaultCookies)->map(static function ($value) {
             return encrypt($value, false);
         })->merge($this->unencryptedCookies)->all();
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -223,8 +223,19 @@ trait MocksApplicationServices
     protected function wasDispatched($needle, array $haystack)
     {
         foreach ($haystack as $dispatched) {
-            if ((is_string($dispatched) && ($dispatched === $needle || is_subclass_of($dispatched, $needle))) ||
-                $dispatched instanceof $needle) {
+            if (
+                (
+                    is_string($dispatched)
+                    &&
+                    (
+                        $dispatched === $needle
+                        ||
+                        is_subclass_of($dispatched, $needle)
+                    )
+                )
+                ||
+                $dispatched instanceof $needle
+            ) {
                 return true;
             }
         }
@@ -267,8 +278,13 @@ trait MocksApplicationServices
             foreach ($this->dispatchedNotifications as $dispatched) {
                 $notified = $dispatched['notifiable'];
 
-                if (($notified === $notifiable ||
-                     $notified->getKey() == $notifiable->getKey()) &&
+                if (
+                    (
+                        $notified === $notifiable
+                        ||
+                        $notified->getKey() == $notifiable->getKey()
+                    )
+                    &&
                     get_class($dispatched['instance']) === $notification
                 ) {
                     return $this;

--- a/src/Illuminate/Foundation/Testing/Constraints/ArraySubset.php
+++ b/src/Illuminate/Foundation/Testing/Constraints/ArraySubset.php
@@ -185,7 +185,7 @@ if (class_exists(Version::class) && (int) Version::series()[0] >= 9) {
          * @param  mixed  $other
          * @param  string  $description
          * @param  bool  $returnResult
-         * @return bool|null
+         * @return bool|null|void
          *
          * @throws \PHPUnit\Framework\ExpectationFailedException
          * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -25,7 +25,7 @@ abstract class AbstractHasher
      */
     public function check($value, $hashedValue, array $options = [])
     {
-        if (strlen($hashedValue) === 0) {
+        if ($hashedValue === '') {
             return false;
         }
 

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -22,7 +22,7 @@ class Argon2IdHasher extends ArgonHasher
             throw new RuntimeException('This password does not use the Argon2id algorithm.');
         }
 
-        if (strlen($hashedValue) === 0) {
+        if ($hashedValue === '') {
             return false;
         }
 

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -14,11 +14,11 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('hash', function ($app) {
+        $this->app->singleton('hash', static function ($app) {
             return new HashManager($app);
         });
 
-        $this->app->singleton('hash.driver', function ($app) {
+        $this->app->singleton('hash.driver', static function ($app) {
             return $app['hash']->driver();
         });
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -78,7 +78,11 @@ trait InteractsWithContentTypes
             }
 
             foreach ($types as $type) {
-                if ($this->matchesType($accept, $type) || $accept === strtok($type, '/').'/*') {
+                if (
+                    self::matchesType($accept, $type)
+                    ||
+                    $accept === strtok($type, '/').'/*'
+                ) {
                     return true;
                 }
             }
@@ -111,7 +115,11 @@ trait InteractsWithContentTypes
                     $type = $mimeType;
                 }
 
-                if ($this->matchesType($type, $accept) || $accept === strtok($type, '/').'/*') {
+                if (
+                    self::matchesType($type, $accept)
+                    ||
+                    $accept === strtok($type, '/').'/*'
+                ) {
                     return $contentType;
                 }
             }

--- a/src/Illuminate/Http/JsonResponse.php
+++ b/src/Illuminate/Http/JsonResponse.php
@@ -90,12 +90,13 @@ class JsonResponse extends BaseJsonResponse
             return true;
         }
 
-        return $this->hasEncodingOption(JSON_PARTIAL_OUTPUT_ON_ERROR) &&
-                    in_array($jsonError, [
-                        JSON_ERROR_RECURSION,
-                        JSON_ERROR_INF_OR_NAN,
-                        JSON_ERROR_UNSUPPORTED_TYPE,
-                    ]);
+        return $this->hasEncodingOption(JSON_PARTIAL_OUTPUT_ON_ERROR)
+               &&
+               in_array($jsonError, [
+                   JSON_ERROR_RECURSION,
+                   JSON_ERROR_INF_OR_NAN,
+                   JSON_ERROR_UNSUPPORTED_TYPE,
+               ]);
     }
 
     /**

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -55,7 +55,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return collect(explode(';', $options))->mapWithKeys(function ($option) {
+        return collect(explode(';', $options))->mapWithKeys(static function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -149,7 +149,7 @@ class RedirectResponse extends BaseRedirectResponse
      * Parse the given errors into an appropriate value.
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider
-     * @return \Illuminate\Support\MessageBag
+     * @return \Illuminate\Contracts\Support\MessageBag
      */
     protected function parseErrors($provider)
     {

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
  * @method array validate(array $rules, ...$params)
  * @method array validateWithBag(string $errorBag, array $rules, ...$params)
  * @method string hasValidSignature(bool $absolute = true)
+ *
+ * @property \Illuminate\Contracts\Session\Session|null $session
  */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {
@@ -176,7 +178,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $segments = explode('/', $this->decodedPath());
 
-        return array_values(array_filter($segments, function ($value) {
+        return array_values(array_filter($segments, static function ($value) {
             return $value !== '';
         }));
     }
@@ -431,6 +433,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             $request->query->all(), $request->request->all(), $request->attributes->all(),
             $request->cookies->all(), $request->files->all(), $request->server->all()
         );
+        assert($newRequest instanceof static);
 
         $newRequest->headers->replace($request->headers->all());
 
@@ -453,7 +456,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      * Filter the given array of files, removing any empty values.
      *
      * @param  mixed  $files
-     * @return mixed
+     * @return mixed|void
      */
     protected function filterFiles($files)
     {
@@ -477,7 +480,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the session associated with the request.
      *
-     * @return \Illuminate\Session\Store
+     * @return \Illuminate\Contracts\Session\Session
      *
      * @throws \RuntimeException
      */
@@ -493,7 +496,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the session associated with the request.
      *
-     * @return \Illuminate\Session\Store|null
+     * @return \Illuminate\Contracts\Session\Session|null
      */
     public function getSession()
     {
@@ -579,7 +582,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getUserResolver()
     {
-        return $this->userResolver ?: function () {
+        return $this->userResolver ?: static function () {
             //
         };
     }
@@ -604,7 +607,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getRouteResolver()
     {
-        return $this->routeResolver ?: function () {
+        return $this->routeResolver ?: static function () {
             //
         };
     }

--- a/src/Illuminate/Http/Resources/CollectsResources.php
+++ b/src/Illuminate/Http/Resources/CollectsResources.php
@@ -46,8 +46,11 @@ trait CollectsResources
             return $this->collects;
         }
 
-        if (Str::endsWith(class_basename($this), 'Collection') &&
-            class_exists($class = Str::replaceLast('Collection', '', get_class($this)))) {
+        if (
+            Str::endsWith(class_basename($this), 'Collection')
+            &&
+            class_exists($class = Str::replaceLast('Collection', '', get_class($this)))
+        ) {
             return $class;
         }
     }

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -74,10 +74,21 @@ trait ConditionallyLoadsAttributes
         $numericKeys = true;
 
         foreach ($data as $key => $value) {
-            if (($value instanceof PotentiallyMissing && $value->isMissing()) ||
-                ($value instanceof self &&
-                $value->resource instanceof PotentiallyMissing &&
-                $value->isMissing())) {
+            if (
+                (
+                    $value instanceof PotentiallyMissing
+                    &&
+                    $value->isMissing()
+                )
+                ||
+                (
+                    $value instanceof self
+                    &&
+                    $value->resource instanceof PotentiallyMissing
+                    &&
+                    $value->isMissing()
+                )
+            ) {
                 unset($data[$key]);
             } else {
                 $numericKeys = $numericKeys && is_numeric($key);

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -75,7 +75,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return tap(new AnonymousResourceCollection($resource, static::class), function ($collection) {
+        return tap(new AnonymousResourceCollection($resource, static::class), static function ($collection) {
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }

--- a/src/Illuminate/Http/Resources/Json/ResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceResponse.php
@@ -92,9 +92,13 @@ class ResourceResponse implements Responsable
      */
     protected function haveAdditionalInformationAndDataIsUnwrapped($data, $with, $additional)
     {
-        return (! empty($with) || ! empty($additional)) &&
-               (! $this->wrapper() ||
-                ! array_key_exists($this->wrapper(), $data));
+        return (! empty($with) || ! empty($additional))
+               &&
+               (
+                   ! $this->wrapper()
+                   ||
+                   ! array_key_exists($this->wrapper(), $data)
+               );
     }
 
     /**

--- a/src/Illuminate/Http/ResponseTrait.php
+++ b/src/Illuminate/Http/ResponseTrait.php
@@ -108,7 +108,7 @@ trait ResponseTrait
     public function withCookie($cookie)
     {
         if (is_string($cookie) && function_exists('cookie')) {
-            $cookie = call_user_func_array('cookie', func_get_args());
+            $cookie = cookie(...func_get_args());
         }
 
         $this->headers->setCookie($cookie);

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -20,7 +20,7 @@ class FileFactory
             return $this->createWithContent($name, $kilobytes);
         }
 
-        return tap(new File($name, tmpfile()), function ($file) use ($kilobytes, $mimeType) {
+        return tap(new File($name, tmpfile()), static function ($file) use ($kilobytes, $mimeType) {
             $file->sizeToReport = $kilobytes * 1024;
             $file->mimeTypeToReport = $mimeType;
         });
@@ -39,7 +39,7 @@ class FileFactory
 
         fwrite($tmpfile, $content);
 
-        return tap(new File($name, $tmpfile), function ($file) use ($tmpfile) {
+        return tap(new File($name, $tmpfile), static function ($file) use ($tmpfile) {
             $file->sizeToReport = fstat($tmpfile)['size'];
         });
     }
@@ -69,7 +69,7 @@ class FileFactory
      */
     protected function generateImage($width, $height, $type)
     {
-        return tap(tmpfile(), function ($temp) use ($width, $height, $type) {
+        return tap(tmpfile(), static function ($temp) use ($width, $height, $type) {
             ob_start();
 
             $image = imagecreatetruecolor($width, $height);

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -119,7 +119,8 @@ class LogManager implements LoggerInterface
                 return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']));
             });
         } catch (Throwable $e) {
-            return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
+            return tap($this->createEmergencyLogger(), static function ($logger) use ($e) {
+                /** @var LoggerInterface $logger */
                 $logger->emergency('Unable to create configured logger. Using emergency logger.', [
                     'exception' => $e,
                 ]);
@@ -166,7 +167,7 @@ class LogManager implements LoggerInterface
         $config = $this->configurationFor('emergency');
 
         $handler = new StreamHandler(
-            $config['path'] ?? $this->app->storagePath().'/logs/laravel.log',
+            $config['path'] ?? ($this->app->storagePath().'/logs/laravel.log'),
             $this->level(['level' => 'debug'])
         );
 
@@ -413,7 +414,8 @@ class LogManager implements LoggerInterface
      */
     protected function formatter()
     {
-        return tap(new LineFormatter(null, $this->dateFormat, true, true), function ($formatter) {
+        return tap(new LineFormatter(null, $this->dateFormat, true, true), static function ($formatter) {
+            /** @var LineFormatter $formatter */
             $formatter->includeStacktraces();
         });
     }
@@ -477,8 +479,8 @@ class LogManager implements LoggerInterface
     /**
      * Unset the given channel instance.
      *
-     * @param  string|null  $name
-     * @return $this
+     * @param  string|null  $driver
+     * @return void
      */
     public function forgetChannel($driver = null)
     {

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -31,6 +31,8 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
     protected function registerIlluminateMailer()
     {
         $this->app->singleton('mailer', function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             $config = $app->make('config')->get('mail');
 
             // Once we have create the mailer instance, we will set a container instance
@@ -84,7 +86,9 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
         // Once we have the transporter registered, we will register the actual Swift
         // mailer instance, passing in the transport instances, which allows us to
         // override this transporter instances during app start-up if necessary.
-        $this->app->singleton('swift.mailer', function ($app) {
+        $this->app->singleton('swift.mailer', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             if ($domain = $app->make('config')->get('mail.domain')) {
                 Swift_DependencyContainer::getInstance()
                                 ->register('mime.idgenerator.idright')
@@ -102,7 +106,7 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSwiftTransport()
     {
-        $this->app->singleton('swift.transport', function ($app) {
+        $this->app->singleton('swift.transport', static function ($app) {
             return new TransportManager($app);
         });
     }
@@ -120,7 +124,9 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
             ], 'laravel-mail');
         }
 
-        $this->app->singleton(Markdown::class, function ($app) {
+        $this->app->singleton(Markdown::class, static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             $config = $app->make('config');
 
             return new Markdown($app->make('view'), [

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -151,6 +151,7 @@ class Mailable implements MailableContract, Renderable
             Container::getInstance()->call([$this, 'build']);
 
             return $mailer->send($this->buildView(), $this->buildViewData(), function ($message) {
+                /** @var Message $message */
                 $this->buildFrom($message)
                      ->buildRecipients($message)
                      ->buildSubject($message)
@@ -387,6 +388,7 @@ class Mailable implements MailableContract, Renderable
     protected function buildDiskAttachments($message)
     {
         foreach ($this->diskAttachments as $attachment) {
+            /** @var \Illuminate\Contracts\Filesystem\Filesystem $storage */
             $storage = Container::getInstance()->make(
                 FilesystemFactory::class
             )->disk($attachment['disk']);
@@ -437,7 +439,8 @@ class Mailable implements MailableContract, Renderable
      */
     public function priority($level = 3)
     {
-        $this->callbacks[] = function ($message) use ($level) {
+        $this->callbacks[] = static function ($message) use ($level) {
+            /** @var Message $message */
             $message->setPriority($level);
         };
 
@@ -640,7 +643,7 @@ class Mailable implements MailableContract, Renderable
             'address' => $expected->email,
         ];
 
-        return collect($this->{$property})->contains(function ($actual) use ($expected) {
+        return collect($this->{$property})->contains(static function ($actual) use ($expected) {
             if (! isset($expected['name'])) {
                 return $actual['address'] == $expected['address'];
             }
@@ -784,7 +787,7 @@ class Mailable implements MailableContract, Renderable
             'path' => $path,
             'name' => $name ?? basename($path),
             'options' => $options,
-        ])->unique(function ($file) {
+        ])->unique(static function ($file) {
             return $file['disk'].$file['path'];
         })->all();
 

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -118,7 +118,7 @@ class Markdown
      */
     public function htmlComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/html';
         }, $this->componentPaths());
     }
@@ -130,7 +130,7 @@ class Markdown
      */
     public function textComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/text';
         }, $this->componentPaths());
     }

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -119,7 +119,7 @@ class MailgunTransport extends Transport
      */
     protected function getTo(Swift_Mime_SimpleMessage $message)
     {
-        return collect($this->allContacts($message))->map(function ($display, $address) {
+        return collect($this->allContacts($message))->map(static function ($display, $address) {
             return $display ? $display." <{$address}>" : $address;
         })->values()->implode(',');
     }

--- a/src/Illuminate/Mail/Transport/Transport.php
+++ b/src/Illuminate/Mail/Transport/Transport.php
@@ -56,7 +56,7 @@ abstract class Transport implements Swift_Transport
      */
     public function registerPlugin(Swift_Events_EventListener $plugin)
     {
-        array_push($this->plugins, $plugin);
+        $this->plugins[] = $plugin;
     }
 
     /**

--- a/src/Illuminate/Mail/TransportManager.php
+++ b/src/Illuminate/Mail/TransportManager.php
@@ -151,7 +151,7 @@ class TransportManager extends Manager
     {
         return tap(new PostmarkTransport(
             $this->config->get('services.postmark.token')
-        ), function ($transport) {
+        ), static function ($transport) {
             $transport->registerPlugin(new ThrowExceptionOnFailurePlugin());
         });
     }

--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -63,7 +63,7 @@ class AnonymousNotifiable
     /**
      * Get the value of the notifiable's primary key.
      *
-     * @return mixed
+     * @return void
      */
     public function getKey()
     {

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -48,10 +48,14 @@ class MailChannel
      */
     public function send($notifiable, Notification $notification)
     {
+        /** @var \Illuminate\Notifications\Messages\MailMessage $message */
         $message = $notification->toMail($notifiable);
 
-        if (! $notifiable->routeNotificationFor('mail', $notification) &&
-            ! $message instanceof Mailable) {
+        if (
+            ! $notifiable->routeNotificationFor('mail', $notification)
+            &&
+            ! $message instanceof Mailable
+        ) {
             return;
         }
 
@@ -207,7 +211,7 @@ class MailChannel
             $recipients = [$recipients];
         }
 
-        return collect($recipients)->mapWithKeys(function ($recipient, $email) {
+        return collect($recipients)->mapWithKeys(static function ($recipient, $email) {
             return is_numeric($email)
                     ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
                     : [$email => $recipient];

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -64,7 +64,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return [new PrivateChannel($channels)];
         }
 
-        return collect($channels)->map(function ($channel) {
+        return collect($channels)->map(static function ($channel) {
             return new PrivateChannel($channel);
         })->all();
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -284,7 +284,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     protected function parseAddresses($value)
     {
-        return collect($value)->map(function ($address, $name) {
+        return collect($value)->map(static function ($address, $name) {
             return [$address, is_numeric($name) ? null : $name];
         })->values()->all();
     }
@@ -297,8 +297,10 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     protected function arrayOfAddresses($address)
     {
-        return is_array($address) ||
-               $address instanceof Arrayable ||
+        return is_array($address)
+               ||
+               $address instanceof Arrayable
+               ||
                $address instanceof Traversable;
     }
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -117,7 +117,7 @@ class NotificationSender
      */
     protected function preferredLocale($notifiable, $notification)
     {
-        return $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+        return $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
             if ($notifiable instanceof HasLocalePreference) {
                 return $notifiable->preferredLocale();
             }

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -31,7 +31,7 @@ class NotificationServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ChannelManager::class, function ($app) {
+        $this->app->singleton(ChannelManager::class, static function ($app) {
             return new ChannelManager($app);
         });
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -128,7 +128,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Get the URL for the previous page.
      *
-     * @return string|null
+     * @return string|void
      */
     public function previousPageUrl()
     {
@@ -283,7 +283,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Get the number of the first item in the slice.
      *
-     * @return int
+     * @return int|null
      */
     public function firstItem()
     {
@@ -293,7 +293,7 @@ abstract class AbstractPaginator implements Htmlable
     /**
      * Get the number of the last item in the slice.
      *
-     * @return int
+     * @return int|null
      */
     public function lastItem()
     {

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -72,7 +72,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return \Illuminate\Contracts\Support\Htmlable
+     * @return \Illuminate\Contracts\View\View
      */
     public function links($view = null, $data = [])
     {
@@ -84,7 +84,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return \Illuminate\Contracts\Support\Htmlable
+     * @return \Illuminate\Contracts\View\View
      */
     public function render($view = null, $data = [])
     {
@@ -135,7 +135,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
     /**
      * Get the URL for the next page.
      *
-     * @return string|null
+     * @return string|void
      */
     public function nextPageUrl()
     {

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -40,7 +40,7 @@ class PaginationServiceProvider extends ServiceProvider
         Paginator::currentPageResolver(function ($pageName = 'page') {
             $page = $this->app['request']->input($pageName);
 
-            if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
+            if ((int) $page >= 1 && filter_var($page, FILTER_VALIDATE_INT) !== false) {
                 return (int) $page;
             }
 

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -75,7 +75,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Get the URL for the next page.
      *
-     * @return string|null
+     * @return string|void
      */
     public function nextPageUrl()
     {
@@ -89,7 +89,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return string
+     * @return \Illuminate\Contracts\View\View
      */
     public function links($view = null, $data = [])
     {
@@ -101,7 +101,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      *
      * @param  string|null  $view
      * @param  array  $data
-     * @return \Illuminate\Contracts\Support\Htmlable
+     * @return \Illuminate\Contracts\View\View
      */
     public function render($view = null, $data = [])
     {

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -112,7 +112,7 @@ class Pipeline implements PipelineContract
      */
     public function thenReturn()
     {
-        return $this->then(function ($passable) {
+        return $this->then(static function ($passable) {
             return $passable;
         });
     }

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -96,7 +96,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
             'ScanIndexForward' => false,
         ]);
 
-        return collect($results['Items'])->map(function ($result) {
+        return collect($results['Items'])->map(static function ($result) {
             return (object) [
                 'id' => $result['uuid']['S'],
                 'connection' => $result['connection']['S'],

--- a/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/NullFailedJobProvider.php
@@ -11,7 +11,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * @param  string  $queue
      * @param  string  $payload
      * @param  \Exception  $exception
-     * @return int|null
+     * @return void
      */
     public function log($connection, $queue, $payload, $exception)
     {
@@ -32,7 +32,7 @@ class NullFailedJobProvider implements FailedJobProviderInterface
      * Get a single failed job.
      *
      * @param  mixed  $id
-     * @return object|null
+     * @return void
      */
     public function find($id)
     {

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -18,7 +18,7 @@ class DatabaseJob extends Job implements JobContract
     /**
      * The database job payload.
      *
-     * @var \stdClass
+     * @var \Illuminate\Queue\Jobs\DatabaseJobRecord
      */
     protected $job;
 
@@ -27,7 +27,7 @@ class DatabaseJob extends Job implements JobContract
      *
      * @param  \Illuminate\Container\Container  $container
      * @param  \Illuminate\Queue\DatabaseQueue  $database
-     * @param  \stdClass  $job
+     * @param  \Illuminate\Queue\Jobs\DatabaseJobRecord  $job
      * @param  string  $connectionName
      * @param  string  $queue
      * @return void

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -156,7 +156,7 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
-        ], function ($value) {
+        ], static function ($value) {
             return ! is_null($value);
         });
     }

--- a/src/Illuminate/Queue/NullQueue.php
+++ b/src/Illuminate/Queue/NullQueue.php
@@ -61,7 +61,7 @@ class NullQueue extends Queue implements QueueContract
      * Pop the next job off of the queue.
      *
      * @param  string|null  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -60,7 +60,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerConnection()
     {
-        $this->app->singleton('queue.connection', function ($app) {
+        $this->app->singleton('queue.connection', static function ($app) {
             return $app['queue']->connection();
         });
     }
@@ -86,7 +86,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerNullConnector($manager)
     {
-        $manager->addConnector('null', function () {
+        $manager->addConnector('null', static function () {
             return new NullConnector;
         });
     }
@@ -99,7 +99,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSyncConnector($manager)
     {
-        $manager->addConnector('sync', function () {
+        $manager->addConnector('sync', static function () {
             return new SyncConnector;
         });
     }
@@ -138,7 +138,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerBeanstalkdConnector($manager)
     {
-        $manager->addConnector('beanstalkd', function () {
+        $manager->addConnector('beanstalkd', static function () {
             return new BeanstalkdConnector;
         });
     }
@@ -151,7 +151,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSqsConnector($manager)
     {
-        $manager->addConnector('sqs', function () {
+        $manager->addConnector('sqs', static function () {
             return new SqsConnector;
         });
     }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -73,8 +73,11 @@ trait SerializesAndRestoresModelIdentifiers
             (new $value->class)->setConnection($value->connection), $value->id
         )->useWritePdo()->get();
 
-        if (is_a($value->class, Pivot::class, true) ||
-            in_array(AsPivot::class, class_uses($value->class))) {
+        if (
+            is_a($value->class, Pivot::class, true)
+            ||
+            in_array(AsPivot::class, class_uses($value->class))
+        ) {
             return $collection;
         }
 
@@ -83,7 +86,7 @@ trait SerializesAndRestoresModelIdentifiers
         $collectionClass = get_class($collection);
 
         return new $collectionClass(
-            collect($value->id)->map(function ($id) use ($collection) {
+            collect($value->id)->map(static function ($id) use ($collection) {
                 return $collection[$id] ?? null;
             })->filter()
         );

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -24,7 +24,9 @@ trait SerializesModels
             ));
         }
 
-        return array_values(array_filter(array_map(function ($p) {
+        return array_values(array_filter(array_map(static function ($p) {
+            /** @var ReflectionProperty $p */
+
             return $p->isStatic() ? null : $p->getName();
         }, $properties)));
     }

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -155,7 +155,7 @@ class SyncQueue extends Queue implements QueueContract
      * Pop the next job off of the queue.
      *
      * @param  string|null  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -206,8 +206,15 @@ class Worker
      */
     protected function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)
     {
-        return ! ((($this->isDownForMaintenance)() && ! $options->force) ||
-            $this->paused ||
+        return ! (
+            (
+                ($this->isDownForMaintenance)()
+                &&
+                ! $options->force
+            )
+            ||
+            $this->paused
+            ||
             $this->events->until(new Looping($connectionName, $queue)) === false);
     }
 
@@ -663,7 +670,7 @@ class Worker
     /**
      * Get the queue manager instance.
      *
-     * @return \Illuminate\Queue\QueueManager
+     * @return QueueManager
      */
     public function getManager()
     {

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -55,7 +55,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function mget(array $keys)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             return $value !== false ? $value : null;
         }, $this->command('mget', [$keys]));
     }
@@ -351,7 +351,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      *
      * @param  string  $script
      * @param  int  $numberOfKeys
-     * @param  dynamic  $arguments
+     * @param  mixed  ...$arguments
      * @return mixed
      */
     public function eval($script, $numberOfKeys, ...$arguments)
@@ -368,7 +368,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function subscribe($channels, Closure $callback)
     {
-        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
+        $this->client->subscribe((array) $channels, static function ($redis, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }
@@ -382,7 +382,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function psubscribe($channels, Closure $callback)
     {
-        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
+        $this->client->psubscribe((array) $channels, static function ($redis, $pattern, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -47,7 +47,7 @@ class PredisConnection extends Connection implements ConnectionContract
 
         foreach ($loop as $message) {
             if ($message->kind === 'message' || $message->kind === 'pmessage') {
-                call_user_func($callback, $message->payload, $message->channel);
+                $callback($message->payload, $message->channel);
             }
         }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -72,6 +72,8 @@ class PhpRedisConnector implements Connector
     protected function createClient(array $config)
     {
         return tap(new Redis, function ($client) use ($config) {
+            /** @var Redis $client */
+
             if ($client instanceof RedisFacade) {
                 throw new LogicException(
                         extension_loaded('redis')
@@ -151,7 +153,9 @@ class PhpRedisConnector implements Connector
             $parameters[] = $options['password'] ?? null;
         }
 
-        return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
+        return tap(new RedisCluster(...$parameters), static function ($client) use ($options) {
+            /** @var RedisCluster $client */
+
             if (! empty($options['prefix'])) {
                 $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
             }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -185,7 +185,7 @@ class RedisManager implements Factory
     {
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
-        return array_filter($parsed, function ($key) {
+        return array_filter($parsed, static function ($key) {
             return ! in_array($key, ['driver', 'username'], true);
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -15,13 +15,15 @@ class RedisServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('redis', function ($app) {
+        $this->app->singleton('redis', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             $config = $app->make('config')->get('database.redis', []);
 
             return new RedisManager($app, Arr::pull($config, 'client', 'phpredis'), $config);
         });
 
-        $this->app->bind('redis.connection', function ($app) {
+        $this->app->bind('redis.connection', static function ($app) {
             return $app['redis']->connection();
         });
     }

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -96,7 +96,7 @@ class ControllerMakeCommand extends GeneratorCommand
         $replace["use {$controllerNamespace}\Controller;\n"] = '';
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace), $replace, parent::buildClass($name)
         );
     }
 
@@ -109,10 +109,12 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $parentModelClass = $this->parseModel($this->option('parent'));
 
-        if (! class_exists($parentModelClass)) {
-            if ($this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $parentModelClass]);
-            }
+        if (
+            !class_exists($parentModelClass)
+            &&
+            $this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)
+        ) {
+            $this->call('make:model', ['name' => $parentModelClass]);
         }
 
         return [
@@ -132,10 +134,12 @@ class ControllerMakeCommand extends GeneratorCommand
     {
         $modelClass = $this->parseModel($this->option('model'));
 
-        if (! class_exists($modelClass)) {
-            if ($this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $modelClass]);
-            }
+        if (
+            !class_exists($modelClass)
+            &&
+            $this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)
+        ) {
+            $this->call('make:model', ['name' => $modelClass]);
         }
 
         return array_merge($replace, [

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -61,7 +61,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
             return [];
         }
 
-        return collect($controller->getMiddleware())->reject(function ($data) use ($method) {
+        return collect($controller->getMiddleware())->reject(static function ($data) use ($method) {
             return static::methodExcludedByOptions($method, $data['options']);
         })->pluck('middleware')->all();
     }
@@ -75,7 +75,16 @@ class ControllerDispatcher implements ControllerDispatcherContract
      */
     protected static function methodExcludedByOptions($method, array $options)
     {
-        return (isset($options['only']) && ! in_array($method, (array) $options['only'])) ||
-            (! empty($options['except']) && in_array($method, (array) $options['except']));
+        return (
+                   isset($options['only'])
+                   &&
+                   !in_array($method, (array)$options['only'])
+               )
+               ||
+               (
+                   !empty($options['except'])
+                   &&
+                   in_array($method, (array)$options['except'])
+               );
     }
 }

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -39,8 +39,11 @@ class Pipeline extends BasePipeline
      */
     protected function handleException($passable, Exception $e)
     {
-        if (! $this->container->bound(ExceptionHandler::class) ||
-            ! $passable instanceof Request) {
+        if (
+            ! $this->container->bound(ExceptionHandler::class)
+            ||
+            ! $passable instanceof Request
+        ) {
             throw $e;
         }
 

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -118,7 +118,9 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route parameters, which should be the base resources.
-        $callback = function ($me) use ($name, $controller, $options) {
+        $callback = static function ($me) use ($name, $controller, $options) {
+            /** @var \Illuminate\Contracts\Routing\Registrar $me */
+
             $me->resource($name, $controller, $options);
         };
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -267,7 +267,7 @@ class Route
     {
         $this->compileRoute();
 
-        foreach ($this->getValidators() as $validator) {
+        foreach (static::getValidators() as $validator) {
             if (! $includingMethod && $validator instanceof MethodValidator) {
                 continue;
             }
@@ -427,7 +427,7 @@ class Route
      */
     public function parametersWithoutNulls()
     {
-        return array_filter($this->parameters(), function ($p) {
+        return array_filter($this->parameters(), static function ($p) {
             return ! is_null($p);
         });
     }
@@ -453,9 +453,19 @@ class Route
      */
     protected function compileParameterNames()
     {
-        preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
+        $uri = $this->getDomain().$this->uri;
 
-        return array_map(function ($m) {
+        if (
+            strpos($uri, '{') === false
+            &&
+            strpos($uri, '}') === false
+        ) {
+            return [];
+        }
+
+        preg_match_all('/\{(.*?)\}/', $uri, $matches);
+
+        return array_map(static function ($m) {
             return trim($m, '?');
         }, $matches[1]);
     }

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -59,7 +59,7 @@ class RouteAction
      */
     protected static function missingAction($uri)
     {
-        return ['uses' => function () use ($uri) {
+        return ['uses' => static function () use ($uri) {
             throw new LogicException("Route for [{$uri}] has no action.");
         }];
     }
@@ -72,7 +72,7 @@ class RouteAction
      */
     protected static function findCallable(array $action)
     {
-        return Arr::first($action, function ($value, $key) {
+        return Arr::first($action, static function ($value, $key) {
             return is_callable($value) && is_numeric($key);
         });
     }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -33,7 +33,7 @@ class RouteBinding
      */
     protected static function createClassBinding($container, $binding)
     {
-        return function ($value, $route) use ($container, $binding) {
+        return static function ($value, $route) use ($container, $binding) {
             // If the binding has an @ sign, we will assume it's being used to delimit
             // the class name from the bind method name. This allows for bindings
             // to run multiple bind methods in a single class for convenience.

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -189,11 +189,14 @@ class RouteCollection implements Countable, IteratorAggregate
      */
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
-        [$fallbacks, $routes] = collect($routes)->partition(function ($route) {
+        [$fallbacks, $routes] = collect($routes)->partition(static function ($route) {
             return $route->isFallback;
         });
+        /** @var $routes \Illuminate\Support\Collection */
 
-        return $routes->merge($fallbacks)->first(function ($value) use ($request, $includingMethod) {
+        return $routes->merge($fallbacks)->first(static function ($value) use ($request, $includingMethod) {
+            /** @var \Illuminate\Routing\Route $value */
+
             return $value->matches($request, $includingMethod);
         });
     }
@@ -234,7 +237,7 @@ class RouteCollection implements Countable, IteratorAggregate
     protected function getRouteForMethods($request, array $methods)
     {
         if ($request->method() === 'OPTIONS') {
-            return (new Route('OPTIONS', $request->path(), function () use ($methods) {
+            return (new Route('OPTIONS', $request->path(), static function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
             }))->bind($request);
         }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -50,8 +50,11 @@ trait RouteDependencyResolverTrait
                 $instanceCount++;
 
                 $this->spliceIntoParameters($parameters, $key, $instance);
-            } elseif (! isset($values[$key - $instanceCount]) &&
-                      $parameter->isDefaultValueAvailable()) {
+            } elseif (
+                ! isset($values[$key - $instanceCount])
+                &&
+                $parameter->isDefaultValueAvailable()
+            ) {
                 $this->spliceIntoParameters($parameters, $key, $parameter->getDefaultValue());
             }
         }
@@ -89,7 +92,7 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
+        return ! is_null(Arr::first($parameters, static function ($value) use ($class) {
             return $value instanceof $class;
         }));
     }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -92,8 +92,8 @@ class RouteParameterBinder
 
         $parameters = array_intersect_key($matches, array_flip($parameterNames));
 
-        return array_filter($parameters, function ($value) {
-            return is_string($value) && strlen($value) > 0;
+        return array_filter($parameters, static function ($value) {
+            return is_string($value) && $value !== '';
         });
     }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -21,7 +21,7 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($action['uses'])
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
-        return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
+        return is_null($subClass) ? $parameters : array_filter($parameters, static function ($p) use ($subClass) {
             return $p->getClass() && $p->getClass()->isSubclassOf($subClass);
         });
     }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -87,7 +87,13 @@ class RouteUrlGenerator
             $route
         ), $parameters);
 
-        if (preg_match('/\{.*?\}/', $uri)) {
+        if (
+            strpos($uri, '{') !== false
+            &&
+            strpos($uri, '}') !== false
+            &&
+            preg_match('/\{.*?\}/', $uri)
+        ) {
             throw UrlGenerationException::forMissingParameters($route);
         }
 
@@ -196,7 +202,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/\{.*?\}/', static function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -648,7 +648,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function runRoute(Request $request, Route $route)
     {
-        $request->setRouteResolver(function () use ($route) {
+        $request->setRouteResolver(static function () use ($route) {
             return $route;
         });
 
@@ -668,7 +668,8 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function runRouteWithinStack(Route $route, Request $request)
     {
-        $shouldSkipMiddleware = $this->container->bound('middleware.disable') &&
+        $shouldSkipMiddleware = $this->container->bound('middleware.disable')
+                                &&
                                 $this->container->make('middleware.disable') === true;
 
         $middleware = $shouldSkipMiddleware ? [] : $this->gatherRouteMiddleware($route);
@@ -1076,7 +1077,9 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     public function currentRouteName()
     {
-        return $this->current() ? $this->current()->getName() : null;
+        $current = $this->current();
+
+        return $current ? $current->getName() : null;
     }
 
     /**

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -42,7 +42,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRouter()
     {
-        $this->app->singleton('router', function ($app) {
+        $this->app->singleton('router', static function ($app) {
             return new Router($app['events'], $app);
         });
     }
@@ -55,6 +55,8 @@ class RoutingServiceProvider extends ServiceProvider
     protected function registerUrlGenerator()
     {
         $this->app->singleton('url', function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Container\Container $app */
+
             $routes = $app['router']->getRoutes();
 
             // The URL generator needs the route collection that exists on the router.
@@ -70,6 +72,8 @@ class RoutingServiceProvider extends ServiceProvider
         });
 
         $this->app->extend('url', function (UrlGeneratorContract $url, $app) {
+            /** @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Container\Container $app */
+
             // Next we will set a few service resolvers on the URL generator so it can
             // get the information it needs to function. This just provides some of
             // the convenience features to this URL generator like "signed" URLs.
@@ -84,7 +88,7 @@ class RoutingServiceProvider extends ServiceProvider
             // If the route collection is "rebound", for example, when the routes stay
             // cached for the application, we will need to rebind the routes on the
             // URL generator instance so it has the latest version of the routes.
-            $app->rebinding('routes', function ($app, $routes) {
+            $app->rebinding('routes', static function ($app, $routes) {
                 $app['url']->setRoutes($routes);
             });
 
@@ -99,7 +103,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function requestRebinder()
     {
-        return function ($app, $request) {
+        return static function ($app, $request) {
             $app['url']->setRequest($request);
         };
     }
@@ -111,7 +115,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRedirector()
     {
-        $this->app->singleton('redirect', function ($app) {
+        $this->app->singleton('redirect', static function ($app) {
             $redirector = new Redirector($app['url']);
 
             // If the session is set on the application instance, we'll inject it into
@@ -132,7 +136,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind(ServerRequestInterface::class, function ($app) {
+        $this->app->bind(ServerRequestInterface::class, static function ($app) {
             if (class_exists(Psr17Factory::class) && class_exists(PsrHttpFactory::class)) {
                 $psr17Factory = new Psr17Factory;
 
@@ -155,7 +159,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrResponse()
     {
-        $this->app->bind(ResponseInterface::class, function () {
+        $this->app->bind(ResponseInterface::class, static function () {
             if (class_exists(NyholmPsrResponse::class)) {
                 return new NyholmPsrResponse;
             }
@@ -175,7 +179,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton(ResponseFactoryContract::class, function ($app) {
+        $this->app->singleton(ResponseFactoryContract::class, static function ($app) {
             return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
         });
     }
@@ -187,7 +191,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerControllerDispatcher()
     {
-        $this->app->singleton(ControllerDispatcherContract::class, function ($app) {
+        $this->app->singleton(ControllerDispatcherContract::class, static function ($app) {
             return new ControllerDispatcher($app);
         });
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -329,7 +329,7 @@ class UrlGenerator implements UrlGeneratorContract
         }
 
         if ($expiration) {
-            $parameters = $parameters + ['expires' => $this->availableAt($expiration)];
+            $parameters += ['expires' => $this->availableAt($expiration)];
         }
 
         ksort($parameters);
@@ -666,7 +666,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function pathFormatter()
     {
-        return $this->formatPathUsing ?: function ($path) {
+        return $this->formatPathUsing ?: static function ($path) {
             return $path;
         };
     }

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -68,10 +68,16 @@ class CookieSessionHandler implements SessionHandlerInterface
     {
         $value = $this->request->cookies->get($sessionId) ?: '';
 
-        if (! is_null($decoded = json_decode($value, true)) && is_array($decoded)) {
-            if (isset($decoded['expires']) && $this->currentTime() <= $decoded['expires']) {
-                return $decoded['data'];
-            }
+        if (
+            !is_null($decoded = json_decode($value, true))
+            &&
+            is_array($decoded)
+            &&
+            isset($decoded['expires'])
+            &&
+            $this->currentTime() <= $decoded['expires']
+        ) {
+            return $decoded['data'];
         }
 
         return '';

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -113,8 +113,9 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      */
     protected function expired($session)
     {
-        return isset($session->last_activity) &&
-            $session->last_activity < Carbon::now()->subMinutes($this->minutes)->getTimestamp();
+        return isset($session->last_activity)
+               &&
+               $session->last_activity < Carbon::now()->subMinutes($this->minutes)->getTimestamp();
     }
 
     /**

--- a/src/Illuminate/Session/FileSessionHandler.php
+++ b/src/Illuminate/Session/FileSessionHandler.php
@@ -66,10 +66,12 @@ class FileSessionHandler implements SessionHandlerInterface
      */
     public function read($sessionId)
     {
-        if ($this->files->isFile($path = $this->path.'/'.$sessionId)) {
-            if ($this->files->lastModified($path) >= Carbon::now()->subMinutes($this->minutes)->getTimestamp()) {
-                return $this->files->sharedGet($path);
-            }
+        if (
+            $this->files->isFile($path = $this->path . '/' . $sessionId)
+            &&
+            $this->files->lastModified($path) >= Carbon::now()->subMinutes($this->minutes)->getTimestamp()
+        ) {
+            return $this->files->sharedGet($path);
         }
 
         return '';
@@ -107,6 +109,7 @@ class FileSessionHandler implements SessionHandlerInterface
                     ->date('<= now - '.$lifetime.' seconds');
 
         foreach ($files as $file) {
+            /** @var \SplFileInfo $file */
             $this->files->delete($file->getRealPath());
         }
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -75,7 +75,9 @@ class StartSession
      */
     protected function startSession(Request $request)
     {
-        return tap($this->getSession($request), function ($session) use ($request) {
+        return tap($this->getSession($request), static function ($session) use ($request) {
+            /** @var \Illuminate\Contracts\Session\Session $session */
+
             $session->setRequestOnHandler($request);
 
             $session->start();
@@ -90,7 +92,9 @@ class StartSession
      */
     public function getSession(Request $request)
     {
-        return tap($this->manager->driver(), function ($session) use ($request) {
+        return tap($this->manager->driver(), static function ($session) use ($request) {
+            /** @var \Illuminate\Contracts\Session\Session $session */
+
             $session->setId($request->cookies->get($session->getName()));
         });
     }
@@ -133,10 +137,14 @@ class StartSession
      */
     protected function storeCurrentUrl(Request $request, $session)
     {
-        if ($request->method() === 'GET' &&
-            $request->route() &&
-            ! $request->ajax() &&
-            ! $request->prefetch()) {
+        if ($request->method() === 'GET'
+            &&
+            $request->route()
+            &&
+            ! $request->ajax()
+            &&
+            ! $request->prefetch()
+        ) {
             $session->setPreviousUrl($request->fullUrl());
         }
     }

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -28,7 +28,7 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionManager()
     {
-        $this->app->singleton('session', function ($app) {
+        $this->app->singleton('session', static function ($app) {
             return new SessionManager($app);
         });
     }
@@ -40,7 +40,9 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionDriver()
     {
-        $this->app->singleton('session.store', function ($app) {
+        $this->app->singleton('session.store', static function ($app) {
+            /** @var \Illuminate\Contracts\Foundation\Application $app */
+
             // First, we will create the session manager which is responsible for the
             // creation of the various session drivers when they are needed by the
             // application instance, and will resolve them on a lazy load basis.

--- a/src/Illuminate/Support/AggregateServiceProvider.php
+++ b/src/Illuminate/Support/AggregateServiceProvider.php
@@ -44,7 +44,11 @@ class AggregateServiceProvider extends ServiceProvider
         foreach ($this->providers as $provider) {
             $instance = $this->app->resolveProvider($provider);
 
-            $provides = array_merge($provides, $instance->provides());
+            $provides[] = $instance->provides();
+        }
+
+        if ($provides !== []) {
+            $provides = array_merge([], ...$provides);
         }
 
         return $provides;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -112,10 +112,14 @@ class Arr
 
         foreach ($array as $key => $value) {
             if (is_array($value) && ! empty($value)) {
-                $results = array_merge($results, static::dot($value, $prepend.$key.'.'));
+                $results[] = static::dot($value, $prepend.$key.'.');
             } else {
-                $results[$prepend.$key] = $value;
+                $results[] = [$prepend.$key => $value];
             }
+        }
+
+        if ($results !== []) {
+            $results = array_merge([], ...$results);
         }
 
         return $results;

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -82,7 +82,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
-        })->filter(function ($value) {
+        })->filter(static function ($value) {
             return ! is_null($value);
         });
 
@@ -100,7 +100,7 @@ class Collection implements ArrayAccess, Enumerable
     public function median($key = null)
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
-            ->filter(function ($item) {
+            ->filter(static function ($item) {
                 return ! is_null($item);
             })->sort()->values();
 
@@ -137,7 +137,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $counts = new self;
 
-        $collection->each(function ($value) use ($counts) {
+        $collection->each(static function ($value) use ($counts) {
             $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1;
         });
 
@@ -145,7 +145,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $highestValue = $sorted->last();
 
-        return $sorted->filter(function ($value) use ($highestValue) {
+        return $sorted->filter(static function ($value) use ($highestValue) {
             return $value == $highestValue;
         })->sort()->keys()->all();
     }
@@ -313,12 +313,12 @@ class Collection implements ArrayAccess, Enumerable
     protected function duplicateComparator($strict)
     {
         if ($strict) {
-            return function ($a, $b) {
+            return static function ($a, $b) {
                 return $a === $b;
             };
         }
 
-        return function ($a, $b) {
+        return static function ($a, $b) {
             return $a == $b;
         };
     }
@@ -1206,11 +1206,11 @@ class Collection implements ArrayAccess, Enumerable
             return $this->getArrayableItems($items);
         }, func_get_args());
 
-        $params = array_merge([function () {
+        $params = array_merge([static function () {
             return new static(func_get_args());
         }, $this->items], $arrayableItems);
 
-        return new static(call_user_func_array('array_map', $params));
+        return new static(array_map(...$params));
     }
 
     /**

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -63,7 +63,7 @@ class ConfigurationUrlParser
             'port' => $url['port'] ?? null,
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
-        ], function ($value) {
+        ], static function ($value) {
             return ! is_null($value);
         });
     }

--- a/src/Illuminate/Support/DateFactory.php
+++ b/src/Illuminate/Support/DateFactory.php
@@ -114,19 +114,29 @@ class DateFactory
     /**
      * Use the given handler when generating dates (class name, callable, or factory).
      *
-     * @param  mixed  $handler
-     * @return mixed
+     * @param  Factory|callable|string  $handler
+     * @return void
      *
      * @throws \InvalidArgumentException
      */
     public static function use($handler)
     {
         if (is_callable($handler) && is_object($handler)) {
-            return static::useCallable($handler);
-        } elseif (is_string($handler)) {
-            return static::useClass($handler);
-        } elseif ($handler instanceof Factory) {
-            return static::useFactory($handler);
+            static::useCallable($handler);
+
+            return;
+        }
+
+        if (is_string($handler)) {
+            static::useClass($handler);
+
+            return;
+        }
+
+        if ($handler instanceof Factory) {
+            static::useFactory($handler);
+
+            return;
         }
 
         throw new InvalidArgumentException('Invalid date creation handler. Please provide a class name, callable, or Carbon factory.');
@@ -212,12 +222,22 @@ class DateFactory
         $dateClass = static::$dateClass ?: $defaultClassName;
 
         // Check if date can be created using public class method...
-        if (method_exists($dateClass, $method) ||
-            method_exists($dateClass, 'hasMacro') && $dateClass::hasMacro($method)) {
+        if (
+            method_exists($dateClass, $method)
+            ||
+            (
+                method_exists($dateClass, 'hasMacro')
+                &&
+                $dateClass::hasMacro($method)
+            )
+        ) {
             return $dateClass::$method(...$parameters);
         }
 
         // If that fails, create the date with the default class..
+        /**
+         * @var \DateTimeInterface $date
+         */
         $date = $defaultClassName::$method(...$parameters);
 
         // If the configured class has an "instance" method, we'll try to pass our date into there...

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -98,7 +98,7 @@ class Env
     public static function get($key, $default = null)
     {
         return Option::fromValue(static::getVariables()->get($key))
-            ->map(function ($value) {
+            ->map(static function ($value) {
                 switch (strtolower($value)) {
                     case 'true':
                     case '(true)':
@@ -120,7 +120,7 @@ class Env
 
                 return $value;
             })
-            ->getOrCall(function () use ($default) {
+            ->getOrCall(static function () use ($default) {
                 return value($default);
             });
     }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -56,7 +56,7 @@ class Event extends Facade
 
         static::fake($eventsToFake);
 
-        return tap($callable(), function () use ($originalDispatcher) {
+        return tap($callable(), static function () use ($originalDispatcher) {
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -52,7 +52,7 @@ abstract class Facade
         if (! static::isMock()) {
             $class = static::getMockableClass();
 
-            return tap($class ? Mockery::spy($class) : Mockery::spy(), function ($spy) {
+            return tap($class ? Mockery::spy($class) : Mockery::spy(), static function ($spy) {
                 static::swap($spy);
             });
         }
@@ -97,7 +97,7 @@ abstract class Facade
      */
     protected static function createFreshMockInstance()
     {
-        return tap(static::createMock(), function ($mock) {
+        return tap(static::createMock(), static function ($mock) {
             static::swap($mock);
 
             $mock->shouldAllowMockingProtectedMethods();
@@ -125,7 +125,8 @@ abstract class Facade
     {
         $name = static::getFacadeAccessor();
 
-        return isset(static::$resolvedInstance[$name]) &&
+        return isset(static::$resolvedInstance[$name])
+               &&
                static::$resolvedInstance[$name] instanceof MockInterface;
     }
 

--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -42,7 +42,7 @@ class HigherOrderCollectionProxy
      */
     public function __get($key)
     {
-        return $this->collection->{$this->method}(function ($value) use ($key) {
+        return $this->collection->{$this->method}(static function ($value) use ($key) {
             return is_array($value) ? $value[$key] : $value->{$key};
         });
     }
@@ -56,7 +56,7 @@ class HigherOrderCollectionProxy
      */
     public function __call($method, $parameters)
     {
-        return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+        return $this->collection->{$this->method}(static function ($value) use ($method, $parameters) {
             return $value->{$method}(...$parameters);
         });
     }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -60,7 +60,7 @@ class LazyCollection implements Enumerable
             return new static;
         }
 
-        $instance = new static(function () use ($number) {
+        $instance = new static(static function () use ($number) {
             for ($current = 1; $current <= $number; $current++) {
                 yield $current;
             }
@@ -78,7 +78,7 @@ class LazyCollection implements Enumerable
      */
     public static function range($from, $to)
     {
-        return new static(function () use ($from, $to) {
+        return new static(static function () use ($from, $to) {
             for (; $from <= $to; $from++) {
                 yield $from;
             }
@@ -122,7 +122,7 @@ class LazyCollection implements Enumerable
 
         $cache = [];
 
-        return new static(function () use ($iterator, &$iteratorIndex, &$cache) {
+        return new static(static function () use ($iterator, &$iteratorIndex, &$cache) {
             for ($index = 0; true; $index++) {
                 if (array_key_exists($index, $cache)) {
                     yield $cache[$index][0] => $cache[$index][1];
@@ -352,7 +352,7 @@ class LazyCollection implements Enumerable
     public function filter(callable $callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return (bool) $value;
             };
         }
@@ -900,8 +900,9 @@ class LazyCollection implements Enumerable
     {
         $predicate = $this->useAsCallable($value)
             ? $value
-            : function ($item) use ($value, $strict) {
-                return $strict ? $item === $value : $item == $value;
+            : static function ($item) use ($value, $strict) {
+                return $strict ? $item === $value
+                               : $item == $value;
             };
 
         foreach ($this as $key => $item) {

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -198,7 +198,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     protected function getMessagesForWildcardKey($key, $format)
     {
         return collect($this->messages)
-                ->filter(function ($messages, $messageKey) use ($key) {
+                ->filter(static function ($messages, $messageKey) use ($key) {
                     return Str::is($key, $messageKey);
                 })
                 ->map(function ($messages, $messageKey) use ($format) {
@@ -221,7 +221,11 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
         $all = [];
 
         foreach ($this->messages as $key => $messages) {
-            $all = array_merge($all, $this->transform($messages, $format, $key));
+            $all[] = $this->transform($messages, $format, $key);
+        }
+
+        if ($all !== []) {
+            $all = array_merge([], ...$all);
         }
 
         return $all;
@@ -249,7 +253,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     protected function transform($messages, $format, $messageKey)
     {
         return collect((array) $messages)
-            ->map(function ($message) use ($format, $messageKey) {
+            ->map(static function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -11,7 +11,7 @@ abstract class ServiceProvider
     /**
      * The application instance.
      *
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\Container\Container
      */
     protected $app;
 
@@ -89,8 +89,12 @@ abstract class ServiceProvider
     protected function loadViewsFrom($path, $namespace)
     {
         $this->callAfterResolving('view', function ($view) use ($path, $namespace) {
-            if (isset($this->app->config['view']['paths']) &&
-                is_array($this->app->config['view']['paths'])) {
+            /** @var \Illuminate\Contracts\View\Factory $view */
+            if (
+                isset($this->app->config['view']['paths'])
+                &&
+                is_array($this->app->config['view']['paths'])
+            ) {
                 foreach ($this->app->config['view']['paths'] as $viewPath) {
                     if (is_dir($appPath = $viewPath.'/vendor/'.$namespace)) {
                         $view->addNamespace($namespace, $appPath);
@@ -111,7 +115,8 @@ abstract class ServiceProvider
      */
     protected function loadTranslationsFrom($path, $namespace)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path, $namespace) {
+        $this->callAfterResolving('translator', static function ($translator) use ($path, $namespace) {
+            /** @var \Illuminate\Contracts\Translation\Translator $translator */
             $translator->addNamespace($namespace, $path);
         });
     }
@@ -124,7 +129,8 @@ abstract class ServiceProvider
      */
     protected function loadJsonTranslationsFrom($path)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path) {
+        $this->callAfterResolving('translator', static function ($translator) use ($path) {
+            /** @var \Illuminate\Contracts\Translation\Translator $translator */
             $translator->addJsonPath($path);
         });
     }
@@ -137,7 +143,8 @@ abstract class ServiceProvider
      */
     protected function loadMigrationsFrom($paths)
     {
-        $this->callAfterResolving('migrator', function ($migrator) use ($paths) {
+        $this->callAfterResolving('migrator', static function ($migrator) use ($paths) {
+            /** @var \Illuminate\Database\Migrations\Migrator $migrator */
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
             }
@@ -152,7 +159,8 @@ abstract class ServiceProvider
      */
     protected function loadFactoriesFrom($paths)
     {
-        $this->callAfterResolving(ModelFactory::class, function ($factory) use ($paths) {
+        $this->callAfterResolving(ModelFactory::class, static function ($factory) use ($paths) {
+            /** @var \Illuminate\Database\Eloquent\Factory $factory */
             foreach ((array) $paths as $path) {
                 $factory->load($path);
             }
@@ -237,7 +245,7 @@ abstract class ServiceProvider
             return $paths;
         }
 
-        return collect(static::$publishes)->reduce(function ($paths, $p) {
+        return collect(static::$publishes)->reduce(static function ($paths, $p) {
             return array_merge($paths, $p);
         }, []);
     }
@@ -308,7 +316,8 @@ abstract class ServiceProvider
     {
         $commands = is_array($commands) ? $commands : func_get_args();
 
-        Artisan::starting(function ($artisan) use ($commands) {
+        Artisan::starting(static function ($artisan) use ($commands) {
+            /** @var \Illuminate\Contracts\Console\Application $artisan */
             $artisan->resolveCommands($commands);
         });
     }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -526,16 +526,16 @@ class Str
         // Convert all dashes/underscores into separator
         $flip = $separator === '-' ? '_' : '-';
 
-        $title = preg_replace('!['.preg_quote($flip).']+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($flip, '!').']+!u', $separator, $title);
 
         // Replace @ with the word 'at'
         $title = str_replace('@', $separator.'at'.$separator, $title);
 
         // Remove all characters that are not the separator, letters, numbers, or whitespace.
-        $title = preg_replace('![^'.preg_quote($separator).'\pL\pN\s]+!u', '', static::lower($title));
+        $title = preg_replace('![^'.preg_quote($separator, '!').'\pL\pN\s]+!u', '', static::lower($title));
 
         // Replace all separator characters and whitespace by a single separator
-        $title = preg_replace('!['.preg_quote($separator).'\s]+!u', $separator, $title);
+        $title = preg_replace('!['.preg_quote($separator, '!').'\s]+!u', $separator, $title);
 
         return trim($title, $separator);
     }
@@ -574,7 +574,11 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+            if (
+                $needle !== ''
+                &&
+                strpos($haystack, (string)$needle) === 0
+            ) {
                 return true;
             }
         }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -167,11 +167,11 @@ class BusFake implements Dispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->commands[$command])->filter(function ($command) use ($callback) {
+        return collect($this->commands[$command])->filter( function ($command) use ($callback) {
             return $callback($command);
         });
     }
@@ -189,7 +189,7 @@ class BusFake implements Dispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
@@ -279,7 +279,7 @@ class BusFake implements Dispatcher
         }
 
         return collect($this->jobsToFake)
-            ->filter(function ($job) use ($command) {
+            ->filter(static function ($job) use ($command) {
                 return $job instanceof Closure
                             ? $job($command)
                             : $job === get_class($command);

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -106,11 +106,11 @@ class EventFake implements Dispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->events[$event])->filter(function ($arguments) use ($callback) {
+        return collect($this->events[$event])->filter(static function ($arguments) use ($callback) {
             return $callback(...$arguments);
         });
     }
@@ -216,7 +216,7 @@ class EventFake implements Dispatcher
         }
 
         return collect($this->eventsToFake)
-            ->filter(function ($event) use ($eventName, $payload) {
+            ->filter(static function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                             ? $event($eventName, $payload)
                             : $event === $eventName;
@@ -250,7 +250,7 @@ class EventFake implements Dispatcher
      *
      * @param  string|object  $event
      * @param  mixed  $payload
-     * @return void
+     * @return null
      */
     public function until($event, $payload = [])
     {

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -86,7 +86,7 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNothingSent()
     {
-        $mailableNames = collect($this->mailables)->map(function ($mailable) {
+        $mailableNames = collect($this->mailables)->map(static function ($mailable) {
             return get_class($mailable);
         })->join(', ');
 
@@ -149,7 +149,7 @@ class MailFake implements Mailer, MailQueue
      */
     public function assertNothingQueued()
     {
-        $mailableNames = collect($this->queuedMailables)->map(function ($mailable) {
+        $mailableNames = collect($this->queuedMailables)->map(static function ($mailable) {
             return get_class($mailable);
         })->join(', ');
 
@@ -169,7 +169,7 @@ class MailFake implements Mailer, MailQueue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
@@ -202,7 +202,7 @@ class MailFake implements Mailer, MailQueue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
@@ -230,7 +230,7 @@ class MailFake implements Mailer, MailQueue
      */
     protected function mailablesOf($type)
     {
-        return collect($this->mailables)->filter(function ($mailable) use ($type) {
+        return collect($this->mailables)->filter(static function ($mailable) use ($type) {
             return $mailable instanceof $type;
         });
     }
@@ -243,7 +243,7 @@ class MailFake implements Mailer, MailQueue
      */
     protected function queuedMailablesOf($type)
     {
-        return collect($this->queuedMailables)->filter(function ($mailable) use ($type) {
+        return collect($this->queuedMailables)->filter(static function ($mailable) use ($type) {
             return $mailable instanceof $type;
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -130,7 +130,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
     {
         $actualCount = collect($this->notifications)
             ->flatten(1)
-            ->reduce(function ($count, $sent) use ($notification) {
+            ->reduce(static function ($count, $sent) use ($notification) {
                 return $count + count($sent[$notification] ?? []);
             }, 0);
 
@@ -154,13 +154,13 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
         $notifications = collect($this->notificationsFor($notifiable, $notification));
 
-        return $notifications->filter(function ($arguments) use ($callback) {
+        return $notifications->filter(static function ($arguments) use ($callback) {
             return $callback(...array_values($arguments));
         })->pluck('notification');
     }
@@ -224,7 +224,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
                 'notification' => $notification,
                 'channels' => $channels ?: $notification->via($notifiable),
                 'notifiable' => $notifiable,
-                'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+                'locale' => $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {
                         return $notifiable->preferredLocale();
                     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -121,12 +121,12 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
     {
-        $chain = collect($expectedChain)->map(function ($job) {
+        $chain = collect($expectedChain)->map(static function ($job) {
             return serialize($job);
         })->all();
 
         PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->filter(function ($job) use ($chain) {
+            $this->pushed($job, $callback)->filter(static function ($job) use ($chain) {
                 return $job->chained == $chain;
             })->isNotEmpty(),
             'The expected chain was not pushed.'
@@ -143,11 +143,11 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function assertPushedWithChainOfClasses($job, $expectedChain, $callback)
     {
-        $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
-            return collect($chain)->map(function ($job) {
+        $matching = $this->pushed($job, $callback)->map->chained->map(static function ($chain) {
+            return collect($chain)->map(static function ($job) {
                 return get_class(unserialize($job));
             });
-        })->filter(function ($chain) use ($expectedChain) {
+        })->filter(static function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;
         });
 
@@ -164,7 +164,7 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return ! collect($chain)->contains(function ($job) {
+        return ! collect($chain)->contains(static function ($job) {
             return ! is_object($job);
         });
     }
@@ -207,7 +207,7 @@ class QueueFake extends QueueManager implements Queue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
@@ -246,7 +246,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function size($queue = null)
     {
-        return collect($this->jobs)->flatten(1)->filter(function ($job) use ($queue) {
+        return collect($this->jobs)->flatten(1)->filter(static function ($job) use ($queue) {
             return $job['queue'] === $queue;
         })->count();
     }
@@ -325,7 +325,7 @@ class QueueFake extends QueueManager implements Queue
      * Pop the next job off of the queue.
      *
      * @param  string|null  $queue
-     * @return \Illuminate\Contracts\Queue\Job|null
+     * @return void
      */
     public function pop($queue = null)
     {

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -117,7 +117,7 @@ trait EnumeratesValues
     public function containsStrict($key, $value = null)
     {
         if (func_num_args() === 2) {
-            return $this->contains(function ($item) use ($key, $value) {
+            return $this->contains(static function ($item) use ($key, $value) {
                 return data_get($item, $key) === $value;
             });
         }
@@ -157,7 +157,7 @@ trait EnumeratesValues
     {
         (new static(func_get_args()))
             ->push($this)
-            ->each(function ($item) {
+            ->each(static function ($item) {
                 VarDumper::dump($item);
             });
 
@@ -189,7 +189,7 @@ trait EnumeratesValues
      */
     public function eachSpread(callable $callback)
     {
-        return $this->each(function ($chunk, $key) use ($callback) {
+        return $this->each(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -252,7 +252,7 @@ trait EnumeratesValues
      */
     public function mapSpread(callable $callback)
     {
-        return $this->map(function ($chunk, $key) use ($callback) {
+        return $this->map(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -269,6 +269,7 @@ trait EnumeratesValues
      */
     public function mapToGroups(callable $callback)
     {
+        /** @var Collection $groups */
         $groups = $this->mapToDictionary($callback);
 
         return $groups->map([$this, 'make']);
@@ -293,7 +294,7 @@ trait EnumeratesValues
      */
     public function mapInto($class)
     {
-        return $this->map(function ($value, $key) use ($class) {
+        return $this->map(static function ($value, $key) use ($class) {
             return new $class($value, $key);
         });
     }
@@ -308,11 +309,11 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->map(function ($value) use ($callback) {
+        return $this->map(static function ($value) use ($callback) {
             return $callback($value);
-        })->filter(function ($value) {
+        })->filter(static function ($value) {
             return ! is_null($value);
-        })->reduce(function ($result, $value) {
+        })->reduce(static function ($result, $value) {
             return is_null($result) || $value < $result ? $value : $result;
         });
     }
@@ -327,9 +328,9 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter(function ($value) {
+        return $this->filter(static function ($value) {
             return ! is_null($value);
-        })->reduce(function ($result, $item) use ($callback) {
+        })->reduce(static function ($result, $item) use ($callback) {
             $value = $callback($item);
 
             return is_null($result) || $value > $result ? $value : $result;
@@ -387,14 +388,14 @@ trait EnumeratesValues
     public function sum($callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return $value;
             };
         } else {
             $callback = $this->valueRetriever($callback);
         }
 
-        return $this->reduce(function ($result, $item) use ($callback) {
+        return $this->reduce(static function ($result, $item) use ($callback) {
             return $result + $callback($item);
         }, 0);
     }
@@ -411,7 +412,9 @@ trait EnumeratesValues
     {
         if ($value) {
             return $callback($this, $value);
-        } elseif ($default) {
+        }
+
+        if ($default) {
             return $default($this, $value);
         }
 
@@ -538,7 +541,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->filter(function ($item) use ($key, $values, $strict) {
+        return $this->filter(static function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
     }
@@ -576,7 +579,7 @@ trait EnumeratesValues
      */
     public function whereNotBetween($key, $values)
     {
-        return $this->filter(function ($item) use ($key, $values) {
+        return $this->filter(static function ($item) use ($key, $values) {
             return data_get($item, $key) < reset($values) || data_get($item, $key) > end($values);
         });
     }
@@ -593,7 +596,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->reject(function ($item) use ($key, $values, $strict) {
+        return $this->reject(static function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
     }
@@ -618,7 +621,7 @@ trait EnumeratesValues
      */
     public function whereInstanceOf($type)
     {
-        return $this->filter(function ($value) use ($type) {
+        return $this->filter(static function ($value) use ($type) {
             return $value instanceof $type;
         });
     }
@@ -657,7 +660,7 @@ trait EnumeratesValues
     {
         $useAsCallable = $this->useAsCallable($callback);
 
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
+        return $this->filter(static function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable
                 ? ! $callback($value, $key)
                 : $value != $callback;
@@ -677,7 +680,7 @@ trait EnumeratesValues
 
         $exists = [];
 
-        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
+        return $this->reject(static function ($item, $key) use ($callback, $strict, &$exists) {
             if (in_array($id = $callback($item, $key), $exists, $strict)) {
                 return true;
             }
@@ -714,7 +717,7 @@ trait EnumeratesValues
      */
     public function toArray()
     {
-        return $this->map(function ($value) {
+        return $this->map(static function ($value) {
             return $value instanceof Arrayable ? $value->toArray() : $value;
         })->all();
     }
@@ -726,7 +729,7 @@ trait EnumeratesValues
      */
     public function jsonSerialize()
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             if ($value instanceof JsonSerializable) {
                 return $value->jsonSerialize();
             } elseif ($value instanceof Jsonable) {
@@ -770,12 +773,12 @@ trait EnumeratesValues
     public function countBy($callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return $value;
             };
         }
 
-        return new static($this->groupBy($callback)->map(function ($value) {
+        return new static($this->groupBy($callback)->map(static function ($value) {
             return $value->count();
         }));
     }
@@ -865,10 +868,10 @@ trait EnumeratesValues
             $operator = '=';
         }
 
-        return function ($item) use ($key, $operator, $value) {
+        return static function ($item) use ($key, $operator, $value) {
             $retrieved = data_get($item, $key);
 
-            $strings = array_filter([$retrieved, $value], function ($value) {
+            $strings = array_filter([$retrieved, $value], static function ($value) {
                 return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
             });
 
@@ -915,7 +918,7 @@ trait EnumeratesValues
             return $value;
         }
 
-        return function ($item) use ($value) {
+        return static function ($item) use ($value) {
             return data_get($item, $value);
         };
     }

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -28,8 +28,11 @@ trait ForwardsCalls
                 throw $e;
             }
 
-            if ($matches['class'] != get_class($object) ||
-                $matches['method'] != $method) {
+            if (
+                $matches['class'] != get_class($object)
+                ||
+                $matches['method'] != $method
+            ) {
                 throw $e;
             }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -361,7 +361,7 @@ if (! function_exists('preg_replace_array')) {
      */
     function preg_replace_array($pattern, array $replacements, $subject)
     {
-        return preg_replace_callback($pattern, function () use (&$replacements) {
+        return preg_replace_callback($pattern, static function () use (&$replacements) {
             foreach ($replacements as $key => $value) {
                 return array_shift($replacements);
             }

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -91,7 +91,7 @@ class MessageSelector
      */
     private function stripConditions($segments)
     {
-        return collect($segments)->map(function ($part) {
+        return collect($segments)->map(static function ($part) {
             return preg_replace('/^[\{\[]([^\[\]\{\}]*)[\}\]]/', '', $part);
         })->all();
     }

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -16,7 +16,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
     {
         $this->registerLoader();
 
-        $this->app->singleton('translator', function ($app) {
+        $this->app->singleton('translator', static function ($app) {
             $loader = $app['translation.loader'];
 
             // When registering the translator component, we'll need to set the default
@@ -39,7 +39,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
      */
     protected function registerLoader()
     {
-        $this->app->singleton('translation.loader', function ($app) {
+        $this->app->singleton('translation.loader', static function ($app) {
             return new FileLoader($app['files'], $app['path.lang']);
         });
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -235,7 +235,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function sortReplacements(array $replace)
     {
-        return (new Collection($replace))->sortBy(function ($value, $key) {
+        return (new Collection($replace))->sortBy(static function ($value, $key) {
             return mb_strlen($key) * -1;
         })->all();
     }

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+/**
+ * @property \Illuminate\Contracts\Translation\Translator $translator
+ * @property \Illuminate\Contracts\Container\Container $container
+ */
 trait FormatsMessages
 {
     use ReplacesAttributes;
@@ -45,7 +49,7 @@ trait FormatsMessages
         // If the rule being validated is a "size" rule, we will need to gather the
         // specific error message for the type of attribute being validated such
         // as a number, file or string which all have different message types.
-        elseif (in_array($rule, $this->sizeRules)) {
+        if (in_array($rule, $this->sizeRules)) {
             return $this->getSizeMessage($attribute, $rule);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Throwable;
 
+/** @property \Illuminate\Contracts\Container\Container $container */
 trait ValidatesAttributes
 {
     /**
@@ -41,7 +42,9 @@ trait ValidatesAttributes
     {
         $acceptable = ['yes', 'on', '1', 1, true, 'true'];
 
-        return $this->validateRequired($attribute, $value) && in_array($value, $acceptable, true);
+        return $this->validateRequired($attribute, $value)
+               &&
+               in_array($value, $acceptable, true);
     }
 
     /**
@@ -151,7 +154,13 @@ trait ValidatesAttributes
      */
     protected function compareDates($attribute, $value, $parameters, $operator)
     {
-        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof DateTimeInterface) {
+        if (
+            ! is_string($value)
+            &&
+            ! is_numeric($value)
+            &&
+            ! $value instanceof DateTimeInterface
+        ) {
             return false;
         }
 
@@ -174,7 +183,8 @@ trait ValidatesAttributes
      */
     protected function getDateFormat($attribute)
     {
-        if ($result = $this->getRule($attribute, 'DateFormat')) {
+        $result = $this->getRule($attribute, 'DateFormat');
+        if ($result) {
             return $result[1][0];
         }
     }
@@ -219,7 +229,9 @@ trait ValidatesAttributes
             $secondDate = $this->getDateTimeWithOptionalFormat($format, $this->getValue($second));
         }
 
-        return ($firstDate && $secondDate) && ($this->compare($firstDate, $secondDate, $operator));
+        return ($firstDate && $secondDate)
+               &&
+               $this->compare($firstDate, $secondDate, $operator);
     }
 
     /**
@@ -231,7 +243,8 @@ trait ValidatesAttributes
      */
     protected function getDateTimeWithOptionalFormat($format, $value)
     {
-        if ($date = DateTime::createFromFormat('!'.$format, $value)) {
+        $date = DateTime::createFromFormat('!'.$format, $value);
+        if ($date) {
             return $date;
         }
 
@@ -265,9 +278,13 @@ trait ValidatesAttributes
      */
     protected function isTestingRelativeDateTime($value)
     {
-        return Carbon::hasTestNow() && is_string($value) && (
-            $value === 'now' || Carbon::hasRelativeKeywords($value)
-        );
+        return Carbon::hasTestNow() && is_string($value)
+               &&
+               (
+                   $value === 'now'
+                   ||
+                   Carbon::hasRelativeKeywords($value)
+               );
     }
 
     /**
@@ -279,7 +296,9 @@ trait ValidatesAttributes
      */
     public function validateAlpha($attribute, $value)
     {
-        return is_string($value) && preg_match('/^[\pL\pM]+$/u', $value);
+        return is_string($value)
+               &&
+               preg_match('/^[\pL\pM]+$/u', $value);
     }
 
     /**
@@ -340,7 +359,9 @@ trait ValidatesAttributes
 
         $size = $this->getSize($attribute, $value);
 
-        return $size >= $parameters[0] && $size <= $parameters[1];
+        return $size >= $parameters[0]
+               &&
+               $size <= $parameters[1];
     }
 
     /**
@@ -382,7 +403,15 @@ trait ValidatesAttributes
             return true;
         }
 
-        if ((! is_string($value) && ! is_numeric($value)) || strtotime($value) === false) {
+        if (
+            (
+                ! is_string($value)
+                &&
+                ! is_numeric($value)
+            )
+            ||
+            strtotime($value) === false
+        ) {
             return false;
         }
 
@@ -411,7 +440,9 @@ trait ValidatesAttributes
 
         $date = DateTime::createFromFormat('!'.$format, $value);
 
-        return $date && $date->format($format) == $value;
+        return $date
+               &&
+               $date->format($format) == $value;
     }
 
     /**
@@ -469,7 +500,8 @@ trait ValidatesAttributes
         $this->requireParameterCount(1, $parameters, 'digits');
 
         return ! preg_match('/[^0-9]/', $value)
-                    && strlen((string) $value) == $parameters[0];
+               &&
+               strlen((string) $value) == $parameters[0];
     }
 
     /**
@@ -487,7 +519,8 @@ trait ValidatesAttributes
         $length = strlen((string) $value);
 
         return ! preg_match('/[^0-9]/', $value)
-                    && $length >= $parameters[0] && $length <= $parameters[1];
+               &&
+               $length >= $parameters[0] && $length <= $parameters[1];
     }
 
     /**
@@ -500,11 +533,20 @@ trait ValidatesAttributes
      */
     public function validateDimensions($attribute, $value, $parameters)
     {
-        if ($this->isValidFileInstance($value) && in_array($value->getMimeType(), ['image/svg+xml', 'image/svg'])) {
+        if (
+            $this->isValidFileInstance($value)
+            &&
+            in_array($value->getMimeType(), ['image/svg+xml', 'image/svg'])
+        ) {
             return true;
         }
 
-        if (! $this->isValidFileInstance($value) || ! $sizeDetails = @getimagesize($value->getRealPath())) {
+        /** @noinspection PhpUsageOfSilenceOperatorInspection */
+        if (
+            ! $this->isValidFileInstance($value)
+            ||
+            ! $sizeDetails = @getimagesize($value->getRealPath())
+        ) {
             return false;
         }
 
@@ -514,8 +556,11 @@ trait ValidatesAttributes
 
         $parameters = $this->parseNamedParameters($parameters);
 
-        if ($this->failsBasicDimensionChecks($parameters, $width, $height) ||
-            $this->failsRatioCheck($parameters, $width, $height)) {
+        if (
+            $this->failsBasicDimensionChecks($parameters, $width, $height)
+            ||
+            $this->failsRatioCheck($parameters, $width, $height)
+        ) {
             return false;
         }
 
@@ -532,11 +577,16 @@ trait ValidatesAttributes
      */
     protected function failsBasicDimensionChecks($parameters, $width, $height)
     {
-        return (isset($parameters['width']) && $parameters['width'] != $width) ||
-               (isset($parameters['min_width']) && $parameters['min_width'] > $width) ||
-               (isset($parameters['max_width']) && $parameters['max_width'] < $width) ||
-               (isset($parameters['height']) && $parameters['height'] != $height) ||
-               (isset($parameters['min_height']) && $parameters['min_height'] > $height) ||
+        return (isset($parameters['width']) && $parameters['width'] != $width)
+               ||
+               (isset($parameters['min_width']) && $parameters['min_width'] > $width)
+               ||
+               (isset($parameters['max_width']) && $parameters['max_width'] < $width)
+               ||
+               (isset($parameters['height']) && $parameters['height'] != $height)
+               ||
+               (isset($parameters['min_height']) && $parameters['min_height'] > $height)
+               ||
                (isset($parameters['max_height']) && $parameters['max_height'] < $height);
     }
 
@@ -579,7 +629,7 @@ trait ValidatesAttributes
             return empty(preg_grep('/^'.preg_quote($value, '/').'$/iu', $data));
         }
 
-        return ! in_array($value, array_values($data));
+        return ! in_array($value, $data);
     }
 
     /**
@@ -617,7 +667,7 @@ trait ValidatesAttributes
 
         $pattern = str_replace('\*', '[^.]+', preg_quote($attribute, '#'));
 
-        return Arr::where(Arr::dot($attributeData), function ($value, $key) use ($pattern) {
+        return Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($pattern) {
             return (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
     }
@@ -632,13 +682,21 @@ trait ValidatesAttributes
      */
     public function validateEmail($attribute, $value, $parameters)
     {
-        if (! is_string($value) && ! (is_object($value) && method_exists($value, '__toString'))) {
+        if (
+            ! is_string($value)
+            &&
+            ! (
+                is_object($value)
+                &&
+                method_exists($value, '__toString')
+            )
+        ) {
             return false;
         }
 
         $validations = collect($parameters)
             ->unique()
-            ->map(function ($validation) {
+            ->map(static function ($validation) {
                 if ($validation === 'rfc') {
                     return new RFCValidation();
                 } elseif ($validation === 'strict') {
@@ -695,10 +753,11 @@ trait ValidatesAttributes
      */
     protected function getExistCount($connection, $table, $column, $value, $parameters)
     {
+        /** @var \Illuminate\Validation\PresenceVerifierInterface $verifier */
         $verifier = $this->getPresenceVerifierFor($connection);
 
         $extra = $this->getExtraConditions(
-            array_values(array_slice($parameters, 2))
+            array_slice($parameters, 2)
         );
 
         if ($this->currentRule instanceof Exists) {
@@ -744,6 +803,7 @@ trait ValidatesAttributes
         // The presence verifier is responsible for counting rows within this store
         // mechanism which might be a relational database or any other permanent
         // data store like Redis, etc. We will use it to determine uniqueness.
+        /** @var \Illuminate\Validation\PresenceVerifierInterface $verifier */
         $verifier = $this->getPresenceVerifierFor($connection);
 
         $extra = $this->getUniqueExtra($parameters);
@@ -818,7 +878,14 @@ trait ValidatesAttributes
     {
         [$connection, $table] = Str::contains($table, '.') ? explode('.', $table, 2) : [null, $table];
 
-        if (Str::contains($table, '\\') && class_exists($table) && is_a($table, Model::class, true)) {
+        if (
+            Str::contains($table, '\\')
+            &&
+            class_exists($table)
+            &&
+            is_a($table, Model::class, true)
+        ) {
+            /** @var Model $model */
             $model = new $table;
 
             $table = $model->getTable();
@@ -838,8 +905,9 @@ trait ValidatesAttributes
      */
     public function getQueryColumn($parameters, $attribute)
     {
-        return isset($parameters[1]) && $parameters[1] !== 'NULL'
-                    ? $parameters[1] : $this->guessColumnForQuery($attribute);
+        return (isset($parameters[1]) && $parameters[1] !== 'NULL')
+                    ? $parameters[1]
+                    : $this->guessColumnForQuery($attribute);
     }
 
     /**
@@ -850,8 +918,11 @@ trait ValidatesAttributes
      */
     public function guessColumnForQuery($attribute)
     {
-        if (in_array($attribute, Arr::collapse($this->implicitAttributes))
-                && ! is_numeric($last = last(explode('.', $attribute)))) {
+        if (
+            in_array($attribute, Arr::collapse($this->implicitAttributes))
+            &&
+            ! is_numeric($last = last(explode('.', $attribute)))
+        ) {
             return $last;
         }
 
@@ -921,11 +992,23 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (
+            is_null($comparedToValue)
+            &&
+            is_numeric($value)
+            &&
+            is_numeric($parameters[0])
+        ) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (
+            is_numeric($value)
+            &&
+            is_numeric($comparedToValue)
+            &&
+            $this->hasRule($attribute, $this->numericRules)
+        ) {
             return $value > $comparedToValue;
         }
 
@@ -952,11 +1035,23 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (
+            is_null($comparedToValue)
+            &&
+            is_numeric($value)
+            &&
+            is_numeric($parameters[0])
+        ) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (
+            is_numeric($value)
+            &&
+            is_numeric($comparedToValue)
+            &&
+            $this->hasRule($attribute, $this->numericRules)
+        ) {
             return $value < $comparedToValue;
         }
 
@@ -983,11 +1078,23 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (
+            is_null($comparedToValue)
+            &&
+            is_numeric($value)
+            &&
+            is_numeric($parameters[0])
+        ) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (
+            is_numeric($value)
+            &&
+            is_numeric($comparedToValue)
+            &&
+            $this->hasRule($attribute, $this->numericRules)
+        ) {
             return $value >= $comparedToValue;
         }
 
@@ -1014,11 +1121,23 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if (
+            is_null($comparedToValue)
+            &&
+            is_numeric($value)
+            &&
+            is_numeric($parameters[0])
+        ) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (
+            is_numeric($value)
+            &&
+            is_numeric($comparedToValue)
+            &&
+            $this->hasRule($attribute, $this->numericRules)
+        ) {
             return $value <= $comparedToValue;
         }
 
@@ -1061,7 +1180,9 @@ trait ValidatesAttributes
             return count(array_diff($value, $parameters)) === 0;
         }
 
-        return ! is_array($value) && in_array((string) $value, $parameters);
+        return ! is_array($value)
+               &&
+               in_array((string) $value, $parameters);
     }
 
     /**
@@ -1080,7 +1201,7 @@ trait ValidatesAttributes
 
         $attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
 
-        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+        $otherValues = Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($parameters) {
             return Str::is($parameters[0], $key);
         });
 
@@ -1144,7 +1265,11 @@ trait ValidatesAttributes
      */
     public function validateJson($attribute, $value)
     {
-        if (! is_scalar($value) && ! method_exists($value, '__toString')) {
+        if (
+            ! is_scalar($value)
+            &&
+            ! method_exists($value, '__toString')
+        ) {
             return false;
         }
 
@@ -1190,7 +1315,9 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $value->getPath() !== '' && in_array($value->guessExtension(), $parameters);
+        return $value->getPath() !== ''
+               &&
+               in_array($value->guessExtension(), $parameters);
     }
 
     /**
@@ -1211,9 +1338,13 @@ trait ValidatesAttributes
             return false;
         }
 
-        return $value->getPath() !== '' &&
-                (in_array($value->getMimeType(), $parameters) ||
-                 in_array(explode('/', $value->getMimeType())[0].'/*', $parameters));
+        return $value->getPath() !== ''
+               &&
+               (
+                   in_array($value->getMimeType(), $parameters)
+                   ||
+                   in_array(explode('/', $value->getMimeType())[0].'/*', $parameters)
+               );
     }
 
     /**
@@ -1234,8 +1365,8 @@ trait ValidatesAttributes
         ];
 
         return ($value instanceof UploadedFile)
-           ? in_array(trim(strtolower($value->getClientOriginalExtension())), $phpExtensions)
-           : in_array(trim(strtolower($value->getExtension())), $phpExtensions);
+           ? in_array(strtolower(trim($value->getClientOriginalExtension())), $phpExtensions)
+           : in_array(strtolower(trim($value->getExtension())), $phpExtensions);
     }
 
     /**
@@ -1303,6 +1434,7 @@ trait ValidatesAttributes
         $auth = $this->container->make('auth');
         $hasher = $this->container->make('hash');
 
+        /** @var \Illuminate\Contracts\Auth\Guard $guard */
         $guard = $auth->guard(Arr::first($parameters));
 
         if ($guard->guest()) {
@@ -1466,7 +1598,7 @@ trait ValidatesAttributes
      */
     protected function convertValuesToBoolean($values)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             if ($value === 'true') {
                 return true;
             } elseif ($value === 'false') {
@@ -1830,7 +1962,7 @@ trait ValidatesAttributes
      */
     protected function parseNamedParameters($parameters)
     {
-        return array_reduce($parameters, function ($result, $item) {
+        return array_reduce($parameters, static function ($result, $item) {
             [$key, $value] = array_pad(explode('=', $item, 2), 2, null);
 
             $result[$key] = $value;

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -39,7 +39,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
      * @param  string  $collection
      * @param  string  $column
      * @param  string  $value
-     * @param  int|null  $excludeId
+     * @param  int|string|null  $excludeId
      * @param  string|null  $idColumn
      * @param  array  $extra
      * @return int
@@ -82,7 +82,7 @@ class DatabasePresenceVerifier implements PresenceVerifierInterface
     {
         foreach ($conditions as $key => $value) {
             if ($value instanceof Closure) {
-                $query->where(function ($query) use ($value) {
+                $query->where(static function ($query) use ($value) {
                     $value($query);
                 });
             } else {

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -138,7 +138,8 @@ trait DatabaseRule
      */
     public function whereIn($column, array $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
+            /** @var \Illuminate\Database\Query\Builder $query */
             $query->whereIn($column, $values);
         });
     }
@@ -152,7 +153,8 @@ trait DatabaseRule
      */
     public function whereNotIn($column, array $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
+            /** @var \Illuminate\Database\Query\Builder $query */
             $query->whereNotIn($column, $values);
         });
     }
@@ -187,7 +189,7 @@ trait DatabaseRule
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map(function ($where) {
+        return collect($this->wheres)->map(static function ($where) {
             return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
         })->implode(',');
     }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -36,7 +36,7 @@ class In
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -34,7 +34,7 @@ class NotIn
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/ValidationData.php
+++ b/src/Illuminate/Validation/ValidationData.php
@@ -55,7 +55,7 @@ class ValidationData
     {
         $keys = [];
 
-        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]+', preg_quote($attribute, '/'));
 
         foreach ($data as $key => $value) {
             if ((bool) preg_match('/^'.$pattern.'/', $key, $matches)) {

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -68,9 +68,10 @@ class ValidationException extends Exception
      */
     public static function withMessages(array $messages)
     {
-        return new static(tap(ValidatorFacade::make([], []), function ($validator) use ($messages) {
+        return new static(tap(ValidatorFacade::make([], []), static function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
                 foreach (Arr::wrap($value) as $message) {
+                    /** @var \Illuminate\Contracts\Validation\Validator $validator */
                     $validator->errors()->add($key, $message);
                 }
             }

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -104,10 +104,15 @@ class ValidationRuleParser
             $rule = new ClosureValidationRule($rule);
         }
 
-        if (! is_object($rule) ||
-            $rule instanceof RuleContract ||
-            ($rule instanceof Exists && $rule->queryCallbacks()) ||
-            ($rule instanceof Unique && $rule->queryCallbacks())) {
+        if (
+            ! is_object($rule)
+            ||
+            $rule instanceof RuleContract
+            ||
+            ($rule instanceof Exists && $rule->queryCallbacks())
+            ||
+            ($rule instanceof Unique && $rule->queryCallbacks())
+        ) {
             return $rule;
         }
 
@@ -124,14 +129,18 @@ class ValidationRuleParser
      */
     protected function explodeWildcardRules($results, $attribute, $rules)
     {
-        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute));
+        $pattern = str_replace('\*', '[^\.]*', preg_quote($attribute, '/'));
 
         $data = ValidationData::initializeAndGatherData($attribute, $this->data);
 
         foreach ($data as $key => $value) {
-            if (Str::startsWith($key, $attribute) || (bool) preg_match('/^'.$pattern.'\z/', $key)) {
+            if (
+                Str::startsWith($key, $attribute)
+                ||
+                (bool) preg_match('/^'.$pattern.'\z/', $key)
+            ) {
                 foreach ((array) $rules as $rule) {
-                    $this->implicitAttributes[$attribute][] = strval($key);
+                    $this->implicitAttributes[$attribute][] = (string)$key;
 
                     $results = $this->mergeRules($results, $key, $rule);
                 }

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -26,7 +26,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerValidationFactory()
     {
-        $this->app->singleton('validator', function ($app) {
+        $this->app->singleton('validator', static function ($app) {
             $validator = new Factory($app['translator'], $app);
 
             // The validation presence verifier is responsible for determining the existence of
@@ -47,7 +47,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerPresenceVerifier()
     {
-        $this->app->singleton('validation.presence', function ($app) {
+        $this->app->singleton('validation.presence', static function ($app) {
             return new DatabasePresenceVerifier($app['db']);
         });
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -158,7 +158,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         return collect(token_get_all($contents))
             ->pluck(0)
-            ->filter(function ($token) {
+            ->filter(static function ($token) {
                 return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
             });
     }
@@ -446,25 +446,25 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $this->conditions[$name] = $callback;
 
-        $this->directive($name, function ($expression) use ($name) {
+        $this->directive($name, static function ($expression) use ($name) {
             return $expression !== ''
                     ? "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('unless'.$name, function ($expression) use ($name) {
+        $this->directive('unless'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('else'.$name, function ($expression) use ($name) {
+        $this->directive('else'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('end'.$name, function () {
+        $this->directive('end'.$name, static function () {
             return '<?php endif; ?>';
         });
     }
@@ -492,13 +492,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $alias = $alias ?: Arr::last(explode('.', $path));
 
-        $this->directive($alias, function ($expression) use ($path) {
+        $this->directive($alias, static function ($expression) use ($path) {
             return $expression
                         ? "<?php \$__env->startComponent('{$path}', {$expression}); ?>"
                         : "<?php \$__env->startComponent('{$path}'); ?>";
         });
 
-        $this->directive('end'.$alias, function ($expression) {
+        $this->directive('end'.$alias, static function ($expression) {
             return '<?php echo $__env->renderComponent(); ?>';
         });
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -43,7 +43,7 @@ trait CompilesEchos
     {
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->rawTags[0], $this->rawTags[1]);
 
-        $callback = function ($matches) {
+        $callback = static function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
@@ -83,7 +83,7 @@ trait CompilesEchos
     {
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
 
-        $callback = function ($matches) {
+        $callback = static function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
             return $matches[1] ? $matches[0] : "<?php echo e({$matches[2]}); ?>{$whitespace}";

--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -37,7 +37,11 @@ trait ManagesEvents
         $registered = [];
 
         foreach ($composers as $callback => $views) {
-            $registered = array_merge($registered, $this->composer($views, $callback));
+            $registered[] = $this->composer($views, $callback);
+        }
+
+        if ($registered !== []) {
+            $registered = array_merge([], ...$registered);
         }
 
         return $registered;

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -299,7 +299,7 @@ class Factory implements FactoryContract
     {
         $extensions = array_keys($this->extensions);
 
-        return Arr::first($extensions, function ($value) use ($path) {
+        return Arr::first($extensions, static function ($value) use ($path) {
             return Str::endsWith($path, '.'.$value);
         });
     }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -145,7 +145,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(function ($extension) use ($name) {
+        return array_map(static function ($extension) use ($name) {
             return str_replace('.', '/', $name).'.'.$extension;
         }, $this->extensions);
     }

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -223,12 +223,13 @@ class View implements ArrayAccess, Htmlable, ViewContract
      * Format the given message provider into a MessageBag.
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array  $provider
-     * @return \Illuminate\Support\MessageBag
+     * @return \Illuminate\Contracts\Support\MessageBag
      */
     protected function formatErrors($provider)
     {
         return $provider instanceof MessageProvider
-                        ? $provider->getMessageBag() : new MessageBag((array) $provider);
+                        ? $provider->getMessageBag()
+                        : new MessageBag((array) $provider);
     }
 
     /**

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -75,7 +75,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerViewFinder()
     {
-        $this->app->bind('view.finder', function ($app) {
+        $this->app->bind('view.finder', static function ($app) {
             return new FileViewFinder($app['files'], $app['config']['view.paths']);
         });
     }
@@ -123,7 +123,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFileEngine($resolver)
     {
-        $resolver->register('file', function () {
+        $resolver->register('file', static function () {
             return new FileEngine;
         });
     }
@@ -136,7 +136,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerPhpEngine($resolver)
     {
-        $resolver->register('php', function () {
+        $resolver->register('php', static function () {
             return new PhpEngine;
         });
     }

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -189,10 +189,14 @@ class DatabaseConnectorTest extends TestCase
 
         $availableDrivers = PDO::getAvailableDrivers();
 
-        if (in_array('odbc', $availableDrivers) &&
-            ($config['odbc'] ?? null) === true) {
+        if (
+            in_array('odbc', $availableDrivers)
+            &&
+            ($config['odbc'] ?? null) === true
+        ) {
             return isset($config['odbc_datasource_name'])
-                ? 'odbc:'.$config['odbc_datasource_name'] : '';
+                ? 'odbc:'.$config['odbc_datasource_name']
+                : '';
         }
 
         if (in_array('sqlsrv', $availableDrivers)) {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -2174,7 +2174,7 @@ class EloquentModelDestroyStub extends Model
 
 class EloquentModelHydrateRawStub extends Model
 {
-    public static function hydrate(array $items, $connection = null)
+    public function hydrate(array $items, $connection = null)
     {
         return 'hydrated';
     }

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -27,20 +27,23 @@ class SupportArrTest extends TestCase
 
     public function testAdd()
     {
-        $array = Arr::add(['name' => 'Desk'], 'price', 100);
-        $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+        $array = Arr::add(['foo' => 'bar'], 1, 99);
+        $this->assertSame(['foo' => 'bar', 1 => 99], $array);
 
-        $this->assertEquals(['surname' => 'Mövsümov'], Arr::add([], 'surname', 'Mövsümov'));
-        $this->assertEquals(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
+        $array = Arr::add(['name' => 'Desk'], 'price', 100);
+        $this->assertSame(['name' => 'Desk', 'price' => 100], $array);
+
+        $this->assertSame(['surname' => 'Mövsümov'], Arr::add([], 'surname', 'Mövsümov'));
+        $this->assertSame(['developer' => ['name' => 'Ferid']], Arr::add([], 'developer.name', 'Ferid'));
     }
 
     public function testCollapse()
     {
         $data = [['foo', 'bar'], ['baz']];
-        $this->assertEquals(['foo', 'bar', 'baz'], Arr::collapse($data));
+        $this->assertSame(['foo', 'bar', 'baz'], Arr::collapse($data));
 
         $array = [[1], [2], [3], ['foo', 'bar'], collect(['baz', 'boom'])];
-        $this->assertEquals([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($array));
+        $this->assertSame([1, 2, 3, 'foo', 'bar', 'baz', 'boom'], Arr::collapse($array));
     }
 
     public function testCrossJoin()
@@ -91,38 +94,38 @@ class SupportArrTest extends TestCase
     public function testDivide()
     {
         [$keys, $values] = Arr::divide(['name' => 'Desk']);
-        $this->assertEquals(['name'], $keys);
-        $this->assertEquals(['Desk'], $values);
+        $this->assertSame(['name'], $keys);
+        $this->assertSame(['Desk'], $values);
     }
 
     public function testDot()
     {
         $array = Arr::dot(['foo' => ['bar' => 'baz']]);
-        $this->assertEquals(['foo.bar' => 'baz'], $array);
+        $this->assertSame(['foo.bar' => 'baz'], $array);
 
         $array = Arr::dot([]);
-        $this->assertEquals([], $array);
+        $this->assertSame([], $array);
 
         $array = Arr::dot(['foo' => []]);
-        $this->assertEquals(['foo' => []], $array);
+        $this->assertSame(['foo' => []], $array);
 
         $array = Arr::dot(['foo' => ['bar' => []]]);
-        $this->assertEquals(['foo.bar' => []], $array);
+        $this->assertSame(['foo.bar' => []], $array);
 
         $array = Arr::dot(['name' => 'taylor', 'languages' => ['php' => true]]);
-        $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
+        $this->assertSame($array, ['name' => 'taylor', 'languages.php' => true]);
     }
 
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];
-        $this->assertEquals(['age' => 26], Arr::except($array, ['name']));
-        $this->assertEquals(['age' => 26], Arr::except($array, 'name'));
+        $this->assertSame(['age' => 26], Arr::except($array, ['name']));
+        $this->assertSame(['age' => 26], Arr::except($array, 'name'));
 
         $array = ['name' => 'taylor', 'framework' => ['language' => 'PHP', 'name' => 'Laravel']];
-        $this->assertEquals(['name' => 'taylor'], Arr::except($array, 'framework'));
-        $this->assertEquals(['name' => 'taylor', 'framework' => ['name' => 'Laravel']], Arr::except($array, 'framework.language'));
-        $this->assertEquals(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
+        $this->assertSame(['name' => 'taylor'], Arr::except($array, 'framework'));
+        $this->assertSame(['name' => 'taylor', 'framework' => ['name' => 'Laravel']], Arr::except($array, 'framework.language'));
+        $this->assertSame(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
     }
 
     public function testExists()
@@ -147,8 +150,8 @@ class SupportArrTest extends TestCase
             return $value >= 150;
         });
 
-        $this->assertEquals(200, $value);
-        $this->assertEquals(100, Arr::first($array));
+        $this->assertSame(200, $value);
+        $this->assertSame(100, Arr::first($array));
     }
 
     public function testLast()
@@ -158,77 +161,77 @@ class SupportArrTest extends TestCase
         $last = Arr::last($array, function ($value) {
             return $value < 250;
         });
-        $this->assertEquals(200, $last);
+        $this->assertSame(200, $last);
 
         $last = Arr::last($array, function ($value, $key) {
             return $key < 2;
         });
-        $this->assertEquals(200, $last);
+        $this->assertSame(200, $last);
 
-        $this->assertEquals(300, Arr::last($array));
+        $this->assertSame(300, Arr::last($array));
     }
 
     public function testFlatten()
     {
         // Flat arrays are unaffected
         $array = ['#foo', '#bar', '#baz'];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays are flattened with existing flat items
         $array = [['#foo', '#bar'], '#baz'];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Flattened array includes "null" items
         $array = [['#foo', null], '#baz', null];
-        $this->assertEquals(['#foo', null, '#baz', null], Arr::flatten($array));
+        $this->assertSame(['#foo', null, '#baz', null], Arr::flatten($array));
 
         // Sets of nested arrays are flattened
         $array = [['#foo', '#bar'], ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Deeply nested arrays are flattened
         $array = [['#foo', ['#bar']], ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays are flattened alongside arrays
         $array = [new Collection(['#foo', '#bar']), ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays containing plain arrays are flattened
         $array = [new Collection(['#foo', ['#bar']]), ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays containing arrays are flattened
         $array = [['#foo', new Collection(['#bar'])], ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz'], Arr::flatten($array));
 
         // Nested arrays containing arrays containing arrays are flattened
         $array = [['#foo', new Collection(['#bar', ['#zap']])], ['#baz']];
-        $this->assertEquals(['#foo', '#bar', '#zap', '#baz'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#zap', '#baz'], Arr::flatten($array));
     }
 
     public function testFlattenWithDepth()
     {
         // No depth flattens recursively
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
-        $this->assertEquals(['#foo', '#bar', '#baz', '#zap'], Arr::flatten($array));
+        $this->assertSame(['#foo', '#bar', '#baz', '#zap'], Arr::flatten($array));
 
         // Specifying a depth only flattens to that depth
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
-        $this->assertEquals(['#foo', ['#bar', ['#baz']], '#zap'], Arr::flatten($array, 1));
+        $this->assertSame(['#foo', ['#bar', ['#baz']], '#zap'], Arr::flatten($array, 1));
 
         $array = [['#foo', ['#bar', ['#baz']]], '#zap'];
-        $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
+        $this->assertSame(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
     public function testGet()
     {
         $array = ['products.desk' => ['price' => 100]];
-        $this->assertEquals(['price' => 100], Arr::get($array, 'products.desk'));
+        $this->assertSame(['price' => 100], Arr::get($array, 'products.desk'));
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         $value = Arr::get($array, 'products.desk');
-        $this->assertEquals(['price' => 100], $value);
+        $this->assertSame(['price' => 100], $value);
 
         // Test null array values
         $array = ['foo' => null, 'bar' => ['baz' => null]];
@@ -239,20 +242,20 @@ class SupportArrTest extends TestCase
         $array = ['products' => ['desk' => ['price' => 100]]];
         $arrayAccessObject = new ArrayObject($array);
         $value = Arr::get($arrayAccessObject, 'products.desk');
-        $this->assertEquals(['price' => 100], $value);
+        $this->assertSame(['price' => 100], $value);
 
         // Test array containing ArrayAccess object
         $arrayAccessChild = new ArrayObject(['products' => ['desk' => ['price' => 100]]]);
         $array = ['child' => $arrayAccessChild];
         $value = Arr::get($array, 'child.products.desk');
-        $this->assertEquals(['price' => 100], $value);
+        $this->assertSame(['price' => 100], $value);
 
         // Test array containing multiple nested ArrayAccess objects
         $arrayAccessChild = new ArrayObject(['products' => ['desk' => ['price' => 100]]]);
         $arrayAccessParent = new ArrayObject(['child' => $arrayAccessChild]);
         $array = ['parent' => $arrayAccessParent];
         $value = Arr::get($array, 'parent.child.products.desk');
-        $this->assertEquals(['price' => 100], $value);
+        $this->assertSame(['price' => 100], $value);
 
         // Test missing ArrayAccess object field
         $arrayAccessChild = new ArrayObject(['products' => ['desk' => ['price' => 100]]]);
@@ -274,7 +277,7 @@ class SupportArrTest extends TestCase
 
         // Test null key returns the whole array
         $array = ['foo', 'bar'];
-        $this->assertEquals($array, Arr::get($array, null));
+        $this->assertSame($array, Arr::get($array, null));
 
         // Test $array not an array
         $this->assertSame('default', Arr::get(null, 'foo', 'default'));
@@ -381,7 +384,7 @@ class SupportArrTest extends TestCase
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];
         $array = Arr::only($array, ['name', 'price']);
-        $this->assertEquals(['name' => 'Desk', 'price' => 100], $array);
+        $this->assertSame(['name' => 'Desk', 'price' => 100], $array);
         $this->assertEmpty(Arr::only($array, ['nonExistingKey']));
     }
 
@@ -404,7 +407,7 @@ class SupportArrTest extends TestCase
             ],
         ];
 
-        $this->assertEquals([
+        $this->assertSame([
             0 => [
                 'tags' => [
                     '#foo', '#bar',
@@ -417,9 +420,9 @@ class SupportArrTest extends TestCase
             ],
         ], Arr::pluck($data, 'comments'));
 
-        $this->assertEquals([['#foo', '#bar'], ['#baz']], Arr::pluck($data, 'comments.tags'));
-        $this->assertEquals([null, null], Arr::pluck($data, 'foo'));
-        $this->assertEquals([null, null], Arr::pluck($data, 'foo.bar'));
+        $this->assertSame([['#foo', '#bar'], ['#baz']], Arr::pluck($data, 'comments.tags'));
+        $this->assertSame([null, null], Arr::pluck($data, 'foo'));
+        $this->assertSame([null, null], Arr::pluck($data, 'foo.bar'));
 
         $array = [
             ['developer' => ['name' => 'Taylor']],
@@ -428,7 +431,7 @@ class SupportArrTest extends TestCase
 
         $array = Arr::pluck($array, 'developer.name');
 
-        $this->assertEquals(['Taylor', 'Abigail'], $array);
+        $this->assertSame(['Taylor', 'Abigail'], $array);
     }
 
     public function testPluckWithArrayValue()
@@ -438,7 +441,7 @@ class SupportArrTest extends TestCase
             ['developer' => ['name' => 'Abigail']],
         ];
         $array = Arr::pluck($array, ['developer', 'name']);
-        $this->assertEquals(['Taylor', 'Abigail'], $array);
+        $this->assertSame(['Taylor', 'Abigail'], $array);
     }
 
     public function testPluckWithKeys()
@@ -451,12 +454,12 @@ class SupportArrTest extends TestCase
         $test1 = Arr::pluck($array, 'role', 'name');
         $test2 = Arr::pluck($array, null, 'name');
 
-        $this->assertEquals([
+        $this->assertSame([
             'Taylor' => 'developer',
             'Abigail' => 'developer',
         ], $test1);
 
-        $this->assertEquals([
+        $this->assertSame([
             'Taylor' => ['name' => 'Taylor', 'role' => 'developer'],
             'Abigail' => ['name' => 'Abigail', 'role' => 'developer'],
         ], $test2);
@@ -474,17 +477,17 @@ class SupportArrTest extends TestCase
     public function testArrayPluckWithArrayAndObjectValues()
     {
         $array = [(object) ['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']];
-        $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, 'name'));
-        $this->assertEquals(['taylor' => 'foo', 'dayle' => 'bar'], Arr::pluck($array, 'email', 'name'));
+        $this->assertSame(['taylor', 'dayle'], Arr::pluck($array, 'name'));
+        $this->assertSame(['taylor' => 'foo', 'dayle' => 'bar'], Arr::pluck($array, 'email', 'name'));
     }
 
     public function testArrayPluckWithNestedKeys()
     {
         $array = [['user' => ['taylor', 'otwell']], ['user' => ['dayle', 'rees']]];
-        $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, 'user.0'));
-        $this->assertEquals(['taylor', 'dayle'], Arr::pluck($array, ['user', 0]));
-        $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, 'user.1', 'user.0'));
-        $this->assertEquals(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, ['user', 1], ['user', 0]));
+        $this->assertSame(['taylor', 'dayle'], Arr::pluck($array, 'user.0'));
+        $this->assertSame(['taylor', 'dayle'], Arr::pluck($array, ['user', 0]));
+        $this->assertSame(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, 'user.1', 'user.0'));
+        $this->assertSame(['taylor' => 'otwell', 'dayle' => 'rees'], Arr::pluck($array, ['user', 1], ['user', 0]));
     }
 
     public function testArrayPluckWithNestedArrays()
@@ -505,18 +508,18 @@ class SupportArrTest extends TestCase
             ],
         ];
 
-        $this->assertEquals([['taylor'], ['abigail', 'dayle']], Arr::pluck($array, 'users.*.first'));
-        $this->assertEquals(['a' => ['taylor'], 'b' => ['abigail', 'dayle']], Arr::pluck($array, 'users.*.first', 'account'));
-        $this->assertEquals([['taylorotwell@gmail.com'], [null, null]], Arr::pluck($array, 'users.*.email'));
+        $this->assertSame([['taylor'], ['abigail', 'dayle']], Arr::pluck($array, 'users.*.first'));
+        $this->assertSame(['a' => ['taylor'], 'b' => ['abigail', 'dayle']], Arr::pluck($array, 'users.*.first', 'account'));
+        $this->assertSame([['taylorotwell@gmail.com'], [null, null]], Arr::pluck($array, 'users.*.email'));
     }
 
     public function testPrepend()
     {
         $array = Arr::prepend(['one', 'two', 'three', 'four'], 'zero');
-        $this->assertEquals(['zero', 'one', 'two', 'three', 'four'], $array);
+        $this->assertSame(['zero', 'one', 'two', 'three', 'four'], $array);
 
         $array = Arr::prepend(['one' => 1, 'two' => 2], 0, 'zero');
-        $this->assertEquals(['zero' => 0, 'one' => 1, 'two' => 2], $array);
+        $this->assertSame(['zero' => 0, 'one' => 1, 'two' => 2], $array);
     }
 
     public function testPull()
@@ -524,19 +527,19 @@ class SupportArrTest extends TestCase
         $array = ['name' => 'Desk', 'price' => 100];
         $name = Arr::pull($array, 'name');
         $this->assertSame('Desk', $name);
-        $this->assertEquals(['price' => 100], $array);
+        $this->assertSame(['price' => 100], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane'];
         $name = Arr::pull($array, 'joe@example.com');
         $this->assertSame('Joe', $name);
-        $this->assertEquals(['jane@localhost' => 'Jane'], $array);
+        $this->assertSame(['jane@localhost' => 'Jane'], $array);
 
         // Does not work for nested keys
         $array = ['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']];
         $name = Arr::pull($array, 'emails.joe@example.com');
         $this->assertNull($name);
-        $this->assertEquals(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
+        $this->assertSame(['emails' => ['joe@example.com' => 'Joe', 'jane@localhost' => 'Jane']], $array);
     }
 
     public function testQuery()
@@ -625,12 +628,12 @@ class SupportArrTest extends TestCase
     {
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::set($array, 'products.desk.price', 200);
-        $this->assertEquals(['products' => ['desk' => ['price' => 200]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => 200]]], $array);
     }
 
     public function testShuffleWithSeed()
     {
-        $this->assertEquals(
+        $this->assertSame(
             Arr::shuffle(range(0, 100, 10), 1234),
             Arr::shuffle(range(0, 100, 10), 1234)
         );
@@ -649,17 +652,17 @@ class SupportArrTest extends TestCase
         ];
 
         $sorted = array_values(Arr::sort($unsorted));
-        $this->assertEquals($expected, $sorted);
+        $this->assertSame($expected, $sorted);
 
         // sort with closure
         $sortedWithClosure = array_values(Arr::sort($unsorted, function ($value) {
             return $value['name'];
         }));
-        $this->assertEquals($expected, $sortedWithClosure);
+        $this->assertSame($expected, $sortedWithClosure);
 
         // sort with dot notation
         $sortedWithDotNotation = array_values(Arr::sort($unsorted, 'name'));
-        $this->assertEquals($expected, $sortedWithDotNotation);
+        $this->assertSame($expected, $sortedWithDotNotation);
     }
 
     public function testSortRecursive()
@@ -728,7 +731,7 @@ class SupportArrTest extends TestCase
             return is_string($value);
         });
 
-        $this->assertEquals([1 => '200', 3 => '400'], $array);
+        $this->assertSame([1 => '200', 3 => '400'], $array);
     }
 
     public function testWhereKey()
@@ -739,56 +742,56 @@ class SupportArrTest extends TestCase
             return is_numeric($key);
         });
 
-        $this->assertEquals(['10' => 1, 20 => 2], $array);
+        $this->assertSame(['10' => 1, 20 => 2], $array);
     }
 
     public function testForget()
     {
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, null);
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => 100]]], $array);
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, []);
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => 100]]], $array);
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, 'products.desk');
-        $this->assertEquals(['products' => []], $array);
+        $this->assertSame(['products' => []], $array);
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, 'products.desk.price');
-        $this->assertEquals(['products' => ['desk' => []]], $array);
+        $this->assertSame(['products' => ['desk' => []]], $array);
 
         $array = ['products' => ['desk' => ['price' => 100]]];
         Arr::forget($array, 'products.final.price');
-        $this->assertEquals(['products' => ['desk' => ['price' => 100]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => 100]]], $array);
 
         $array = ['shop' => ['cart' => [150 => 0]]];
         Arr::forget($array, 'shop.final.cart');
-        $this->assertEquals(['shop' => ['cart' => [150 => 0]]], $array);
+        $this->assertSame(['shop' => ['cart' => [150 => 0]]], $array);
 
         $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
         Arr::forget($array, 'products.desk.price.taxes');
-        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50]]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => ['original' => 50]]]], $array);
 
         $array = ['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]];
         Arr::forget($array, 'products.desk.final.taxes');
-        $this->assertEquals(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
+        $this->assertSame(['products' => ['desk' => ['price' => ['original' => 50, 'taxes' => 60]]]], $array);
 
         $array = ['products' => ['desk' => ['price' => 50], null => 'something']];
         Arr::forget($array, ['products.amount.all', 'products.desk.price']);
-        $this->assertEquals(['products' => ['desk' => [], null => 'something']], $array);
+        $this->assertSame(['products' => ['desk' => [], null => 'something']], $array);
 
         // Only works on first level keys
         $array = ['joe@example.com' => 'Joe', 'jane@example.com' => 'Jane'];
         Arr::forget($array, 'joe@example.com');
-        $this->assertEquals(['jane@example.com' => 'Jane'], $array);
+        $this->assertSame(['jane@example.com' => 'Jane'], $array);
 
         // Does not work for nested keys
         $array = ['emails' => ['joe@example.com' => ['name' => 'Joe'], 'jane@localhost' => ['name' => 'Jane']]];
         Arr::forget($array, ['emails.joe@example.com', 'emails.jane@localhost']);
-        $this->assertEquals(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
+        $this->assertSame(['emails' => ['joe@example.com' => ['name' => 'Joe']]], $array);
     }
 
     public function testWrap()
@@ -797,22 +800,22 @@ class SupportArrTest extends TestCase
         $array = ['a'];
         $object = new stdClass;
         $object->value = 'a';
-        $this->assertEquals(['a'], Arr::wrap($string));
-        $this->assertEquals($array, Arr::wrap($array));
-        $this->assertEquals([$object], Arr::wrap($object));
-        $this->assertEquals([], Arr::wrap(null));
-        $this->assertEquals([null], Arr::wrap([null]));
-        $this->assertEquals([null, null], Arr::wrap([null, null]));
-        $this->assertEquals([''], Arr::wrap(''));
-        $this->assertEquals([''], Arr::wrap(['']));
-        $this->assertEquals([false], Arr::wrap(false));
-        $this->assertEquals([false], Arr::wrap([false]));
-        $this->assertEquals([0], Arr::wrap(0));
+        $this->assertSame(['a'], Arr::wrap($string));
+        $this->assertSame($array, Arr::wrap($array));
+        $this->assertSame([$object], Arr::wrap($object));
+        $this->assertSame([], Arr::wrap(null));
+        $this->assertSame([null], Arr::wrap([null]));
+        $this->assertSame([null, null], Arr::wrap([null, null]));
+        $this->assertSame([''], Arr::wrap(''));
+        $this->assertSame([''], Arr::wrap(['']));
+        $this->assertSame([false], Arr::wrap(false));
+        $this->assertSame([false], Arr::wrap([false]));
+        $this->assertSame([0], Arr::wrap(0));
 
         $obj = new stdClass;
         $obj->value = 'a';
         $obj = unserialize(serialize($obj));
-        $this->assertEquals([$obj], Arr::wrap($obj));
+        $this->assertSame([$obj], Arr::wrap($obj));
         $this->assertSame($obj, Arr::wrap($obj)[0]);
     }
 }


### PR DESCRIPTION
- fix phpdocs
- use some more modern phpdocs (e.g. array → Model[] | https://suckup.de/2020/02/modern-phpdoc-annotations/)
- add static for anonymous functions (less work for PHP and for the IDE, because $this is not allowed)
- use "array-unpacking" (https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop)
- replace "call_user_func" (#29932 ← the tests passed, but maybe I missed something here)
- use "array_values()" only if needed
- fix usage of "preg_quote()" (https://www.php.net/manual/en/function.preg-quote.php)
- code style for if-condition (http://suckup.de/2020/01/do-not-fear-the-white-space-in-your-code/)
- optimize some if-condition orders (reported by Php Inspections {EA Ultimate} → https://plugins.jetbrains.com/plugin/10215-php-inspections-ea-ultimate-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/framework/31700)
<!-- Reviewable:end -->
