### PR TITLE
Make v7 console commands signature definition consistent

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -8,11 +8,11 @@ use Illuminate\Filesystem\Filesystem;
 class StubPublishCommand extends Command
 {
     /**
-     * The name and signature of the console command.
+     * The console command name.
      *
      * @var string
      */
-    protected $signature = 'stub:publish';
+    protected $name = 'stub:publish';
 
     /**
      * The console command description.


### PR DESCRIPTION
This PR makes Artisan commands signature definition consistent for the new commands.

In v7 there were 2 new console commands introduced: `ComponentMakeCommand` & `StubPublishCommand`.

Component make command signature defined using `$name` class property while Stub publish command uses `$signature` class property.

I'm proposing to use `$name` property with `getOptions` & `getArguments` methods because these commands will be more flexible for extension.
This question was raised before #30077 for the old commands, but due to the breaking changes there was no easy migration solution. Let's follow this convention for the future commands.
