### PR TITLE
Change FactoryBuilder states() to merge instead of replace

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -128,7 +128,7 @@ class FactoryBuilder
     public function states($states)
     {
         $states = is_array($states) ? $states : func_get_args();
-        
+
         $this->activeStates = array_merge($this->activeStates, $states);
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -127,7 +127,9 @@ class FactoryBuilder
      */
     public function states($states)
     {
-        $this->activeStates = is_array($states) ? $states : func_get_args();
+        $states = is_array($states) ? $states : func_get_args();
+        
+        $this->activeStates = array_merge($this->activeStates, $states);
 
         return $this;
     }

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -99,6 +99,8 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
 
+        $factory->state(FactoryBuildableServer::class, 'memory', ['tags' => ['Memory']]);
+
         $app->singleton(Factory::class, function ($app) use ($factory) {
             return $factory;
         });
@@ -214,6 +216,20 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $this->assertSame('active', $server->status);
         $this->assertSame('inline', $inlineServer->status);
+    }
+
+    public function testCreatingModelsWithMultipleStates()
+    {
+        $server = factory(FactoryBuildableServer::class)->create();
+
+        $mergedServer = factory(FactoryBuildableServer::class)
+            ->state('inline')
+            ->state('memory')
+            ->create();
+
+        $this->assertSame('active', $server->status);
+        $this->assertSame('inline', $mergedServer->status);
+        $this->assertSame(['Memory'], $mergedServer->tags);
     }
 
     public function testCreatingModelsWithRelationships()


### PR DESCRIPTION
This changes the functionality of the `FactoryBuilder->states()` method to merge parameters with the existing `activeStates` instead of replacing them.

As an example, we use factory macros to add dynamic states when the macro is called. When the `states()` functionality is replacing (as is currently), it means the order of the methods in our tests impacts the state of the created object:

```php
// ->withComments() is a factory macro that adds dynamic state

// Currently, we must ensure `state()` is called first because `->state()` will reset any states we've already set
factory(Post::class)->state('published')->withComments(5)->create();

// Ideally, order wouldn't matter and `->state()` would add to the existing states
factory(Post::class)->withComments(5)->state('published')->create();
```

I targeted `master` because I believe this is technically a breaking change. If someone were intentionally using `->state()` to replace state (not sure why they would be), this change would break their implementation. I also didn't provide a way to keep the replace functionality, as I couldn't think of a valid use case for it.

However, I'd be fine if this was able to get into 7.x!