### PR TITLE
[7.x] Expire the jobs cache keys after 1 day

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -474,7 +474,13 @@ class Worker
             return;
         }
 
+        if (! $this->cache->get('job-exceptions:'.$uuid)) {
+            $this->cache->put('job-exceptions:'.$uuid, 0, Carbon::now()->addDay());
+        }
+
         if ($maxExceptions <= $this->cache->increment('job-exceptions:'.$uuid)) {
+            $this->cache->forget('job-exceptions:'.$uuid);
+
             $this->failJob($job, $e);
         }
     }


### PR DESCRIPTION
This PR ensures the exception cache keys have a TTL set.