### PR TITLE
[7.x] Add HasCasterClass interface

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/HasCasterClass.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/HasCasterClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Database\Eloquent;
+
+interface HasCasterClass
+{
+    /**
+     * Get the caster class for this class
+     *
+     * @return string
+     */
+    public static function getCasterClass();
+}

--- a/src/Illuminate/Contracts/Database/Eloquent/HasCasterClass.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/HasCasterClass.php
@@ -5,7 +5,7 @@ namespace Illuminate\Contracts\Database\Eloquent;
 interface HasCasterClass
 {
     /**
-     * Get the caster class for this class
+     * Get the caster class for this class.
      *
      * @return string
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Contracts\Database\Eloquent\HasCasterClass;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -1061,7 +1062,13 @@ trait HasAttributes
      */
     protected function resolveCasterClass($key)
     {
-        if (strpos($castType = $this->getCasts()[$key], ':') === false) {
+        $castType = $this->getCasts()[$key];
+
+        if (is_subclass_of($castType, HasCasterClass::class)) {
+            $castType = $castType::getCasterClass();
+        }
+
+        if (strpos($castType, ':') === false) {
             return new $castType;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1064,17 +1064,20 @@ trait HasAttributes
     {
         $castType = $this->getCasts()[$key];
 
+        $arguments = [];
+
+        if (strpos($castType, ':') !== false) {
+            $segments = explode(':', $castType, 2);
+
+            $castType = $segments[0];
+            $arguments = explode(',', $segments[1]);
+        }
+
         if (is_subclass_of($castType, HasCasterClass::class)) {
             $castType = $castType::getCasterClass();
         }
 
-        if (strpos($castType, ':') === false) {
-            return new $castType;
-        }
-
-        $segments = explode(':', $castType, 2);
-
-        return new $segments[0](...explode(',', $segments[1]));
+        return new $castType(...$arguments);
     }
 
     /**


### PR DESCRIPTION
This PR adds an interface which allows castable types to specify their caster class. This approach has two advantages:

- Packages can provide caster classes with less configuration required from the user
- The casting configuration on models can now tell what class a property will be casted to, instead of what caster will be used.

As an example:

```php
// Instead of this
class ModelX extends Model
{
    protected $casts = [
        'data' => CastToDTO::class . ':' . MyDTO::class,
    ];
}
```

```php
// You could do this
class ModelY extends Model
{
    protected $casts = [
        'data' => MyDTO::class,
    ];
}
```

The underlying `MyDTO` class would look like this:

```php
class MyDTO implements HasCasterClass
{
    public static function getCasterClass()
    {
        return CastToDTO::class . ':' . static::class;
    }
}
```

As you can tell from the example, my use case is with our DTO package. I would prefer our users to specify what type of DTO they want to cast to, instead of having to manually specify `CastToDTO::class . ':' . MyDTO::class` for each cast. The `getCasterClass` would be done in our abstract DataTransferObject implementation, and the user wouldn't have to worry about it.