### PR TITLE
[7.x] Only define the query option when query parameters were specified

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -462,13 +462,18 @@ class PendingRequest
             );
         }
 
+        if (! empty($options['query'])) {
+            $options['query'] = array_merge_recursive(
+                $options['query'], $this->parseQueryParams($url)
+            );
+        }
+
         $this->pendingFiles = [];
 
         return retry($this->tries ?? 1, function () use ($method, $url, $options) {
             try {
                 return tap(new Response($this->buildClient()->request($method, $url, $this->mergeOptions([
                     'laravel_data' => $options[$this->bodyFormat] ?? [],
-                    'query' => $this->parseQueryParams($url),
                     'on_stats' => function ($transferStats) {
                         $this->transferStats = $transferStats;
                     },


### PR DESCRIPTION
This allows multiple query parameters with the same name to be used (see #31918 for a use case). This is currently only possible by specifying the query parameters in the URL, rather than using the query option. If the consumer does not provide query parameters via the options, it assumed there are no additional query parameters to be passed to Guzzle.

Should tests be required for this, I'd appreciate if someone could help me out. I haven't yet been able to add a working test case, due to the strange inner workings of Guzzle and its PSR7 response object.

Fixes #31918