### PR TITLE
[6.x] Add ability to check for $delay in fakeQueue assertions

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -212,7 +212,7 @@ class QueueFake extends QueueManager implements Queue
         };
 
         return collect($this->jobs[$job])->filter(function ($data) use ($callback) {
-            return $callback($data['job'], $data['queue']);
+            return $callback($data['job'], $data['queue'], $data['delay']);
         })->pluck('job');
     }
 
@@ -257,13 +257,16 @@ class QueueFake extends QueueManager implements Queue
      * @param  string  $job
      * @param  mixed  $data
      * @param  string|null  $queue
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     *
      * @return mixed
      */
-    public function push($job, $data = '', $queue = null)
+    public function push($job, $data = '', $queue = null, $delay = null)
     {
         $this->jobs[is_object($job) ? get_class($job) : $job][] = [
             'job' => $job,
             'queue' => $queue,
+            'delay' => $delay,
         ];
     }
 
@@ -291,7 +294,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->push($job, $data, $queue);
+        return $this->push($job, $data, $queue, $delay);
     }
 
     /**
@@ -318,7 +321,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function laterOn($queue, $delay, $job, $data = '')
     {
-        return $this->push($job, $data, $queue);
+        return $this->push($job, $data, $queue, $delay);
     }
 
     /**

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -258,7 +258,6 @@ class QueueFake extends QueueManager implements Queue
      * @param  mixed  $data
      * @param  string|null  $queue
      * @param  \DateTimeInterface|\DateInterval|int|null  $delay
-     *
      * @return mixed
      */
     public function push($job, $data = '', $queue = null, $delay = null)


### PR DESCRIPTION
As in previous PR https://github.com/laravel/framework/pull/31818 I found that fakeQueues give no way to check for the correct $delay parameter passed to them.

With this PR, we can rewrite the test like this, to also check the `$delay` value.
```
 public function testQueuedEventHandlersAreQueued2()
{
        $d = new Dispatcher;

        $fakeQueue = new QueueFake(new Container());

        $d->setQueueResolver(function () use ($fakeQueue) {
            return $fakeQueue;
        });

        $d->listen('some.event', TestDispatcherConnectionQueuedHandler::class.'@handle');
        $d->dispatch('some.event', ['foo', 'bar']);

        $fakeQueue->assertPushedOn('my_queue', CallQueuedListener::class, function ($job, $q, $delay) {
            return $delay == 10; // <--- the 10 here is the expected amount for $delay
        });
}
```
If this is accepted, I will force push https://github.com/laravel/framework/pull/31818 to also check for delay, as mentioned above.