### PR TITLE
[7.x] Optimize conditions.

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -164,7 +164,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      */
     protected function userFromRecaller($recaller)
     {
-        if (! $recaller->valid() || $this->recallAttempted) {
+        if ($this->recallAttempted || ! $recaller->valid()) {
             return;
         }
 

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -266,7 +266,7 @@ class BroadcastManager implements FactoryContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if ($name !== 'null' && ! is_null($name)) {
             return $this->app['config']["broadcasting.connections.{$name}"];
         }
 

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -23,7 +23,7 @@ class BoundMethod
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
-        if (static::isCallableWithAtSign($callback) || $defaultMethod) {
+        if ($defaultMethod || static::isCallableWithAtSign($callback)) {
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }
 

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -697,7 +697,7 @@ class Container implements ArrayAccess, ContainerContract
         // If the requested type is registered as a singleton we'll want to cache off
         // the instances in "memory" so we can return it later without creating an
         // entirely new instance of an object on each subsequent request for it.
-        if ($this->isShared($abstract) && ! $needsContextualBuild) {
+        if (! $needsContextualBuild && $this->isShared($abstract)) {
             $this->instances[$abstract] = $object;
         }
 
@@ -1010,7 +1010,7 @@ class Container implements ArrayAccess, ContainerContract
             $abstract = $this->getAlias($abstract);
         }
 
-        if (is_null($callback) && $abstract instanceof Closure) {
+        if ($abstract instanceof Closure && is_null($callback)) {
             $this->globalResolvingCallbacks[] = $abstract;
         } else {
             $this->resolvingCallbacks[$abstract][] = $callback;

--- a/src/Illuminate/Database/Concerns/ManagesTransactions.php
+++ b/src/Illuminate/Database/Concerns/ManagesTransactions.php
@@ -68,8 +68,8 @@ trait ManagesTransactions
         // On a deadlock, MySQL rolls back the entire transaction so we can't just
         // retry the query. We have to throw this exception all the way out and
         // let the developer handle it in another way. We will decrement too.
-        if ($this->causedByConcurrencyError($e) &&
-            $this->transactions > 1) {
+        if ($this->transactions > 1 &&
+            $this->causedByConcurrencyError($e)) {
             $this->transactions--;
 
             throw $e;
@@ -80,8 +80,8 @@ trait ManagesTransactions
         // if we haven't we will return and try this query again in our loop.
         $this->rollBack();
 
-        if ($this->causedByConcurrencyError($e) &&
-            $currentAttempt < $maxAttempts) {
+        if ($currentAttempt < $maxAttempts &&
+            $this->causedByConcurrencyError($e)) {
             return;
         }
 
@@ -191,8 +191,8 @@ trait ManagesTransactions
     {
         $this->transactions--;
 
-        if ($this->causedByConcurrencyError($e) &&
-            $currentAttempt < $maxAttempts) {
+        if ($currentAttempt < $maxAttempts &&
+            $this->causedByConcurrencyError($e)) {
             return;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -184,7 +184,7 @@ trait GuardsAttributes
      */
     protected function fillableFromArray(array $attributes)
     {
-        if (count($this->getFillable()) > 0 && ! static::$unguarded) {
+        if (! static::$unguarded && count($this->getFillable()) > 0) {
             return array_intersect_key($attributes, array_flip($this->getFillable()));
         }
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -316,7 +316,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $class = $class ?: static::class;
 
-        if (! get_class_vars($class)['timestamps'] || ! $class::UPDATED_AT) {
+        if (! $class::UPDATED_AT || ! get_class_vars($class)['timestamps']) {
             return true;
         }
 
@@ -733,7 +733,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $this->fireModelEvent('saved', false);
 
-        if ($this->isDirty() && ($options['touch'] ?? true)) {
+        if (($options['touch'] ?? true) && $this->isDirty()) {
             $this->touchOwners();
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -692,7 +692,7 @@ class Builder
         // If the column is making a JSON reference we'll check to see if the value
         // is a boolean. If it is, we'll add the raw boolean string as an actual
         // value to the query to ensure this is properly handled by the query.
-        if (Str::contains($column, '->') && is_bool($value)) {
+        if (is_bool($value) && Str::contains($column, '->')) {
             $value = new Expression($value ? 'true' : 'false');
 
             if (is_string($column)) {

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -175,11 +175,11 @@ class Blueprint
      */
     protected function addImpliedCommands(Grammar $grammar)
     {
-        if (count($this->getAddedColumns()) > 0 && ! $this->creating()) {
+        if (! $this->creating() && count($this->getAddedColumns()) > 0) {
             array_unshift($this->commands, $this->createCommand('add'));
         }
 
-        if (count($this->getChangedColumns()) > 0 && ! $this->creating()) {
+        if (! $this->creating() && count($this->getChangedColumns()) > 0) {
             array_unshift($this->commands, $this->createCommand('change'));
         }
 

--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -971,7 +971,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($column->autoIncrement && in_array($column->type, $this->serials)) {
             return ' auto_increment primary key';
         }
     }
@@ -1027,7 +1027,7 @@ class MySqlGrammar extends Grammar
      */
     protected function modifySrid(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->srid) && is_int($column->srid) && $column->srid > 0) {
+        if ($column->srid > 0 && is_int($column->srid) && ! is_null($column->srid)) {
             return ' srid '.$column->srid;
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/PostgresGrammar.php
@@ -948,7 +948,7 @@ class PostgresGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if ((in_array($column->type, $this->serials) || ($column->generatedAs !== null)) && $column->autoIncrement) {
+        if ($column->autoIncrement && (in_array($column->type, $this->serials) || ($column->generatedAs !== null))) {
             return ' primary key';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -857,7 +857,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($column->autoIncrement && in_array($column->type, $this->serials)) {
             return ' primary key autoincrement';
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -843,7 +843,7 @@ class SqlServerGrammar extends Grammar
      */
     protected function modifyIncrement(Blueprint $blueprint, Fluent $column)
     {
-        if (in_array($column->type, $this->serials) && $column->autoIncrement) {
+        if ($column->autoIncrement && in_array($column->type, $this->serials)) {
             return ' identity primary key';
         }
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -611,7 +611,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function register($provider, $force = false)
     {
-        if (($registered = $this->getProvider($provider)) && ! $force) {
+        if (! $force && ($registered = $this->getProvider($provider))) {
             return $registered;
         }
 
@@ -802,7 +802,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     protected function loadDeferredProviderIfNeeded($abstract)
     {
-        if ($this->isDeferredService($abstract) && ! isset($this->instances[$abstract])) {
+        if (! isset($this->instances[$abstract]) && $this->isDeferredService($abstract)) {
             $this->loadDeferredProvider($abstract);
         }
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -519,7 +519,7 @@ trait MakesHttpRequests
      */
     protected function formatServerHeaderKey($name)
     {
-        if (! Str::startsWith($name, 'HTTP_') && $name !== 'CONTENT_TYPE' && $name !== 'REMOTE_ADDR') {
+        if ($name !== 'REMOTE_ADDR' && $name !== 'CONTENT_TYPE' && ! Str::startsWith($name, 'HTTP_')) {
             return 'HTTP_'.$name;
         }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MocksApplicationServices.php
@@ -223,8 +223,8 @@ trait MocksApplicationServices
     protected function wasDispatched($needle, array $haystack)
     {
         foreach ($haystack as $dispatched) {
-            if ((is_string($dispatched) && ($dispatched === $needle || is_subclass_of($dispatched, $needle))) ||
-                $dispatched instanceof $needle) {
+            if ($dispatched instanceof $needle ||
+                (is_string($dispatched) && ($dispatched === $needle || is_subclass_of($dispatched, $needle)))) {
                 return true;
             }
         }
@@ -267,9 +267,9 @@ trait MocksApplicationServices
             foreach ($this->dispatchedNotifications as $dispatched) {
                 $notified = $dispatched['notifiable'];
 
-                if (($notified === $notifiable ||
-                     $notified->getKey() == $notifiable->getKey()) &&
-                    get_class($dispatched['instance']) === $notification
+                if (get_class($dispatched['instance']) === $notification &&
+                    ($notified === $notifiable ||
+                     $notified->getKey() == $notifiable->getKey())
                 ) {
                     return $this;
                 }

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -75,9 +75,9 @@ trait ConditionallyLoadsAttributes
 
         foreach ($data as $key => $value) {
             if (($value instanceof PotentiallyMissing && $value->isMissing()) ||
-                ($value instanceof self &&
-                $value->resource instanceof PotentiallyMissing &&
-                $value->isMissing())) {
+                ($value->isMissing() &&
+                 $value instanceof self &&
+                 $value->resource instanceof PotentiallyMissing)) {
                 unset($data[$key]);
             } else {
                 $numericKeys = $numericKeys && is_numeric($key);

--- a/src/Illuminate/Mail/SendQueuedMailable.php
+++ b/src/Illuminate/Mail/SendQueuedMailable.php
@@ -82,7 +82,7 @@ class SendQueuedMailable
      */
     public function retryAfter()
     {
-        if (! method_exists($this->mailable, 'retryAfter') && ! isset($this->mailable->retryAfter)) {
+        if (! isset($this->mailable->retryAfter) && ! method_exists($this->mailable, 'retryAfter')) {
             return;
         }
 

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -51,8 +51,8 @@ class MailChannel
     {
         $message = $notification->toMail($notifiable);
 
-        if (! $notifiable->routeNotificationFor('mail', $notification) &&
-            ! $message instanceof Mailable) {
+        if (! $message instanceof Mailable &&
+            ! $notifiable->routeNotificationFor('mail', $notification)) {
             return;
         }
 

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -124,7 +124,7 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function retryAfter()
     {
-        if (! method_exists($this->notification, 'retryAfter') && ! isset($this->notification->retryAfter)) {
+        if (! isset($this->notification->retryAfter) && ! method_exists($this->notification, 'retryAfter')) {
             return;
         }
 
@@ -138,7 +138,7 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function retryUntil()
     {
-        if (! method_exists($this->notification, 'retryUntil') && ! isset($this->notification->timeoutAt)) {
+        if (! isset($this->notification->timeoutAt) && ! method_exists($this->notification, 'retryUntil')) {
             return;
         }
 

--- a/src/Illuminate/Pagination/PaginationServiceProvider.php
+++ b/src/Illuminate/Pagination/PaginationServiceProvider.php
@@ -40,7 +40,7 @@ class PaginationServiceProvider extends ServiceProvider
         Paginator::currentPageResolver(function ($pageName = 'page') {
             $page = $this->app['request']->input($pageName);
 
-            if (filter_var($page, FILTER_VALIDATE_INT) !== false && (int) $page >= 1) {
+            if ((int) $page >= 1 && filter_var($page, FILTER_VALIDATE_INT) !== false) {
                 return (int) $page;
             }
 

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -169,7 +169,7 @@ abstract class Queue
      */
     public function getJobRetryDelay($job)
     {
-        if (! method_exists($job, 'retryAfter') && ! isset($job->retryAfter)) {
+        if (! isset($job->retryAfter) && ! method_exists($job, 'retryAfter')) {
             return;
         }
 
@@ -187,7 +187,7 @@ abstract class Queue
      */
     public function getJobExpiration($job)
     {
-        if (! method_exists($job, 'retryUntil') && ! isset($job->timeoutAt)) {
+        if (! isset($job->timeoutAt) && ! method_exists($job, 'retryUntil')) {
             return;
         }
 

--- a/src/Illuminate/Queue/QueueManager.php
+++ b/src/Illuminate/Queue/QueueManager.php
@@ -207,7 +207,7 @@ class QueueManager implements FactoryContract, MonitorContract
      */
     protected function getConfig($name)
     {
-        if (! is_null($name) && $name !== 'null') {
+        if ($name !== 'null' && ! is_null($name)) {
             return $this->app['config']["queue.connections.{$name}"];
         }
 

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -229,7 +229,7 @@ class RedisQueue extends Queue implements QueueContract
 
         [$job, $reserved] = $nextJob;
 
-        if (! $job && ! is_null($this->blockFor) && $block &&
+        if ($block && ! $job && ! is_null($this->blockFor) &&
             $this->getConnection()->blpop([$queue.':notify'], $this->blockFor)) {
             return $this->retrieveNextJob($queue, false);
         }

--- a/src/Illuminate/Routing/Pipeline.php
+++ b/src/Illuminate/Routing/Pipeline.php
@@ -39,8 +39,8 @@ class Pipeline extends BasePipeline
      */
     protected function handleException($passable, Throwable $e)
     {
-        if (! $this->container->bound(ExceptionHandler::class) ||
-            ! $passable instanceof Request) {
+        if (! $passable instanceof Request ||
+            ! $this->container->bound(ExceptionHandler::class)) {
             throw $e;
         }
 

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -36,7 +36,7 @@ class RouteSignatureParameters
     {
         [$class, $method] = Str::parseCallback($uses);
 
-        if (! method_exists($class, $method) && is_callable($class, $method)) {
+        if (is_callable($class, $method) && ! method_exists($class, $method)) {
             return [];
         }
 

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -97,7 +97,7 @@ class Store implements Session
         if ($data = $this->handler->read($this->getId())) {
             $data = @unserialize($this->prepareForUnserialize($data));
 
-            if ($data !== false && ! is_null($data) && is_array($data)) {
+            if (is_array($data) && $data !== false && ! is_null($data)) {
                 return $data;
             }
         }

--- a/src/Illuminate/Support/Traits/ForwardsCalls.php
+++ b/src/Illuminate/Support/Traits/ForwardsCalls.php
@@ -28,8 +28,8 @@ trait ForwardsCalls
                 throw $e;
             }
 
-            if ($matches['class'] != get_class($object) ||
-                $matches['method'] != $method) {
+            if ($matches['method'] != $method ||
+                $matches['class'] != get_class($object)) {
                 throw $e;
             }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -815,7 +815,7 @@ class TestResponse implements ArrayAccess
     {
         $decodedResponse = json_decode($this->getContent(), true);
 
-        if (is_null($decodedResponse) || $decodedResponse === false) {
+        if ($decodedResponse === false || is_null($decodedResponse)) {
             if ($this->exception) {
                 throw $this->exception;
             } else {

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -63,7 +63,7 @@ class FileLoader implements Loader
             return $this->loadJsonPaths($locale);
         }
 
-        if (is_null($namespace) || $namespace === '*') {
+        if ($namespace === '*' || is_null($namespace)) {
             return $this->loadPath($this->path, $locale, $group);
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -917,11 +917,11 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ((is_numeric($value) && is_numeric($parameters[0])) && is_null($comparedToValue)) {
             return $this->getSize($attribute, $value) > $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (is_numeric($comparedToValue) && is_numeric($value) && $this->hasRule($attribute, $this->numericRules)) {
             return $value > $comparedToValue;
         }
 
@@ -948,11 +948,11 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lt');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ((is_numeric($value) && is_numeric($parameters[0])) && is_null($comparedToValue)) {
             return $this->getSize($attribute, $value) < $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (is_numeric($comparedToValue) && is_numeric($value) && $this->hasRule($attribute, $this->numericRules)) {
             return $value < $comparedToValue;
         }
 
@@ -979,11 +979,11 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Gte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ((is_numeric($value) && is_numeric($parameters[0])) && is_null($comparedToValue)) {
             return $this->getSize($attribute, $value) >= $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (is_numeric($comparedToValue) && is_numeric($value) && $this->hasRule($attribute, $this->numericRules)) {
             return $value >= $comparedToValue;
         }
 
@@ -1010,11 +1010,11 @@ trait ValidatesAttributes
 
         $this->shouldBeNumeric($attribute, 'Lte');
 
-        if (is_null($comparedToValue) && (is_numeric($value) && is_numeric($parameters[0]))) {
+        if ((is_numeric($value) && is_numeric($parameters[0])) && is_null($comparedToValue)) {
             return $this->getSize($attribute, $value) <= $parameters[0];
         }
 
-        if ($this->hasRule($attribute, $this->numericRules) && is_numeric($value) && is_numeric($comparedToValue)) {
+        if (is_numeric($comparedToValue) && is_numeric($value) && $this->hasRule($attribute, $this->numericRules)) {
             return $value <= $comparedToValue;
         }
 

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -48,7 +48,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
     {
         $query = $this->table($collection)->where($column, '=', $value);
 
-        if (! is_null($excludeId) && $excludeId !== 'NULL') {
+        if ($excludeId !== 'NULL' && ! is_null($excludeId)) {
             $query->where($idColumn ?: 'id', '<>', $excludeId);
         }
 

--- a/tests/Database/DatabaseConnectorTest.php
+++ b/tests/Database/DatabaseConnectorTest.php
@@ -189,8 +189,8 @@ class DatabaseConnectorTest extends TestCase
 
         $availableDrivers = PDO::getAvailableDrivers();
 
-        if (in_array('odbc', $availableDrivers) &&
-            ($config['odbc'] ?? null) === true) {
+        if (($config['odbc'] ?? null) === true &&
+            in_array('odbc', $availableDrivers)) {
             return isset($config['odbc_datasource_name'])
                 ? 'odbc:'.$config['odbc_datasource_name'] : '';
         }


### PR DESCRIPTION
Some conditions are notably more costly than other ones.
For instance, as strict comparisons, will always be faster to execute than any function.

In compound AND and OR conditions, it makes sense to always evaluate the fastest condition first, to avoid extra necessary compute time.

---

The modified `\Illuminate\Auth\SessionGuard::userFromRecaller` method is a good example.
If `$this->recallAttempted` is falsy we return right away; in the previous implementation, `$recaller->valid()` was calling 2 extra methods.

---

None of the conditions base behaivours have been altered.