### PR TITLE
[6.x] Unset pivotParent on Pivot::unsetRelations()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -301,4 +301,17 @@ trait AsPivot
 
         return $query;
     }
+
+    /**
+     * Unset all the loaded relations for the instance.
+     *
+     * @return $this
+     */
+    public function unsetRelations()
+    {
+        $this->pivotParent = null;
+        $this->relations = [];
+
+        return $this;
+    }
 }

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -152,6 +152,31 @@ class DatabaseEloquentPivotTest extends TestCase
         $this->assertEquals($model->getCreatedAtColumn(), $pivotWithoutParent->getCreatedAtColumn());
         $this->assertEquals($model->getUpdatedAtColumn(), $pivotWithoutParent->getUpdatedAtColumn());
     }
+
+    public function testWithoutRelations()
+    {
+        $original = new Pivot();
+
+        $original->pivotParent = 'foo';
+        $original->setRelation('bar', 'baz');
+
+        $this->assertEquals('baz', $original->getRelation('bar'));
+
+        $pivot = $original->withoutRelations();
+
+        $this->assertInstanceOf(Pivot::class, $pivot);
+        $this->assertNotSame($pivot, $original);
+        $this->assertEquals('foo', $original->pivotParent);
+        $this->assertNull($pivot->pivotParent);
+        $this->assertTrue($original->relationLoaded('bar'));
+        $this->assertFalse($pivot->relationLoaded('bar'));
+
+        $pivot = $original->unsetRelations();
+
+        $this->assertSame($pivot, $original);
+        $this->assertNull($pivot->pivotParent);
+        $this->assertFalse($pivot->relationLoaded('bar'));
+    }
 }
 
 class DatabaseEloquentPivotTestDateStub extends Pivot


### PR DESCRIPTION
(Continuation of #31930)

Currently the `Model::unsetRelations()` method (and by extension the `Model::withoutRelations()` method) can be used to unset relations on Models, which is primarily useful right before serialization (e.g. queues)

However the `pivotParent`, which is a hardcoded relation on every Pivot instance, is not unset. This PR aims to fix that. 

For context, my particular use-case:
I have a queued job which accepts a Pivot as a constructor argument. If this Pivot has the pivotParent loaded PHP will crash as soon as Laravel starts to serialize the Pivot due to a circular reference between the Pivot and its parent causing an infinite loop.

Normally calling `unsetRelations` or `withoutRelations` would solve this issue (in the case of a Model), but since Pivots have this extra relation it doesn't.