### PR TITLE
[7.x] Add as() function to HTTP client reponse

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -62,6 +62,17 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Get the decoded body of the response as the given class.
+     *
+     * @param  string $class
+     * @return mixed
+     */
+    public function as($class)
+    {
+        return new $class($this->json());
+    }
+
+    /**
      * Get a header from the response.
      *
      * @param  string  $header


### PR DESCRIPTION
This function helps with marshaling the JSON response into a class. This becomes handy and provides a more declarative API if you want to wrap response data into an object to have type support.

## Example
I usually use `Fluent` to wrap HTTP responses, an example usage could look like this:

```php
/**
* @property int $id
* @property string $title
* @property string $body
*/
class PostResponse extends \Illuminate\Support\Fluent
{

}
```

```php
$post = $response->as(PostReponse::class);

// sweet type support here
dd($post->title);
```