### PR TITLE
[7.x] Add combinations() and permutations() to Collection, LazyCollection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -161,7 +161,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get a combination of n items of this collection
+     * Get a combination of n items of this collection.
      *
      * @param int $n
      * @return LazyCollection
@@ -1255,11 +1255,10 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Get permutations of this collection
+     * Get permutations of this collection.
      *
      * @param void
      * @return LazyCollection
-     *
      */
     public function permutations()
     {

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1257,7 +1257,6 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Get permutations of this collection.
      *
-     * @param void
      * @return LazyCollection
      */
     public function permutations()

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -161,6 +161,18 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Get a combination of n items of this collection
+     *
+     * @param int $n
+     * @return LazyCollection
+     */
+    public function combinations(int $n)
+    {
+        return new LazyCollection(
+            (new Itertool($this->items))->combinations($n));
+    }
+
+    /**
      * Determine if an item exists in the collection.
      *
      * @param  mixed  $key
@@ -1240,6 +1252,19 @@ class Collection implements ArrayAccess, Enumerable
     public function pad($size, $value)
     {
         return new static(array_pad($this->items, $size, $value));
+    }
+
+    /**
+     * Get permutations of this collection
+     *
+     * @param void
+     * @return LazyCollection
+     *
+     */
+    public function permutations()
+    {
+        return new LazyCollection(
+            (new Itertool($this->items))->permutations());
     }
 
     /**

--- a/src/Illuminate/Support/Itertool.php
+++ b/src/Illuminate/Support/Itertool.php
@@ -1,0 +1,102 @@
+<?php
+
+
+namespace Illuminate\Support;
+
+
+class Itertool
+{
+    private $items;
+
+    public function __construct($items)
+    {
+        $this->items = $items;
+    }
+
+    public function combinations(int $n)
+    {
+        $size = count($this->items);
+        if ($n <= 0 || $n > $size) {
+            return;
+        }
+        $keys = range(0, $n - 1);
+        do {
+            yield $this->only($keys);
+        } while ($this->nextCombination($keys, $size));
+    }
+
+
+    private function only($keys)
+    {
+        $a = [];
+        foreach ($keys as $v) {
+            $a[] = $this->items[$v];
+        }
+        return $a;
+    }
+
+    private function nextCombination(&$iter, $size)
+    {
+        $i = 0;
+        $n = count($iter);
+        $j = $n - 1 - $i;
+        $carry = 0;
+        while ($j >= 0) {
+            $iter[$j] += 1;
+            $carry = $iter[$j] == $size - $i ? 1 : 0;
+            if ($carry == 0) {
+                break;
+            }
+            $i += 1;
+            $j = $n - 1 - $i;
+        }
+        if ($carry == 0 && $j >= 0) {
+            $j += 1;
+            for (; $j < $n; $j++) {
+                $iter[$j] = $iter[$j - 1] + 1;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function permutations()
+    {
+        if (count($this->items) == 0) {
+            return;
+        } else if (count($this->items) == 1) {
+            yield $this->items;
+            return;
+        }
+        $size = count($this->items);
+        $keys = range(0, $size - 1);
+        while (true) {
+            yield $this->only($keys);
+            $i = $size - 2;
+            while ($i >= 0 && $keys[$i] > $keys[$i + 1])
+                $i--;
+            if ($i < 0)
+                break;
+            $j = $size - 1;
+            while ($keys[$i] > $keys[$j])
+                $j--;
+            self::swap($keys, $i, $j);
+            self::reverse($keys, $i + 1, $size - 1);
+        }
+    }
+
+    private static function swap(&$items, int $i, int $j)
+    {
+        $tmp = $items[$i];
+        $items[$i] = $items[$j];
+        $items[$j] = $tmp;
+    }
+
+    private static function reverse(&$items, int $from, int $to)
+    {
+        while ($from < $to) {
+            self::swap($items, $from++, $to--);
+        }
+    }
+}

--- a/src/Illuminate/Support/Itertool.php
+++ b/src/Illuminate/Support/Itertool.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Illuminate\Support;
-
 
 class Itertool
 {
@@ -25,13 +23,13 @@ class Itertool
         } while ($this->nextCombination($keys, $size));
     }
 
-
     private function only($keys)
     {
         $a = [];
         foreach ($keys as $v) {
             $a[] = $this->items[$v];
         }
+
         return $a;
     }
 
@@ -55,6 +53,7 @@ class Itertool
             for (; $j < $n; $j++) {
                 $iter[$j] = $iter[$j - 1] + 1;
             }
+
             return true;
         } else {
             return false;
@@ -65,8 +64,9 @@ class Itertool
     {
         if (count($this->items) == 0) {
             return;
-        } else if (count($this->items) == 1) {
+        } elseif (count($this->items) == 1) {
             yield $this->items;
+
             return;
         }
         $size = count($this->items);
@@ -74,13 +74,21 @@ class Itertool
         while (true) {
             yield $this->only($keys);
             $i = $size - 2;
-            while ($i >= 0 && $keys[$i] > $keys[$i + 1])
+
+            while ($i >= 0 && $keys[$i] > $keys[$i + 1]) {
                 $i--;
-            if ($i < 0)
+            }
+
+            if ($i < 0) {
                 break;
+            }
+
             $j = $size - 1;
-            while ($keys[$i] > $keys[$j])
+
+            while ($keys[$i] > $keys[$j]) {
                 $j--;
+            }
+
             self::swap($keys, $i, $j);
             self::reverse($keys, $i + 1, $size - 1);
         }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1212,7 +1212,7 @@ class LazyCollection implements Enumerable
 
     /**
      * Get permutations of this collection.
-     * @param void
+     *
      * @return LazyCollection
      */
     public function permutations()

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -199,6 +199,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Get combinations of n item of this collection
+     *
+     * @param int $n
+     * @return LazyCollection
+     */
+    public function combinations(int $n)
+    {
+        return $this->passthru('combinations', [$n]);
+    }
+
+    /**
      * Determine if an item exists in the enumerable.
      *
      * @param  mixed  $key
@@ -1197,6 +1208,16 @@ class LazyCollection implements Enumerable
                 yield $value;
             }
         });
+    }
+
+    /**
+     * Get permutations of this collection
+     * @param void
+     * @return LazyCollection
+     */
+    public function permutations()
+    {
+        return $this->passthru('permutations', func_get_args());
     }
 
     /**

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -199,7 +199,7 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Get combinations of n item of this collection
+     * Get combinations of n item of this collection.
      *
      * @param int $n
      * @return LazyCollection
@@ -1211,7 +1211,7 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Get permutations of this collection
+     * Get permutations of this collection.
      * @param void
      * @return LazyCollection
      */

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4053,7 +4053,7 @@ class SupportCollectionTest extends TestCase
                 [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4],
                 [3, 2, 4, 1], [3, 4, 1, 2], [3, 4, 2, 1],
                 [4, 1, 2, 3], [4, 1, 3, 2], [4, 2, 1, 3],
-                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1],
             ]
         );
         $count = 0;
@@ -4062,8 +4062,6 @@ class SupportCollectionTest extends TestCase
         }
         $this->assertEquals($count, 720);
     }
-
-
 
     /**
      * @dataProvider collectionClassProvider

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4013,6 +4013,60 @@ class SupportCollectionTest extends TestCase
 
     /**
      * @dataProvider collectionClassProvider
+     * @param Collection $collection
+     */
+    public function testCombinations($collection)
+    {
+        $collection = new $collection([1, 2, 3, 4]);
+        $this->assertEmpty($collection->combinations(0));
+        $this->assertEquals(
+            $collection->combinations(1)->collect()->toArray(), [[1], [2], [3], [4]]);
+        $this->assertEquals(
+            $collection->combinations(2)->collect()->toArray(),
+            [[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
+        );
+        $this->assertEquals(
+            $collection->combinations(3)->collect()->toArray(),
+            [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+        );
+        $this->assertEquals(
+            $collection->combinations(4)->collect()->toArray(),
+            [[1, 2, 3, 4]]
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     * @param Collection $collection
+     */
+    public function testPermutations($collection)
+    {
+        $collection = new $collection([1, 2, 3, 4]);
+        $this->assertEmpty((new $collection([]))->permutations()->collect()->toArray());
+        $this->assertEquals(
+            $collection->permutations()->collect()->toArray(),
+            [
+                [1, 2, 3, 4], [1, 2, 4, 3], [1, 3, 2, 4],
+                [1, 3, 4, 2], [1, 4, 2, 3], [1, 4, 3, 2],
+                [2, 1, 3, 4], [2, 1, 4, 3], [2, 3, 1, 4],
+                [2, 3, 4, 1], [2, 4, 1, 3], [2, 4, 3, 1],
+                [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4],
+                [3, 2, 4, 1], [3, 4, 1, 2], [3, 4, 2, 1],
+                [4, 1, 2, 3], [4, 1, 3, 2], [4, 2, 1, 3],
+                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+            ]
+        );
+        $count = 0;
+        foreach ((new $collection([1, 2, 3, 4, 5, 6]))->permutations() as $v) {
+            $count++;
+        }
+        $this->assertEquals($count, 720);
+    }
+
+
+
+    /**
+     * @dataProvider collectionClassProvider
      */
     public function testWhereNotNull($collection)
     {

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1140,6 +1140,22 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testCombinationsIsLazy()
+    {
+        $data = $this->make([1, 2, 3, 4]);
+        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+            $collection->combinations(3);
+        });
+    }
+
+    public function testPermutationsIsLazy()
+    {
+        $data = $this->make([1, 2, 3, 4]);
+        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+            $collection->permutations();
+        });
+    }
+
     public function testWhenNotEmptyIsLazy()
     {
         $this->assertEnumerates(1, function ($collection) {

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -171,4 +171,44 @@ class SupportLazyCollectionTest extends TestCase
         $this->assertSame([1, 2, 3, 4, 5], $data);
         $this->assertSame([1, 2, 3, 4, 5], $tapped);
     }
+
+    public function testCombinations()
+    {
+        $data = new LazyCollection([1, 2, 3, 4]);
+        $this->assertEmpty($data->combinations(0));
+        $this->assertEquals(
+            $data->combinations(1)->collect()->toArray(), [[1], [2], [3], [4]]);
+        $this->assertEquals(
+            $data->combinations(2)->collect()->toArray(),
+            [[1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4]]
+        );
+        $this->assertEquals(
+            $data->combinations(3)->collect()->toArray(),
+            [[1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4]]
+        );
+        $this->assertEquals(
+            $data->combinations(4)->collect()->toArray(),
+            [[1, 2, 3, 4]]
+        );
+    }
+
+    public function testPermutations()
+    {
+        $collection = new LazyCollection([1, 2, 3, 4]);
+        $this->assertEmpty(LazyCollection::empty()->permutations()->collect()->toArray());
+        $this->assertEquals(
+            $collection->permutations()->collect()->toArray(),
+            [
+                [1, 2, 3, 4], [1, 2, 4, 3], [1, 3, 2, 4],
+                [1, 3, 4, 2], [1, 4, 2, 3], [1, 4, 3, 2],
+                [2, 1, 3, 4], [2, 1, 4, 3], [2, 3, 1, 4],
+                [2, 3, 4, 1], [2, 4, 1, 3], [2, 4, 3, 1],
+                [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4],
+                [3, 2, 4, 1], [3, 4, 1, 2], [3, 4, 2, 1],
+                [4, 1, 2, 3], [4, 1, 3, 2], [4, 2, 1, 3],
+                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+            ]
+        );
+        $this->assertEquals((new LazyCollection([1, 2, 3, 4, 5, 6]))->permutations()->count(), 720);
+    }
 }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -206,7 +206,7 @@ class SupportLazyCollectionTest extends TestCase
                 [3, 1, 2, 4], [3, 1, 4, 2], [3, 2, 1, 4],
                 [3, 2, 4, 1], [3, 4, 1, 2], [3, 4, 2, 1],
                 [4, 1, 2, 3], [4, 1, 3, 2], [4, 2, 1, 3],
-                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1]
+                [4, 2, 3, 1], [4, 3, 1, 2], [4, 3, 2, 1],
             ]
         );
         $this->assertEquals((new LazyCollection([1, 2, 3, 4, 5, 6]))->permutations()->count(), 720);


### PR DESCRIPTION
Brute force is a comfortable way to solve problems -- let the computer work
for you. Many languages have it. 

- C++: next_permutation in "algorithm"
- python: combinations, permutations in "itertools"
- scala: combinations, permutations in the collections that implements Seq.

I wan't to add these to the framework since php spl doesn't have them yet.

#### usage:

```php
//a collection of [[1, 2], [1, 3], [2, 3]];
collect([1, 2, 3])->combinations(2);

//a collection of [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]];
collect([1, 2, 3])->permutations();

//you can combine them or with any other functions in the collection
//example: get a collection of [[1, 2], [2, 1], [1, 3], [3, 1], [2, 3], [3, 2]]
collect([1, 2, 3])
    ->combinations(2)
    ->flatMap(fn ($v) => collect($v)->permutations())
    ->all();
```

I add them to Collection and LazyCollection, return LazyCollection in both cases (the result can be quite large).
No modify to the existing code.

