### PR TITLE
[7.x] Optimize container

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -662,10 +662,8 @@ class Container implements ArrayAccess, ContainerContract
     protected function resolve($abstract, $parameters = [], $raiseEvents = true)
     {
         $abstract = $this->getAlias($abstract);
-
-        $needsContextualBuild = ! empty($parameters) || ! is_null(
-            $this->getContextualConcrete($abstract)
-        );
+        $concrete = $this->getContextualConcrete($abstract);
+        $needsContextualBuild = ! empty($parameters) || ! is_null($concrete);
 
         // If an instance of the type is currently being managed as a singleton we'll
         // just return an existing instance instead of instantiating new instances
@@ -676,7 +674,11 @@ class Container implements ArrayAccess, ContainerContract
 
         $this->with[] = $parameters;
 
-        $concrete = $this->getConcrete($abstract);
+        // If we don't have any contextual concrete binding for the given abstract,
+        // we'll continue to find the concrete type in the bindings array
+        if (is_null($concrete)) {
+            $concrete = $this->getConcrete($abstract);
+        }
 
         // We're ready to instantiate an instance of the concrete type registered for
         // the binding. This will instantiate the types, as well as resolve any of
@@ -723,10 +725,6 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getConcrete($abstract)
     {
-        if (! is_null($concrete = $this->getContextualConcrete($abstract))) {
-            return $concrete;
-        }
-
         // If we don't have a registered resolver or concrete for the type, we'll just
         // assume each type is a concrete name and will attempt to resolve it as is
         // since the container should be able to resolve concretes automatically.

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -662,7 +662,9 @@ class Container implements ArrayAccess, ContainerContract
     protected function resolve($abstract, $parameters = [], $raiseEvents = true)
     {
         $abstract = $this->getAlias($abstract);
+        
         $concrete = $this->getContextualConcrete($abstract);
+
         $needsContextualBuild = ! empty($parameters) || ! is_null($concrete);
 
         // If an instance of the type is currently being managed as a singleton we'll
@@ -674,8 +676,6 @@ class Container implements ArrayAccess, ContainerContract
 
         $this->with[] = $parameters;
 
-        // If we don't have any contextual concrete binding for the given abstract,
-        // we'll continue to find the concrete type in the bindings array
         if (is_null($concrete)) {
             $concrete = $this->getConcrete($abstract);
         }


### PR DESCRIPTION
What I saw is the `getContextualConcrete` method is called **twice** during the execution of the `resolve` method, in case the given `$parameters` is empty.

We're able to make it to be called **once** by capturing its return value, and then before calling the `getConcrete` method, we will check if that value is null. If the value is not null, just use it.

The behavior is exactly the same, the benefit is reducing an unnecessary method call.