### PR TITLE
[6.x] Fix phpredis "zadd" and "exists" on cluster

### DIFF
--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "suggest": {
-        "ext-redis": "Required to use the phpredis connector.",
+        "ext-redis": "Required to use the phpredis connector (^4.0).",
         "predis/predis": "Required to use the predis connector (^1.0)."
     },
     "extra": {


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/29637 and https://github.com/laravel/framework/issues/30473

By not using `executeRaw`, the cluster connection will call the correct redis command.