### PR TITLE
[8.x] Add ability to convert DB calls into Data Object classes

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -108,7 +108,7 @@ class Connection implements ConnectionInterface
     /**
      * The class to fetch as if $fetchMode is set to PDO::FETCH_CLASS.
      *
-     * @var null|int
+     * @var null|string
      */
     protected $fetchClass = null;
 

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -160,4 +160,13 @@ interface ConnectionInterface
      * @return array
      */
     public function pretend(Closure $callback);
+
+    /**
+     * Convert the output from a stdClass to a specified object class.
+     *
+     * @param  string|null  $class  The classname of the value object to convert the output to.
+     *                              If set to NULL, it will reset the fetchMode and fetchClass.
+     * @return void
+     */
+    public function setFetchClass($class);
 }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1384,7 +1384,7 @@ class Builder
         // Ignore calls to the underlying QueryBuilder's `asClass`/`as` method
         // as Eloquent models already are converted into an object.
         // We will silently ignore this call, as it's not an exceptional case.
-        if (in_array($method, ['as', 'asClass'])) {
+        if (in_array($method, ['as', 'asClass'], true)) {
             return $this;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1381,6 +1381,13 @@ class Builder
             return $this->toBase()->{$method}(...$parameters);
         }
 
+        // Ignore calls to the underlying QueryBuilder's `asClass`/`as` method
+        // as Eloquent models already are converted into an object.
+        // We will silently ignore this call, as it's not an exceptional case.
+        if (in_array($method, ['as', 'asClass'])) {
+            return $this;
+        }
+
         $this->forwardCallTo($this->query, $method, $parameters);
 
         return $this;

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2231,6 +2231,32 @@ class Builder
     }
 
     /**
+     * Convert the output from a stdClass to a specified object class.
+     *
+     * @param  string  $class The classname of the value object to convert the output to.
+     * @return $this
+     */
+    public function asClass($class)
+    {
+        $this->connection->setFetchClass($class);
+
+        return $this;
+    }
+
+    /**
+     * Convert the output from a stdClass to a specified object class.
+     * Alias for asClass.
+     *
+     * @param  string  $class The classname of the value object to convert the output to.
+     * @return $this
+     * @see self::asClass()
+     */
+    public function as($class)
+    {
+        return $this->asClass($class);
+    }
+
+    /**
      * Run a pagination count query.
      *
      * @param  array  $columns
@@ -3092,6 +3118,12 @@ class Builder
 
         if (Str::startsWith($method, 'where')) {
             return $this->dynamicWhere($method, $parameters);
+        }
+
+        if (Str::endsWith($method, 'As')) {
+            $this->asClass(array_shift($parameters));
+            $method = substr($method, 0, strlen($method) - 2);
+            return $this->$method($parameters);
         }
 
         static::throwBadMethodCallException($method);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2256,6 +2256,33 @@ class Builder
         return $this->asClass($class);
     }
 
+
+    /**
+     * Dynamically call `asClass` when calling another method as well.
+     *
+     * @param  string  $method
+     * @param  array   $parameters
+     * @return void
+     */
+    public function dynamicAs($method, $parameters)
+    {
+        // First parameter much be the class name, so let's pass that into `asClass`
+        // and remove it from the parameters array, so that the rest of the parameters can
+        // be passed to the $method.
+        $this->asClass(array_shift($parameters));
+
+        // Remove "As" from the end of the $method name, so that we can call $method.
+        $method = substr($method, 0, strlen($method) - 2);
+
+        // If the $parameters is empty, call $method without passing in parameters,
+        // or else the default parameters won't be used.
+        if (empty($parameters)) {
+            return $this->$method();
+        }
+
+        return $this->$method($parameters);
+    }
+
     /**
      * Run a pagination count query.
      *
@@ -3121,9 +3148,7 @@ class Builder
         }
 
         if (Str::endsWith($method, 'As')) {
-            $this->asClass(array_shift($parameters));
-            $method = substr($method, 0, strlen($method) - 2);
-            return $this->$method($parameters);
+            return $this->dynamicAs($method, $parameters);
         }
 
         static::throwBadMethodCallException($method);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2256,7 +2256,6 @@ class Builder
         return $this->asClass($class);
     }
 
-
     /**
      * Dynamically call `asClass` when calling another method as well.
      *

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2622,9 +2622,9 @@ class DatabaseQueryBuilderTest extends TestCase
 
     public function testJsonPathEscaping()
     {
-//         $expectedWithJsonEscaped = <<<SQL
-// select json_unquote(json_extract(`json`, '$."\'))#"'))
-// SQL;
+        $expectedWithJsonEscaped = <<<SQL
+select json_unquote(json_extract(`json`, '$."\'))#"'))
+SQL;
 
         $builder = $this->getMySqlBuilder();
         $builder->select("json->'))#");

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -186,4 +186,33 @@ class QueryBuilderTest extends DatabaseTestCase
             (object) ['title' => 'Bar Post', 'content' => 'Lorem Ipsum.'],
         ]);
     }
+
+    public function testConvertingToValueObjectClass()
+    {
+        $result = DB::table('posts')->as(PostValueObject::class)->first();
+
+        $this->assertInstanceOf(PostValueObject::class, $result);
+        $this->assertEquals('Lorem Ipsum.', $result->content);
+    }
+
+    public function testConvertingToValueObjectClassWithFirstAs()
+    {
+        $result = DB::table('posts')->firstAs(PostValueObject::class);
+
+        $this->assertInstanceOf(PostValueObject::class, $result);
+        $this->assertEquals('Lorem Ipsum.', $result->content);
+
+        $result = DB::table('posts')->firstAs(PostValueObject::class, 'id', 'title', 'content');
+
+        $this->assertInstanceOf(PostValueObject::class, $result);
+        $this->assertEquals('Lorem Ipsum.', $result->content);
+    }
+}
+
+class PostValueObject
+{
+    public $id;
+    public $title;
+    public $content;
+    public $created_at;
 }


### PR DESCRIPTION
This adds the ability to pull items from the database as a pre-defined class instead of only as a `stdClass`.

This is particularly helpful in cases where you have a large number of joins and select specific values. For example, in our project, we have database tables that follow a schema defined by a tool we utilize, and so to get reasonable information, we end up having to do 5 separate joins. In this case, an Eloquent model does not make as much sense as just a Value Object. This would allow us to define that value object, and have the queries set directly onto that value object, instead of having to convert from a stdClass.

Think of it like a half-way point between full eloquent and basic stdClass.

This adds 2 methods, as well as dynamic versions of the functionality, to the Query Builder:

- `asClass`: Sets the Class that the return should be.
- `as`: This is just an alias for `asClass` for ease on a developer and improved readability.
- `<method>As`: first calls `asClass`, then calls `<method>`. The first parameter is the class, and the rest of the parameters are passed to `<method>`. This allows for calling `getAs(Object::class)` for example.

Under the hood, this uses the PDO::FETCH_CLASS fetch type. This just reveals this functionality into the query builder.

If you try to call the `asClass` or `as` methods on an Eloquent Query builder, it just silently ignores it, as we are already returned a class for that.

This doesn't change any existing functionality, only adds new functionality, so it has no backwards compatibility breaks.

### Usage Example:
-----

```php
// Returns: Collection of PostMetaValueObject
$postMetas = DB::table('post')
    ->join('post_metadata as pm', 'pm.post_id', '=', 'post.id')
    ->select([
        'post.title',
        ...
        'pm.location',
    ])->getAs(PostMetaValueObject::class);

// Or

$postMetas = DB::table('post')
    ->join('post_metadata as pm', 'pm.post_id', '=', 'post.id')
    ->select([
        'post.title',
        ...
        'pm.location',
    ])->as(PostMetaValueObject::class)
    ->get();
```