### PR TITLE
[7.x] Remove Swift Mailer bindings

### DIFF
--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -67,8 +67,6 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
         return [
             'mail.manager',
             'mailer',
-            'swift.mailer',
-            'swift.transport',
             Markdown::class,
         ];
     }


### PR DESCRIPTION
As we've discussed in PR #32145 - we don't want to return Swift Mailer bindings in 7.x.

So, that PR removes them from the `provides()` method of the `MailServiceProvider`.