### PR TITLE
[6.x] Add custom date casting format to carbon object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -506,8 +506,10 @@ trait HasAttributes
             case 'date':
                 return $this->asDate($value);
             case 'datetime':
-            case 'custom_datetime':
                 return $this->asDateTime($value);
+            case 'custom_datetime':
+                $format = explode(':', $this->getCasts()[$key], 2)[1];
+                return tap($this->asDateTime($value))->setToStringFormat($format);
             case 'timestamp':
                 return $this->asTimestamp($value);
             default:


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The purposes of this PR is to make eloquent respect the custom date formats that are defined in `protected $casts = []` in cases where a single attribute is accessed. Currently the custom date formatting is only applied when date attributes are converted to strings in `addCastAttributesToArray`.

Obviously this is because eloquent is designed to return a Carbon date object when a single date attribute is accessed. However we can still tell that Carbon object which format to use when it is converted to a string.

For example with how things are now it works like this:

```
use Illuminate\Database\Eloquent\Model;

class Invoice extends Model
{
    protected $casts = [
        'transaction_date' => 'date:m/d/Y',
    ];
}

$invoice = new Invoice;
$invoice->transaction_date = '2020-11-25';

(string)$invoice->transaction_date // 2020-02-05 00:00:00
```

With this change in place you instead get this:
```
(string)$invoice->transaction_date // 11/25/2020
```

This shouldn't break anything because `getAttribute` will still return a Carbon date object, but if and when that date object is converted to a string the desired format will be used instead of the default format.

Having something like this in place will reduce the amount of additional code that needs to be written in order to convert dates to the desired format.