### PR TITLE
[7.x] Return bindings for SwiftMailer

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -15,6 +15,7 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
     public function register()
     {
         $this->registerIlluminateMailer();
+        $this->registerSwiftMailer();
         $this->registerMarkdownRenderer();
     }
 
@@ -31,6 +32,22 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
 
         $this->app->bind('mailer', function ($app) {
             return $app->make('mail.manager')->mailer();
+        });
+    }
+
+    /**
+     * Register the Swift Mailer instance.
+     *
+     * @return void
+     */
+    public function registerSwiftMailer()
+    {
+        $this->app->singleton('swift.mailer', function ($app) {
+            return $app->make('mailer')->getSwiftMailer();
+        });
+
+        $this->app->singleton('swift.transport', function ($app) {
+            return $app->make('swift.mailer')->getTransport();
         });
     }
 


### PR DESCRIPTION
Merged PR #31073 has removed `swift.mailer` and `swift.transport` bindings from the `MailServiceProvider` which [still claims to provide them](https://github.com/laravel/framework/blob/caf562f8e2d165898d6e8abe0549a5fb7384d92d/src/Illuminate/Mail/MailServiceProvider.php#L70-L71).

We could either remove proper lines from the `provides()` method or return those bindings.

This PR returns bindings because their removal seems to be a breaking change.