### PR TITLE
[7.x] Fix a bug with slash prefix

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -229,10 +229,12 @@ class CompiledRouteCollection extends AbstractRouteCollection
         if (empty($attributes['action']['prefix'] ?? '')) {
             $baseUri = $attributes['uri'];
         } else {
+            $prefixParts = trim($attributes['action']['prefix'], '/');
+
             $baseUri = trim(implode(
                 '/', array_slice(
                     explode('/', trim($attributes['uri'], '/')),
-                    count(explode('/', trim($attributes['action']['prefix'], '/')))
+                    count($prefixParts !== '' ? explode('/', $prefixParts) : [])
                 )
             ), '/');
         }


### PR DESCRIPTION
Fixes an issue where the prefix could be a slash. Can maybe use some polishing.

```
Route::prefix('/')->group(function ($router) {
    $router->view('welcome/user', 'welcome');
});
```

Fixes https://github.com/laravel/framework/issues/31759