### PR TITLE
[7.x] Add message to RequestException

### DIFF
--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -21,7 +21,7 @@ class RequestException extends Exception
      */
     public function __construct(Response $response)
     {
-        parent::__construct("{$response->effectiveUri()} returned status code {$response->status()}", $response->status());
+        parent::__construct("{$response->effectiveUri()} returned status code {$response->status()}.", $response->status());
 
         $this->response = $response;
     }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -21,6 +21,8 @@ class RequestException extends Exception
      */
     public function __construct(Response $response)
     {
+        parent::__construct("{$response->effectiveUri()} returned status code {$response->status()}", $response->status());
+
         $this->response = $response;
     }
 }


### PR DESCRIPTION
Just add a message to RequestException with the URI and the response status code to simplify error handling when using `throw()` because currently the exception message is empty 