### PR TITLE
[8.x] New sometimes if validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/SometimesIf.php
+++ b/src/Illuminate/Validation/Rules/SometimesIf.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Illuminate\Validation\Rules;
+
+class SometimesIf
+{
+    /**
+     * The condition that validates the attribute.
+     *
+     * @var callable|bool
+     */
+    public $condition;
+
+    /**
+     * Create a new required sometimes rule based on a condition.
+     *
+     * @param  callable|bool  $condition
+     * @return void
+     */
+    public function __construct($condition)
+    {
+        $this->condition = $condition;
+    }
+
+    /**
+     * Convert the rule to a sometimes string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (is_callable($this->condition)) {
+            return call_user_func($this->condition) ? 'sometimes' : '';
+        }
+
+        return $this->condition ? 'sometimes' : '';
+    }
+}

--- a/src/Illuminate/Validation/Rules/SometimesIf.php
+++ b/src/Illuminate/Validation/Rules/SometimesIf.php
@@ -12,7 +12,7 @@ class SometimesIf
     public $condition;
 
     /**
-     * Create a new required sometimes rule based on a condition.
+     * Create a new sometimes rule based on a condition.
      *
      * @param  callable|bool  $condition
      * @return void

--- a/tests/Validation/ValidationSometimesIfTest.php
+++ b/tests/Validation/ValidationSometimesIfTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Illuminate\Validation\Rules\SometimesIf;
+use PHPUnit\Framework\TestCase;
+
+class ValidationSometimesIfTest extends TestCase
+{
+    public function testItClousureReturnsFormatsAStringVersionOfTheRule()
+    {
+        $rule = new SometimesIf(function () {
+            return true;
+        });
+
+        $this->assertSame('sometimes', (string) $rule);
+
+        $rule = new SometimesIf(function () {
+            return false;
+        });
+
+        $this->assertSame('', (string) $rule);
+
+        $rule = new SometimesIf(true);
+
+        $this->assertSame('sometimes', (string) $rule);
+
+        $rule = new SometimesIf(false);
+
+        $this->assertSame('', (string) $rule);
+    }
+}


### PR DESCRIPTION
I'm thinking that a "sometimes if" rule will be a handly addition, its a custom rule that I use a lot in my personals projects and I'm sure that is a very common problem we all have once in a while.

Use case: When we reuse a custom request class for editing and creating items

For example, let's say I'm storing a user where his name, email and password are required when storing but when editing we may only need one of the fields (lets say the user only edits the email), we can use that rule to not require the fields to be present when the user is being edited:

```
<?php

namespace App\Http\Requests;

use App\Rules\SometimesIf;
use Illuminate\Foundation\Http\FormRequest;

class UserRequest extends FormRequest
{
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            // The fields doesn't need to be present if we are editing ($this->user is
            // part of the request only when editing)
            'name' => ['required', 'string', new SometimesIf($this->user)],
            'email' => ['required', 'email', new SometimesIf($this->user)],
            'password' => ['required', 'min:6', new SometimesIf($this->user)],
        ];
    }
}
 ```

```
// So this request is valid only if updating
->putJson('users/99', ['email' => 'me@me.com'])  // Valid: Only the email will be affected

// And this one invalid since some data is missing:
->postJson('users', ['email' => 'me@me.com'])  // Invalid: Missing required data for creating
```
