### PR TITLE
[7.x] No slashed SQS prefix when prefix ends with a hyphen or underscore

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -149,8 +149,12 @@ class SqsQueue extends Queue implements QueueContract
     {
         $queue = $queue ?: $this->default;
 
+        $prefix = Str::endsWith($this->prefix, ['-', '_']) === true
+            ? $this->prefix
+            : rtrim($this->prefix, '/').'/';
+
         return filter_var($queue, FILTER_VALIDATE_URL) === false
-            ? rtrim($this->prefix, '/').'/'.Str::finish($queue, $this->suffix)
+            ? $prefix.Str::finish($queue, $this->suffix)
             : $queue;
     }
 

--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -149,9 +149,9 @@ class SqsQueue extends Queue implements QueueContract
     {
         $queue = $queue ?: $this->default;
 
-        $prefix = Str::endsWith($this->prefix, ['-', '_']) === true
-            ? $this->prefix
-            : rtrim($this->prefix, '/').'/';
+        $prefix = Str::endsWith($this->prefix, ['-', '_']) === false
+            ? rtrim($this->prefix, '/').'/'
+            : $this->prefix;
 
         return filter_var($queue, FILTER_VALIDATE_URL) === false
             ? $prefix.Str::finish($queue, $this->suffix)

--- a/tests/Queue/QueueSqsQueueTest.php
+++ b/tests/Queue/QueueSqsQueueTest.php
@@ -161,4 +161,16 @@ class QueueSqsQueueTest extends TestCase
         $queueUrl = $this->baseUrl.'/'.$this->account.'/test'.$suffix;
         $this->assertEquals($queueUrl, $queue->getQueue('test-staging'));
     }
+
+    public function testGetQueueWithoutAddingTrailingSlashAfterPrefix()
+    {
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix.'staging');
+        $this->assertEquals($this->prefix.'staging/'.$this->queueName, $queue->getQueue($this->queueName));
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix.'staging-');
+        $this->assertEquals($this->prefix.'staging-'.$this->queueName, $queue->getQueue($this->queueName));
+
+        $queue = new SqsQueue($this->sqs, $this->queueName, $this->prefix.'staging_');
+        $this->assertEquals($this->prefix.'staging_'.$this->queueName, $queue->getQueue($this->queueName));
+    }
 }


### PR DESCRIPTION
This is the follow-up for https://github.com/laravel/framework/pull/32081

**Goal**: only set a slashed prefix when the prefix does not end with a hyphen or underscore.

Original commit on the slashed prefix: https://github.com/laravel/framework/commit/384897eda1821611488308a06df19ccf6f16116f

I can see why the trailing slash on the prefix works in a single queue/single environment (and to prevent a boatload of 400 bad requests on faulty urls)
Facing multiple queues on SQS together with multiple environments brings a challenge in the configuration and usage setup.

With this PR I would like to propose to not create a slashed prefix if one of the regular divider characters `-` and `_` are at the end.
(AWS SQS naming docs at: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html)
This will greatly improve the ease of adding multiple queues on a single SQS connection for multiple environments (instead of creating a bypass or passing full urls into jobs and workers)

Default scenario 1
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/high`

Default scenario 2
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/high`

Current non-working scenario on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test-`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test-/high` <-- incorrect url

New scenario 1 on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test-`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test-high`

New scenario 2 on a test-environment
`SQS_PREFIX=https://sqs.eu-west-1.amazonaws.com/1337/test_`
Result: `https://sqs.eu-west-1.amazonaws.com/1337/test_high`

Extra explanation:
1 : The SQS is the only queue in the framework with the granular prefix/suffix options
2: Removing the trailing slash will break backwards compatibility
3: The suffix is (sometimes) used for the split between staging and production. With AWS SQS it's common to have the environment as a prefix, since the AWS SQS console filters on a `"<query>*"` pattern.

Feedback is more than welcome. Please let me know if I need to supply more details/examples or add to a certain test to validate this addition.