### PR TITLE
[7.x] Fix camel casing relationship

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1520,7 +1520,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function resolveChildRouteBinding($childType, $value, $field)
     {
-        return $this->{Str::plural($childType)}()->where($field, $value)->first();
+        return $this->{Str::plural(Str::camel($childType))}()->where($field, $value)->first();
     }
 
     /**

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1616,6 +1616,23 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('1|test-slug', $router->dispatch(Request::create('foo/1/test-slug', 'GET'))->getContent());
     }
 
+    public function testParentChildImplicitBindingsProperlyCamelCased()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/{user}/{test_team:id}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function (RoutingTestUserModel $user, RoutingTestTeamModel $testTeam) {
+                $this->assertInstanceOf(RoutingTestUserModel::class, $user);
+                $this->assertInstanceOf(RoutingTestTeamModel::class, $testTeam);
+
+                return $user->value.'|'.$testTeam->value;
+            },
+        ]);
+
+        $this->assertSame('1|4', $router->dispatch(Request::create('foo/1/4', 'GET'))->getContent());
+    }
+
     public function testImplicitBindingsWithOptionalParameterWithExistingKeyInUri()
     {
         $router = $this->getRouter();
@@ -2122,6 +2139,11 @@ class RoutingTestUserModel extends Model
     public function posts()
     {
         return new RoutingTestPostModel;
+    }
+
+    public function testTeams()
+    {
+        return new RoutingTestTeamModel;
     }
 
     public function getRouteKeyName()


### PR DESCRIPTION
Always camelCase the relationship name.

Fixes https://github.com/laravel/framework/issues/32216