### PR TITLE
[7.x] Add missing argument to the Broadcast::routes() method

### DIFF
--- a/src/Illuminate/Support/Facades/Broadcast.php
+++ b/src/Illuminate/Support/Facades/Broadcast.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Broadcasting\Factory as BroadcastingFactoryContract;
  * @method static void connection($name = null);
  * @method static \Illuminate\Broadcasting\Broadcasters\Broadcaster channel(string $channel, callable|string  $callback, array $options = [])
  * @method static mixed auth(\Illuminate\Http\Request $request)
- * @method static void routes()
+ * @method static void routes(array $attributes = null)
  *
  * @see \Illuminate\Contracts\Broadcasting\Factory
  */


### PR DESCRIPTION
The `attributes` argument is missing from the `@method` annotation in the Broadcast Facade.
![image](https://user-images.githubusercontent.com/13980973/78337713-b411e200-7591-11ea-8a41-ddf1c82a5067.png)
This PR adds the missing argument to make the annotation identical to the `BroadcastManager::routes` method signature.
