### PR TITLE
[7.x] Fix null value injected from container in routes

### DIFF
--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -41,7 +41,7 @@ trait RouteDependencyResolverTrait
 
         $values = array_values($parameters);
 
-        $shouldSkipValue = new \StdClass;
+        $shouldSkipValue = new \stdClass;
 
         foreach ($reflector->getParameters() as $key => $parameter) {
             $instance = $this->transformDependency($parameter, $parameters, $shouldSkipValue);

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -441,6 +441,30 @@ class RoutingRouteTest extends TestCase
         unset($_SERVER['__test.route_inject']);
     }
 
+    public function testNullValuesCanBeInjectedIntoRoutes()
+    {
+        $container = new Container;
+        $router = new Router(new Dispatcher, $container);
+        $container->singleton(Registrar::class, function () use ($router) {
+            return $router;
+        });
+
+        $container->bind(RoutingTestUserModel::class, function() {
+            return null;
+        });
+
+        $router->get('foo/{team}/{post}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (?RoutingTestUserModel $userFromContainer, RoutingTestTeamModel $team, $postId) {
+                $this->assertSame(null, $userFromContainer);
+                $this->assertInstanceOf(RoutingTestTeamModel::class, $team);
+                $this->assertSame('bar', $team->value);
+                $this->assertSame('baz', $postId);
+            },
+        ]);
+        $router->dispatch(Request::create('foo/bar/baz', 'GET'))->getContent();
+    }
+
     public function testOptionsResponsesAreGeneratedByDefault()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
Hi, 

This PR fixes https://github.com/laravel/ideas/issues/2114 (no idea why this bug have been moved to ideas, maybe I haven't made me understood 😕)

Context:
When injecting something witch can be null, the `\Illuminate\Routing\RouteDependencyResolverTrait::resolveMethodDependencies` method doesn't add it to parameters to inject, because it can't difference it from void return.

I've added a default return value, to indicate that we want to strip the value, to allow null value.

- This PR should not be a breaking change: all tests pass, and the previous behavior was not changed.
- A test to address this case was added.

You can reproduce the bug with:
```php
class AppServiceProvider extends ServiceProvider
{
    public function register()
    {
        $this->app->bind(Service::class, fn() => null);
    }

    public function boot()
    {
        Route::get('/foo/{id}', function (?Service $service, string $id) {
            // Argument 1 passed ... must be an instance of Service or null, string given.
        });

        Route::get('/not-working', function (?Service $service) {
            // Too few arguments ... 0 passed ... and exactly 1 expected.
        });

        Route::get('/working', function (?Service $service = null) {
            // Working
        });
    }
}
```

And see the errors thrown:
- https://flareapp.io/share/bP9OdL5Q
- https://flareapp.io/share/omwgpomE

Thanks.

Matt'

PS: If you read this, and can answer to this https://twitter.com/mathieutu/status/1236997027122249728?s=20, I would like to propose a PR for the router with a quite important breaking change, and so understand why the behavior of Laravel routing is like that, and why it is different from _standard_ one.
Thanks.
