### PR TITLE
[7.x] Improve container test

### DIFF
--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -198,6 +198,15 @@ class ContainerTest extends TestCase
         $this->assertSame($bound, $resolved);
     }
 
+    public function testBindingAnInstanceAsShared()
+    {
+        $container = new Container;
+        $bound = new stdClass;
+        $container->instance('foo', $bound);
+        $object = $container->make('foo');
+        $this->assertSame($bound, $object);
+    }
+
     public function testResolutionOfDefaultParameters()
     {
         $container = new Container;


### PR DESCRIPTION
I didn't see any assertion for testing the practical usage of the `instance()` method so I sent this pull request to add one.