### PR TITLE
[7.x] Update phpdoc $index to nullable

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1346,7 +1346,7 @@ class Blueprint
      *
      * @param  string  $type
      * @param  string|array  $columns
-     * @param  string  $index
+     * @param  string|null  $index
      * @param  string|null  $algorithm
      * @return \Illuminate\Support\Fluent
      */

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1350,7 +1350,7 @@ class Blueprint
      * @param  string|null  $algorithm
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null)
+    protected function indexCommand($type, $columns, $index = null, $algorithm = null)
     {
         $columns = (array) $columns;
 


### PR DESCRIPTION
Based on the usage `$index` should be nullable.
```
public function primary($columns, $name = null, $algorithm = null)
{
    return $this->indexCommand('primary', $columns, $name, $algorithm);
}

public function index($columns, $name = null, $algorithm = null)
{
    return $this->indexCommand('index', $columns, $name, $algorithm);
}
```