### PR TITLE
[7.x] Remove dead code from event tests

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -455,19 +455,6 @@ class TestDispatcherConnectionQueuedHandler implements ShouldQueue
     }
 }
 
-class TestDispatcherQueuedHandlerCustomQueue implements ShouldQueue
-{
-    public function handle()
-    {
-        //
-    }
-
-    public function queue($queue, $handler, array $payload)
-    {
-        $queue->push($handler, $payload);
-    }
-}
-
 class ExampleEvent
 {
     //


### PR DESCRIPTION
This stub class is created on 2015 and does not seem to be in use anywhere in the tests.