### PR TITLE
[7.x] Correct argument data type

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -178,7 +178,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected function getOpenAndClosingPhpTokens($contents)
     {
         return collect(token_get_all($contents))
-            ->pluck(0)
+            ->pluck('0')
             ->filter(function ($token) {
                 return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
             });


### PR DESCRIPTION
The number 0 works fine even though we state very clear that the `pluck` method of the Collection class accepts `string|array`.

https://github.com/laravel/framework/blob/60f3e5a8ba06c08bc0ab21d0f698ed29cbfc6c13/src/Illuminate/Support/Collection.php#L616-L626

This works because deep inside we're using the `explode` function which turns this number into a string anyway.

I have checked the entire codebase and nowhere we're passing a number into the Collection `pluck` method like this.