### PR TITLE
[7.x] Add HTTP client assertions assertNotSent() and assertNothingSent()

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -192,6 +192,33 @@ class Factory
     }
 
     /**
+     * Assert that a request / response pair was not recorded matching a given truth test.
+     *
+     * @param  callable  $callback
+     * @return void
+     */
+    public function assertNotSent($callback)
+    {
+        PHPUnit::assertFalse(
+            $this->recorded($callback)->count() > 0,
+            'Unexpected request was recorded.'
+        );
+    }
+
+    /**
+     * Assert that no request / response pair was recorded.
+     *
+     * @return void
+     */
+    public function assertNothingSent()
+    {
+        PHPUnit::assertEmpty(
+            $this->recorded,
+            'Requests were recorded.'
+        );
+    }
+
+    /**
      * Assert that every created response sequence is empty.
      *
      * @return void

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -87,6 +87,27 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testSpecificRequestIsNotBeingSent()
+    {
+        $this->factory->fake();
+
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->assertNotSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/form' &&
+                $request['name'] === 'Peter';
+        });
+    }
+
+    public function testNoRequestIsNotBeingSent()
+    {
+        $this->factory->fake();
+
+        $this->factory->assertNothingSent();
+    }
+
     public function testCanSendMultipartData()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR adds a new assertion to the new HTTP client called `assertNotSent`.

Similar to the given helper method `assertSent`, this new one tests the opposite: if a specific request was `not` sent.

Here is an example:

```php
Http::assertNotSent(function ($request) {
    return $request->hasHeader('X-First', 'foo') &&
           $request->url() == 'http://test.com/users' &&
           $request['name'] == 'Taylor' &&
           $request['role'] == 'Developer';
});
```

Since there are no specific tests for the assertion helpers, I added one to the HTTP client test file.
