### PR TITLE
[7.x] Support returning an instance of a caster

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/Castable.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/Castable.php
@@ -7,7 +7,7 @@ interface Castable
     /**
      * Get the name of the caster class to use when casting from / to this cast target.
      *
-     * @return string
+     * @return string|\Illuminate\Contracts\Database\Eloquent\CastsAttributes|\Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes
      */
     public static function castUsing();
 }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1066,7 +1066,7 @@ trait HasAttributes
 
         $arguments = [];
 
-        if (strpos($castType, ':') !== false) {
+        if (is_string($castType) && strpos($castType, ':') !== false) {
             $segments = explode(':', $castType, 2);
 
             $castType = $segments[0];
@@ -1075,6 +1075,10 @@ trait HasAttributes
 
         if (is_subclass_of($castType, Castable::class)) {
             $castType = $castType::castUsing();
+        }
+
+        if (is_object($castType)) {
+            return $castType;
         }
 
         return new $castType(...$arguments);

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -130,6 +130,12 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         ]);
 
         $this->assertEquals('argument', $model->value_object_caster_with_argument);
+
+        $model->setRawAttributes([
+            'value_object_caster_with_caster_instance' => serialize(new ValueObject('hello')),
+        ]);
+
+        $this->assertInstanceOf(ValueObject::class, $model->value_object_caster_with_caster_instance);
     }
 }
 
@@ -155,6 +161,7 @@ class TestEloquentModelWithCustomCast extends Model
         'options' => JsonCaster::class,
         'value_object_with_caster' => ValueObject::class,
         'value_object_caster_with_argument' => ValueObject::class.':argument',
+        'value_object_caster_with_caster_instance' => ValueObjectWithCasterInstance::class,
     ];
 }
 
@@ -246,6 +253,14 @@ class ValueObject implements Castable
     public static function castUsing()
     {
         return ValueObjectCaster::class;
+    }
+}
+
+class ValueObjectWithCasterInstance extends ValueObject
+{
+    public static function castUsing()
+    {
+        return new ValueObjectCaster();
     }
 }
 


### PR DESCRIPTION
See https://github.com/laravel/framework/pull/32215#issuecomment-608517597

---

With the addition of the `Castable` interface (https://github.com/laravel/docs/pull/5934), it makes sense to allow direct instantiation from within a `Castable::castUsing` implementation. A common usecase could be something like this:

```php
class EloquentDataTransferObject extends DataTransferObject implements Castable
{
    public static function castUsing()
    {
        return new DataTransferObjectCaster(static::class);
    }
}
```

Which allows a kind of "generic" cast. All classes extending `EloquentDataTransferObject` can now directly be used as a cast type, and will be casted to the correct implementation of `EloquentDataTransferObject`.

Eg.

```php
class MyData extends EloquentDataTransferObject {
    public int $property = 1;
}

class ModelX extends Model
{
    protected $casts = [
        'data' => MyData::class,
    ];
}
``` 