### PR TITLE
[7.x] Fix serialization of models when sending notifications

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -52,7 +52,7 @@ class SendQueuedNotifications implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  mixed  $notifiables
+     * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
      * @param  \Illuminate\Notifications\Notification  $notification
      * @param  array|null  $channels
      * @return void

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -142,7 +142,7 @@ class SendQueuedNotifications implements ShouldQueue
     /**
      * Wrap the notifiable(s) in a collection.
      *
-     * @param mixed $notifiables
+     * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
      * @return \Illuminate\Support\Collection
      */
     protected function wrapNotifiables($notifiables)

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -2,9 +2,12 @@
 
 namespace Illuminate\Tests\Notifications;
 
+use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Support\Collection;
+use Illuminate\Tests\Integration\Notifications\NotifiableUser;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -25,5 +28,27 @@ class NotificationSendQueuedNotificationTest extends TestCase
                 && $channels === null;
         });
         $job->handle($manager);
+    }
+
+    public function testSerializationOfNotifiableModel()
+    {
+        $identifier = new ModelIdentifier(NotifiableUser::class, [null], [], null);
+        $serializedIdentifier = serialize($identifier);
+
+        $job = new SendQueuedNotifications(new NotifiableUser(), 'notification');
+        $serialized = serialize($job);
+
+        $this->assertStringContainsString($serializedIdentifier, $serialized);
+    }
+
+    public function testSerializationOfNormalNotifiable()
+    {
+        $notifiable = new AnonymousNotifiable();
+        $serializedNotifiable = serialize($notifiable);
+
+        $job = new SendQueuedNotifications($notifiable, 'notification');
+        $serialized = serialize($job);
+
+        $this->assertStringContainsString($serializedNotifiable, $serialized);
     }
 }


### PR DESCRIPTION
Fixes #32039, caused by a previous pull request of mine (#31675).

Wrapping models in a normal collection causes them to no longer be properly serialized as the normal collection does not implement `Illuminate\Contracts\Queue\QueueableCollection`. So Models are now wrapped in an eloquent collection instead.

I also added an extra check to prevent the job from wrapping the notifiable(s) if it receives a collection (rather than a object or an array), this makes sure any custom queueable collections aren't re-wrapped (breaking their serialization logic)