### PR TITLE
[7.x] Adds "when" method to the Mailable class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -758,6 +758,25 @@ class Mailable implements MailableContract, Renderable
 
         return $this;
     }
+    
+    /**
+     * Apply the callback's message changes if the given "value" is true.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
 
     /**
      * Attach a file to the message.

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -758,7 +758,7 @@ class Mailable implements MailableContract, Renderable
 
         return $this;
     }
-    
+
     /**
      * Apply the callback's message changes if the given "value" is true.
      *


### PR DESCRIPTION
This could be useful for example when conditionally attaching files, setting different subjects or maybe even using different views.

Here is an example use case:
```
return $this->from('info@example.com')
            ->when($cv, function ($message) use ($cv) {
                $message->attach($cv->getRealPath(), [
                    'as' => $cv->getClientOriginalName(),
                    'mime' => $cv->getClientMimeType(),
                ]);
            })
            ->subject('Example subject')
            ->view('mail.example');
```

Method signature is the exact same as the `when` method on the `Illuminate\Database\Concerns\BuildsQueries` trait, maybe for the future it's an idea to extract it (and similar methods) to a more generally reusable trait? One with a slightly different signature can also be found in `Illuminate\Support\Collection`, I believe they could be used interchangeably. 