### PR TITLE
[7.x] Intelligently drop unnamed prefix name routes when caching

### DIFF
--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -195,7 +195,14 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function addToSymfonyRoutesCollection(SymfonyRouteCollection $symfonyRoutes, Route $route)
     {
-        if (! $name = $route->getName()) {
+        $name = $route->getName();
+
+        if (Str::endsWith($name, '.') &&
+            ! is_null($symfonyRoutes->get($name))) {
+            $name = null;
+        }
+
+        if (! $name) {
             $route->name($name = $this->generateRouteName());
 
             $this->add($route);


### PR DESCRIPTION
In Laravel 6.x, when using route name groups, any routes not given a more an explicit name would be given the group name. For example:

```php
Route::name('admin.')->group(function () {
    Route::get('/dashboard');
    Route::get('/users');
});
```

Both of the routes above would be receive the route name `admin.`. This, of course, is odd behavior but was not particularly problematic until Laravel 7.x route caching was introduced.

Laravel 7.x uses Symfony's very fast route matcher, but that route matcher requires **every** route to have a unique name. This has introduced a significant barrier to upgrade to Laravel 7.x because people are now forced to remove the route name prefix from the group or literally assign a route name to every single route within the group explicitly. 

In my opinion, when caching, the framework should assign a generated name to a route **if the route's name ends in a `.` and it will create a duplicate route name error**. When we encounter routes like these, I think it is safe to make the assumption that the developer did not actually intend for them to have a name at all and likely have been unaware they were receiving a name in previous Laravel releases. In fact, this caused a problem with Laravel Nova itself that even I did not expect.

This will significantly ease the burden of upgrading to Laravel 7.x when using route name groups with no breaking changes since we are only changing behavior in a situation where the code was about to throw an exception anyways.