### PR TITLE
[7.x] Fix doc @return class in InteractsWithConsole

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -35,7 +35,7 @@ trait InteractsWithConsole
      *
      * @param  string  $command
      * @param  array  $parameters
-     * @return \Illuminate\Foundation\Testing\PendingCommand|int
+     * @return \Illuminate\Testing\PendingCommand|int
      */
     public function artisan($command, $parameters = [])
     {


### PR DESCRIPTION
`\Illuminate\Foundation\Testing\PendingCommand` is now `Illuminate\Testing\PendingCommand`