### PR TITLE
[7.x] fix mysql schema for srid (point)

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -16,7 +16,7 @@ class MySqlGrammar extends Grammar
      */
     protected $modifiers = [
         'Unsigned', 'Charset', 'Collate', 'VirtualAs', 'StoredAs', 'Nullable',
-        'Default', 'Increment', 'Comment', 'After', 'First', 'Srid',
+        'Srid', 'Default', 'Increment', 'Comment', 'After', 'First',
     ];
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -940,6 +940,26 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `geo` add `coordinates` point not null', $statements[0]);
     }
 
+    public function testAddingPointWithSrid()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates', 4326);
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` point not null srid 4326', $statements[0]);
+    }
+
+    public function testAddingPointWithSridColumn()
+    {
+        $blueprint = new Blueprint('geo');
+        $blueprint->point('coordinates', 4326)->after('id');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `geo` add `coordinates` point not null srid 4326 after `id`', $statements[0]);
+    }
+
     public function testAddingLineString()
     {
         $blueprint = new Blueprint('geo');


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As described in #31543 if a migration add a column of type `POINT` using the SRID parameter and also uses the `after` modifier, the generated SQL is invalid.

Steps to reproduce:

~~~php
Schema::create('test', function (Blueprint $table) {
    $table->bigIncrements('id');
});
        
Schema::table('test', function (Blueprint $table) {
    $table->point('location', 4326)->after('id');
});
~~~

Expected SQL:

~~~sql
alter table `test` add `location` point not null srid 4326 after `id`;
~~~

Actual SQL:

~~~sql
alter table `test` add `location` point not null after `id` srid 4326;
~~~

When adding modifiers, the `Grammar` base class iterates over the `$modifiers` array and processes them in other:

https://github.com/laravel/framework/blob/7.x/src/Illuminate/Database/Schema/Grammars/Grammar.php#L144-L161

This PR, moves the `'Srid'` modifier sooner in the `MySqlGrammar`'s `$modifier` array, so it is processed before the relevant modifiers.

I added two tests: 

- one to check syntax using the SRID without the `after` modifier
- one to check syntax using the SRID with the `after` modifier

As this is a bugfix and version 6.x is LTS I will send another PR to the 6.x branch