### PR TITLE
[7.x] Add withoutComponentTags() to Blade facade docblock

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -19,6 +19,7 @@ namespace Illuminate\Support\Facades;
  * @method static void setEchoFormat(string $format)
  * @method static void withDoubleEncoding()
  * @method static void withoutDoubleEncoding()
+ * @method static void withoutComponentTags()
  *
  * @see \Illuminate\View\Compilers\BladeCompiler
  */


### PR DESCRIPTION
While upgrading to Laravel 7.x I noticed that the withoutComponentTags() was missing in the docblock of `Illuminate/Support/Facades/Blade.php`.

This PR adds it.