### PR TITLE
[6.x] Add Redis facade funnel and throttle doc blocks

### DIFF
--- a/src/Illuminate/Support/Facades/Redis.php
+++ b/src/Illuminate/Support/Facades/Redis.php
@@ -4,6 +4,8 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Redis\Connections\Connection connection(string $name = null)
+ * @method static \Illuminate\Redis\Limiters\ConcurrencyLimiterBuilder funnel(string $name)
+ * @method static \Illuminate\Redis\Limiters\DurationLimiterBuilder throttle(string $name)
  *
  * @see \Illuminate\Redis\RedisManager
  * @see \Illuminate\Contracts\Redis\Factory


### PR DESCRIPTION
This PR adds the `funnel` and `throttle` methods to the Redis facade via a doc block so that IDEs can autocomplete them