### PR TITLE
[8.x] Eliminate the need to exclude soft delete records manually

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -37,6 +37,13 @@ trait DatabaseRule
     protected $using = [];
 
     /**
+     * The model being queried.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
+     */
+    protected $model;
+
+    /**
      * Create a new rule instance.
      *
      * @param  string  $table
@@ -62,10 +69,10 @@ trait DatabaseRule
             return $table;
         }
 
-        $model = new $table;
+        $this->model = new $table;
 
-        return $model instanceof Model
-                ? $model->getTable()
+        return $this->model instanceof Model
+                ? $this->model->getTable()
                 : $table;
     }
 


### PR DESCRIPTION
This pull request is for solving a problem to manually eliminate the soft deleted records in Unique rule. Currently, the developer has to write manually to exclude the soft deleted records for every model. With this modification, the unique method will automatically check whether the model implements soft delete or not, if yes then it excludes the soft deleted records itself, without explicitly mentioning it with every rule. But still, if user want to check all the records they can simply use the checkSoftDelete method

Following cases are covered in this PR

1. Check If the table name is the class name
2. Check if the Model implementing the SoftDelete Trait
3. Check if the user wants to check the SoftDelete Records