### PR TITLE
[7.x] Match Symfony's Command::setHidden declaration

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -170,7 +170,7 @@ class Command extends SymfonyCommand
     /**
      * {@inheritdoc}
      */
-    public function setHidden($hidden)
+    public function setHidden(bool $hidden)
     {
         parent::setHidden($this->hidden = $hidden);
 


### PR DESCRIPTION
Source of declaration mismatch: `Symfony\Component\Console\Command\Command::setHidden(bool $hidden)` - `vendor/symfony/console/Command/Command.php:456`
https://github.com/symfony/console/commit/101b74fffdbf055a694b92d36916a96a8a972b9b

After installing **Laravel v7.0.7** on **PHP 7.3.12** via `laravel new` I got a few declaration mismatches with Symfony. Two in Carbon which appear to be documented and with a fix pending here: https://github.com/briannesbitt/Carbon/issues/2033 and this one in 
`Illuminate\Console\Command::setHidden($hidden)` with a mismatch to `Symfony\Component\Console\Command\Command::setHidden(bool $hidden)`

Installed **Symfony is v5.0.5**. Errors were displayed in Tinkerwell.

This very well may be a PHP 7.3 issue. Cannot replicate using PHP 7.4

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
