### PR TITLE
[7.x] Allow configuring the timeout for the smtp driver

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -230,6 +230,10 @@ class MailManager implements FactoryContract
             $transport->setLocalDomain($config['local_domain']);
         }
 
+        if (isset($config['timeout'])) {
+            $transport->setTimeout($config['timeout']);
+        }
+
         return $transport;
     }
 


### PR DESCRIPTION
The default is "(int) 30" seconds.

laravel/laravel PR => https://github.com/laravel/laravel/pull/5262