### PR TITLE
[7.x] Implement HigherOrderWhenProxy for Collections

### DIFF
--- a/src/Illuminate/Support/HigherOrderWhenProxy.php
+++ b/src/Illuminate/Support/HigherOrderWhenProxy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @mixin \Illuminate\Support\Enumerable
+ */
+class HigherOrderWhenProxy
+{
+    /**
+     * The collection being operated on.
+     *
+     * @var \Illuminate\Support\Enumerable
+     */
+    protected $collection;
+
+    /**
+     * The condition for proxying.
+     *
+     * @var bool
+     */
+    protected $condition;
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  \Illuminate\Support\Enumerable  $collection
+     * @param  bool  $condition
+     * @return void
+     */
+    public function __construct(Enumerable $collection, $condition)
+    {
+        $this->condition = $condition;
+        $this->collection = $collection;
+    }
+
+    /**
+     * Proxy accessing an attribute onto the collection.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->condition
+            ? $this->collection->{$key}
+            : $this->collection;
+    }
+
+    /**
+     * Proxy a method call onto the collection.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->condition
+            ? $this->collection->{$method}(...$parameters)
+            : $this->collection;
+    }
+}

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Enumerable;
 use Illuminate\Support\HigherOrderCollectionProxy;
+use Illuminate\Support\HigherOrderWhenProxy;
 use JsonSerializable;
 use Symfony\Component\VarDumper\VarDumper;
 use Traversable;
@@ -404,12 +405,16 @@ trait EnumeratesValues
      * Apply the callback if the value is truthy.
      *
      * @param  bool|mixed  $value
-     * @param  callable  $callback
+     * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback, callable $default = null)
+    public function when($value, callable $callback = null, callable $default = null)
     {
+        if (! $callback) {
+            return new HigherOrderWhenProxy($this, $value);
+        }
+
         if ($value) {
             return $callback($this, $value);
         } elseif ($default) {


### PR DESCRIPTION
Hi there, 👋 

This PR allows us to use a higher-order proxy for the `Collection::when` method.

```php
// With this PR, this:
$collection->when($condition, function ($collection) use ($item) {
    $collection->push($item);
});

// ... can be refactored as this:
$collection->when($condition)->push($item);
```

I have also added the `__get()` magic method so that we can even chain other higher-order proxy methods like so:

```php
// This:
$collection->when($condition, function ($collection) {
    $collection->map->parseIntoSomething();
});

// ... can be refactored as this:
$collection->when($condition)->map->parseIntoSomething();
```

If this is something you'd like to include in the Laravel framework, I will add some tests and update the documentation accordingly.

Cheers. 🍀 
