### PR TITLE
[7.x] Remove an unnecessary callback

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1226,9 +1226,7 @@ class Grammar extends BaseGrammar
      */
     protected function concatenate($segments)
     {
-        return implode(' ', array_filter($segments, function ($value) {
-            return (string) $value !== '';
-        }));
+        return implode(' ', array_filter($segments));
     }
 
     /**


### PR DESCRIPTION
This PR removes an unnecessary callback.

Since the purpose is removing empties, it is unnecessary to pass in a callback because [If no callback is supplied, all entries of array equal to FALSE (see converting to boolean) will be removed.](https://www.php.net/manual/en/function.array-filter.php)
