### PR TITLE
[7.x] Remove useless setUp() method

### DIFF
--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -46,11 +46,6 @@ class SendingMailWithLocaleTest extends TestCase
         ]);
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testMailIsSentWithDefaultLocale()
     {
         Mail::to('test@mail.com')->send(new TestMail);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Remove useless `setUp()` method.