### PR TITLE
[7.x] Added State class helper ("The missing Enum")

### DIFF
--- a/src/Illuminate/Support/State.php
+++ b/src/Illuminate/Support/State.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Support;
+
+use BadMethodCallException;
+
+class State
+{
+    /**
+     * Current state.
+     *
+     * @var string
+     */
+    protected $current;
+
+    /**
+     * Possible states for this current instance.
+     *
+     * @var array
+     */
+    protected $states = [];
+
+    /**
+     * Create a new instance with a list of available states.
+     *
+     * @param  array|null  $states
+     */
+    public function __construct(array $states = null)
+    {
+        $this->states = $states ?? $this->states;
+    }
+
+    /**
+     * Return the enumerated value.
+     *
+     * @return mixed
+     */
+    public function value()
+    {
+        return array_key_exists($this->current, $this->states)
+            ? $this->states[$this->current]
+            : $this->current;
+    }
+
+    /**
+     * Returns if the state exists.
+     *
+     * @param  string  $state
+     * @return bool
+     */
+    public function has(string $state)
+    {
+        if (is_string(array_key_first($this->states))) {
+            return array_key_exists($state, $this->states);
+        }
+
+        return in_array($state, $this->states, true);
+    }
+
+    /**
+     * Returns if the current state is equal to the issued one.
+     *
+     * @param  string  $state
+     * @return bool
+     */
+    public function is(string $state)
+    {
+        return $this->current === $state;
+    }
+
+    /**
+     * Return the current state.
+     *
+     * @return string|null
+     */
+    public function current()
+    {
+        return $this->current;
+    }
+
+    /**
+     * Return all possible states.
+     *
+     * @return array
+     */
+    public function states()
+    {
+        return $this->states;
+    }
+
+    /**
+     * Handle dynamically setting the state.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return \Illuminate\Support\State
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __call($name, $arguments)
+    {
+        if ($this->has($name)) {
+            $this->current = $name;
+
+            return $this;
+        }
+
+        throw new BadMethodCallException("The state [$name] is not in the list of possible states.");
+    }
+
+    /**
+     * Transform the class instance into a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->current ?? '';
+    }
+
+    /**
+     * Creates a new Enumerate instance.
+     *
+     * @param  array  $states
+     * @param  string|null  $initial
+     * @return mixed
+     */
+    public static function from(array $states, string $initial = null)
+    {
+        $instance = (new static($states));
+
+        if ($initial) {
+            $instance->{$initial}();
+        }
+
+        return $instance;
+    }
+}

--- a/tests/Support/SupportStateTest.php
+++ b/tests/Support/SupportStateTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\State;
+
+class SupportStateTest extends TestCase
+{
+    public function testCreatesEnumerate()
+    {
+        $this->assertInstanceOf(State::class, State::from(['foo', 'bar']));
+    }
+
+    public function testCreatesEnumerateWithInitialValue()
+    {
+        $enum = State::from(['foo', 'bar'], 'foo');
+
+        $this->assertEquals('foo', $enum->current());
+    }
+
+    public function testSetsStates()
+    {
+        $enum = State::from($states = ['foo', 'bar', 'quz']);
+
+        $this->assertEquals($states, $enum->states());
+    }
+
+    public function testStateExists()
+    {
+        $enum = State::from(['foo', 'bar', 'quz']);
+
+        $this->assertTrue($enum->has('foo'));
+        $this->assertFalse($enum->has('doesnt_exists'));
+
+        $enum = State::from($states = [
+            'foo' => 10,
+            'qux' => null
+        ]);
+
+        $this->assertTrue($enum->has('foo'));
+        $this->assertTrue($enum->has('qux'));
+    }
+
+    public function testIs()
+    {
+        $enum = State::from(['foo', 'bar', 'quz']);
+
+        $this->assertFalse($enum->is('foo'));
+        $this->assertFalse($enum->is('bar'));
+
+        $enum->foo();
+
+        $this->assertTrue($enum->is('foo'));
+        $this->assertFalse($enum->is('bar'));
+    }
+
+    public function testCurrentState()
+    {
+        $enum = State::from(['foo', 'bar', 'quz']);
+
+        $this->assertNull($enum->current());
+
+        $enum->foo();
+
+        $this->assertEquals('foo', $enum->current());
+    }
+
+    public function testDynamicallySetsStatesAndReturnsCurrentValue()
+    {
+        $enum = State::from($states = ['foo', 'bar', 'quz']);
+
+        foreach ($states as $state) {
+            $this->assertInstanceOf(State::class, $enum->{$state}());
+            $this->assertEquals($state, $enum->value());
+        }
+    }
+
+    public function testReturnsMapValue()
+    {
+        $enum = State::from($states = [
+            'foo' => 10,
+            'bar' => function() {return true; },
+            'quz' => [],
+            'qux' => null
+        ]);
+
+        $this->assertIsInt($enum->foo()->value());
+        $this->assertIsCallable($enum->bar()->value());
+        $this->assertIsArray($enum->quz()->value());
+        $this->assertNull($enum->qux()->value());
+    }
+
+    public function testExceptionWhenStateInvalid()
+    {
+        $this->expectException(BadMethodCallException::class);
+
+        $enum = State::from($states = ['foo', 'bar', 'quz']);
+
+        $enum->invalid();
+    }
+
+    public function testToString()
+    {
+        $enum = State::from($states = ['foo', 'bar', 'quz']);
+
+        $this->assertEquals('', (string) $enum);
+
+        $enum->foo();
+
+        $this->assertEquals('foo', (string) $enum);
+
+        $enum = State::from($states = [
+            'foo' => 10,
+            'bar' => function() {return true; },
+            'quz' => [],
+            'qux' => null
+        ]);
+
+        $enum->bar();
+
+        $this->assertEquals('bar', (string) $enum);
+    }
+
+    public function testUsesInitialState()
+    {
+        $class = new class extends State {
+            protected $current = 'foo';
+            protected $states = ['foo', 'bar'];
+        };
+
+        $this->assertEquals('foo', $class->current());
+    }
+}

--- a/tests/Support/SupportStateTest.php
+++ b/tests/Support/SupportStateTest.php
@@ -3,8 +3,8 @@
 namespace Illuminate\Tests\Support;
 
 use BadMethodCallException;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\State;
+use PHPUnit\Framework\TestCase;
 
 class SupportStateTest extends TestCase
 {
@@ -36,7 +36,7 @@ class SupportStateTest extends TestCase
 
         $enum = State::from($states = [
             'foo' => 10,
-            'qux' => null
+            'qux' => null,
         ]);
 
         $this->assertTrue($enum->has('foo'));
@@ -81,9 +81,11 @@ class SupportStateTest extends TestCase
     {
         $enum = State::from($states = [
             'foo' => 10,
-            'bar' => function() {return true; },
+            'bar' => function () {
+                return true;
+            },
             'quz' => [],
-            'qux' => null
+            'qux' => null,
         ]);
 
         $this->assertIsInt($enum->foo()->value());
@@ -113,9 +115,11 @@ class SupportStateTest extends TestCase
 
         $enum = State::from($states = [
             'foo' => 10,
-            'bar' => function() {return true; },
+            'bar' => function () {
+                return true;
+            },
             'quz' => [],
-            'qux' => null
+            'qux' => null,
         ]);
 
         $enum->bar();


### PR DESCRIPTION
This `State` class allows another class (or just itself) to have a state from a given state list, much like Enum. It supports associative and sequential arrays. You can set any state from the list using a fluent method.

```php
$podcast = Podcast::create([
    'title' => 'Episode 23: Organizing your time',
    'state' => State::from(['announced', 'live', 'published'])->announced()
]);

$podcast->state->published();
$podcast->save();
```

This may come handy when defining states for a Model, which avoids the burden of setting up the database for enum types.

It also allows for the developer to extend it with their own prepared State class:

```php
class PodcastState extend State
{
    protected $current = 'announced';
    protected $states = ['announced', 'live', 'published'];
}

Podcast::create([
    'title' => 'Episode 23: Organizing your time',
    'state' => new PodcastState,
]);
```

That's the gist, but there is more:

### Create an associative array and give back other values:

```php
$state = State::from([
    'announced' => 'prepared',
    'live' => 'in-progress',
    'published' => 'complete',
])->announced();

echo $state->value(); // "prepared"
```

### Quickly validate the current state or other states

```php
if ($state->is('live')) {
    return 'The podcast is live!';
}

if ($state->has('live')) {
   return 'This podcast will be recorded live';
}
```

Please comment so I don't feel alone.