### PR TITLE
[7.x] Fire MessageLogged after the message has been logged.

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -171,9 +171,9 @@ class Logger implements LoggerInterface
      */
     protected function writeLog($level, $message, $context)
     {
-        $this->fireLogEvent($level, $message = $this->formatMessage($message), $context);
+        $this->logger->{$level}($message = $this->formatMessage($message), $context);
 
-        $this->logger->{$level}($message, $context);
+        $this->fireLogEvent($level, $message, $context);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `MessageLogged` event should be fired after the message was logged, not before.