### PR TITLE
[7.x] Fix parse options double called

### DIFF
--- a/src/Illuminate/Http/UploadedFile.php
+++ b/src/Illuminate/Http/UploadedFile.php
@@ -33,7 +33,7 @@ class UploadedFile extends SymfonyUploadedFile
      */
     public function store($path, $options = [])
     {
-        return $this->storeAs($path, $this->hashName(), $this->parseOptions($options));
+        return $this->storeAs($path, $this->hashName(), $options);
     }
 
     /**


### PR DESCRIPTION
When the store method is called, the options parameter is passed to the storeAs method without any processing. I checked the relevant code and git history, and I think it is unnecessary.

```php
public function store($path, $options = [])
{
    return $this->storeAs($path, $this->hashName(), $this->parseOptions($options));
}
```
```php
public function storeAs($path, $name, $options = [])
{
    $options = $this->parseOptions($options);

    $disk = Arr::pull($options, 'disk');

    return Container::getInstance()->make(FilesystemFactory::class)->disk($disk)->putFileAs(
        $path, $this, $name, $options
    );
}
```

English is not my first language. If my description is not appropriate, please help me edit it. thx...