### PR TITLE
[8.x] Add the ability to remove orders from the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2018,6 +2018,21 @@ class Builder
     }
 
     /**
+     * Remove all the existing orders from the query.
+     *
+     * @return static
+     */
+    public function removeOrders()
+    {
+        $this->orders = null;
+        $this->unionOrders = null;
+        $this->bindings['order'] = [];
+        $this->bindings['unionOrder'] = [];
+
+        return $this;
+    }
+
+    /**
      * Get an array with all orders with a given column removed.
      *
      * @param  string  $column

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1132,6 +1132,29 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
+    public function testRemoveOrders()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+        $this->assertSame('select * from "users" order by "name" asc', $builder->toSql());
+        $builder->removeOrders();
+        $this->assertSame('select * from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('first');
+        $builder->union($this->getBuilder()->select('*')->from('second'));
+        $builder->orderBy('name');
+        $this->assertSame('(select * from "first") union (select * from "second") order by "name" asc', $builder->toSql());
+        $builder->removeOrders();
+        $this->assertSame('(select * from "first") union (select * from "second")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByRaw('?', [true]);
+        $this->assertEquals([true], $builder->getBindings());
+        $builder->removeOrders();
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testOrderByInvalidDirectionParam()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
It's really nice to be able to define default orders on models and relationships. For example:

```php
class Account extends Model
{
    public function users()
    {
        return $this->hasMany(User::class)->orderBy('name');
    }
}
```

Now when you access `$account->users`, the users will be sorted properly. And the same goes for if you use the `$account->users()` query builder. Nice. 👍 

However, this can be problematic if you ever need to order the relationship by something else. For example:

```php
// Try to order by the emails, and not the name
$users = $account->users()->orderBy('email');
```

Because of the default `orderBy()` on the relationship, this will still first sort by the `name`, and then by the `email`, which may not be desirable.

This happens because new orders get added to the query builder, they do not replace existing orders. And that's good behaviour. But then how do you handle those situations where you really do want to remove the default order by? Right now you'd have to stop using the relationship, and just use the model directly, which isn't ideal.

This PR adds a very simple `removeOrders()` method to the query builder that lets you quickly remove all the existing orders. Here's how you would use it:

```php
// Remove the existing "name" order, and then order by "email"
$users = $account->users()->removeOrders()->orderBy('email');
```

I'm not saying this is the most eloquent looking code, but practically it's quite helpful, since it allows you to apply default orders to your models and relationships, which tend to work for 99% of the cases, while still providing an escape hatch should you need it. 