### PR TITLE
[7.x] PHPDoc fix for Auth methods

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -73,7 +73,7 @@ trait GuardHelpers
     /**
      * Get the ID for the currently authenticated user.
      *
-     * @return int|null
+     * @return int|string|null
      */
     public function id()
     {

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -199,7 +199,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Get the ID for the currently authenticated user.
      *
-     * @return int|null
+     * @return int|string|null
      */
     public function id()
     {

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -8,7 +8,7 @@ namespace Illuminate\Support\Facades;
  * @method static bool check()
  * @method static bool guest()
  * @method static \Illuminate\Contracts\Auth\Authenticatable|null user()
- * @method static int|null id()
+ * @method static int|string|null id()
  * @method static bool validate(array $credentials = [])
  * @method static void setUser(\Illuminate\Contracts\Auth\Authenticatable $user)
  * @method static bool attempt(array $credentials = [], bool $remember = false)


### PR DESCRIPTION
This fix is needed for the static code analysis we run. In our setup Auth::id() wil return een string as user id. As far as I know, this is not prohibited by laravel (please let me know if I'am wrong).

This wil fix wil help other developpers who also depend on correct return types in de docblock.