### PR TITLE
[7.x] Add assertFound method

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -139,6 +139,23 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has a 302 status code.
+     *
+     * @return $this
+     */
+    public function assertFound()
+    {
+        $actual = $this->getStatusCode();
+
+        PHPUnit::assertTrue(
+            302 === $actual,
+            'Response status code ['.$actual.'] does not match expected 302 status code.'
+        );
+
+        return $this;
+    }
+
+    /**
      * Assert that the response has a forbidden status code.
      *
      * @return $this

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -232,6 +232,22 @@ class TestResponseTest extends TestCase
         $response->assertNotFound();
     }
 
+    public function testAssertFound()
+    {
+        $statusCode = 500;
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->expectExceptionMessage('Response status code ['.$statusCode.'] does not match expected 302 status code.');
+
+        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+            $response->setStatusCode($statusCode);
+        });
+
+        $response = TestResponse::fromBaseResponse($baseResponse);
+        $response->assertFound();
+    }
+
     public function testAssertForbidden()
     {
         $statusCode = 500;


### PR DESCRIPTION
This PR adds an `assertFound` method which could be very useful to assert redirection generated by Laravel [Validation Logic](https://laravel.com/docs/master/validation)

It could replace this code in tests:

```diff
- $response->assertStatus(302);
+ $response->assertFound();
```