### PR TITLE
[7.x] Blade newline fixes

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -358,8 +358,8 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     protected function addFooters($result)
     {
-        return ltrim($result, PHP_EOL)
-                .PHP_EOL.implode(PHP_EOL, array_reverse($this->footer));
+        return ltrim($result, "\n")
+                ."\n".implode("\n", array_reverse($this->footer));
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -59,7 +59,7 @@ trait CompilesComponents
      */
     public static function compileClassComponentOpening(string $component, string $data, string $hash)
     {
-        return implode(PHP_EOL, [
+        return implode("\n", [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
             '<?php if ($component->shouldRender()): ?>',
@@ -76,7 +76,7 @@ trait CompilesComponents
     {
         $hash = array_pop(static::$componentHashStack);
 
-        return implode(PHP_EOL, [
+        return implode("\n", [
             '<?php if (isset($__componentOriginal'.$hash.')): ?>',
             '<?php $component = $__componentOriginal'.$hash.'; ?>',
             '<?php unset($__componentOriginal'.$hash.'); ?>',
@@ -92,7 +92,7 @@ trait CompilesComponents
      */
     public function compileEndComponentClass()
     {
-        return static::compileEndComponent().PHP_EOL.implode(PHP_EOL, [
+        return static::compileEndComponent()."\n".implode("\n", [
             '<?php endif; ?>',
         ]);
     }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -22,7 +22,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler)->compileSlots('<x-slot name="foo">
 </x-slot>');
 
-        $this->assertSame("@slot('foo') ".PHP_EOL.' @endslot', trim($result));
+        $this->assertSame("@slot('foo') \n".' @endslot', trim($result));
     }
 
     public function testBasicComponentParsing()

--- a/tests/View/Blade/BladeExtendsTest.php
+++ b/tests/View/Blade/BladeExtendsTest.php
@@ -8,11 +8,11 @@ class BladeExtendsTest extends AbstractBladeTestCase
     {
         $string = '@extends(\'foo\')
 test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
+        $expected = "test\n".'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
-        $string = '@extends(name(foo))'.PHP_EOL.'test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
+        $string = '@extends(name(foo))'."\n".'test';
+        $expected = "test\n".'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
@@ -20,12 +20,12 @@ test';
     {
         $string = '@extends(\'foo\')
 test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
+        $expected = "test\n".'<?php echo $__env->make(\'foo\', \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
 
         // use the same compiler instance to compile another template with @extends directive
-        $string = '@extends(name(foo))'.PHP_EOL.'test';
-        $expected = 'test'.PHP_EOL.'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
+        $string = "@extends(name(foo))\ntest";
+        $expected = "test\n".'<?php echo $__env->make(name(foo), \Illuminate\Support\Arr::except(get_defined_vars(), [\'__data\', \'__path\']))->render(); ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
The behaviour of an app should not be different depending on what OS it is deployed on. Most deployments checkout code by downloading a zip of the repo, which will have the blade views with unix style newlines. Dynamically generated stuff should also new unix style newlines, so that responses returned to users have unix style newlines, and **not** some a mix of unix and windows style on Windows server deployments.