### PR TITLE
Update test.unit.stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/test.unit.stub
+++ b/src/Illuminate/Foundation/Console/stubs/test.unit.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {


### PR DESCRIPTION
When generating tests with `php artisan make:test --unit`, this is the template that is used for the test.

Because the stub uses `PHPUnit\Framework\TestCase`, my tests cannot find my factories.

Changing `PHPUnit\Framework\TestCase` to `Tests\TestCase` fixes the problem.

The `feature` test type's stub already uses `Tests\TestCase`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
