### PR TITLE
[8.x] Add dispatchToQueue to contract

### DIFF
--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -155,7 +155,7 @@ class Schedule
             $job = CallQueuedClosure::create($job);
         }
 
-        $this->getDispatcher()->dispatch(
+        $this->getDispatcher()->dispatchToQueue(
             $job->onConnection($connection)->onQueue($queue)
         );
     }

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -22,6 +22,14 @@ interface Dispatcher
     public function dispatchNow($command, $handler = null);
 
     /**
+     * Dispatch a command to its appropriate handler behind a queue.
+     *
+     * @param  mixed  $command
+     * @return mixed
+     */
+    public function dispatchToQueue($command);
+
+    /**
      * Determine if the given command has a handler.
      *
      * @param  mixed  $command


### PR DESCRIPTION
### DOT NOT MERGE YET - DEPENDS ON #31935

It would be useful to have `dispatchToQueue` available on the dispatcher contract, so it is available to call whenever we have code where we already know we want to dispatch to the queue, such as in the scheduler.