### PR TITLE
[7.x] Http client query string support

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -604,19 +604,6 @@ class PendingRequest
     }
 
     /**
-     * Parse the query parameters in the given URL.
-     *
-     * @param  string  $url
-     * @return array
-     */
-    public function parseQueryParams(string $url)
-    {
-        return tap([], function (&$query) use ($url) {
-            parse_str(parse_url($url, PHP_URL_QUERY), $query);
-        });
-    }
-
-    /**
      * Register a stub callable that will intercept requests and be able to return stub responses.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -376,10 +376,10 @@ class PendingRequest
      * Issue a GET request to the given URL.
      *
      * @param  string  $url
-     * @param  array  $query
+     * @param  array|string|null  $query
      * @return \Illuminate\Http\Client\Response
      */
-    public function get(string $url, array $query = [])
+    public function get(string $url, $query = null)
     {
         return $this->send('GET', $url, [
             'query' => $query,
@@ -468,7 +468,6 @@ class PendingRequest
             try {
                 return tap(new Response($this->buildClient()->request($method, $url, $this->mergeOptions([
                     'laravel_data' => $options[$this->bodyFormat] ?? [],
-                    'query' => $this->parseQueryParams($url),
                     'on_stats' => function ($transferStats) {
                         $this->transferStats = $transferStats;
                     },

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -223,4 +223,70 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $responseCookie['Value']);
         $this->assertSame('https://laravel.com', $responseCookie['Domain']);
     }
+
+    public function testGetWithArrayQueryParam()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get', ['foo' => 'bar']);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar';
+        });
+    }
+
+    public function testGetWithStringQueryParam()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get', 'foo=bar');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar';
+        });
+    }
+
+    public function testGetWithQuery()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get?foo=bar&page=1');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo=bar&page=1';
+        });
+    }
+
+    public function testGetWithQueryWontEncode()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get?foo;bar;1;5;10&page=1');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1';
+        });
+    }
+
+    public function testGetWithArrayQueryParamOverwrites()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?hello=world';
+        });
+    }
+
+    public function testGetWithArrayQueryParamEncodes()
+    {
+        $this->factory->fake();
+
+        $this->factory->get('http://foo.com/get', ['foo;bar; space test' => 'laravel']);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel';
+        });
+    }
 }


### PR DESCRIPTION
This is the PR for the issue reported earlier here: https://github.com/laravel/ideas/issues/2137

This doesn't break any existing usage and should work just fine since Guzzle itself supports query params in URI and there is no need to parse and send them as an array like it was being done previously.

You can refer Guzzle docs for [query](http://docs.guzzlephp.org/en/stable/request-options.html#query) request option.

There is one point to note here, tho.

Guzzle's default behavior is that, if we pass the `query` request option with either a string or array (empty or with values), it will overwrite "all query string values supplied in the URI of a request"

So as per Guzzle (And I tested this case), this is what happens:

```php
// Send a GET request to /get?foo=bar
Http::get('https://example.com/get?abc=123', ['foo' => 'bar']);

// Guzzle will automatically replace and turn the above URI to:
// https://example.com/get?foo=bar
```

While it's Guzzle that's doing this, I'm just putting this out here to highlight its behavior so it doesn't cause a confusion.

# Examples

This PR will support the following variations of a GET request.

```php
Http::get('https://example.com/get');
// URL: https://example.com/get

Http::get('https://example.com/get?abc=123');
// URL: https://example.com/get?abc=123

Http::get('https://example.com/get', ['foo' => 'bar']);
// URL: https://example.com/get?foo=bar

Http::get('https://example.com/get', 'foo=bar');
// URL: https://example.com/get?foo=bar

Http::get('https://example.com/get?abc;foo;bar;1;10;2&p=2');
// URL: https://example.com/get?abc;foo;bar;1;10;2&p=2

Http::get('https://example.com/get', 'abc;foo;bar;1;10;2&p=2');
// URL: https://example.com/get?abc;foo;bar;1;10;2&p=2

Http::get('https://example.com/get', ['abc;foo;1;10;2' => 'bar', 'p' => 2]);
// URL: https://example.com/get?abc%3Bfoo%3B1%3B10%3B2=bar&p=2

// Notice how Guzzle handles the encoding part if the query is an array, and it has these chars that need encoding, otherwise it just passes as is giving us more control.
```

This also resolves two old issues reported in Zttp (Similar to mine, the same encoding issue).

```php
// Issue: https://github.com/kitetail/zttp/issues/77
Http::get('https://example.com/get?api.version=1');
// URL: https://example.com/get?api.version=1

// Issue: https://github.com/kitetail/zttp/issues/42
Http::get('http://localhost:8002/monitoring/stats?mount=/test.mp3');
// URL: http://localhost:8002/monitoring/stats?mount=/test.mp3
```

