### PR TITLE
[6.x] Allow Broadcast Authorization Callbacks To Accept "Guests"

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -6,7 +6,6 @@ use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Pusher\Pusher;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class PusherBroadcaster extends Broadcaster
 {
@@ -41,11 +40,6 @@ class PusherBroadcaster extends Broadcaster
     public function auth($request)
     {
         $channelName = $this->normalizeChannelName($request->channel_name);
-
-        if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName)) {
-            throw new AccessDeniedHttpException;
-        }
 
         return parent::verifyUserCanAccessChannel(
             $request, $channelName

--- a/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/RedisBroadcaster.php
@@ -4,7 +4,6 @@ namespace Illuminate\Broadcasting\Broadcasters;
 
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Support\Arr;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class RedisBroadcaster extends Broadcaster
 {
@@ -59,11 +58,6 @@ class RedisBroadcaster extends Broadcaster
         $channelName = $this->normalizeChannelName(
             str_replace($this->prefix, '', $request->channel_name)
         );
-
-        if ($this->isGuardedChannel($request->channel_name) &&
-            ! $this->retrieveUser($request, $channelName)) {
-            throw new AccessDeniedHttpException;
-        }
 
         return parent::verifyUserCanAccessChannel(
             $request, $channelName


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR allows Broadcast channels [authorization callbacks](https://laravel.com/docs/6.x/broadcasting#defining-authorization-callbacks) to define "guest users", based on how [`Gates` do](https://laravel.com/docs/6.x/authorization#guest-users), since #24576.

This implements Idea [#1227](https://github.com/laravel/ideas/issues/1227), with the checking methods pretty much copied from the ones currently used by [`Gate`](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Auth/Access/Gate.php#L378).

At the moment, both the `PusherBroadcaster` and `RedisBroadcaster` throw `AccessDeniedHttpException` when [`retrieveUser()`](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php#L46) returns `null`, during private channels authorizations, before executing the user-defined authorization callback:
```
if ($this->isGuardedChannel($request->channel_name) &&
    ! $this->retrieveUser($request, $channelName)) {
    throw new AccessDeniedHttpException;
}
```

Therefore, it is impossible to use private channels with authentication methods that are not tied to a `User`, like Passport's [Client Credentials Grant](https://laravel.com/docs/6.x/passport#client-credentials-grant-tokens), that is used for machine-to-machine communication, as pointed out in Passport issue [#1166](https://github.com/laravel/passport/issues/1166).

Also, I imagine that the current check is in place to prevent the `$user` variable from being `null` in the authorization callback. However, if this code was executed when subscribing to a public channel, the `isGuardedChannel()` method would return `false`, and the `$user` variable could be passed with a `null` value to the authorization callback. I believe this doesn't happen because no HTTP request is made when subscribing to a public channel.

But with the methods from the `Gate` guest user authorization, this depends on how the callback is defined, and a `null` `$user` will only be allowed when an `optional` type-hint or a `null` default value is defined:
```
protected function parameterAllowsGuests($parameter)
{
    return ($parameter->getClass() && $parameter->allowsNull()) ||
           ($parameter->isDefaultValueAvailable() && is_null($parameter->getDefaultValue()));
}
```
