### PR TITLE
[7.x] Provide support for custom minutes interval

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -124,8 +124,10 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run every specified minutes.
      *
-     * @param  int $minutes
+     * @param  int  $minutes
      * @return $this
+     *
+     * @throws \OutOfRangeException
      */
     public function everyFewMinutes($minutes)
     {

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -122,6 +122,21 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every specified minutes.
+     *
+     * @param  int $minutes
+     * @return $this
+     */
+    public function everyFewMinutes(int $minutes)
+    {
+        if ($minutes > 59 || $minutes < 2) {
+            throw new \OutOfRangeException('Minutes need to be between 2 and 59');
+        }
+
+        return $this->spliceIntoPosition(1, '*/' . $minutes);
+    }
+
+    /**
      * Schedule the event to run hourly.
      *
      * @return $this

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -127,7 +127,7 @@ trait ManagesFrequencies
      * @param  int $minutes
      * @return $this
      */
-    public function everyFewMinutes(int $minutes)
+    public function everyFewMinutes($minutes)
     {
         if ($minutes > 59 || $minutes < 2) {
             throw new \OutOfRangeException('Minutes need to be between 2 and 59');

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -33,6 +33,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 
+    public function testEveryFewMinutes()
+    {
+        $this->assertSame('*/24 * * * *', $this->event->everyFewMinutes(24)->getExpression());
+    }
+
     public function testDaily()
     {
         $this->assertSame('0 0 * * *', $this->event->daily()->getExpression());


### PR DESCRIPTION
This PR provides support for specifying a custom frequency (in minutes) that can be specified by the user for scheduling.

For example, if there is a need to schedule every 25 minutes `everyFewMinutes(25)` could be called.