### PR TITLE
[7.x] Make tests windows 10 compatible

### DIFF
--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -359,11 +359,12 @@ class FoundationApplicationTest extends TestCase
     {
         $app = new Application('/base/path');
 
-        $this->assertSame('/base/path/bootstrap/cache/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/base/path/bootstrap/cache/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/base/path/bootstrap/cache/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/base/path/bootstrap/cache/routes-v7.php', $app->getCachedRoutesPath());
-        $this->assertSame('/base/path/bootstrap/cache/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/routes-v7.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/events.php', $app->getCachedEventsPath());
     }
 
     public function testEnvPathsAreUsedForCachePathsWhenSpecified()
@@ -399,11 +400,12 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
 
-        $this->assertSame('/base/path/relative/path/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/base/path/relative/path/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/base/path/relative/path/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/base/path/relative/path/routes.php', $app->getCachedRoutesPath());
-        $this->assertSame('/base/path/relative/path/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame('/base/path'.$ds.'relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/events.php', $app->getCachedEventsPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
@@ -423,11 +425,12 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
 
-        $this->assertSame('/relative/path/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/relative/path/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/relative/path/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/relative/path/routes.php', $app->getCachedRoutesPath());
-        $this->assertSame('/relative/path/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame($ds.'relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame($ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame($ds.'relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame($ds.'relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame($ds.'relative/path/events.php', $app->getCachedEventsPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],


### PR DESCRIPTION
These tests just fail on windows because of the directory separator.

![image](https://user-images.githubusercontent.com/6961695/76855605-b58b9c80-6866-11ea-99ab-1e1a64270614.png)
