### PR TITLE
[7.x] Adds missing throws tag for docblock

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -193,6 +193,8 @@ class ComponentTagCompiler
      *
      * @param  string  $component
      * @return string
+     *
+     * @throws InvalidArgumentException
      */
     protected function componentClass(string $component)
     {


### PR DESCRIPTION
This method seemingly is missing @throws tags in docblock