### PR TITLE
Make ChannelManager (Notification) macroable

### DIFF
--- a/src/Illuminate/Notifications/ChannelManager.php
+++ b/src/Illuminate/Notifications/ChannelManager.php
@@ -7,10 +7,13 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Notifications\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\Notifications\Factory as FactoryContract;
 use Illuminate\Support\Manager;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 
 class ChannelManager extends Manager implements DispatcherContract, FactoryContract
 {
+    use Macroable;
+
     /**
      * The default channel used to deliver messages.
      *


### PR DESCRIPTION
I wanted to create a macro to send notifications to a particular internal email address without having to pull it out of my config each time.  I was surprised it wasn't already macroable and figured others could also find a use for it.