### PR TITLE
run php artisan route:cache,route bindings wrong

### DIFF
--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -59,7 +59,7 @@ class RouteGroup
     {
         $old = $old['prefix'] ?? null;
 
-        return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+        return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
     }
 
     /**


### PR DESCRIPTION
When I use the route cache, the prefix route binding parameters will report an error, so I trace the source code and modify it here is no problem
![image](https://user-images.githubusercontent.com/20275621/77682155-6dd8e380-6fd1-11ea-9b93-805d5cd8502e.png)

![image](https://user-images.githubusercontent.com/20275621/77681739-c8257480-6fd0-11ea-9af1-aedc96b88036.png)

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
