### PR TITLE
[7.x] Provide flexibility with the new terse syntax

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -30,15 +30,15 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     /**
      * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
      *
-     * @param  string $foreignTable
+     * @param  string|null  $foreignTable
      * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained(string $foreignTable = '')
+    public function constrained($foreignTable = null)
     {
-        if ($foreignTable === '') {
+        if (!$foreignTable) {
             return $this->references('id')->on(Str::plural(Str::before($this->name, '_id')));
         }
-        
+
         return $this->references('id')->on($foreignTable);
     }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -35,7 +35,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($foreignTable = null)
     {
-        if (!$foreignTable) {
+        if (! $foreignTable) {
             return $this->references('id')->on(Str::plural(Str::before($this->name, '_id')));
         }
 

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -30,11 +30,16 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     /**
      * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
      *
+     * @param  string $foreignTable
      * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained()
+    public function constrained(string $foreignTable = '')
     {
-        return $this->references('id')->on(Str::plural(Str::before($this->name, '_id')));
+        if ($foreignTable === '') {
+            return $this->references('id')->on(Str::plural(Str::before($this->name, '_id')));
+        }
+        
+        return $this->references('id')->on($foreignTable);
     }
 
     /**


### PR DESCRIPTION
If a custom foreign id column name is used then the new syntax does not currently allow for selection of the foreign table.

With this change, it becomes possible to do so while still being able to use the compact syntax.

Example, if the foreign id column being used is `contributor_id` for a foreign key constraint towards `id` on `users` table, then this PR would allow for

```php
$table->foreignId('contributor_id')->constrained('users');
```

instead of having to use

```php
$table->unsignedBigInteger('contributor_id');
$table->foreign('contributor_id')->references('id')->on('users');
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
