### PR TITLE
[8.x] Make protected getValue($attribute) function public

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -904,7 +904,7 @@ class Validator implements ValidatorContract
      * @param  string  $attribute
      * @return mixed
      */
-    protected function getValue($attribute)
+    public function getValue($attribute)
     {
         return Arr::get($this->data, $attribute);
     }


### PR DESCRIPTION
The `after` validation hook is great for complex logic, but you'll most likely always need access to the data someway.

Currently, you have two options to access a single data attribute within the callback:

1.  ```PHP
    $validator->after(function ($validator) use ($data) {
        $email = $data['email'];
    });
    ```

2. ```PHP
    $validator->after(function ($validator) {
        $email = $validator->getData()['email'];
    });
    ```

Readability is improved with this PR by making the `protected function getValue($attribute)` public:

```PHP
$validator->after(function ($validator) {
    $email = $validator->getValue('email');
});
```