### PR TITLE
[7.x] Make policy stubs customizable

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -78,17 +78,11 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         $model = str_replace('/', '\\', $model);
 
-        $namespaceModel = $this->laravel->getNamespace().$model;
-
         if (Str::startsWith($model, '\\')) {
-            $stub = str_replace('NamespacedDummyModel', trim($model, '\\'), $stub);
+            $namespacedModel = trim($model, '\\');
         } else {
-            $stub = str_replace('NamespacedDummyModel', $namespaceModel, $stub);
+            $namespacedModel = $this->laravel->getNamespace().$model;
         }
-
-        $stub = str_replace(
-            "use {$namespaceModel};\nuse {$namespaceModel};", "use {$namespaceModel};", $stub
-        );
 
         $model = class_basename(trim($model, '\\'));
 
@@ -96,15 +90,34 @@ class PolicyMakeCommand extends GeneratorCommand
 
         $dummyModel = Str::camel($model) === 'user' ? 'model' : $model;
 
-        $stub = str_replace('DocDummyModel', Str::snake($dummyModel, ' '), $stub);
+        $replace = [
+            'NamespacedDummyModel' => $namespacedModel,
+            '{{ namespacedModel }}' => $namespacedModel,
+            '{{namespacedModel}}' => $namespacedModel,
+            'DummyModel' => $model,
+            '{{ model }}' => $model,
+            '{{model}}' => $model,
+            'dummyModel' => Str::camel($dummyModel),
+            '{{ modelVariable }}' => Str::camel($dummyModel),
+            '{{modelVariable}}' => Str::camel($dummyModel),
+            'DocDummyModel' => Str::snake($dummyModel, ' '),
+            '{{ modelDoc }}' => Str::snake($dummyModel, ' '),
+            '{{modelDoc}}' => Str::snake($dummyModel, ' '),
+            'DocDummyPluralModel' => Str::snake(Str::pluralStudly($dummyModel), ' '),
+            '{{ modelDocPlural }}' => Str::snake(Str::pluralStudly($dummyModel), ' '),
+            '{{modelDocPlural}}' => Str::snake(Str::pluralStudly($dummyModel), ' '),
+            'DummyUser' => $dummyUser,
+            '{{ user }}' => $dummyUser,
+            '{{user}}' => $dummyUser,
+        ];
 
-        $stub = str_replace('DummyModel', $model, $stub);
+        $stub = str_replace(
+            array_keys($replace), array_values($replace), $stub
+        );
 
-        $stub = str_replace('dummyModel', Str::camel($dummyModel), $stub);
-
-        $stub = str_replace('DummyUser', $dummyUser, $stub);
-
-        return str_replace('DocDummyPluralModel', Str::snake(Str::pluralStudly($dummyModel), ' '), $stub);
+        return str_replace(
+            "use {$namespacedModel};\nuse {$namespacedModel};", "use {$namespacedModel};", $stub
+        );
     }
 
     /**
@@ -115,8 +128,21 @@ class PolicyMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('model')
-                    ? __DIR__.'/stubs/policy.stub'
-                    : __DIR__.'/stubs/policy.plain.stub';
+                    ? $this->resolveStubPath('/stubs/policy.stub')
+                    : $this->resolveStubPath('/stubs/policy.plain.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -43,6 +43,8 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.create.stub') => $stubsPath.'/migration.create.stub',
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.stub') => $stubsPath.'/migration.stub',
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => $stubsPath.'/migration.update.stub',
+            realpath(__DIR__.'/../../Foundation/Console/stubs/policy.plain.stub') => $stubsPath.'/policy.plain.stub',
+            realpath(__DIR__.'/../../Foundation/Console/stubs/policy.stub') => $stubsPath.'/policy.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => $stubsPath.'/controller.api.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => $stubsPath.'/controller.invokable.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => $stubsPath.'/controller.model.api.stub',

--- a/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.plain.stub
@@ -1,11 +1,11 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use NamespacedDummyUserModel;
+use {{ namespacedUserModel }};
 
-class DummyClass
+class {{ class }}
 {
     use HandlesAuthorization;
 

--- a/src/Illuminate/Foundation/Console/stubs/policy.stub
+++ b/src/Illuminate/Foundation/Console/stubs/policy.stub
@@ -1,93 +1,93 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Auth\Access\HandlesAuthorization;
-use NamespacedDummyModel;
-use NamespacedDummyUserModel;
+use {{ namespacedModel }};
+use {{ namespacedUserModel }};
 
-class DummyClass
+class {{ class }}
 {
     use HandlesAuthorization;
 
     /**
-     * Determine whether the user can view any DocDummyPluralModel.
+     * Determine whether the user can view any {{ modelDocPlural }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \{{ namespacedUserModel }}  $user
      * @return mixed
      */
-    public function viewAny(DummyUser $user)
+    public function viewAny({{ user }} $user)
     {
         //
     }
 
     /**
-     * Determine whether the user can view the DocDummyModel.
+     * Determine whether the user can view the {{ modelDoc }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return mixed
      */
-    public function view(DummyUser $user, DummyModel $dummyModel)
+    public function view({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
     /**
-     * Determine whether the user can create DocDummyPluralModel.
+     * Determine whether the user can create {{ modelDocPlural }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
+     * @param  \{{ namespacedUserModel }}  $user
      * @return mixed
      */
-    public function create(DummyUser $user)
+    public function create({{ user }} $user)
     {
         //
     }
 
     /**
-     * Determine whether the user can update the DocDummyModel.
+     * Determine whether the user can update the {{ modelDoc }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return mixed
      */
-    public function update(DummyUser $user, DummyModel $dummyModel)
+    public function update({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
     /**
-     * Determine whether the user can delete the DocDummyModel.
+     * Determine whether the user can delete the {{ modelDoc }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return mixed
      */
-    public function delete(DummyUser $user, DummyModel $dummyModel)
+    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
     /**
-     * Determine whether the user can restore the DocDummyModel.
+     * Determine whether the user can restore the {{ modelDoc }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return mixed
      */
-    public function restore(DummyUser $user, DummyModel $dummyModel)
+    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //
     }
 
     /**
-     * Determine whether the user can permanently delete the DocDummyModel.
+     * Determine whether the user can permanently delete the {{ modelDoc }}.
      *
-     * @param  \NamespacedDummyUserModel  $user
-     * @param  \NamespacedDummyModel  $dummyModel
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
      * @return mixed
      */
-    public function forceDelete(DummyUser $user, DummyModel $dummyModel)
+    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //
     }


### PR DESCRIPTION
This makes the stubs used for `make:policy` customizable.

Related to #31052.