### PR TITLE
[7.x] Catch MethodNotAllowedException from Symfony matcher

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -5,6 +5,7 @@ namespace Illuminate\Routing;
 use Illuminate\Container\Container;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
 use Symfony\Component\Routing\RequestContext;
@@ -100,7 +101,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             if ($result = $matcher->matchRequest($request)) {
                 $route = $this->getByName($result['_route']);
             }
-        } catch (ResourceNotFoundException $e) {
+        } catch (ResourceNotFoundException | MethodNotAllowedException $e) {
             //
         }
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31756