### PR TITLE
[7.x] Change default parameter of trim method to a space

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -524,7 +524,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function trim($characters = ' ')
+    public function trim($characters = ' \t\n\r\0\x0B')
     {
         return new static(trim(...array_merge([$this->value], func_get_args())));
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -524,7 +524,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function trim($characters = null)
+    public function trim($characters = ' ')
     {
         return new static(trim(...array_merge([$this->value], func_get_args())));
     }


### PR DESCRIPTION
Previously, the method had  `null` as default parameter. So whenever you were using the method, you had to supply an empty space to trim the empty space (which wouldn't make the code look elegant for which laravel is so good at). Here's a simple fix.

Update: The default php trim() function truncates spaces, tabs and new lines. Updates are applied to give the trim method similar specifications by default. 