### PR TITLE
[6.x] Add item to list of causedByLostConnection errors

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -42,6 +42,7 @@ trait DetectsLostConnections
             'Login timeout expired',
             'Connection refused',
             'running with the --read-only option so it cannot execute this statement',
+            'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
         ]);
     }
 }


### PR DESCRIPTION
The Microsoft ODBC driver for SQL server throws the following error when a connection becomes unusable.

“SQLSTATE[IMC06]: [Microsoft][ODBC Driver 17 for SQL Server]The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.”