### PR TITLE
[7.x] Fix ComponentAttributeBag merge behaviour

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -116,7 +116,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             }
 
             if ($key !== 'class') {
-                $attributes[$key] = $attributeDefaults[$key] ?? $value;
+                $attributes[$key] = $value ?? $attributeDefaults[$key];
 
                 continue;
             }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -116,7 +116,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             }
 
             if ($key !== 'class') {
-                $attributes[$key] = $value ?? $attributeDefaults[$key];
+                $attributes[$key] = $value;
 
                 continue;
             }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -12,9 +12,11 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag(['class' => 'font-bold', 'name' => 'test']);
 
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4']));
-        $this->assertSame('class="mt-4 font-bold" name="foo"', (string) $bag->merge(['class' => 'mt-4', 'name' => 'foo']));
+        $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4', 'name' => 'foo']));
+        $this->assertSame('class="mt-4 font-bold" id="bar" name="test"', (string) $bag->merge(['class' => 'mt-4', 'id' => 'bar']));
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag(['class' => 'mt-4']));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')->merge(['class' => 'mt-4']));
+        $this->assertSame('class="italic" name="test"', (string) $bag->only('name')->merge(['class' => 'italic', 'name' => 'default']));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->merge(['class' => 'mt-4'])->only('class'));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')(['class' => 'mt-4']));
         $this->assertSame('font-bold', $bag->get('class'));

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -17,6 +17,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag(['class' => 'mt-4']));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')->merge(['class' => 'mt-4']));
         $this->assertSame('name="test" class="font-bold"', (string) $bag->merge(['name' => 'default']));
+        $this->assertSame('class="font-bold" name="test"', (string) $bag->merge([]));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->merge(['class' => 'mt-4'])->only('class'));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')(['class' => 'mt-4']));
         $this->assertSame('font-bold', $bag->get('class'));

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -16,7 +16,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $this->assertSame('class="mt-4 font-bold" id="bar" name="test"', (string) $bag->merge(['class' => 'mt-4', 'id' => 'bar']));
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag(['class' => 'mt-4']));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')->merge(['class' => 'mt-4']));
-        $this->assertSame('class="italic" name="test"', (string) $bag->only('name')->merge(['class' => 'italic', 'name' => 'default']));
+        $this->assertSame('name="test" class="font-bold"', (string) $bag->merge(['name' => 'default']));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->merge(['class' => 'mt-4'])->only('class'));
         $this->assertSame('class="mt-4 font-bold"', (string) $bag->only('class')(['class' => 'mt-4']));
         $this->assertSame('font-bold', $bag->get('class'));


### PR DESCRIPTION
This PR is to fix the bug I raised in #31898.  Below is an illustration of what this PR fixes.

With a component that defines some **default** attributes:

```blade
<table {{ $attributes->merge(['width' => '600', 'class' => 'mb-4']) }}>
  ...
</table>
```

If the component is used like this

```html
<x-my-table width="100%" class="mt-2" />
```

We would expect the rendered template to be:
```html
<table class="mb-4 mt-2" width="100%">
  ...
</table>
```

But the current implementation renders:
```html
<table class="mb-4 mt-2" width="600">>
  ...
</table>
```

This PR fixes the implementation of ComponentAttributeBag::merge() so that it doesn't ignore attribute values specified in the template that is calling the component.

`ViewComponentAttributeBagTest` has been updated.