### PR TITLE
[7.x] Add an `explode` method to collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -510,6 +510,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Explodes the values into chunks at the boundaries of the delimiter.
+     *
+     * @param  string  $delimiter
+     * @return static
+     */
+    public function explode($delimiter)
+    {
+        return $this->lazy()->explode($delimiter);
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -509,6 +509,31 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Explodes the values into chunks at the boundaries of the delimiter.
+     *
+     * @param  string  $delimiter
+     * @return static
+     */
+    public function explode($delimiter)
+    {
+        return new static(function () use ($delimiter) {
+            $chunk = [];
+
+            foreach ($this as $key => $value) {
+                if ($value == $delimiter) {
+                    yield new Collection($chunk);
+
+                    $chunk = [];
+                } else {
+                    $chunk[$key] = $value;
+                }
+            }
+
+            yield new Collection($chunk);
+        });
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1624,6 +1624,39 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testExplode($collection)
+    {
+        $data = new $collection([1, 2, 0, 3, 0, 4, 5, 6, 7]);
+
+        $this->assertSame(
+            [[1, 2], [3], [4, 5, 6, 7]],
+            $data->explode(0)->map->values()->toArray()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testExplodeWithEmptyCollection($collection)
+    {
+        $data = new $collection([]);
+
+        $this->assertSame([[]], $data->explode(0)->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testExplodeWithJustTheDelimiter($collection)
+    {
+        $data = new $collection([',']);
+
+        $this->assertSame([[], []], $data->explode(',')->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);


### PR DESCRIPTION
Allows a collection to be exploded into chunks, using a delimiter:

```php
collect([1, 2, 0, 4, 0, 6])->explode(0); // [[1, 2], [4], [6]]
```

---

I chose `explode` instead of a name with "chunk" or "split", because neither of those names indicate that the delimiter will be lost. Since the native `explode` method on a string discards the delimiter, it's an apt name here.

---

Together with #31775, this can be used to process lines of huge in-memory strings, [without the need for creating huge arrays in-memory](https://github.com/spatie/robots-txt/issues/19):

```php
$robotsMetaTag = LazyCollection::fromString($hugeHtml)
    ->explode(PHP_EOL)
    ->filter(fn ($line) => isRobotsMetaTagLine($line->implode('')))
    ->first();
```