### PR TITLE
[7.x] Add console test method to expect a confirmation question

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -76,7 +76,7 @@ class PendingCommand
      * Specify a question that should be asked when the command runs.
      *
      * @param  string  $question
-     * @param  string  $answer
+     * @param  string|bool  $answer
      * @return $this
      */
     public function expectsQuestion($question, $answer)
@@ -84,6 +84,18 @@ class PendingCommand
         $this->test->expectedQuestions[] = [$question, $answer];
 
         return $this;
+    }
+
+    /**
+     * Specify a confirmation question that should be asked when the command runs.
+     *
+     * @param  string  $question
+     * @param  string  $answer
+     * @return $this
+     */
+    public function expectsConfirmation($question, $answer = 'no')
+    {
+        return $this->expectsQuestion($question, $answer === 'yes');
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -95,7 +95,7 @@ class PendingCommand
      */
     public function expectsConfirmation($question, $answer = 'no')
     {
-        return $this->expectsQuestion($question, $answer === 'yes');
+        return $this->expectsQuestion($question, strtolower($answer) === 'yes');
     }
 
     /**


### PR DESCRIPTION
While creating tests for an Artisan command, I came to a quite interesting situation. I found out that expecting a confirmation question is different than answering any other question because answers such as `'Yes'` or `'No'` do not work here. Actually, a `bool` value has to be passed.

## Scenario

This is an example of a command that could be tested:

```php
<?php

namespace App\Console\Commands;

use Illuminate\Console\Command;

class ExampleCommand extends Command
{
    /**
     * The name and signature of the console command.
     *
     * @var string
     */
    protected $signature = 'foo:bar';

    /**
     * The console command description.
     *
     * @var string
     */
    protected $description = 'An example of a command with a confirmation question';

    /**
     * Execute the console command.
     *
     * @return int
     */
    public function handle(): int
    {
        if (! $this->confirm('Do you want to continue?')) {
            return 1;
        }

        $this->info('Completed the task successfully.');

        return 0;
    }
}
```

An example of the test following the official documentation:

```php
<?php

namespace Tests\Feature;

use Tests\TestCase;

class ExampleCommandTest extends TestCase
{
    public function testHandle()
    {
        $this->artisan('foo:bar')
            ->expectsQuestion('Do you want to continue?', 'no')
            ->assertExitCode(1);
    }
}
```

Running this test will result into the following error:

```
Expected status code 1 but received 0.
Failed asserting that 0 matches expected 1.
Expected :1
Actual   :0
```

The confirmation question requires `true` or `false` as the result value. So the right and confusing way is following:

```php
$this->artisan('foo:bar')
    ->expectsQuestion('Do you want to continue?', false)
    ->assertExitCode(1);
```

## Conclusion

To comply with the available method in Artisan commands for the confirmation question, `confirm()`, I created a test method and updated the documentation for the `expectsQuestion()` method.

The example test after merging this PR would look like this:

```php
<?php

namespace Tests\Feature;

use Tests\TestCase;

class ExampleCommandTest extends TestCase
{
    public function testHandle()
    {
        $this->artisan('foo:bar')
            ->expectsConfirmation('Do you want to continue?', 'no')
            ->assertExitCode(1);
    }
}
``` 