### PR TITLE
[7.x] Use local variable when resolving component view

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -61,9 +61,9 @@ abstract class Component
 
         $factory = Container::getInstance()->make('view');
 
-        return $factory->exists($this->render())
-                    ? $this->render()
-                    : $this->createBladeViewFromString($factory, $this->render());
+        return $factory->exists($view)
+                    ? $view
+                    : $this->createBladeViewFromString($factory, $view);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `resolveView` methods first expression calls its `render` method to try to resolve view and save the `render` call results into a local variable.

If the value is not a `View` instance the local local variable is not used and the `render` is called at least twice again.

As the `render` method can return an interpolated string representing its component's view, this PR changes the `resolveView` implementation to reuse the local variable already available.

No tests were added, nor changed, as this PR only changes an implementation detail and does not change any behavior.