### PR TITLE
[7.x] Add apiResource in RouteRegistrar

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -110,6 +110,19 @@ class RouteRegistrar
         return $this->router->resource($name, $controller, $this->attributes + $options);
     }
 
+	/**
+	 * Route an API resource to a controller.
+	 *
+	 * @param  string  $name
+	 * @param  string  $controller
+	 * @param  array  $options
+	 * @return \Illuminate\Routing\PendingResourceRegistration
+	 */
+	public function apiResource($name, $controller, array $options = [])
+	{
+		return $this->router->apiResource($name, $controller, $this->attributes + $options);
+	}
+
     /**
      * Create a route group with shared attributes.
      *

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -110,18 +110,18 @@ class RouteRegistrar
         return $this->router->resource($name, $controller, $this->attributes + $options);
     }
 
-	/**
-	 * Route an API resource to a controller.
-	 *
-	 * @param  string  $name
-	 * @param  string  $controller
-	 * @param  array  $options
-	 * @return \Illuminate\Routing\PendingResourceRegistration
-	 */
-	public function apiResource($name, $controller, array $options = [])
-	{
-		return $this->router->apiResource($name, $controller, $this->attributes + $options);
-	}
+    /**
+     * Route an API resource to a controller.
+     *
+     * @param  string  $name
+     * @param  string  $controller
+     * @param  array  $options
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function apiResource($name, $controller, array $options = [])
+    {
+        return $this->router->apiResource($name, $controller, $this->attributes + $options);
+    }
 
     /**
      * Create a route group with shared attributes.


### PR DESCRIPTION
Since Laravel 7.X has a new (optimized) routing implemented, route names are more important, and caching routes will break if naming collisions happen.

Normally you can use `Route::name('posts')->resource(.....` to change the name of a group (useful for nested routes like: /posts/{post}/comments)

HOWEVER, this is not possible with `apiResource`.

I propose this change to allow that. Its just a convenience to replace:

```php
Route::name('posts')->resource('posts/{post}/comments', 'PostCommentsController')->only(['index', 'show', 'store', 'update', 'destroy']);
```

With:

```php
Route::name('posts')->apiResource('posts/{post}/comments', 'PostCommentsController');
```