### PR TITLE
[7.x] Ensure queues are only suffixed once

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -5,6 +5,7 @@ namespace Illuminate\Queue;
 use Aws\Sqs\SqsClient;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Jobs\SqsJob;
+use Illuminate\Support\Str;
 
 class SqsQueue extends Queue implements QueueContract
 {
@@ -149,7 +150,7 @@ class SqsQueue extends Queue implements QueueContract
         $queue = $queue ?: $this->default;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-            ? rtrim($this->prefix, '/').'/'.$queue.$this->suffix
+            ? rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix)
             : $queue;
     }
 

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -153,4 +153,12 @@ class QueueSqsQueueTest extends TestCase
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix;
         $this->assertEquals($queueUrl, $queue->getQueue('test'));
     }
+
+    public function testGetQueueEnsuresTheQueueIsOnlySuffixedOnce()
+    {
+        $queue = new SqsQueue($this->sqs, "{$this->queueName}-staging", $this->prefix, $suffix = '-staging');
+        $this->assertEquals($this->queueUrl.$suffix, $queue->getQueue(null));
+        $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix;
+        $this->assertEquals($queueUrl, $queue->getQueue('test-staging'));
+    }
 }


### PR DESCRIPTION
This is a follow up of https://github.com/laravel/framework/pull/31784. We found a problem with the following scenario:

If the `SQS_SUFFIX` is defined as `production` and `staging` in each environment respectively and the vapor manifest looks like this:

```yml
environments:
    production:
        queues:
            - default-production
            - emails-production
    staging:
        queues:
            - default-staging
            - emails-staging
```

The first queue is going to be picked as the default SQS queue and assigned in the `config/queue.php`

```php
'sqs' => [
    'driver' => 'sqs',
    'queue' => 'default-production', // or default-staging depending of the environment
    'suffix' => '-production', // or -staging depending of the environment
],
```

If you send a job to a queue explicitly, it is going to be resolved correctly:

```php
// Depending of the environment, this resolves the queue as:
//
// https://sqs.someregion.amazonaws.com/account-id/emails-production
// https://sqs.someregion.amazonaws.com/account-id/emails-staging
dispatch(new SendWelcomeEmail($user))->onQueue('emails');

// This explicit default queue usage also resolves as:
//
// https://sqs.someregion.amazonaws.com/account-id/default-production
// https://sqs.someregion.amazonaws.com/account-id/default-staging
dispatch(new SendWelcomeEmail($user))->onQueue('default');
```

But if you try to rely on the default queue, it suffixes the queue twice:

```php
// This resolves the queue as
// https://sqs.someregion.amazonaws.com/account-id/default-production-production
// https://sqs.someregion.amazonaws.com/account-id/default-staging-staging
dispatch(new SendWelcomeEmail($user));
```
This happens because at runtime in Vapor, we don't control the default queue name and because it is already suffixed, it gets suffixed twice during the queue name resolution.

This PR fixes that by ensuring queues get only suffixed once, and does it in a non breaking way for applications not relying on this suffix feature.

```php
// With this PR, default queues are resolved correctly
//
// https://sqs.someregion.amazonaws.com/account-id/default-production
// https://sqs.someregion.amazonaws.com/account-id/default-staging
dispatch(new SendWelcomeEmail($user));
```