### PR TITLE
[8.x] Fixed component class view reference

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -53,11 +53,7 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function writeView()
     {
-        $view = collect(explode('/', $this->argument('name')))
-            ->map(function ($part) {
-                return Str::kebab($part);
-            })
-            ->implode('.');
+        $view = $this->getView();
 
         $path = resource_path('views').'/'.str_replace('.', '/', 'components.'.$view);
 
@@ -91,9 +87,23 @@ class ComponentMakeCommand extends GeneratorCommand
 
         return str_replace(
             'DummyView',
-            'view(\'components.'.Str::kebab(class_basename($name)).'\')',
+            'view(\'components.'.$this->getView().'\')',
             parent::buildClass($name)
         );
+    }
+
+    /**
+     * Gets the view path relative to the components dir.
+     *
+     * @return string view
+     */
+    protected function getView()
+    {
+        return collect(explode('/', $this->argument('name')))
+            ->map(function ($part) {
+                return Str::kebab($part);
+            })
+            ->implode('.');
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -93,7 +93,7 @@ class ComponentMakeCommand extends GeneratorCommand
     }
 
     /**
-     * Gets the view path relative to the components dir.
+     * Get the view name relative to the components directory.
      *
      * @return string view
      */


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Just an small fix here. So `php artisan make:component FormError` works so good straight out of the box. This PR however is aimed to fix the locating of the `view` (blade file) in the Component class for views that are kept inside subfolders in the `views/components` folder.

When you run `php artisan make:component Errors/Sub1/FormError` all the files are created in the right places but currently in the `FormError@render()` 
```php
    public function render()
    {
        return view('components.form-error');
    } 
```
instead of 
```php
    public function render()
    {
        return view('components.errors.sub1.form-error');
    }
```

Currently you will have to visit the component class to make a fix. 

Cheers