### PR TITLE
[7.x] Return serializer option to PhpRedisConnector

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -98,6 +98,10 @@ class PhpRedisConnector implements Connector
                 $client->setOption(Redis::OPT_READ_TIMEOUT, $config['read_timeout']);
             }
 
+            if (! empty($config['serializer'])) {
+                $client->setOption(Redis::OPT_SERIALIZER, $config['serializer']);
+            }
+
             if (! empty($config['scan'])) {
                 $client->setOption(Redis::OPT_SCAN, $config['scan']);
             }
@@ -154,6 +158,10 @@ class PhpRedisConnector implements Connector
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
             if (! empty($options['prefix'])) {
                 $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
+            }
+
+            if (! empty($options['serializer'])) {
+                $client->setOption(RedisCluster::OPT_SERIALIZER, $options['serializer']);
             }
 
             if (! empty($options['scan'])) {


### PR DESCRIPTION
It's a long story from #31393 to #31417 via #31402. At the moment errors don't reproduce locally and in github actions. Looks like target files are the same, but infrastructure has changed slightly. I make an effort to reproduce it locally with infrastructure from broken test, but result was the same.

I can't explain this, so let's try another shot.