### PR TITLE
[6.x] Fix delete function of MorphPivots with primary key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -45,6 +45,10 @@ class MorphPivot extends Pivot
      */
     public function delete()
     {
+        if (isset($this->attributes[$this->getKeyName()])) {
+            return (int) parent::delete();
+        }
+
         if ($this->fireModelEvent('deleting') === false) {
             return 0;
         }


### PR DESCRIPTION
The AsPivot trait has a fallback to the delete function of the Model 
class if a primary key is set. So far, this fallback is missing in the 
overridden delete function of MorphPivot, which leads to errors upon 
calling it on MorphPivot models with a primary key.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
