### PR TITLE
[7.x] Allow custom redirect path in Exception Handler for AuthorizationException

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -242,7 +242,18 @@ class Handler implements ExceptionHandlerContract
     {
         return $request->expectsJson()
                     ? response()->json(['message' => $exception->getMessage()], 401)
-                    : redirect()->guest($exception->redirectTo() ?? route('login'));
+                    : redirect()->guest($exception->redirectTo() ?? $this->unauthenticatedRedirectPath($request));
+    }
+
+    /**
+     * Get the login redirect path.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function unauthenticatedRedirectPath($request)
+    {
+        return route('login');
     }
 
     /**

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Foundation;
 
 use Exception;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
@@ -207,6 +208,22 @@ class FoundationExceptionsHandlerTest extends TestCase
         $logger->shouldNotReceive('error');
 
         $this->handler->report(new SuspiciousOperationException('Invalid method override "__CONSTRUCT"'));
+    }
+
+    public function testCustomRedirectPathForAuthenticationException()
+    {
+        $handler = new class($this->container) extends Handler {
+            protected function unauthenticatedRedirectPath($request)
+            {
+                return '/custom/login';
+            }
+        };
+
+        $redirector = m::mock(Redirector::class);
+        $this->container->instance('redirect', $redirector);
+        $redirector->shouldReceive('guest')->once()->with('/custom/login');
+
+        $handler->render(Request::create('/'), new AuthenticationException);
     }
 }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

In some projects I have worked on it is common to have two (or more) login routes to the app when using different guards. For example one for members and other for admin users.

This PR adds a protect method `unauthenticatedRedirectPath` which allows the developer to customize the redirect path when an AuthorizationException is thrown.

This method receives the request object so one could assess the redirect path based on the request.

One test was added to test the redirect to a custom path when handling an AuthorizationException.