### PR TITLE
[7.x] Fix adding routes dynamically

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -27,6 +27,13 @@ class CompiledRouteCollection extends AbstractRouteCollection
     protected $attributes = [];
 
     /**
+     * An array of the routes that were added after loading the compiled routes.
+     *
+     * @var \Illuminate\Routing\RouteCollection|null
+     */
+    protected $routes;
+
+    /**
      * The router instance used by the route.
      *
      * @var \Illuminate\Routing\Router
@@ -61,21 +68,32 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function add(Route $route)
     {
-        $name = $route->getName() ?: $this->generateRouteName();
+        if (! $this->routes) {
+            $this->routes = new RouteCollection;
 
-        $this->attributes[$name] = [
-            'methods' => $route->methods(),
-            'uri' => $route->uri(),
-            'action' => $route->getAction() + ['as' => $name],
-            'fallback' => $route->isFallback,
-            'defaults' => $route->defaults,
-            'wheres' => $route->wheres,
-            'bindingFields' => $route->bindingFields(),
-        ];
+            foreach ($this->mapAttributesToRoutes() as $existingRoute) {
+                $this->routes->add($existingRoute);
+            }
+        }
 
-        $this->compiled = [];
+        return $this->routes->add($route);
+    }
 
-        return $route;
+    /**
+     * Recompile the routes.
+     *
+     * @return void
+     */
+    public function recompile()
+    {
+        if ($this->routes) {
+            ['compiled' => $compiled, 'attributes' => $attributes] = $this->routes->compile();
+
+            $this->compiled = $compiled;
+            $this->attributes = $attributes;
+
+            $this->routes = null;
+        }
     }
 
     /**
@@ -88,8 +106,8 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function match(Request $request)
     {
-        if (empty($this->compiled) && $this->attributes) {
-            $this->recompileRoutes();
+        if ($this->routes) {
+            return $this->routes->match($request);
         }
 
         $route = null;
@@ -110,16 +128,6 @@ class CompiledRouteCollection extends AbstractRouteCollection
     }
 
     /**
-     * Recompile the routes from the attributes array.
-     *
-     * @return void
-     */
-    protected function recompileRoutes()
-    {
-        $this->compiled = $this->dumper()->getCompiledRoutes();
-    }
-
-    /**
      * Get routes from the collection by method.
      *
      * @param  string|null  $method
@@ -127,6 +135,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function get($method = null)
     {
+        if ($this->routes) {
+            return $this->routes->get($method);
+        }
+
         return $this->getRoutesByMethod()[$method] ?? [];
     }
 
@@ -138,6 +150,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function hasNamedRoute($name)
     {
+        if ($this->routes) {
+            return $this->routes->hasNamedRoute($name);
+        }
+
         return isset($this->attributes[$name]);
     }
 
@@ -149,6 +165,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByName($name)
     {
+        if ($this->routes) {
+            return $this->routes->getByName($name);
+        }
+
         return isset($this->attributes[$name]) ? $this->newRoute($this->attributes[$name]) : null;
     }
 
@@ -160,6 +180,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByAction($action)
     {
+        if ($this->routes) {
+            return $this->routes->getByAction($action);
+        }
+
         $attributes = collect($this->attributes)->first(function (array $attributes) use ($action) {
             return $attributes['action']['controller'] === $action;
         });
@@ -174,6 +198,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getRoutes()
     {
+        if ($this->routes) {
+            return $this->routes->getRoutes();
+        }
+
         return $this->mapAttributesToRoutes()->values()->all();
     }
 
@@ -184,6 +212,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getRoutesByMethod()
     {
+        if ($this->routes) {
+            return $this->routes->getRoutesByMethod();
+        }
+
         return $this->mapAttributesToRoutes()
             ->groupBy(function (Route $route) {
                 return $route->methods();
@@ -203,6 +235,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getRoutesByName()
     {
+        if ($this->routes) {
+            return $this->routes->getRoutesByName();
+        }
+
         return $this->mapAttributesToRoutes()->keyBy(function (Route $route) {
             return $route->getName();
         })->all();

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -44,6 +44,8 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertCount(1, $this->routeCollection);
     }
 
@@ -53,6 +55,8 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertInstanceOf(Route::class, $outputRoute);
         $this->assertEquals($inputRoute, $outputRoute);
     }
@@ -63,6 +67,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'route_name',
         ]));
+        $this->routeCollection->recompile();
 
         $this->assertSame('route_name', $routeIndex->getName());
         $this->assertSame('route_name', $this->routeCollection->getByName('route_name')->getName());
@@ -85,6 +90,8 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
     }
 
@@ -100,12 +107,16 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertCount(1, $this->routeCollection);
 
         $this->routeCollection->add($routeShow = $this->newRoute('GET', 'bar/show', [
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertCount(2, $this->routeCollection);
 
         $this->assertInstanceOf(ArrayIterator::class, $this->routeCollection->getIterator());
@@ -119,10 +130,14 @@ class CompiledRouteCollectionTest extends IntegrationTest
         ]);
 
         $this->routeCollection->add($routeIndex);
+        $this->routeCollection->recompile();
+
         $this->assertCount(1, $this->routeCollection);
 
         // Add exactly the same route
         $this->routeCollection->add($routeIndex);
+        $this->routeCollection->recompile();
+
         $this->assertCount(1, $this->routeCollection);
 
         // Add a non-existing route
@@ -130,6 +145,8 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'BarController@show',
             'as' => 'bar_show',
         ]));
+        $this->routeCollection->recompile();
+
         $this->assertCount(2, $this->routeCollection);
     }
 
@@ -139,16 +156,15 @@ class CompiledRouteCollectionTest extends IntegrationTest
             'uses' => 'FooController@index',
             'as' => 'foo_index',
         ]));
-
         $this->routeCollection->add($routeShow = $this->newRoute('GET', 'foo/show', [
             'uses' => 'FooController@show',
             'as' => 'foo_show',
         ]));
-
         $this->routeCollection->add($routeNew = $this->newRoute('POST', 'bar', [
             'uses' => 'BarController@create',
             'as' => 'bar_create',
         ]));
+        $this->routeCollection->recompile();
 
         $allRoutes = [
             $routeIndex,
@@ -178,6 +194,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->routeCollection->add($routesByName['foo_index']);
         $this->routeCollection->add($routesByName['foo_show']);
         $this->routeCollection->add($routesByName['bar_create']);
+        $this->routeCollection->recompile();
 
         $this->assertEquals($routesByName, $this->routeCollection->getRoutesByName());
     }
@@ -202,6 +219,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->routeCollection->add($routes['foo_index']);
         $this->routeCollection->add($routes['foo_show']);
         $this->routeCollection->add($routes['bar_create']);
+        $this->routeCollection->recompile();
 
         $this->assertEquals([
             'GET' => [
@@ -233,6 +251,11 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->assertEquals($routeB, $this->routeCollection->getByName('overwrittenRouteA'));
         $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));
 
+        $this->routeCollection->recompile();
+
+        // The lookups of $routeA should not be there anymore, because they are no longer valid.
+        $this->assertNull($this->routeCollection->getByName('routeA'));
+        $this->assertNull($this->routeCollection->getByAction('View@view'));
         // The lookups of $routeB are still there.
         $this->assertEquals($routeB, $this->routeCollection->getByName('overwrittenRouteA'));
         $this->assertEquals($routeB, $this->routeCollection->getByAction('OverwrittenView@view'));


### PR DESCRIPTION
This refactor fixes a bug where it wasn't possible anymore both dynamically add routes and set custom configuration on them. Because atm routes immediately get serialized into an array when added to a collection, calling methods like `->name` and `->where` wouldn't work because the object couldn't assign them by reference anymore.

The general idea behind the changes here is that if a route was added dynamically at runtime, route caching probably isn't applicable anymore so we fallback to the old `RouteCollection` instance.

Fixes https://github.com/laravel/nova-issues/issues/2410