### PR TITLE
[6.x] Update doc blocks for Authorizable to indicate support for multiple abilities

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Foundation/Auth/Access/Authorizable.php
@@ -7,38 +7,38 @@ use Illuminate\Contracts\Auth\Access\Gate;
 trait Authorizable
 {
     /**
-     * Determine if the entity has a given ability.
+     * Determine if the entity has the given abilities.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function can($ability, $arguments = [])
+    public function can($abilities, $arguments = [])
     {
-        return app(Gate::class)->forUser($this)->check($ability, $arguments);
+        return app(Gate::class)->forUser($this)->check($abilities, $arguments);
     }
 
     /**
-     * Determine if the entity does not have a given ability.
+     * Determine if the entity does not have the given abilities.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function cant($ability, $arguments = [])
+    public function cant($abilities, $arguments = [])
     {
-        return ! $this->can($ability, $arguments);
+        return ! $this->can($abilities, $arguments);
     }
 
     /**
-     * Determine if the entity does not have a given ability.
+     * Determine if the entity does not have the given abilities.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function cannot($ability, $arguments = [])
+    public function cannot($abilities, $arguments = [])
     {
-        return $this->cant($ability, $arguments);
+        return $this->cant($abilities, $arguments);
     }
 }


### PR DESCRIPTION
The `Illuminate\Contracts\Auth\Access\Gate` contract allows checking multiple abilities at once.
It seems the `Authorizable` trait was not updated when the change to the contract was made.