### PR TITLE
[7.x] Don't overwrite published stub files by default

### DIFF
--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -12,7 +12,7 @@ class StubPublishCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'stub:publish';
+    protected $signature = 'stub:publish {--force : Overwrite any existing files}';
 
     /**
      * The console command description.
@@ -54,7 +54,9 @@ class StubPublishCommand extends Command
         ];
 
         foreach ($files as $from => $to) {
-            file_put_contents($to, file_get_contents($from));
+            if (! file_exists($to) || $this->option('force')) {
+                file_put_contents($to, file_get_contents($from));
+            }
         }
 
         $this->info('Stubs published successfully.');


### PR DESCRIPTION
This change modifies the `stub:publish` command so that it won't overwrite stub files that have already been published to the application. This aligns its behavior with the `vendor:publish` command.

This is useful when someone needs to re-publish the stub files later. For example, if they only want to keep the stub files they've modified in their application's stubs directory, or if new stub files are added later on.

You can still overwrite existing stub files by passing the `--force` flag.