### PR TITLE
[7.x] Use null comparison instead of the function

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -190,7 +190,7 @@ class Gate implements GateContract
                 $policy, $user, $ability, $arguments
             );
 
-            if (! is_null($result)) {
+            if ($result !== null) {
                 return $result;
             }
 
@@ -362,7 +362,7 @@ class Gate implements GateContract
             $user, $ability, $arguments
         );
 
-        if (is_null($result)) {
+        if ($result === null) {
             $result = $this->callAuthCallback($user, $ability, $arguments);
         }
 
@@ -384,11 +384,11 @@ class Gate implements GateContract
      */
     protected function canBeCalledWithUser($user, $class, $method = null)
     {
-        if (! is_null($user)) {
+        if ($user !== null) {
             return true;
         }
 
-        if (! is_null($method)) {
+        if ($method !== null) {
             return $this->methodAllowsGuests($class, $method);
         }
 
@@ -451,7 +451,7 @@ class Gate implements GateContract
     protected function parameterAllowsGuests($parameter)
     {
         return ($parameter->getClass() && $parameter->allowsNull()) ||
-               ($parameter->isDefaultValueAvailable() && is_null($parameter->getDefaultValue()));
+               ($parameter->isDefaultValueAvailable() && $parameter->getDefaultValue() === null);
     }
 
     /**
@@ -484,7 +484,7 @@ class Gate implements GateContract
                 continue;
             }
 
-            if (! is_null($result = $before($user, $ability, $arguments))) {
+            if (($result = $before($user, $ability, $arguments)) !== null) {
                 return $result;
             }
         }
@@ -525,7 +525,7 @@ class Gate implements GateContract
     protected function resolveAuthCallback($user, $ability, array $arguments)
     {
         if (isset($arguments[0]) &&
-            ! is_null($policy = $this->getPolicyFor($arguments[0])) &&
+            ($policy = $this->getPolicyFor($arguments[0])) !== null &&
             $callback = $this->resolvePolicyCallback($user, $ability, $arguments, $policy)) {
             return $callback;
         }
@@ -650,7 +650,7 @@ class Gate implements GateContract
             // When we receive a non-null result from this before method, we will return it
             // as the "final" results. This will allow developers to override the checks
             // in this policy to return the result for all rules defined in the class.
-            if (! is_null($result)) {
+            if ($result !== null) {
                 return $result;
             }
 

--- a/src/Illuminate/Auth/AuthManager.php
+++ b/src/Illuminate/Auth/AuthManager.php
@@ -80,7 +80,7 @@ class AuthManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if ($config === null) {
             throw new InvalidArgumentException("Auth guard [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/CreatesUserProviders.php
+++ b/src/Illuminate/Auth/CreatesUserProviders.php
@@ -23,7 +23,7 @@ trait CreatesUserProviders
      */
     public function createUserProvider($provider = null)
     {
-        if (is_null($config = $this->getProviderConfiguration($provider))) {
+        if (($config = $this->getProviderConfiguration($provider)) === null) {
             return;
         }
 

--- a/src/Illuminate/Auth/DatabaseUserProvider.php
+++ b/src/Illuminate/Auth/DatabaseUserProvider.php
@@ -138,7 +138,7 @@ class DatabaseUserProvider implements UserProvider
      */
     protected function getGenericUser($user)
     {
-        if (! is_null($user)) {
+        if ($user !== null) {
             return new GenericUser((array) $user);
         }
     }

--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -166,7 +166,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function newModelQuery($model = null)
     {
-        return is_null($model)
+        return $model === null
                 ? $this->createModel()->newQuery()
                 : $model->newQuery();
     }

--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -33,7 +33,7 @@ trait GuardHelpers
      */
     public function authenticate()
     {
-        if (! is_null($user = $this->user())) {
+        if (($user = $this->user()) !== null) {
             return $user;
         }
 
@@ -47,7 +47,7 @@ trait GuardHelpers
      */
     public function hasUser()
     {
-        return ! is_null($this->user);
+        return $this->user !== null;
     }
 
     /**
@@ -57,7 +57,7 @@ trait GuardHelpers
      */
     public function check()
     {
-        return ! is_null($this->user());
+        return $this->user() !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -54,7 +54,7 @@ class Authorize
      */
     protected function getGateArguments($request, $models)
     {
-        if (is_null($models)) {
+        if ($models === null) {
             return [];
         }
 

--- a/src/Illuminate/Auth/MustVerifyEmail.php
+++ b/src/Illuminate/Auth/MustVerifyEmail.php
@@ -13,7 +13,7 @@ trait MustVerifyEmail
      */
     public function hasVerifiedEmail()
     {
-        return ! is_null($this->email_verified_at);
+        return $this->email_verified_at !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -51,7 +51,7 @@ class PasswordBroker implements PasswordBrokerContract
         // "flash" data in the session to indicate to the developers the errors.
         $user = $this->getUser($credentials);
 
-        if (is_null($user)) {
+        if ($user === null) {
             return static::INVALID_USER;
         }
 
@@ -107,7 +107,7 @@ class PasswordBroker implements PasswordBrokerContract
      */
     protected function validateReset(array $credentials)
     {
-        if (is_null($user = $this->getUser($credentials))) {
+        if (($user = $this->getUser($credentials)) === null) {
             return static::INVALID_USER;
         }
 

--- a/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php
@@ -61,7 +61,7 @@ class PasswordBrokerManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if ($config === null) {
             throw new InvalidArgumentException("Password resetter [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Auth/RequestGuard.php
+++ b/src/Illuminate/Auth/RequestGuard.php
@@ -50,7 +50,7 @@ class RequestGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->user !== null) {
             return $this->user;
         }
 
@@ -67,9 +67,9 @@ class RequestGuard implements Guard
      */
     public function validate(array $credentials = [])
     {
-        return ! is_null((new static(
-            $this->callback, $credentials['request'], $this->getProvider()
-        ))->user());
+        return (new static(
+                $this->callback, $credentials['request'], $this->getProvider()
+            ))->user() !== null;
     }
 
     /**

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -127,7 +127,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->user !== null) {
             return $this->user;
         }
 
@@ -136,14 +136,14 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // First we will try to load the user using the identifier in the session if
         // one exists. Otherwise we will check for a "remember me" cookie in this
         // request, and if one exists, attempt to retrieve the user using that.
-        if (! is_null($id) && $this->user = $this->provider->retrieveById($id)) {
+        if ($id !== null && $this->user = $this->provider->retrieveById($id)) {
             $this->fireAuthenticatedEvent($this->user);
         }
 
         // If the user is null, but we decrypt a "recaller" cookie we can attempt to
         // pull the user data on that cookie which serves as a remember cookie on
         // the application. Once we have a user we can return it to the caller.
-        if (is_null($this->user) && ! is_null($recaller = $this->recaller())) {
+        if ($this->user === null && ($recaller = $this->recaller()) !== null) {
             $this->user = $this->userFromRecaller($recaller);
 
             if ($this->user) {
@@ -173,9 +173,9 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
         // the application. Once we have a user we can return it to the caller.
         $this->recallAttempted = true;
 
-        $this->viaRemember = ! is_null($user = $this->provider->retrieveByToken(
-            $recaller->id(), $recaller->token()
-        ));
+        $this->viaRemember = ($user = $this->provider->retrieveByToken(
+                $recaller->id(), $recaller->token()
+            )) !== null;
 
         return $user;
     }
@@ -187,7 +187,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function recaller()
     {
-        if (is_null($this->request)) {
+        if ($this->request === null) {
             return;
         }
 
@@ -239,7 +239,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function onceUsingId($id)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        if (($user = $this->provider->retrieveById($id)) !== null) {
             $this->setUser($user);
 
             return $user;
@@ -382,7 +382,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function hasValidCredentials($user, $credentials)
     {
-        $validated = ! is_null($user) && $this->provider->validateCredentials($user, $credentials);
+        $validated = $user !== null && $this->provider->validateCredentials($user, $credentials);
 
         if ($validated) {
             $this->fireValidatedEvent($user);
@@ -400,7 +400,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     public function loginUsingId($id, $remember = false)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        if (($user = $this->provider->retrieveById($id)) !== null) {
             $this->login($user, $remember);
 
             return $user;
@@ -498,7 +498,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
 
         $this->clearUserDataFromStorage();
 
-        if (! is_null($this->user) && ! empty($user->getRememberToken())) {
+        if ($this->user !== null && ! empty($user->getRememberToken())) {
             $this->cycleRememberToken($user);
         }
 
@@ -526,7 +526,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     {
         $this->session->remove($this->getName());
 
-        if (! is_null($this->recaller())) {
+        if ($this->recaller() !== null) {
             $this->getCookieJar()->queue($this->getCookieJar()
                     ->forget($this->getRecallerName()));
         }

--- a/src/Illuminate/Auth/TokenGuard.php
+++ b/src/Illuminate/Auth/TokenGuard.php
@@ -72,7 +72,7 @@ class TokenGuard implements Guard
         // If we've already retrieved the user for the current request we can just
         // return it back immediately. We do not want to fetch the user data on
         // every call to this method because that would be tremendously slow.
-        if (! is_null($this->user)) {
+        if ($this->user !== null) {
             return $this->user;
         }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -266,7 +266,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if ($name !== null && $name !== 'null') {
             return $this->app['config']["broadcasting.connections.{$name}"];
         }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -285,7 +285,7 @@ abstract class Broadcaster implements BroadcasterContract
 
         $guards = $options['guards'] ?? null;
 
-        if (is_null($guards)) {
+        if ($guards === null) {
             return $request->user();
         }
 

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -94,7 +94,7 @@ class CacheManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if ($config === null) {
             throw new InvalidArgumentException("Cache store [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -65,7 +65,7 @@ class DatabaseStore implements Store
         // If we have a cache record we will check the expiration time against current
         // time on the system and see if the record has expired. If it has, we will
         // remove the records from the database table so it isn't returned again.
-        if (is_null($cache)) {
+        if ($cache === null) {
             return;
         }
 
@@ -155,7 +155,7 @@ class DatabaseStore implements Store
             // If there is no value in the cache, we will return false here. Otherwise the
             // value will be decrypted and we will proceed with this function to either
             // increment or decrement this value based on the given action callbacks.
-            if (is_null($cache)) {
+            if ($cache === null) {
                 return false;
             }
 

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -75,7 +75,7 @@ class FileStore implements Store
         );
 
         if ($result !== false && $result > 0) {
-            if (! is_null($this->filePermission)) {
+            if ($this->filePermission !== null) {
                 $this->files->chmod($path, $this->filePermission);
             }
 

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -42,7 +42,7 @@ abstract class Lock implements LockContract
      */
     public function __construct($name, $seconds, $owner = null)
     {
-        if (is_null($owner)) {
+        if ($owner === null) {
             $owner = Str::random();
         }
 

--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -53,7 +53,7 @@ class RedisStore extends TaggableStore implements LockProvider
     {
         $value = $this->connection()->get($this->prefix.$key);
 
-        return ! is_null($value) ? $this->unserialize($value) : null;
+        return $value !== null ? $this->unserialize($value) : null;
     }
 
     /**
@@ -73,7 +73,7 @@ class RedisStore extends TaggableStore implements LockProvider
         }, $keys));
 
         foreach ($values as $index => $value) {
-            $results[$keys[$index]] = ! is_null($value) ? $this->unserialize($value) : null;
+            $results[$keys[$index]] = $value !== null ? $this->unserialize($value) : null;
         }
 
         return $results;
@@ -110,7 +110,7 @@ class RedisStore extends TaggableStore implements LockProvider
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
+            $manyResult = $manyResult === null ? $result : $result && $manyResult;
         }
 
         $this->connection()->exec();

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -67,7 +67,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function has($key)
     {
-        return ! is_null($this->get($key));
+        return $this->get($key) !== null;
     }
 
     /**
@@ -99,7 +99,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (is_null($value)) {
+        if ($value === null) {
             $this->event(new CacheMissed($key));
 
             $value = value($default);
@@ -156,7 +156,7 @@ class Repository implements ArrayAccess, CacheContract
         // If we could not find the cache value, we will fire the missed event and get
         // the default value for this cache value. This default could be a callback
         // so we will execute the value function which will resolve it if needed.
-        if (is_null($value)) {
+        if ($value === null) {
             $this->event(new CacheMissed($key));
 
             return isset($keys[$key]) ? value($keys[$key]) : null;
@@ -312,7 +312,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the value did not exist in the cache, we will put the value in the cache
         // so it exists for subsequent requests. Then, we will return true so it is
         // easy to know if the value gets added. Otherwise, we will return false.
-        if (is_null($this->get($key))) {
+        if ($this->get($key) === null) {
             return $this->put($key, $value, $ttl);
         }
 
@@ -376,7 +376,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately and if
         // not we will execute the given Closure and cache the result of that for a
         // given number of seconds so it's available for all subsequent requests.
-        if (! is_null($value)) {
+        if ($value !== null) {
             return $value;
         }
 
@@ -411,7 +411,7 @@ class Repository implements ArrayAccess, CacheContract
         // If the item exists in the cache we will just return this immediately
         // and if not we will execute the given Closure and cache the result
         // of that forever so it is available for all subsequent requests.
-        if (! is_null($value)) {
+        if ($value !== null) {
             return $value;
         }
 
@@ -483,7 +483,7 @@ class Repository implements ArrayAccess, CacheContract
 
         $cache = $this->store->tags(is_array($names) ? $names : func_get_args());
 
-        if (! is_null($this->events)) {
+        if ($this->events !== null) {
             $cache->setEventDispatcher($this->events);
         }
 

--- a/src/Illuminate/Cache/RetrievesMultipleKeys.php
+++ b/src/Illuminate/Cache/RetrievesMultipleKeys.php
@@ -37,7 +37,7 @@ trait RetrievesMultipleKeys
         foreach ($values as $key => $value) {
             $result = $this->put($key, $value, $seconds);
 
-            $manyResult = is_null($manyResult) ? $result : $result && $manyResult;
+            $manyResult = $manyResult === null ? $result : $result && $manyResult;
         }
 
         return $manyResult ?: false;

--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -67,7 +67,7 @@ trait InteractsWithIO
      */
     public function argument($key = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->input->getArguments();
         }
 
@@ -103,7 +103,7 @@ trait InteractsWithIO
      */
     public function option($key = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->input->getOptions();
         }
 

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -15,7 +15,7 @@ trait ConfirmableTrait
      */
     public function confirmToProceed($warning = 'Application In Production!', $callback = null)
     {
-        $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
+        $callback = $callback === null ? $this->getDefaultConfirmCallback() : $callback;
 
         $shouldConfirm = value($callback);
 

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -444,7 +444,7 @@ class Event
      */
     protected function ensureOutputIsBeingCaptured()
     {
-        if (is_null($this->output) || $this->output == $this->getDefaultOutput()) {
+        if ($this->output === null || $this->output == $this->getDefaultOutput()) {
             $this->sendOutputTo(storage_path('logs/schedule-'.sha1($this->mutexName()).'.log'));
         }
     }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -55,7 +55,7 @@ class BoundMethod
         $method = count($segments) === 2
                         ? $segments[1] : $defaultMethod;
 
-        if (is_null($method)) {
+        if ($method === null) {
             throw new InvalidArgumentException('Method not provided.');
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -226,7 +226,7 @@ class Container implements ArrayAccess, ContainerContract
         // If no concrete type was given, we will simply set the concrete type to the
         // abstract type. After that, the concrete type to be registered as shared
         // without being forced to state their classes in both of the parameters.
-        if (is_null($concrete)) {
+        if ($concrete === null) {
             $concrete = $abstract;
         }
 
@@ -659,9 +659,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $abstract = $this->getAlias($abstract);
 
-        $needsContextualBuild = ! empty($parameters) || ! is_null(
-            $this->getContextualConcrete($abstract)
-        );
+        $needsContextualBuild = ! empty($parameters) || $this->getContextualConcrete($abstract) !== null;
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -719,7 +717,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getConcrete($abstract)
     {
-        if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
+        if (($concrete = $this->getContextualConcrete($abstract)) !== null) {
             return $concrete;
         }
 
@@ -741,7 +739,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getContextualConcrete($abstract)
     {
-        if (! is_null($binding = $this->findInContextualBindings($abstract))) {
+        if (($binding = $this->findInContextualBindings($abstract)) !== null) {
             return $binding;
         }
 
@@ -753,7 +751,7 @@ class Container implements ArrayAccess, ContainerContract
         }
 
         foreach ($this->abstractAliases[$abstract] as $alias) {
-            if (! is_null($binding = $this->findInContextualBindings($alias))) {
+            if (($binding = $this->findInContextualBindings($alias)) !== null) {
                 return $binding;
             }
         }
@@ -819,7 +817,7 @@ class Container implements ArrayAccess, ContainerContract
         // If there are no constructors, that means there are no dependencies then
         // we can just resolve the instances of the objects right away, without
         // resolving any other types or dependencies out of these containers.
-        if (is_null($constructor)) {
+        if ($constructor === null) {
             array_pop($this->buildStack);
 
             return new $concrete;
@@ -868,7 +866,7 @@ class Container implements ArrayAccess, ContainerContract
             // If the class is null, it means the dependency is a string or some other
             // primitive type which we can not resolve since it is not a class and
             // we will just bomb out with an error since we have no-where to go.
-            $results[] = is_null($dependency->getClass())
+            $results[] = $dependency->getClass() === null
                             ? $this->resolvePrimitive($dependency)
                             : $this->resolveClass($dependency);
         }
@@ -920,7 +918,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function resolvePrimitive(ReflectionParameter $parameter)
     {
-        if (! is_null($concrete = $this->getContextualConcrete('$'.$parameter->name))) {
+        if (($concrete = $this->getContextualConcrete('$' . $parameter->name)) !== null) {
             return $concrete instanceof Closure ? $concrete($this) : $concrete;
         }
 
@@ -1006,7 +1004,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if (is_null($callback) && $abstract instanceof Closure) {
+        if ($callback === null && $abstract instanceof Closure) {
             $this->globalResolvingCallbacks[] = $abstract;
         } else {
             $this->resolvingCallbacks[$abstract][] = $callback;
@@ -1026,7 +1024,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if ($abstract instanceof Closure && is_null($callback)) {
+        if ($abstract instanceof Closure && $callback === null) {
             $this->globalAfterResolvingCallbacks[] = $abstract;
         } else {
             $this->afterResolvingCallbacks[$abstract][] = $callback;
@@ -1205,7 +1203,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public static function getInstance()
     {
-        if (is_null(static::$instance)) {
+        if (static::$instance === null) {
             static::$instance = new static;
         }
 

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -16,7 +16,7 @@ class Util
      */
     public static function arrayWrap($value)
     {
-        if (is_null($value)) {
+        if ($value === null) {
             return [];
         }
 

--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -110,7 +110,7 @@ class CookieJar implements JarContract
      */
     public function hasQueued($key, $path = null)
     {
-        return ! is_null($this->queued($key, null, $path));
+        return $this->queued($key, null, $path) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -216,7 +216,7 @@ trait ManagesTransactions
         // We allow developers to rollback to a certain transaction level. We will verify
         // that this given transaction level is valid before attempting to rollback to
         // that level. If it's not we will just return out and not attempt anything.
-        $toLevel = is_null($toLevel)
+        $toLevel = $toLevel === null
                     ? $this->transactions - 1
                     : $toLevel;
 

--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -251,7 +251,7 @@ class Connection implements ConnectionInterface
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 
@@ -771,7 +771,7 @@ class Connection implements ConnectionInterface
      */
     protected function reconnectIfMissingConnection()
     {
-        if (is_null($this->pdo)) {
+        if ($this->pdo === null) {
             $this->reconnect();
         }
     }
@@ -899,7 +899,7 @@ class Connection implements ConnectionInterface
      */
     public function getDoctrineConnection()
     {
-        if (is_null($this->doctrineConnection)) {
+        if ($this->doctrineConnection === null) {
             $driver = $this->getDoctrineDriver();
 
             $this->doctrineConnection = new DoctrineConnection(array_filter([

--- a/src/Illuminate/Database/ConnectionResolver.php
+++ b/src/Illuminate/Database/ConnectionResolver.php
@@ -39,7 +39,7 @@ class ConnectionResolver implements ConnectionResolverInterface
      */
     public function connection($name = null)
     {
-        if (is_null($name)) {
+        if ($name === null) {
             $name = $this->getDefaultConnection();
         }
 

--- a/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateMakeCommand.php
@@ -124,7 +124,7 @@ class MigrateMakeCommand extends BaseCommand
      */
     protected function getMigrationPath()
     {
-        if (! is_null($targetPath = $this->input->getOption('path'))) {
+        if (($targetPath = $this->input->getOption('path')) !== null) {
             return ! $this->usingRealPath()
                             ? $this->laravel->basePath().'/'.$targetPath
                             : $targetPath;

--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -148,7 +148,7 @@ class DatabaseManager implements ConnectionResolverInterface
         // If the configuration doesn't exist, we'll throw an exception and bail.
         $connections = $this->app['config']['database.connections'];
 
-        if (is_null($config = Arr::get($connections, $name))) {
+        if (($config = Arr::get($connections, $name)) === null) {
             throw new InvalidArgumentException("Database connection [{$name}] not configured.");
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -224,7 +224,7 @@ class Builder
      */
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
-        if ($column instanceof Closure && is_null($operator)) {
+        if ($column instanceof Closure && $operator === null) {
             $column($query = $this->model->newQueryWithoutRelationships());
 
             $this->query->addNestedWhereQuery($query->getQuery(), $boolean);
@@ -274,7 +274,7 @@ class Builder
      */
     public function latest($column = null)
     {
-        if (is_null($column)) {
+        if ($column === null) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -291,7 +291,7 @@ class Builder
      */
     public function oldest($column = null)
     {
-        if (is_null($column)) {
+        if ($column === null) {
             $column = $this->model->getCreatedAtColumn() ?? 'created_at';
         }
 
@@ -382,7 +382,7 @@ class Builder
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -400,7 +400,7 @@ class Builder
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (! is_null($model = $this->find($id, $columns))) {
+        if (($model = $this->find($id, $columns)) !== null) {
             return $model;
         }
 
@@ -416,7 +416,7 @@ class Builder
      */
     public function firstOrNew(array $attributes = [], array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) !== null) {
             return $instance;
         }
 
@@ -432,7 +432,7 @@ class Builder
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (! is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) !== null) {
             return $instance;
         }
 
@@ -465,7 +465,7 @@ class Builder
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -487,7 +487,7 @@ class Builder
             $columns = ['*'];
         }
 
-        if (! is_null($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -831,7 +831,7 @@ class Builder
     protected function addUpdatedAtColumn(array $values)
     {
         if (! $this->model->usesTimestamps() ||
-            is_null($this->model->getUpdatedAtColumn())) {
+            $this->model->getUpdatedAtColumn() === null) {
             return $values;
         }
 
@@ -974,7 +974,7 @@ class Builder
         // We will keep track of how many wheres are on the query before running the
         // scope so that we can properly group the added scope constraints in the
         // query as their own isolated nested where statement and avoid issues.
-        $originalWhereCount = is_null($query->wheres)
+        $originalWhereCount = $query->wheres === null
                     ? 0 : count($query->wheres);
 
         $result = $scope(...array_values($parameters)) ?? $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -152,7 +152,7 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         $models->filter(function ($model) use ($name) {
-            return ! is_null($model) && ! $model->relationLoaded($name);
+            return $model !== null && ! $model->relationLoaded($name);
         })->load($relation);
 
         if (empty($path)) {
@@ -339,7 +339,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function unique($key = null, $strict = false)
     {
-        if (! is_null($key)) {
+        if ($key !== null) {
             return parent::unique($key, $strict);
         }
 
@@ -354,7 +354,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function only($keys)
     {
-        if (is_null($keys)) {
+        if ($keys === null) {
             return new static($this->items);
         }
 
@@ -406,7 +406,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getDictionary($items = null)
     {
-        $items = is_null($items) ? $this->items : $items;
+        $items = $items === null ? $this->items : $items;
 
         $dictionary = [];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -284,7 +284,7 @@ trait HasAttributes
             // If the value is null, we'll still go ahead and set it in this list of
             // attributes since null is used to represent empty relationships if
             // if it a has one or belongs to type relationships on the models.
-            elseif (is_null($value)) {
+            elseif ($value === null) {
                 $relation = $value;
             }
 
@@ -298,7 +298,7 @@ trait HasAttributes
             // If the relation value has been set, we will set it on this attributes
             // list for returning. If it was not arrayable or null, we'll not set
             // the value on the array because it is some type of invalid value.
-            if (isset($relation) || is_null($value)) {
+            if (isset($relation) || $value === null) {
                 $attributes[$key] = $relation;
             }
 
@@ -426,7 +426,7 @@ trait HasAttributes
         $relation = $this->$method();
 
         if (! $relation instanceof Relation) {
-            if (is_null($relation)) {
+            if ($relation === null) {
                 throw new LogicException(sprintf(
                     '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
                 ));
@@ -503,7 +503,7 @@ trait HasAttributes
     {
         $castType = $this->getCastType($key);
 
-        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
+        if ($value === null && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 
@@ -635,7 +635,7 @@ trait HasAttributes
             return $this;
         }
 
-        if ($this->isJsonCastable($key) && ! is_null($value)) {
+        if ($this->isJsonCastable($key) && $value !== null) {
             $value = $this->castAttributeAsJson($key, $value);
         }
 
@@ -715,7 +715,7 @@ trait HasAttributes
     {
         $caster = $this->resolveCasterClass($key);
 
-        if (is_null($value)) {
+        if ($value === null) {
             $this->attributes = array_merge($this->attributes, array_map(
                 function () {
                 },
@@ -1359,7 +1359,7 @@ trait HasAttributes
 
         if ($attribute === $original) {
             return true;
-        } elseif (is_null($attribute)) {
+        } elseif ($attribute === null) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($attribute) ===

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -204,7 +204,7 @@ trait HasEvents
 
         $result = static::$dispatcher->$method(new $this->dispatchesEvents[$event]($this));
 
-        if (! is_null($result)) {
+        if ($result !== null) {
             return $result;
         }
     }
@@ -219,7 +219,7 @@ trait HasEvents
     {
         if (is_array($result)) {
             $result = array_filter($result, function ($response) {
-                return ! is_null($response);
+                return $response !== null;
             });
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -20,7 +20,7 @@ trait HasGlobalScopes
      */
     public static function addGlobalScope($scope, Closure $implementation = null)
     {
-        if (is_string($scope) && ! is_null($implementation)) {
+        if (is_string($scope) && $implementation !== null) {
             return static::$globalScopes[static::class][$scope] = $implementation;
         } elseif ($scope instanceof Closure) {
             return static::$globalScopes[static::class][spl_object_hash($scope)] = $scope;
@@ -39,7 +39,7 @@ trait HasGlobalScopes
      */
     public static function hasGlobalScope($scope)
     {
-        return ! is_null(static::getGlobalScope($scope));
+        return static::getGlobalScope($scope) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -172,7 +172,7 @@ trait HasRelationships
         // If no relation name was given, we will use this debug backtrace to extract
         // the calling method's name and use that as the relationship name as most
         // of the time this will be what we desire to use for the relationships.
-        if (is_null($relation)) {
+        if ($relation === null) {
             $relation = $this->guessBelongsToRelation();
         }
 
@@ -181,7 +181,7 @@ trait HasRelationships
         // If no foreign key was supplied, we can use a backtrace to guess the proper
         // foreign key name by using the name of the relationship function, which
         // when combined with an "_id" should conventionally match the columns.
-        if (is_null($foreignKey)) {
+        if ($foreignKey === null) {
             $foreignKey = Str::snake($relation).'_'.$instance->getKeyName();
         }
 
@@ -451,7 +451,7 @@ trait HasRelationships
         // If no relationship name was passed, we will pull backtraces to get the
         // name of the calling function. We will use that function name as the
         // title of this relation since that is a great convention to apply.
-        if (is_null($relation)) {
+        if ($relation === null) {
             $relation = $this->guessBelongsToManyRelation();
         }
 
@@ -467,7 +467,7 @@ trait HasRelationships
         // If no table name was provided, we can guess it by concatenating the two
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.
-        if (is_null($table)) {
+        if ($table === null) {
             $table = $this->joiningTable($related, $instance);
         }
 
@@ -608,7 +608,7 @@ trait HasRelationships
             );
         });
 
-        return ! is_null($caller) ? $caller['function'] : null;
+        return $caller !== null ? $caller['function'] : null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -40,13 +40,13 @@ trait HasTimestamps
 
         $updatedAtColumn = $this->getUpdatedAtColumn();
 
-        if (! is_null($updatedAtColumn) && ! $this->isDirty($updatedAtColumn)) {
+        if ($updatedAtColumn !== null && ! $this->isDirty($updatedAtColumn)) {
             $this->setUpdatedAt($time);
         }
 
         $createdAtColumn = $this->getCreatedAtColumn();
 
-        if (! $this->exists && ! is_null($createdAtColumn) && ! $this->isDirty($createdAtColumn)) {
+        if (! $this->exists && $createdAtColumn !== null && ! $this->isDirty($createdAtColumn)) {
             $this->setCreatedAt($time);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -359,7 +359,7 @@ trait QueriesRelationships
             return $this;
         }
 
-        if (is_null($this->query->columns)) {
+        if ($this->query->columns === null) {
             $this->query->select([$this->query->from.'.*']);
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -911,7 +911,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $this->mergeAttributesFromClassCasts();
 
-        if (is_null($this->getKeyName())) {
+        if ($this->getKeyName() === null) {
             throw new Exception('No primary key defined on model.');
         }
 
@@ -1222,7 +1222,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function is($model)
     {
-        return ! is_null($model) &&
+        return $model !== null &&
                $this->getKey() === $model->getKey() &&
                $this->getTable() === $model->getTable() &&
                $this->getConnectionName() === $model->getConnectionName();
@@ -1587,7 +1587,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        return $this->getAttribute($offset) !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -76,7 +76,7 @@ class BelongsTo extends Relation
      */
     public function getResults()
     {
-        if (is_null($this->child->{$this->foreignKey})) {
+        if ($this->child->{$this->foreignKey} === null) {
             return $this->getDefaultFor($this->parent);
         }
 
@@ -132,7 +132,7 @@ class BelongsTo extends Relation
         // to query for via the eager loading query. We will add them to an array then
         // execute a "where in" statement to gather up all of those related records.
         foreach ($models as $model) {
-            if (! is_null($value = $model->{$this->foreignKey})) {
+            if (($value = $model->{$this->foreignKey}) !== null) {
                 $keys[] = $value;
             }
         }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -407,7 +407,7 @@ class BelongsToMany extends Relation
             return $this;
         }
 
-        if (is_null($value)) {
+        if ($value === null) {
             throw new InvalidArgumentException('The provided value may not be null.');
         }
 
@@ -462,7 +462,7 @@ class BelongsToMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (is_null($instance = $this->find($id, $columns))) {
+        if (($instance = $this->find($id, $columns)) === null) {
             $instance = $this->related->newInstance();
         }
 
@@ -477,7 +477,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -494,7 +494,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->create($attributes, $joining, $touch);
         }
 
@@ -512,7 +512,7 @@ class BelongsToMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [], array $joining = [], $touch = true)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             return $this->create($values, $joining, $touch);
         }
 
@@ -580,7 +580,7 @@ class BelongsToMany extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -610,7 +610,7 @@ class BelongsToMany extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -624,7 +624,7 @@ class BelongsToMany extends Relation
      */
     public function getResults()
     {
-        return ! is_null($this->parent->{$this->parentKey})
+        return $this->parent->{$this->parentKey} !== null
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -417,7 +417,7 @@ trait InteractsWithPivotTable
             // If associated IDs were passed to the method we will only delete those
             // associations, otherwise all of the association ties will be broken.
             // We'll return the numbers of affected rows when we do the deletes.
-            if (! is_null($ids)) {
+            if ($ids !== null) {
                 $ids = $this->parseIds($ids);
 
                 if (empty($ids)) {

--- a/src/Illuminate/Database/Eloquent/Relations/HasMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasMany.php
@@ -13,7 +13,7 @@ class HasMany extends HasOneOrMany
      */
     public function getResults()
     {
-        return ! is_null($this->getParentKey())
+        return $this->getParentKey() !== null
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -224,7 +224,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrNew(array $attributes)
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes);
         }
 
@@ -270,7 +270,7 @@ class HasManyThrough extends Relation
      */
     public function firstOrFail($columns = ['*'])
     {
-        if (! is_null($model = $this->first($columns))) {
+        if (($model = $this->first($columns)) !== null) {
             return $model;
         }
 
@@ -334,7 +334,7 @@ class HasManyThrough extends Relation
             if (count($result) === count(array_unique($id))) {
                 return $result;
             }
-        } elseif (! is_null($result)) {
+        } elseif ($result !== null) {
             return $result;
         }
 
@@ -348,7 +348,7 @@ class HasManyThrough extends Relation
      */
     public function getResults()
     {
-        return ! is_null($this->farParent->{$this->localKey})
+        return $this->farParent->{$this->localKey} !== null
                 ? $this->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -17,7 +17,7 @@ class HasOne extends HasOneOrMany
      */
     public function getResults()
     {
-        if (is_null($this->getParentKey())) {
+        if ($this->getParentKey() === null) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -180,7 +180,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function findOrNew($id, $columns = ['*'])
     {
-        if (is_null($instance = $this->find($id, $columns))) {
+        if (($instance = $this->find($id, $columns)) === null) {
             $instance = $this->related->newInstance();
 
             $this->setForeignAttributesForCreate($instance);
@@ -198,7 +198,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrNew(array $attributes, array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->related->newInstance($attributes + $values);
 
             $this->setForeignAttributesForCreate($instance);
@@ -216,7 +216,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function firstOrCreate(array $attributes, array $values = [])
     {
-        if (is_null($instance = $this->where($attributes)->first())) {
+        if (($instance = $this->where($attributes)->first()) === null) {
             $instance = $this->create($attributes + $values);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphMany.php
@@ -13,7 +13,7 @@ class MorphMany extends MorphOneOrMany
      */
     public function getResults()
     {
-        return ! is_null($this->getParentKey())
+        return $this->getParentKey() !== null
                 ? $this->query->get()
                 : $this->related->newCollection();
     }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphOne.php
@@ -17,7 +17,7 @@ class MorphOne extends MorphOneOrMany
      */
     public function getResults()
     {
-        if (is_null($this->getParentKey())) {
+        if ($this->getParentKey() === null) {
             return $this->getDefaultFor($this->parent);
         }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -177,7 +177,7 @@ class MorphTo extends BelongsTo
     protected function matchToMorphParents($type, Collection $results)
     {
         foreach ($results as $result) {
-            $ownerKey = ! is_null($this->ownerKey) ? $result->{$this->ownerKey} : $result->getKey();
+            $ownerKey = $this->ownerKey !== null ? $result->{$this->ownerKey} : $result->getKey();
 
             if (isset($this->dictionary[$type][$ownerKey])) {
                 foreach ($this->dictionary[$type][$ownerKey] as $model) {
@@ -227,7 +227,7 @@ class MorphTo extends BelongsTo
      */
     public function touch()
     {
-        if (! is_null($this->child->{$this->foreignKey})) {
+        if ($this->child->{$this->foreignKey} !== null) {
             parent::touch();
         }
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -349,7 +349,7 @@ abstract class Relation
      */
     protected static function buildMorphMapFromModels(array $models = null)
     {
-        if (is_null($models) || Arr::isAssoc($models)) {
+        if ($models === null || Arr::isAssoc($models)) {
             return $models;
         }
 

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -85,7 +85,7 @@ trait SoftDeletes
 
         $this->{$this->getDeletedAtColumn()} = $time;
 
-        if ($this->timestamps && ! is_null($this->getUpdatedAtColumn())) {
+        if ($this->timestamps && $this->getUpdatedAtColumn() !== null) {
             $this->{$this->getUpdatedAtColumn()} = $time;
 
             $columns[$this->getUpdatedAtColumn()] = $this->fromDateTime($time);
@@ -131,7 +131,7 @@ trait SoftDeletes
      */
     public function trashed()
     {
-        return ! is_null($this->{$this->getDeletedAtColumn()});
+        return $this->{$this->getDeletedAtColumn()} !== null;
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/MigrationCreator.php
+++ b/src/Illuminate/Database/Migrations/MigrationCreator.php
@@ -109,7 +109,7 @@ class MigrationCreator
      */
     protected function getStub($table, $create)
     {
-        if (is_null($table)) {
+        if ($table === null) {
             $stub = $this->files->exists($customPath = $this->customStubPath.'/migration.stub')
                             ? $customPath
                             : $this->stubPath().'/migration.stub';
@@ -144,7 +144,7 @@ class MigrationCreator
         // Here we will replace the table place-holders with the table specified by
         // the developer, which is useful for quickly creating a tables creation
         // or update migration from the console instead of typing it manually.
-        if (! is_null($table)) {
+        if ($table !== null) {
             $stub = str_replace(
                 ['DummyTable', '{{ table }}', '{{table}}'],
                 $table, $stub

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -551,7 +551,7 @@ class Migrator
      */
     public function setConnection($name)
     {
-        if (! is_null($name)) {
+        if ($name !== null) {
             $this->resolver->setDefaultConnection($name);
         }
 
@@ -579,7 +579,7 @@ class Migrator
      */
     protected function getSchemaGrammar($connection)
     {
-        if (is_null($grammar = $connection->getSchemaGrammar())) {
+        if (($grammar = $connection->getSchemaGrammar()) === null) {
             $connection->useDefaultSchemaGrammar();
 
             $grammar = $connection->getSchemaGrammar();

--- a/src/Illuminate/Database/MySqlConnection.php
+++ b/src/Illuminate/Database/MySqlConnection.php
@@ -27,7 +27,7 @@ class MySqlConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -27,7 +27,7 @@ class PostgresConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -360,7 +360,7 @@ class Builder
 
         foreach ($columns as $as => $column) {
             if (is_string($as) && $this->isQueryable($column)) {
-                if (is_null($this->columns)) {
+                if ($this->columns === null) {
                     $this->select($this->from.'.*');
                 }
 
@@ -652,14 +652,14 @@ class Builder
         // If the columns is actually a Closure instance, we will assume the developer
         // wants to begin a nested where statement which is wrapped in parenthesis.
         // We'll add that Closure to the query then return back out immediately.
-        if ($column instanceof Closure && is_null($operator)) {
+        if ($column instanceof Closure && $operator === null) {
             return $this->whereNested($column, $boolean);
         }
 
         // If the column is a Closure instance and there is an operator value, we will
         // assume the developer wants to run a subquery and then compare the result
         // of that subquery with the given value that was provided to the method.
-        if ($this->isQueryable($column) && ! is_null($operator)) {
+        if ($this->isQueryable($column) && $operator !== null) {
             [$sub, $bindings] = $this->createSub($column);
 
             return $this->addBinding($bindings, 'where')
@@ -683,7 +683,7 @@ class Builder
         // If the value is "null", we will just assume the developer wants to add a
         // where null clause to the query. So, we will allow a short-cut here to
         // that method for convenience so the developer doesn't have to check.
-        if (is_null($value)) {
+        if ($value === null) {
             return $this->whereNull($column, $boolean, $operator !== '=');
         }
 
@@ -767,7 +767,7 @@ class Builder
      */
     protected function invalidOperatorAndValue($operator, $value)
     {
-        return is_null($value) && in_array($operator, $this->operators) &&
+        return $value === null && in_array($operator, $this->operators) &&
              ! in_array($operator, ['=', '<>', '!=']);
     }
 
@@ -1989,7 +1989,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if ($lastId !== null) {
             $this->where($column, '<', $lastId);
         }
 
@@ -2009,7 +2009,7 @@ class Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
-        if (! is_null($lastId)) {
+        if ($lastId !== null) {
             $this->where($column, '>', $lastId);
         }
 
@@ -2073,7 +2073,7 @@ class Builder
     {
         $this->lock = $value;
 
-        if (! is_null($this->lock)) {
+        if ($this->lock !== null) {
             $this->useWritePdo();
         }
 
@@ -2267,7 +2267,7 @@ class Builder
      */
     public function cursor()
     {
-        if (is_null($this->columns)) {
+        if ($this->columns === null) {
             $this->columns = ['*'];
         }
 
@@ -2305,7 +2305,7 @@ class Builder
         // given columns / key. Once we have the results, we will be able to take
         // the results and get the exact data that was requested for the query.
         $queryResult = $this->onceWithColumns(
-            is_null($key) ? [$column] : [$column, $key],
+            $key === null ? [$column] : [$column, $key],
             function () {
                 return $this->processor->processSelect(
                     $this, $this->runSelect()
@@ -2337,7 +2337,7 @@ class Builder
      */
     protected function stripTableForPluck($column)
     {
-        if (is_null($column)) {
+        if ($column === null) {
             return $column;
         }
 
@@ -2358,7 +2358,7 @@ class Builder
     {
         $results = [];
 
-        if (is_null($key)) {
+        if ($key === null) {
             foreach ($queryResult as $row) {
                 $results[] = $row->$column;
             }
@@ -2383,7 +2383,7 @@ class Builder
     {
         $results = [];
 
-        if (is_null($key)) {
+        if ($key === null) {
             foreach ($queryResult as $row) {
                 $results[] = $row[$column];
             }
@@ -2612,7 +2612,7 @@ class Builder
     {
         $original = $this->columns;
 
-        if (is_null($original)) {
+        if ($original === null) {
             $this->columns = $columns;
         }
 
@@ -2814,7 +2814,7 @@ class Builder
         // If an ID is passed to the method, we will set the where clause to check the
         // ID to let developers to simply and quickly remove a single row from this
         // database without manually specifying the "where" clauses on the query.
-        if (! is_null($id)) {
+        if ($id !== null) {
             $this->where($this->from.'.id', '=', $id);
         }
 

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -54,7 +54,7 @@ class Grammar extends BaseGrammar
         // can build the query and concatenate all the pieces together as one.
         $original = $query->columns;
 
-        if (is_null($query->columns)) {
+        if ($query->columns === null) {
             $query->columns = ['*'];
         }
 
@@ -88,7 +88,7 @@ class Grammar extends BaseGrammar
             // To compile the query, we'll spin through each component of the query and
             // see if that component exists. If it does we'll just call the compiler
             // function for the component which is responsible for making the SQL.
-            if (isset($query->$component) && ! is_null($query->$component)) {
+            if (isset($query->$component) && $query->$component !== null) {
                 $method = 'compile'.ucfirst($component);
 
                 $sql[$component] = $this->$method($query, $query->$component);
@@ -133,7 +133,7 @@ class Grammar extends BaseGrammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (! is_null($query->aggregate)) {
+        if ($query->aggregate !== null) {
             return;
         }
 
@@ -170,9 +170,9 @@ class Grammar extends BaseGrammar
         return collect($joins)->map(function ($join) use ($query) {
             $table = $this->wrapTable($join->table);
 
-            $nestedJoins = is_null($join->joins) ? '' : ' '.$this->compileJoins($query, $join->joins);
+            $nestedJoins = $join->joins === null ? '' : ' '.$this->compileJoins($query, $join->joins);
 
-            $tableAndNestedJoins = is_null($join->joins) ? $table : '('.$table.$nestedJoins.')';
+            $tableAndNestedJoins = $join->joins === null ? $table : '('.$table.$nestedJoins.')';
 
             return trim("{$join->type} join {$tableAndNestedJoins} {$this->compileWheres($join)}");
         })->implode(' ');
@@ -189,7 +189,7 @@ class Grammar extends BaseGrammar
         // Each type of where clauses has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice
         // and maintainable since each clause has a very small method that it uses.
-        if (is_null($query->wheres)) {
+        if ($query->wheres === null) {
             return '';
         }
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -97,7 +97,7 @@ class PostgresGrammar extends Grammar
         // If the query is actually performing an aggregating select, we will let that
         // compiler handle the building of the select clauses, as it will need some
         // more syntax that is best handled by that function to keep things neat.
-        if (! is_null($query->aggregate)) {
+        if ($query->aggregate !== null) {
             return;
         }
 

--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -33,7 +33,7 @@ class SqlServerGrammar extends Grammar
         // If an offset is present on the query, we will need to wrap the query in
         // a big "ANSI" offset syntax block. This is very nasty compared to the
         // other database systems but is necessary for implementing features.
-        if (is_null($query->columns)) {
+        if ($query->columns === null) {
             $query->columns = ['*'];
         }
 
@@ -51,7 +51,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function compileColumns(Builder $query, $columns)
     {
-        if (! is_null($query->aggregate)) {
+        if ($query->aggregate !== null) {
             return;
         }
 
@@ -82,7 +82,7 @@ class SqlServerGrammar extends Grammar
             return $from.' '.$query->lock;
         }
 
-        if (! is_null($query->lock)) {
+        if ($query->lock !== null) {
             return $from.' with(rowlock,'.($query->lock ? 'updlock,' : '').'holdlock)';
         }
 

--- a/src/Illuminate/Database/SQLiteConnection.php
+++ b/src/Illuminate/Database/SQLiteConnection.php
@@ -51,7 +51,7 @@ class SQLiteConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -79,7 +79,7 @@ class Blueprint
         $this->table = $table;
         $this->prefix = $prefix;
 
-        if (! is_null($callback)) {
+        if ($callback !== null) {
             $callback($this);
         }
     }
@@ -120,7 +120,7 @@ class Blueprint
             $method = 'compile'.ucfirst($command->name);
 
             if (method_exists($grammar, $method) || $grammar::hasMacro($method)) {
-                if (! is_null($sql = $grammar->$method($this, $command, $connection))) {
+                if (($sql = $grammar->$method($this, $command, $connection)) !== null) {
                     $statements = array_merge($statements, (array) $sql);
                 }
             }

--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -79,7 +79,7 @@ class ChangeColumn
             // Doctrine column definitions - which is necessary because Laravel and Doctrine
             // use some different terminology for various column attributes on the tables.
             foreach ($fluent->getAttributes() as $key => $value) {
-                if (! is_null($option = static::mapFluentOptionToDoctrine($key))) {
+                if (($option = static::mapFluentOptionToDoctrine($key)) !== null) {
                     if (method_exists($column, $method = 'set'.ucfirst($option))) {
                         $column->{$method}(static::mapFluentValueToDoctrine($option, $value));
                         continue;

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -84,11 +84,11 @@ abstract class Grammar extends BaseGrammar
         // Once we have the basic foreign key creation statement constructed we can
         // build out the syntax for what should happen on an update or delete of
         // the affected columns, which will get something like "cascade", etc.
-        if (! is_null($command->onDelete)) {
+        if ($command->onDelete !== null) {
             $sql .= " on delete {$command->onDelete}";
         }
 
-        if (! is_null($command->onUpdate)) {
+        if ($command->onUpdate !== null) {
             $sql .= " on update {$command->onUpdate}";
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -107,7 +107,7 @@ class MySqlGrammar extends Grammar
         // table is being created on. We will add these to the create table query.
         if (isset($blueprint->charset)) {
             $sql .= ' default character set '.$blueprint->charset;
-        } elseif (! is_null($charset = $connection->getConfig('charset'))) {
+        } elseif (($charset = $connection->getConfig('charset')) !== null) {
             $sql .= ' default character set '.$charset;
         }
 
@@ -116,7 +116,7 @@ class MySqlGrammar extends Grammar
         // connection that the query is targeting. We'll add it to this SQL query.
         if (isset($blueprint->collation)) {
             $sql .= " collate '{$blueprint->collation}'";
-        } elseif (! is_null($collation = $connection->getConfig('collation'))) {
+        } elseif (($collation = $connection->getConfig('collation')) !== null) {
             $sql .= " collate '{$collation}'";
         }
 
@@ -135,7 +135,7 @@ class MySqlGrammar extends Grammar
     {
         if (isset($blueprint->engine)) {
             return $sql.' engine = '.$blueprint->engine;
-        } elseif (! is_null($engine = $connection->getConfig('engine'))) {
+        } elseif (($engine = $connection->getConfig('engine')) !== null) {
             return $sql.' engine = '.$engine;
         }
 
@@ -869,7 +869,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->virtualAs)) {
+        if ($column->virtualAs !== null) {
             return " as ({$column->virtualAs})";
         }
     }
@@ -883,7 +883,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->storedAs)) {
+        if ($column->storedAs !== null) {
             return " as ({$column->storedAs}) stored";
         }
     }
@@ -911,7 +911,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCharset(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->charset)) {
+        if ($column->charset !== null) {
             return ' character set '.$column->charset;
         }
     }
@@ -925,7 +925,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if ($column->collation !== null) {
             return " collate '{$column->collation}'";
         }
     }
@@ -939,7 +939,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        if (is_null($column->virtualAs) && is_null($column->storedAs)) {
+        if ($column->virtualAs === null && $column->storedAs === null) {
             return $column->nullable ? ' null' : ' not null';
         }
 
@@ -957,7 +957,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }
@@ -985,7 +985,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyFirst(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->first)) {
+        if ($column->first !== null) {
             return ' first';
         }
     }
@@ -999,7 +999,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyAfter(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->after)) {
+        if ($column->after !== null) {
             return ' after '.$this->wrap($column->after);
         }
     }
@@ -1013,7 +1013,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyComment(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->comment)) {
+        if ($column->comment !== null) {
             return " comment '".addslashes($column->comment)."'";
         }
     }
@@ -1027,7 +1027,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifySrid(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->srid) && is_int($column->srid) && $column->srid > 0) {
+        if ($column->srid !== null && is_int($column->srid) && $column->srid > 0) {
             return ' srid '.$column->srid;
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -158,15 +158,15 @@ class PostgresGrammar extends Grammar
     {
         $sql = parent::compileForeign($blueprint, $command);
 
-        if (! is_null($command->deferrable)) {
+        if ($command->deferrable !== null) {
             $sql .= $command->deferrable ? ' deferrable' : ' not deferrable';
         }
 
-        if ($command->deferrable && ! is_null($command->initiallyImmediate)) {
+        if ($command->deferrable && $command->initiallyImmediate !== null) {
             $sql .= $command->initiallyImmediate ? ' initially immediate' : ' initially deferred';
         }
 
-        if (! is_null($command->notValid)) {
+        if ($command->notValid !== null) {
             $sql .= ' not valid';
         }
 
@@ -526,11 +526,11 @@ class PostgresGrammar extends Grammar
      */
     protected function generatableColumn($type, Fluent $column)
     {
-        if (! $column->autoIncrement && is_null($column->generatedAs)) {
+        if (! $column->autoIncrement && $column->generatedAs === null) {
             return $type;
         }
 
-        if ($column->autoIncrement && is_null($column->generatedAs)) {
+        if ($column->autoIncrement && $column->generatedAs === null) {
             return with([
                 'integer' => 'serial',
                 'bigint' => 'bigserial',
@@ -685,7 +685,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTime(Fluent $column)
     {
-        return 'time'.(is_null($column->precision) ? '' : "($column->precision)").' without time zone';
+        return 'time'.($column->precision === null ? '' : "($column->precision)").' without time zone';
     }
 
     /**
@@ -696,7 +696,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimeTz(Fluent $column)
     {
-        return 'time'.(is_null($column->precision) ? '' : "($column->precision)").' with time zone';
+        return 'time'.($column->precision === null ? '' : "($column->precision)").' with time zone';
     }
 
     /**
@@ -707,7 +707,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestamp(Fluent $column)
     {
-        $columnType = 'timestamp'.(is_null($column->precision) ? '' : "($column->precision)").' without time zone';
+        $columnType = 'timestamp'.($column->precision === null ? '' : "($column->precision)").' without time zone';
 
         return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
@@ -720,7 +720,7 @@ class PostgresGrammar extends Grammar
      */
     protected function typeTimestampTz(Fluent $column)
     {
-        $columnType = 'timestamp'.(is_null($column->precision) ? '' : "($column->precision)").' with time zone';
+        $columnType = 'timestamp'.($column->precision === null ? '' : "($column->precision)").' with time zone';
 
         return $column->useCurrent ? "$columnType default CURRENT_TIMESTAMP" : $columnType;
     }
@@ -908,7 +908,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if ($column->collation !== null) {
             return ' collate '.$this->wrapValue($column->collation);
         }
     }
@@ -934,7 +934,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -80,14 +80,14 @@ class SQLiteGrammar extends Grammar
             // are building, since SQLite needs foreign keys on the tables creation.
             $sql .= $this->getForeignKey($foreign);
 
-            if (! is_null($foreign->onDelete)) {
+            if ($foreign->onDelete !== null) {
                 $sql .= " on delete {$foreign->onDelete}";
             }
 
             // If this foreign key specifies the action to be taken on update we will add
             // that to the statement here. We'll append it to this SQL and then return
             // the SQL so we can keep adding any other foreign constraints onto this.
-            if (! is_null($foreign->onUpdate)) {
+            if ($foreign->onUpdate !== null) {
                 $sql .= " on update {$foreign->onUpdate}";
             }
 
@@ -121,7 +121,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function addPrimaryKeys(Blueprint $blueprint)
     {
-        if (! is_null($primary = $this->getCommandByName($blueprint, 'primary'))) {
+        if (($primary = $this->getCommandByName($blueprint, 'primary')) !== null) {
             return ", primary key ({$this->columnize($primary->columns)})";
         }
     }
@@ -843,7 +843,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -801,7 +801,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyCollate(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->collation)) {
+        if ($column->collation !== null) {
             return ' collate '.$column->collation;
         }
     }
@@ -829,7 +829,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if ($column->default !== null) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/SqlServerConnection.php
+++ b/src/Illuminate/Database/SqlServerConnection.php
@@ -69,7 +69,7 @@ class SqlServerConnection extends Connection
      */
     public function getSchemaBuilder()
     {
-        if (is_null($this->schemaGrammar)) {
+        if ($this->schemaGrammar === null) {
             $this->useDefaultSchemaGrammar();
         }
 

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -220,7 +220,7 @@ class Dispatcher implements DispatcherContract
             // If a response is returned from the listener and event halting is enabled
             // we will just return this response, and not call the rest of the event
             // listeners. Otherwise we will add the response on the response list.
-            if ($halt && ! is_null($response)) {
+            if ($halt && $response !== null) {
                 return $response;
             }
 

--- a/src/Illuminate/Filesystem/Cache.php
+++ b/src/Illuminate/Filesystem/Cache.php
@@ -52,7 +52,7 @@ class Cache extends AbstractCache
     {
         $contents = $this->repository->get($this->key);
 
-        if (! is_null($contents)) {
+        if ($contents !== null) {
             $this->setFromStorage($contents);
         }
     }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -477,7 +477,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         // If an explicit base URL has been set on the disk configuration then we will use
         // it as the base URL instead of the default path. This allows the developer to
         // have full control over the base path for this filesystem's generated URLs.
-        if (! is_null($url = $this->driver->getConfig()->get('url'))) {
+        if (($url = $this->driver->getConfig()->get('url')) !== null) {
             return $this->concatPathToUrl($url, $adapter->getPathPrefix().$path);
         }
 
@@ -714,7 +714,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     protected function parseVisibility($visibility)
     {
-        if (is_null($visibility)) {
+        if ($visibility === null) {
             return;
         }
 

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -51,7 +51,7 @@ class AliasLoader
      */
     public static function getInstance(array $aliases = [])
     {
-        if (is_null(static::$instance)) {
+        if (static::$instance === null) {
             return static::$instance = new static($aliases);
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1006,7 +1006,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected function normalizeCachePath($key, $default)
     {
-        if (is_null($env = Env::get($key))) {
+        if (($env = Env::get($key)) === null) {
             return $this->bootstrapPath($default);
         }
 
@@ -1254,7 +1254,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function getNamespace()
     {
-        if (! is_null($this->namespace)) {
+        if ($this->namespace !== null) {
             return $this->namespace;
         }
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -126,7 +126,7 @@ class HandleExceptions
      */
     public function handleShutdown()
     {
-        if (! is_null($error = error_get_last()) && $this->isFatal($error['type'])) {
+        if (($error = error_get_last()) !== null && $this->isFatal($error['type'])) {
             $this->handleException($this->fatalErrorFromPhpError($error, 0));
         }
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -327,7 +327,7 @@ class Kernel implements KernelContract
      */
     protected function getArtisan()
     {
-        if (is_null($this->artisan)) {
+        if ($this->artisan === null) {
             return $this->artisan = (new Artisan($this->app, $this->events, $this->app->version()))
                                 ->resolveCommands($this->commands);
         }

--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -99,7 +99,7 @@ class ServeCommand extends Command
      */
     protected function canTryAnotherPort()
     {
-        return is_null($this->input->getOption('port')) &&
+        return $this->input->getOption('port') === null &&
                ($this->input->getOption('tries') > $this->portOffset);
     }
 

--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -111,7 +111,7 @@ class VendorPublishCommand extends Command
             $choices = $this->publishableChoices()
         );
 
-        if ($choice == $choices[0] || is_null($choice)) {
+        if ($choice == $choices[0] || $choice === null) {
             return;
         }
 

--- a/src/Illuminate/Foundation/EnvironmentDetector.php
+++ b/src/Illuminate/Foundation/EnvironmentDetector.php
@@ -46,7 +46,7 @@ class EnvironmentDetector
         // First we will check if an environment argument was passed via console arguments
         // and if it was that automatically overrides as the environment. Otherwise, we
         // will check the environment as a "web" request like a typical HTTP request.
-        if (! is_null($value = $this->getEnvironmentArgument($args))) {
+        if (($value = $this->getEnvironmentArgument($args)) !== null) {
             return $value;
         }
 

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -145,9 +145,9 @@ class Handler implements ExceptionHandlerContract
     {
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
-            return $e instanceof $type;
-        }));
+        return Arr::first($dontReport, function ($type) use ($e) {
+                return $e instanceof $type;
+            }) !== null;
     }
 
     /**

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -98,7 +98,7 @@ class PackageManifest
      */
     protected function getManifest()
     {
-        if (! is_null($this->manifest)) {
+        if ($this->manifest !== null) {
             return $this->manifest;
         }
 

--- a/src/Illuminate/Foundation/ProviderRepository.php
+++ b/src/Illuminate/Foundation/ProviderRepository.php
@@ -106,7 +106,7 @@ class ProviderRepository
      */
     public function shouldRecompile($manifest, $providers)
     {
-        return is_null($manifest) || $manifest['providers'] != $providers;
+        return $manifest === null || $manifest['providers'] != $providers;
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -49,7 +49,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function setRootControllerNamespace()
     {
-        if (! is_null($this->namespace)) {
+        if ($this->namespace !== null) {
             $this->app[UrlGenerator::class]->setRootControllerNamespace($this->namespace);
         }
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -113,7 +113,7 @@ trait MakesHttpRequests
      */
     public function withoutMiddleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if ($middleware === null) {
             $this->app->instance('middleware.disable', true);
 
             return $this;
@@ -139,7 +139,7 @@ trait MakesHttpRequests
      */
     public function withMiddleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if ($middleware === null) {
             unset($this->app['middleware.disable']);
 
             return $this;

--- a/src/Illuminate/Foundation/Testing/WithFaker.php
+++ b/src/Illuminate/Foundation/Testing/WithFaker.php
@@ -32,7 +32,7 @@ trait WithFaker
      */
     protected function faker($locale = null)
     {
-        return is_null($locale) ? $this->faker : $this->makeFaker($locale);
+        return $locale === null ? $this->faker : $this->makeFaker($locale);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -112,7 +112,7 @@ if (! function_exists('app')) {
      */
     function app($abstract = null, array $parameters = [])
     {
-        if (is_null($abstract)) {
+        if ($abstract === null) {
             return Container::getInstance();
         }
 
@@ -156,7 +156,7 @@ if (! function_exists('auth')) {
      */
     function auth($guard = null)
     {
-        if (is_null($guard)) {
+        if ($guard === null) {
             return app(AuthFactory::class);
         }
 
@@ -264,7 +264,7 @@ if (! function_exists('config')) {
      */
     function config($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return app('config');
         }
 
@@ -308,7 +308,7 @@ if (! function_exists('cookie')) {
     {
         $cookie = app(CookieFactory::class);
 
-        if (is_null($name)) {
+        if ($name === null) {
             return $cookie;
         }
 
@@ -519,7 +519,7 @@ if (! function_exists('logger')) {
      */
     function logger($message = null, array $context = [])
     {
-        if (is_null($message)) {
+        if ($message === null) {
             return app('log');
         }
 
@@ -636,7 +636,7 @@ if (! function_exists('redirect')) {
      */
     function redirect($to = null, $status = 302, $headers = [], $secure = null)
     {
-        if (is_null($to)) {
+        if ($to === null) {
             return app('redirect');
         }
 
@@ -667,7 +667,7 @@ if (! function_exists('request')) {
      */
     function request($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return app('request');
         }
 
@@ -677,7 +677,7 @@ if (! function_exists('request')) {
 
         $value = app('request')->__get($key);
 
-        return is_null($value) ? value($default) : $value;
+        return $value === null ? value($default) : $value;
     }
 }
 
@@ -806,7 +806,7 @@ if (! function_exists('session')) {
      */
     function session($key = null, $default = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return app('session');
         }
 
@@ -855,7 +855,7 @@ if (! function_exists('trans')) {
      */
     function trans($key = null, $replace = [], $locale = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return app('translator');
         }
 
@@ -890,7 +890,7 @@ if (! function_exists('__')) {
      */
     function __($key = null, $replace = [], $locale = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $key;
         }
 
@@ -909,7 +909,7 @@ if (! function_exists('url')) {
      */
     function url($path = null, $parameters = [], $secure = null)
     {
-        if (is_null($path)) {
+        if ($path === null) {
             return app(UrlGenerator::class);
         }
 

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -93,7 +93,7 @@ class Factory
     {
         $this->record();
 
-        if (is_null($callback)) {
+        if ($callback === null) {
             $callback = function () {
                 return static::response();
             };

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -565,7 +565,7 @@ class PendingRequest
                      ->filter()
                      ->first();
 
-                if (is_null($response)) {
+                if ($response === null) {
                     return $handler($request, $options);
                 } elseif (is_array($response)) {
                     return Factory::response($response);

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -62,7 +62,7 @@ class Request implements ArrayAccess
      */
     public function hasHeader($key, $value = null)
     {
-        return is_null($value)
+        return $value === null
                     ? ! empty($this->request->getHeaders()[$key])
                     : in_array($value, $this->headers()[$key]);
     }

--- a/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithContentTypes.php
@@ -107,7 +107,7 @@ trait InteractsWithContentTypes
             foreach ($contentTypes as $contentType) {
                 $type = $contentType;
 
-                if (! is_null($mimeType = $this->getMimeType($contentType))) {
+                if (($mimeType = $this->getMimeType($contentType)) !== null) {
                     $type = $mimeType;
                 }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -30,7 +30,7 @@ trait InteractsWithInput
      */
     public function hasHeader($key)
     {
-        return ! is_null($this->header($key));
+        return $this->header($key) !== null;
     }
 
     /**
@@ -305,7 +305,7 @@ trait InteractsWithInput
      */
     public function hasCookie($key)
     {
-        return ! is_null($this->cookie($key));
+        return $this->cookie($key) !== null;
     }
 
     /**
@@ -341,7 +341,7 @@ trait InteractsWithInput
     protected function convertUploadedFiles(array $files)
     {
         return array_map(function ($file) {
-            if (is_null($file) || (is_array($file) && empty(array_filter($file)))) {
+            if ($file === null || (is_array($file) && empty(array_filter($file)))) {
                 return $file;
             }
 
@@ -405,7 +405,7 @@ trait InteractsWithInput
      */
     protected function retrieveItem($source, $key, $default)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->$source->all();
         }
 

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -74,7 +74,7 @@ class RedirectResponse extends BaseRedirectResponse
     public function withInput(array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
-            ! is_null($input) ? $input : $this->request->input()
+            $input !== null ? $input : $this->request->input()
         ));
 
         return $this;

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -354,7 +354,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             $this->json = new ParameterBag((array) json_decode($this->getContent(), true));
         }
 
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->json;
         }
 
@@ -533,7 +533,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $route = call_user_func($this->getRouteResolver());
 
-        if (is_null($route) || is_null($param)) {
+        if ($route === null || $param === null) {
             return $route;
         }
 
@@ -688,7 +688,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function __isset($key)
     {
-        return ! is_null($this->__get($key));
+        return $this->__get($key) !== null;
     }
 
     /**

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -32,7 +32,7 @@ trait ConditionallyLoadsAttributes
                 );
             }
 
-            if ($value instanceof self && is_null($value->resource)) {
+            if ($value instanceof self && $value->resource === null) {
                 $data[$key] = null;
             }
         }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -112,7 +112,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public function toArray($request)
     {
-        if (is_null($this->resource)) {
+        if ($this->resource === null) {
             return [];
         }
 

--- a/src/Illuminate/Http/Resources/Json/ResourceCollection.php
+++ b/src/Illuminate/Http/Resources/Json/ResourceCollection.php
@@ -125,7 +125,7 @@ class ResourceCollection extends JsonResource implements Countable, IteratorAggr
     {
         if ($this->preserveAllQueryParameters) {
             $this->resource->appends($request->query());
-        } elseif (! is_null($this->queryParameters)) {
+        } elseif ($this->queryParameters !== null) {
             $this->resource->appends($this->queryParameters);
         }
 

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -188,7 +188,7 @@ class LogManager implements LoggerInterface
     {
         $config = $this->configurationFor($name);
 
-        if (is_null($config)) {
+        if ($config === null) {
             throw new InvalidArgumentException("Log [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -107,7 +107,7 @@ class MailManager implements FactoryContract
     {
         $config = $this->getConfig($name);
 
-        if (is_null($config)) {
+        if ($config === null) {
             throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
         }
 

--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -460,7 +460,7 @@ class Mailer implements MailerContract, MailQueueContract
         }
 
         return $view->mailer($this->name)->later(
-            $delay, is_null($queue) ? $this->queue : $queue
+            $delay, $queue === null ? $this->queue : $queue
         );
     }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -94,7 +94,7 @@ class MailChannel
             return $message->view;
         }
 
-        if (property_exists($message, 'theme') && ! is_null($message->theme)) {
+        if (property_exists($message, 'theme') && $message->theme !== null) {
             $this->markdown->theme($message->theme);
         }
 
@@ -140,7 +140,7 @@ class MailChannel
 
         $this->addAttachments($mailMessage, $message);
 
-        if (! is_null($message->priority)) {
+        if ($message->priority !== null) {
             $mailMessage->setPriority($message->priority);
         }
 

--- a/src/Illuminate/Notifications/DatabaseNotification.php
+++ b/src/Illuminate/Notifications/DatabaseNotification.php
@@ -61,7 +61,7 @@ class DatabaseNotification extends Model
      */
     public function markAsRead()
     {
-        if (is_null($this->read_at)) {
+        if ($this->read_at === null) {
             $this->forceFill(['read_at' => $this->freshTimestamp()])->save();
         }
     }
@@ -73,7 +73,7 @@ class DatabaseNotification extends Model
      */
     public function markAsUnread()
     {
-        if (! is_null($this->read_at)) {
+        if ($this->read_at !== null) {
             $this->forceFill(['read_at' => null])->save();
         }
     }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -186,7 +186,7 @@ class NotificationSender
 
                 $notification->id = $notificationId;
 
-                if (! is_null($this->locale)) {
+                if ($this->locale !== null) {
                     $notification->locale = $this->locale;
                 }
 

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -193,7 +193,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function fragment($fragment = null)
     {
-        if (is_null($fragment)) {
+        if ($fragment === null) {
             return $this->fragment;
         }
 
@@ -211,7 +211,7 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function appends($key, $value = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $this;
         }
 

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -31,7 +31,7 @@ class RetryCommand extends Command
         foreach ($this->getJobIds() as $id) {
             $job = $this->laravel['queue.failer']->find($id);
 
-            if (is_null($job)) {
+            if ($job === null) {
                 $this->error("Unable to find failed job with ID [{$id}].");
             } else {
                 $this->retryJob($job);

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -157,7 +157,7 @@ class Listener
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
         ], function ($value) {
-            return ! is_null($value);
+            return $value !== null;
         });
     }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -227,7 +227,7 @@ abstract class Queue
      */
     public static function createPayloadUsing($callback)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             static::$createPayloadCallbacks = [];
         } else {
             static::$createPayloadCallbacks[] = $callback;

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -207,7 +207,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if ($name !== null && $name !== 'null') {
             return $this->app['config']["queue.connections.{$name}"];
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -190,7 +190,7 @@ class RedisQueue extends Queue implements QueueContract
     {
         $this->migrateExpiredJobs($queue.':delayed', $queue);
 
-        if (! is_null($this->retryAfter)) {
+        if ($this->retryAfter !== null) {
             $this->migrateExpiredJobs($queue.':reserved', $queue);
         }
     }
@@ -229,7 +229,7 @@ class RedisQueue extends Queue implements QueueContract
 
         [$job, $reserved] = $nextJob;
 
-        if (! $job && ! is_null($this->blockFor) && $block &&
+        if (! $job && $this->blockFor !== null && $block &&
             $this->getConnection()->blpop([$queue.':notify'], $this->blockFor)) {
             return $this->retrieveNextJob($queue, false);
         }

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -130,7 +130,7 @@ class SqsQueue extends Queue implements QueueContract
             'AttributeNames' => ['ApproximateReceiveCount'],
         ]);
 
-        if (! is_null($response['Messages']) && count($response['Messages']) > 0) {
+        if ($response['Messages'] !== null && count($response['Messages']) > 0) {
             return new SqsJob(
                 $this->container, $this->sqs, $response['Messages'][0],
                 $this->connectionName, $queue

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -191,7 +191,7 @@ class Worker
      */
     protected function timeoutForJob($job, WorkerOptions $options)
     {
-        return $job && ! is_null($job->timeout()) ? $job->timeout() : $options->timeout;
+        return $job && $job->timeout() !== null ? $job->timeout() : $options->timeout;
     }
 
     /**
@@ -239,7 +239,7 @@ class Worker
             $this->stop(12);
         } elseif ($this->queueShouldRestart($lastRestart)) {
             $this->stop();
-        } elseif ($options->stopWhenEmpty && is_null($job)) {
+        } elseif ($options->stopWhenEmpty && $job === null) {
             $this->stop();
         }
     }
@@ -279,7 +279,7 @@ class Worker
     {
         try {
             foreach (explode(',', $queue) as $queue) {
-                if (! is_null($job = $connection->pop($queue))) {
+                if (($job = $connection->pop($queue)) !== null) {
                     return $job;
                 }
             }
@@ -397,7 +397,7 @@ class Worker
             // another listener (or this same one). We will re-throw this exception after.
             if (! $job->isDeleted() && ! $job->isReleased() && ! $job->hasFailed()) {
                 $job->release(
-                    method_exists($job, 'delaySeconds') && ! is_null($job->delaySeconds())
+                    method_exists($job, 'delaySeconds') && $job->delaySeconds() !== null
                                 ? $job->delaySeconds()
                                 : $options->delay
                 );
@@ -419,7 +419,7 @@ class Worker
      */
     protected function markJobAsFailedIfAlreadyExceedsMaxAttempts($connectionName, $job, $maxTries)
     {
-        $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
+        $maxTries = $job->maxTries() !== null ? $job->maxTries() : $maxTries;
 
         $timeoutAt = $job->timeoutAt();
 
@@ -447,7 +447,7 @@ class Worker
      */
     protected function markJobAsFailedIfWillExceedMaxAttempts($connectionName, $job, $maxTries, Throwable $e)
     {
-        $maxTries = ! is_null($job->maxTries()) ? $job->maxTries() : $maxTries;
+        $maxTries = $job->maxTries() !== null ? $job->maxTries() : $maxTries;
 
         if ($job->timeoutAt() && $job->timeoutAt() <= Carbon::now()->getTimestamp()) {
             $this->failJob($job, $e);
@@ -469,8 +469,8 @@ class Worker
      */
     protected function markJobAsFailedIfWillExceedMaxExceptions($connectionName, $job, Throwable $e)
     {
-        if (! $this->cache || is_null($uuid = $job->uuid()) ||
-            is_null($maxExceptions = $job->maxExceptions())) {
+        if (! $this->cache || ($uuid = $job->uuid()) === null ||
+            ($maxExceptions = $job->maxExceptions()) === null) {
             return;
         }
 

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -304,7 +304,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $pipeline = $this->client()->pipeline();
 
-        return is_null($callback)
+        return $callback === null
             ? $pipeline
             : tap($pipeline, $callback)->exec();
     }
@@ -319,7 +319,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     {
         $transaction = $this->client()->multi();
 
-        return is_null($callback)
+        return $callback === null
             ? $transaction
             : tap($transaction, $callback)->exec();
     }

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -27,7 +27,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function handleMatchedRoute(Request $request, $route)
     {
-        if (! is_null($route)) {
+        if ($route !== null) {
             return $route->bind($request);
         }
 
@@ -59,7 +59,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
         return array_values(array_filter(
             $methods,
             function ($method) use ($request) {
-                return ! is_null($this->matchAgainstRoutes($this->get($method), $request, false));
+                return $this->matchAgainstRoutes($this->get($method), $request, false) !== null;
             }
         ));
     }
@@ -198,7 +198,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
         $name = $route->getName();
 
         if (Str::endsWith($name, '.') &&
-            ! is_null($symfonyRoutes->get($name))) {
+            $symfonyRoutes->get($name) !== null) {
             $name = null;
         }
 
@@ -206,7 +206,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
             $route->name($name = $this->generateRouteName());
 
             $this->add($route);
-        } elseif (! is_null($symfonyRoutes->get($name))) {
+        } elseif ($symfonyRoutes->get($name) !== null) {
             throw new LogicException("Unable to prepare route [{$route->uri}] for serialization. Another route has already been assigned name [{$name}].");
         }
 

--- a/src/Illuminate/Routing/Console/ControllerMakeCommand.php
+++ b/src/Illuminate/Routing/Console/ControllerMakeCommand.php
@@ -49,9 +49,9 @@ class ControllerMakeCommand extends GeneratorCommand
             $stub = '/stubs/controller.stub';
         }
 
-        if ($this->option('api') && is_null($stub)) {
+        if ($this->option('api') && $stub === null) {
             $stub = '/stubs/controller.api.stub';
-        } elseif ($this->option('api') && ! is_null($stub) && ! $this->option('invokable')) {
+        } elseif ($this->option('api') && $stub !== null && ! $this->option('invokable')) {
             $stub = str_replace('.stub', '.api.stub', $stub);
         }
 

--- a/src/Illuminate/Routing/Matching/HostValidator.php
+++ b/src/Illuminate/Routing/Matching/HostValidator.php
@@ -16,7 +16,7 @@ class HostValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        if (is_null($route->getCompiled()->getHostRegex())) {
+        if ($route->getCompiled()->getHostRegex() === null) {
             return true;
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -171,7 +171,7 @@ class ThrottleRequests
             'X-RateLimit-Remaining' => $remainingAttempts,
         ];
 
-        if (! is_null($retryAfter)) {
+        if ($retryAfter !== null) {
             $headers['Retry-After'] = $retryAfter;
             $headers['X-RateLimit-Reset'] = $this->availableAt($retryAfter);
         }
@@ -189,7 +189,7 @@ class ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (is_null($retryAfter)) {
+        if ($retryAfter === null) {
             return $this->limiter->retriesLeft($key, $maxAttempts);
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -101,7 +101,7 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
      */
     protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
     {
-        if (is_null($retryAfter)) {
+        if ($retryAfter === null) {
             return $this->remaining;
         }
 

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -39,7 +39,7 @@ class MiddlewareNameResolver
         // which may be run using the Pipeline which accepts this string format.
         [$name, $parameters] = array_pad(explode(':', $name, 2), 2, null);
 
-        return ($map[$name] ?? $name).(! is_null($parameters) ? ':'.$parameters : '');
+        return ($map[$name] ?? $name).($parameters !== null ? ':'.$parameters : '');
     }
 
     /**

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -140,7 +140,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new StreamedResponse($callback, 200, $headers);
 
-        if (! is_null($name)) {
+        if ($name !== null) {
             $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
                 $disposition,
                 $name,
@@ -164,7 +164,7 @@ class ResponseFactory implements FactoryContract
     {
         $response = new BinaryFileResponse($file, 200, $headers, true, $disposition);
 
-        if (! is_null($name)) {
+        if ($name !== null) {
             return $response->setContentDisposition($disposition, $name, $this->fallbackName($name));
         }
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -434,7 +434,7 @@ class Route
     public function parametersWithoutNulls()
     {
         return array_filter($this->parameters(), function ($p) {
-            return ! is_null($p);
+            return $p !== null;
         });
     }
 
@@ -671,7 +671,7 @@ class Route
      */
     public function domain($domain = null)
     {
-        if (is_null($domain)) {
+        if ($domain === null) {
             return $this->getDomain();
         }
 
@@ -783,7 +783,7 @@ class Route
      */
     public function named(...$patterns)
     {
-        if (is_null($routeName = $this->getName())) {
+        if (($routeName = $this->getName()) === null) {
             return false;
         }
 
@@ -880,7 +880,7 @@ class Route
      */
     public function gatherMiddleware()
     {
-        if (! is_null($this->computedMiddleware)) {
+        if ($this->computedMiddleware !== null) {
             return $this->computedMiddleware;
         }
 
@@ -899,7 +899,7 @@ class Route
      */
     public function middleware($middleware = null)
     {
-        if (is_null($middleware)) {
+        if ($middleware === null) {
             return (array) ($this->action['middleware'] ?? []);
         }
 

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -21,7 +21,7 @@ class RouteAction
         // If no action is passed in right away, we assume the user will make use of
         // fluent routing. In that case, we set a default closure, to be executed
         // if the user never explicitly sets an action to handle the given uri.
-        if (is_null($action)) {
+        if ($action === null) {
             return static::missingAction($uri);
         }
 

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -58,7 +58,7 @@ class RouteBinding
     public static function forModel($container, $class, $callback = null)
     {
         return function ($value) use ($container, $class, $callback) {
-            if (is_null($value)) {
+            if ($value === null) {
                 return;
             }
 

--- a/src/Illuminate/Routing/RouteCollection.php
+++ b/src/Illuminate/Routing/RouteCollection.php
@@ -170,7 +170,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function get($method = null)
     {
-        return is_null($method) ? $this->getRoutes() : Arr::get($this->routes, $method, []);
+        return $method === null ? $this->getRoutes() : Arr::get($this->routes, $method, []);
     }
 
     /**
@@ -181,7 +181,7 @@ class RouteCollection extends AbstractRouteCollection
      */
     public function hasNamedRoute($name)
     {
-        return ! is_null($this->getByName($name));
+        return $this->getByName($name) !== null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -92,9 +92,9 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
-            return $value instanceof $class;
-        }));
+        return Arr::first($parameters, function ($value) use ($class) {
+                return $value instanceof $class;
+            }) !== null;
     }
 
     /**

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -37,7 +37,7 @@ class RouteParameterBinder
         // If the route has a regular expression for the host part of the URI, we will
         // compile that and get the parameter matches for this domain. We will then
         // merge them into this parameters array so that this array is completed.
-        if (! is_null($this->route->compiled->getHostRegex())) {
+        if ($this->route->compiled->getHostRegex() !== null) {
             $parameters = $this->bindHostParameters(
                 $request, $parameters
             );

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -172,7 +172,7 @@ class RouteRegistrar
      */
     protected function compileAction($action)
     {
-        if (is_null($action)) {
+        if ($action === null) {
             return $this->attributes;
         }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -21,7 +21,7 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($action['uses'])
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
-        return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
+        return $subClass === null ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
             return $p->getClass() && $p->getClass()->isSubclassOf($subClass);
         });
     }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -242,13 +242,13 @@ class RouteUrlGenerator
         // If the URI has a fragment we will move it to the end of this URI since it will
         // need to come after any query string that may be added to the URL else it is
         // not going to be available. We will remove it then append it back on here.
-        if (! is_null($fragment = parse_url($uri, PHP_URL_FRAGMENT))) {
+        if (($fragment = parse_url($uri, PHP_URL_FRAGMENT)) !== null) {
             $uri = preg_replace('/#.*/', '', $uri);
         }
 
         $uri .= $this->getRouteQueryString($parameters);
 
-        return is_null($fragment) ? $uri : $uri."#{$fragment}";
+        return $fragment === null ? $uri : $uri."#{$fragment}";
     }
 
     /**

--- a/src/Illuminate/Routing/SortedMiddleware.php
+++ b/src/Illuminate/Routing/SortedMiddleware.php
@@ -42,7 +42,7 @@ class SortedMiddleware extends Collection
 
             $priorityIndex = $this->priorityMapIndex($priorityMap, $middleware);
 
-            if (! is_null($priorityIndex)) {
+            if ($priorityIndex !== null) {
                 // This middleware is in the priority map. If we have encountered another middleware
                 // that was also in the priority map and was at a lower priority than the current
                 // middleware, we will move this middleware to be above the previous encounter.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -296,11 +296,11 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatScheme($secure = null)
     {
-        if (! is_null($secure)) {
+        if ($secure !== null) {
             return $secure ? 'https://' : 'http://';
         }
 
-        if (is_null($this->cachedScheme)) {
+        if ($this->cachedScheme === null) {
             $this->cachedScheme = $this->forceScheme ?: $this->request->getScheme().'://';
         }
 
@@ -413,7 +413,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function route($name, $parameters = [], $absolute = true)
     {
-        if (! is_null($route = $this->routes->getByName($name))) {
+        if (($route = $this->routes->getByName($name)) !== null) {
             return $this->toRoute($route, $parameters, $absolute);
         }
 
@@ -455,7 +455,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function action($action, $parameters = [], $absolute = true)
     {
-        if (is_null($route = $this->routes->getByAction($action = $this->formatAction($action)))) {
+        if (($route = $this->routes->getByAction($action = $this->formatAction($action))) === null) {
             throw new InvalidArgumentException("Action {$action} not defined.");
         }
 
@@ -527,8 +527,8 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function formatRoot($scheme, $root = null)
     {
-        if (is_null($root)) {
-            if (is_null($this->cachedRoot)) {
+        if ($root === null) {
+            if ($this->cachedRoot === null) {
                 $this->cachedRoot = $this->forcedRoot ?: $this->request->root();
             }
 

--- a/src/Illuminate/Session/CookieSessionHandler.php
+++ b/src/Illuminate/Session/CookieSessionHandler.php
@@ -68,7 +68,7 @@ class CookieSessionHandler implements SessionHandlerInterface
     {
         $value = $this->request->cookies->get($sessionId) ?: '';
 
-        if (! is_null($decoded = json_decode($value, true)) && is_array($decoded)) {
+        if (($decoded = json_decode($value, true)) !== null && is_array($decoded)) {
             if (isset($decoded['expires']) && $this->currentTime() <= $decoded['expires']) {
                 return $decoded['data'];
             }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -201,7 +201,7 @@ class StartSession
      */
     protected function sessionConfigured()
     {
-        return ! is_null($this->manager->getSessionConfig()['driver'] ?? null);
+        return ($this->manager->getSessionConfig()['driver'] ?? null) !== null;
     }
 
     /**
@@ -214,6 +214,6 @@ class StartSession
     {
         $config = $config ?: $this->manager->getSessionConfig();
 
-        return ! is_null($config['driver'] ?? null);
+        return ($config['driver'] ?? null) !== null;
     }
 }

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -97,7 +97,7 @@ class Store implements Session
         if ($data = $this->handler->read($this->getId())) {
             $data = @unserialize($this->prepareForUnserialize($data));
 
-            if ($data !== false && ! is_null($data) && is_array($data)) {
+            if ($data !== false && $data !== null && is_array($data)) {
                 return $data;
             }
         }
@@ -202,7 +202,7 @@ class Store implements Session
     public function has($key)
     {
         return ! collect(is_array($key) ? $key : func_get_args())->contains(function ($key) {
-            return is_null($this->get($key));
+            return $this->get($key) === null;
         });
     }
 
@@ -240,7 +240,7 @@ class Store implements Session
     {
         $old = $this->getOldInput($key);
 
-        return is_null($key) ? count($old) > 0 : ! is_null($old);
+        return $key === null ? count($old) > 0 : $old !== null;
     }
 
     /**
@@ -293,7 +293,7 @@ class Store implements Session
      */
     public function remember($key, Closure $callback)
     {
-        if (! is_null($value = $this->get($key))) {
+        if (($value = $this->get($key)) !== null) {
             return $value;
         }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -31,7 +31,7 @@ class Arr
      */
     public static function add($array, $key, $value)
     {
-        if (is_null(static::get($array, $key))) {
+        if (static::get($array, $key) === null) {
             static::set($array, $key, $value);
         }
 
@@ -161,7 +161,7 @@ class Arr
      */
     public static function first($array, callable $callback = null, $default = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             if (empty($array)) {
                 return value($default);
             }
@@ -190,7 +190,7 @@ class Arr
      */
     public static function last($array, callable $callback = null, $default = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             return empty($array) ? value($default) : end($array);
         }
 
@@ -285,7 +285,7 @@ class Arr
             return value($default);
         }
 
-        if (is_null($key)) {
+        if ($key === null) {
             return $array;
         }
 
@@ -351,7 +351,7 @@ class Arr
      */
     public static function hasAny($array, $keys)
     {
-        if (is_null($keys)) {
+        if ($keys === null) {
             return false;
         }
 
@@ -421,7 +421,7 @@ class Arr
             // If the key is "null", we will just append the value to the array and keep
             // looping. Otherwise we will key the array using the value of the key we
             // received from the developer. Then we'll return the final array form.
-            if (is_null($key)) {
+            if ($key === null) {
                 $results[] = $itemValue;
             } else {
                 $itemKey = data_get($item, $key);
@@ -448,7 +448,7 @@ class Arr
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        $key = $key === null || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }
@@ -463,7 +463,7 @@ class Arr
      */
     public static function prepend($array, $value, $key = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             array_unshift($array, $value);
         } else {
             $array = [$key => $value] + $array;
@@ -500,7 +500,7 @@ class Arr
      */
     public static function random($array, $number = null)
     {
-        $requested = is_null($number) ? 1 : $number;
+        $requested = $number === null ? 1 : $number;
 
         $count = count($array);
 
@@ -510,7 +510,7 @@ class Arr
             );
         }
 
-        if (is_null($number)) {
+        if ($number === null) {
             return $array[array_rand($array)];
         }
 
@@ -541,7 +541,7 @@ class Arr
      */
     public static function set(&$array, $key, $value)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $array = $value;
         }
 
@@ -574,7 +574,7 @@ class Arr
      */
     public static function shuffle($array, $seed = null)
     {
-        if (is_null($seed)) {
+        if ($seed === null) {
             shuffle($array);
         } else {
             mt_srand($seed);
@@ -651,7 +651,7 @@ class Arr
      */
     public static function wrap($value)
     {
-        if (is_null($value)) {
+        if ($value === null) {
             return [];
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -43,7 +43,7 @@ class Collection implements ArrayAccess, Enumerable
             return new static;
         }
 
-        if (is_null($callback)) {
+        if ($callback === null) {
             return new static(range(1, $number));
         }
 
@@ -83,7 +83,7 @@ class Collection implements ArrayAccess, Enumerable
         $items = $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return $value !== null;
         });
 
         if ($count = $items->count()) {
@@ -101,7 +101,7 @@ class Collection implements ArrayAccess, Enumerable
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
             ->filter(function ($item) {
-                return ! is_null($item);
+                return $item !== null;
             })->sort()->values();
 
         $count = $values->count();
@@ -768,7 +768,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function only($keys)
     {
-        if (is_null($keys)) {
+        if ($keys === null) {
             return new static($this->items);
         }
 
@@ -873,7 +873,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function random($number = null)
     {
-        if (is_null($number)) {
+        if ($number === null) {
             return Arr::random($this->items);
         }
 
@@ -1316,7 +1316,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function offsetSet($key, $value)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             $this->items[] = $value;
         } else {
             $this->items[$key] = $value;

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -62,7 +62,7 @@ class ConfigurationUrlParser
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
         ], function ($value) {
-            return ! is_null($value);
+            return $value !== null;
         });
     }
 

--- a/src/Illuminate/Support/Facades/Cookie.php
+++ b/src/Illuminate/Support/Facades/Cookie.php
@@ -19,7 +19,7 @@ class Cookie extends Facade
      */
     public static function has($key)
     {
-        return ! is_null(static::$app['request']->cookie($key, null));
+        return static::$app['request']->cookie($key, null) !== null;
     }
 
     /**

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -30,7 +30,7 @@ class LazyCollection implements Enumerable
     {
         if ($source instanceof Closure || $source instanceof self) {
             $this->source = $source;
-        } elseif (is_null($source)) {
+        } elseif ($source === null) {
             $this->source = static::empty();
         } else {
             $this->source = $this->getArrayableItems($source);
@@ -66,7 +66,7 @@ class LazyCollection implements Enumerable
             }
         });
 
-        return is_null($callback) ? $instance : $instance->map($callback);
+        return $callback === null ? $instance : $instance->map($callback);
     }
 
     /**
@@ -351,7 +351,7 @@ class LazyCollection implements Enumerable
      */
     public function filter(callable $callback = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return (bool) $value;
             };
@@ -377,7 +377,7 @@ class LazyCollection implements Enumerable
     {
         $iterator = $this->getIterator();
 
-        if (is_null($callback)) {
+        if ($callback === null) {
             if (! $iterator->valid()) {
                 return value($default);
             }
@@ -440,7 +440,7 @@ class LazyCollection implements Enumerable
      */
     public function get($key, $default = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return;
         }
 
@@ -590,7 +590,7 @@ class LazyCollection implements Enumerable
         $needle = $placeholder = new stdClass;
 
         foreach ($this as $key => $value) {
-            if (is_null($callback) || $callback($value, $key)) {
+            if ($callback === null || $callback($value, $key)) {
                 $needle = $value;
             }
         }
@@ -613,7 +613,7 @@ class LazyCollection implements Enumerable
             foreach ($this as $item) {
                 $itemValue = data_get($item, $value);
 
-                if (is_null($key)) {
+                if ($key === null) {
                     yield $itemValue;
                 } else {
                     $itemKey = data_get($item, $key);
@@ -769,12 +769,12 @@ class LazyCollection implements Enumerable
     {
         if ($keys instanceof Enumerable) {
             $keys = $keys->all();
-        } elseif (! is_null($keys)) {
+        } elseif ($keys !== null) {
             $keys = is_array($keys) ? $keys : func_get_args();
         }
 
         return new static(function () use ($keys) {
-            if (is_null($keys)) {
+            if ($keys === null) {
                 yield from $this;
             } else {
                 $keys = array_flip($keys);
@@ -820,7 +820,7 @@ class LazyCollection implements Enumerable
     {
         $result = $this->collect()->random(...func_get_args());
 
-        return is_null($number) ? $result : new static($result);
+        return $number === null ? $result : new static($result);
     }
 
     /**
@@ -962,7 +962,7 @@ class LazyCollection implements Enumerable
 
         $instance = $this->skip($offset);
 
-        return is_null($length) ? $instance : $instance->take($length);
+        return $length === null ? $instance : $instance->take($length);
     }
 
     /**
@@ -1253,7 +1253,7 @@ class LazyCollection implements Enumerable
     {
         $value = is_string($value) ? explode('.', $value) : $value;
 
-        $key = is_null($key) || is_array($key) ? $key : explode('.', $key);
+        $key = $key === null || is_array($key) ? $key : explode('.', $key);
 
         return [$value, $key];
     }

--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -77,7 +77,7 @@ abstract class Manager
     {
         $driver = $driver ?: $this->getDefaultDriver();
 
-        if (is_null($driver)) {
+        if ($driver === null) {
             throw new InvalidArgumentException(sprintf(
                 'Unable to resolve NULL driver for [%s].', static::class
             ));

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -109,7 +109,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
             return false;
         }
 
-        if (is_null($key)) {
+        if ($key === null) {
             return $this->any();
         }
 
@@ -156,7 +156,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
      */
     public function first($key = null, $format = null)
     {
-        $messages = is_null($key) ? $this->all($format) : $this->get($key, $format);
+        $messages = $key === null ? $this->all($format) : $this->get($key, $format);
 
         $firstMessage = Arr::first($messages, null, '');
 

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -252,7 +252,7 @@ abstract class ServiceProvider
      */
     public static function pathsToPublish($provider = null, $group = null)
     {
-        if (! is_null($paths = static::pathsForProviderOrGroup($provider, $group))) {
+        if (($paths = static::pathsForProviderOrGroup($provider, $group)) !== null) {
             return $paths;
         }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -550,7 +550,7 @@ class Stringable
         if ($this->isEmpty()) {
             $result = $callback($this);
 
-            return is_null($result) ? $this : $result;
+            return $result === null ? $this : $result;
         }
 
         return $this;

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -124,7 +124,7 @@ trait EnumeratesValues
         }
 
         if ($this->useAsCallable($key)) {
-            return ! is_null($this->first($key));
+            return $this->first($key) !== null;
         }
 
         foreach ($this as $item) {
@@ -312,9 +312,9 @@ trait EnumeratesValues
         return $this->map(function ($value) use ($callback) {
             return $callback($value);
         })->filter(function ($value) {
-            return ! is_null($value);
+            return $value !== null;
         })->reduce(function ($result, $value) {
-            return is_null($result) || $value < $result ? $value : $result;
+            return $result === null || $value < $result ? $value : $result;
         });
     }
 
@@ -329,11 +329,11 @@ trait EnumeratesValues
         $callback = $this->valueRetriever($callback);
 
         return $this->filter(function ($value) {
-            return ! is_null($value);
+            return $value !== null;
         })->reduce(function ($result, $item) use ($callback) {
             $value = $callback($item);
 
-            return is_null($result) || $value > $result ? $value : $result;
+            return $result === null || $value > $result ? $value : $result;
         });
     }
 
@@ -387,7 +387,7 @@ trait EnumeratesValues
      */
     public function sum($callback = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return $value;
             };
@@ -770,7 +770,7 @@ trait EnumeratesValues
      */
     public function countBy($callback = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             $callback = function ($value) {
                 return $value;
             };

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -39,7 +39,7 @@ if (! function_exists('blank')) {
      */
     function blank($value)
     {
-        if (is_null($value)) {
+        if ($value === null) {
             return true;
         }
 
@@ -136,13 +136,13 @@ if (! function_exists('data_get')) {
      */
     function data_get($target, $key, $default = null)
     {
-        if (is_null($key)) {
+        if ($key === null) {
             return $target;
         }
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        while (! is_null($segment = array_shift($key))) {
+        while (($segment = array_shift($key)) !== null) {
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();
@@ -316,7 +316,7 @@ if (! function_exists('object_get')) {
      */
     function object_get($object, $key, $default = null)
     {
-        if (is_null($key) || trim($key) == '') {
+        if ($key === null || trim($key) == '') {
             return $object;
         }
 
@@ -342,9 +342,9 @@ if (! function_exists('optional')) {
      */
     function optional($value = null, callable $callback = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             return new Optional($value);
-        } elseif (! is_null($value)) {
+        } elseif ($value !== null) {
             return $callback($value);
         }
     }
@@ -415,7 +415,7 @@ if (! function_exists('tap')) {
      */
     function tap($value, $callback = null)
     {
-        if (is_null($callback)) {
+        if ($callback === null) {
             return new HigherOrderTapProxy($value);
         }
 
@@ -544,6 +544,6 @@ if (! function_exists('with')) {
      */
     function with($value, callable $callback = null)
     {
-        return is_null($callback) ? $value : $callback($value);
+        return $callback === null ? $value : $callback($value);
     }
 }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -200,7 +200,7 @@ class TestResponse implements ArrayAccess
             $this->isRedirect(), 'Response status code ['.$this->getStatusCode().'] is not a redirect status code.'
         );
 
-        if (! is_null($uri)) {
+        if ($uri !== null) {
             $this->assertLocation($uri);
         }
 
@@ -222,7 +222,7 @@ class TestResponse implements ArrayAccess
 
         $actual = $this->headers->get($headerName);
 
-        if (! is_null($value)) {
+        if ($value !== null) {
             PHPUnit::assertEquals(
                 $value, $this->headers->get($headerName),
                 "Header [{$headerName}] was found, but value [{$actual}] does not match [{$value}]."
@@ -292,7 +292,7 @@ class TestResponse implements ArrayAccess
             "Cookie [{$cookieName}] not present on response."
         );
 
-        if (! $cookie || is_null($value)) {
+        if (! $cookie || $value === null) {
             return $this;
         }
 
@@ -661,11 +661,11 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonStructure(array $structure = null, $responseData = null)
     {
-        if (is_null($structure)) {
+        if ($structure === null) {
             return $this->assertExactJson($this->json());
         }
 
-        if (is_null($responseData)) {
+        if ($responseData === null) {
             $responseData = $this->decodeResponseJson();
         }
 
@@ -788,7 +788,7 @@ class TestResponse implements ArrayAccess
 
         $errors = $json[$responseKey];
 
-        if (is_null($keys) && count($errors) > 0) {
+        if ($keys === null && count($errors) > 0) {
             PHPUnit::fail(
                 'Response has unexpected validation errors: '.PHP_EOL.PHP_EOL.
                 json_encode($errors, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
@@ -815,7 +815,7 @@ class TestResponse implements ArrayAccess
     {
         $decodedResponse = json_decode($this->getContent(), true);
 
-        if (is_null($decodedResponse) || $decodedResponse === false) {
+        if ($decodedResponse === null || $decodedResponse === false) {
             if ($this->exception) {
                 throw $this->exception;
             } else {
@@ -867,7 +867,7 @@ class TestResponse implements ArrayAccess
 
         $this->ensureResponseHasView();
 
-        if (is_null($value)) {
+        if ($value === null) {
             PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value(Arr::get($this->original->gatherData(), $key)));
@@ -964,7 +964,7 @@ class TestResponse implements ArrayAccess
             return $this->assertSessionHasAll($key);
         }
 
-        if (is_null($value)) {
+        if ($value === null) {
             PHPUnit::assertTrue(
                 $this->session()->has($key),
                 "Session is missing expected key [{$key}]."
@@ -1018,7 +1018,7 @@ class TestResponse implements ArrayAccess
             return $this;
         }
 
-        if (is_null($value)) {
+        if ($value === null) {
             PHPUnit::assertTrue(
                 $this->session()->getOldInput($key),
                 "Session is missing expected key [{$key}]."
@@ -1075,7 +1075,7 @@ class TestResponse implements ArrayAccess
             return $this->assertSessionHasNoErrors();
         }
 
-        if (is_null($this->session()->get('errors'))) {
+        if ($this->session()->get('errors') === null) {
             PHPUnit::assertTrue(true);
 
             return $this;
@@ -1217,7 +1217,7 @@ class TestResponse implements ArrayAccess
      */
     public function streamedContent()
     {
-        if (! is_null($this->streamedContent)) {
+        if ($this->streamedContent !== null) {
             return $this->streamedContent;
         }
 

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -63,7 +63,7 @@ class FileLoader implements Loader
             return $this->loadJsonPaths($locale);
         }
 
-        if (is_null($namespace) || $namespace === '*') {
+        if ($namespace === null || $namespace === '*') {
             return $this->loadPath($this->path, $locale, $group);
         }
 
@@ -141,7 +141,7 @@ class FileLoader implements Loader
                 if ($this->files->exists($full = "{$path}/{$locale}.json")) {
                     $decoded = json_decode($this->files->get($full), true);
 
-                    if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
+                    if ($decoded === null || json_last_error() !== JSON_ERROR_NONE) {
                         throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
                     }
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -43,7 +43,7 @@ class MessageSelector
     private function extract($segments, $number)
     {
         foreach ($segments as $part) {
-            if (! is_null($line = $this->extractFromString($part, $number))) {
+            if (($line = $this->extractFromString($part, $number)) !== null) {
                 return $line;
             }
         }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -120,9 +120,9 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
             $locales = $fallback ? $this->localeArray($locale) : [$locale];
 
             foreach ($locales as $locale) {
-                if (! is_null($line = $this->getLine(
-                    $namespace, $group, $locale, $item, $replace
-                ))) {
+                if (($line = $this->getLine(
+                        $namespace, $group, $locale, $item, $replace
+                    )) !== null) {
                     return $line ?? $key;
                 }
             }
@@ -325,7 +325,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
     {
         $segments = parent::parseKey($key);
 
-        if (is_null($segments[0])) {
+        if ($segments[0] === null) {
             $segments[0] = '*';
         }
 

--- a/src/Illuminate/Validation/Concerns/FormatsMessages.php
+++ b/src/Illuminate/Validation/Concerns/FormatsMessages.php
@@ -25,7 +25,7 @@ trait FormatsMessages
         // First we will retrieve the custom message for the validation rule if one
         // exists. If a custom validation message is being used we'll return the
         // custom message, otherwise we'll keep searching for a valid message.
-        if (! is_null($inlineMessage)) {
+        if ($inlineMessage !== null) {
             return $inlineMessage;
         }
 
@@ -296,7 +296,7 @@ trait FormatsMessages
     {
         $actualValue = $this->getValue($attribute);
 
-        if (is_scalar($actualValue) || is_null($actualValue)) {
+        if (is_scalar($actualValue) || $actualValue === null) {
             $message = str_replace(':input', $this->getDisplayableValue($attribute, $actualValue), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -259,7 +259,7 @@ trait ReplacesAttributes
      */
     protected function replaceGt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -277,7 +277,7 @@ trait ReplacesAttributes
      */
     protected function replaceLt($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -295,7 +295,7 @@ trait ReplacesAttributes
      */
     protected function replaceGte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 
@@ -313,7 +313,7 @@ trait ReplacesAttributes
      */
     protected function replaceLte($message, $attribute, $rule, $parameters)
     {
-        if (is_null($value = $this->getValue($parameters[0]))) {
+        if (($value = $this->getValue($parameters[0])) === null) {
             return str_replace(':value', $this->getDisplayableAttribute($parameters[0]), $message);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -192,7 +192,7 @@ trait ValidatesAttributes
         if ($this->isTestingRelativeDateTime($value)) {
             $date = $this->getDateTime($value);
 
-            if (! is_null($date)) {
+            if ($date !== null) {
                 return $date->getTimestamp();
             }
         }
@@ -732,7 +732,7 @@ trait ValidatesAttributes
         if (isset($parameters[2])) {
             [$idColumn, $id] = $this->getUniqueIds($parameters);
 
-            if (! is_null($id)) {
+            if ($id !== null) {
                 $id = stripslashes($id);
             }
         }
@@ -917,7 +917,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
@@ -948,7 +948,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
@@ -979,7 +979,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
@@ -1010,7 +1010,7 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ($comparedToValue === null && (is_numeric($value) && is_numeric($parameters[0]))) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
@@ -1367,7 +1367,7 @@ trait ValidatesAttributes
      */
     public function validateRequired($attribute, $value)
     {
-        if (is_null($value)) {
+        if ($value === null) {
             return false;
         } elseif (is_string($value) && trim($value) === '') {
             return false;

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -48,7 +48,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
     {
         $query = $this->table($collection)->where($column, '=', $value);
 
-        if (! is_null($excludeId) && $excludeId !== 'NULL') {
+        if ($excludeId !== null && $excludeId !== 'NULL') {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
         }
 

--- a/src/Illuminate/Validation/Factory.php
+++ b/src/Illuminate/Validation/Factory.php
@@ -104,14 +104,14 @@ class Factory implements FactoryContract
         // The presence verifier is responsible for checking the unique and exists data
         // for the validator. It is behind an interface so that multiple versions of
         // it may be written besides database. We'll inject it into the validator.
-        if (! is_null($this->verifier)) {
+        if ($this->verifier !== null) {
             $validator->setPresenceVerifier($this->verifier);
         }
 
         // Next we'll set the IoC container instance of the validator, which is used to
         // resolve out class based validator extensions. If it is not set then these
         // types of extensions will not be possible on these validation instances.
-        if (! is_null($this->container)) {
+        if ($this->container !== null) {
             $validator->setContainer($this->container);
         }
 
@@ -147,7 +147,7 @@ class Factory implements FactoryContract
      */
     protected function resolve(array $data, array $rules, array $messages, array $customAttributes)
     {
-        if (is_null($this->resolver)) {
+        if ($this->resolver === null) {
             return new Validator($this->translator, $data, $rules, $messages, $customAttributes);
         }
 

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -86,7 +86,7 @@ trait DatabaseRule
             return $this->using($column);
         }
 
-        if (is_null($value)) {
+        if ($value === null) {
             return $this->whereNull($column);
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -624,7 +624,7 @@ class Validator implements ValidatorContract
             return true;
         }
 
-        return ! is_null(Arr::get($this->data, $attribute, 0));
+        return Arr::get($this->data, $attribute, 0) !== null;
     }
 
     /**
@@ -836,7 +836,7 @@ class Validator implements ValidatorContract
      */
     public function hasRule($attribute, $rules)
     {
-        return ! is_null($this->getRule($attribute, $rules));
+        return $this->getRule($attribute, $rules) !== null;
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -139,7 +139,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             $this->setPath($path);
         }
 
-        if (! is_null($this->cachePath)) {
+        if ($this->cachePath !== null) {
             $contents = $this->compileString($this->files->get($this->getPath()));
 
             if (! empty($this->getPath())) {
@@ -538,11 +538,11 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function component($class, $alias = null, $prefix = '')
     {
-        if (! is_null($alias) && Str::contains($alias, '\\')) {
+        if ($alias !== null && Str::contains($alias, '\\')) {
             [$class, $alias] = [$alias, $class];
         }
 
-        if (is_null($alias)) {
+        if ($alias === null) {
             $alias = Str::contains($class, '\\View\\Components\\')
                             ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(function ($segment) {
                                 return Str::kebab($segment);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -320,7 +320,7 @@ class ComponentTagCompiler
             $attribute = $match['attribute'];
             $value = $match['value'] ?? null;
 
-            if (is_null($value)) {
+            if ($value === null) {
                 $value = 'true';
 
                 $attribute = Str::start($attribute, 'bind:');

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -19,7 +19,7 @@ trait CompilesConditionals
      */
     protected function compileAuth($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard === null ? '()' : $guard;
 
         return "<?php if(auth()->guard{$guard}->check()): ?>";
     }
@@ -32,7 +32,7 @@ trait CompilesConditionals
      */
     protected function compileElseAuth($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard === null ? '()' : $guard;
 
         return "<?php elseif(auth()->guard{$guard}->check()): ?>";
     }
@@ -55,7 +55,7 @@ trait CompilesConditionals
      */
     protected function compileGuest($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard === null ? '()' : $guard;
 
         return "<?php if(auth()->guard{$guard}->guest()): ?>";
     }
@@ -68,7 +68,7 @@ trait CompilesConditionals
      */
     protected function compileElseGuest($guard = null)
     {
-        $guard = is_null($guard) ? '()' : $guard;
+        $guard = $guard === null ? '()' : $guard;
 
         return "<?php elseif(auth()->guard{$guard}->guest()): ?>";
     }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -12,7 +12,7 @@ trait CompilesTranslations
      */
     protected function compileLang($expression)
     {
-        if (is_null($expression)) {
+        if ($expression === null) {
             return '<?php $__env->startTranslation(); ?>';
         } elseif ($expression[1] === '[') {
             return "<?php \$__env->startTranslation{$expression}; ?>";

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -50,7 +50,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function only($keys)
     {
-        if (is_null($keys)) {
+        if ($keys === null) {
             $values = $this->attributes;
         } else {
             $keys = Arr::wrap($keys);
@@ -69,7 +69,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function except($keys)
     {
-        if (is_null($keys)) {
+        if ($keys === null) {
             $values = $this->attributes;
         } else {
             $keys = Arr::wrap($keys);

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -97,7 +97,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
             // another view gets rendered in the future by the application developer.
             $this->factory->flushStateIfDoneRendering();
 
-            return ! is_null($response) ? $response : $contents;
+            return $response !== null ? $response : $contents;
         } catch (Throwable $e) {
             $this->factory->flushState();
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -29,7 +29,7 @@ class CheckForMaintenanceModeTest extends TestCase
 
     protected function setUp(): void
     {
-        if (is_null($this->files)) {
+        if ($this->files === null) {
             $this->files = new Filesystem;
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2558,7 +2558,7 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertTrue($c->contains(function ($value) {
-            return is_null($value);
+            return $value === null;
         }));
     }
 
@@ -2599,7 +2599,7 @@ class SupportCollectionTest extends TestCase
         ]);
 
         $this->assertTrue($c->some(function ($value) {
-            return is_null($value);
+            return $value === null;
         }));
     }
 
@@ -4123,7 +4123,7 @@ class TestAccessorEloquentTestStub
         $accessor = 'get'.lcfirst($attribute).'Attribute';
 
         if (method_exists($this, $accessor)) {
-            return ! is_null($this->$accessor());
+            return $this->$accessor() !== null;
         }
 
         return isset($this->$attribute);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3504,7 +3504,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['name' => 'first', 'title' => null]]], []);
         $v->sometimes('foo.*.name', 'Required|String', function ($i) {
-            return is_null($i['foo'][0]['title']);
+            return $i['foo'][0]['title'] === null;
         });
         $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
     }


### PR DESCRIPTION
```
is_null($var)
```
is equal to
```
$var === null
```
but the null comparison is preferred. It is also faster based on various benchmarks available on the web and discussion.

https://stackoverflow.com/questions/8228837/is-nullx-vs-x-null-in-php
https://stackoverflow.com/questions/9671659/php-is-null-and-null
https://hakre.wordpress.com/2011/03/29/php-is_null-vs-null/