### PR TITLE
[6.x] Check if an array lock exists before releasing it

### DIFF
--- a/src/Illuminate/Cache/ArrayLock.php
+++ b/src/Illuminate/Cache/ArrayLock.php
@@ -67,6 +67,10 @@ class ArrayLock extends Lock
      */
     public function release()
     {
+        if (! $this->exists()) {
+            return false;
+        }
+
         if (! $this->isOwnedByCurrentProcess()) {
             return false;
         }

--- a/tests/Cache/CacheArrayStoreTest.php
+++ b/tests/Cache/CacheArrayStoreTest.php
@@ -181,4 +181,15 @@ class CacheArrayStoreTest extends TestCase
 
         $this->assertTrue($wannabeOwner->acquire());
     }
+
+    public function testReleasingLockAfterAlreadyForceReleasedByAnotherOwnerFails()
+    {
+        $store = new ArrayStore;
+        $owner = $store->lock('foo', 10);
+        $wannabeOwner = $store->lock('foo', 10);
+        $owner->acquire();
+        $wannabeOwner->forceRelease();
+
+        $this->assertFalse($wannabeOwner->release());
+    }
 }


### PR DESCRIPTION
It just fixes the thing where we would be thrown an [Undefined index {index}](https://github.com/laravel/framework/pull/30253#issuecomment-593665419) exception when releasing a non-existing array lock.

Reference: https://github.com/laravel/framework/pull/30253#issuecomment-593665419

Thanks to @timacdonald for [adding the **ArrayLock**](https://github.com/laravel/framework/pull/30253) and [the test](https://github.com/timacdonald/framework/commit/226ea0767b21178890b469470a1f534c73e139d9?diff=unified) for this PR!