### PR TITLE
[7.x] Fix output of attribute with or without merge()

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -109,12 +109,6 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $attributes = [];
 
         foreach ($this->attributes as $key => $value) {
-            if ($value === true) {
-                $attributes[$key] = $key;
-
-                continue;
-            }
-
             if ($key !== 'class') {
                 $attributes[$key] = $value;
 
@@ -126,7 +120,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             ));
         }
 
-        return new static(array_merge($attributeDefaults, array_filter($attributes)));
+        return new static(array_merge($attributeDefaults, $attributes));
     }
 
     /**
@@ -225,10 +219,12 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $string = '';
 
-        foreach ($this->attributes as $key => $value) {
-            $string .= $value === true
-                    ? ' '.$key
-                    : ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+        foreach (array_filter($this->attributes) as $key => $value) {
+            if ($value === true) {
+                $value = $key;
+            }
+
+            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
         }
 
         return trim($string);

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -219,7 +219,11 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $string = '';
 
-        foreach (array_filter($this->attributes) as $key => $value) {
+        foreach ($this->attributes as $key => $value) {
+            if ($value === false || is_null($value)) {
+                continue;
+            }
+
             if ($value === true) {
                 $value = $key;
             }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -37,5 +37,18 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('', (string) $bag);
         $this->assertSame('', (string) $bag->merge());
+
+        $bag = new ComponentAttributeBag([
+            'test-string' => 'ok',
+            'test-null' => null,
+            'test-false' => false,
+            'test-true' => true,
+            'test-0' => 0,
+            'test-0-string' => '0',
+            'test-empty-string' => '',
+        ]);
+
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }
 }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -27,5 +27,15 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag([]);
 
         $this->assertSame('class="mt-4"', (string) $bag->merge(['class' => 'mt-4']));
+
+        $bag = new ComponentAttributeBag(['checked' => true]);
+
+        $this->assertSame('checked="checked"', (string) $bag);
+        $this->assertSame('checked="checked"', (string) $bag->merge());
+
+        $bag = new ComponentAttributeBag(['checked' => false]);
+
+        $this->assertSame('', (string) $bag);
+        $this->assertSame('', (string) $bag->merge());
     }
 }


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/31939

This PR makes `<input {{ $attributes->merge() }} />` and `<input {{ $attributes }} />` output the same attribute string. Previously values that were `true` or "falsy" where treated differently. Now these are treated the same way with our without the use of `merge()`:

```php
$bag = new ComponentAttributeBag([
    'test-string' => 'ok', // Keep
    'test-null' => null, // Remove
    'test-false' => false, // Remove
    'test-true' => true, // Keep it simple for now and render as test-true="test-true"
    'test-0' => 0, // Keep
    'test-0-string' => '0', // Keep
    'test-empty-string' => '' // Keep
]);
```

This PR uses `checked="checked"` instead of just `checked` for attributes with the value `true` - both are valid HTML. The longer version is also what Vue uses: https://github.com/vuejs/vue/blob/ae788136069bbf4f04de773aa0aa390a236342ed/test/ssr/ssr.sync.spec.js#L183.

Normally this syntax is only used for what the HTML spec calls "boolean attributes" (`checked`, `disabled` etc), but for now this will be the output for any attribute that has the value `true`. Vue for example has special handling for this.

