### PR TITLE
[8.x] Switched to dragonmantank/cron-expression v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^1.1",
-        "dragonmantank/cron-expression": "^2.0",
+        "dragonmantank/cron-expression": "^3.0",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",
         "league/flysystem": "^1.0.8",

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "suggest": {
-        "dragonmantank/cron-expression": "Required to use scheduler (^2.0).",
+        "dragonmantank/cron-expression": "Required to use scheduler (^3.0).",
         "guzzlehttp/guzzle": "Required to use the ping methods on schedules (^6.3.1|^7.0).",
         "illuminate/bus": "Required to use the scheduled job dispatcher (^8.0)",
         "illuminate/container": "Required to use the scheduler (^8.0)",


### PR DESCRIPTION
Their changes between v2 and v3 are outlined here: https://github.com/dragonmantank/cron-expression/releases/tag/v3.0.0.

Note that any PR that tries to change the version constraint to `^2.0|^3.0` on the 7.x branch should **not** be merged. v3 contains genuinely breaking changes, which may break apps. This PR itself will need to be listed on the Laravel 8 upgrading guide.