### PR TITLE
[7.x] Add descriptive message for route not found

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -40,7 +40,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             return $this->getRouteForMethods($request, $others);
         }
 
-        throw new NotFoundHttpException;
+        throw new NotFoundHttpException('Page not found.');
     }
 
     /**


### PR DESCRIPTION
Even though the exception in itself is descriptive, it feels best to also set a message so the returned JSON payload from an API request has its message key populated.

Fixes https://github.com/laravel/framework/issues/31757