### PR TITLE
[6.x] Change cookie helper signature to match CookieFactory

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -299,13 +299,13 @@ if (! function_exists('cookie')) {
      * @param  int  $minutes
      * @param  string|null  $path
      * @param  string|null  $domain
-     * @param  bool  $secure
+     * @param  bool|null  $secure
      * @param  bool  $httpOnly
      * @param  bool  $raw
      * @param  string|null  $sameSite
      * @return \Illuminate\Cookie\CookieJar|\Symfony\Component\HttpFoundation\Cookie
      */
-    function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
+    function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
         $cookie = app(CookieFactory::class);
 


### PR DESCRIPTION
**TL;DR**
This changes the `cookie()` helper signature to match the `CookieFactory::make` function. These appear to have been mismatched since #23200.

Set to 6.x as recommended by @GrahamCampbell in https://github.com/laravel/framework/pull/31970

**Problem**
I was looking into the below warning we were getting on our frontend SPA in Chrome. I had already set the `secure` config option to `true` in `config/session.php`. So I decided to investigate why the cookie was not being sent with the `secure` flag as expected.

> A cookie associated with a cross-site resource at https://example.com/ was set without the `SameSite` attribute. A future release of Chrome will only deliver cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.

**Investigation**
The cookie was being returned by using the `response->cookie` method as described in the docs (https://laravel.com/docs/7.x/responses#attaching-cookies-to-responses). 

```php
return response($content)->cookie('token', $jwtToken);
```

After looking into that method I realised it is using the `cookie()` helper function under the hood and this had the`$secure = false` as one of its arguments this explained why it was not using the setting specified in the  `session.php` config. 

**Workaround**
To provide an immediate fix for our application I changed the code to use the `Cookie::make` factory method directly since this does use the configured value as the method signature for that method has `$secure = null`.  So we changed our response code to this:

```php
return response($content)->cookie(\Cookie::make('token', $jwtToken));
```

**Fix**
Changed `cookie()` helper function signature from `$secure = false` to `$secure = null` to match the `CookieFactory::make` function . 