### PR TITLE
[7.x] Add the ability to remove orders from the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2018,6 +2018,25 @@ class Builder
     }
 
     /**
+     * Remove all existing orders and optionally add a new order.
+     *
+     * @return static
+     */
+    public function reorder($column = null, $direction = 'asc')
+    {
+        $this->orders = null;
+        $this->unionOrders = null;
+        $this->bindings['order'] = [];
+        $this->bindings['unionOrder'] = [];
+
+        if ($column) {
+            return $this->orderBy($column, $direction);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get an array with all orders with a given column removed.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2020,7 +2020,7 @@ class Builder
     /**
      * Remove all existing orders and optionally add a new order.
      *
-     * @return static
+     * @return $this
      */
     public function reorder($column = null, $direction = 'asc')
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1108,6 +1108,35 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([1, 1, 'news', 'opinion'], $builder->getBindings());
     }
 
+    public function testReorder()
+    {
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+        $this->assertSame('select * from "users" order by "name" asc', $builder->toSql());
+        $builder->reorder();
+        $this->assertSame('select * from "users"', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderBy('name');
+        $this->assertSame('select * from "users" order by "name" asc', $builder->toSql());
+        $builder->reorder('email', 'desc');
+        $this->assertSame('select * from "users" order by "email" desc', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('first');
+        $builder->union($this->getBuilder()->select('*')->from('second'));
+        $builder->orderBy('name');
+        $this->assertSame('(select * from "first") union (select * from "second") order by "name" asc', $builder->toSql());
+        $builder->reorder();
+        $this->assertSame('(select * from "first") union (select * from "second")', $builder->toSql());
+
+        $builder = $this->getBuilder();
+        $builder->select('*')->from('users')->orderByRaw('?', [true]);
+        $this->assertEquals([true], $builder->getBindings());
+        $builder->reorder();
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testOrderBySubQueries()
     {
         $expected = 'select * from "users" order by (select "created_at" from "logins" where "user_id" = "users"."id" limit 1)';


### PR DESCRIPTION
[Replaces #32176]

It's really nice to be able to define default orders on models and relationships. For example:

```php
class Account extends Model
{
    public function users()
    {
        return $this->hasMany(User::class)->orderBy('name');
    }
}
```

Now when you access `$account->users`, the users will be sorted properly. And the same goes for if you use the `$account->users()` query builder. Nice. 👍 

However, this can be problematic if you ever need to order the relationship by something else. For example:

```php
// Try to order by the emails, and not the name
// This will not work. It will reorder by name first, then email
$users = $account->users()->orderBy('email');
```

Because of the default `orderBy()` on the relationship, this will still first sort by the `name`, and then by the `email`, which may not be desirable.

This happens because new orders get added to the query builder, they do not replace existing orders. And that's good behaviour. But then how do you handle those situations where you really do want to remove the default order by? Right now you'd have to stop using the relationship, and just use the model directly, which isn't ideal.

This PR adds a very simple `reorder($column = null, $direction = null)` method to the query builder that lets you quickly remove all the existing orders, and optionally add a new one. Here's how you would use it:

```php
// Remove the existing "name" order, and then order by "email".
$users = $account->users()->reorder('email');

// Remove the existing "name" order, and then order using a scope
$users = $account->users()->reorder()->orderBySomeScope();
```

This syntax is inspired by the Rails [reorder](https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-reorder) method, which does the same thing.