### PR TITLE
[8.x] Alias eloquent with-relationships

### DIFF
--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -513,7 +513,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $relation->shouldReceive('initRelation')->once()->with(['models'], 'orders')->andReturn(['models']);
         $relation->shouldReceive('getEager')->once()->andReturn(['results']);
         $relation->shouldReceive('match')->once()->with(['models'], ['results'], 'orders')->andReturn(['models.matched']);
-        $builder->shouldReceive('getRelation')->once()->with('orders')->andReturn($relation);
+        $builder->shouldReceive('getRelation')->once()->with('orders', null)->andReturn($relation);
         $results = $builder->eagerLoadRelations(['models']);
 
         $this->assertEquals(['models.matched'], $results);


### PR DESCRIPTION
This pr enables relationships to be loaded with an alias name.

this allows you to use the same relationship multiple times with different constraints which is not possible today. Today you will have to add new relationships to the model to accomplish this.

This aligns the with-method with the withCount-method which supports aliases today: https://laravel.com/docs/7.x/eloquent-relationships#counting-related-models

For me personally I have a need for this with a graphql library that uses eloquent to create eager loaded queries. Since graphql supports aliases I would need to create different versions of relationship if an alias is used with different params that might change the constraints.

```
$user = EloquentTestUser::with([
            'posts as aliasPosts' => function($q) {
                $q->where('name', 'Second Post');
            },
            'posts.childPosts' => function($q) {
            },
            'posts.childPosts AS aliasChildPosts' => function($q) {
                $q->where('name', 'Child Post2');
            }
        ])->first();
```
