### PR TITLE
[7.x] Append accessors to relationships

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1422,15 +1422,15 @@ trait HasAttributes
         [$appends , $relationshipAppends]=  collect(array_unique(
             array_merge($this->appends, is_string($attributes) ? func_get_args() : $attributes)
         ))->partition(function ($append){
-            return strpos($append, '.') === false;
+            return !preg_match('/[.:]/', $append);
         });
 
         $appends->each(function ($append){
-            array_push($this->appends, $append);
+           $this->appends = array_merge($this->appends, explode(',',$append));
         });
 
             $relationshipAppends->each(function ($append){
-                [$relationKey, $accessor] = explode('.', $append, 2);
+                [$relationKey, $accessor] = preg_split('/[.:]/', $append, 2);
 
                 BaseCollection::wrap($this->getRelation($relationKey))->each->append($accessor);
             });

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1418,9 +1418,22 @@ trait HasAttributes
      */
     public function append($attributes)
     {
-        $this->appends = array_unique(
+
+        [$appends , $relationshipAppends]=  collect(array_unique(
             array_merge($this->appends, is_string($attributes) ? func_get_args() : $attributes)
-        );
+        ))->partition(function ($append){
+            return strpos($append, '.') === false;
+        });
+
+        $appends->each(function ($append){
+            array_push($this->appends, $append);
+        });
+
+            $relationshipAppends->each(function ($append){
+                [$relationKey, $accessor] = explode('.', $append);
+
+                BaseCollection::wrap($this->getRelation($relationKey))->each->append($accessor);
+            });
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1430,7 +1430,7 @@ trait HasAttributes
         });
 
             $relationshipAppends->each(function ($append){
-                [$relationKey, $accessor] = explode('.', $append);
+                [$relationKey, $accessor] = explode('.', $append, 2);
 
                 BaseCollection::wrap($this->getRelation($relationKey))->each->append($accessor);
             });

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1433,6 +1433,8 @@ trait HasAttributes
     }
 
     /**
+     * Append attributes to this model
+     *
      * @param  BaseCollection  $appends
      * @return  void
      */
@@ -1443,6 +1445,8 @@ trait HasAttributes
     }
 
     /**
+     * Send accessors to the related models
+     *
      * @param  BaseCollection  $appends
      * @return  void
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1434,6 +1434,7 @@ trait HasAttributes
 
     /**
      * @param  BaseCollection  $appends
+     * @return  void
      */
     protected function appendToSelf($appends){
         $appends->each(function ($append){
@@ -1443,6 +1444,8 @@ trait HasAttributes
 
     /**
      * @param  BaseCollection  $appends
+     * @return  void
+
      */
     protected function appendToRelation($appends)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1419,23 +1419,38 @@ trait HasAttributes
     public function append($attributes)
     {
 
-        [$appends , $relationshipAppends]=  collect(array_unique(
+        [$appends , $relationshipAppends] =  collect(array_unique(
             array_merge($this->appends, is_string($attributes) ? func_get_args() : $attributes)
         ))->partition(function ($append){
             return !preg_match('/[.:]/', $append);
         });
 
-        $appends->each(function ($append){
-           $this->appends = array_merge($this->appends, explode(',',$append));
-        });
+       $this->appendToSelf($appends);
 
-            $relationshipAppends->each(function ($append){
-                [$relationKey, $accessor] = preg_split('/[.:]/', $append, 2);
-
-                BaseCollection::wrap($this->getRelation($relationKey))->each->append($accessor);
-            });
+       $this->appendToRelation($relationshipAppends);
 
         return $this;
+    }
+
+    /**
+     * @param  BaseCollection  $appends
+     */
+    protected function appendToSelf($appends){
+        $appends->each(function ($append){
+            $this->appends = array_merge($this->appends, explode(',',$append));
+        });
+    }
+
+    /**
+     * @param  BaseCollection  $appends
+     */
+    protected function appendToRelation($appends)
+    {
+        $appends->each(function ($append){
+            [$relationKey, $accessor] = preg_split('/[.:]/', $append, 2);
+
+            BaseCollection::wrap($this->getRelation($relationKey))->each->append($accessor);
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1525,6 +1525,19 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals([], $model->toArray());
     }
 
+    public function testAppendingOfRelatedAttributes()
+    {
+        $model = new EloquentModelStub();
+
+        $model->setRelation('relatedToMany', new Collection([new EloquentModelAppendsStub(), new EloquentModelAppendsStub()]));
+        $model->setRelation('relatedToOne', new EloquentModelAppendsStub());
+
+        $model->append(['relatedToOne:is_admin,camelCased', 'relatedToMany:is_admin,camelCased']);
+
+        $this->assertArrayHasKey('camelCased', $model->relatedToOne->toArray());
+        $this->assertArrayHasKey('is_admin', $model->relatedToOne->toArray());
+    }
+
     public function testGetMutatedAttributes()
     {
         $model = new EloquentModelGetMutatorsStub;

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1534,8 +1534,10 @@ class DatabaseEloquentModelTest extends TestCase
 
         $model->append(['relatedToOne:is_admin,camelCased', 'relatedToMany:is_admin,camelCased']);
 
-        $this->assertArrayHasKey('camelCased', $model->relatedToOne->toArray());
-        $this->assertArrayHasKey('is_admin', $model->relatedToOne->toArray());
+        $model->relatedToMany->push($model->relatedToOne)->each(function ($relation){
+        $this->assertArrayHasKey('camelCased', $relation->toArray());
+        $this->assertArrayHasKey('is_admin', $relation->toArray());
+        });
     }
 
     public function testGetMutatedAttributes()


### PR DESCRIPTION
Sometimes when you query a model with relationships, the associated relationships have models with accessors that you want appended to them. Currently you need to do something like:
```  

   $u = User::first()->load('posts.comments');

   $u->posts->each(function ($post){
       $post->setAttribute('myPostAccessor', $post->myPostAccessor);
       $post->comments->each(function ($comment){
           $comment->setAttribute('myAccessor', $comment->myAccessor);
       });
   });
```
to append the accessor(s). While you can use `$with` on the model itself; not always do you want to have it permanently appended to the model. What this PR proposes is to be able to use a cleaner syntax to append accessors at runtime the same way currently used for eager loading:
```
 User::first()->load('posts.comments')
        ->append([
            'posts:fooAccessor,barAccessor', 
            'posts.comments:bazAccessor,quxAccessor'
        ]);
```
This is totally backwards compatible.
