### PR TITLE
[7.x] Added configurable key for destroy method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -890,7 +890,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a
         // correct set of attributes in case the developers wants to check these.
-        $key = $key ?? ($instance = new static)->getKeyName();
+        $instance = new static;
+        $key = $key ?? $instance->getKeyName();
 
         foreach ($instance->whereIn($key, $ids)->get() as $model) {
             if ($model->delete()) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -871,9 +871,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * Destroy the models for the given IDs.
      *
      * @param  \Illuminate\Support\Collection|array|int  $ids
+     * @param  string|null  $key
      * @return int
      */
-    public static function destroy($ids)
+    public static function destroy($ids, string $key = null)
     {
         // We'll initialize a count here so we will return the total number of deletes
         // for the operation. The developers can then check this number as a boolean
@@ -889,7 +890,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         // We will actually pull the models from the database table and call delete on
         // each of them individually so that their events get fired properly with a
         // correct set of attributes in case the developers wants to check these.
-        $key = ($instance = new static)->getKeyName();
+        $key = $key ?? ($instance = new static)->getKeyName();
 
         foreach ($instance->whereIn($key, $ids)->get() as $model) {
             if ($model->delete()) {


### PR DESCRIPTION
Currently Eloquent Model `destroy()` method is fetching objects from DB only by primary key.
This PR allows passing a second optional parametar to that method to specify which column to look at.