### PR TITLE
[7.x] Add str() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\HigherOrderTapProxy;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Str;
 
 if (! function_exists('append_config')) {
     /**
@@ -402,6 +403,19 @@ if (! function_exists('retry')) {
 
             goto beginning;
         }
+    }
+}
+
+if (! function_exists('str')) {
+    /**
+     * Get a new stringable object from the given string.
+     *
+     * @param  string  $string
+     * @return \Illuminate\Support\Stringable
+     */
+    function str($string)
+    {
+        return Str::of($string);
     }
 }
 


### PR DESCRIPTION
It's no secret, I love me a good string helper.

It was a sad day for me when they were all gone from the core...

BUT! HERE is the one helper to rule them all: `str()`

This will be the last string helper ever pulled into Laravel. The helper to end all helpers.

Witness its beauty:
```php
str('how majestic')->finish(' is the str helper');
str('watch it dance')->between('watch ', 'dance');
str('with such grace')->explode(' ')->implode(' ');
```

We have `collect()` and love it, `str()` is a natural companion.
