### PR TITLE
[7.x] Add getPdo to ConnectionInterface.php

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -7,6 +7,13 @@ use Closure;
 interface ConnectionInterface
 {
     /**
+     * Get the current PDO connection.
+     *
+     * @return \PDO
+     */
+    public function getPdo();
+    
+    /**
      * Begin a fluent query against a database table.
      *
      * @param  \Closure|\Illuminate\Database\Query\Builder|string  $table


### PR DESCRIPTION
This stops Intelephense showing errors for `getPdo` if using `DB::connection()`.

Since `\Illuminate\Support\Facades\DB` has
```php
/* @method static \Illuminate\Database\ConnectionInterface connection(string $name = null)
```
![image](https://user-images.githubusercontent.com/1820017/75888578-5e1f1280-5e0a-11ea-86e5-f77d6e080172.png)

Apparently it must not break anything because `ConnectionInterface` is only used by `\Illuminate\Database\Connection`.