### PR TITLE
[6.x] Restore php 7.4 compatibility for paginator resources and objects

### DIFF
--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -50,6 +50,10 @@ trait DelegatesToResource
      */
     public function offsetExists($offset)
     {
+        if (is_object($this->resource)) {
+            return $this->__isset($offset);
+        }
+
         return isset($this->resource[$offset]);
     }
 
@@ -61,6 +65,10 @@ trait DelegatesToResource
      */
     public function offsetGet($offset)
     {
+        if (is_object($this->resource)) {
+            return $this->__get($offset);
+        }
+
         return $this->resource[$offset];
     }
 
@@ -73,6 +81,12 @@ trait DelegatesToResource
      */
     public function offsetSet($offset, $value)
     {
+        if (is_object($this->resource)) {
+            $this->resource->{$offset} = $value;
+
+            return;
+        }
+
         $this->resource[$offset] = $value;
     }
 
@@ -84,6 +98,12 @@ trait DelegatesToResource
      */
     public function offsetUnset($offset)
     {
+        if (is_object($this->resource)) {
+            $this->__unset($offset);
+
+            return;
+        }
+
         unset($this->resource[$offset]);
     }
 

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -528,6 +528,33 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    public function testPaginatorResourceWorksWithObject()
+    {
+        Route::get('/', function () {
+            $paginator = new LengthAwarePaginator(
+                collect([(object) ['id' => 5, 'title' => 'Test Title']]),
+                10, 15, 1
+            );
+
+            return new PostCollectionResource($paginator);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                [
+                    'id' => 5,
+                    'title' => 'Test Title',
+                ],
+            ],
+        ]);
+    }
+
     public function testPaginatorResourceCanPreserveQueryParameters()
     {
         Route::get('/', function () {


### PR DESCRIPTION
Restores php 7.4 compatibility for paginator resources that receives objects (for example from the query builder) instead of models.

Fixes #31703 and fixes #29916