### PR TITLE
[8.x] Add custom date casting format to carbon object

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -535,7 +535,7 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'custom_datetime':
                 $format = explode(':', $this->getCasts()[$key], 2)[1];
-                return $this->asDateTime($value)->settings([ 'toStringFormat' => $format ]);
+                return $this->asDateTime($value)->settings(['toStringFormat' => $format]);
             case 'timestamp':
                 return $this->asTimestamp($value);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -532,8 +532,10 @@ trait HasAttributes
             case 'date':
                 return $this->asDate($value);
             case 'datetime':
-            case 'custom_datetime':
                 return $this->asDateTime($value);
+            case 'custom_datetime':
+                $format = explode(':', $this->getCasts()[$key], 2)[1];
+                return $this->asDateTime($value)->settings([ 'toStringFormat' => $format ]);
             case 'timestamp':
                 return $this->asTimestamp($value);
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -535,6 +535,7 @@ trait HasAttributes
                 return $this->asDateTime($value);
             case 'custom_datetime':
                 $format = explode(':', $this->getCasts()[$key], 2)[1];
+
                 return $this->asDateTime($value)->settings(['toStringFormat' => $format]);
             case 'timestamp':
                 return $this->asTimestamp($value);

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -35,6 +35,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertSame('2019-10 10:15', $user->toArray()['datetime_field']);
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
+        $this->assertSame('2019-10', (string)$user->date_field);
+        $this->assertSame('2019-10 10:15', (string)$user->datetime_field);
     }
 }
 

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -35,8 +35,8 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
         $this->assertSame('2019-10 10:15', $user->toArray()['datetime_field']);
         $this->assertInstanceOf(Carbon::class, $user->date_field);
         $this->assertInstanceOf(Carbon::class, $user->datetime_field);
-        $this->assertSame('2019-10', (string)$user->date_field);
-        $this->assertSame('2019-10 10:15', (string)$user->datetime_field);
+        $this->assertSame('2019-10', (string) $user->date_field);
+        $this->assertSame('2019-10 10:15', (string) $user->datetime_field);
     }
 }
 


### PR DESCRIPTION
The purposes of this PR is to make eloquent respect the custom date formats that are defined in `protected $casts = []` in cases where a single attribute is accessed. Currently the custom date formatting is only applied when date attributes are converted to strings in `addCastAttributesToArray`.

Obviously this is because eloquent is designed to return a Carbon date object when a single date attribute is accessed. However we can still tell that Carbon object which format to use when it is converted to a string.

For example with how things are now it works like this:

```
use Illuminate\Database\Eloquent\Model;

class Invoice extends Model
{
    protected $casts = [
        'transaction_date' => 'date:m/d/Y',
    ];
}

$invoice = new Invoice;
$invoice->transaction_date = '2020-11-25';

(string)$invoice->transaction_date // 2020-11-25 00:00:00
```

With this change in place you instead get this:
```
(string)$invoice->transaction_date // 11/25/2020
```

Current implementations may be designed around the expectation that the default format will be used when the Carbon object is converted to a string, so this could be included as a low or medium impact change for v8.

Having something like this in place will reduce the amount of additional code that needs to be written in order to convert dates to the desired format and makes the date casting feature more idiomatic.