### PR TITLE
[8.x] Depend on database contracts

### DIFF
--- a/src/Illuminate/Database/Capsule/Manager.php
+++ b/src/Illuminate/Database/Capsule/Manager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Capsule;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Connectors\ConnectionFactory;
 use Illuminate\Database\DatabaseManager;
@@ -24,10 +25,10 @@ class Manager
     /**
      * Create a new database capsule manager.
      *
-     * @param  \Illuminate\Container\Container|null  $container
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerContract $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Schema;
 
 use BadMethodCallException;
 use Closure;
-use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
@@ -87,11 +87,11 @@ class Blueprint
     /**
      * Execute the blueprint against the database.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return void
      */
-    public function build(Connection $connection, Grammar $grammar)
+    public function build(ConnectionInterface $connection, Grammar $grammar)
     {
         foreach ($this->toSql($connection, $grammar) as $statement) {
             $connection->statement($statement);
@@ -101,11 +101,11 @@ class Blueprint
     /**
      * Get the raw SQL statements for the blueprint.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface $connection
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return array
      */
-    public function toSql(Connection $connection, Grammar $grammar)
+    public function toSql(ConnectionInterface $connection, Grammar $grammar)
     {
         $this->addImpliedCommands($grammar);
 
@@ -132,12 +132,12 @@ class Blueprint
     /**
      * Ensure the commands on the blueprint are valid for the connection type.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface $connection
      * @return void
      *
      * @throws \BadMethodCallException
      */
-    protected function ensureCommandsAreValid(Connection $connection)
+    protected function ensureCommandsAreValid(ConnectionInterface $connection)
     {
         if ($connection instanceof SQLiteConnection) {
             if ($this->commandsNamed(['dropColumn', 'renameColumn'])->count() > 1) {

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -4,7 +4,7 @@ namespace Illuminate\Database\Schema;
 
 use Closure;
 use Doctrine\DBAL\Types\Type;
-use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
 use LogicException;
 use RuntimeException;
 
@@ -13,7 +13,7 @@ class Builder
     /**
      * The database connection instance.
      *
-     * @var \Illuminate\Database\Connection
+     * @var \Illuminate\Database\ConnectionInterface
      */
     protected $connection;
 
@@ -41,10 +41,10 @@ class Builder
     /**
      * Create a new database Schema manager.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @return void
      */
-    public function __construct(Connection $connection)
+    public function __construct(ConnectionInterface $connection)
     {
         $this->connection = $connection;
         $this->grammar = $connection->getSchemaGrammar();
@@ -342,7 +342,7 @@ class Builder
     /**
      * Get the database connection instance.
      *
-     * @return \Illuminate\Database\Connection
+     * @return \Illuminate\Database\ConnectionInterface
      */
     public function getConnection()
     {
@@ -352,10 +352,10 @@ class Builder
     /**
      * Set the database connection instance.
      *
-     * @param  \Illuminate\Database\Connection  $connection
+     * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @return $this
      */
-    public function setConnection(Connection $connection)
+    public function setConnection(ConnectionInterface $connection)
     {
         $this->connection = $connection;
 

--- a/src/Illuminate/Queue/Capsule/Manager.php
+++ b/src/Illuminate/Queue/Capsule/Manager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Queue\Capsule;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Support\Traits\CapsuleManagerTrait;
@@ -25,10 +26,10 @@ class Manager
     /**
      * Create a new queue capsule manager.
      *
-     * @param  \Illuminate\Container\Container|null  $container
+     * @param  \Illuminate\Contracts\Container\Container|null $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(ContainerContract $container = null)
     {
         $this->setupContainer($container ?: new Container);
 


### PR DESCRIPTION
More depending on interfaces instead of concrete instances. As discussed in a [previous PR](https://github.com/laravel/framework/pull/31450), I'm running some Illuminate components in a legacy project, and sometimes static analysis yells at me.

I believe this should go on the 7.x branch, but I seem to never get that right. Feedback is obviously welcome.