### PR TITLE
[7.x] Add support for default values for the "props" blade tag

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -148,6 +148,9 @@ trait CompilesComponents
     protected function compileProps($expression)
     {
         return "<?php \$attributes = \$attributes->exceptProps{$expression}; ?>
+<?php foreach (array_filter({$expression}, 'is_string', ARRAY_FILTER_USE_KEY) as \$__key => \$__value) {
+    \$\$__key = \$\$__key ?? \$__value;
+} ?>
 <?php \$__defined_vars = get_defined_vars(); ?>
 <?php foreach (\$attributes as \$__key => \$__value) {
     if (array_key_exists(\$__key, \$__defined_vars)) unset(\$\$__key);

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -90,7 +90,11 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $props = [];
 
-        foreach ($keys as $key) {
+        foreach ($keys as $key => $defaultValue) {
+            // If the "key" value is a numeric key, we assume that no default value
+            // has been specified, and use the "default value" as the key.
+            $key = is_numeric($key) ? $defaultValue : $key;
+
             $props[] = $key;
             $props[] = Str::kebab($key);
         }


### PR DESCRIPTION
Currently, to make default properties for anonymous components, you have to either upgrade to a full component with a component class, or maybe do something like the following:

```php
<!-- /resources/views/components/alert.blade.php -->

@props(['type', 'message'])
@php
    $type = $type ?? 'info'
@endphp

<div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }}>
    {{ $message }}
</div>
```

This PR adds support for default property values that you specify in the props tag.

For the previous example, this would look something like the following:

```php
@props(['type' => 'info', 'message'])
```

This benefits the user, as it's more terse and looks neater (in my opinion).

It should not conflict with how the props tag works currently, as users were not expected to pass associative or mixed arrays as arguments.

As for tests, I could not find any tests related to the props tag, so I'm no sure what I need to do.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
