### PR TITLE
[7.x] Extract events tests to dedicated files

### DIFF
--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -373,40 +373,11 @@ class EventsDispatcherTest extends TestCase
         unset($_SERVER['__event.test1']);
         unset($_SERVER['__event.test2']);
     }
-
-    public function testEventSubscribers()
-    {
-        $d = new Dispatcher($container = m::mock(Container::class));
-        $subs = m::mock(ExampleSubscriber::class);
-        $subs->shouldReceive('subscribe')->once()->with($d);
-        $container->shouldReceive('make')->once()->with(ExampleSubscriber::class)->andReturn($subs);
-
-        $d->subscribe(ExampleSubscriber::class);
-        $this->assertTrue(true);
-    }
-
-    public function testEventSubscribeCanAcceptObject()
-    {
-        $d = new Dispatcher();
-        $subs = m::mock(ExampleSubscriber::class);
-        $subs->shouldReceive('subscribe')->once()->with($d);
-
-        $d->subscribe($subs);
-        $this->assertTrue(true);
-    }
 }
 
 class ExampleEvent
 {
     //
-}
-
-class ExampleSubscriber
-{
-    public function subscribe($e)
-    {
-        //
-    }
 }
 
 interface SomeEventInterface

--- a/tests/Events/EventsSubscriberTest.php
+++ b/tests/Events/EventsSubscriberTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Events;
+
+use Illuminate\Container\Container;
+use Illuminate\Events\Dispatcher;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class EventsSubscriberTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testEventSubscribers()
+    {
+        $d = new Dispatcher($container = m::mock(Container::class));
+        $subs = m::mock(ExampleSubscriber::class);
+        $subs->shouldReceive('subscribe')->once()->with($d);
+        $container->shouldReceive('make')->once()->with(ExampleSubscriber::class)->andReturn($subs);
+
+        $d->subscribe(ExampleSubscriber::class);
+        $this->assertTrue(true);
+    }
+
+    public function testEventSubscribeCanAcceptObject()
+    {
+        $d = new Dispatcher();
+        $subs = m::mock(ExampleSubscriber::class);
+        $subs->shouldReceive('subscribe')->once()->with($d);
+
+        $d->subscribe($subs);
+        $this->assertTrue(true);
+    }
+}
+
+class ExampleSubscriber
+{
+    public function subscribe($e)
+    {
+        //
+    }
+}

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Tests\Events;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\Queue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Testing\Fakes\QueueFake;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class QueuedEventsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testQueuedEventHandlersAreQueued()
+    {
+        $d = new Dispatcher;
+        $queue = m::mock(Queue::class);
+
+        $queue->shouldReceive('connection')->once()->with(null)->andReturnSelf();
+
+        $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
+
+        $d->setQueueResolver(function () use ($queue) {
+            return $queue;
+        });
+
+        $d->listen('some.event', TestDispatcherQueuedHandler::class.'@someMethod');
+        $d->dispatch('some.event', ['foo', 'bar']);
+    }
+
+    public function testCustomizedQueuedEventHandlersAreQueued()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container());
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherConnectionQueuedHandler::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushedOn('my_queue', CallQueuedListener::class);
+    }
+}
+
+class TestDispatcherQueuedHandler implements ShouldQueue
+{
+    public function handle()
+    {
+        //
+    }
+}
+
+class TestDispatcherConnectionQueuedHandler implements ShouldQueue
+{
+    public $connection = 'redis';
+
+    public $delay = 10;
+
+    public $queue = 'my_queue';
+
+    public function handle()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This PR extracts all the tests related to the events which implement the queued interface into a separate file.
Also the same thing for the subscribe feature.