### PR TITLE
[7.x] Allow use of invokable controllers in tuple routes

### DIFF
--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -24,6 +24,13 @@ class RouteAction
         if (is_null($action)) {
             return static::missingAction($uri);
         }
+        
+        // If the action is an array and $action[1] (the method) is not set, we
+        // can set it to __invoke allowing for use of invokable controllers
+        // using tuple notation like Route::get('/', [WelcomeController::class]);
+        if (is_array($action) && !isset($action[1])) {
+            $action[1] = '__invoke';
+        }
 
         // If the action is already a Closure instance, we will just set that instance
         // as the "uses" property, because there is nothing else we need to do when


### PR DESCRIPTION
On my new projects I remove the namespace from the RouteServiceProvider and use invokable controllers, so my routes look like `Route::get('/hello', HelloController::class)`. On legacy apps with lots of string notation routes that depend on the default namespace I can't do that. I can use invokable controllers within the default namespace, but if outside the default namespace I have to actually pass '__invoke' as the second parameter in tuple notation like `Route::get('/hello', [HelloController::class, '__invoke'])`. This feels slightly awkward.

This change simply sets the second parameter of the tuple array, if not set, to __invoke. So I would  be able to simply use `Route::get('/hello', [HelloController::class])`.

Yes, I understand that tuple implies two parameters so this might not be a desirable change. The best counterargument I can make is that it doesn't change any existing behavior and feels slightly less weird to me than adding __invoke as a second parameter.
