### PR TITLE
[7.x] Added queue suffix for SQS driver

### DIFF
--- a/src/Illuminate/Queue/Connectors/SqsConnector.php
+++ b/src/Illuminate/Queue/Connectors/SqsConnector.php
@@ -23,7 +23,7 @@ class SqsConnector implements ConnectorInterface
         }
 
         return new SqsQueue(
-            new SqsClient($config), $config['queue'], $config['prefix'] ?? ''
+            new SqsClient($config), $config['queue'], $config['prefix'] ?? '', $config['suffix'] ?? ''
         );
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -30,18 +30,27 @@ class SqsQueue extends Queue implements QueueContract
     protected $prefix;
 
     /**
+     * The queue name suffix.
+     *
+     * @var string
+     */
+    private $suffix;
+
+    /**
      * Create a new Amazon SQS queue instance.
      *
      * @param  \Aws\Sqs\SqsClient  $sqs
      * @param  string  $default
      * @param  string  $prefix
+     * @param  string  $suffix
      * @return void
      */
-    public function __construct(SqsClient $sqs, $default, $prefix = '')
+    public function __construct(SqsClient $sqs, $default, $prefix = '', $suffix = '')
     {
         $this->sqs = $sqs;
         $this->prefix = $prefix;
         $this->default = $default;
+        $this->suffix = $suffix;
     }
 
     /**
@@ -140,7 +149,8 @@ class SqsQueue extends Queue implements QueueContract
         $queue = $queue ?: $this->default;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-                        ? rtrim($this->prefix, '/').'/'.$queue : $queue;
+            ? rtrim($this->prefix, '/').'/'.$queue.$this->suffix
+            : $queue;
     }
 
     /**

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -145,4 +145,12 @@ class QueueSqsQueueTest extends TestCase
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test';
         $this->assertEquals($queueUrl, $queue->getQueue($queueUrl));
     }
+
+    public function testGetQueueProperlyResolvesUrlWithSuffix()
+    {
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix, $suffix = '-staging');
+        $this->assertEquals($this->queueUrl.$suffix, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix;
+        $this->assertEquals($queueUrl, $queue->getQueue('test'));
+    }
 }


### PR DESCRIPTION
When using multiple queues and environments it is hard to use different queues per environment (especially when using laravel vapor).

This PR allows suffixing the queue names by optionally adding a suffix entry to the SQS config in queue.php.

So, by adding a `suffix` to the config/queue.php file:

```diff
// config/queue.php

'sqs' => [
	'driver' => 'sqs',
	...
	'queue' => env('SQS_QUEUE', 'your-queue-name'),
+	'suffix' => env('SQS_SUFFIX'),
	'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
],
```

A job using the "imports" queue will yield distinct suffixed queue url's based on the `SQS_SUFFIX` environment variable, ie:

* https://sqs.someregion.amazonaws.com/account-id/imports-staging
* https://sqs.someregion.amazonaws.com/account-id/imports-production

Omitting the suffix config will yield the current (expected) behaviour:

* https://sqs.someregion.amazonaws.com/account-id/imports

**Other references:**

* https://github.com/laravel/framework/pull/25610
* https://github.com/laravel/framework/pull/27086
