### PR TITLE
[6.x] Unset pivotParent on withoutRelations()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -301,4 +301,17 @@ trait AsPivot
 
         return $query;
     }
+
+    /**
+     * Duplicate the instance and unset all the loaded relations.
+     *
+     * @return $this
+     */
+    public function withoutRelations()
+    {
+        $model = clone $this;
+        $model->pivotParent = null;
+
+        return $model->unsetRelations();
+    }
 }


### PR DESCRIPTION
Pivot models have an extra relational property called `$pivotParent`, currently this does not get unset with the `withoutRelations()` function, this PR fixes that