### PR TITLE
[7.x] Remove an unnecessary checking

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -298,7 +298,7 @@ class Arr
         }
 
         foreach (explode('.', $key) as $segment) {
-            if (static::accessible($array) && static::exists($array, $segment)) {
+            if (static::exists($array, $segment)) {
                 $array = $array[$segment];
             } else {
                 return value($default);


### PR DESCRIPTION
To this point of the execution, the given `$array` is already confirmed as accessible. 

We have checked it at the very beginning:
https://github.com/laravel/framework/blob/6442cc93ea0d7008a7ce0e92492fd3d29f29b23d/src/Illuminate/Support/Arr.php#L284-L286