### PR TITLE
[7.x] Add missing var and return

### DIFF
--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -632,7 +632,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     /**
      * Fires the validated event if the dispatcher is set.
      *
-     * @param $user
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @return void
      */
     protected function fireValidatedEvent($user)
     {

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -446,7 +446,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Zip the collection together with one or more arrays.
      *
-     * @param  mixed ...$items
+     * @param  mixed  ...$items
      * @return \Illuminate\Support\Collection
      */
     public function zip($items)

--- a/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
@@ -26,6 +26,7 @@ class HigherOrderBuilderProxy
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $builder
      * @param  string  $method
+     * @return void
      */
     public function __construct(Builder $builder, $method)
     {

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -13,6 +13,8 @@ class BelongsTo extends Relation
 
     /**
      * The child model instance of the relation.
+     *
+     * @var \Illuminate\Database\Eloquent\Model
      */
     protected $child;
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -51,11 +51,15 @@ class Blueprint
 
     /**
      * The default character set that should be used for the table.
+     *
+     * @var string
      */
     public $charset;
 
     /**
      * The collation that should be used for the table.
+     *
+     * @var string
      */
     public $collation;
 

--- a/src/Illuminate/Http/Client/ResponseSequence.php
+++ b/src/Illuminate/Http/Client/ResponseSequence.php
@@ -89,7 +89,7 @@ class ResponseSequence
     /**
      * Push a response to the sequence.
      *
-     * @param  mixed $response
+     * @param  mixed  $response
      * @return $this
      */
     public function pushResponse($response)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1214,7 +1214,7 @@ class Collection implements ArrayAccess, Enumerable
      * e.g. new Collection([1, 2, 3])->zip([4, 5, 6]);
      *      => [[1, 4], [2, 5], [3, 6]]
      *
-     * @param  mixed ...$items
+     * @param  mixed  ...$items
      * @return static
      */
     public function zip($items)

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1151,7 +1151,7 @@ class LazyCollection implements Enumerable
      * e.g. new LazyCollection([1, 2, 3])->zip([4, 5, 6]);
      *      => [[1, 4], [2, 5], [3, 6]]
      *
-     * @param  mixed ...$items
+     * @param  mixed  ...$items
      * @return static
      */
     public function zip($items)

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -760,9 +760,9 @@ class AuthAccessGateTest extends TestCase
     /**
      * @dataProvider hasAbilitiesTestDataProvider
      *
-     * @param array $abilitiesToSet
-     * @param array|string $abilitiesToCheck
-     * @param bool $expectedHasValue
+     * @param  array  $abilitiesToSet
+     * @param  array|string  $abilitiesToCheck
+     * @param  bool  $expectedHasValue
      */
     public function testHasAbilities($abilitiesToSet, $abilitiesToCheck, $expectedHasValue)
     {

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -223,7 +223,7 @@ class CacheRepositoryTest extends TestCase
 
     /**
      * @dataProvider dataProviderTestGetSeconds
-     * @param mixed $duration
+     * @param  mixed  $duration
      */
     public function testGetSeconds($duration)
     {

--- a/tests/Cache/RedisCacheIntegrationTest.php
+++ b/tests/Cache/RedisCacheIntegrationTest.php
@@ -28,7 +28,7 @@ class RedisCacheIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddTwice($driver)
     {
@@ -44,7 +44,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddFalse($driver)
     {
@@ -60,7 +60,7 @@ class RedisCacheIntegrationTest extends TestCase
      *
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRedisCacheAddNull($driver)
     {

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1991,12 +1991,6 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
-    /**
-     * Test that the getOriginal method on an Eloquent model also uses the casts array.
-     *
-     * @param void
-     * @return void
-     */
     public function testGetOriginalCastsAttributes()
     {
         $model = new EloquentModelCastingStub();

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -547,7 +547,7 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @param string $file
+     * @param  string  $file
      * @return int
      */
     private function getFilePermissions($file)

--- a/tests/Http/HttpJsonResponseTest.php
+++ b/tests/Http/HttpJsonResponseTest.php
@@ -79,7 +79,7 @@ class HttpJsonResponseTest extends TestCase
     }
 
     /**
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @dataProvider jsonErrorDataProvider
      */

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -47,9 +47,9 @@ class DatabaseMySqlConnectionTest extends TestCase
     /**
      * @dataProvider floatComparisonsDataProvider
      *
-     * @param float  $value       the value to compare against the JSON value
-     * @param string $operator    the comparison operator to use. e.g. '<', '>', '='
-     * @param bool   $shouldMatch true if the comparison should match, false if not
+     * @param  float  $value        the value to compare against the JSON value
+     * @param  string  $operator    the comparison operator to use. e.g. '<', '>', '='
+     * @param  bool  $shouldMatch   true if the comparison should match, false if not
      */
     public function testJsonFloatComparison(float $value, string $operator, bool $shouldMatch): void
     {

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -78,11 +78,6 @@ class sendRawEmailMock
         $this->getResponse = $responseValue;
     }
 
-    /**
-     * Mock the get() call for the sendRawEmail response.
-     * @param  [type] $key [description]
-     * @return [type]      [description]
-     */
     public function get($key)
     {
         return $this->getResponse;

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -39,7 +39,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testExpiredJobsArePopped($driver)
     {
@@ -111,7 +111,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopProperlyPopsJobOffOfRedis($driver)
     {
@@ -146,7 +146,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopProperlyPopsDelayedJobOffOfRedis($driver)
     {
@@ -173,7 +173,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testPopPopsDelayedJobOffOfRedisWhenExpireNull($driver)
     {
@@ -202,7 +202,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testBlockingPopProperlyPopsJobOffOfRedis($driver)
     {
@@ -223,7 +223,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testBlockingPopProperlyPopsExpiredJobs($driver)
     {
@@ -254,7 +254,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testNotExpireJobsWhenExpireNull($driver)
     {
@@ -299,7 +299,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testExpireJobsWhenExpireSet($driver)
     {
@@ -328,7 +328,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testRelease($driver)
     {
@@ -369,7 +369,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testReleaseInThePast($driver)
     {
@@ -387,7 +387,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testDelete($driver)
     {
@@ -411,7 +411,7 @@ class RedisQueueIntegrationTest extends TestCase
     /**
      * @dataProvider redisDriverProvider
      *
-     * @param string $driver
+     * @param  string  $driver
      */
     public function testSize($driver)
     {
@@ -430,7 +430,7 @@ class RedisQueueIntegrationTest extends TestCase
     }
 
     /**
-     * @param string $driver
+     * @param  string  $driver
      * @param  string  $default
      * @param  string  $connection
      * @param  int  $retryAfter

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -96,8 +96,8 @@ class FakeRedisConnnector implements Connector
     /**
      * Create a new clustered Predis connection.
      *
-     * @param array $config
-     * @param array $options
+     * @param  array  $config
+     * @param  array  $options
      * @return \Illuminate\Contracts\Redis\Connection
      */
     public function connect(array $config, array $options)
@@ -108,9 +108,9 @@ class FakeRedisConnnector implements Connector
     /**
      * Create a new clustered Predis connection.
      *
-     * @param array $config
-     * @param array $clusterOptions
-     * @param array $options
+     * @param  array  $config
+     * @param  array  $clusterOptions
+     * @param  array  $options
      * @return \Illuminate\Contracts\Redis\Connection
      */
     public function connectToCluster(array $config, array $clusterOptions, array $options)


### PR DESCRIPTION
Add missing `@var` and `@return`.
Also properly spaces params