### PR TITLE
[7.x] Replace property_exists with ??

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastEvent.php
+++ b/src/Illuminate/Broadcasting/BroadcastEvent.php
@@ -44,8 +44,8 @@ class BroadcastEvent implements ShouldQueue
     public function __construct($event)
     {
         $this->event = $event;
-        $this->tries = property_exists($event, 'tries') ? $event->tries : null;
-        $this->timeout = property_exists($event, 'timeout') ? $event->timeout : null;
+        $this->tries = $event->tries ?? null;
+        $this->timeout = $event->timeout ?? null;
     }
 
     /**

--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -34,7 +34,6 @@ trait DatabaseTransactions
      */
     protected function connectionsToTransact()
     {
-        return property_exists($this, 'connectionsToTransact')
-                            ? $this->connectionsToTransact : [null];
+        return  $this->connectionsToTransact ?? [null];
     }
 }

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -101,8 +101,7 @@ trait RefreshDatabase
      */
     protected function connectionsToTransact()
     {
-        return property_exists($this, 'connectionsToTransact')
-                            ? $this->connectionsToTransact : [null];
+        return $this->connectionsToTransact ?? [null];
     }
 
     /**
@@ -112,8 +111,7 @@ trait RefreshDatabase
      */
     protected function shouldDropViews()
     {
-        return property_exists($this, 'dropViews')
-                            ? $this->dropViews : false;
+        return $this->dropViews ?? false;
     }
 
     /**
@@ -123,7 +121,6 @@ trait RefreshDatabase
      */
     protected function shouldDropTypes()
     {
-        return property_exists($this, 'dropTypes')
-                            ? $this->dropTypes : false;
+        return $this->dropTypes ?? false;
     }
 }

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -84,7 +84,7 @@ trait ConditionallyLoadsAttributes
             }
         }
 
-        if (property_exists($this, 'preserveKeys') && $this->preserveKeys === true) {
+        if (($this->preserveKeys ?? false) === true) {
             return $data;
         }
 

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -183,9 +183,9 @@ class Mailable implements MailableContract, Renderable
             return $this->later($this->delay, $queue);
         }
 
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->connection ?? null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->pushOn(
             $queueName ?: null, $this->newQueuedJob()
@@ -201,9 +201,9 @@ class Mailable implements MailableContract, Renderable
      */
     public function later($delay, Queue $queue)
     {
-        $connection = property_exists($this, 'connection') ? $this->connection : null;
+        $connection = $this->connection ?? null;
 
-        $queueName = property_exists($this, 'queue') ? $this->queue : null;
+        $queueName = $this->queue ?? null;
 
         return $queue->connection($connection)->laterOn(
             $queueName ?: null, $delay, $this->newQueuedJob()

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -37,8 +37,8 @@ class SendQueuedMailable
     public function __construct(MailableContract $mailable)
     {
         $this->mailable = $mailable;
-        $this->tries = property_exists($mailable, 'tries') ? $mailable->tries : null;
-        $this->timeout = property_exists($mailable, 'timeout') ? $mailable->timeout : null;
+        $this->tries = $mailable->tries ?? null;
+        $this->timeout = $mailable->timeout ?? null;
     }
 
     /**

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -60,8 +60,8 @@ class SendQueuedNotifications implements ShouldQueue
         $this->channels = $channels;
         $this->notification = $notification;
         $this->notifiables = Collection::wrap($notifiables);
-        $this->tries = property_exists($notification, 'tries') ? $notification->tries : null;
-        $this->timeout = property_exists($notification, 'timeout') ? $notification->timeout : null;
+        $this->tries = $notification->tries ?? null;
+        $this->timeout = $notification->timeout ?? null;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Most of the `propery_exists` statements can be replaced by the null coalescence operator: `??`.
This PR brings these following changes.