### PR TITLE
[7.x] Fix docblock

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -31,7 +31,7 @@ class PackageManifest
     /**
      * The manifest path.
      *
-     * @var string|null
+     * @var string
      */
     public $manifestPath;
 


### PR DESCRIPTION
The `$manifestPath` can't be `null`. 