### PR TITLE
[7.x] Add temporaryUrl docblock in Storage facade

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -28,6 +28,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static bool deleteDirectory(string $directory)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertExists(string|array $path)
  * @method static \Illuminate\Contracts\Filesystem\Filesystem assertMissing(string|array $path)
+ * @method static string temporaryUrl(string  $path, \DateTimeInterface  $expiration, array  $options)
  *
  * @see \Illuminate\Filesystem\FilesystemManager
  */


### PR DESCRIPTION
Just adding this missing docblock i needed in my project to avoid errors in my IDE and enable autocompletion.
