### PR TITLE
[7.x] Add Arr::every method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -152,6 +152,24 @@ class Arr
     }
 
     /**
+     * Determine if all items pass the given truth test.
+     *
+     * @param  iterable  $array
+     * @param  callable  $callback
+     * @return bool
+     */
+    public static function every($array, callable $callback)
+    {
+        foreach ($array as $key => $value) {
+            if (! $callback($value, $key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Return the first element in an array passing a given truth test.
      *
      * @param  iterable  $array

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -136,22 +136,6 @@ class Arr
     }
 
     /**
-     * Determine if the given key exists in the provided array.
-     *
-     * @param  \ArrayAccess|array  $array
-     * @param  string|int  $key
-     * @return bool
-     */
-    public static function exists($array, $key)
-    {
-        if ($array instanceof ArrayAccess) {
-            return $array->offsetExists($key);
-        }
-
-        return array_key_exists($key, $array);
-    }
-
-    /**
      * Determine if all items pass the given truth test.
      *
      * @param  iterable  $array
@@ -167,6 +151,22 @@ class Arr
         }
 
         return true;
+    }
+
+    /**
+     * Determine if the given key exists in the provided array.
+     *
+     * @param  \ArrayAccess|array  $array
+     * @param  string|int  $key
+     * @return bool
+     */
+    public static function exists($array, $key)
+    {
+        if ($array instanceof ArrayAccess) {
+            return $array->offsetExists($key);
+        }
+
+        return array_key_exists($key, $array);
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -125,6 +125,17 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['framework' => ['language' => 'PHP']], Arr::except($array, ['name', 'framework.name']));
     }
 
+    public function testEvery()
+    {
+        $this->assertTrue(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
+            return $item < 7;
+        }));
+
+        $this->assertFalse(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
+            return $item < 4;
+        }));
+    }
+
     public function testExists()
     {
         $this->assertTrue(Arr::exists([1], 0));
@@ -137,17 +148,6 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists([null], 1));
         $this->assertFalse(Arr::exists(['a' => 1], 0));
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
-    }
-
-    public function testEvery()
-    {
-        $this->assertTrue(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
-            return $item < 7;
-        }));
-
-        $this->assertFalse(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
-            return $item < 4;
-        }));
     }
 
     public function testFirst()

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -139,6 +139,17 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::exists(new Collection(['a' => null]), 'b'));
     }
 
+    public function testEvery()
+    {
+        $this->assertTrue(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
+            return $item < 7;
+        }));
+
+        $this->assertFalse(Arr::every([1, 2, 3, 4, 5, 6], function ($item) {
+            return $item < 4;
+        }));
+    }
+
     public function testFirst()
     {
         $array = [100, 200, 300];


### PR DESCRIPTION
This PR introduces the `Arr::every` method.

------

In some cases – e.g. validation rules – we might want to check if every item in the given array is passing the given truth test. Right now we need to use a `foreach` loop. The `Arr::every` simplifies this and provides a nicer approach:

```
// Before

foreach ($array as $key => $value) {
    if (! $callback($value, $key)) {
        return false;
    }
}

return true;
```

```
// After

Arr::every($array, function ($value, $key) {
    // perform check
});
```