### PR TITLE
[7.x] Add support for dot notation within json translations

### DIFF
--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -106,7 +106,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
         // only one level deep so we do not need to do any fancy searching through it.
         $this->load('*', '*', $locale);
 
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
+        $line = Arr::get($this->loaded['*']['*'][$locale], $key);
 
         // If we can't find a translation for the JSON key, we will attempt to translate it
         // using the typical translation file. This way developers can always just use a


### PR DESCRIPTION
Currently, if we choose to use `json` files for translations we can't use nested translation keys. What I mean is currently I can do this
```json
{
    "admin" : "some text"
}
```
and the output of `__('admin')` would be `some text`

if I do
```json
    "admin" : {
		"roles" : "some other text"
	}
```
and the output of `__('admin')` would be 
```php
   [
     "roles" => "some other text",
   ]
```

BUT if I want to do `__('admin.roles')` I will get `admin.roles` INSTEAD of `some other text`
With this PR I can access `__('admin.roles')` and get `some other text`.

Also `php array` and `json` translations will be consistent, currently `php array` works fine