### PR TITLE
[7.x] Enabling Windows absolute paths normalizing

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -148,6 +148,13 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $namespace;
 
     /**
+     * The application namespace.
+     *
+     * @var array
+     */
+    protected $absolutePathPrefixes = [DIRECTORY_SEPARATOR];
+
+    /**
      * Create a new Illuminate application instance.
      *
      * @param  string|null  $basePath
@@ -1010,7 +1017,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
             return $this->bootstrapPath($default);
         }
 
-        return Str::startsWith($env, '/')
+        return Str::startsWith($env, $this->absolutePathPrefixes)
                 ? $env
                 : $this->basePath($env);
     }
@@ -1269,5 +1276,16 @@ class Application extends Container implements ApplicationContract, CachesConfig
         }
 
         throw new RuntimeException('Unable to detect application namespace.');
+    }
+
+    /**
+     * Add new prefix to list of absolute path prefixes.
+     *
+     * @param  string  $prefix
+     * @return void
+     */
+    public function addAbsolutePathPrefix(string $prefix): void
+    {
+        $this->absolutePathPrefixes[] = $prefix;
     }
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -148,7 +148,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     protected $namespace;
 
     /**
-     * The application namespace.
+     * The prefixes of absolute paths for normalization.
      *
      * @var array
      */

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -441,7 +441,7 @@ class FoundationApplicationTest extends TestCase
     public function testEnvPathsAreAbsoluteInWindows()
     {
         $app = new Application(__DIR__);
-        $app->addAbsolutePathPrefix("C:");
+        $app->addAbsolutePathPrefix('C:');
         $_SERVER['APP_SERVICES_CACHE'] = 'C:\framework\services.php';
         $_SERVER['APP_PACKAGES_CACHE'] = 'C:\framework\packages.php';
         $_SERVER['APP_CONFIG_CACHE'] = 'C:\framework\config.php';

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -437,6 +437,30 @@ class FoundationApplicationTest extends TestCase
             $_SERVER['APP_EVENTS_CACHE']
         );
     }
+
+    public function testEnvPathsAreAbsoluteInWindows() {
+        $app = new Application(__DIR__);
+        $app->addAbsolutePathPrefix("C:");
+        $_SERVER['APP_SERVICES_CACHE'] = 'C:\framework\services.php';
+        $_SERVER['APP_PACKAGES_CACHE'] = 'C:\framework\packages.php';
+        $_SERVER['APP_CONFIG_CACHE'] = 'C:\framework\config.php';
+        $_SERVER['APP_ROUTES_CACHE'] = 'C:\framework\routes.php';
+        $_SERVER['APP_EVENTS_CACHE'] = 'C:\framework\events.php';
+
+        $this->assertSame('C:\framework\services.php', $app->getCachedServicesPath());
+        $this->assertSame('C:\framework\packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('C:\framework\config.php', $app->getCachedConfigPath());
+        $this->assertSame('C:\framework\routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('C:\framework\events.php', $app->getCachedEventsPath());
+
+        unset(
+            $_SERVER['APP_SERVICES_CACHE'],
+            $_SERVER['APP_PACKAGES_CACHE'],
+            $_SERVER['APP_CONFIG_CACHE'],
+            $_SERVER['APP_ROUTES_CACHE'],
+            $_SERVER['APP_EVENTS_CACHE']
+        );
+    }
 }
 
 class ApplicationBasicServiceProviderStub extends ServiceProvider

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -438,7 +438,8 @@ class FoundationApplicationTest extends TestCase
         );
     }
 
-    public function testEnvPathsAreAbsoluteInWindows() {
+    public function testEnvPathsAreAbsoluteInWindows()
+    {
         $app = new Application(__DIR__);
         $app->addAbsolutePathPrefix("C:");
         $_SERVER['APP_SERVICES_CACHE'] = 'C:\framework\services.php';


### PR DESCRIPTION
Some of our devs are working on Windows machines and we've found that there's a big problem with normalizing cache path when it's an absolute path. With Unix systems it's great, because in these cases Laravel only needs to check if a string starts with `'/'`.Withn Windows it could be more problematic, because absolute path starts with drive capital letter and a colon, eg. `'C:'`.

That's why I added `absolutePathPrefixes` array that could be modified for everyone. In default mode it's not affecting anything else.