### PR TITLE
[7.x ] Publish rule stub

### DIFF
--- a/src/Illuminate/Foundation/Console/RuleMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/RuleMakeCommand.php
@@ -34,7 +34,11 @@ class RuleMakeCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/rule.stub';
+        $relativePath = '/stubs/rule.stub';
+
+        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
+            ? $customPath
+            : __DIR__.$relativePath;
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/StubPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/StubPublishCommand.php
@@ -45,6 +45,7 @@ class StubPublishCommand extends Command
             realpath(__DIR__.'/../../Database/Migrations/stubs/migration.update.stub') => $stubsPath.'/migration.update.stub',
             realpath(__DIR__.'/../../Foundation/Console/stubs/policy.plain.stub') => $stubsPath.'/policy.plain.stub',
             realpath(__DIR__.'/../../Foundation/Console/stubs/policy.stub') => $stubsPath.'/policy.stub',
+            realpath(__DIR__.'/../../Foundation/Console/stubs/rule.stub') => $stubsPath.'/rule.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.api.stub') => $stubsPath.'/controller.api.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.invokable.stub') => $stubsPath.'/controller.invokable.stub',
             realpath(__DIR__.'/../../Routing/Console/stubs/controller.model.api.stub') => $stubsPath.'/controller.model.api.stub',

--- a/src/Illuminate/Foundation/Console/stubs/rule.stub
+++ b/src/Illuminate/Foundation/Console/stubs/rule.stub
@@ -1,10 +1,10 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Contracts\Validation\Rule;
 
-class DummyClass implements Rule
+class {{ class }} implements Rule
 {
     /**
      * Create a new rule instance.


### PR DESCRIPTION
This PR adds the `rule.stub` to the files that will be published when running `php artisan stub:publish`.

If there is a published stub, `make:rule` will make use of it.