### PR TITLE
[7.x] Adding console command assertion expectsChoice()

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -24,6 +24,13 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
+     * All of the expected choice questions.
+     *
+     * @var array
+     */
+    public $expectedChoices = [];
+
+    /**
      * All of the expected questions.
      *
      * @var array
@@ -46,6 +53,18 @@ trait InteractsWithConsole
         $this->beforeApplicationDestroyed(function () {
             if (count($this->expectedQuestions)) {
                 $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
+            }
+
+            if (count($this->expectedChoices)) {
+                foreach ($this->expectedChoices as $question => $answers) {
+                    $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
+
+                    $this->$assertion(
+                        $answers['expected'],
+                        $answers['actual'],
+                        'Question "'.$question.'" has different options.'
+                    );
+                }
             }
 
             if (count($this->expectedOutput)) {

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -24,18 +24,18 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
-     * All of the expected choice questions.
-     *
-     * @var array
-     */
-    public $expectedChoices = [];
-
-    /**
      * All of the expected questions.
      *
      * @var array
      */
     public $expectedQuestions = [];
+
+    /**
+     * All of the expected choice questions.
+     *
+     * @var array
+     */
+    public $expectedChoices = [];    
 
     /**
      * Call artisan command and return code.
@@ -59,7 +59,7 @@ trait InteractsWithConsole
                 foreach ($this->expectedChoices as $question => $answers) {
                     $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
 
-                    $this->$assertion(
+                    $this->{$assertion}(
                         $answers['expected'],
                         $answers['actual'],
                         'Question "'.$question.'" has different options.'

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -55,7 +55,7 @@ trait InteractsWithConsole
                 $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
             }
 
-            if (count($this->expectedChoices)) {
+            if (count($this->expectedChoices) > 0) {
                 foreach ($this->expectedChoices as $question => $answers) {
                     $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
 

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -99,6 +99,25 @@ class PendingCommand
     }
 
     /**
+     * Specify an expected choice question with expected answers that will be asked/shown when the command runs.
+     *
+     * @param  string  $question
+     * @param  string  $answer
+     * @param  array  $answers
+     * @param  bool  $strict
+     * @return $this
+     */
+    public function expectsChoice($question, $answer, $answers, $strict = false)
+    {
+        $this->test->expectedChoices[$question] = [
+            'expected' => $answers,
+            'strict' => $strict,
+        ];
+
+        return $this->expectsQuestion($question, $answer);
+    }
+
+    /**
      * Specify output that should be printed when the command runs.
      *
      * @param  string  $output
@@ -181,6 +200,10 @@ class PendingCommand
                 ->once()
                 ->ordered()
                 ->with(Mockery::on(function ($argument) use ($question) {
+                    if (isset($this->test->expectedChoices[$question[0]])) {
+                        $this->test->expectedChoices[$question[0]]['actual'] = $argument->getAutocompleterValues();
+                    }
+
                     return $argument->getQuestion() == $question[0];
                 }))
                 ->andReturnUsing(function () use ($question, $i) {


### PR DESCRIPTION
This PR adds a new console test method for asking `choices`.

## Current State

You can ask a multiple-choice question in a Laravel command with the `choice` method:

```php
$name = $this->choice('What is your name?', ['Taylor', 'Dayle'], $defaultIndex);
```

Currently, you can `only assert` the `message` of this question and define a reply like:

```php
$this->artisan('question')
  ->expectsQuestion('What is your name?', 'Taylor')
  ->assertExitCode(0);
}
```

What you `cannot test` here are the given choices: `['Taylor', 'Dayle']`
Depending on how your command looks like, these choices may change through input.

## Solution

In order to solve this problem, this PR adds a new method to expect choices. The code above can now be tested like:

```php
$this->artisan('question')
  ->expectsChoice('What is your name?', 'Taylor', ['Taylor', 'Dayle'])
  ->assertExitCode(0);
}
```

Next to the message and the reply, you can now define the expected available choices as well.

Per default we compare both arrays ignoring the order using `assertEqualsCanonicalizing`, if needed can switch to `assertEquals` via a fourth parameter.

```php
$this->artisan('question')
  ->expectsChoice('What is your name?', 'Taylor', ['Taylor', 'Dayle'], true)
  ->assertExitCode(0);
}
```