### PR TITLE
[7.x] Implement adding middleware to HTTP client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -90,6 +90,13 @@ class PendingRequest
     protected $stubCallbacks;
 
     /**
+     * The middleware that will be run as part of this request
+     *
+     * @var array
+     */
+    protected $middleware = [];
+
+    /**
      * Create a new HTTP Client instance.
      *
      * @param  \Illuminate\Http\Client\Factory|null  $factory
@@ -509,6 +516,10 @@ class PendingRequest
             $stack->push($this->buildBeforeSendingHandler());
             $stack->push($this->buildRecorderHandler());
             $stack->push($this->buildStubHandler());
+
+            foreach ($this->middleware as $middleware) {
+                $stack->push($middleware);
+            }
         });
     }
 
@@ -612,6 +623,16 @@ class PendingRequest
     public function stub($callback)
     {
         $this->stubCallbacks = collect($callback);
+
+        return $this;
+    }
+
+    /**
+     * Add the given middleware to the request
+     */
+    public function withMiddleware(array $middleware)
+    {
+        $this->middleware = array_merge($this->middleware, $middleware);
 
         return $this;
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -92,7 +92,7 @@ class PendingRequest
     /**
      * The middleware that will be run as part of this request.
      *
-     * @var array
+     * @var callable[]
      */
     protected $middleware = [];
 
@@ -629,6 +629,9 @@ class PendingRequest
 
     /**
      * Add the given middleware to the request.
+     *
+     * @param  callable[]  $middleware
+     * @return $this
      */
     public function withMiddleware(array $middleware)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -90,7 +90,7 @@ class PendingRequest
     protected $stubCallbacks;
 
     /**
-     * The middleware that will be run as part of this request
+     * The middleware that will be run as part of this request.
      *
      * @var array
      */
@@ -628,7 +628,7 @@ class PendingRequest
     }
 
     /**
-     * Add the given middleware to the request
+     * Add the given middleware to the request.
      */
     public function withMiddleware(array $middleware)
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows for adding Guzzle middleware to a request made with the Laravel HTTP client.

```php
Http::withMiddleware([
  Middleware::mapRequest(function (RequestInterface $request) {
    // modify request
    return $request;
  }
])->get('http://example.com');
```

Currently, the only way to do this is to override the entire Guzzle handler, which removes the middleware for `beforeSending()` callbacks, recording and stubbing.

```php
Http::withOptions(['handler' => $customHandler])
  ->beforeSending(function () {
    // not called
  })
  ->get('http://example.com');
```

This is useful for the same reason that Guzzle middleware in general are useful. In my case, I needed to compute a HMAC of a request and add it as a header.

```php
$hmacMiddleware = Middleware::mapRequest(function (RequestInterface $request) {
  $key = config('services.third_party.secret');
  $body = (string)$request->getBody();

  $hmac = base64_encode(hash_hmac('sha256', $body, $key, true));

  return $request->withHeader('Authorization', "hmac {$hmac}");
});

Http::withMiddleware([$hmacMiddleware])
  ->get('http://example.com');
```