### PR TITLE
[7.x] Loop through multiple arrays in parallel

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -669,7 +669,7 @@ class Arr
         $result = [];
 
         foreach (array_map(null, ...$arrays) as $values) {
-            array_push($result, call_user_func_array($callback, $values));
+            $result[] = call_user_func_array($callback, $values);
         }
 
         return $result;

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -659,7 +659,7 @@ class Arr
     }
     
     /**
-     * Loop through multiple arrays in parallel
+     * Loop through multiple arrays in parallel.
      *
      * @param iterable ...$arrays
      * @return array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -657,4 +657,21 @@ class Arr
 
         return is_array($value) ? $value : [$value];
     }
+    
+    /**
+     * Loop through multiple arrays in parallel
+     *
+     * @param iterable ...$arrays
+     * @return array
+     */
+    public static function map(callable $callback, ...$arrays)
+    {
+        $result = [];
+
+        foreach (array_map(null, ...$arrays) as $values) {
+            array_push($result, call_user_func_array($callback, $values));
+        }
+
+        return $result;
+    }
 }


### PR DESCRIPTION
It will work like list comprehension in Elixir, Python

## Usage Example
```
$array1 = array(1,2,3);
$array2 = array(4,5,6);

$data = Illuminate\Support\Arr::map(function($item1, $item2) {
	    return $item1 * $item2;
}, $array1, $array2);

// [4,10,18]
```
The helper can take the variable number of arrays.