### PR TITLE
[6.x] Avoid deadlock in test when sharing process group

### DIFF
--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -448,6 +448,8 @@ class FilesystemTest extends TestCase
         $content = str_repeat('123456', 1000000);
         $result = 1;
 
+        posix_setpgid(0, 0);
+
         for ($i = 1; $i <= 20; $i++) {
             $pid = pcntl_fork();
 


### PR DESCRIPTION
The testSharedGet test spawns child processes and waits for them to
exit. The main process will wait for all child processes in its own
process group.

While this usually works, the processes involved in the test case are
not necessarily the only processes in their process group. Should
PHPUnit itself be executing in a child process, its parent process
will also be there, causing a deadlock.

This change will move the main test process into its own process group
before forking to avoid the aforementioned situation.