### PR TITLE
[7.x] Use getTable() instead of class_basename for relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -644,7 +644,7 @@ trait HasRelationships
      */
     public function joiningTableSegment()
     {
-        return Str::snake(class_basename($this));
+        return Str::singular($this->getTable());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1530,7 +1530,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->getKeyName();
+        return Str::singular($this->getTable()).'_'.$this->getKeyName();
     }
 
     /**


### PR DESCRIPTION
Ran into a bug where we extended a packages model which used the `$table` property to set the table name. The new model had a different class name than the library model, and the relationships used the name of the new class instead of the value of the `$table` property to generate foreign keys.

Updating `getForeignKey()` and `joiningTableSegment()` to use `getTable()` instead of `class_basename()` fixes this issue.