### PR TITLE
[6.x] SetCacheHeaders should cache responses with a status code of 204

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -21,7 +21,7 @@ class SetCacheHeaders
     {
         $response = $next($request);
 
-        if (! $request->isMethodCacheable() || ! $response->getContent()) {
+        if (! $request->isMethodCacheable()) {
             return $response;
         }
 


### PR DESCRIPTION
Currently, SetCacheHeaders middleware does not cache successful responses with a status code of 204, because those have no content. I would expect 204 responses are cacheable.

I see two options:
* remove the condition to cache only responses that have content (see PR)
* only, if the status code is 204, remove the condition to cache only responses that have content

As this could be a breaking change, maybe it's better to include it in a next major release.