### PR TITLE
[6.x] Fixed bad dependency assumptions

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -2,12 +2,17 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Closure;
 use DateTimeInterface;
 use Illuminate\Console\Application;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\ProcessUtils;
 use Illuminate\Support\Traits\Macroable;
+use RuntimeException;
 
 class Schedule
 {
@@ -35,6 +40,13 @@ class Schedule
     protected $schedulingMutex;
 
     /**
+     * The job dispatcher implementation.
+     *
+     * @var \Illuminate\Contracts\Bus\Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
      * The timezone the date should be evaluated on.
      *
      * @var \DateTimeZone|string
@@ -50,6 +62,12 @@ class Schedule
     public function __construct($timezone = null)
     {
         $this->timezone = $timezone;
+
+        if (! class_exists(Container::class)) {
+            throw new RuntimeException(
+                'The container implementation is required to use the scheduler. Please install illuminate/container.'
+            );
+        }
 
         $container = Container::getInstance();
 
@@ -107,16 +125,50 @@ class Schedule
     public function job($job, $queue = null, $connection = null)
     {
         return $this->call(function () use ($job, $queue, $connection) {
-            $job = is_string($job) ? resolve($job) : $job;
+            $job = is_string($job) ? Container::getInstance()->make($job) : $job;
 
             if ($job instanceof ShouldQueue) {
-                dispatch($job)
-                    ->onConnection($connection ?? $job->connection)
-                    ->onQueue($queue ?? $job->queue);
+                $this->dispatchToQueue($job, $queue ?? $job->queue, $connection ?? $job->connection);
             } else {
-                dispatch_now($job);
+                $this->dispatchNow($job);
             }
         })->name(is_string($job) ? $job : get_class($job));
+    }
+
+    /**
+     * Dispatch the given job to the queue.
+     *
+     * @param  object  $job
+     * @param  string|null  $queue
+     * @param  string|null  $connection
+     * @return void
+     */
+    protected function dispatchToQueue($job, $queue, $connection)
+    {
+        if ($job instanceof Closure) {
+            if (! class_exists(CallQueuedClosure::class)) {
+                throw new RuntimeException(
+                    'To enable support for closure jobs, please install illuminate/queue.'
+                );
+            }
+
+            $job = CallQueuedClosure::create($job);
+        }
+
+        $this->getDispatcher()->dispatch(
+            $job->onConnection($connection)->onQueue($queue)
+        );
+    }
+
+    /**
+     * Dispatch the given job right now.
+     *
+     * @param  object  $job
+     * @return void
+     */
+    protected function dispatchNow($job)
+    {
+        $this->getDispatcher()->dispatchNow($job);
     }
 
     /**
@@ -208,5 +260,27 @@ class Schedule
         }
 
         return $this;
+    }
+
+    /**
+     * Get the job dispatcher, if available.
+     *
+     * @return \Illuminate\Contracts\Bus\Dispatcher
+     */
+    protected function getDispatcher()
+    {
+        if ($this->dispatcher === null) {
+            try {
+                $this->dispatcher = Container::getInstance()->make(Dispatcher::class);
+            } catch (BindingResolutionException $e) {
+                throw new RuntimeException(
+                    'Unable to resolve the dispatcher from the service container. Please bind it or install illuminate/bus.',
+                    $e->getCode(),
+                    $e
+                );
+            }
+        }
+
+        return $this->dispatcher;
     }
 }

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -31,9 +31,12 @@
         }
     },
     "suggest": {
-        "dragonmantank/cron-expression": "Required to use scheduling component (^2.0).",
+        "dragonmantank/cron-expression": "Required to use scheduler (^2.0).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.0|^7.0).",
-        "illuminate/filesystem": "Required to use the generator command (^6.0)"
+        "illuminate/bus": "Required to use the scheduled job dispatcher (^6.0)",
+        "illuminate/container": "Required to use the scheduler (^6.0)",
+        "illuminate/filesystem": "Required to use the generator command (^6.0)",
+        "illuminate/queue": "Required to use closures for scheduled jobs (^6.0)"
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -17,7 +17,6 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
-use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
@@ -387,7 +386,7 @@ if (! function_exists('dispatch')) {
     function dispatch($job)
     {
         if ($job instanceof Closure) {
-            $job = new CallQueuedClosure(new SerializableClosure($job));
+            $job = CallQueuedClosure::create($job);
         }
 
         return new PendingDispatch($job);

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Queue;
 
+use Closure;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -35,6 +36,17 @@ class CallQueuedClosure implements ShouldQueue
     public function __construct(SerializableClosure $closure)
     {
         $this->closure = $closure;
+    }
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  \Closure  $closure
+     * @return self
+     */
+    public static function create(Closure $job)
+    {
+        return new self(new SerializableClosure($job));
     }
 
     /**

--- a/tests/Integration/Console/JobSchedulingTest.php
+++ b/tests/Integration/Console/JobSchedulingTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Integration\Console;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Queue;


### PR DESCRIPTION
1. The scheduler uses the native container (and not the contract), and so we must ensure that it is recommended to users both by composer, and by friendly runtime exceptions. If we wanna refactor it to use the contract, that is a job for the master branch.
2. We should not be calling stuff from the foundation helper functions file. We should instead be resolving the jobs and the job dispatcher from the container, and providing good developer experience if we fail to resolve it. Removal of the calls to the foundation functions also made it clear we actually had an dependency on `illuminate/queue` too, for packing Closures.

---

Closes #31891.