### PR TITLE
[7.x] Allow nested env variables.

### DIFF
--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -99,7 +99,13 @@ class Env
                     return $matches[2];
                 }
 
-                return $value;
+                return preg_replace_callback(
+                    '/\${([a-zA-Z0-9_.]+)}/',
+                    function ($matches) {
+                        return static::get($matches[1]);
+                    },
+                    $value
+                );
             })
             ->getOrCall(function () use ($default) {
                 return value($default);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -637,6 +637,24 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('x"null"x', env('foo'));
     }
 
+    public function testNestedEnvVar()
+    {
+        $_SERVER['foo'] = 'var with nested [${bar}]';
+        $_SERVER['bar'] = 'bar var';
+
+        $this->assertSame('bar var', env('bar'));
+        $this->assertSame('var with nested [bar var]', env('foo'));
+
+        unset($_SERVER['bar']);
+    }
+
+    public function testUndefinedNestedEnvVar()
+    {
+        $_SERVER['foo'] = 'var with nested [${bar}]';
+
+        $this->assertSame('var with nested []', env('foo'));
+    }
+
     public function testGetFromENVFirst()
     {
         $_ENV['foo'] = 'From $_ENV';


### PR DESCRIPTION
Hi,
Dotenv allows nested env var with the shape `VAR=${NESTED} foo`
see https://github.com/vlucas/phpdotenv#nesting-variables

This PR allows exactly the same for all env var, and not only those coming from .env.

Example of usage:
I'm using Heroku cloud provider with review apps (app launched for each PR). The name of the app is automatically generated, and provided as `HEROKU_APP_NAME`. 

The url is composed from the name of the app and the herokuapp.com domain.

With this PR, I can just set the env var like that:
<img width="394" alt="Screenshot 2020-03-11 at 18 09 35" src="https://user-images.githubusercontent.com/11351322/76444178-d4e87c80-63c3-11ea-9c41-6a8a04477191.png">

This should not be a breaking change, as Dotenv has this behavior, so every Laravel developer local environment behave like that.


2 tests were added for this case, no other test was broken.

Thanks,
Matt'