### PR TITLE
[7.x] Eliminate the need to exclude soft delete records manually

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -37,6 +37,13 @@ trait DatabaseRule
     protected $using = [];
 
     /**
+     * The model being queried.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $model;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $table
@@ -62,10 +69,10 @@ trait DatabaseRule
             return $table;
         }
 
-        $model = new $table;
+        $this->model = new $table;
 
-        return $model instanceof Model
-                ? $model->getTable()
+        return $this->model instanceof Model
+                ? $this->model->getTable()
                 : $table;
     }
 

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -24,9 +24,9 @@ class Unique
     protected $idColumn = 'id';
 
     /**
-     * Indicates that the soft deleted records must be checked even if the model implements soft delete
+     * Indicates that the soft deleted records must be checked even if the model implements soft delete.
      *
-     * @var boolean
+     * @var bool
      */
     protected $checkSoftDelete = false;
 
@@ -65,7 +65,7 @@ class Unique
     }
 
     /**
-     * Checks for soft deleted records even if the model implements soft delete
+     * Checks for soft deleted records even if the model implements soft delete.
      * @return $this
      */
     public function checkSoftDelete()
@@ -76,7 +76,7 @@ class Unique
     }
 
     /**
-     * Eliminate the need to exclude soft delete records
+     * Eliminate the need to exclude soft delete records.
      * @return $this
      */
     protected function ignoreSoftDelete()
@@ -85,7 +85,7 @@ class Unique
             return $this;
         }
 
-        if (!$this->model->hasGlobalScope(SoftDeletingScope::class)) {
+        if (! $this->model->hasGlobalScope(SoftDeletingScope::class)) {
             return $this;
         }
 

--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Validation\Rules;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class Unique
 {
@@ -21,6 +22,13 @@ class Unique
      * @var string
      */
     protected $idColumn = 'id';
+
+    /**
+     * Indicates that the soft deleted records must be checked even if the model implements soft delete
+     *
+     * @var boolean
+     */
+    protected $checkSoftDelete = false;
 
     /**
      * Ignore the given ID during the unique check.
@@ -57,6 +65,44 @@ class Unique
     }
 
     /**
+     * Checks for soft deleted records even if the model implements soft delete
+     * @return $this
+     */
+    public function checkSoftDelete()
+    {
+        $this->checkSoftDelete = true;
+
+        return $this;
+    }
+
+    /**
+     * Eliminate the need to exclude soft delete records
+     * @return $this
+     */
+    protected function ignoreSoftDelete()
+    {
+        if (is_null($this->model)) {
+            return $this;
+        }
+
+        if (!$this->model->hasGlobalScope(SoftDeletingScope::class)) {
+            return $this;
+        }
+
+        if (collect($this->wheres)->firstWhere('column', $this->model->getDeletedAtColumn())) {
+            return $this;
+        }
+
+        if ($this->checkSoftDelete) {
+            return $this;
+        }
+
+        $this->whereNull($this->model->getDeletedAtColumn());
+
+        return $this;
+    }
+
+    /**
      * Convert the rule to a validation string.
      *
      * @return string
@@ -68,7 +114,7 @@ class Unique
             $this->column,
             $this->ignore ? '"'.addslashes($this->ignore).'"' : 'NULL',
             $this->idColumn,
-            $this->formatWheres()
+            $this->ignoreSoftDelete()->formatWheres()
         ), ',');
     }
 }


### PR DESCRIPTION
This pull request is for solving a problem to manually eliminate the soft deleted records in **Unique rule.** Currently, the developer has to write manually to exclude the soft deleted records for every model. With this modification, the unique method will automatically check whether the model implements soft delete or not, if yes then it excludes the soft deleted records itself, without explicitly mentioning it with every rule. But still, if user want to check all the records they can simply use the `checkSoftDelete` method

Following cases are covered in this PR

1. Check If the table name is the class name
2. Check if the Model implementing the SoftDelete Trait
3. Check if the user wants to check the SoftDelete Records