### PR TITLE
[7.x] Fix docblock

### DIFF
--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -293,7 +293,7 @@ class Factory implements FactoryContract
      * Get the extension used by the view file.
      *
      * @param  string  $path
-     * @return string
+     * @return string|null
      */
     protected function getExtension($path)
     {


### PR DESCRIPTION
The `Arr::first` function will return _null_ when no item is satisfied which makes `null` a possible return value of the `getExtension` function.