### PR TITLE
[7.x] Widen return of StatefulGuard::onceUsingId()

### DIFF
--- a/src/Illuminate/Contracts/Auth/StatefulGuard.php
+++ b/src/Illuminate/Contracts/Auth/StatefulGuard.php
@@ -43,7 +43,7 @@ interface StatefulGuard extends Guard
      * Log the given user ID into the application without sessions or cookies.
      *
      * @param  mixed  $id
-     * @return bool
+     * @return \Illuminate\Contracts\Auth\Authenticatable|bool
      */
     public function onceUsingId($id);
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31743

Right now `Illuminate\Auth\SessionGuard::onceUsingId()` returns either `\Illuminate\Contracts\Auth\Authenticatable` or boolean false, but the `Illuminate\Contracts\Auth\StatefulGuard::onceUsingId()` contract specifies that only a boolean value may be returned.

This PR widens the allowed return of the contract to match the actual usage within the framework with the most minimal B/C break possible (as the other option is to remove the object return from the SessionGuard).