### PR TITLE
[7.x] Fix root URI not showing

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -688,7 +688,7 @@ class Route
     {
         $uri = rtrim($prefix, '/').'/'.ltrim($this->uri, '/');
 
-        return $this->setUri(trim($uri, '/'));
+        return $this->setUri($uri !== '/' ? trim($uri, '/') : $uri);
     }
 
     /**


### PR DESCRIPTION
This makes sure there's always a root URI showing in `route:list` for the root url.