### PR TITLE
[7.x] Add throws doc block for makeWith

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -609,6 +609,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  array  $parameters
      * @return mixed
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
     public function makeWith($abstract, array $parameters = [])
     {


### PR DESCRIPTION
It seems that the `makeWith` method should have the same doc-block as it's original, since it is just an alias for `make`