### PR TITLE
[7.x] Throw an exception when APP_KEY is missing in .env

### DIFF
--- a/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
+++ b/src/Illuminate/Foundation/Console/KeyGenerateCommand.php
@@ -29,6 +29,7 @@ class KeyGenerateCommand extends Command
     /**
      * Execute the console command.
      *
+     * @throws \Exception
      * @return void
      */
     public function handle()
@@ -37,6 +38,10 @@ class KeyGenerateCommand extends Command
 
         if ($this->option('show')) {
             return $this->line('<comment>'.$key.'</comment>');
+        }
+
+        if (! $this->checkForKey()) {
+            throw new \Exception('Key \'APP_KEY\' does not exist in file \'.env\'. Please add it.');
         }
 
         // Next, we will replace the application key in the environment file so it is
@@ -107,5 +112,15 @@ class KeyGenerateCommand extends Command
         $escaped = preg_quote('='.$this->laravel['config']['app.key'], '/');
 
         return "/^APP_KEY{$escaped}/m";
+    }
+
+    /**
+     * Check if key exist in .env.
+     *
+     * @return bool|int
+     */
+    protected function checkForKey()
+    {
+        return preg_match('/^APP_KEY/m', file_get_contents($this->laravel->environmentFilePath()));
     }
 }


### PR DESCRIPTION
When the key 'APP_KEY' is missing in the .env file, the command should
fail and not print 'Application key set successfully.'

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
