### PR TITLE
[7.x] Remove unused import in MailManager

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -12,7 +12,6 @@ use Illuminate\Mail\Transport\LogTransport;
 use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Mail\Transport\SesTransport;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Manager;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Postmark\ThrowExceptionOnFailurePlugin;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87493/76691205-c78ff400-6648-11ea-9fbb-65489606baf0.png)

Probably a leftover from the refactor from TransportManager I presume.