### PR TITLE
[7.x] Fix annotation for Schema::unique()

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Fluent;
  * @method ColumnDefinition primary() Add a primary index
  * @method ColumnDefinition spatialIndex() Add a spatial index
  * @method ColumnDefinition storedAs(string $expression) Create a stored generated column (MySQL)
- * @method ColumnDefinition unique() Add a unique index
+ * @method ColumnDefinition unique(string $indexName = null) Add a unique index
  * @method ColumnDefinition unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method ColumnDefinition useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
  * @method ColumnDefinition virtualAs(string $expression) Create a virtual generated column (MySQL)


### PR DESCRIPTION
Fix annotation for Schema::unique()

The Schema's `unique()` function call accepts index name just like `index()`.