### PR TITLE
[8.x] Skip date casting for custom casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -620,9 +620,7 @@ trait HasAttributes
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
             return $this->setMutatedAttributeValue($key, $value);
-        }
-
-        elseif ($this->isClassCastable($key)) {
+        } elseif ($this->isClassCastable($key)) {
             $this->setClassCastableAttribute($key, $value);
 
             return $this;

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -622,17 +622,17 @@ trait HasAttributes
             return $this->setMutatedAttributeValue($key, $value);
         }
 
+        elseif ($this->isClassCastable($key)) {
+            $this->setClassCastableAttribute($key, $value);
+
+            return $this;
+        }
+
         // If an attribute is listed as a "date", we'll convert it from a DateTime
         // instance into a form proper for storage on the database tables using
         // the connection grammar's date format. We will auto set the values.
         elseif ($value && $this->isDateAttribute($key)) {
             $value = $this->fromDateTime($value);
-        }
-
-        if ($this->isClassCastable($key)) {
-            $this->setClassCastableAttribute($key, $value);
-
-            return $this;
         }
 
         if ($this->isJsonCastable($key) && ! is_null($value)) {

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Integration\Database;
 
+use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Database\Eloquent\Model;
@@ -113,6 +114,13 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $this->assertSame('117 Spencer St.', $model->address->lineOne);
     }
+
+    public function testCustomCastSkipsDateCasting()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+
+        $model->updated_at = Carbon::now();
+    }
 }
 
 class TestEloquentModelWithCustomCast extends Model
@@ -135,6 +143,7 @@ class TestEloquentModelWithCustomCast extends Model
         'other_password' => HashCaster::class.':md5',
         'uppercase' => UppercaseCaster::class,
         'options' => JsonCaster::class,
+        'updated_at' => DateTimeWithMicrosecondsCaster::class,
     ];
 }
 
@@ -187,6 +196,21 @@ class JsonCaster implements CastsAttributes
     public function set($model, $key, $value, $attributes)
     {
         return json_encode($value);
+    }
+}
+
+class DateTimeWithMicrosecondsCaster implements CastsAttributes
+{
+    public function get($model, string $key, $value, array $attributes)
+    {
+        //
+    }
+
+    public function set($model, string $key, $value, array $attributes)
+    {
+        return is_null($value)
+            ? null
+            : $value->format('Y-m-d H:i:s.u');
     }
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 /**
  * @group integration
@@ -119,7 +120,11 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
     {
         $model = new TestEloquentModelWithCustomCast;
 
-        $model->updated_at = Carbon::now();
+        $model->updated_at = $now = Carbon::now()->microseconds(14);
+
+        $this->assertSame(14, $model->updated_at->microsecond);
+
+        $this->assertTrue(Str::endsWith(json_decode($model->toJson())->updated_at, '14Z'));
     }
 }
 
@@ -203,7 +208,9 @@ class DateTimeWithMicrosecondsCaster implements CastsAttributes
 {
     public function get($model, string $key, $value, array $attributes)
     {
-        //
+        return is_null($value)
+            ? null
+            : Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
     }
 
     public function set($model, string $key, $value, array $attributes)


### PR DESCRIPTION
Hey!

I just noticed, when you have custom casts on attributes which are also in the `$dates` property, they will first be cast to an date string and after that, the custom cast would be applied.

Considering this, custom casts could not be shared between dates that are defined in the `$dates` property and not. But why not just using the `$dateFormat` property? This property will be applied to all date attributes. So, mixed formats are not supported.

Example:

```php
class Task extends Model
{
    protected $casts = [
        'created_at'  => DateTimeWithMicrosecondsCaster::class,
        'finished_at' => DateTimeWithMicrosecondsCaster::class,
        'updated_at'  => 'datetime:Y-m-d H:i.s',
    ];
}

class DateTimeWithMicrosecondsCaster implements CastsAttributes
{
    public function get($model, string $key, $value, array $attributes)
    {
        return is_null($value)
            ? null
            : Carbon::createFromFormat('Y-m-d H:i:s.u', $value);
    }

    public function set($model, string $key, $value, array $attributes)
    {
        return is_null($value)
            ? null
            : $value->format('Y-m-d H:i:s.u');
    }
}
```

Note: This will be a breaking change, since users will eventually have to change their custom cast classes.