### PR TITLE
[7.x] Eloquent JSON encode: escaping UTF8/16/32 characters

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -788,13 +788,48 @@ trait HasAttributes
 
     /**
      * Encode the given value as JSON.
+     * UTF8, UTF16, UTF32 characters are escaped from input value ONLY IF database collation/charset DOES NOT allow them.
      *
      * @param  mixed  $value
      * @return string
      */
     protected function asJson($value)
     {
-        return json_encode($value);
+        return json_encode($value, $this->databaseConnectionAllowsUnicode() ? 
+                                            JSON_UNESCAPED_UNICODE : 0 );
+    }
+    
+    /**
+     * Returns the collation of the database to which our model is connecting.
+     * The collation is retrieved from /config/database.php @ "connections" key
+     *
+     * @return string
+     */
+    protected function getConnectionCollation()
+    {
+        return config('database.connections')[$this->getConnectionName()]['collation'];
+    }
+    
+    /**
+     * Returns the character set with which our model is connecting to database.
+     * The character set is retrieved from /config/database.php @ "connections" key
+     *
+     * @return string
+     */
+    protected function getConnectionCharset()
+    {
+        return config('database.connections')[$this->getConnectionName()]['charset'];
+    }
+    
+    /**
+     * Determines if our database collation and connection driver allow unicode.
+     *
+     * @return bool
+     */
+    protected function databaseConnectionAllowsUnicode()
+    {
+        return strpos('utf', $this->getConnectionCollation()) === 0 &&
+                strpos('utf', $this->getConnectionCharset()) === 0 ;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -828,8 +828,8 @@ trait HasAttributes
      */
     protected function databaseConnectionAllowsUnicode()
     {
-        return strpos('utf', $this->getConnectionCollation()) === 0 &&
-                strpos('utf', $this->getConnectionCharset()) === 0 ;
+        return strpos($this->getConnectionCollation(), 'utf') === 0 &&
+                strpos($this->getConnectionCharset(), 'utf') === 0 ;
     }
 
     /**


### PR DESCRIPTION
When casting to JSON in eloquent models, the cast by default **escapes** unicode characters (such as ă, ț, î, etc). In case of UTF8/16/32 specific characters this behaviour leads to incorrect data input into database (they are converted to \u021bie, \u0103, etc), even if database driver and database itself are set to allow UTF8/16/32 characters.

Suppose we have a model A:
```
class A extends Model
{
    protected $casts = [
        'column' => 'json'
    ];
}
```

When we insert a new row with following characters, they'll be converted before insertion:
```
public function index()
{
    \App\A::create([
        'column' => [  'ț', 'â', 'ă' ]
    ]);

    dd(\App\A::first()); // #attributes:[ column=> ["\u021b", "\u00e2", "\u0103"] ]
}
```
------------------

This pull request aims to fix this behaviour: to prevent unicode characters from being escaped by json_encode() if database connection driver allows utf* charsets. Most MySQL databases use utf8mb4_* as collation. 

I hope you will find my contribution helpful.
