### PR TITLE
[7.x] Add support of relation using casted key

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1103,6 +1103,7 @@ trait HasAttributes
                        : $this->normalizeCastClassResponse($key, $castedValues[$key] = $caster->set($this, $key, $value, $this->attributes))
             );
         }
+
         return $castedValues;
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -221,7 +221,7 @@ class BelongsToMany extends Relation
     protected function addWhereConstraints()
     {
         $this->query->where(
-            $this->getQualifiedForeignPivotKeyName(), '=', $this->parent->{$this->parentKey}
+            $this->getQualifiedForeignPivotKeyName(), '=', $this->parent->onlyRaw($this->parentKey)[$this->parentKey] ?? $this->parent->{$this->parentKey}
         );
 
         return $this;
@@ -275,7 +275,7 @@ class BelongsToMany extends Relation
         // children back to their parent using the dictionary and the keys on the
         // the parent models. Then we will return the hydrated models back out.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->{$this->parentKey}])) {
+            if (isset($dictionary[$key = ($model->onlyRaw($this->parentKey)[$this->parentKey] ?? $model->{$this->parentKey})])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -345,7 +345,7 @@ trait InteractsWithPivotTable
     {
         $record[$this->relatedPivotKey] = $id;
 
-        $record[$this->foreignPivotKey] = $this->parent->{$this->parentKey};
+        $record[$this->foreignPivotKey] = $this->parent->onlyRaw($this->parentKey)[$this->parentKey] ?? $this->parent->{$this->parentKey};
 
         // If the record needs to have creation and update timestamps, we will make
         // them by calling the parent model's "freshTimestamp" method which will
@@ -541,7 +541,7 @@ trait InteractsWithPivotTable
             call_user_func_array([$query, 'whereIn'], $arguments);
         }
 
-        return $query->where($this->foreignPivotKey, $this->parent->{$this->parentKey});
+        return $query->where($this->foreignPivotKey, $this->parent->onlyRaw($this->parentKey)[$this->parentKey] ?? $this->parent->{$this->parentKey});
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -91,7 +91,7 @@ class HasManyThrough extends Relation
      */
     public function addConstraints()
     {
-        $localValue = $this->farParent[$this->localKey];
+        $localValue = $this->farParent->onlyRaw($this->localKey)[$this->localKey] ?? $this->farParent[$this->localKey];
 
         $this->performJoin();
 
@@ -186,7 +186,7 @@ class HasManyThrough extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = ($model->onlyRaw($this->localKey)[$this->localKey] ?? $model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->related->newCollection($dictionary[$key])
                 );

--- a/src/Illuminate/Database/Eloquent/Relations/HasOne.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOne.php
@@ -62,7 +62,7 @@ class HasOne extends HasOneOrMany
     public function newRelatedInstanceFor(Model $parent)
     {
         return $this->related->newInstance()->setAttribute(
-            $this->getForeignKeyName(), $parent->{$this->localKey}
+            $this->getForeignKeyName(), ($parent->onlyRaw($this->localKey)[$this->localKey] ?? $parent->{$this->localKey})
         );
     }
 }

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -131,7 +131,7 @@ abstract class HasOneOrMany extends Relation
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = ($model->onlyRaw($this->localKey)[$this->localKey] ?? $model->getAttribute($this->localKey))])) {
                 $model->setRelation(
                     $relation, $this->getRelationValue($dictionary, $key, $type)
                 );
@@ -166,8 +166,8 @@ abstract class HasOneOrMany extends Relation
     {
         $foreign = $this->getForeignKeyName();
 
-        return $results->mapToDictionary(function ($result) use ($foreign) {
-            return [$result->{$foreign} => $result];
+        return $results->mapToDictionary(function (Model $result) use ($foreign) {
+            return [($result->onlyRaw($foreign)[$foreign] ?? $result->{$foreign}) => $result];
         })->all();
     }
 
@@ -373,7 +373,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function getParentKey()
     {
-        return $this->parent->getAttribute($this->localKey);
+        return $this->parent->onlyRaw($this->localKey)[$this->localKey] ?? $this->parent->getAttribute($this->localKey);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneThrough.php
@@ -52,7 +52,7 @@ class HasOneThrough extends HasManyThrough
         // link them up with their children using the keyed dictionary to make the
         // matching very convenient and easy work. Then we'll just return them.
         foreach ($models as $model) {
-            if (isset($dictionary[$key = $model->getAttribute($this->localKey)])) {
+            if (isset($dictionary[$key = $model->onlyRaw($this->localKey)[$this->localKey] ?? $model->getAttribute($this->localKey)])) {
                 $value = $dictionary[$key];
                 $model->setRelation(
                     $relation, reset($value)

--- a/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyWithDefaultAttributesTest.php
@@ -42,7 +42,7 @@ class DatabaseEloquentBelongsToManyWithDefaultAttributesTest extends TestCase
         $parent->shouldReceive('getKey')->andReturn(1);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
 
         $builder = m::mock(Builder::class);
         $related = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -100,26 +100,26 @@ class DatabaseEloquentBelongsToTest extends TestCase
     {
         $relation = $this->getRelation();
         $result1 = m::mock(stdClass::class);
-        $result1->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $result1->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $result2 = m::mock(stdClass::class);
-        $result2->shouldReceive('getAttribute')->with('id')->andReturn(2);
+        $result2->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 2]);
         $model1 = new EloquentBelongsToModelStub;
         $model1->foreign_key = 1;
         $model2 = new EloquentBelongsToModelStub;
         $model2->foreign_key = 2;
         $models = $relation->match([$model1, $model2], new Collection([$result1, $result2]), 'foo');
 
-        $this->assertEquals(1, $models[0]->foo->getAttribute('id'));
-        $this->assertEquals(2, $models[1]->foo->getAttribute('id'));
+        $this->assertEquals(['id' => 1], $models[0]->foo->onlyRaw('id'));
+        $this->assertEquals(['id' => 2], $models[1]->foo->onlyRaw('id'));
     }
 
     public function testAssociateMethodSetsForeignKeyOnModel()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
         $relation = $this->getRelation($parent);
         $associate = m::mock(Model::class);
-        $associate->shouldReceive('getAttribute')->once()->with('id')->andReturn(1);
+        $associate->shouldReceive('onlyRaw')->once()->with('id')->andReturn(['id' => 1]);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
         $parent->shouldReceive('setRelation')->once()->with('relation', $associate);
 
@@ -129,7 +129,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testDissociateMethodUnsetsForeignKeyOnModel()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', null);
 
@@ -142,7 +142,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
     public function testAssociateMethodSetsForeignKeyOnModelById()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
         $relation = $this->getRelation($parent);
         $parent->shouldReceive('setAttribute')->once()->with('foreign_key', 1);
 
@@ -186,6 +186,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
         $this->builder = m::mock(Builder::class);
         $this->builder->shouldReceive('where')->with('relation.id', '=', 'foreign.value');
         $this->related = m::mock(Model::class);
+        $this->related->shouldReceive('onlyRaw')->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
         $this->related->shouldReceive('getKeyType')->andReturn($keyType);
         $this->related->shouldReceive('getKeyName')->andReturn('id');
         $this->related->shouldReceive('getTable')->andReturn('relation');

--- a/tests/Database/DatabaseEloquentCastedRelationIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentCastedRelationIntegrationTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Builder;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseEloquentCastedRelationIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->migrateDefault();
+        $this->seedDefaultData();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('model_a_s');
+        $this->schema()->drop('model_b_s');
+    }
+
+    /**
+     * Migrate tables for classes with a Laravel "default" HasOneThrough setup.
+     */
+    protected function migrateDefault()
+    {
+        $this->schema()->create('model_a_s', function ($table) {
+            $table->increments('id');
+            $table->string('uuid')->unique();
+        });
+
+        $this->schema()->create('model_b_s', function ($table) {
+            $table->increments('id');
+            $table->string('model_a_uuid');
+            $table->foreign('model_a_uuid')->references('uuid')->on('model_a_s');
+        });
+
+        $this->schema()->create('model_c_s', function ($table) {
+            $table->increments('id');
+            $table->string('uuid')->unique();
+        });
+
+        $this->schema()->create('model_a_model_c', function ($table) {
+            $table->increments('id');
+            $table->string('model_a_uuid');
+            $table->foreign('model_a_uuid')->references('uuid')->on('model_a_s');
+            $table->string('model_c_uuid');
+            $table->foreign('model_c_uuid')->references('uuid')->on('model_c_s');
+        });
+    }
+
+    /**
+     * Seed data for a default HasOneThrough setup.
+     */
+    protected function seedDefaultData()
+    {
+        $modelA1 = ModelA::create(['uuid' => 'A-XXX-XXX-1']);
+        $modelA2 = ModelA::create(['uuid' => 'A-XXX-XXX-2']);
+        ModelB::create(['model_a_uuid' => 'A-XXX-XXX-1']);
+        ModelB::create(['model_a_uuid' => 'A-XXX-XXX-1']);
+        $modelC1 = ModelC::create(['uuid' => 'C-XXX-XXX-1']);
+        $modelC2 = ModelC::create(['uuid' => 'C-XXX-XXX-2']);
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return Connection
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+
+    public function testRelationOneToOneAToB()
+    {
+        /** @var ModelA $modelA */
+        $modelA = ModelA::all()->first();
+
+        $this->assertInstanceOf(ModelB::class, $modelA->oneModelB);
+        $this->assertSame($modelA->uuid->value, $modelA->oneModelB->model_a_uuid->value);
+    }
+
+    public function testRelationOneToOneBToA()
+    {
+        /** @var ModelB $modelB */
+        $modelB = ModelB::all()->first();
+
+        $this->assertInstanceOf(ModelA::class, $modelB->oneModelA);
+        $this->assertSame($modelB->model_a_uuid->value, $modelB->oneModelA->uuid->value);
+    }
+
+    public function testRelationOneToManyAToB()
+    {
+        /** @var ModelA $modelA */
+        $modelA = ModelA::all()->first();
+        $modelBs = $modelA->manyModelB;
+
+        $this->assertEquals(2, $modelBs->count());
+
+        $this->assertInstanceOf(ModelB::class, $modelBs->get(0));
+        $this->assertSame($modelA->uuid->value, $modelBs->get(0)->model_a_uuid->value);
+
+        $this->assertInstanceOf(ModelB::class, $modelBs->get(1));
+        $this->assertSame($modelA->uuid->value, $modelBs->get(1)->model_a_uuid->value);
+    }
+
+    public function testRelationManyToOneBToA()
+    {
+        /** @var Collection $modelBs */
+        $modelBs = ModelB::all();
+
+        $this->assertEquals(2, $modelBs->count());
+
+        $this->assertInstanceOf(ModelA::class, $modelBs->get(0)->oneModelA);
+        $this->assertSame($modelBs->get(0)->model_a_uuid->value, $modelBs->get(0)->oneModelA->uuid->value);
+
+        $this->assertInstanceOf(ModelA::class, $modelBs->get(1)->oneModelA);
+        $this->assertSame($modelBs->get(1)->model_a_uuid->value, $modelBs->get(1)->oneModelA->uuid->value);
+    }
+
+    public function testRelationManyToManyBToC()
+    {
+        /** @var ModelA $modelA */
+        $modelA = ModelA::all()->first();
+
+        /* Create relations */
+        $modelA->manyModelC()->saveMany([
+            ModelC::firstWhere(['uuid' => 'C-XXX-XXX-1']),
+            ModelC::firstWhere(['uuid' => 'C-XXX-XXX-2'])]);
+
+        $modelCs = $modelA->manyModelC;
+
+        $this->assertEquals(2, $modelCs->count());
+        $this->assertSame('C-XXX-XXX-1', $modelCs->get(0)->uuid->value);
+        $this->assertSame('C-XXX-XXX-2', $modelCs->get(1)->uuid->value);
+    }
+
+    public function testRelationManyToManyCToB()
+    {
+        /** @var ModelC $modelC */
+        $modelC = ModelC::all()->first();
+
+        /* Create relations */
+        $modelC->manyModelA()->saveMany([
+            ModelA::firstWhere(['uuid' => 'A-XXX-XXX-1']),
+            ModelA::firstWhere(['uuid' => 'A-XXX-XXX-2'])]);
+
+        $modelAs = $modelC->manyModelA;
+
+        $this->assertEquals(2, $modelAs->count());
+        $this->assertSame('A-XXX-XXX-1', $modelAs->get(0)->uuid->value);
+        $this->assertSame('A-XXX-XXX-2', $modelAs->get(1)->uuid->value);
+    }
+}
+
+/**
+ * @property object uuid
+ * @property ModelB oneModelB
+ * @property Collection manyModelB
+ * @property Collection manyModelC
+ */
+class ModelA extends Model
+{
+    protected $casts = ['uuid' => ToObject::class];
+    protected $fillable = ['uuid'];
+    public $timestamps = false;
+
+    public function oneModelB()
+    {
+        return $this->hasOne(ModelB::class, 'model_a_uuid', 'uuid');
+    }
+
+    public function manyModelB()
+    {
+        return $this->hasMany(ModelB::class, 'model_a_uuid', 'uuid');
+    }
+
+    public function manyModelC()
+    {
+        return $this->belongsToMany(
+            ModelC::class,
+            'model_a_model_c',
+            'model_a_uuid',
+            'model_c_uuid');
+    }
+}
+
+/**
+ * @property ModelA oneModelA
+ * @property object model_a_uuid
+ */
+class ModelB extends Model
+{
+    protected $casts = ['model_a_uuid' => ToObject::class];
+    protected $fillable = ['model_a_uuid'];
+    public $timestamps = false;
+
+    public function oneModelA()
+    {
+        return $this->belongsTo(ModelA::class, 'model_a_uuid', 'uuid');
+    }
+}
+
+/**
+ * @property Collection manyModelA
+ * @property object uuid
+ */
+class ModelC extends Model
+{
+    protected $casts = ['uuid' => ToObject::class];
+    protected $fillable = ['uuid'];
+    public $timestamps = false;
+
+    public function manyModelA()
+    {
+        return $this->belongsToMany(
+            ModelA::class,
+            'model_a_model_c',
+            'model_c_uuid',
+            'model_a_uuid');
+    }
+}
+
+class ToObject implements CastsAttributes
+{
+    public function set($model, string $key, $value, array $attributes): string
+    {
+        return is_string($value) ? $value : strval($value->value ?? null);
+    }
+
+    public function get($model, string $key, $value, array $attributes): object
+    {
+        return (object)['value' => $value];
+    }
+}

--- a/tests/Database/DatabaseEloquentCastedRelationIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentCastedRelationIntegrationTest.php
@@ -158,7 +158,7 @@ class DatabaseEloquentCastedRelationIntegrationTest extends TestCase
         /* Create relations */
         $modelA->manyModelC()->saveMany([
             ModelC::firstWhere(['uuid' => 'C-XXX-XXX-1']),
-            ModelC::firstWhere(['uuid' => 'C-XXX-XXX-2'])]);
+            ModelC::firstWhere(['uuid' => 'C-XXX-XXX-2']), ]);
 
         $modelCs = $modelA->manyModelC;
 
@@ -175,7 +175,7 @@ class DatabaseEloquentCastedRelationIntegrationTest extends TestCase
         /* Create relations */
         $modelC->manyModelA()->saveMany([
             ModelA::firstWhere(['uuid' => 'A-XXX-XXX-1']),
-            ModelA::firstWhere(['uuid' => 'A-XXX-XXX-2'])]);
+            ModelA::firstWhere(['uuid' => 'A-XXX-XXX-2']), ]);
 
         $modelAs = $modelC->manyModelA;
 
@@ -262,6 +262,6 @@ class ToObject implements CastsAttributes
 
     public function get($model, string $key, $value, array $attributes): object
     {
-        return (object)['value' => $value];
+        return (object) ['value' => $value];
     }
 }

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -260,7 +260,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
 

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -61,7 +61,7 @@ class DatabaseEloquentHasOneTest extends TestCase
     public function testHasOneWithDynamicDefaultUseParentModel()
     {
         $relation = $this->getRelation()->withDefault(function ($newModel, $parentModel) {
-            $newModel->username = $parentModel->username;
+            $newModel->username = $parentModel->onlyRaw('username')['username'];
         });
 
         $this->builder->shouldReceive('first')->once()->andReturnNull();
@@ -72,7 +72,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
         $this->assertSame($newModel, $relation->getResults());
 
-        $this->assertSame('taylor', $newModel->username);
+        $this->assertSame('taylor', $newModel->getAttribute('username'));
 
         $this->assertSame(1, $newModel->getAttribute('foreign_key'));
     }
@@ -204,8 +204,8 @@ class DatabaseEloquentHasOneTest extends TestCase
         $this->related = m::mock(Model::class);
         $this->builder->shouldReceive('getModel')->andReturn($this->related);
         $this->parent = m::mock(Model::class);
-        $this->parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
-        $this->parent->shouldReceive('getAttribute')->with('username')->andReturn('taylor');
+        $this->parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
+        $this->parent->shouldReceive('onlyRaw')->with('username')->andReturn(['username' => 'taylor']);
         $this->parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $this->parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $this->parent->shouldReceive('newQueryWithoutScopes')->andReturn($this->builder);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -201,6 +201,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testOnlyRaw()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['project' => 'laravel'], $model->only('project'));
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->onlyRaw('first_name', 'last_name'));
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->onlyRaw(['first_name', 'last_name']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;

--- a/tests/Database/DatabaseEloquentMorphTest.php
+++ b/tests/Database/DatabaseEloquentMorphTest.php
@@ -261,7 +261,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
@@ -276,7 +276,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
         $builder->shouldReceive('where')->once()->with('table.morph_type', get_class($parent));
 
@@ -297,7 +297,7 @@ class DatabaseEloquentMorphTest extends TestCase
         $related = m::mock(Model::class);
         $builder->shouldReceive('getModel')->andReturn($related);
         $parent = m::mock(EloquentModelNamespacedStub::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $parent->shouldReceive('getMorphClass')->andReturn($alias);
         $builder->shouldReceive('where')->once()->with('table.morph_type', $alias);
 

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -69,6 +69,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
+
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
         $relation->expects($this->once())->method('touchIfTouching');
 
@@ -90,7 +91,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $parent->shouldReceive('getCreatedAtColumn')->andReturn('created_at');
         $parent->shouldReceive('getUpdatedAtColumn')->andReturn('updated_at');
         $parent->shouldReceive('getMorphClass')->andReturn(get_class($parent));
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
 
         $builder = m::mock(Builder::class);
         $related = m::mock(Model::class);

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -107,7 +107,7 @@ class DatabaseEloquentMorphToTest extends TestCase
     public function testAssociateMethodSetsForeignKeyAndTypeOnModel()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->once()->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
 
         $relation = $this->getRelationAssociate($parent);
 
@@ -125,7 +125,7 @@ class DatabaseEloquentMorphToTest extends TestCase
     public function testAssociateMethodIgnoresNullValue()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->once()->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
 
         $relation = $this->getRelationAssociate($parent);
 
@@ -139,7 +139,7 @@ class DatabaseEloquentMorphToTest extends TestCase
     public function testDissociateMethodDeletesUnsetsKeyAndTypeOnModel()
     {
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->once()->with('foreign_key')->andReturn('foreign.value');
+        $parent->shouldReceive('onlyRaw')->once()->with('foreign_key')->andReturn(['foreign_key' => 'foreign.value']);
 
         $relation = $this->getRelation($parent);
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -41,7 +41,7 @@ class DatabaseEloquentRelationTest extends TestCase
     {
         $builder = m::mock(Builder::class);
         $parent = m::mock(Model::class);
-        $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+        $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
         $related = m::mock(EloquentNoTouchingModelStub::class)->makePartial();
         $builder->shouldReceive('getModel')->andReturn($related);
         $builder->shouldReceive('whereNotNull');
@@ -72,7 +72,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder = m::mock(Builder::class);
             $parent = m::mock(Model::class);
 
-            $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+            $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
             $builder->shouldReceive('getModel')->andReturn($related);
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
@@ -104,7 +104,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder = m::mock(Builder::class);
             $parent = m::mock(Model::class);
 
-            $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+            $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
             $builder->shouldReceive('getModel')->andReturn($related);
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
@@ -117,7 +117,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder = m::mock(Builder::class);
             $anotherParent = m::mock(Model::class);
 
-            $anotherParent->shouldReceive('getAttribute')->with('id')->andReturn(2);
+            $anotherParent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 2]);
             $anotherBuilder->shouldReceive('getModel')->andReturn($anotherRelated);
             $anotherBuilder->shouldReceive('whereNotNull');
             $anotherBuilder->shouldReceive('where');
@@ -154,7 +154,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $builder = m::mock(Builder::class);
             $parent = m::mock(Model::class);
 
-            $parent->shouldReceive('getAttribute')->with('id')->andReturn(1);
+            $parent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 1]);
             $builder->shouldReceive('getModel')->andReturn($related);
             $builder->shouldReceive('whereNotNull');
             $builder->shouldReceive('where');
@@ -167,7 +167,7 @@ class DatabaseEloquentRelationTest extends TestCase
             $anotherBuilder = m::mock(Builder::class);
             $anotherParent = m::mock(Model::class);
 
-            $anotherParent->shouldReceive('getAttribute')->with('id')->andReturn(2);
+            $anotherParent->shouldReceive('onlyRaw')->with('id')->andReturn(['id' => 2]);
             $anotherBuilder->shouldReceive('getModel')->andReturn($relatedChild);
             $anotherBuilder->shouldReceive('whereNotNull');
             $anotherBuilder->shouldReceive('where');
@@ -262,6 +262,7 @@ class DatabaseEloquentRelationTest extends TestCase
         });
 
         $model = new EloquentRelationResetModelStub;
+
         $relation = new EloquentRelationStub($model->newQuery(), $model);
 
         $result = $relation->foo();

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -113,6 +113,34 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $this->assertSame('117 Spencer St.', $model->address->lineOne);
     }
+
+    public function testGettingSubsetOfRawAttributes()
+    {
+        $model = new TestEloquentModelWithCustomCast;
+
+        $model->uppercase = 'taylor';
+        $model->address = (object)[
+            'lineOne' => 'line1',
+            'lineTwo' => 'line2',
+        ];
+
+        $this->assertSame(['uppercase' => 'TAYLOR'], $model->onlyRaw('uppercase'));
+        $this->assertSame(['uppercase' => 'TAYLOR'], $model->onlyRaw(['uppercase']));
+        $this->assertSame(['address_line_one' => 'line1'], $model->onlyRaw(['address_line_one']));
+        $this->assertSame(['address_line_two' => 'line2'], $model->onlyRaw(['address_line_two']));
+        $this->assertSame(
+            ['address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2']],
+            $model->onlyRaw(['address']));
+        $this->assertSame(
+            ['address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2'], 'uppercase' => 'TAYLOR'],
+            $model->onlyRaw(['address', 'uppercase']));
+        $this->assertSame([
+                'address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2'],
+                'uppercase' => 'TAYLOR',
+                'address_line_one' => 'line1',
+                'address_line_two' => 'line2'],
+            $model->onlyRaw(['address', 'uppercase', 'address_line_one', 'address_line_two']));
+    }
 }
 
 class TestEloquentModelWithCustomCast extends Model

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -119,7 +119,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model = new TestEloquentModelWithCustomCast;
 
         $model->uppercase = 'taylor';
-        $model->address = (object)[
+        $model->address = (object) [
             'lineOne' => 'line1',
             'lineTwo' => 'line2',
         ];
@@ -135,10 +135,10 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
             ['address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2'], 'uppercase' => 'TAYLOR'],
             $model->onlyRaw(['address', 'uppercase']));
         $this->assertSame([
-                'address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2'],
-                'uppercase' => 'TAYLOR',
-                'address_line_one' => 'line1',
-                'address_line_two' => 'line2'],
+            'address' => ['address_line_one' => 'line1', 'address_line_two' => 'line2'],
+            'uppercase' => 'TAYLOR',
+            'address_line_one' => 'line1',
+            'address_line_two' => 'line2', ],
             $model->onlyRaw(['address', 'uppercase', 'address_line_one', 'address_line_two']));
     }
 }


### PR DESCRIPTION
This PR follow the bug report moved to ideas:

https://github.com/laravel/ideas/issues/2144

In summary this PR adds a function HasAttributes::onlyRaw() to get attributes as they shall be saved in database after casting. This is then used in all relations methods to get the real key's value to be used for the relation query.

In the code 2 patterns can be found:

`$this->child->{$this->foreignKey}` changed to: `$this->child->onlyRaw($this->foreignKey)[$this->foreignKey] ?? $this->child->{$this->foreignKey})`.

And:

`$model->getAttribute($this->ownerKey)` changed to:
`$model->onlyRaw($this->ownerKey)[$this->ownerKey] ?? $model->getAttribute($this->ownerKey)`

I believe this might be an inconsistent behavior as the first one authorize the user to create his own property which will be used instead of the one in `$attributes` .
In all changes, I in purpose let the `?? previous_behaviour` to reduce the risks of back compatibly breaks.

This make the code cumbersome, I belive the use of `$model->onlyRaw($this->keyName)[$this->keyName]` shall be enough. (however this will break some tests using real properties instead of $attribute[$key]).

A better/lighter name could be found to replace `$model->onlyRaw($this->keyName)[$this->keyName]` too..., if you got ideas, let's find something :-)

Please let's me know if you have any ideas, comments, etc...