### PR TITLE
[7.x] No slashed SQS prefix when prefix ends with a hyphen or underscore

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -149,8 +149,12 @@ class SqsQueue extends Queue implements QueueContract
     {
         $queue = $queue ?: $this->default;
 
+        $prefix = Str::endsWith($this->prefix, ['-', '_']) === true
+            ? $this->prefix
+            : rtrim($this->prefix, '/').'/';
+
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-            ? rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix)
+            ? $prefix.Str::finish($queue, $this->suffix)
             : $queue;
     }
 


### PR DESCRIPTION
Goal: only set a slashed prefix when the prefix does not end with a hyphen or underscore.

Original commit on the slashed prefix: https://github.com/laravel/framework/commit/384897eda1821611488308a06df19ccf6f16116f

I can see why the trailing slash on the prefix works in a single queue/single environment (and to prevent a boatload of 400 bad requests on faulty urls)
Facing multiple queues on SQS together with multiple environments brings a challenge in the configuration and usage setup.

With this PR I would like to propose to not create a slashed prefix if one of the regular divider characters `-` and `_` are at the end.
(AWS SQS naming docs at: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html)
This will greatly improve the ease of adding multiple queues on a single SQS connection for multiple environments (instead of creating a bypass or passing full urls into jobs and workers)

Default scenario 1
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/high`

Default scenario 2
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/high`

Current non-working scenario on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test-`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test-/high` <-- incorrect url

New scenario 1 on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test-`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test-high`

New scenario 2 on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test_`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test_high`

Feedback is more than welcome. Please let me know if I need to supply more details/examples or add to a certain test to validate this addition.