### PR TITLE
[7.x] Use yield for dataProviders

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -566,16 +566,14 @@ class AuthAccessGateTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return \Generator
      */
     public function notCallableDataProvider()
     {
-        return [
-            [1],
-            [new stdClass],
-            [[]],
-            [1.1],
-        ];
+        yield [1];
+        yield [new stdClass];
+        yield [[]];
+        yield [1.1];
     }
 
     public function testAuthorizeThrowsUnauthorizedException()
@@ -773,26 +771,27 @@ class AuthAccessGateTest extends TestCase
         $this->assertEquals($expectedHasValue, $gate->has($abilitiesToCheck));
     }
 
+    /**
+     * @return \Generator
+     */
     public function hasAbilitiesTestDataProvider()
     {
         $abilities = ['foo' => 'foo', 'bar' => 'bar'];
         $noAbilities = [];
 
-        return [
-            [$abilities, ['test.foo', 'test.bar'], true],
-            [$abilities, ['test.bar', 'test.foo'], true],
-            [$abilities, ['test.bar', 'test.foo', 'test.baz'], false],
-            [$abilities, ['test.bar'], true],
-            [$abilities, ['baz'], false],
-            [$abilities, [''], false],
-            [$abilities, [], true],
-            [$abilities, 'test.bar', true],
-            [$abilities, 'test.foo', true],
-            [$abilities, '', false],
-            [$noAbilities, '', false],
-            [$noAbilities, [], true],
-        ];
-    }
+        yield [$abilities, ['test.foo', 'test.bar'], true];
+        yield [$abilities, ['test.bar', 'test.foo'], true];
+        yield [$abilities, ['test.bar', 'test.foo', 'test.baz'], false];
+        yield [$abilities, ['test.bar'], true];
+        yield [$abilities, ['baz'], false];
+        yield [$abilities, [''], false];
+        yield [$abilities, [], true];
+        yield [$abilities, 'test.bar', true];
+        yield [$abilities, 'test.foo', true];
+        yield [$abilities, '', false];
+        yield [$noAbilities, '', false];
+        yield [$noAbilities, [], true];
+        }
 
     public function testClassesCanBeDefinedAsCallbacksUsingAtNotationForGuests()
     {

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -791,7 +791,7 @@ class AuthAccessGateTest extends TestCase
         yield [$abilities, '', false];
         yield [$noAbilities, '', false];
         yield [$noAbilities, [], true];
-        }
+    }
 
     public function testClassesCanBeDefinedAsCallbacksUsingAtNotationForGuests()
     {

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -292,21 +292,22 @@ class BroadcasterTest extends TestCase
         $this->assertEquals($shouldMatch, $this->broadcaster->channelNameMatchesPattern($channel, $pattern));
     }
 
+    /**
+     * @return \Generator
+     */
     public function channelNameMatchPatternProvider()
     {
-        return [
-            ['something', 'something', true],
-            ['something.23', 'something.{id}', true],
-            ['something.23.test', 'something.{id}.test', true],
-            ['something.23.test.42', 'something.{id}.test.{id2}', true],
-            ['something-23:test-42', 'something-{id}:test-{id2}', true],
-            ['something..test.42', 'something.{id}.test.{id2}', true],
-            ['23:string:test', '{id}:string:{text}', true],
-            ['something.23', 'something', false],
-            ['something.23.test.42', 'something.test.{id}', false],
-            ['something-23-test-42', 'something-{id}-test', false],
-            ['23:test', '{id}:test:abcd', false],
-        ];
+        yield ['something', 'something', true];
+        yield ['something.23', 'something.{id}', true];
+        yield ['something.23.test', 'something.{id}.test', true];
+        yield ['something.23.test.42', 'something.{id}.test.{id2}', true];
+        yield ['something-23:test-42', 'something-{id}:test-{id2}', true];
+        yield ['something..test.42', 'something.{id}.test.{id2}', true];
+        yield ['23:string:test', '{id}:string:{text}', true];
+        yield ['something.23', 'something', false];
+        yield ['something.23.test.42', 'something.test.{id}', false];
+        yield ['something-23-test-42', 'something-{id}-test', false];
+        yield ['23:test', '{id}:test:abcd', false];
     }
 }
 

--- a/tests/Broadcasting/UsePusherChannelsNamesTest.php
+++ b/tests/Broadcasting/UsePusherChannelsNamesTest.php
@@ -44,6 +44,9 @@ class UsePusherChannelConventionsTest extends TestCase
         );
     }
 
+    /**
+     * @return \Generator
+     */
     public function channelsProvider()
     {
         $prefixesInfos = [
@@ -67,10 +70,9 @@ class UsePusherChannelConventionsTest extends TestCase
             '{a}-{b}.{c}',
         ];
 
-        $tests = [];
         foreach ($prefixesInfos as $prefixInfos) {
             foreach ($channels as $channel) {
-                $tests[] = [
+                yield [
                     $prefixInfos['prefix'].$channel,
                     $channel,
                     $prefixInfos['guarded'],
@@ -78,13 +80,11 @@ class UsePusherChannelConventionsTest extends TestCase
             }
         }
 
-        $tests[] = ['private-private-test', 'private-test', true];
-        $tests[] = ['private-presence-test', 'presence-test', true];
-        $tests[] = ['presence-private-test', 'private-test', true];
-        $tests[] = ['presence-presence-test', 'presence-test', true];
-        $tests[] = ['public-test', 'public-test', false];
-
-        return $tests;
+        yield ['private-private-test', 'private-test', true];
+        yield ['private-presence-test', 'presence-test', true];
+        yield ['presence-private-test', 'private-test', true];
+        yield ['presence-presence-test', 'presence-test', true];
+        yield ['public-test', 'public-test', false];
     }
 }
 

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -208,17 +208,18 @@ class CacheRepositoryTest extends TestCase
         $this->assertFalse($result);
     }
 
+    /**
+     * @return \Generator
+     */
     public function dataProviderTestGetSeconds()
     {
         Carbon::setTestNow(Carbon::parse($this->getTestDate()));
 
-        return [
-            [Carbon::now()->addMinutes(5)],
-            [(new DateTime($this->getTestDate()))->modify('+5 minutes')],
-            [(new DateTimeImmutable($this->getTestDate()))->modify('+5 minutes')],
-            [new DateInterval('PT5M')],
-            [300],
-        ];
+        yield [Carbon::now()->addMinutes(5)];
+        yield [(new DateTime($this->getTestDate()))->modify('+5 minutes')];
+        yield [(new DateTimeImmutable($this->getTestDate()))->modify('+5 minutes')];
+        yield [new DateInterval('PT5M')];
+        yield [300];
     }
 
     /**

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -42,13 +42,14 @@ class DatabaseConnectorTest extends TestCase
         $this->assertSame($result, $connection);
     }
 
+    /**
+     * @return \Generator
+     */
     public function mySqlConnectProvider()
     {
-        return [
-            ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:host=foo;port=111;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-            ['mysql:unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']],
-        ];
+        yield ['mysql:host=foo;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']];
+        yield ['mysql:host=foo;port=111;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']];
+        yield ['mysql:unix_socket=baz;dbname=bar', ['host' => 'foo', 'database' => 'bar', 'port' => 111, 'unix_socket' => 'baz', 'collation' => 'utf8_unicode_ci', 'charset' => 'utf8']];
     }
 
     public function testPostgresConnectCallsCreateConnectionWithProperArguments()

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -25,14 +25,15 @@ class HttpJsonResponseTest extends TestCase
         $this->assertSame('bar', $response->getData()->foo);
     }
 
-    public function setAndRetrieveDataProvider(): array
+    /**
+     * @return \Generator
+     */
+    public function setAndRetrieveDataProvider()
     {
-        return [
-            'Jsonable data' => [new JsonResponseTestJsonableObject],
-            'JsonSerializable data' => [new JsonResponseTestJsonSerializeObject],
-            'Arrayable data' => [new JsonResponseTestArrayableObject],
-            'Array data' => [['foo' => 'bar']],
-        ];
+        yield 'Jsonable data' => [new JsonResponseTestJsonableObject];
+        yield 'JsonSerializable data' => [new JsonResponseTestJsonSerializeObject];
+        yield 'Arrayable data' => [new JsonResponseTestArrayableObject];
+        yield 'Array data' => [['foo' => 'bar']];
     }
 
     public function testGetOriginalContent()
@@ -89,7 +90,7 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return \Generator
      */
     public function jsonErrorDataProvider()
     {
@@ -105,11 +106,9 @@ class HttpJsonResponseTest extends TestCase
         // NAN or INF can't be encoded
         $nan = NAN;
 
-        return [
-            [$resource],
-            [$recursiveObject],
-            [$nan],
-        ];
+        yield [$resource];
+        yield [$recursiveObject];
+        yield [$nan];
     }
 }
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -79,14 +79,15 @@ class HttpRequestTest extends TestCase
         $this->assertEquals($expected, $request->segment($segment, 'default'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function segmentProvider()
     {
-        return [
-            ['', 1, 'default'],
-            ['foo/bar//baz', 1, 'foo'],
-            ['foo/bar//baz', 2, 'bar'],
-            ['foo/bar//baz', 3, 'baz'],
-        ];
+        yield ['', 1, 'default'];
+        yield ['foo/bar//baz', 1, 'foo'];
+        yield ['foo/bar//baz', 2, 'bar'];
+        yield ['foo/bar//baz', 3, 'baz'];
     }
 
     /**
@@ -101,14 +102,15 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $request->segments());
     }
 
+    /**
+     * @return \Generator
+     */
     public function segmentsProvider()
     {
-        return [
-            ['', []],
-            ['foo/bar', ['foo', 'bar']],
-            ['foo/bar//baz', ['foo', 'bar', 'baz']],
-            ['foo/0/bar', ['foo', '0', 'bar']],
-        ];
+        yield ['', []];
+        yield ['foo/bar', ['foo', 'bar']];
+        yield ['foo/bar//baz', ['foo', 'bar', 'baz']];
+        yield ['foo/0/bar', ['foo', '0', 'bar']];
     }
 
     public function testUrlMethod()

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -62,19 +62,20 @@ class DatabaseMySqlConnectionTest extends TestCase
         );
     }
 
-    public function floatComparisonsDataProvider(): array
+    /**
+     * @return \Generator
+     */
+    public function floatComparisonsDataProvider()
     {
-        return [
-            [0.2, '=', true],
-            [0.2, '>', false],
-            [0.2, '<', false],
-            [0.1, '=', false],
-            [0.1, '<', false],
-            [0.1, '>', true],
-            [0.3, '=', false],
-            [0.3, '<', true],
-            [0.3, '>', false],
-        ];
+        yield [0.2, '=', true];
+        yield [0.2, '>', false];
+        yield [0.2, '<', false];
+        yield [0.1, '=', false];
+        yield [0.1, '<', false];
+        yield [0.1, '>', true];
+        yield [0.3, '=', false];
+        yield [0.3, '<', true];
+        yield [0.3, '>', false];
     }
 
     public function testFloatValueStoredCorrectly(): void

--- a/tests/Integration/Routing/RouteRedirectTest.php
+++ b/tests/Integration/Routing/RouteRedirectTest.php
@@ -28,19 +28,19 @@ class RouteRedirectTest extends TestCase
         $response->assertStatus(301);
     }
 
-    public function routeRedirectDataSets(): array
+    /**
+     * @return \Generator
+     */
+    public function routeRedirectDataSets()
     {
-        return [
-            'route redirect with no parameters' => ['from', 'to', '/from', '/to'],
-            'route redirect with one parameter' => ['from/{param}/{param2?}', 'to', '/from/value1', '/to'],
-            'route redirect with two parameters' => ['from/{param}/{param2?}', 'to', '/from/value1/value2', '/to'],
-            'route redirect with one parameter replacement' => ['users/{user}/repos', 'members/{user}/repos', '/users/22/repos', '/members/22/repos'],
-            'route redirect with two parameter replacements' => ['users/{user}/repos/{repo}', 'members/{user}/projects/{repo}', '/users/22/repos/laravel-framework', '/members/22/projects/laravel-framework'],
-            'route redirect with two parameter replacements' => ['users/{user}/repos/{repo}', 'members/{user}/projects/{repo}', '/users/22/repos/laravel-framework', '/members/22/projects/laravel-framework'],
-            'route redirect with non existent optional parameter replacements' => ['users/{user?}', 'members/{user?}', '/users', '/members'],
-            'route redirect with existing parameter replacements' => ['users/{user?}', 'members/{user?}', '/users/22', '/members/22'],
-            'route redirect with two optional replacements' => ['users/{user?}/{repo?}', 'members/{user?}', '/users/22', '/members/22'],
-            'route redirect with two optional replacements that switch position' => ['users/{user?}/{switch?}', 'members/{switch?}/{user?}', '/users/11/22', '/members/22/11'],
-        ];
+        yield 'route redirect with no parameters' => ['from', 'to', '/from', '/to'];
+        yield 'route redirect with one parameter' => ['from/{param}/{param2?}', 'to', '/from/value1', '/to'];
+        yield 'route redirect with two parameters' => ['from/{param}/{param2?}', 'to', '/from/value1/value2', '/to'];
+        yield 'route redirect with one parameter replacement' => ['users/{user}/repos', 'members/{user}/repos', '/users/22/repos', '/members/22/repos'];
+        yield 'route redirect with two parameter replacements' => ['users/{user}/repos/{repo}', 'members/{user}/projects/{repo}', '/users/22/repos/laravel-framework', '/members/22/projects/laravel-framework'];
+        yield 'route redirect with non existent optional parameter replacements' => ['users/{user?}', 'members/{user?}', '/users', '/members'];
+        yield 'route redirect with existing parameter replacements' => ['users/{user?}', 'members/{user?}', '/users/22', '/members/22'];
+        yield 'route redirect with two optional replacements' => ['users/{user?}/{repo?}', 'members/{user?}', '/users/22', '/members/22'];
+        yield 'route redirect with two optional replacements that switch position' => ['users/{user?}/{switch?}', 'members/{switch?}/{user?}', '/users/11/22', '/members/22/11'];
     }
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -520,13 +520,14 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('http://sub.foo.com/foo/bar', $url->route('foo'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function providerRouteParameters()
     {
-        return [
-            [['test' => 123]],
-            [['one' => null, 'test' => 123]],
-            [['one' => '', 'test' => 123]],
-        ];
+        yield [['test' => 123]];
+        yield [['one' => null, 'test' => 123]];
+        yield [['one' => '', 'test' => 123]];
     }
 
     /**

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -37,337 +37,338 @@ class ConfigurationUrlParserTest extends TestCase
         ], ConfigurationUrlParser::getDriverAliases());
 
         $this->assertEquals([
-            'driver' => 'mysql',
+            yield 'driver' => 'mysql',
         ], (new ConfigurationUrlParser)->parseConfiguration('some-particular-alias://null'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function databaseUrls()
     {
-        return [
-            'simple URL' => [
-                'mysql://foo:bar@localhost/baz',
-                [
-                    'driver' => 'mysql',
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'host' => 'localhost',
-                    'database' => 'baz',
-                ],
+        yield 'simple URL' => [
+            'mysql://foo:bar@localhost/baz',
+            [
+                'driver' => 'mysql',
+                'username' => 'foo',
+                'password' => 'bar',
+                'host' => 'localhost',
+                'database' => 'baz',
             ],
-            'simple URL with port' => [
-                'mysql://foo:bar@localhost:134/baz',
-                [
-                    'driver' => 'mysql',
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'host' => 'localhost',
-                    'port' => 134,
-                    'database' => 'baz',
-                ],
+        ];
+        yield 'simple URL with port' => [
+            'mysql://foo:bar@localhost:134/baz',
+            [
+                'driver' => 'mysql',
+                'username' => 'foo',
+                'password' => 'bar',
+                'host' => 'localhost',
+                'port' => 134,
+                'database' => 'baz',
             ],
-            'sqlite relative URL with host' => [
-                'sqlite://localhost/foo/database.sqlite',
-                [
-                    'database' => 'foo/database.sqlite',
-                    'driver' => 'sqlite',
-                    'host' => 'localhost',
-                ],
+        ];
+        yield 'sqlite relative URL with host' => [
+            'sqlite://localhost/foo/database.sqlite',
+            [
+                'database' => 'foo/database.sqlite',
+                'driver' => 'sqlite',
+                'host' => 'localhost',
             ],
-            'sqlite absolute URL with host' => [
-                'sqlite://localhost//tmp/database.sqlite',
-                [
-                    'database' => '/tmp/database.sqlite',
-                    'driver' => 'sqlite',
-                    'host' => 'localhost',
-                ],
+        ];
+        yield 'sqlite absolute URL with host' => [
+            'sqlite://localhost//tmp/database.sqlite',
+            [
+                'database' => '/tmp/database.sqlite',
+                'driver' => 'sqlite',
+                'host' => 'localhost',
             ],
-            'sqlite relative URL without host' => [
-                'sqlite:///foo/database.sqlite',
-                [
-                    'database' => 'foo/database.sqlite',
-                    'driver' => 'sqlite',
-                ],
+        ];
+        yield 'sqlite relative URL without host' => [
+            'sqlite:///foo/database.sqlite',
+            [
+                'database' => 'foo/database.sqlite',
+                'driver' => 'sqlite',
             ],
-            'sqlite absolute URL without host' => [
-                'sqlite:////tmp/database.sqlite',
-                [
-                    'database' => '/tmp/database.sqlite',
-                    'driver' => 'sqlite',
-                ],
+        ];
+        yield 'sqlite absolute URL without host' => [
+            'sqlite:////tmp/database.sqlite',
+            [
+                'database' => '/tmp/database.sqlite',
+                'driver' => 'sqlite',
             ],
-            'sqlite memory' => [
-                'sqlite:///:memory:',
-                [
-                    'database' => ':memory:',
-                    'driver' => 'sqlite',
-                ],
+        ];
+        yield 'sqlite memory' => [
+            'sqlite:///:memory:',
+            [
+                'database' => ':memory:',
+                'driver' => 'sqlite',
             ],
-            'params parsed from URL override individual params' => [
-                [
-                    'url' => 'mysql://foo:bar@localhost/baz',
-                    'password' => 'lulz',
-                    'driver' => 'sqlite',
-                ],
-                [
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'host' => 'localhost',
-                    'database' => 'baz',
-                    'driver' => 'mysql',
-                ],
+        ];
+        yield 'params parsed from URL override individual params' => [
+            [
+                'url' => 'mysql://foo:bar@localhost/baz',
+                'password' => 'lulz',
+                'driver' => 'sqlite',
             ],
-            'params not parsed from URL but individual params are preserved' => [
-                [
-                    'url' => 'mysql://foo:bar@localhost/baz',
-                    'port' => 134,
-                ],
-                [
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'host' => 'localhost',
-                    'port' => 134,
-                    'database' => 'baz',
-                    'driver' => 'mysql',
-                ],
+            [
+                'username' => 'foo',
+                'password' => 'bar',
+                'host' => 'localhost',
+                'database' => 'baz',
+                'driver' => 'mysql',
             ],
-            'query params from URL are used as extra params' => [
-                'url' => 'mysql://foo:bar@localhost/database?charset=UTF-8',
-                [
-                    'driver' => 'mysql',
-                    'database' => 'database',
-                    'host' => 'localhost',
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'charset' => 'UTF-8',
-                ],
+        ];
+        yield 'params not parsed from URL but individual params are preserved' => [
+            [
+                'url' => 'mysql://foo:bar@localhost/baz',
+                'port' => 134,
             ],
-            'simple URL with driver set apart' => [
-                [
-                    'url' => '//foo:bar@localhost/baz',
-                    'driver' => 'sqlsrv',
-                ],
-                [
-                    'username' => 'foo',
-                    'password' => 'bar',
-                    'host' => 'localhost',
-                    'database' => 'baz',
-                    'driver' => 'sqlsrv',
-                ],
+            [
+                'username' => 'foo',
+                'password' => 'bar',
+                'host' => 'localhost',
+                'port' => 134,
+                'database' => 'baz',
+                'driver' => 'mysql',
             ],
-            'simple URL with percent encoding' => [
-                'mysql://foo%3A:bar%2F@localhost/baz+baz%40',
-                [
-                    'username' => 'foo:',
-                    'password' => 'bar/',
-                    'host' => 'localhost',
-                    'database' => 'baz+baz@',
-                    'driver' => 'mysql',
-                ],
+        ];
+        yield 'query params from URL are used as extra params' => [
+            'url' => 'mysql://foo:bar@localhost/database?charset=UTF-8',
+            [
+                'driver' => 'mysql',
+                'database' => 'database',
+                'host' => 'localhost',
+                'username' => 'foo',
+                'password' => 'bar',
+                'charset' => 'UTF-8',
             ],
-            'simple URL with percent sign in password' => [
-                'mysql://foo:bar%25bar@localhost/baz',
-                [
-                    'username' => 'foo',
-                    'password' => 'bar%bar',
-                    'host' => 'localhost',
-                    'database' => 'baz',
-                    'driver' => 'mysql',
-                ],
+        ];
+        yield 'simple URL with driver set apart' => [
+            [
+                'url' => '//foo:bar@localhost/baz',
+                'driver' => 'sqlsrv',
             ],
-            'URL with mssql alias driver' => [
-                'mssql://null',
-                [
-                    'driver' => 'sqlsrv',
-                ],
+            [
+                'username' => 'foo',
+                'password' => 'bar',
+                'host' => 'localhost',
+                'database' => 'baz',
+                'driver' => 'sqlsrv',
             ],
-            'URL with sqlsrv alias driver' => [
-                'sqlsrv://null',
-                [
-                    'driver' => 'sqlsrv',
-                ],
+        ];
+        yield 'simple URL with percent encoding' => [
+            'mysql://foo%3A:bar%2F@localhost/baz+baz%40',
+            [
+                'username' => 'foo:',
+                'password' => 'bar/',
+                'host' => 'localhost',
+                'database' => 'baz+baz@',
+                'driver' => 'mysql',
             ],
-            'URL with mysql alias driver' => [
-                'mysql://null',
-                [
-                    'driver' => 'mysql',
-                ],
+        ];
+        yield 'simple URL with percent sign in password' => [
+            'mysql://foo:bar%25bar@localhost/baz',
+            [
+                'username' => 'foo',
+                'password' => 'bar%bar',
+                'host' => 'localhost',
+                'database' => 'baz',
+                'driver' => 'mysql',
             ],
-            'URL with mysql2 alias driver' => [
-                'mysql2://null',
-                [
-                    'driver' => 'mysql',
-                ],
+        ];
+        yield 'URL with mssql alias driver' => [
+            'mssql://null',
+            [
+                'driver' => 'sqlsrv',
             ],
-            'URL with postgres alias driver' => [
-                'postgres://null',
-                [
-                    'driver' => 'pgsql',
-                ],
+        ];
+        yield 'URL with sqlsrv alias driver' => [
+            'sqlsrv://null',
+            [
+                'driver' => 'sqlsrv',
             ],
-            'URL with postgresql alias driver' => [
-                'postgresql://null',
-                [
-                    'driver' => 'pgsql',
-                ],
+        ];
+        yield 'URL with mysql alias driver' => [
+            'mysql://null',
+            [
+                'driver' => 'mysql',
             ],
-            'URL with pgsql alias driver' => [
-                'pgsql://null',
-                [
-                    'driver' => 'pgsql',
-                ],
+        ];
+        yield 'URL with mysql2 alias driver' => [
+            'mysql2://null',
+            [
+                'driver' => 'mysql',
             ],
-            'URL with sqlite alias driver' => [
-                'sqlite://null',
-                [
-                    'driver' => 'sqlite',
-                ],
+        ];
+        yield 'URL with postgres alias driver' => [
+            'postgres://null',
+            [
+                'driver' => 'pgsql',
             ],
-            'URL with sqlite3 alias driver' => [
-                'sqlite3://null',
-                [
-                    'driver' => 'sqlite',
-                ],
+        ];
+        yield 'URL with postgresql alias driver' => [
+            'postgresql://null',
+            [
+                'driver' => 'pgsql',
             ],
+        ];
+        yield 'URL with pgsql alias driver' => [
+            'pgsql://null',
+            [
+                'driver' => 'pgsql',
+            ],
+        ];
+        yield 'URL with sqlite alias driver' => [
+            'sqlite://null',
+            [
+                'driver' => 'sqlite',
+            ],
+        ];
+        yield 'URL with sqlite3 alias driver' => [
+            'sqlite3://null',
+            [
+                'driver' => 'sqlite',
+            ],
+        ];
 
-            'URL with unknown driver' => [
-                'foo://null',
-                [
-                    'driver' => 'foo',
-                ],
+        yield 'URL with unknown driver' => [
+            'foo://null',
+            [
+                'driver' => 'foo',
             ],
-            'Sqlite with foreign_key_constraints' => [
-                'sqlite:////absolute/path/to/database.sqlite?foreign_key_constraints=true',
-                [
-                    'driver' => 'sqlite',
-                    'database' => '/absolute/path/to/database.sqlite',
-                    'foreign_key_constraints' => true,
-                ],
+        ];
+        yield 'Sqlite with foreign_key_constraints' => [
+            'sqlite:////absolute/path/to/database.sqlite?foreign_key_constraints=true',
+            [
+                'driver' => 'sqlite',
+                'database' => '/absolute/path/to/database.sqlite',
+                'foreign_key_constraints' => true,
             ],
+        ];
 
-            'Most complex example with read and write subarrays all in string' => [
-                'mysql://root:@null/database?read[host][]=192.168.1.1&write[host][]=196.168.1.2&sticky=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&prefix=',
-                [
-                    'read' => [
-                        'host' => ['192.168.1.1'],
-                    ],
-                    'write' => [
-                        'host' => ['196.168.1.2'],
-                    ],
-                    'sticky' => true,
-                    'driver' => 'mysql',
-                    'database' => 'database',
-                    'username' => 'root',
-                    'password' => '',
-                    'charset' => 'utf8mb4',
-                    'collation' => 'utf8mb4_unicode_ci',
-                    'prefix' => '',
+        yield 'Most complex example with read and write subarrays all in string' => [
+            'mysql://root:@null/database?read[host][]=192.168.1.1&write[host][]=196.168.1.2&sticky=true&charset=utf8mb4&collation=utf8mb4_unicode_ci&prefix=',
+            [
+                'read' => [
+                    'host' => ['192.168.1.1'],
                 ],
+                'write' => [
+                    'host' => ['196.168.1.2'],
+                ],
+                'sticky' => true,
+                'driver' => 'mysql',
+                'database' => 'database',
+                'username' => 'root',
+                'password' => '',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
             ],
+        ];
 
-            'Full example from doc that prove that there isn\'t any Breaking Change' => [
-                [
-                    'driver' => 'mysql',
-                    'host' => '127.0.0.1',
-                    'port' => '3306',
-                    'database' => 'forge',
-                    'username' => 'forge',
-                    'password' => '',
-                    'unix_socket' => '',
-                    'charset' => 'utf8mb4',
-                    'collation' => 'utf8mb4_unicode_ci',
-                    'prefix' => '',
-                    'prefix_indexes' => true,
-                    'strict' => true,
-                    'engine' => null,
-                    'options' => ['foo' => 'bar'],
-                ],
-                [
-                    'driver' => 'mysql',
-                    'host' => '127.0.0.1',
-                    'port' => '3306',
-                    'database' => 'forge',
-                    'username' => 'forge',
-                    'password' => '',
-                    'unix_socket' => '',
-                    'charset' => 'utf8mb4',
-                    'collation' => 'utf8mb4_unicode_ci',
-                    'prefix' => '',
-                    'prefix_indexes' => true,
-                    'strict' => true,
-                    'engine' => null,
-                    'options' => ['foo' => 'bar'],
-                ],
+        yield 'Full example from doc that prove that there isn\'t any Breaking Change' => [
+            [
+                'driver' => 'mysql',
+                'host' => '127.0.0.1',
+                'port' => '3306',
+                'database' => 'forge',
+                'username' => 'forge',
+                'password' => '',
+                'unix_socket' => '',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+                'prefix_indexes' => true,
+                'strict' => true,
+                'engine' => null,
+                'options' => ['foo' => 'bar'],
             ],
+            [
+                'driver' => 'mysql',
+                'host' => '127.0.0.1',
+                'port' => '3306',
+                'database' => 'forge',
+                'username' => 'forge',
+                'password' => '',
+                'unix_socket' => '',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+                'prefix_indexes' => true,
+                'strict' => true,
+                'engine' => null,
+                'options' => ['foo' => 'bar'],
+            ],
+        ];
 
-            'Full example from doc with url overwriting parameters' => [
-                [
-                    'url' => 'mysql://root:pass@db/local',
-                    'driver' => 'mysql',
-                    'host' => '127.0.0.1',
-                    'port' => '3306',
-                    'database' => 'forge',
-                    'username' => 'forge',
-                    'password' => '',
-                    'unix_socket' => '',
-                    'charset' => 'utf8mb4',
-                    'collation' => 'utf8mb4_unicode_ci',
-                    'prefix' => '',
-                    'prefix_indexes' => true,
-                    'strict' => true,
-                    'engine' => null,
-                    'options' => ['foo' => 'bar'],
-                ],
-                [
-                    'driver' => 'mysql',
-                    'host' => 'db',
-                    'port' => '3306',
-                    'database' => 'local',
-                    'username' => 'root',
-                    'password' => 'pass',
-                    'unix_socket' => '',
-                    'charset' => 'utf8mb4',
-                    'collation' => 'utf8mb4_unicode_ci',
-                    'prefix' => '',
-                    'prefix_indexes' => true,
-                    'strict' => true,
-                    'engine' => null,
-                    'options' => ['foo' => 'bar'],
-                ],
+        yield 'Full example from doc with url overwriting parameters' => [
+            [
+                'url' => 'mysql://root:pass@db/local',
+                'driver' => 'mysql',
+                'host' => '127.0.0.1',
+                'port' => '3306',
+                'database' => 'forge',
+                'username' => 'forge',
+                'password' => '',
+                'unix_socket' => '',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+                'prefix_indexes' => true,
+                'strict' => true,
+                'engine' => null,
+                'options' => ['foo' => 'bar'],
             ],
-            'Redis Example' => [
-                [
-                    // Coming directly from Heroku documentation
-                    'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111',
-                    'host' => '127.0.0.1',
-                    'password' =>  null,
-                    'port' =>  6379,
-                    'database' => 0,
-                ],
-                [
-                    'driver' => 'redis',
-                    'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
-                    'port' => 111,
-                    'database' => 0,
-                    'username' => 'h',
-                    'password' => 'asdfqwer1234asdf',
-                ],
+            [
+                'driver' => 'mysql',
+                'host' => 'db',
+                'port' => '3306',
+                'database' => 'local',
+                'username' => 'root',
+                'password' => 'pass',
+                'unix_socket' => '',
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+                'prefix_indexes' => true,
+                'strict' => true,
+                'engine' => null,
+                'options' => ['foo' => 'bar'],
             ],
-            'Redis example where URL ends with "/" and database is not present'  => [
-                [
-                    'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111/',
-                    'host' => '127.0.0.1',
-                    'password' =>  null,
-                    'port' =>  6379,
-                    'database' => 2,
-                ],
-                [
-                    'driver' => 'redis',
-                    'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
-                    'port' => 111,
-                    'database' => 2,
-                    'username' => 'h',
-                    'password' => 'asdfqwer1234asdf',
-                ],
+        ];
+        yield 'Redis Example' => [
+            [
+                // Coming directly from Heroku documentation
+                'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111',
+                'host' => '127.0.0.1',
+                'password' =>  null,
+                'port' =>  6379,
+                'database' => 0,
+            ],
+            [
+                'driver' => 'redis',
+                'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
+                'port' => 111,
+                'database' => 0,
+                'username' => 'h',
+                'password' => 'asdfqwer1234asdf',
+            ],
+        ];
+        yield 'Redis example where URL ends with "/" and database is not present'  => [
+            [
+                'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111/',
+                'host' => '127.0.0.1',
+                'password' =>  null,
+                'port' =>  6379,
+                'database' => 2,
+            ],
+            [
+                'driver' => 'redis',
+                'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
+                'port' => 111,
+                'database' => 2,
+                'username' => 'h',
+                'password' => 'asdfqwer1234asdf',
             ],
         ];
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4073,14 +4073,12 @@ class SupportCollectionTest extends TestCase
     /**
      * Provides each collection class, respectively.
      *
-     * @return array
+     * @return \Generator
      */
     public function collectionClassProvider()
     {
-        return [
-            [Collection::class],
-            [LazyCollection::class],
-        ];
+        yield [Collection::class];
+        yield [LazyCollection::class];
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -660,7 +660,7 @@ class SupportHelpersTest extends TestCase
         yield ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'];
         yield ['//', [], '', ''];
         yield ['/%s/', ['a'], '', ''];
-         // The internal pointer of this array is not at the beginning
+        // The internal pointer of this array is not at the beginning
         yield ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'];
     }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -644,23 +644,24 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('From $_ENV', env('foo'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function providesPregReplaceArrayData()
     {
         $pointerArray = ['Taylor', 'Otwell'];
 
         next($pointerArray);
 
-        return [
-            ['/:[a-z_]+/', ['8:30', '9:00'], 'The event will take place between :start and :end', 'The event will take place between 8:30 and 9:00'],
-            ['/%s/', ['Taylor'], 'Hi, %s', 'Hi, Taylor'],
-            ['/%s/', ['Taylor', 'Otwell'], 'Hi, %s %s', 'Hi, Taylor Otwell'],
-            ['/%s/', [], 'Hi, %s %s', 'Hi,  '],
-            ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'],
-            ['//', [], '', ''],
-            ['/%s/', ['a'], '', ''],
-            // The internal pointer of this array is not at the beginning
-            ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'],
-        ];
+        yield ['/:[a-z_]+/', ['8:30', '9:00'], 'The event will take place between :start and :end', 'The event will take place between 8:30 and 9:00'];
+        yield ['/%s/', ['Taylor'], 'Hi, %s', 'Hi, Taylor'];
+        yield ['/%s/', ['Taylor', 'Otwell'], 'Hi, %s %s', 'Hi, Taylor Otwell'];
+        yield ['/%s/', [], 'Hi, %s %s', 'Hi,  '];
+        yield ['/%s/', ['a', 'b', 'c'], 'Hi', 'Hi'];
+        yield ['//', [], '', ''];
+        yield ['/%s/', ['a'], '', ''];
+         // The internal pointer of this array is not at the beginning
+        yield ['/%s/', $pointerArray, 'Hi, %s %s', 'Hi, Taylor Otwell'];
     }
 
     /** @dataProvider providesPregReplaceArrayData */

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -439,36 +439,38 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::slug(null));
     }
 
+    /**
+     * @return \Generator
+     */
     public function validUuidList()
     {
-        return [
-            ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
-            ['00000000-0000-0000-0000-000000000000'],
-            ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'],
-            ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'],
-            ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'],
-        ];
+        yield ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'];
+        yield ['00000000-0000-0000-0000-000000000000'];
+        yield ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'];
+        yield ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'];
+        yield ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'];
     }
 
+    /**
+     * @return \Generator
+     */
     public function invalidUuidList()
     {
-        return [
-            ['not a valid uuid so we can test this'],
-            ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
-            [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
-            ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
-            ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'],
-            ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
-            ['af6f8cb0c57d11e19b210800200c9a66'],
-            ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
-        ];
+        yield ['not a valid uuid so we can test this'];
+        yield ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '];
+        yield [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'];
+        yield ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'];
+        yield ['af6f8cb-c57d-11e1-9b21-0800200c9a66'];
+        yield ['af6f8cb0c57d11e19b210800200c9a66'];
+        yield ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'];
     }
 }
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -22,49 +22,49 @@ class TranslationMessageSelectorTest extends TestCase
      */
     public function chooseTestData()
     {
-            yield ['first', 'first', 1];
-            yield ['first', 'first', 10];
-            yield ['first', 'first|second', 1];
-            yield ['second', 'first|second', 10];
-            yield ['second', 'first|second', 0];
+        yield ['first', 'first', 1];
+        yield ['first', 'first', 10];
+        yield ['first', 'first|second', 1];
+        yield ['second', 'first|second', 10];
+        yield ['second', 'first|second', 0];
 
-            yield ['first', '{0}  first|{1}second', 0];
-            yield ['first', '{1}first|{2}second', 1];
-            yield ['second', '{1}first|{2}second', 2];
-            yield ['first', '{2}first|{1}second', 2];
-            yield ['second', '{9}first|{10}second', 0];
-            yield ['first', '{9}first|{10}second', 1];
-            yield ['', '{0}|{1}second', 0];
-            yield ['', '{0}first|{1}', 1];
-            yield ['first', '{1.3}first|{2.3}second', 1.3];
-            yield ['second', '{1.3}first|{2.3}second', 2.3];
-            yield ['first
-            line', '{1}first
-            line|{2}second', 1];
-            ["first \n
-            line", "{1}first \n
-            line|{2}second", 1];
+        yield ['first', '{0}  first|{1}second', 0];
+        yield ['first', '{1}first|{2}second', 1];
+        yield ['second', '{1}first|{2}second', 2];
+        yield ['first', '{2}first|{1}second', 2];
+        yield ['second', '{9}first|{10}second', 0];
+        yield ['first', '{9}first|{10}second', 1];
+        yield ['', '{0}|{1}second', 0];
+        yield ['', '{0}first|{1}', 1];
+        yield ['first', '{1.3}first|{2.3}second', 1.3];
+        yield ['second', '{1.3}first|{2.3}second', 2.3];
+        yield ['first
+        line', '{1}first
+        line|{2}second', 1];
+        ["first \n
+        line", "{1}first \n
+        line|{2}second", 1];
 
-            yield ['first', '{0}  first|[1,9]second', 0];
-            yield ['second', '{0}first|[1,9]second', 1];
-            yield ['second', '{0}first|[1,9]second', 10];
-            yield ['first', '{0}first|[2,9]second', 1];
-            yield ['second', '[4,*]first|[1,3]second', 1];
-            yield ['first', '[4,*]first|[1,3]second', 100];
-            yield ['second', '[1,5]first|[6,10]second', 7];
-            yield ['first', '[*,4]first|[5,*]second', 1];
-            yield ['second', '[5,*]first|[*,4]second', 1];
-            yield ['second', '[5,*]first|[*,4]second', 0];
+        yield ['first', '{0}  first|[1,9]second', 0];
+        yield ['second', '{0}first|[1,9]second', 1];
+        yield ['second', '{0}first|[1,9]second', 10];
+        yield ['first', '{0}first|[2,9]second', 1];
+        yield ['second', '[4,*]first|[1,3]second', 1];
+        yield ['first', '[4,*]first|[1,3]second', 100];
+        yield ['second', '[1,5]first|[6,10]second', 7];
+        yield ['first', '[*,4]first|[5,*]second', 1];
+        yield ['second', '[5,*]first|[*,4]second', 1];
+        yield ['second', '[5,*]first|[*,4]second', 0];
 
-            yield ['first', '{0}first|[1,3]second|[4,*]third', 0];
-            yield ['second', '{0}first|[1,3]second|[4,*]third', 1];
-            yield ['third', '{0}first|[1,3]second|[4,*]third', 9];
+        yield ['first', '{0}first|[1,3]second|[4,*]third', 0];
+        yield ['second', '{0}first|[1,3]second|[4,*]third', 1];
+        yield ['third', '{0}first|[1,3]second|[4,*]third', 9];
 
-            yield ['first', 'first|second|third', 1];
-            yield ['second', 'first|second|third', 9];
-            yield ['second', 'first|second|third', 0];
+        yield ['first', 'first|second|third', 1];
+        yield ['second', 'first|second|third', 9];
+        yield ['second', 'first|second|third', 0];
 
-            yield ['first', '{0}  first | { 1 } second', 0];
-            yield ['first', '[4,*]first | [1,3]second', 100];
+        yield ['first', '{0}  first | { 1 } second', 0];
+        yield ['first', '[4,*]first | [1,3]second', 100];
     }
 }

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -41,7 +41,7 @@ class TranslationMessageSelectorTest extends TestCase
         yield ['first
         line', '{1}first
         line|{2}second', 1];
-        ["first \n
+        yield ["first \n
         line", "{1}first \n
         line|{2}second", 1];
 

--- a/tests/Translation/TranslationMessageSelectorTest.php
+++ b/tests/Translation/TranslationMessageSelectorTest.php
@@ -17,53 +17,54 @@ class TranslationMessageSelectorTest extends TestCase
         $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function chooseTestData()
     {
-        return [
-            ['first', 'first', 1],
-            ['first', 'first', 10],
-            ['first', 'first|second', 1],
-            ['second', 'first|second', 10],
-            ['second', 'first|second', 0],
+            yield ['first', 'first', 1];
+            yield ['first', 'first', 10];
+            yield ['first', 'first|second', 1];
+            yield ['second', 'first|second', 10];
+            yield ['second', 'first|second', 0];
 
-            ['first', '{0}  first|{1}second', 0],
-            ['first', '{1}first|{2}second', 1],
-            ['second', '{1}first|{2}second', 2],
-            ['first', '{2}first|{1}second', 2],
-            ['second', '{9}first|{10}second', 0],
-            ['first', '{9}first|{10}second', 1],
-            ['', '{0}|{1}second', 0],
-            ['', '{0}first|{1}', 1],
-            ['first', '{1.3}first|{2.3}second', 1.3],
-            ['second', '{1.3}first|{2.3}second', 2.3],
-            ['first
+            yield ['first', '{0}  first|{1}second', 0];
+            yield ['first', '{1}first|{2}second', 1];
+            yield ['second', '{1}first|{2}second', 2];
+            yield ['first', '{2}first|{1}second', 2];
+            yield ['second', '{9}first|{10}second', 0];
+            yield ['first', '{9}first|{10}second', 1];
+            yield ['', '{0}|{1}second', 0];
+            yield ['', '{0}first|{1}', 1];
+            yield ['first', '{1.3}first|{2.3}second', 1.3];
+            yield ['second', '{1.3}first|{2.3}second', 2.3];
+            yield ['first
             line', '{1}first
-            line|{2}second', 1],
+            line|{2}second', 1];
             ["first \n
             line", "{1}first \n
-            line|{2}second", 1],
+            line|{2}second", 1];
 
-            ['first', '{0}  first|[1,9]second', 0],
-            ['second', '{0}first|[1,9]second', 1],
-            ['second', '{0}first|[1,9]second', 10],
-            ['first', '{0}first|[2,9]second', 1],
-            ['second', '[4,*]first|[1,3]second', 1],
-            ['first', '[4,*]first|[1,3]second', 100],
-            ['second', '[1,5]first|[6,10]second', 7],
-            ['first', '[*,4]first|[5,*]second', 1],
-            ['second', '[5,*]first|[*,4]second', 1],
-            ['second', '[5,*]first|[*,4]second', 0],
+            yield ['first', '{0}  first|[1,9]second', 0];
+            yield ['second', '{0}first|[1,9]second', 1];
+            yield ['second', '{0}first|[1,9]second', 10];
+            yield ['first', '{0}first|[2,9]second', 1];
+            yield ['second', '[4,*]first|[1,3]second', 1];
+            yield ['first', '[4,*]first|[1,3]second', 100];
+            yield ['second', '[1,5]first|[6,10]second', 7];
+            yield ['first', '[*,4]first|[5,*]second', 1];
+            yield ['second', '[5,*]first|[*,4]second', 1];
+            yield ['second', '[5,*]first|[*,4]second', 0];
 
-            ['first', '{0}first|[1,3]second|[4,*]third', 0],
-            ['second', '{0}first|[1,3]second|[4,*]third', 1],
-            ['third', '{0}first|[1,3]second|[4,*]third', 9],
+            yield ['first', '{0}first|[1,3]second|[4,*]third', 0];
+            yield ['second', '{0}first|[1,3]second|[4,*]third', 1];
+            yield ['third', '{0}first|[1,3]second|[4,*]third', 9];
 
-            ['first', 'first|second|third', 1],
-            ['second', 'first|second|third', 9],
-            ['second', 'first|second|third', 0],
+            yield ['first', 'first|second|third', 1];
+            yield ['second', 'first|second|third', 9];
+            yield ['second', 'first|second|third', 0];
 
-            ['first', '{0}  first | { 1 } second', 0],
-            ['first', '[4,*]first | [1,3]second', 100],
-        ];
+            yield ['first', '{0}  first | { 1 } second', 0];
+            yield ['first', '[4,*]first | [1,3]second', 100];
     }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2357,263 +2357,265 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    /**
+     * @return \Generator
+     */
     public function validUrls()
     {
-        return [
-            ['aaa://fully.qualified.domain/path'],
-            ['aaas://fully.qualified.domain/path'],
-            ['about://fully.qualified.domain/path'],
-            ['acap://fully.qualified.domain/path'],
-            ['acct://fully.qualified.domain/path'],
-            ['acr://fully.qualified.domain/path'],
-            ['adiumxtra://fully.qualified.domain/path'],
-            ['afp://fully.qualified.domain/path'],
-            ['afs://fully.qualified.domain/path'],
-            ['aim://fully.qualified.domain/path'],
-            ['apt://fully.qualified.domain/path'],
-            ['attachment://fully.qualified.domain/path'],
-            ['aw://fully.qualified.domain/path'],
-            ['barion://fully.qualified.domain/path'],
-            ['beshare://fully.qualified.domain/path'],
-            ['bitcoin://fully.qualified.domain/path'],
-            ['blob://fully.qualified.domain/path'],
-            ['bolo://fully.qualified.domain/path'],
-            ['callto://fully.qualified.domain/path'],
-            ['cap://fully.qualified.domain/path'],
-            ['chrome://fully.qualified.domain/path'],
-            ['chrome-extension://fully.qualified.domain/path'],
-            ['cid://fully.qualified.domain/path'],
-            ['coap://fully.qualified.domain/path'],
-            ['coaps://fully.qualified.domain/path'],
-            ['com-eventbrite-attendee://fully.qualified.domain/path'],
-            ['content://fully.qualified.domain/path'],
-            ['crid://fully.qualified.domain/path'],
-            ['cvs://fully.qualified.domain/path'],
-            ['data://fully.qualified.domain/path'],
-            ['dav://fully.qualified.domain/path'],
-            ['dict://fully.qualified.domain/path'],
-            ['dlna-playcontainer://fully.qualified.domain/path'],
-            ['dlna-playsingle://fully.qualified.domain/path'],
-            ['dns://fully.qualified.domain/path'],
-            ['dntp://fully.qualified.domain/path'],
-            ['dtn://fully.qualified.domain/path'],
-            ['dvb://fully.qualified.domain/path'],
-            ['ed2k://fully.qualified.domain/path'],
-            ['example://fully.qualified.domain/path'],
-            ['facetime://fully.qualified.domain/path'],
-            ['fax://fully.qualified.domain/path'],
-            ['feed://fully.qualified.domain/path'],
-            ['feedready://fully.qualified.domain/path'],
-            ['file://fully.qualified.domain/path'],
-            ['filesystem://fully.qualified.domain/path'],
-            ['finger://fully.qualified.domain/path'],
-            ['fish://fully.qualified.domain/path'],
-            ['ftp://fully.qualified.domain/path'],
-            ['geo://fully.qualified.domain/path'],
-            ['gg://fully.qualified.domain/path'],
-            ['git://fully.qualified.domain/path'],
-            ['gizmoproject://fully.qualified.domain/path'],
-            ['go://fully.qualified.domain/path'],
-            ['gopher://fully.qualified.domain/path'],
-            ['gtalk://fully.qualified.domain/path'],
-            ['h323://fully.qualified.domain/path'],
-            ['ham://fully.qualified.domain/path'],
-            ['hcp://fully.qualified.domain/path'],
-            ['http://fully.qualified.domain/path'],
-            ['https://fully.qualified.domain/path'],
-            ['iax://fully.qualified.domain/path'],
-            ['icap://fully.qualified.domain/path'],
-            ['icon://fully.qualified.domain/path'],
-            ['im://fully.qualified.domain/path'],
-            ['imap://fully.qualified.domain/path'],
-            ['info://fully.qualified.domain/path'],
-            ['iotdisco://fully.qualified.domain/path'],
-            ['ipn://fully.qualified.domain/path'],
-            ['ipp://fully.qualified.domain/path'],
-            ['ipps://fully.qualified.domain/path'],
-            ['irc://fully.qualified.domain/path'],
-            ['irc6://fully.qualified.domain/path'],
-            ['ircs://fully.qualified.domain/path'],
-            ['iris://fully.qualified.domain/path'],
-            ['iris.beep://fully.qualified.domain/path'],
-            ['iris.lwz://fully.qualified.domain/path'],
-            ['iris.xpc://fully.qualified.domain/path'],
-            ['iris.xpcs://fully.qualified.domain/path'],
-            ['itms://fully.qualified.domain/path'],
-            ['jabber://fully.qualified.domain/path'],
-            ['jar://fully.qualified.domain/path'],
-            ['jms://fully.qualified.domain/path'],
-            ['keyparc://fully.qualified.domain/path'],
-            ['lastfm://fully.qualified.domain/path'],
-            ['ldap://fully.qualified.domain/path'],
-            ['ldaps://fully.qualified.domain/path'],
-            ['magnet://fully.qualified.domain/path'],
-            ['mailserver://fully.qualified.domain/path'],
-            ['mailto://fully.qualified.domain/path'],
-            ['maps://fully.qualified.domain/path'],
-            ['market://fully.qualified.domain/path'],
-            ['message://fully.qualified.domain/path'],
-            ['mid://fully.qualified.domain/path'],
-            ['mms://fully.qualified.domain/path'],
-            ['modem://fully.qualified.domain/path'],
-            ['ms-help://fully.qualified.domain/path'],
-            ['ms-settings://fully.qualified.domain/path'],
-            ['ms-settings-airplanemode://fully.qualified.domain/path'],
-            ['ms-settings-bluetooth://fully.qualified.domain/path'],
-            ['ms-settings-camera://fully.qualified.domain/path'],
-            ['ms-settings-cellular://fully.qualified.domain/path'],
-            ['ms-settings-cloudstorage://fully.qualified.domain/path'],
-            ['ms-settings-emailandaccounts://fully.qualified.domain/path'],
-            ['ms-settings-language://fully.qualified.domain/path'],
-            ['ms-settings-location://fully.qualified.domain/path'],
-            ['ms-settings-lock://fully.qualified.domain/path'],
-            ['ms-settings-nfctransactions://fully.qualified.domain/path'],
-            ['ms-settings-notifications://fully.qualified.domain/path'],
-            ['ms-settings-power://fully.qualified.domain/path'],
-            ['ms-settings-privacy://fully.qualified.domain/path'],
-            ['ms-settings-proximity://fully.qualified.domain/path'],
-            ['ms-settings-screenrotation://fully.qualified.domain/path'],
-            ['ms-settings-wifi://fully.qualified.domain/path'],
-            ['ms-settings-workplace://fully.qualified.domain/path'],
-            ['msnim://fully.qualified.domain/path'],
-            ['msrp://fully.qualified.domain/path'],
-            ['msrps://fully.qualified.domain/path'],
-            ['mtqp://fully.qualified.domain/path'],
-            ['mumble://fully.qualified.domain/path'],
-            ['mupdate://fully.qualified.domain/path'],
-            ['mvn://fully.qualified.domain/path'],
-            ['news://fully.qualified.domain/path'],
-            ['nfs://fully.qualified.domain/path'],
-            ['ni://fully.qualified.domain/path'],
-            ['nih://fully.qualified.domain/path'],
-            ['nntp://fully.qualified.domain/path'],
-            ['notes://fully.qualified.domain/path'],
-            ['oid://fully.qualified.domain/path'],
-            ['opaquelocktoken://fully.qualified.domain/path'],
-            ['pack://fully.qualified.domain/path'],
-            ['palm://fully.qualified.domain/path'],
-            ['paparazzi://fully.qualified.domain/path'],
-            ['pkcs11://fully.qualified.domain/path'],
-            ['platform://fully.qualified.domain/path'],
-            ['pop://fully.qualified.domain/path'],
-            ['pres://fully.qualified.domain/path'],
-            ['prospero://fully.qualified.domain/path'],
-            ['proxy://fully.qualified.domain/path'],
-            ['psyc://fully.qualified.domain/path'],
-            ['query://fully.qualified.domain/path'],
-            ['redis://fully.qualified.domain/path'],
-            ['rediss://fully.qualified.domain/path'],
-            ['reload://fully.qualified.domain/path'],
-            ['res://fully.qualified.domain/path'],
-            ['resource://fully.qualified.domain/path'],
-            ['rmi://fully.qualified.domain/path'],
-            ['rsync://fully.qualified.domain/path'],
-            ['rtmfp://fully.qualified.domain/path'],
-            ['rtmp://fully.qualified.domain/path'],
-            ['rtsp://fully.qualified.domain/path'],
-            ['rtsps://fully.qualified.domain/path'],
-            ['rtspu://fully.qualified.domain/path'],
-            ['s3://fully.qualified.domain/path'],
-            ['secondlife://fully.qualified.domain/path'],
-            ['service://fully.qualified.domain/path'],
-            ['session://fully.qualified.domain/path'],
-            ['sftp://fully.qualified.domain/path'],
-            ['sgn://fully.qualified.domain/path'],
-            ['shttp://fully.qualified.domain/path'],
-            ['sieve://fully.qualified.domain/path'],
-            ['sip://fully.qualified.domain/path'],
-            ['sips://fully.qualified.domain/path'],
-            ['skype://fully.qualified.domain/path'],
-            ['smb://fully.qualified.domain/path'],
-            ['sms://fully.qualified.domain/path'],
-            ['smtp://fully.qualified.domain/path'],
-            ['snews://fully.qualified.domain/path'],
-            ['snmp://fully.qualified.domain/path'],
-            ['soap.beep://fully.qualified.domain/path'],
-            ['soap.beeps://fully.qualified.domain/path'],
-            ['soldat://fully.qualified.domain/path'],
-            ['spotify://fully.qualified.domain/path'],
-            ['ssh://fully.qualified.domain/path'],
-            ['steam://fully.qualified.domain/path'],
-            ['stun://fully.qualified.domain/path'],
-            ['stuns://fully.qualified.domain/path'],
-            ['submit://fully.qualified.domain/path'],
-            ['svn://fully.qualified.domain/path'],
-            ['tag://fully.qualified.domain/path'],
-            ['teamspeak://fully.qualified.domain/path'],
-            ['tel://fully.qualified.domain/path'],
-            ['teliaeid://fully.qualified.domain/path'],
-            ['telnet://fully.qualified.domain/path'],
-            ['tftp://fully.qualified.domain/path'],
-            ['things://fully.qualified.domain/path'],
-            ['thismessage://fully.qualified.domain/path'],
-            ['tip://fully.qualified.domain/path'],
-            ['tn3270://fully.qualified.domain/path'],
-            ['turn://fully.qualified.domain/path'],
-            ['turns://fully.qualified.domain/path'],
-            ['tv://fully.qualified.domain/path'],
-            ['udp://fully.qualified.domain/path'],
-            ['unreal://fully.qualified.domain/path'],
-            ['urn://fully.qualified.domain/path'],
-            ['ut2004://fully.qualified.domain/path'],
-            ['vemmi://fully.qualified.domain/path'],
-            ['ventrilo://fully.qualified.domain/path'],
-            ['videotex://fully.qualified.domain/path'],
-            ['view-source://fully.qualified.domain/path'],
-            ['wais://fully.qualified.domain/path'],
-            ['webcal://fully.qualified.domain/path'],
-            ['ws://fully.qualified.domain/path'],
-            ['wss://fully.qualified.domain/path'],
-            ['wtai://fully.qualified.domain/path'],
-            ['wyciwyg://fully.qualified.domain/path'],
-            ['xcon://fully.qualified.domain/path'],
-            ['xcon-userid://fully.qualified.domain/path'],
-            ['xfire://fully.qualified.domain/path'],
-            ['xmlrpc.beep://fully.qualified.domain/path'],
-            ['xmlrpc.beeps://fully.qualified.domain/path'],
-            ['xmpp://fully.qualified.domain/path'],
-            ['xri://fully.qualified.domain/path'],
-            ['ymsgr://fully.qualified.domain/path'],
-            ['z39.50://fully.qualified.domain/path'],
-            ['z39.50r://fully.qualified.domain/path'],
-            ['z39.50s://fully.qualified.domain/path'],
-            ['http://a.pl'],
-            ['http://localhost/url.php'],
-            ['http://local.dev'],
-            ['http://google.com'],
-            ['http://www.google.com'],
-            ['http://goog_le.com'],
-            ['https://google.com'],
-            ['http://illuminate.dev'],
-            ['http://localhost'],
-            ['https://laravel.com/?'],
-            ['http://президент.рф/'],
-            ['http://스타벅스코리아.com'],
-            ['http://xn--d1abbgf6aiiy.xn--p1ai/'],
-            ['https://laravel.com?'],
-            ['https://laravel.com?q=1'],
-            ['https://laravel.com/?q=1'],
-            ['https://laravel.com#'],
-            ['https://laravel.com#fragment'],
-            ['https://laravel.com/#fragment'],
-        ];
+        yield ['aaa://fully.qualified.domain/path'];
+        yield ['aaas://fully.qualified.domain/path'];
+        yield ['about://fully.qualified.domain/path'];
+        yield ['acap://fully.qualified.domain/path'];
+        yield ['acct://fully.qualified.domain/path'];
+        yield ['acr://fully.qualified.domain/path'];
+        yield ['adiumxtra://fully.qualified.domain/path'];
+        yield ['afp://fully.qualified.domain/path'];
+        yield ['afs://fully.qualified.domain/path'];
+        yield ['aim://fully.qualified.domain/path'];
+        yield ['apt://fully.qualified.domain/path'];
+        yield ['attachment://fully.qualified.domain/path'];
+        yield ['aw://fully.qualified.domain/path'];
+        yield ['barion://fully.qualified.domain/path'];
+        yield ['beshare://fully.qualified.domain/path'];
+        yield ['bitcoin://fully.qualified.domain/path'];
+        yield ['blob://fully.qualified.domain/path'];
+        yield ['bolo://fully.qualified.domain/path'];
+        yield ['callto://fully.qualified.domain/path'];
+        yield ['cap://fully.qualified.domain/path'];
+        yield ['chrome://fully.qualified.domain/path'];
+        yield ['chrome-extension://fully.qualified.domain/path'];
+        yield ['cid://fully.qualified.domain/path'];
+        yield ['coap://fully.qualified.domain/path'];
+        yield ['coaps://fully.qualified.domain/path'];
+        yield ['com-eventbrite-attendee://fully.qualified.domain/path'];
+        yield ['content://fully.qualified.domain/path'];
+        yield ['crid://fully.qualified.domain/path'];
+        yield ['cvs://fully.qualified.domain/path'];
+        yield ['data://fully.qualified.domain/path'];
+        yield ['dav://fully.qualified.domain/path'];
+        yield ['dict://fully.qualified.domain/path'];
+        yield ['dlna-playcontainer://fully.qualified.domain/path'];
+        yield ['dlna-playsingle://fully.qualified.domain/path'];
+        yield ['dns://fully.qualified.domain/path'];
+        yield ['dntp://fully.qualified.domain/path'];
+        yield ['dtn://fully.qualified.domain/path'];
+        yield ['dvb://fully.qualified.domain/path'];
+        yield ['ed2k://fully.qualified.domain/path'];
+        yield ['example://fully.qualified.domain/path'];
+        yield ['facetime://fully.qualified.domain/path'];
+        yield ['fax://fully.qualified.domain/path'];
+        yield ['feed://fully.qualified.domain/path'];
+        yield ['feedready://fully.qualified.domain/path'];
+        yield ['file://fully.qualified.domain/path'];
+        yield ['filesystem://fully.qualified.domain/path'];
+        yield ['finger://fully.qualified.domain/path'];
+        yield ['fish://fully.qualified.domain/path'];
+        yield ['ftp://fully.qualified.domain/path'];
+        yield ['geo://fully.qualified.domain/path'];
+        yield ['gg://fully.qualified.domain/path'];
+        yield ['git://fully.qualified.domain/path'];
+        yield ['gizmoproject://fully.qualified.domain/path'];
+        yield ['go://fully.qualified.domain/path'];
+        yield ['gopher://fully.qualified.domain/path'];
+        yield ['gtalk://fully.qualified.domain/path'];
+        yield ['h323://fully.qualified.domain/path'];
+        yield ['ham://fully.qualified.domain/path'];
+        yield ['hcp://fully.qualified.domain/path'];
+        yield ['http://fully.qualified.domain/path'];
+        yield ['https://fully.qualified.domain/path'];
+        yield ['iax://fully.qualified.domain/path'];
+        yield ['icap://fully.qualified.domain/path'];
+        yield ['icon://fully.qualified.domain/path'];
+        yield ['im://fully.qualified.domain/path'];
+        yield ['imap://fully.qualified.domain/path'];
+        yield ['info://fully.qualified.domain/path'];
+        yield ['iotdisco://fully.qualified.domain/path'];
+        yield ['ipn://fully.qualified.domain/path'];
+        yield ['ipp://fully.qualified.domain/path'];
+        yield ['ipps://fully.qualified.domain/path'];
+        yield ['irc://fully.qualified.domain/path'];
+        yield ['irc6://fully.qualified.domain/path'];
+        yield ['ircs://fully.qualified.domain/path'];
+        yield ['iris://fully.qualified.domain/path'];
+        yield ['iris.beep://fully.qualified.domain/path'];
+        yield ['iris.lwz://fully.qualified.domain/path'];
+        yield ['iris.xpc://fully.qualified.domain/path'];
+        yield ['iris.xpcs://fully.qualified.domain/path'];
+        yield ['itms://fully.qualified.domain/path'];
+        yield ['jabber://fully.qualified.domain/path'];
+        yield ['jar://fully.qualified.domain/path'];
+        yield ['jms://fully.qualified.domain/path'];
+        yield ['keyparc://fully.qualified.domain/path'];
+        yield ['lastfm://fully.qualified.domain/path'];
+        yield ['ldap://fully.qualified.domain/path'];
+        yield ['ldaps://fully.qualified.domain/path'];
+        yield ['magnet://fully.qualified.domain/path'];
+        yield ['mailserver://fully.qualified.domain/path'];
+        yield ['mailto://fully.qualified.domain/path'];
+        yield ['maps://fully.qualified.domain/path'];
+        yield ['market://fully.qualified.domain/path'];
+        yield ['message://fully.qualified.domain/path'];
+        yield ['mid://fully.qualified.domain/path'];
+        yield ['mms://fully.qualified.domain/path'];
+        yield ['modem://fully.qualified.domain/path'];
+        yield ['ms-help://fully.qualified.domain/path'];
+        yield ['ms-settings://fully.qualified.domain/path'];
+        yield ['ms-settings-airplanemode://fully.qualified.domain/path'];
+        yield ['ms-settings-bluetooth://fully.qualified.domain/path'];
+        yield ['ms-settings-camera://fully.qualified.domain/path'];
+        yield ['ms-settings-cellular://fully.qualified.domain/path'];
+        yield ['ms-settings-cloudstorage://fully.qualified.domain/path'];
+        yield ['ms-settings-emailandaccounts://fully.qualified.domain/path'];
+        yield ['ms-settings-language://fully.qualified.domain/path'];
+        yield ['ms-settings-location://fully.qualified.domain/path'];
+        yield ['ms-settings-lock://fully.qualified.domain/path'];
+        yield ['ms-settings-nfctransactions://fully.qualified.domain/path'];
+        yield ['ms-settings-notifications://fully.qualified.domain/path'];
+        yield ['ms-settings-power://fully.qualified.domain/path'];
+        yield ['ms-settings-privacy://fully.qualified.domain/path'];
+        yield ['ms-settings-proximity://fully.qualified.domain/path'];
+        yield ['ms-settings-screenrotation://fully.qualified.domain/path'];
+        yield ['ms-settings-wifi://fully.qualified.domain/path'];
+        yield ['ms-settings-workplace://fully.qualified.domain/path'];
+        yield ['msnim://fully.qualified.domain/path'];
+        yield ['msrp://fully.qualified.domain/path'];
+        yield ['msrps://fully.qualified.domain/path'];
+        yield ['mtqp://fully.qualified.domain/path'];
+        yield ['mumble://fully.qualified.domain/path'];
+        yield ['mupdate://fully.qualified.domain/path'];
+        yield ['mvn://fully.qualified.domain/path'];
+        yield ['news://fully.qualified.domain/path'];
+        yield ['nfs://fully.qualified.domain/path'];
+        yield ['ni://fully.qualified.domain/path'];
+        yield ['nih://fully.qualified.domain/path'];
+        yield ['nntp://fully.qualified.domain/path'];
+        yield ['notes://fully.qualified.domain/path'];
+        yield ['oid://fully.qualified.domain/path'];
+        yield ['opaquelocktoken://fully.qualified.domain/path'];
+        yield ['pack://fully.qualified.domain/path'];
+        yield ['palm://fully.qualified.domain/path'];
+        yield ['paparazzi://fully.qualified.domain/path'];
+        yield ['pkcs11://fully.qualified.domain/path'];
+        yield ['platform://fully.qualified.domain/path'];
+        yield ['pop://fully.qualified.domain/path'];
+        yield ['pres://fully.qualified.domain/path'];
+        yield ['prospero://fully.qualified.domain/path'];
+        yield ['proxy://fully.qualified.domain/path'];
+        yield ['psyc://fully.qualified.domain/path'];
+        yield ['query://fully.qualified.domain/path'];
+        yield ['redis://fully.qualified.domain/path'];
+        yield ['rediss://fully.qualified.domain/path'];
+        yield ['reload://fully.qualified.domain/path'];
+        yield ['res://fully.qualified.domain/path'];
+        yield ['resource://fully.qualified.domain/path'];
+        yield ['rmi://fully.qualified.domain/path'];
+        yield ['rsync://fully.qualified.domain/path'];
+        yield ['rtmfp://fully.qualified.domain/path'];
+        yield ['rtmp://fully.qualified.domain/path'];
+        yield ['rtsp://fully.qualified.domain/path'];
+        yield ['rtsps://fully.qualified.domain/path'];
+        yield ['rtspu://fully.qualified.domain/path'];
+        yield ['s3://fully.qualified.domain/path'];
+        yield ['secondlife://fully.qualified.domain/path'];
+        yield ['service://fully.qualified.domain/path'];
+        yield ['session://fully.qualified.domain/path'];
+        yield ['sftp://fully.qualified.domain/path'];
+        yield ['sgn://fully.qualified.domain/path'];
+        yield ['shttp://fully.qualified.domain/path'];
+        yield ['sieve://fully.qualified.domain/path'];
+        yield ['sip://fully.qualified.domain/path'];
+        yield ['sips://fully.qualified.domain/path'];
+        yield ['skype://fully.qualified.domain/path'];
+        yield ['smb://fully.qualified.domain/path'];
+        yield ['sms://fully.qualified.domain/path'];
+        yield ['smtp://fully.qualified.domain/path'];
+        yield ['snews://fully.qualified.domain/path'];
+        yield ['snmp://fully.qualified.domain/path'];
+        yield ['soap.beep://fully.qualified.domain/path'];
+        yield ['soap.beeps://fully.qualified.domain/path'];
+        yield ['soldat://fully.qualified.domain/path'];
+        yield ['spotify://fully.qualified.domain/path'];
+        yield ['ssh://fully.qualified.domain/path'];
+        yield ['steam://fully.qualified.domain/path'];
+        yield ['stun://fully.qualified.domain/path'];
+        yield ['stuns://fully.qualified.domain/path'];
+        yield ['submit://fully.qualified.domain/path'];
+        yield ['svn://fully.qualified.domain/path'];
+        yield ['tag://fully.qualified.domain/path'];
+        yield ['teamspeak://fully.qualified.domain/path'];
+        yield ['tel://fully.qualified.domain/path'];
+        yield ['teliaeid://fully.qualified.domain/path'];
+        yield ['telnet://fully.qualified.domain/path'];
+        yield ['tftp://fully.qualified.domain/path'];
+        yield ['things://fully.qualified.domain/path'];
+        yield ['thismessage://fully.qualified.domain/path'];
+        yield ['tip://fully.qualified.domain/path'];
+        yield ['tn3270://fully.qualified.domain/path'];
+        yield ['turn://fully.qualified.domain/path'];
+        yield ['turns://fully.qualified.domain/path'];
+        yield ['tv://fully.qualified.domain/path'];
+        yield ['udp://fully.qualified.domain/path'];
+        yield ['unreal://fully.qualified.domain/path'];
+        yield ['urn://fully.qualified.domain/path'];
+        yield ['ut2004://fully.qualified.domain/path'];
+        yield ['vemmi://fully.qualified.domain/path'];
+        yield ['ventrilo://fully.qualified.domain/path'];
+        yield ['videotex://fully.qualified.domain/path'];
+        yield ['view-source://fully.qualified.domain/path'];
+        yield ['wais://fully.qualified.domain/path'];
+        yield ['webcal://fully.qualified.domain/path'];
+        yield ['ws://fully.qualified.domain/path'];
+        yield ['wss://fully.qualified.domain/path'];
+        yield ['wtai://fully.qualified.domain/path'];
+        yield ['wyciwyg://fully.qualified.domain/path'];
+        yield ['xcon://fully.qualified.domain/path'];
+        yield ['xcon-userid://fully.qualified.domain/path'];
+        yield ['xfire://fully.qualified.domain/path'];
+        yield ['xmlrpc.beep://fully.qualified.domain/path'];
+        yield ['xmlrpc.beeps://fully.qualified.domain/path'];
+        yield ['xmpp://fully.qualified.domain/path'];
+        yield ['xri://fully.qualified.domain/path'];
+        yield ['ymsgr://fully.qualified.domain/path'];
+        yield ['z39.50://fully.qualified.domain/path'];
+        yield ['z39.50r://fully.qualified.domain/path'];
+        yield ['z39.50s://fully.qualified.domain/path'];
+        yield ['http://a.pl'];
+        yield ['http://localhost/url.php'];
+        yield ['http://local.dev'];
+        yield ['http://google.com'];
+        yield ['http://www.google.com'];
+        yield ['http://goog_le.com'];
+        yield ['https://google.com'];
+        yield ['http://illuminate.dev'];
+        yield ['http://localhost'];
+        yield ['https://laravel.com/?'];
+        yield ['http://президент.рф/'];
+        yield ['http://스타벅스코리아.com'];
+        yield ['http://xn--d1abbgf6aiiy.xn--p1ai/'];
+        yield ['https://laravel.com?'];
+        yield ['https://laravel.com?q=1'];
+        yield ['https://laravel.com/?q=1'];
+        yield ['https://laravel.com#'];
+        yield ['https://laravel.com#fragment'];
+        yield ['https://laravel.com/#fragment'];
     }
 
+    /**
+     * @return \Generator
+     */
     public function invalidUrls()
     {
-        return [
-            ['aslsdlks'],
-            ['google.com'],
-            ['://google.com'],
-            ['http ://google.com'],
-            ['http:/google.com'],
-            ['http://google.com::aa'],
-            ['http://google.com:aa'],
-            ['http://127.0.0.1:aa'],
-            ['http://[::1'],
-            ['foo://bar'],
-            ['javascript://test%0Aalert(321)'],
-        ];
+        yield ['aslsdlks'];
+        yield ['google.com'];
+        yield ['://google.com'];
+        yield ['http ://google.com'];
+        yield ['http:/google.com'];
+        yield ['http://google.com::aa'];
+        yield ['http://google.com:aa'];
+        yield ['http://127.0.0.1:aa'];
+        yield ['http://[::1'];
+        yield ['foo://bar'];
+        yield ['javascript://test%0Aalert(321)'];
     }
 
     public function testValidateActiveUrl()
@@ -4781,36 +4783,38 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    /**
+     * @return \Generator
+     */
     public function validUuidList()
     {
-        return [
-            ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
-            ['00000000-0000-0000-0000-000000000000'],
-            ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'],
-            ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'],
-            ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'],
-            ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'],
-        ];
+        yield ['a0a2a2d2-0b87-4a18-83f2-2529882be2de'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'];
+        yield ['00000000-0000-0000-0000-000000000000'];
+        yield ['e60d3f48-95d7-4d8d-aad0-856f29a27da2'];
+        yield ['ff6f8cb0-c57d-11e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-21e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-31e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-41e1-9b21-0800200c9a66'];
+        yield ['ff6f8cb0-c57d-51e1-9b21-0800200c9a66'];
+        yield ['FF6F8CB0-C57D-11E1-9B21-0800200C9A66'];
     }
 
+    /**
+     * @return \Generator
+     */
     public function invalidUuidList()
     {
-        return [
-            ['not a valid uuid so we can test this'],
-            ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL],
-            ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '],
-            [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'],
-            ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'],
-            ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'],
-            ['af6f8cb-c57d-11e1-9b21-0800200c9a66'],
-            ['af6f8cb0c57d11e19b210800200c9a66'],
-            ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'],
-        ];
+        yield ['not a valid uuid so we can test this'];
+        yield ['zf6f8cb0-c57d-11e1-9b21-0800200c9a66'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'.PHP_EOL];
+        yield ['145a1e72-d11d-11e8-a8d5-f2801f1b9fd1 '];
+        yield [' 145a1e72-d11d-11e8-a8d5-f2801f1b9fd1'];
+        yield ['145a1e72-d11d-11e8-a8d5-f2z01f1b9fd1'];
+        yield ['3f6f8cb0-c57d-11e1-9b21-0800200c9a6'];
+        yield ['af6f8cb-c57d-11e1-9b21-0800200c9a66'];
+        yield ['af6f8cb0c57d11e19b210800200c9a66'];
+        yield ['ff6f8cb0-c57da-51e1-9b21-0800200c9a66'];
     }
 
     public function providesPassingExcludeIfData()

--- a/tests/View/ViewFileViewFinderTest.php
+++ b/tests/View/ViewFileViewFinderTest.php
@@ -146,11 +146,12 @@ class ViewFileViewFinderTest extends TestCase
         $this->assertFalse($finder->hasHintInformation('::foo.bar'));
     }
 
+    /**
+     * @return \Generator
+     */
     public function pathsProvider()
     {
-        return [
-            ['incorrect_path', 'incorrect_path'],
-        ];
+        yield ['incorrect_path', 'incorrect_path'];
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Use `dataProviders` with `yield`.
This provides an elegant syntax for large provides arrays.

This also helps ensuring that they are no data set for each test, as it was the case for `routeRedirectDataSets` - set `route redirect with two parameter replacements`.