### PR TITLE
[7.x] Add morphClass settings in relationship definition

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOneOrMany.php
@@ -31,11 +31,11 @@ abstract class MorphOneOrMany extends HasOneOrMany
      * @param  string  $localKey
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $type, $id, $localKey)
+    public function __construct(Builder $query, Model $parent, $type, $id, $localKey, $morphClass = null)
     {
         $this->morphType = $type;
 
-        $this->morphClass = $parent->getMorphClass();
+        $this->morphClass = $morphClass ?? $parent->getMorphClass();
 
         parent::__construct($query, $parent, $id, $localKey);
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -17,6 +17,13 @@ class MorphTo extends BelongsTo
     protected $morphType;
 
     /**
+     * The class name of the morph type constraint.
+     *
+     * @var string
+     */
+    protected $morphClass;
+
+    /**
      * The models whose relations are being eager loaded.
      *
      * @var \Illuminate\Database\Eloquent\Collection
@@ -55,9 +62,10 @@ class MorphTo extends BelongsTo
      * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $morphClass)
     {
         $this->morphType = $type;
+        $this->morphClass = $morphClass;
 
         parent::__construct($query, $parent, $foreignKey, $ownerKey, $relation);
     }
@@ -195,12 +203,14 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
+        $morphClass = $this->morphClass ?? $model->getMorphClass();
+
         $this->parent->setAttribute(
             $this->foreignKey, $model instanceof Model ? $model->getKey() : null
         );
 
         $this->parent->setAttribute(
-            $this->morphType, $model instanceof Model ? $model->getMorphClass() : null
+            $this->morphType, $model instanceof Model ? $morphClass : null
         );
 
         return $this->parent->setRelation($this->relationName, $model);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -203,14 +203,14 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
-        $morphClass = $this->morphClass ?? $model->getMorphClass();
-
         $this->parent->setAttribute(
-            $this->foreignKey, $model instanceof Model ? $model->getKey() : null
+            $this->foreignKey,
+            $model instanceof Model ? $model->getKey() : null
         );
 
         $this->parent->setAttribute(
-            $this->morphType, $model instanceof Model ? $morphClass : null
+            $this->morphType,
+            $this->morphClass ?? ($model instanceof Model ? $model->getMorphClass() : null)
         );
 
         return $this->parent->setRelation($this->relationName, $model);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -17,6 +17,13 @@ class MorphTo extends BelongsTo
     protected $morphType;
 
     /**
+     * The class name of the morph type constraint.
+     *
+     * @var string
+     */
+    protected $morphClass;
+
+    /**
      * The models whose relations are being eager loaded.
      *
      * @var \Illuminate\Database\Eloquent\Collection
@@ -55,9 +62,10 @@ class MorphTo extends BelongsTo
      * @param  string  $relation
      * @return void
      */
-    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
+    public function __construct(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $morphClass = null)
     {
         $this->morphType = $type;
+        $this->morphClass = $morphClass;
 
         parent::__construct($query, $parent, $foreignKey, $ownerKey, $relation);
     }
@@ -195,12 +203,14 @@ class MorphTo extends BelongsTo
      */
     public function associate($model)
     {
+        $morphClass = $this->morphClass ?? $model->getMorphClass();
+
         $this->parent->setAttribute(
             $this->foreignKey, $model instanceof Model ? $model->getKey() : null
         );
 
         $this->parent->setAttribute(
-            $this->morphType, $model instanceof Model ? $model->getMorphClass() : null
+            $this->morphType, $model instanceof Model ? $morphClass : null
         );
 
         return $this->parent->setRelation($this->relationName, $model);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -47,11 +47,13 @@ class MorphToMany extends BelongsToMany
      * @return void
      */
     public function __construct(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
+                                $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false, $morphClass = null)
     {
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
-        $this->morphClass = $inverse ? $query->getModel()->getMorphClass() : $parent->getMorphClass();
+        $this->morphClass = $morphClass ? $morphClass 
+                                        : ($inverse ? $query->getModel()->getMorphClass() 
+                                                    : $parent->getMorphClass());
 
         parent::__construct(
             $query, $parent, $table, $foreignPivotKey,

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -52,7 +52,7 @@ class MorphToMany extends BelongsToMany
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
         $this->morphClass = $morphClass ? $morphClass 
-                                        : ($inverse ? $query->getModel()->getMorphClass() 
+                                        : ($inverse ? $query->getModel()->getMorphClass()
                                                     : $parent->getMorphClass());
 
         parent::__construct(

--- a/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphToMany.php
@@ -51,7 +51,7 @@ class MorphToMany extends BelongsToMany
     {
         $this->inverse = $inverse;
         $this->morphType = $name.'_type';
-        $this->morphClass = $morphClass ? $morphClass 
+        $this->morphClass = $morphClass ? $morphClass
                                         : ($inverse ? $query->getModel()->getMorphClass()
                                                     : $parent->getMorphClass());
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -974,7 +974,6 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('Normal file', $attachements[1]->name);
     }
 
-
     public function testEmptyMorphToRelationship()
     {
         $photo = new EloquentTestPhoto;

--- a/tests/Integration/Database/EloquentRelationshipsTest.php
+++ b/tests/Integration/Database/EloquentRelationshipsTest.php
@@ -159,9 +159,9 @@ class CustomPost extends Post
         return new CustomMorphOne($query, $parent, $type, $id, $localKey);
     }
 
-    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey)
+    protected function newMorphMany(Builder $query, Model $parent, $type, $id, $localKey, $morphClass = null)
     {
-        return new CustomMorphMany($query, $parent, $type, $id, $localKey);
+        return new CustomMorphMany($query, $parent, $type, $id, $localKey, $morphClass);
     }
 
     protected function newBelongsToMany(Builder $query, Model $parent, $table, $foreignPivotKey, $relatedPivotKey,
@@ -183,15 +183,15 @@ class CustomPost extends Post
     }
 
     protected function newMorphToMany(Builder $query, Model $parent, $name, $table, $foreignPivotKey,
-        $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false)
+        $relatedPivotKey, $parentKey, $relatedKey, $relationName = null, $inverse = false, $morphClass = null)
     {
         return new CustomMorphToMany($query, $parent, $name, $table, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey,
-            $relationName, $inverse);
+            $relationName, $inverse, $morphClass);
     }
 
-    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation)
+    protected function newMorphTo(Builder $query, Model $parent, $foreignKey, $ownerKey, $type, $relation, $morphClass = null)
     {
-        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation);
+        return new CustomMorphTo($query, $parent, $foreignKey, $ownerKey, $type, $relation, $morphClass);
     }
 }
 


### PR DESCRIPTION
Imagine a use case where users could like and dislike contents, like posts or images and you need to use a polymorphic relationship.

```php
class Post extends Model
{
}

class Image extends Model
{
}

class User extends Model
{
    public function likedPosts()
    {
        return $this->morphedByMany(Post::class, 'likeable');
    }

    public function dislikedPosts()
    {
        return $this->morphedByMany(Post::class, 'likeable');
    }
}
```

```php
User::find(1)->likedPosts()->save(Post::find(1));
User::find(1)->dislikedPosts; //it returns Post with id 1
```

This code obviously does not work as expected because Laravel cannot discriminate between liked and disliked posts because in the pivot table likeable_type is always "App/Post".
In a more abstract way to explain things, you cannot have more semantic types for the same model using the same morph relation without using more tables. This limitation refers both to `morphTo` and `morphMany` relationships.

This PR introduce a new parameter to all the morph* methods an relationships in order to set a custom `$morphClass` to define, if needed, the relationship semantic.

```php
class User extends Model
{
    public function likedPosts()
    {
        return $this->morphedByMany(Post::class, 'likeable', 'likeables', 'likeable_id', 'user_id', 'id', 'id', 'liked_post');
    }

    public function dislikedPosts()
    {
        return $this->morphedByMany(Post::class, 'likeable', 'likeables', 'likeable_id', 'user_id', 'id', 'id', 'disliked_post');
    }
}
```

Obviously custom morphClass definition is needed using `morphMap` method (https://laravel.com/docs/5.8/eloquent-relationships#custom-polymorphic-types):

```php
use Illuminate\Database\Eloquent\Relations\Relation;

Relation::morphMap([
    'liked_post' => 'App\Post',
    'disliked_post' => 'App\Post',
]);
```