### PR TITLE
[8.x] Remove fallback links

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -47,7 +47,6 @@ class StorageLinkCommand extends Command
      */
     protected function links()
     {
-        return $this->laravel['config']['filesystems.links'] ??
-               [public_path('storage') => storage_path('app/public')];
+        return $this->laravel['config']['filesystems.links'] ?? [];
     }
 }


### PR DESCRIPTION
now that L7 has the `filesystems.links` key by default, and the config file comes pre-populated with the storage to public link, let's remove it from the command.