### PR TITLE
[7.x] Fix output of component attributes

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -109,12 +109,6 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $attributes = [];
 
         foreach ($this->attributes as $key => $value) {
-            if ($value === true) {
-                $attributes[$key] = $key;
-
-                continue;
-            }
-
             if ($key !== 'class') {
                 $attributes[$key] = $value;
 
@@ -126,7 +120,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             ));
         }
 
-        return new static(array_merge($attributeDefaults, array_filter($attributes)));
+        return new static(array_merge($attributeDefaults, $attributes));
     }
 
     /**
@@ -226,9 +220,15 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $string = '';
 
         foreach ($this->attributes as $key => $value) {
-            $string .= $value === true
-                    ? ' '.$key
-                    : ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
+            if ($value === false || is_null($value)) {
+                continue;
+            }
+
+            if ($value === true) {
+                $value = $key;
+            }
+
+            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
         }
 
         return trim($string);

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -39,6 +39,6 @@ class ViewComponentAttributeBagTest extends TestCase
         ]);
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
     }
 }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -27,5 +27,18 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag([]);
 
         $this->assertSame('class="mt-4"', (string) $bag->merge(['class' => 'mt-4']));
+
+        $bag = new ComponentAttributeBag([
+            'test-string' => 'ok',
+            'test-null' => null,
+            'test-false' => false,
+            'test-true' => true,
+            'test-0' => 0,
+            'test-0-string' => '0',
+            'test-empty-string' => '',
+        ]);
+
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }
 }


### PR DESCRIPTION
Closes https://github.com/laravel/framework/issues/31939

This PR fixes multiple issues with how component attributes are rendered. `$attribute` and `$attributes->merge()` results in different rendered attributes for values that are `true` or casts to `false`. For example `min="0"` is currently removed when using merge() (see full example below).

Here is an attempt to summarise the changes. In short `$attribute` and `$attribute->merge()` now have identical output and are rendered the same way as Vue.

`<x-input :checked="false">`, `<x-input :checked="null">`, `<x-input :checked="">` → `<input>` 
Previously `<input checked="">`  and `<input>`

`<x-input :min="0">`, `<x-input :min="'0'">` → `<input min="0">` 
Previously `<input min="0">`  and `<input>`

`<x-input :checked="true">` → `<input checked="checked">` 
Previously `<input checked>`  and `<input checked="checked">`

This last example is handled a bit simpler than Vue. Vue differentiate boolean attributes (`checked`, `disabled`, `itemscope` etc) and normal attributes. This PR doesn't (but it could be added in another PR).

### An example where min="0" is removed when using merge()

A blade component with attributes:
```php
<input type="number" {{ $attributes }} />
```

For an input with type number it's reasonable to have min="0":
```php
<x-number min="0" max="10" class="p-4" />
```
This render as:
```html
<input type="number" min="0" max="10" class="p-4" />
```

But if you used `merge()`:
```php
<input type="number" {{ $attributes->merge(['class' => 'm-4']) }} />
```

The attribute with **value 0 is removed**:
```html
<input type="number" max="10" class="p-4 m-4" />
```

### Another example with an attribute with a value `false` that is rendered differently when using with or without merge()

With a component that simply prints it's attributes:

```php
<input {{ $attributes }} />
```

If the component is used like this:

```php
<x-input :disabled="false" />
```

We would expect the rendered template to be:

```php
<input />
```

But the current implementation renders:

```php
<input disabled="" />
```

But if the component uses `merge()` like this:

```php
<input {{ $attributes->merge() }} />
```

The output is what one would expect:

```php
<input />
```

