### PR TITLE
[7.x] fix matching trailing slashes with the cached router

### DIFF
--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -399,6 +399,16 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->assertEquals('fallback', $routes->match(Request::create('/bar/1', 'GET'))->getName());
     }
 
+    /** @group Slash */
+    public function testMatchingSlashedRoutes()
+    {
+        $this->routeCollection->add(
+            $route = $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/'))->getName());
+    }
+
     public function testSlashPrefixIsProperlyHandled()
     {
         $this->routeCollection->add($this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'prefix' => '/']));

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -399,7 +399,6 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->assertEquals('fallback', $routes->match(Request::create('/bar/1', 'GET'))->getName());
     }
 
-    /** @group Slash */
     public function testMatchingSlashedRoutes()
     {
         $this->routeCollection->add(


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/31768

This enables the Symfony matcher to return another route when a trailing slash is found while the definition didn't embed one - and vice versa.

IIUC, Laravel doesn't do redirections for trailing slashes but calls the same controller instead. This does it.