### PR TITLE
[7.x] No need to start mysql on host, the one from `services` is used

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
-      - name: Start MySQL
-        run: sudo /etc/init.d/mysql start
-
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
         env:


### PR DESCRIPTION
Per discussion in https://github.com/laravel/framework/pull/31548#pullrequestreview-372326919

For me tests are still green, indicating it's not used.