### PR TITLE
[6.x] Fixed PHPUnit warnings

### DIFF
--- a/src/Illuminate/Foundation/Testing/Assert.php
+++ b/src/Illuminate/Foundation/Testing/Assert.php
@@ -5,6 +5,10 @@ namespace Illuminate\Foundation\Testing;
 use ArrayAccess;
 use Illuminate\Foundation\Testing\Constraints\ArraySubset;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\DirectoryExists;
+use PHPUnit\Framework\Constraint\FileExists;
+use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\InvalidArgumentException;
 use PHPUnit\Runner\Version;
 use PHPUnit\Util\InvalidArgumentHelper;
@@ -46,6 +50,43 @@ if (class_exists(Version::class) && (int) Version::series()[0] >= 8) {
 
             PHPUnit::assertThat($array, $constraint, $msg);
         }
+
+        /**
+         * Asserts that a file does not exist.
+         *
+         * @param  string  $filename
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+        {
+            static::assertThat($filename, new LogicalNot(new FileExists), $message);
+        }
+
+        /**
+         * Asserts that a directory does not exist.
+         *
+         * @param  string  $directory
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
+        {
+            static::assertThat($directory, new LogicalNot(new DirectoryExists), $message);
+        }
+
+        /**
+         * Asserts that a string matches a given regular expression.
+         *
+         * @param  string  $pattern
+         * @param  string  $string
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+        {
+            static::assertThat($string, new RegularExpression($pattern), $message);
+        }
     }
 } else {
     /**
@@ -65,6 +106,43 @@ if (class_exists(Version::class) && (int) Version::series()[0] >= 8) {
         public static function assertArraySubset($subset, $array, bool $checkForIdentity = false, string $msg = ''): void
         {
             PHPUnit::assertArraySubset($subset, $array, $checkForIdentity, $msg);
+        }
+
+        /**
+         * Asserts that a file does not exist.
+         *
+         * @param  string  $filename
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertFileDoesNotExist(string $filename, string $message = ''): void
+        {
+            static::assertThat($filename, new LogicalNot(new FileExists), $message);
+        }
+
+        /**
+         * Asserts that a directory does not exist.
+         *
+         * @param  string  $directory
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertDirectoryDoesNotExist(string $directory, string $message = ''): void
+        {
+            static::assertThat($directory, new LogicalNot(new DirectoryExists), $message);
+        }
+
+        /**
+         * Asserts that a string matches a given regular expression.
+         *
+         * @param  string  $pattern
+         * @param  string  $string
+         * @param  string  $message
+         * @return void
+         */
+        public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+        {
+            static::assertThat($string, new RegularExpression($pattern), $message);
         }
     }
 }

--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Stream;
 use Illuminate\Contracts\Filesystem\FileExistsException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Http\UploadedFile;
 use InvalidArgumentException;
 use League\Flysystem\Adapter\Local;
@@ -145,7 +146,7 @@ class FilesystemAdapterTest extends TestCase
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $this->assertTrue($filesystemAdapter->delete('file.txt'));
-        $this->assertFileNotExists($this->tempDir.'/file.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/file.txt');
     }
 
     public function testDeleteReturnsFalseWhenFileNotFound()
@@ -179,7 +180,7 @@ class FilesystemAdapterTest extends TestCase
         $filesystemAdapter = new FilesystemAdapter($this->filesystem);
         $filesystemAdapter->move('/foo/foo.txt', '/foo/foo2.txt');
 
-        $this->assertFileNotExists($this->tempDir.'/foo/foo.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/foo/foo.txt');
 
         $this->assertFileExists($this->tempDir.'/foo/foo2.txt');
         $this->assertEquals($data, file_get_contents($this->tempDir.'/foo/foo2.txt'));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\Assert;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
@@ -110,11 +111,11 @@ class FilesystemTest extends TestCase
 
         $files = new Filesystem;
         $files->delete($this->tempDir.'/file1.txt');
-        $this->assertFileNotExists($this->tempDir.'/file1.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/file1.txt');
 
         $files->delete([$this->tempDir.'/file2.txt', $this->tempDir.'/file3.txt']);
-        $this->assertFileNotExists($this->tempDir.'/file2.txt');
-        $this->assertFileNotExists($this->tempDir.'/file3.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/file2.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/file3.txt');
     }
 
     public function testPrependExistingFiles()
@@ -144,8 +145,8 @@ class FilesystemTest extends TestCase
         file_put_contents($this->tempDir.'/foo/file.txt', 'Hello World');
         $files = new Filesystem;
         $files->deleteDirectory($this->tempDir.'/foo');
-        $this->assertDirectoryNotExists($this->tempDir.'/foo');
-        $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
+        Assert::assertDirectoryDoesNotExist($this->tempDir.'/foo');
+        Assert::assertFileDoesNotExist($this->tempDir.'/foo/file.txt');
     }
 
     public function testDeleteDirectoryReturnFalseWhenNotADirectory()
@@ -163,7 +164,7 @@ class FilesystemTest extends TestCase
         $files = new Filesystem;
         $files->cleanDirectory($this->tempDir.'/foo');
         $this->assertDirectoryExists($this->tempDir.'/foo');
-        $this->assertFileNotExists($this->tempDir.'/foo/file.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/foo/file.txt');
     }
 
     public function testMacro()
@@ -228,7 +229,7 @@ class FilesystemTest extends TestCase
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
         $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
-        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
+        Assert::assertDirectoryDoesNotExist($this->tempDir.'/tmp');
     }
 
     public function testMoveDirectoryMovesEntireDirectoryAndOverwrites()
@@ -249,9 +250,9 @@ class FilesystemTest extends TestCase
         $this->assertFileExists($this->tempDir.'/tmp2/bar.txt');
         $this->assertDirectoryExists($this->tempDir.'/tmp2/nested');
         $this->assertFileExists($this->tempDir.'/tmp2/nested/baz.txt');
-        $this->assertFileNotExists($this->tempDir.'/tmp2/foo2.txt');
-        $this->assertFileNotExists($this->tempDir.'/tmp2/bar2.txt');
-        $this->assertDirectoryNotExists($this->tempDir.'/tmp');
+        Assert::assertFileDoesNotExist($this->tempDir.'/tmp2/foo2.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/tmp2/bar2.txt');
+        Assert::assertDirectoryDoesNotExist($this->tempDir.'/tmp');
     }
 
     public function testMoveDirectoryReturnsFalseWhileOverwritingAndUnableToDeleteDestinationDirectory()
@@ -304,7 +305,7 @@ class FilesystemTest extends TestCase
         $files = new Filesystem;
         $files->move($this->tempDir.'/foo.txt', $this->tempDir.'/bar.txt');
         $this->assertFileExists($this->tempDir.'/bar.txt');
-        $this->assertFileNotExists($this->tempDir.'/foo.txt');
+        Assert::assertFileDoesNotExist($this->tempDir.'/foo.txt');
     }
 
     public function testNameReturnsName()

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Mail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
@@ -91,7 +92,7 @@ class SendingMailWithLocaleTest extends TestCase
 
         Mail::to('test@mail.com')->locale('es')->send(new TimestampTestMail);
 
-        $this->assertRegExp('/nombre (en|dentro de) (un|1) día/',
+        Assert::assertMatchesRegularExpression('/nombre (en|dentro de) (un|1) día/',
             app('swift.transport')->messages()[0]->getBody()
         );
 

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Foundation\Testing\Assert;
 use Illuminate\Mail\Mailable;
 use Illuminate\Notifications\Channels\MailChannel;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -150,7 +151,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
             app('swift.transport')->messages()[0]->getBody()
         );
 
-        $this->assertRegExp('/dans (1|un) jour/',
+        Assert::assertMatchesRegularExpression('/dans (1|un) jour/',
             app('swift.transport')->messages()[0]->getBody()
         );
 


### PR DESCRIPTION
In Laravel 9, we can bump the minimum PHPUnit version to 9.1, but until then, we'll need to make the new stuff is available if we want to be able to work with PHPUnit 10 in the future, which we probably will do if we want to be able to test Laravel 6 on PHP 8.0 and even 8.1.