### PR TITLE
[7.x] Use standard {{ rootNamespace }} instead of DummyRootNamespace

### DIFF
--- a/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
+++ b/src/Illuminate/Routing/Console/stubs/controller.invokable.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use DummyRootNamespaceHttp\Controllers\Controller;
+use {{ rootNamespace }}Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
 class {{ class }} extends Controller


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
