### PR TITLE
[8.x] Add default connection to model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -716,7 +716,7 @@ trait HasRelationships
     protected function newRelatedInstance($class)
     {
         return tap(new $class, function ($instance) {
-
+            //
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -716,9 +716,7 @@ trait HasRelationships
     protected function newRelatedInstance($class)
     {
         return tap(new $class, function ($instance) {
-            if (! $instance->getConnectionName()) {
-                $instance->setConnection($this->connection);
-            }
+
         });
     }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -169,6 +169,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
+
+        if (! $this->getConnectionName()) {
+            $this->connection = config('database.default');
+        }
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -169,10 +169,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $this->syncOriginal();
 
         $this->fill($attributes);
-
-        if (! $this->getConnectionName()) {
-            $this->connection = config('database.default');
-        }
     }
 
     /**


### PR DESCRIPTION
When I try to set a relation from a model with no default connection to a model with an undefined connection, the undefined connection is defined as the other connection.  

However, I suppose that a model connects with a default connection, if I do not define the connection.

I consider this situation as a bug.

For example;

In another database I have a `foo` table and when I want to connect with the `baz` table in my default database, it tries to look at the other database and gives error. In order not to take error, I have to define the connection for the model with `baz` table. So, I am forced to define default connection for my all models.  

I think, if I do not define the connection, it should set the relation with the default connection.