### PR TITLE
[6.x] `Str::is()` wildcard does not match new lines

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -243,7 +243,7 @@ class Str
             // pattern such as "library/*", making any string check convenient.
             $pattern = str_replace('\*', '.*', $pattern);
 
-            if (preg_match('#^'.$pattern.'\z#u', $value) === 1) {
+            if (preg_match('#^'.$pattern.'\z#us', $value) === 1) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -222,6 +222,9 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::is(['a*', 'b*'], 123));
         $this->assertTrue(Str::is(['*2*', 'b*'], 11211));
 
+        // new lines
+        $this->assertTrue(Str::is('foo/*', "foo/\nbar"));
+
         $this->assertTrue(Str::is('*/foo', 'blah/baz/foo'));
 
         $valueObject = new StringableObjectStub('foo/bar/baz');


### PR DESCRIPTION
Closes #32180

According to the docs `str_is` or `Str::is` is supposed to use asterisks as wildcards, but the internal regular expression uses the `u` (PCRE_UTF8) modifier without including the `s` (PCRE_DOTALL) modifier.

This PR aligns the code to the original intent of the function.

