### PR TITLE
[7.x] Avoid global app() when compiling components

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -61,7 +61,7 @@ trait CompilesComponents
     {
         return implode(PHP_EOL, [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
-            '<?php $component = app()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
+            '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php if ($component->shouldRender()): ?>',
             '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
         ]);

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -18,7 +18,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
     public function testClassComponentsAreCompiled()
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
-<?php $component = app()->make(Test::class, ["foo" => "bar"]); ?>
+<?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php if ($component->shouldRender()): ?>
 <?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
     }


### PR DESCRIPTION
The requirement of `app()` global function means that third-party consumption of illuminate/view will not be able to render components without reproducing an `app()` global.

Since `$__env->getContainer()` is [guaranteed to be a `Container` contract](https://github.com/illuminate/view/blob/v7.0.8/Factory.php#L526-L545), `$__env->getContainer()` should be able to be used as a drop-in replacement for `app()` in this scenario.