### PR TITLE
[7.x] Route trailing slash bug

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -703,4 +703,15 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
             return $this->route($key);
         });
     }
+
+    /**
+     * Clones the current request.
+     */
+    public function __clone()
+    {
+        parent::__clone();
+
+        $this->pathInfo = null;
+        $this->requestUri = null;
+    }
 }

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -423,10 +423,6 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public static function createFromBase(SymfonyRequest $request)
     {
-        if ($request instanceof static) {
-            return $request;
-        }
-
         $newRequest = (new static)->duplicate(
             $request->query->all(), $request->request->all(), $request->attributes->all(),
             $request->cookies->all(), $request->files->all(), $request->server->all()
@@ -702,16 +698,5 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
         return Arr::get($this->all(), $key, function () use ($key) {
             return $this->route($key);
         });
-    }
-
-    /**
-     * Clones the current request.
-     */
-    public function __clone()
-    {
-        parent::__clone();
-
-        $this->pathInfo = null;
-        $this->requestUri = null;
     }
 }

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -154,7 +154,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
     {
         $trimmedRequest = Request::createFromBase($request);
 
-        $parts = explode('?', $request->server->get('REQUEST_URI'));
+        $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
 
         $trimmedRequest->server->set(
             'REQUEST_URI', rtrim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -152,7 +152,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     protected function requestWithoutTrailingSlash(Request $request)
     {
-        $trimmedRequest = clone $request;
+        $trimmedRequest = Request::createFromBase($request);
 
         $trimmedRequest->server->set(
             'REQUEST_URI', rtrim($request->server->get('REQUEST_URI'), '/')

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -154,8 +154,10 @@ class CompiledRouteCollection extends AbstractRouteCollection
     {
         $trimmedRequest = Request::createFromBase($request);
 
+        $parts = explode('?', $request->server->get('REQUEST_URI'));
+
         $trimmedRequest->server->set(
-            'REQUEST_URI', rtrim($request->server->get('REQUEST_URI'), '/')
+            'REQUEST_URI', rtrim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')
         );
 
         return $trimmedRequest;

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -7,9 +7,11 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Routing\CompiledRouteCollection;
 use Illuminate\Tests\Integration\IntegrationTest;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Tests\Integration\Routing\Fixtures\TrailingSlashBugMiddleware;
 
 class CompiledRouteCollectionTest extends IntegrationTest
 {
@@ -448,6 +450,20 @@ class CompiledRouteCollectionTest extends IntegrationTest
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/'))->getName());
+    }
+
+    public function testTrailingSlashIsTrimmedWhenMatchingCachedRoutes()
+    {
+        $this->routeCollection->add(
+            $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $request = Request::create('/foo/bar/');
+
+        // Access to request path info before matching route
+        $request->getPathInfo();
+
+        $this->assertSame('foo', $this->collection()->match($request)->getName());
     }
 
     /**

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -7,11 +7,9 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
-use Illuminate\Routing\CompiledRouteCollection;
 use Illuminate\Tests\Integration\IntegrationTest;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Illuminate\Tests\Integration\Routing\Fixtures\TrailingSlashBugMiddleware;
 
 class CompiledRouteCollectionTest extends IntegrationTest
 {

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -30,10 +30,6 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->router = $this->app['router'];
 
         $this->routeCollection = new RouteCollection;
-
-        // $this->routeCollection = (new CompiledRouteCollection([], []))
-        //     ->setRouter($this->router)
-        //     ->setContainer($this->app);
     }
 
     protected function tearDown(): void
@@ -448,6 +444,15 @@ class CompiledRouteCollectionTest extends IntegrationTest
         );
 
         $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/'))->getName());
+    }
+
+    public function testMatchingUriWithQuery()
+    {
+        $this->routeCollection->add(
+            $route = $this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $this->assertSame('foo', $this->collection()->match(Request::create('/foo/bar/?foo=bar'))->getName());
     }
 
     public function testTrailingSlashIsTrimmedWhenMatchingCachedRoutes()


### PR DESCRIPTION
Replaces https://github.com/laravel/framework/pull/32031

Alternative approach to cloning the request. I deliberately removed the instanceof check in the createFromBase method because otherwise this wouldn't be possible. 