### PR TITLE
[7.x] Exposable component fields

### DIFF
--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -59,6 +59,19 @@ class ViewComponentTest extends TestCase
         $this->assertArrayNotHasKey('taylor', $variables);
     }
 
+    public function testItCanExposeMethodsAndProperties()
+    {
+        $component = new TestExposableViewComponent();
+        $variables = $component->data();
+
+        $this->assertArrayHasKey('hello', $variables);
+        $this->assertArrayHasKey('taylor', $variables);
+        $this->assertArrayNotHasKey('notExposed', $variables);
+        $this->assertArrayNotHasKey('notExposedMethod', $variables);
+        $this->assertArrayNotHasKey('render', $variables);
+        $this->assertArrayNotHasKey('__construct', $variables);
+    }
+
     public function testMethodsOverridePropertyValues()
     {
         $component = new TestHelloPropertyHelloMethodComponent();
@@ -148,6 +161,37 @@ class TestExceptedViewComponent extends Component
     }
 
     public function hello2()
+    {
+        return $this->taylor = '';
+    }
+
+    public function render()
+    {
+        return 'test';
+    }
+}
+
+class TestExposableViewComponent extends Component
+{
+    protected $exposedMethods = ['hello'];
+
+    protected $exposedProperties = ['taylor'];
+
+    public $taylor = 'Otwell';
+
+    public $notExposed = 'hide';
+
+    public function __construct()
+    {
+        //
+    }
+
+    public function hello($string = 'world')
+    {
+        return $string;
+    }
+
+    public function notExposedMethod()
     {
         return $this->taylor = '';
     }


### PR DESCRIPTION
Currently laravel has to do reflation twice per component class on the page on each and every request to extract methods and properties and then cache (memoize) it.

This is not a horrible performance hit, but it is always nice to offer a more fastidious user a way to avoid reflection if they decide to boost their performance.

So laravel gracefully uses slower reflection technique if the user does not mention the exposed fields to the component. 

Convention in the absence of Configuration.

- Let me  mention that this change is fully backward-compatible.

Sample component :
```php
<?php
class TestRegularViewComponent extends Component
{
    protected $exposedProperties = ['title'];

    protected $exposedMethods = ['heyMan'];

    public $title;

    public function render()
    {
        return 'alert';
    }

    public function heyMan()
    {
        return 'alert: 🦠 19';
    }
}
```
