### PR TITLE
[7.x] Remove an unnecessary checking

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -85,7 +85,7 @@ class Grammar extends BaseGrammar
         $sql = [];
 
         foreach ($this->selectComponents as $component) {
-            if (isset($query->$component) && ! is_null($query->$component)) {
+            if (isset($query->$component)) {
                 $method = 'compile'.ucfirst($component);
 
                 $sql[$component] = $this->$method($query, $query->$component);


### PR DESCRIPTION
Once a variable `is set`, it's basically **not** `null`. If that's correct, I think we just cut the cost of checking in half. Just consider how many times we hit this line of code :thinking: 

Reference: 
https://www.php.net/manual/en/function.isset.php
https://www.php.net/manual/en/types.comparisons.php
