### PR TITLE
[7.x] Add support for Str::format

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -233,6 +233,30 @@ class Str
     }
 
     /**
+     * Format a string with values.
+     *
+     * @param  string  $subject
+     * @param  array   $values
+     * @return string
+     */
+    public static function format($subject, array $values)
+    {
+        preg_match_all('/(?<!{){(\w*)}(?!})/', $subject, $matches);
+
+        $i = 0;
+
+        foreach ($matches[1] as $ref) {
+            $key = $ref === '' ? $i++ : $ref;
+            $limit = $ref === '' ? 1 : -1;
+            $subject = preg_replace('/(?<!{)\{'.preg_quote($ref).'\}(?!})/', $values[$key], $subject, $limit);
+        }
+
+        $subject = preg_replace('/{{(\w*)}}/', '{\1}', $subject);
+
+        return $subject;
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|array  $pattern

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -236,22 +236,22 @@ class Str
      * Format a string with values.
      *
      * @param  string  $subject
-     * @param  array   $values
+     * @param  \ArrayAccess|array  $values
      * @return string
      */
-    public static function format($subject, array $values)
+    public static function format($subject, $values)
     {
-        preg_match_all('/(?<!{){(\w*)}(?!})/', $subject, $matches);
+        preg_match_all('/(?<!{){([\w\.]*)}(?!})/', $subject, $matches);
 
         $i = 0;
 
         foreach ($matches[1] as $ref) {
             $key = $ref === '' ? $i++ : $ref;
             $limit = $ref === '' ? 1 : -1;
-            $subject = preg_replace('/(?<!{)\{'.preg_quote($ref).'\}(?!})/', $values[$key], $subject, $limit);
+            $subject = preg_replace('/(?<!{)\{'.preg_quote($ref).'\}(?!})/', Arr::get($values, $key), $subject, $limit);
         }
 
-        $subject = preg_replace('/{{(\w*)}}/', '{\1}', $subject);
+        $subject = preg_replace('/{{([\w\.]*)}}/', '{\1}', $subject);
 
         return $subject;
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -205,6 +205,17 @@ class Stringable
     }
 
     /**
+     * Format a string with values.
+     *
+     * @param  \ArrayAccess|array  $values
+     * @return static
+     */
+    public function format($values)
+    {
+        return new static(Str::format($this->value, $values));
+    }
+
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|array  $pattern

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -53,6 +53,7 @@ class SupportStrTest extends TestCase
         $this->assertEquals('Steve Lacey', Str::format('{1} {}', ['Lacey', 'Steve']));
         $this->assertEquals('Steve Lacey', Str::format('{1} {0}', ['Lacey', 'Steve']));
         $this->assertEquals('Steve Lacey', Str::format('{a} {b}', ['a' => 'Steve', 'b' => 'Lacey']));
+        $this->assertEquals('Steve Lacey', Str::format('{a.b}', ['a' => ['b' => 'Steve Lacey']]));
     }
 
     public function testFormatEscapeBraces()
@@ -62,34 +63,19 @@ class SupportStrTest extends TestCase
         $this->assertEquals('\{1\} \{0\}', Str::format('\{1\} \{0\}', ['Lacey', 'Steve']));
     }
 
-    public function testFormatNoticeOnUndefinedOffset0()
+    public function testFormatMissingKey()
     {
-        $this->assertEquals('Steve ', @Str::format('{a} {}', ['a' => 'Steve']));
-
-        $this->expectNotice();
-        $this->expectExceptionMessage('Undefined offset: 0');
-
-        Str::format('{a} {}', ['a' => 'Steve']);
+        $this->assertEquals('Steve ', Str::format('{a} {}', ['a' => 'Steve']));
     }
 
-    public function testFormatNoticeOnUndefinedOffset1()
+    public function testFormatMissingPositionalKey()
     {
-        $this->assertEquals(' Steve', @Str::format('{1} {a}', ['a' => 'Steve']));
-
-        $this->expectNotice();
-        $this->expectExceptionMessage('Undefined offset: 1');
-
-        Str::format('{1} {a}', ['a' => 'Steve']);
+        $this->assertEquals(' Steve', Str::format('{1} {a}', ['a' => 'Steve']));
     }
 
-    public function testFormatNoticeOnUndefinedStringOffset()
+    public function testFormatMissingStringKey()
     {
-        $this->assertEquals(' Steve', @Str::format('{b} {a}', ['a' => 'Steve']));
-
-        $this->expectNotice();
-        $this->expectExceptionMessage('Undefined index: b');
-
-        Str::format('{b} {a}', ['a' => 'Steve']);
+        $this->assertEquals(' Steve', Str::format('{b} {a}', ['a' => 'Steve']));
     }
 
     public function testFormatNull()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -46,6 +46,57 @@ class SupportStrTest extends TestCase
         $this->assertSame('ae oe ue Ae Oe Ue', Str::ascii('ä ö ü Ä Ö Ü', 'de'));
     }
 
+    public function testFormat()
+    {
+        $this->assertEquals('Steve Lacey', Str::format('{} {}', ['Steve', 'Lacey']));
+        $this->assertEquals('Steve Lacey', Str::format('{} {1}', ['Steve', 'Lacey']));
+        $this->assertEquals('Steve Lacey', Str::format('{1} {}', ['Lacey', 'Steve']));
+        $this->assertEquals('Steve Lacey', Str::format('{1} {0}', ['Lacey', 'Steve']));
+        $this->assertEquals('Steve Lacey', Str::format('{a} {b}', ['a' => 'Steve', 'b' => 'Lacey']));
+    }
+
+    public function testFormatEscapeBraces()
+    {
+        $this->assertEquals('{1} {0}', Str::format('{{1}} {{0}}', ['Lacey', 'Steve']));
+        $this->assertEquals('\Steve \Lacey', Str::format('\{1} \{0}', ['Lacey', 'Steve']));
+        $this->assertEquals('\{1\} \{0\}', Str::format('\{1\} \{0\}', ['Lacey', 'Steve']));
+    }
+
+    public function testFormatNoticeOnUndefinedOffset0()
+    {
+        $this->assertEquals('Steve ', @Str::format('{a} {}', ['a' => 'Steve']));
+
+        $this->expectNotice();
+        $this->expectExceptionMessage('Undefined offset: 0');
+
+        Str::format('{a} {}', ['a' => 'Steve']);
+    }
+
+    public function testFormatNoticeOnUndefinedOffset1()
+    {
+        $this->assertEquals(' Steve', @Str::format('{1} {a}', ['a' => 'Steve']));
+
+        $this->expectNotice();
+        $this->expectExceptionMessage('Undefined offset: 1');
+
+        Str::format('{1} {a}', ['a' => 'Steve']);
+    }
+
+    public function testFormatNoticeOnUndefinedStringOffset()
+    {
+        $this->assertEquals(' Steve', @Str::format('{b} {a}', ['a' => 'Steve']));
+
+        $this->expectNotice();
+        $this->expectExceptionMessage('Undefined index: b');
+
+        Str::format('{b} {a}', ['a' => 'Steve']);
+    }
+
+    public function testFormatNull()
+    {
+        $this->assertEquals('', Str::format('{}', [null]));
+    }
+
     public function testStartsWith()
     {
         $this->assertTrue(Str::startsWith('jason', 'jas'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -100,6 +100,43 @@ class SupportStringableTest extends TestCase
         $this->assertSame('ae oe ue Ae Oe Ue', (string) $this->stringable('ä ö ü Ä Ö Ü')->ascii('de'));
     }
 
+    public function testFormat()
+    {
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{} {}')->format(['Steve', 'Lacey']));
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{} {1}')->format(['Steve', 'Lacey']));
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{1} {}')->format(['Lacey', 'Steve']));
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{1} {0}')->format(['Lacey', 'Steve']));
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{a} {b}')->format(['a' => 'Steve', 'b' => 'Lacey']));
+        $this->assertEquals('Steve Lacey', (string) $this->stringable('{a.b}')->format(['a' => ['b' => 'Steve Lacey']]));
+    }
+
+    public function testFormatEscapeBraces()
+    {
+        $this->assertEquals('{1} {0}', (string) $this->stringable('{{1}} {{0}}')->format(['Lacey', 'Steve']));
+        $this->assertEquals('\Steve \Lacey', (string) $this->stringable('\{1} \{0}')->format(['Lacey', 'Steve']));
+        $this->assertEquals('\{1\} \{0\}', (string) $this->stringable('\{1\} \{0\}')->format(['Lacey', 'Steve']));
+    }
+
+    public function testFormatMissingKey()
+    {
+        $this->assertEquals('Steve ', (string) $this->stringable('{a} {}')->format(['a' => 'Steve']));
+    }
+
+    public function testFormatMissingPositionalKey()
+    {
+        $this->assertEquals(' Steve', (string) $this->stringable('{1} {a}')->format(['a' => 'Steve']));
+    }
+
+    public function testFormatMissingStringKey()
+    {
+        $this->assertEquals(' Steve', (string) $this->stringable('{b} {a}')->format(['a' => 'Steve']));
+    }
+
+    public function testFormatNull()
+    {
+        $this->assertEquals('', (string) $this->stringable('{}')->format([null]));
+    }
+
     public function testStartsWith()
     {
         $this->assertTrue($this->stringable('jason')->startsWith('jas'));


### PR DESCRIPTION
This is mostly a copy of [Python's String.format](https://docs.python.org/3.4/library/string.html#string-formatting), a more intuitive `sprintf` (https://github.com/laravel/ideas/issues/2124)

`Str::format` works as shown, it allows for the formatting of predefined template strings using automatic, positional and key placeholders: `{}`, `{1}`, `{key}`.

```php
Str::format('acme.{network}.app.{id}', ['id' => 123, 'network' => 'testserver'])
=> "acme.testserver.app.123"

Str::format('acme.{}.app.{}', ['testserver', 123])
=> "acme.testserver.app.123"

Str::format('acme.{0}.app.{1}', ['testserver', 123])
=> "acme.testserver.app.123"

Str::format('acme.{1}.app.{0}', [123, 'testserver'])
=> "acme.testserver.app.123"
```

The idea is that you'd use this in places where you don't want to use interpolation, or want to supply a standard template for something else to customize.

I use it on occasion to do things like format a class constant, which allows for fixed templates that can be shared, reused and/or pulled from config:

```php
class UserChannel extends Channel
{
    const FORMAT = 'acme.{network}.user.{id}';

    public function __construct(User $user)
    {
        $this->name = Str::format(self::FORMAT, [
            'id' => $user->id,
            'network' => config('app.network.name'),
        ]);
    }
}
```

Dot notation is supported:

```php
>>> Str::format('{company.name}', ['company' => ['name' => 'acme']])
=> "acme"
```

Models (+ anything that implements ArrayAccess) is supported:

```php
>>> Str::format('{name} (@{username})', User::first())
=> "Taylor Otwell (@taylorotwell)"
```

Nulls and missing values result in an empty insertion:

```php
>>> Str::format('acme.{network}.app.{id}', ['id' => 123, 'network' => null])
=> "acme..app.123"
```

Escaping is supported the same way as in Python `{{}}` -> `{}`:

```php
>>> Str::format('acme.{{network}}.app.{id}', ['id' => 123])
=> "acme.{network}.app.123"
```

**Edit:** Switched away from `E_NOTICE` on missing key in favour of supporting dot notation; also, the `E_NOTICE` were hard to test because Laravel breaks PHPUnit's `convertNoticesToExceptions` by calling `set_error_handler` on a full run