### PR TITLE
[7.x] Replace spy with mock

### DIFF
--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -24,7 +24,7 @@ class SupportFacadesEventTest extends TestCase
     {
         parent::setUp();
 
-        $this->events = m::spy(Dispatcher::class);
+        $this->events = m::mock(Dispatcher::class);
 
         $container = new Container;
         $container->instance('events', $this->events);


### PR DESCRIPTION
This PR replaces spy with mock in SupportFacadesEventTest. Because 'shouldHaveReceived' or 'shouldNotHaveReceived' are never used.