### PR TITLE
[7.x] Fixing the `app.debug` type when using phpunit.xml

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -337,12 +337,14 @@ class Handler implements ExceptionHandlerContract
      */
     protected function renderExceptionContent(Throwable $e)
     {
+        $debug = (bool) config('app.debug');
+        
         try {
-            return config('app.debug') && class_exists(Whoops::class)
+            return $debug && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
-                        : $this->renderExceptionWithSymfony($e, config('app.debug'));
+                        : $this->renderExceptionWithSymfony($e, $debug);
         } catch (Exception $e) {
-            return $this->renderExceptionWithSymfony($e, config('app.debug'));
+            return $this->renderExceptionWithSymfony($e, $debug);
         }
     }
 


### PR DESCRIPTION
I'm getting an error when `phpunit.xml` env variable:

```
TypeError : Argument 1 passed to Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer::__construct() must be a boolean or a callable, string given.
```

More details: https://github.com/ARCANEDEV/MissingUrlsRedirector/pull/2/checks?check_run_id=489983756#step:6:13

I debugged the value of `config('app.debug')`, it equals to `"1"` instead of `true`.

To fix it (workaround):

https://github.com/ARCANEDEV/MissingUrlsRedirector/pull/2/commits/a6f4efec3c30a66ffc9d6fb3e436069b65b5fee4

You can use [this package](https://github.com/ARCANEDEV/MissingUrlsRedirector) to reproduce the issue.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
