### PR TITLE
[7.x] Fix incompatible contract for Mail Facade

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -2,13 +2,14 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Illuminate\Contracts\Mail\Factory;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use PHPUnit\Framework\Assert as PHPUnit;
 
-class MailFake implements Mailer, MailQueue
+class MailFake implements Factory, Mailer, MailQueue
 {
     /**
      * The mailer currently being used to send a message.


### PR DESCRIPTION
`Illuminate\Notifications\Channels\MailChannel` has been updated in v7.x to use `Illuminate\Contracts\Mail\Factory` contract instead of `Illuminate\Contracts\Mail\Mailer` but `Illuminate\Support\Testing\Fakes\MailFake` doesn't implement `Illuminate\Contracts\Mail\Factory` which results in following error
`TypeError: Argument 1 passed to Illuminate\Notifications\Channels\MailChannel::__construct() must implement interface Illuminate\Contracts\Mail\Factory, instance of Illuminate\Support\Testing\Fakes\MailFake given`.

This pr fix the above issue.