### PR TITLE
[6.x] Default to longblob on MySQL.

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -723,7 +723,7 @@ class MySqlGrammar extends Grammar
      */
     protected function typeBinary(Fluent $column)
     {
-        return 'blob';
+        return 'longblob';
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -845,7 +845,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('alter table `users` add `foo` blob not null', $statements[0]);
+        $this->assertSame('alter table `users` add `foo` longblob not null', $statements[0]);
     }
 
     public function testAddingUuid()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fixes bug #3544 & issue laravel/ideas#2092 by defaulting blob() to LONGBLOB for MySQL.