### PR TITLE
[7.x] Remove extra code from illuminate/container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -143,7 +143,7 @@ class Container implements ArrayAccess, ContainerContract
     {
         $aliases = [];
 
-        foreach (Util::arrayWrap($concrete) as $c) {
+        foreach ((array) $concrete as $c) {
             $aliases[] = $this->getAlias($c);
         }
 

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -62,7 +62,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function give($implementation)
     {
-        foreach (Util::arrayWrap($this->concrete) as $concrete) {
+        foreach ((array) $this->concrete as $concrete) {
             $this->container->addContextualBinding($concrete, $this->needs, $implementation);
         }
     }

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -7,23 +7,6 @@ use Closure;
 class Util
 {
     /**
-     * If the given value is not an array and not null, wrap it in one.
-     *
-     * From Arr::wrap() in Illuminate\Support.
-     *
-     * @param  mixed  $value
-     * @return array
-     */
-    public static function arrayWrap($value)
-    {
-        if (is_null($value)) {
-            return [];
-        }
-
-        return is_array($value) ? $value : [$value];
-    }
-
-    /**
      * Return the default value of the given value.
      *
      * From global value() helper in Illuminate\Support.

--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -4,7 +4,6 @@ namespace Illuminate\Tests\Container;
 
 use Illuminate\Container\Util;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 class UtilTest extends TestCase
 {
@@ -14,30 +13,5 @@ class UtilTest extends TestCase
         $this->assertSame('foo', Util::unwrapIfClosure(function () {
             return 'foo';
         }));
-    }
-
-    public function testArrayWrap()
-    {
-        $string = 'a';
-        $array = ['a'];
-        $object = new stdClass;
-        $object->value = 'a';
-        $this->assertEquals(['a'], Util::arrayWrap($string));
-        $this->assertEquals($array, Util::arrayWrap($array));
-        $this->assertEquals([$object], Util::arrayWrap($object));
-        $this->assertEquals([], Util::arrayWrap(null));
-        $this->assertEquals([null], Util::arrayWrap([null]));
-        $this->assertEquals([null, null], Util::arrayWrap([null, null]));
-        $this->assertEquals([''], Util::arrayWrap(''));
-        $this->assertEquals([''], Util::arrayWrap(['']));
-        $this->assertEquals([false], Util::arrayWrap(false));
-        $this->assertEquals([false], Util::arrayWrap([false]));
-        $this->assertEquals([0], Util::arrayWrap(0));
-
-        $obj = new stdClass;
-        $obj->value = 'a';
-        $obj = unserialize(serialize($obj));
-        $this->assertEquals([$obj], Util::arrayWrap($obj));
-        $this->assertSame($obj, Util::arrayWrap($obj)[0]);
     }
 }


### PR DESCRIPTION
Since we do not deal with objects at all, (The wrapped variable can only be an string or an array as documented.) the native php type-casting does the job perfectly, like it is used in many other parts of the class.
I did not see the point to define and use a helper util method for that.
It seems the util is created to decouple the container from array helper class and replace the Arr::wrap