### PR TITLE
[7.x] Fix exit code of down/up commands when already down/up

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -37,7 +37,7 @@ class DownCommand extends Command
             if (file_exists(storage_path('framework/down'))) {
                 $this->comment('Application is already down.');
 
-                return true;
+                return 0;
             }
 
             file_put_contents(storage_path('framework/down'),

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -32,7 +32,7 @@ class UpCommand extends Command
             if (! file_exists(storage_path('framework/down'))) {
                 $this->comment('Application is already up.');
 
-                return true;
+                return 0;
             }
 
             unlink(storage_path('framework/down'));


### PR DESCRIPTION
This will return exit code 0 instead of boolean true. The boolean will be cast to an int resulting in exit code 1, but if the application is already down/up exit code 0 would be desirable.

## Change
```diff
$ php artisan down
Application is now in maintenance mode.
$ echo $?
0
$ php artisan down
Application is already down.
$ echo $?
- 1
+ 0

$ php artisan up
Application is now live.
$ echo $?
0
$ php artisan up
Application is already up.
$ echo $?
- 1
+ 0
```

## Context
Our deploymenttool (DeployHQ) performs `php artisan down` before uploading the changes, but stops if this fails. If the deployment fails later in the process - composer install or a migration might fail - our tool stops and the application is still in maintenance mode. If we fix the error and restart the deployment `php artisan down` now returns an exit code other than 0 and our tool thinks it failed and stops the deployment. This results in a 'locked' state where we have to manually bring the application back up before we can start a new deployment.