### PR TITLE
[6.x] Prevent long URLs from breaking email layouts

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/themes/default.css
+++ b/src/Illuminate/Mail/resources/views/html/themes/default.css
@@ -290,3 +290,9 @@ img {
     font-size: 15px;
     text-align: center;
 }
+
+/* Utilities */
+
+.break-all {
+    word-break: break-all;
+}

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -52,13 +52,11 @@
 @slot('subcopy')
 @lang(
     "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\n".
-    'into your web browser: [:displayableActionUrl](:actionURL)',
+    'into your web browser:',
     [
         'actionText' => $actionText,
-        'actionURL' => $actionUrl,
-        'displayableActionUrl' => $displayableActionUrl,
     ]
-)
+) <span class="break-all">[{{ $displayableActionUrl }}]({{ $actionUrl }})</span>
 @endslot
 @endisset
 @endcomponent


### PR DESCRIPTION
Long URLs will break the default email notification layout because they don't wrap:

<img width="1330" alt="Screen Shot 2020-03-31 at 5 17 38 PM" src="https://user-images.githubusercontent.com/3410149/78082851-a1bd5b80-7379-11ea-9a6e-05b19b462e06.png">

I added a new utility class to the default mail theme and modified the notification layout so that  URLs in notifications are forced to wrap:

<img width="1314" alt="Screen Shot 2020-03-31 at 5 17 12 PM" src="https://user-images.githubusercontent.com/3410149/78083062-1e503a00-737a-11ea-806b-8483829bbbb4.png">

I'd consider this a breaking change because I had to update a translation string in the notification layout.