### PR TITLE
[7.x] Use stricter assertions when asserting string

### DIFF
--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -84,10 +84,10 @@ class CommandTest extends TestCase
 
         $command->run($input, $output);
 
-        $this->assertEquals('test-first-argument', $command->argument('argument-one'));
-        $this->assertequals('test-second-argument', $command->argument('argument-two'));
-        $this->assertEquals('test-first-option', $command->option('option-one'));
-        $this->assertEquals('test-second-option', $command->option('option-two'));
+        $this->assertSame('test-first-argument', $command->argument('argument-one'));
+        $this->assertSame('test-second-argument', $command->argument('argument-two'));
+        $this->assertSame('test-first-option', $command->option('option-one'));
+        $this->assertSame('test-second-option', $command->option('option-two'));
     }
 
     public function testTheInputSetterOverwrite()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -224,7 +224,7 @@ class DatabaseEloquentModelTest extends TestCase
         $newInstance = $model->newInstance();
 
         $this->assertArrayHasKey('foo', $newInstance->getCasts());
-        $this->assertEquals('date', $newInstance->getCasts()['foo']);
+        $this->assertSame('date', $newInstance->getCasts()['foo']);
     }
 
     public function testCreateMethodSavesNewModel()
@@ -2043,8 +2043,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(0.443, $model->floatAttribute);
 
         $this->assertIsString($model->getOriginal('stringAttribute'));
-        $this->assertEquals('432', $model->getOriginal('stringAttribute'));
-        $this->assertEquals('12', $model->stringAttribute);
+        $this->assertSame('432', $model->getOriginal('stringAttribute'));
+        $this->assertSame('12', $model->stringAttribute);
 
         $this->assertIsBool($model->getOriginal('boolAttribute'));
         $this->assertTrue($model->getOriginal('boolAttribute'));

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -240,7 +240,7 @@ class DatabaseEloquentRelationTest extends TestCase
 
         $original->setRelation('foo', 'baz');
 
-        $this->assertEquals('baz', $original->getRelation('foo'));
+        $this->assertSame('baz', $original->getRelation('foo'));
 
         $model = $original->withoutRelations();
 

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -187,7 +187,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
     {
         $this->migrator->setConnection('default');
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
-        $this->assertEquals('default', $this->migrator->getConnection());
+        $this->assertSame('default', $this->migrator->getConnection());
     }
 
     public function testConnectionPriorToMigrationIsNotChangedAfterRollback()
@@ -195,7 +195,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->setConnection('default');
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
-        $this->assertEquals('default', $this->migrator->getConnection());
+        $this->assertSame('default', $this->migrator->getConnection());
     }
 
     public function testConnectionPriorToMigrationIsNotChangedWhenNoOutstandingMigrationsExist()
@@ -204,7 +204,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->migrator->setConnection('default');
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
-        $this->assertEquals('default', $this->migrator->getConnection());
+        $this->assertSame('default', $this->migrator->getConnection());
     }
 
     public function testConnectionPriorToMigrationIsNotChangedWhenNothingToRollback()
@@ -213,7 +213,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->migrator->rollback([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
-        $this->assertEquals('default', $this->migrator->getConnection());
+        $this->assertSame('default', $this->migrator->getConnection());
     }
 
     public function testConnectionPriorToMigrationIsNotChangedAfterMigrateReset()
@@ -221,6 +221,6 @@ class DatabaseMigratorIntegrationTest extends TestCase
         $this->migrator->setConnection('default');
         $this->migrator->run([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
         $this->migrator->reset([__DIR__.'/migrations/one'], ['database' => 'sqlite2']);
-        $this->assertEquals('default', $this->migrator->getConnection());
+        $this->assertSame('default', $this->migrator->getConnection());
     }
 }

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -123,7 +123,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertEquals("DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE [dbo].[foo] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM SYS.COLUMNS WHERE [object_id] = OBJECT_ID('[dbo].[foo]') AND [name] in ('bar') AND [default_object_id] <> 0;EXEC(@sql);alter table \"foo\" drop column \"bar\"", $statements[0]);
+        $this->assertSame("DECLARE @sql NVARCHAR(MAX) = '';SELECT @sql += 'ALTER TABLE [dbo].[foo] DROP CONSTRAINT ' + OBJECT_NAME([default_object_id]) + ';' FROM SYS.COLUMNS WHERE [object_id] = OBJECT_ID('[dbo].[foo]') AND [name] in ('bar') AND [default_object_id] <> 0;EXEC(@sql);alter table \"foo\" drop column \"bar\"", $statements[0]);
     }
 
     public function testDropPrimary()
@@ -203,7 +203,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
-        $this->assertEquals('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
+        $this->assertSame('drop index "photos_imageable_type_imageable_id_index" on "photos"', $statements[0]);
         $this->assertStringContainsString('alter table "photos" drop column "imageable_type", "imageable_id"', $statements[1]);
     }
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -48,10 +48,10 @@ class EventsDispatcherTest extends TestCase
         });
 
         $response = $d->dispatch('foo', ['bar'], true);
-        $this->assertEquals('here', $response);
+        $this->assertSame('here', $response);
 
         $response = $d->until('foo', ['bar']);
-        $this->assertEquals('here', $response);
+        $this->assertSame('here', $response);
     }
 
     public function testResponseWhenNoListenersAreSet()

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -239,7 +239,7 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter->put('bar.txt', $stream);
 
         $spy->shouldHaveReceived('putStream');
-        $this->assertEquals('some-data', $filesystemAdapter->get('bar.txt'));
+        $this->assertSame('some-data', $filesystemAdapter->get('bar.txt'));
     }
 
     public function testPutFileAs()

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -16,21 +16,21 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model = new TestEloquentModelWithCustomCast;
         $model->uppercase = 'taylor';
 
-        $this->assertEquals('TAYLOR', $model->uppercase);
-        $this->assertEquals('TAYLOR', $model->getAttributes()['uppercase']);
-        $this->assertEquals('TAYLOR', $model->toArray()['uppercase']);
+        $this->assertSame('TAYLOR', $model->uppercase);
+        $this->assertSame('TAYLOR', $model->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $model->toArray()['uppercase']);
 
         $unserializedModel = unserialize(serialize($model));
 
-        $this->assertEquals('TAYLOR', $unserializedModel->uppercase);
-        $this->assertEquals('TAYLOR', $unserializedModel->getAttributes()['uppercase']);
-        $this->assertEquals('TAYLOR', $unserializedModel->toArray()['uppercase']);
+        $this->assertSame('TAYLOR', $unserializedModel->uppercase);
+        $this->assertSame('TAYLOR', $unserializedModel->getAttributes()['uppercase']);
+        $this->assertSame('TAYLOR', $unserializedModel->toArray()['uppercase']);
 
         $model = new TestEloquentModelWithCustomCast;
 
         $model->address = $address = new Address('110 Kingsbrook St.', 'My Childhood House');
         $address->lineOne = '117 Spencer St.';
-        $this->assertEquals('117 Spencer St.', $model->getAttributes()['address_line_one']);
+        $this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
 
         $model = new TestEloquentModelWithCustomCast;
 
@@ -39,20 +39,20 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
             'address_line_two' => 'My Childhood House',
         ]);
 
-        $this->assertEquals('110 Kingsbrook St.', $model->address->lineOne);
-        $this->assertEquals('My Childhood House', $model->address->lineTwo);
+        $this->assertSame('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertSame('My Childhood House', $model->address->lineTwo);
 
-        $this->assertEquals('110 Kingsbrook St.', $model->toArray()['address_line_one']);
-        $this->assertEquals('My Childhood House', $model->toArray()['address_line_two']);
+        $this->assertSame('110 Kingsbrook St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
 
         $model->address->lineOne = '117 Spencer St.';
 
         $this->assertFalse(isset($model->toArray()['address']));
-        $this->assertEquals('117 Spencer St.', $model->toArray()['address_line_one']);
-        $this->assertEquals('My Childhood House', $model->toArray()['address_line_two']);
+        $this->assertSame('117 Spencer St.', $model->toArray()['address_line_one']);
+        $this->assertSame('My Childhood House', $model->toArray()['address_line_two']);
 
-        $this->assertEquals('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
-        $this->assertEquals('My Childhood House', json_decode($model->toJson(), true)['address_line_two']);
+        $this->assertSame('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
+        $this->assertSame('My Childhood House', json_decode($model->toJson(), true)['address_line_two']);
 
         $model->address = null;
 
@@ -104,14 +104,14 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
             'address_line_two' => 'My Childhood House',
         ]);
 
-        $this->assertEquals('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->address->lineOne);
 
         $model->setRawAttributes([
             'address_line_one' => '117 Spencer St.',
             'address_line_two' => 'My Childhood House',
         ]);
 
-        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
     }
 }
 

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -229,8 +229,8 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         );
         foreach ($post->tagsWithCustomExtraPivot as $tag) {
             $this->assertSame('exclude', $tag->pivot->flag);
-            $this->assertEquals('1507630210', $tag->pivot->getAttributes()['created_at']);
-            $this->assertEquals('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
+            $this->assertSame('1507630210', $tag->pivot->getAttributes()['created_at']);
+            $this->assertSame('1507630220', $tag->pivot->getAttributes()['updated_at']); // +10 seconds
         }
     }
 

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -72,7 +72,7 @@ class EloquentWithCountTest extends DatabaseTestCase
 
         $result = Model1::withCount('twos')->toSql();
 
-        $this->assertEquals('select "one".*, (select count(*) from "two" where "one"."id" = "two"."one_id") as "twos_count" from "one"', $result);
+        $this->assertSame('select "one".*, (select count(*) from "two" where "one"."id" = "two"."one_id") as "twos_count" from "one"', $result);
     }
 }
 

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -65,7 +65,7 @@ class ResourceTest extends TestCase
             'abstract' => 'Test abstract',
         ]));
 
-        $this->assertEquals('{"id":5,"title":"Test Title","custom":true}', $resource->toJson());
+        $this->assertSame('{"id":5,"title":"Test Title","custom":true}', $resource->toJson());
     }
 
     public function testAnObjectsMayBeConvertedToJson()

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -313,7 +313,7 @@ class ModelSerializationTest extends TestCase
 
         $serialized = serialize(new ModelSerializationParentAccessibleTestClass($user, $user, $user));
 
-        $this->assertEquals(
+        $this->assertSame(
             'O:78:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationParentAccessibleTestClass":2:{s:4:"user";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}s:8:"'."\0".'*'."\0".'user2";O:45:"Illuminate\\Contracts\\Database\\ModelIdentifier":4:{s:5:"class";s:61:"Illuminate\\Tests\\Integration\\Queue\\ModelSerializationTestUser";s:2:"id";i:1;s:9:"relations";a:0:{}s:10:"connection";s:9:"testbench";}}', $serialized
         );
     }

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -318,7 +318,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $routes->add($this->newRoute('GET', '/', ['uses' => 'FooController@index', 'as' => 'bar']));
 
-        $this->assertEquals('foo', $routes->match(Request::create('/', 'GET'))->getName());
+        $this->assertSame('foo', $routes->match(Request::create('/', 'GET'))->getName());
     }
 
     public function testMatchingFindsRouteWithDifferentMethodDynamically()
@@ -360,7 +360,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $routes->add($this->newRoute('GET', '/bar/{id}', ['uses' => 'FooController@index', 'as' => 'bar']));
 
-        $this->assertEquals('bar', $routes->match(Request::create('/bar/1', 'GET'))->getName());
+        $this->assertSame('bar', $routes->match(Request::create('/bar/1', 'GET'))->getName());
     }
 
     public function testMatchingFallbackRouteCatchesAll()
@@ -374,7 +374,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $routes->add($this->newRoute('GET', '/bar/{id}', ['uses' => 'FooController@index', 'as' => 'bar']));
 
-        $this->assertEquals('fallback', $routes->match(Request::create('/baz/1', 'GET'))->getName());
+        $this->assertSame('fallback', $routes->match(Request::create('/baz/1', 'GET'))->getName());
     }
 
     public function testMatchingCachedFallbackTakesPrecedenceOverDynamicFallback()
@@ -385,7 +385,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $routes->add($this->fallbackRoute(['uses' => 'FooController@index', 'as' => 'dynamic_fallback']));
 
-        $this->assertEquals('fallback', $routes->match(Request::create('/baz/1', 'GET'))->getName());
+        $this->assertSame('fallback', $routes->match(Request::create('/baz/1', 'GET'))->getName());
     }
 
     public function testMatchingCachedFallbackTakesPrecedenceOverDynamicRouteWithWrongMethod()
@@ -396,7 +396,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $routes->add($this->newRoute('POST', '/bar/{id}', ['uses' => 'FooController@index', 'as' => 'bar']));
 
-        $this->assertEquals('fallback', $routes->match(Request::create('/bar/1', 'GET'))->getName());
+        $this->assertSame('fallback', $routes->match(Request::create('/bar/1', 'GET'))->getName());
     }
 
     public function testSlashPrefixIsProperlyHandled()
@@ -405,7 +405,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $route = $this->collection()->getByAction('FooController@index');
 
-        $this->assertEquals('foo/bar', $route->uri());
+        $this->assertSame('foo/bar', $route->uri());
     }
 
     public function testRouteBindingsAreProperlySaved()
@@ -418,7 +418,7 @@ class CompiledRouteCollectionTest extends IntegrationTest
 
         $route = $this->collection()->getByName('foo');
 
-        $this->assertEquals('profile/{user}/posts/{post}/show', $route->uri());
+        $this->assertSame('profile/{user}/posts/{post}/show', $route->uri());
         $this->assertSame(['user' => 'username', 'post' => 'slug'], $route->bindingFields());
     }
 

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -45,7 +45,7 @@ class RequestValidationTest extends TestCase
         try {
             $request->validateWithBag('some_bag', ['name' => 'string']);
         } catch (ValidationException $validationException) {
-            $this->assertEquals('some_bag', $validationException->errorBag);
+            $this->assertSame('some_bag', $validationException->errorBag);
         }
     }
 }

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -46,7 +46,7 @@ class ValidatorTest extends DatabaseTestCase
 
         $validator->passes();
 
-        $this->assertEquals('name at line 1 must be a string!', $validator->getMessageBag()->all()[0]);
+        $this->assertSame('name at line 1 must be a string!', $validator->getMessageBag()->all()[0]);
     }
 
     protected function getValidator(array $data, array $rules)

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -124,7 +124,7 @@ class MailMailableTest extends TestCase
 
         $mailable = unserialize(serialize($mailable));
 
-        $this->assertEquals('array', $mailable->mailer);
+        $this->assertSame('array', $mailable->mailer);
     }
 }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -155,7 +155,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $mailer->alwaysReturnPath('taylorotwell@gmail.com');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
-            $this->assertEquals('taylorotwell@gmail.com', $message->getReturnPath());
+            $this->assertSame('taylorotwell@gmail.com', $message->getReturnPath());
         });
         $mailer->send('foo', ['data'], function ($m) {
             //

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -91,8 +91,8 @@ class PipelineTest extends TestCase
             ->through($function)
             ->thenReturn();
 
-        $this->assertEquals('bar', $result);
-        $this->assertEquals('foo', $_SERVER['__test.pipe.one']);
+        $this->assertSame('bar', $result);
+        $this->assertSame('foo', $_SERVER['__test.pipe.one']);
 
         unset($_SERVER['__test.pipe.one']);
     }

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -91,7 +91,7 @@ class DurationLimiterTest extends TestCase
             return 'foo';
         });
 
-        $this->assertEquals('foo', $result);
+        $this->assertSame('foo', $result);
     }
 
     private function redis()

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -10,27 +10,27 @@ class RouteUriTest extends TestCase
     public function testRouteUrisAreProperlyParsed()
     {
         $parsed = RouteUri::parse('/foo');
-        $this->assertEquals('/foo', $parsed->uri);
+        $this->assertSame('/foo', $parsed->uri);
         $this->assertEquals([], $parsed->bindingFields);
 
         $parsed = RouteUri::parse('/foo/{bar}');
-        $this->assertEquals('/foo/{bar}', $parsed->uri);
+        $this->assertSame('/foo/{bar}', $parsed->uri);
         $this->assertEquals([], $parsed->bindingFields);
 
         $parsed = RouteUri::parse('/foo/{bar:slug}');
-        $this->assertEquals('/foo/{bar}', $parsed->uri);
+        $this->assertSame('/foo/{bar}', $parsed->uri);
         $this->assertEquals(['bar' => 'slug'], $parsed->bindingFields);
 
         $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug}');
-        $this->assertEquals('/foo/{bar}/baz/{qux}', $parsed->uri);
+        $this->assertSame('/foo/{bar}/baz/{qux}', $parsed->uri);
         $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
 
         $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug?}');
-        $this->assertEquals('/foo/{bar}/baz/{qux?}', $parsed->uri);
+        $this->assertSame('/foo/{bar}/baz/{qux?}', $parsed->uri);
         $this->assertEquals(['qux' => 'slug'], $parsed->bindingFields);
 
         $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug?}/{test:id?}');
-        $this->assertEquals('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
+        $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
         $this->assertEquals(['qux' => 'slug', 'test' => 'id'], $parsed->bindingFields);
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -383,7 +383,7 @@ class RoutingRouteTest extends TestCase
             return 'foo';
         })->name('foo');
 
-        $this->assertEquals('slug', $route->bindingFieldFor('bar'));
+        $this->assertSame('slug', $route->bindingFieldFor('bar'));
 
         $route = $router->get('foo/{bar:slug}/{baz}', function () {
             return 'foo';
@@ -797,7 +797,7 @@ class RoutingRouteTest extends TestCase
             //
         }]);
 
-        $this->assertEquals('profiles/{user}/portfolios/foo', $route->uri());
+        $this->assertSame('profiles/{user}/portfolios/foo', $route->uri());
     }
 
     public function testDotDoesNotMatchEverything()

--- a/tests/Session/ArraySessionHandlerTest.php
+++ b/tests/Session/ArraySessionHandlerTest.php
@@ -34,7 +34,7 @@ class ArraySessionHandlerTest extends TestCase
 
         $handler->write('foo', 'bar');
 
-        $this->assertEquals('bar', $handler->read('foo'));
+        $this->assertSame('bar', $handler->read('foo'));
     }
 
     public function test_it_reads_data_from_an_almost_expired_session()
@@ -44,7 +44,7 @@ class ArraySessionHandlerTest extends TestCase
         $handler->write('foo', 'bar');
 
         Carbon::setTestNow(Carbon::now()->addMinutes(10));
-        $this->assertEquals('bar', $handler->read('foo'));
+        $this->assertSame('bar', $handler->read('foo'));
         Carbon::setTestNow();
     }
 
@@ -55,7 +55,7 @@ class ArraySessionHandlerTest extends TestCase
         $handler->write('foo', 'bar');
 
         Carbon::setTestNow(Carbon::now()->addMinutes(10)->addSecond());
-        $this->assertEquals('', $handler->read('foo'));
+        $this->assertSame('', $handler->read('foo'));
         Carbon::setTestNow();
     }
 
@@ -63,7 +63,7 @@ class ArraySessionHandlerTest extends TestCase
     {
         $handler = new ArraySessionHandler(10);
 
-        $this->assertEquals('', $handler->read('foo'));
+        $this->assertSame('', $handler->read('foo'));
     }
 
     public function test_it_writes_session_data()
@@ -71,10 +71,10 @@ class ArraySessionHandlerTest extends TestCase
         $handler = new ArraySessionHandler(10);
 
         $this->assertTrue($handler->write('foo', 'bar'));
-        $this->assertEquals('bar', $handler->read('foo'));
+        $this->assertSame('bar', $handler->read('foo'));
 
         $this->assertTrue($handler->write('foo', 'baz'));
-        $this->assertEquals('baz', $handler->read('foo'));
+        $this->assertSame('baz', $handler->read('foo'));
     }
 
     public function test_it_destroys_a_session()
@@ -86,7 +86,7 @@ class ArraySessionHandlerTest extends TestCase
         $handler->write('foo', 'bar');
 
         $this->assertTrue($handler->destroy('foo'));
-        $this->assertEquals('', $handler->read('foo'));
+        $this->assertSame('', $handler->read('foo'));
     }
 
     public function test_it_cleans_up_old_sessions()
@@ -97,7 +97,7 @@ class ArraySessionHandlerTest extends TestCase
 
         $handler->write('foo', 'bar');
         $this->assertTrue($handler->gc(300));
-        $this->assertEquals('bar', $handler->read('foo'));
+        $this->assertSame('bar', $handler->read('foo'));
 
         Carbon::setTestNow(Carbon::now()->addSecond());
 
@@ -106,8 +106,8 @@ class ArraySessionHandlerTest extends TestCase
         Carbon::setTestNow(Carbon::now()->addMinutes(5));
 
         $this->assertTrue($handler->gc(300));
-        $this->assertEquals('', $handler->read('foo'));
-        $this->assertEquals('qux', $handler->read('baz'));
+        $this->assertSame('', $handler->read('foo'));
+        $this->assertSame('qux', $handler->read('baz'));
 
         Carbon::setTestNow();
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4328,11 +4328,11 @@ class ValidationValidatorTest extends TestCase
 
         $implicit_no_connection = $v->parseTable(ImplicitTableModel::class);
         $this->assertEquals(null, $implicit_no_connection[0]);
-        $this->assertEquals('implicit_table_models', $implicit_no_connection[1]);
+        $this->assertSame('implicit_table_models', $implicit_no_connection[1]);
 
         $explicit_no_connection = $v->parseTable(ExplicitTableModel::class);
         $this->assertEquals(null, $explicit_no_connection[0]);
-        $this->assertEquals('explicits', $explicit_no_connection[1]);
+        $this->assertSame('explicits', $explicit_no_connection[1]);
 
         $noneloquent_no_connection = $v->parseTable(NonEloquentModel::class);
         $this->assertEquals(null, $noneloquent_no_connection[0]);
@@ -4340,27 +4340,27 @@ class ValidationValidatorTest extends TestCase
 
         $raw_no_connection = $v->parseTable('table');
         $this->assertEquals(null, $raw_no_connection[0]);
-        $this->assertEquals('table', $raw_no_connection[1]);
+        $this->assertSame('table', $raw_no_connection[1]);
 
         $implicit_connection = $v->parseTable('connection.'.ImplicitTableModel::class);
-        $this->assertEquals('connection', $implicit_connection[0]);
-        $this->assertEquals('implicit_table_models', $implicit_connection[1]);
+        $this->assertSame('connection', $implicit_connection[0]);
+        $this->assertSame('implicit_table_models', $implicit_connection[1]);
 
         $explicit_connection = $v->parseTable('connection.'.ExplicitTableModel::class);
-        $this->assertEquals('connection', $explicit_connection[0]);
-        $this->assertEquals('explicits', $explicit_connection[1]);
+        $this->assertSame('connection', $explicit_connection[0]);
+        $this->assertSame('explicits', $explicit_connection[1]);
 
         $explicit_model_implicit_connection = $v->parseTable(ExplicitTableAndConnectionModel::class);
-        $this->assertEquals('connection', $explicit_model_implicit_connection[0]);
-        $this->assertEquals('explicits', $explicit_model_implicit_connection[1]);
+        $this->assertSame('connection', $explicit_model_implicit_connection[0]);
+        $this->assertSame('explicits', $explicit_model_implicit_connection[1]);
 
         $noneloquent_connection = $v->parseTable('connection.'.NonEloquentModel::class);
-        $this->assertEquals('connection', $noneloquent_connection[0]);
+        $this->assertSame('connection', $noneloquent_connection[0]);
         $this->assertEquals(NonEloquentModel::class, $noneloquent_connection[1]);
 
         $raw_connection = $v->parseTable('connection.table');
-        $this->assertEquals('connection', $raw_connection[0]);
-        $this->assertEquals('table', $raw_connection[1]);
+        $this->assertSame('connection', $raw_connection[0]);
+        $this->assertSame('table', $raw_connection[1]);
     }
 
     public function testUsingSettersWithImplicitRules()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -21,14 +21,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler)->compileSlots('<x-slot name="foo">
 </x-slot>');
 
-        $this->assertEquals("@slot('foo') \n @endslot", trim($result));
+        $this->assertSame("@slot('foo') \n @endslot", trim($result));
     }
 
     public function testBasicComponentParsing()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="foo" limit="5" @click="foo" required /><x-alert /></div>');
 
-        $this->assertEquals("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>
 @endcomponentClass @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?>
@@ -39,7 +39,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
-        $this->assertEquals("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>
 @endcomponentClass</div>", trim($result));
     }
@@ -48,7 +48,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile user-id="1"></x-profile>');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -56,7 +56,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x-foo:alert></x-foo:alert>');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -64,7 +64,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x:foo:alert></x-foo:alert>');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -72,7 +72,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert/></div>');
 
-        $this->assertEquals("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?>
 @endcomponentClass</div>", trim($result));
     }
@@ -86,7 +86,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->guessClassName('alert');
 
-        $this->assertEquals("App\View\Components\Alert", trim($result));
+        $this->assertSame("App\View\Components\Alert", trim($result));
 
         Container::setInstance(null);
     }
@@ -100,7 +100,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->guessClassName('base.alert');
 
-        $this->assertEquals("App\View\Components\Base\Alert", trim($result));
+        $this->assertSame("App\View\Components\Base\Alert", trim($result));
 
         Container::setInstance(null);
     }
@@ -109,7 +109,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>
 @endcomponentClass", trim($result));
     }
@@ -118,7 +118,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>
 @endcomponentClass", trim($result));
     }
@@ -127,7 +127,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert :title="$title" class="bar" />');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
 <?php \$component->withAttributes(['class' => 'bar']); ?>
 @endcomponentClass", trim($result));
     }
@@ -137,7 +137,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert>
 </x-alert>');
 
-        $this->assertEquals("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
 <?php \$component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
     }
@@ -153,7 +153,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->compileTags('<x-anonymous-component name="Taylor" :age="31" wire:model="foo" />');
 
-        $this->assertEquals("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
 <?php \$component->withAttributes(['name' => 'Taylor','age' => 31,'wire:model' => 'foo']); ?>
 @endcomponentClass", trim($result));
     }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -11,18 +11,18 @@ class ViewComponentAttributeBagTest extends TestCase
     {
         $bag = new ComponentAttributeBag(['class' => 'font-bold', 'name' => 'test']);
 
-        $this->assertEquals('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4']));
-        $this->assertEquals('class="mt-4 font-bold" name="foo"', (string) $bag->merge(['class' => 'mt-4', 'name' => 'foo']));
-        $this->assertEquals('class="mt-4 font-bold" name="test"', (string) $bag(['class' => 'mt-4']));
-        $this->assertEquals('class="mt-4 font-bold"', (string) $bag->only('class')->merge(['class' => 'mt-4']));
-        $this->assertEquals('class="mt-4 font-bold"', (string) $bag->merge(['class' => 'mt-4'])->only('class'));
-        $this->assertEquals('class="mt-4 font-bold"', (string) $bag->only('class')(['class' => 'mt-4']));
-        $this->assertEquals('font-bold', $bag->get('class'));
-        $this->assertEquals('bar', $bag->get('foo', 'bar'));
-        $this->assertEquals('font-bold', $bag['class']);
+        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4']));
+        $this->assertSame('class="mt-4 font-bold" name="foo"', (string) $bag->merge(['class' => 'mt-4', 'name' => 'foo']));
+        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag(['class' => 'mt-4']));
+        $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')->merge(['class' => 'mt-4']));
+        $this->assertSame('class="mt-4 font-bold"', (string) $bag->merge(['class' => 'mt-4'])->only('class'));
+        $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')(['class' => 'mt-4']));
+        $this->assertSame('font-bold', $bag->get('class'));
+        $this->assertSame('bar', $bag->get('foo', 'bar'));
+        $this->assertSame('font-bold', $bag['class']);
 
         $bag = new ComponentAttributeBag([]);
 
-        $this->assertEquals('class="mt-4"', (string) $bag->merge(['class' => 'mt-4']));
+        $this->assertSame('class="mt-4"', (string) $bag->merge(['class' => 'mt-4']));
     }
 }

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -14,8 +14,8 @@ class ViewComponentTest extends TestCase
         $variables = $component->data();
 
         $this->assertEquals(10, $variables['votes']);
-        $this->assertEquals('world', $variables['hello']());
-        $this->assertEquals('taylor', $variables['hello']('taylor'));
+        $this->assertSame('world', $variables['hello']());
+        $this->assertSame('taylor', $variables['hello']('taylor'));
     }
 
     public function testPublicMethodsWithNoArgsAreEagerlyInvokedAndNotCached()
@@ -26,7 +26,7 @@ class ViewComponentTest extends TestCase
         $variables = $component->data();
         $this->assertEquals(1, $component->counter);
 
-        $this->assertEquals('noArgs val', $variables['noArgs']);
+        $this->assertSame('noArgs val', $variables['noArgs']);
         $this->assertEquals(0, $variables['counter']);
 
         // make sure non-public members are not invoked nor counted.
@@ -52,7 +52,7 @@ class ViewComponentTest extends TestCase
         $variables = $component->data();
 
         // Ignored methods (with no args) are not invoked behind the scenes.
-        $this->assertEquals('Otwell', $component->taylor);
+        $this->assertSame('Otwell', $component->taylor);
 
         $this->assertArrayNotHasKey('hello', $variables);
         $this->assertArrayNotHasKey('hello2', $variables);
@@ -64,11 +64,11 @@ class ViewComponentTest extends TestCase
         $component = new TestHelloPropertyHelloMethodComponent();
         $variables = $component->data();
         $this->assertArrayHasKey('hello', $variables);
-        $this->assertEquals('world', $variables['hello']());
+        $this->assertSame('world', $variables['hello']());
 
         // protected methods do not override public properties.
         $this->assertArrayHasKey('world', $variables);
-        $this->assertEquals('world property', $variables['world']);
+        $this->assertSame('world property', $variables['world']);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Use stricter assertions when asserting string; from `assertEquals` to `assertSame`.
