### PR TITLE
[7.x] 3.5x faster micro performance enhancement for data_get()

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -145,6 +145,10 @@ if (! function_exists('data_get')) {
         foreach ($key as $i => $segment) {
             unset($key[$i]);
 
+            if ($segment === null) {
+                return $target;
+            }
+
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -145,7 +145,7 @@ if (! function_exists('data_get')) {
         foreach ($key as $i => $segment) {
             unset($key[$i]);
 
-            if ($segment === null) {
+            if (is_null($segment)) {
                 return $target;
             }
 

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -142,7 +142,7 @@ if (! function_exists('data_get')) {
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        foreach($key as $i => $segment) {
+        foreach ($key as $i => $segment) {
             unset($key[$i]);
     
             if ($segment === '*') {

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -144,7 +144,7 @@ if (! function_exists('data_get')) {
 
         foreach ($key as $i => $segment) {
             unset($key[$i]);
-    
+
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -142,7 +142,9 @@ if (! function_exists('data_get')) {
 
         $key = is_array($key) ? $key : explode('.', $key);
 
-        while (! is_null($segment = array_shift($key))) {
+        foreach($key as $i => $segment) {
+            unset($key[$i]);
+    
             if ($segment === '*') {
                 if ($target instanceof Collection) {
                     $target = $target->all();


### PR DESCRIPTION
Replace `while:array_shift` with `foreach:unset`. This operation is 3.5x faster. It is arguably more readable as well.

In my isolation tests with 1000 iterations:

- While loop `1.969ms`
- Foreach loop `0.527ms`