### PR TITLE
[7.x] Added renameColumn() enum support

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -33,12 +33,16 @@ class ChangeColumn
             ));
         }
 
+        $schema = $connection->getDoctrineSchemaManager();
+        $databasePlatform = $schema->getDatabasePlatform();
+        $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
+
         $tableDiff = static::getChangedDiff(
-            $grammar, $blueprint, $schema = $connection->getDoctrineSchemaManager()
+            $grammar, $blueprint, $schema
         );
 
         if ($tableDiff !== false) {
-            return (array) $schema->getDatabasePlatform()->getAlterTableSQL($tableDiff);
+            return (array) $databasePlatform->getAlterTableSQL($tableDiff);
         }
 
         return [];

--- a/src/Illuminate/Database/Schema/Grammars/RenameColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/RenameColumn.php
@@ -22,13 +22,15 @@ class RenameColumn
      */
     public static function compile(Grammar $grammar, Blueprint $blueprint, Fluent $command, Connection $connection)
     {
+        $schema = $connection->getDoctrineSchemaManager();
+        $databasePlatform = $schema->getDatabasePlatform();
+        $databasePlatform->registerDoctrineTypeMapping('enum', 'string');
+
         $column = $connection->getDoctrineColumn(
             $grammar->getTablePrefix().$blueprint->getTable(), $command->from
         );
 
-        $schema = $connection->getDoctrineSchemaManager();
-
-        return (array) $schema->getDatabasePlatform()->getAlterTableSQL(static::getRenamedDiff(
+        return (array) $databasePlatform->getAlterTableSQL(static::getRenamedDiff(
             $grammar, $blueprint, $command, $column, $schema
         ));
     }

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Facade;
 use PHPUnit\Framework\TestCase;
 
@@ -40,12 +41,12 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testDropAllTablesWorksWithForeignKeys()
     {
-        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
         });
 
-        $this->db->connection()->getSchemaBuilder()->create('table2', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('table2', function (Blueprint $table) {
             $table->integer('id');
             $table->string('user_id');
             $table->foreign('user_id')->references('id')->on('table1');
@@ -64,7 +65,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
     {
         $this->db->connection()->setTablePrefix('test_');
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
         });
@@ -81,7 +82,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'prefix_indexes' => false,
         ]);
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
             $table->integer('id');
             $table->string('name')->index();
         });
@@ -98,7 +99,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'prefix_indexes' => true,
         ]);
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
             $table->integer('id');
             $table->string('name')->index();
         });

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -5,29 +5,17 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Orchestra\Testbench\TestCase;
 
-class DatabaseMySqlConnectionTest extends TestCase
+class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
 {
     const TABLE = 'player';
     const FLOAT_COL = 'float_col';
     const JSON_COL = 'json_col';
-
     const FLOAT_VAL = 0.2;
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('app.debug', 'true');
-        $app['config']->set('database.default', 'mysql');
-    }
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        if (! isset($_SERVER['CI'])) {
-            $this->markTestSkipped('This test is only executed on CI.');
-        }
 
         if (! Schema::hasTable(self::TABLE)) {
             Schema::create(self::TABLE, function (Blueprint $table) {

--- a/tests/Integration/Database/DatabaseMySqlTestCase.php
+++ b/tests/Integration/Database/DatabaseMySqlTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Orchestra\Testbench\TestCase;
+
+abstract class DatabaseMySqlTestCase extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+        $app['config']->set('database.default', 'mysql');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! isset($_SERVER['CI'])) {
+            $this->markTestSkipped('This test is only executed on CI.');
+        }
+    }
+}

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
+{
+    public function testRenameColumnOnTableWithEnum()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->renameColumn('name', 'username');
+        });
+
+        $this->assertTrue(Schema::hasColumn('users', 'username'));
+    }
+
+    public function testChangeColumnOnTableWithEnum()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('age')->charset('')->change();
+        });
+
+        $this->assertEquals('integer', Schema::getColumnType('users', 'age'));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->integer('id');
+            $table->string('name');
+            $table->string('age');
+            $table->enum('color', ['red', 'blue']);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::drop('users');
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
This PR adds support for tables with `enum` columns in migration files.

## Current State

It's impossible to `renameColumn()` or `change()` column types on tables with an enum-column in your migrations.

There is also a big warning in the [docs](https://laravel.com/docs/7.x/migrations#modifying-columns).

## Solution
I just add the type to doctrines internal mapping and it works.

```php
$schema = $connection->getDoctrineSchemaManager();
$databasePlatform = $schema->getDatabasePlatform();
$databasePlatform->registerDoctrineTypeMapping('enum', 'string');
```

## What's still unsupported
Renaming and changing an `enum` column directly. I will take a look into this after this PR.

Thanks to my friend @bosske1 for working with me on this.
Also thanks to @staudenmeir who was so kind as to answer my questions.