### PR TITLE
[7.x] Times helper method

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -467,6 +467,19 @@ if (! function_exists('throw_unless')) {
     }
 }
 
+if (! function_exists('times')) {
+    /**
+     * Throw the given exception unless the given condition is true.
+     *
+     * @param $times
+     * @return \Illuminate\Support\Collection
+     */
+    function times($times)
+    {
+        return collect(range(1, $times));
+    }
+}
+
 if (! function_exists('trait_uses_recursive')) {
     /**
      * Returns all traits used by a trait and its traits.

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -469,7 +469,7 @@ if (! function_exists('throw_unless')) {
 
 if (! function_exists('times')) {
     /**
-     * Throw the given exception unless the given condition is true.
+     * Returns a collection of a set number of items to easily loop through.
      *
      * @param $times
      * @return \Illuminate\Support\Collection


### PR DESCRIPTION
Current ugly ways to loop a set number of times...

```php
foreach (range(1, 5) as $i) { // }
```

```php
for ($i = 0; $i < 5; $i++) { // }
```

```php
collect(range(1, 5))->each(function ($i) { // })
```

Proposed way with helper method...

```php
times(5)->each(function ($i) { // }
```

Open for suggestion for the name of this method as it could be misinterpreted that the method is mathematical and the parameter is being multiplied?



