### PR TITLE
[7.x] Publish the form request stub used by RequestMakeCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/RequestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RequestMakeCommand.php
@@ -34,7 +34,20 @@ class RequestMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/request.stub';
+        return $this->resolveStubPath('/stubs/request.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -37,6 +37,7 @@ class StubPublishCommand extends Command
             __DIR__.'/stubs/job.stub' => $stubsPath.'/job.stub',
             __DIR__.'/stubs/model.pivot.stub' => $stubsPath.'/model.pivot.stub',
             __DIR__.'/stubs/model.stub' => $stubsPath.'/model.stub',
+            __DIR__.'/stubs/request.stub' => $stubsPath.'/request.stub',
             __DIR__.'/stubs/test.stub' => $stubsPath.'/test.stub',
             __DIR__.'/stubs/test.unit.stub' => $stubsPath.'/test.unit.stub',
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',

--- a/src/Illuminate/Foundation/Console/stubs/request.stub
+++ b/src/Illuminate/Foundation/Console/stubs/request.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class DummyClass extends FormRequest
+class {{ class }} extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.


### PR DESCRIPTION
With V7 we got the awesome `stubs:publish` command which covers a lot of things.

One thing it doesn't cover is the default FormRequest, which is something I feel would be quite a good stub for things if you create your own base FormRequest class with custom methods and you want all the created form requests to extend your new base class.

This PR simply updates the RequestMakeCommand to function the same as the generators that have their stubs published.
