### PR TITLE
[7.x] Match Response::redirectToRoute/Action params with Redirector

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -113,7 +113,7 @@ interface ResponseFactory
      * Create a new redirect response to a named route.
      *
      * @param  string  $route
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
@@ -124,7 +124,7 @@ interface ResponseFactory
      * Create a new redirect response to a controller action.
      *
      * @param  string  $action
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse

--- a/src/Illuminate/Routing/ResponseFactory.php
+++ b/src/Illuminate/Routing/ResponseFactory.php
@@ -212,7 +212,7 @@ class ResponseFactory implements FactoryContract
      * Create a new redirect response to a named route.
      *
      * @param  string  $route
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse
@@ -226,7 +226,7 @@ class ResponseFactory implements FactoryContract
      * Create a new redirect response to a controller action.
      *
      * @param  string  $action
-     * @param  array  $parameters
+     * @param  mixed  $parameters
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\RedirectResponse

--- a/src/Illuminate/Support/Facades/Response.php
+++ b/src/Illuminate/Support/Facades/Response.php
@@ -15,8 +15,8 @@ use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
  * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse download(\SplFileInfo|string $file, string|null $name = null, array $headers = [], string|null $disposition = 'attachment')
  * @method static \Symfony\Component\HttpFoundation\BinaryFileResponse file($file, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectTo(string $path, int $status = 302, array $headers = [], bool|null $secure = null)
- * @method static \Illuminate\Http\RedirectResponse redirectToRoute(string $route, array $parameters = [], int $status = 302, array $headers = [])
- * @method static \Illuminate\Http\RedirectResponse redirectToAction(string $action, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse redirectToRoute(string $route, mixed $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse redirectToAction(string $action, mixed $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse redirectGuest(string $path, int $status = 302, array $headers = [], bool|null $secure = null)
  * @method static \Illuminate\Http\RedirectResponse redirectToIntended(string $default = '/', int $status = 302, array $headers = [], bool|null $secure = null)
  *


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Currently the `\Illuminate\Routing\ResponseFactory::redirectToRoute` and `redirectToAction` both expect `$parameter` to be an `array`. This should actually be `mixed`, because they call `\Illuminate\Routing\Redirector::route` and `action`. Both of these methods have `mixed` in their doc block.

The problem with `$parameter` being documented as an `array` is not being able to pass models without your IDE complaining:
```php
return \Illuminate\Support\Facades\Response::redirectToRoute('orders.show', $order');
```

The benefit of this PR is that your IDE won't complain about `$parameter` not being an `array`.