### PR TITLE
[7.x] Add new `fromString` constructor to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -31,6 +31,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Create a new collection instance from the characters in the given string.
+     *
+     * @param  string  $string
+     * @return static
+     */
+    public static function fromString($string)
+    {
+        return new static(str_split($string));
+    }
+
+    /**
      * Create a new collection by invoking the callback a given amount of times.
      *
      * @param  int  $number

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -70,6 +70,21 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Create a new collection instance from the characters in the given string.
+     *
+     * @param  string  $string
+     * @return static
+     */
+    public static function fromString($string)
+    {
+        return new static(function () use ($string) {
+            for ($i = 0, $l = Str::length($string); $i < $l; $i++) {
+                yield $string[$i];
+            }
+        });
+    }
+
+    /**
      * Create an enumerable with the given range.
      *
      * @param  int  $from

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -24,6 +24,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testFromString($collection)
+    {
+        $data = $collection::fromString('123');
+
+        $this->assertSame(['1', '2', '3'], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testFirstReturnsFirstItemInCollection($collection)
     {
         $c = new $collection(['foo', 'bar']);


### PR DESCRIPTION
This allows you to lazily iterate over the characters in a string:

```php
foreach (LazyCollection::fromString($hugeString) as $character) {
    //
}
```