### PR TITLE
[7.x] FileViewFinder: Resolve hinted paths

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -192,7 +192,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function addNamespace($namespace, $hints)
     {
-        $hints = (array) $hints;
+        $hints = array_map([$this, 'resolvePath'], (array) $hints);
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($this->hints[$namespace], $hints);
@@ -210,7 +210,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function prependNamespace($namespace, $hints)
     {
-        $hints = (array) $hints;
+        $hints = array_map([$this, 'resolvePath'], (array) $hints);
 
         if (isset($this->hints[$namespace])) {
             $hints = array_merge($hints, $this->hints[$namespace]);
@@ -228,7 +228,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     public function replaceNamespace($namespace, $hints)
     {
-        $this->hints[$namespace] = (array) $hints;
+        $this->hints[$namespace] = array_map([$this, 'resolvePath'], (array) $hints);
     }
 
     /**


### PR DESCRIPTION
Regular paths added to the `FileViewFinder` class are resolved (i.e.converted to absolute paths), but hinted paths are not (stored in `$hints`). It would be logical and coherent to apply the same standard to all paths.

What brings me to propose this pull requests is issue #31789. The problem is that vendors might register their views paths using the `addNamespace` method by passing a relative path, that will be later used by other classes as provided. When views are cached, the path to the view matters, as its hash is used to identify the view. This pull request would solve some variations of that bug such as those described [here](https://github.com/laravel/framework/pull/31206#issuecomment-595813356).

All tests were passed in my local environment.

