### PR TITLE
[6.x] Fix Eloquent loadMissing() with 4 or more length relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -161,7 +161,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $models = $models->pluck($name);
 
-        if ($models->first() instanceof BaseCollection) {
+        if ($models->whereNotNull()->first() instanceof BaseCollection) {
             $models = $models->collapse();
         }
 

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -62,6 +62,20 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
         $this->assertArrayNotHasKey('id', $posts[0]->comments[1]->parent->revisions[0]->getAttributes());
     }
 
+    public function testLoadMissingWithFourLengthRelations()
+    {
+        $posts = Post::with('comments', 'user')->get();
+
+        DB::enableQueryLog();
+
+        $posts->loadMissing('comments.parent.revisions.comment');
+
+        $this->assertCount(3, DB::getQueryLog());
+        $this->assertTrue($posts[0]->comments[0]->relationLoaded('parent'));
+        $this->assertTrue($posts[0]->comments[1]->parent->relationLoaded('revisions'));
+        $this->assertTrue($posts[0]->comments[1]->parent->revisions[0]->relationLoaded('comment'));
+    }
+
     public function testLoadMissingWithClosure()
     {
         $posts = Post::with('comments')->get();
@@ -130,6 +144,11 @@ class Revision extends Model
     public $timestamps = false;
 
     protected $guarded = ['id'];
+
+    public function comment()
+    {
+        return $this->belongsTo(Comment::class);
+    }
 }
 
 class User extends Model


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request fixes Eloquent loadMissing() error when we input 4 or more length relations.

Currently, loadMissing() may throw BadMethodCallException when we input 4 or more length relations and an Intermediate relation is one-to-one or one-to-many(inverse) relationships.
I add a test demonstrates the bug and fix loadMissing().
