### PR TITLE
[7.x] Replace 'localhost' with '127.0.0.1' in MySQL connector

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -129,6 +129,14 @@ class MySqlConnector extends Connector implements ConnectorInterface
     {
         extract($config, EXTR_SKIP);
 
+        /**
+         * 'localhost' and '127.0.0.1' is not treated the same in MySQL.
+         * With 'localhost', Unix socket will be used instead of TCP.
+         *
+         * See https://dev.mysql.com/doc/refman/8.0/en/can-not-connect-to-server.html
+         */
+        $host = ($host === 'localhost') ? '127.0.0.1' : $host;
+
         return isset($port)
                     ? "mysql:host={$host};port={$port};dbname={$database}"
                     : "mysql:host={$host};dbname={$database}";


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end-users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR replaces `localhost` with `127.0.0.1` in MySQL connector *when Unix socket is not set*. MySQL will use Unix socket when `localhost` is specified. Documentation from the [MySQL 8 reference manual](https://dev.mysql.com/doc/refman/8.0/en/can-not-connect-to-server.html):

> A Unix socket file is used if you do not specify a host name **or if you specify the special host name localhost.**

## Testing

Run two migration each specifying `localhost` and `127.0.0.1` as `DB_HOST`. With `localhost` the migration should fail with the error:

```
$ DB_HOST=localhost php artisan migrate:refresh

   Illuminate\Database\QueryException 

  SQLSTATE[HY000] [2002] No such file or directory (SQL: select * from information_schema.tables where table_schema = homestead and table_name = migrations and table_type = 'BASE TABLE')
```

With this PR the migration should be successful for both `localhost` and `127.0.0.1`.
