### PR TITLE
[7.x] Bug with trailing slash in cached routes matcher

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -703,4 +703,15 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->route($key);
         });
     }
+
+    /**
+     * Clones the current request.
+     */
+    public function __clone()
+    {
+        parent::__clone();
+
+        $this->pathInfo = null;
+        $this->requestUri = null;
+    }
 }

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -7,9 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Routing\CompiledRouteCollection;
 use Illuminate\Tests\Integration\IntegrationTest;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Tests\Integration\Routing\Fixtures\TrailingSlashBugMiddleware;
 
 class CompiledRouteCollectionTest extends IntegrationTest
 {
@@ -448,6 +450,20 @@ class CompiledRouteCollectionTest extends IntegrationTest
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/'))->getName());
+    }
+
+    public function testTrailingSlashIsTrimmedWhenMatchingCachedRoutes()
+    {
+        $this->routeCollection->add(
+            $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $request = Request::create('/foo/bar/');
+
+        // Access to request path info before matching route
+        $request->getPathInfo();
+
+        $this->assertSame('foo', $this->collection()->match($request)->getName());
     }
 
     /**


### PR DESCRIPTION
If `getPathInfo()` or `getRequestUri()` methods are called on request before route matching on `CompiledRouteCollection`, the trimmed request will keep old `pathInfo` and `requestUri` because they are cached into properties inside the request. 

Now I set to null the two properties inside `__clone` magic method of the request, so when cloning the request for trimming they are reset but maybe it's better to just have a method inside the request to reset the cached properties when needed.