### PR TITLE
[7.x] Improve doc block for app()->call()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -581,9 +581,11 @@ class Container implements ArrayAccess, ContainerContract
      * Call the given Closure / class@method and inject its dependencies.
      *
      * @param  callable|string  $callback
-     * @param  array  $parameters
+     * @param  array<string, mixed>  $parameters
      * @param  string|null  $defaultMethod
      * @return mixed
+     *
+     * @throws \InvalidArgumentException
      */
     public function call($callback, array $parameters = [], $defaultMethod = null)
     {


### PR DESCRIPTION
1. Obviously this method may throws `\InvalidArgumentException`.
2. Since laravel supports only the associative form of array for `$parameters`, and sequential for may or may not work, it is better to reflect the fact in the doc-blocks, explicitly.
(For readers: mixed[string] means that the keys are meant to be string and values are mixed)

- I am not very sure the `\ReflectionException` but it seems to be also needed. You may add it yourself or ask me to do a force push for it.