### PR TITLE
[7.x] Throw exception when adding routes after caching

### DIFF
--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -247,4 +247,16 @@ class RouteCollection extends AbstractRouteCollection
 
         return $symfonyRoutes;
     }
+
+    /**
+     * Convert the collection to a CompiledRouteCollection instance.
+     *
+     * @return \Illuminate\Routing\CompiledRouteCollection
+     */
+    public function toCompiledRouteCollection()
+    {
+        ['compiled' => $compiled, 'attributes' => $attributes] = $this->compile();
+
+        return new CompiledRouteCollection($compiled, $attributes);
+    }
 }


### PR DESCRIPTION
This will prevent dynamically adding routes when routes are cached.