### PR TITLE
[7.x] Add nested array support to assertDatabaseHas

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -21,9 +21,19 @@ trait InteractsWithDatabase
      */
     protected function assertDatabaseHas($table, array $data, $connection = null)
     {
-        $this->assertThat(
-            $table, new HasInDatabase($this->getConnection($connection), $data)
-        );
+        foreach ($data as $record) {
+            if (is_array($record)) {
+                $this->assertThat(
+                    $table, new HasInDatabase($this->getConnection($connection), $record)
+                );
+                continue;
+            }
+
+            $this->assertThat(
+                $table, new HasInDatabase($this->getConnection($connection), $data)
+            );
+            break;
+        }
 
         return $this;
     }

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -42,7 +42,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $this->assertDatabaseHas($this->table, [
             $this->data,
-            $this->data
+            $this->data,
         ]);
     }
 
@@ -59,7 +59,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $this->assertDatabaseHas($this->table, [
             $this->data,
-            $this->data
+            $this->data,
         ]);
     }
 
@@ -78,7 +78,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $this->assertDatabaseHas($this->table, [
             $this->data,
-            $this->data
+            $this->data,
         ]);
     }
 
@@ -100,7 +100,7 @@ class FoundationInteractsWithDatabaseTest extends TestCase
 
         $this->assertDatabaseHas($this->table, [
             $this->data,
-            $this->data
+            $this->data,
         ]);
     }
 

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -39,6 +39,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseHas($this->table, $this->data);
+
+        $this->assertDatabaseHas($this->table, [
+            $this->data,
+            $this->data
+        ]);
     }
 
     public function testSeeInDatabaseDoesNotFindResults()
@@ -51,6 +56,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect());
 
         $this->assertDatabaseHas($this->table, $this->data);
+
+        $this->assertDatabaseHas($this->table, [
+            $this->data,
+            $this->data
+        ]);
     }
 
     public function testSeeInDatabaseFindsNotMatchingResults()
@@ -65,6 +75,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $builder->shouldReceive('get')->andReturn(collect([['title' => 'Forge']]));
 
         $this->assertDatabaseHas($this->table, $this->data);
+
+        $this->assertDatabaseHas($this->table, [
+            $this->data,
+            $this->data
+        ]);
     }
 
     public function testSeeInDatabaseFindsManyNotMatchingResults()
@@ -82,6 +97,11 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         );
 
         $this->assertDatabaseHas($this->table, $this->data);
+
+        $this->assertDatabaseHas($this->table, [
+            $this->data,
+            $this->data
+        ]);
     }
 
     public function testDontSeeInDatabaseDoesNotFindResults()


### PR DESCRIPTION
```
//before 

$this->assertDatabaseHas('users', [
    'name' => 'John',
    'job' => 'Developer'
]);
$this->assertDatabaseHas('users', [
    'name' => 'Doe',
    'job' => 'Developer'
]);


//after

$this->assertDatabaseHas('users', [
    [
        'name' => 'John',
        'job' => 'Developer'
    ],
    [
        'name' => 'Doe',
        'job' => 'Developer'
    ],
]);
```