### PR TITLE
[6.x] When Models have one-to-one relationship, Eloquent loadMissing() may throw BadMethodCallException.

### DIFF
--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -154,7 +154,8 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function sponsorPost() {
+    public function sponsorPost()
+    {
         return $this->hasOne(SponsorPost::class);
     }
 }
@@ -194,7 +195,8 @@ class Ad extends Model
 
     protected $guarded = ['id'];
 
-    public function adRevisions() {
+    public function adRevisions()
+    {
         return $this->hasMany(AdRevisions::class);
     }
 }

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -105,9 +105,6 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 
     public function testLoadMissingThrowsBadMethodCallException()
     {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Method Illuminate\Database\Eloquent\Collection::relationLoaded does not exist.');
-
         $user = User::create();
 
         $post1 = Post::create(['user_id' => $user->id]);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR is a bug report related to loadMissing(). When Models have one-to-one relationship, Illuminate\Database\Eloquent\Collection::loadMissing() may throw BadMethodCallException.

Illuminate\Database\Eloquent\Collection::loadMissingRelation() call $models->collapse() if $models->first() is Collection.
But When Models have one-to-one relationship, $models->first() may be null and $models->collapse() not called.
Therefore $model->relationLoaded() is called in spite of $model is Collection in next recursive call.

Check testLoadMissingThrowsBadMethodCallException() that I added.

I think $models->first() should be $models->whereNotNull()->first() in loadMissingRelation().

I'm sorry for my poor English and bad examples.