### PR TITLE
[7.x] Add support for passing exception for nested keys in trim strings

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
+++ b/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php
@@ -22,6 +22,7 @@ class TrimStrings extends TransformsRequest
      */
     protected function transform($key, $value)
     {
+        $key = preg_replace('/\.\d+/', '.*', $key);
         if (in_array($key, $this->except, true)) {
             return $value;
         }

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -21,11 +21,11 @@ class TrimStringsTest extends TestCase
             'lmn' => [
                 [
                     'abc' => ' 123 ',
-                    'pqr' => ' 111 '
+                    'pqr' => ' 111 ',
                 ],
                 [
                     'abc' => ' 222 ',
-                    'pqr' => ' 333 '
+                    'pqr' => ' 333 ',
                 ]
             ]
         ]);
@@ -54,6 +54,6 @@ class TrimStringsWithExceptAttribute extends TrimStrings
         'foo',
         'bar',
         'pqr.*',
-        'lmn.*.abc'
+        'lmn.*.abc',
     ];
 }

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -26,8 +26,8 @@ class TrimStringsTest extends TestCase
                 [
                     'abc' => ' 222 ',
                     'pqr' => ' 333 ',
-                ]
-            ]
+                ],
+            ],
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);

--- a/tests/Foundation/Http/Middleware/TrimStringsTest.php
+++ b/tests/Foundation/Http/Middleware/TrimStringsTest.php
@@ -17,6 +17,17 @@ class TrimStringsTest extends TestCase
             'xyz' => '  456  ',
             'foo' => '  789  ',
             'bar' => '  010  ',
+            'pqr' => [' 000 ', '111', ' 123'],
+            'lmn' => [
+                [
+                    'abc' => ' 123 ',
+                    'pqr' => ' 111 '
+                ],
+                [
+                    'abc' => ' 222 ',
+                    'pqr' => ' 333 '
+                ]
+            ]
         ]);
         $symfonyRequest->server->set('REQUEST_METHOD', 'GET');
         $request = Request::createFromBase($symfonyRequest);
@@ -26,6 +37,13 @@ class TrimStringsTest extends TestCase
             $this->assertSame('456', $request->get('xyz'));
             $this->assertSame('  789  ', $request->get('foo'));
             $this->assertSame('  010  ', $request->get('bar'));
+            $this->assertSame(' 000 ', $request->get('pqr')[0]);
+            $this->assertSame('111', $request->get('pqr')[1]);
+            $this->assertSame(' 123', $request->get('pqr')[2]);
+            $this->assertSame(' 123 ', $request->get('lmn')[0]['abc']);
+            $this->assertSame('111', $request->get('lmn')[0]['pqr']);
+            $this->assertSame(' 222 ', $request->get('lmn')[1]['abc']);
+            $this->assertSame('333', $request->get('lmn')[1]['pqr']);
         });
     }
 }
@@ -35,5 +53,7 @@ class TrimStringsWithExceptAttribute extends TrimStrings
     protected $except = [
         'foo',
         'bar',
+        'pqr.*',
+        'lmn.*.abc'
     ];
 }


### PR DESCRIPTION
**Aim:**

This PR aims to pass the generic format to except the nested keys in TrimStrings middleware.

**Current Behaviour:**
```
$request = [
   'abc' => ' 123 ',
   'lmn' => [  ' 123 ', ' 111 ', ' 222 ' ],
   'pqr' => [
        [
              'abc' => ' 123 ',
              'xyz' => ' 111 '
        ],
        [
              'abc' => ' 222 ',
              'xyz' => ' 333'
        ]
    ]
];

```

```
$except = [
   'abc' ,   // this works
   'lmn.*'  // this doesn't work
   'lmn.0' // this works but need to specify the index number
   'pqr.*.abc' // this doesn't work
   'pqr.0.abc' // this works but need to specify the index number
];
```

**Proposed Solution**
Converting the keys with the index number to the '.*' so that it can be matched against the generic pattern passed in the `$except` attribute of the TrimString middleware.

```
'lmn.0' => 'lmn.*',
'pqr.0.abc' => 'pqr.*.abc'

```