### PR TITLE
[7.x] Support higher order functions on Paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -689,6 +689,11 @@ abstract class AbstractPaginator implements Htmlable
         return $this->forwardCallTo($this->getCollection(), $method, $parameters);
     }
 
+    public function __get($key)
+    {
+        return $this->getCollection()->{$key};
+    }
+
     /**
      * Render the contents of the paginator when casting to string.
      *

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -62,4 +62,19 @@ class PaginatorTest extends TestCase
 
         $this->assertSame($p->path(), 'http://website.com/test');
     }
+
+    public function testHigherOrderFunctions()
+    {
+        $entity = new class {
+            public $value = 'item';
+
+            public function setValue($string)
+            {
+                $this->value = $string;
+            }
+        };
+        $p = new Paginator([new $entity()], 2, 2);
+        $p->map->setValue('laravel');
+        $this->assertSame('laravel', $p->first()->value);
+    }
 }


### PR DESCRIPTION
Laravel supports higher-order functions on Collections but the Paginator who depends on collection doesn't support them. this PR adds the support of higher-order functions to Paginator

it will make it easy to do 
```php
$author = Author::find(1);
$posts = Posts::findByAuthor($author->id)->paginate(20);
$posts->each->setRelation('author',$author);
```

instead of 
```php
$author = Author::find(1);
$posts = Posts::findByAuthor($author->id)->paginate(20);
$posts->each(function($post) use ($author) {
    $post->setRelation('author',$author);
});
```

before this PR the **first snippet** would throw `Undefined property: Illuminate\Pagination\Paginator::$each` exception.

also, I tried to look at some places in the core for the best practice of implementing the get but couldn't find anything so I went for the simplest solution