### PR TITLE
[7.x] Adds "unless" method to Mailable class

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -887,6 +887,19 @@ class Mailable implements MailableContract, Renderable
     }
 
     /**
+     * Apply the callback's message changes if the given "value" is false.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  mixed  $default
+     * @return mixed|$this
+     */
+    public function unless($value, $callback, $default = null)
+    {
+        return $this->when(! $value, $callback, $default);
+    }
+
+    /**
      * Dynamically bind parameters to the message.
      *
      * @param  string  $method


### PR DESCRIPTION
Adds opposite `Mailable::unless` method for `Mailable::when` introduced in PR #31828.

Example use case:
```php
return $this->from('info@example.com')
            ->subject('Example subject')
            ->view('mail.example')
            ->unless($product->downloadable, function ($message) use ($shippingInfo) {
                $message->attach($shippingInfo->getRealPath(), [
                    'as' => $shippingInfo->getClientOriginalName(),
                    'mime' => $shippingInfo->getClientMimeType(),
                ]);
            });
```