### PR TITLE
[8.x] Method to determine if all elements are equals in collection

### DIFF
--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -228,6 +228,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function every($key, $operator = null, $value = null);
 
     /**
+     * Determine if all items are equals.
+     *
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function allEquals(callable $callback = null);
+
+    /**
      * Get all items except for those with the specified keys.
      *
      * @param  mixed  $keys

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -223,6 +223,29 @@ trait EnumeratesValues
     }
 
     /**
+     * Determine if all items are equals.
+     *
+     * @param  callable  $callback
+     * @return bool
+     */
+    public function allEquals(callable $callback = null)
+    {
+        if ($this->isEmpty()) {
+            return true;
+        }
+
+        $callback = $callback ?? function ($element) {
+            return $element;
+        };
+
+        $baseToCompare = $callback($this->first());
+
+        return $this->every(function ($element) use ($callback, $baseToCompare) {
+            return $baseToCompare === $callback($element);
+        });
+    }
+
+    /**
      * Get the first item by the given key value pair.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4120,7 +4120,7 @@ class SupportCollectionTest extends TestCase
             ['simpleKey' => 'simpleValue'],
             ['simpleKey' => 'anotherSimpleValue'],
         ])->collect();
-        $this->assertfalse(
+        $this->assertFalse(
             $dataWithCustomElementNotRepeated->allEquals(function ($element) {
                 return $element['simpleKey'];
             })

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4092,6 +4092,42 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testAllEquals($collection)
+    {
+        $emptyCollection = $collection::make([])->collect();
+        $this->assertTrue($emptyCollection->allEquals());
+
+        $dataWithSingleElement = $collection::make([1])->collect();
+        $dataWithSimpleRepeated = $collection::make([1, 1])->collect();
+        $dataWithSimpleNotRepeated = $collection::make([1, 2])->collect();
+        $this->assertTrue($dataWithSingleElement->allEquals());
+        $this->assertTrue($dataWithSimpleRepeated->allEquals());
+        $this->assertFalse($dataWithSimpleNotRepeated->allEquals());
+
+        $dataWithCustomElementRepeated = $collection::make([
+            ['simpleKey' => 'simpleValue'],
+            ['simpleKey' => 'simpleValue'],
+        ])->collect();
+        $this->assertTrue(
+            $dataWithCustomElementRepeated->allEquals(function ($element) {
+                return $element['simpleKey'];
+            })
+        );
+
+        $dataWithCustomElementNotRepeated = $collection::make([
+            ['simpleKey' => 'simpleValue'],
+            ['simpleKey' => 'anotherSimpleValue'],
+        ])->collect();
+        $this->assertfalse(
+            $dataWithCustomElementNotRepeated->allEquals(function ($element) {
+                return $element['simpleKey'];
+            })
+        );
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello!

I realized that it is very common in some of my applications a necessity of check if all elements (or attributes of them) in an collection are equals.

In this PR, I implemented a allEquals (I'm accepting suggestions of better names) method to solve this:

``` php
collect([
    1,
    1,
])->allEquals(); // true

collect([
    1,
    2,
])->allEquals(); // false
```

Its possible to handle more complex cases using a callback:
``` php
collect([
    new User(['name' => 'Robert', 'age'  => 25]),
    new User(['name' => 'Bob', 'age'  => 25]),
])->allEquals(function ($element) {
  return $element->age;
}); // true

collect([
    new User(['name' => 'Robert', 'age'  => 25]),
    new User(['name' => 'Bob', 'age'  => 25]),
])->allEquals(function ($element) {
  return $element->name;
}); // false
```

Suggestions are welcome!
Thanks.