### PR TITLE
[7.x] Optimize Str::startsWith()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -604,7 +604,7 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && substr($haystack, 0, strlen($needle)) === (string) $needle) {
+            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -73,6 +73,9 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith('Malmö', 'Malmö'));
         $this->assertFalse(Str::startsWith('Jönköping', 'Jonko'));
         $this->assertFalse(Str::startsWith('Malmö', 'Malmo'));
+        $this->assertTrue(Str::startsWith('你好', '你'));
+        $this->assertFalse(Str::startsWith('你好', '好'));
+        $this->assertFalse(Str::startsWith('你好', 'a'));
     }
 
     public function testEndsWith()
@@ -100,6 +103,9 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::endsWith('Malmö', 'mö'));
         $this->assertFalse(Str::endsWith('Jönköping', 'oping'));
         $this->assertFalse(Str::endsWith('Malmö', 'mo'));
+        $this->assertTrue(Str::endsWith('你好', '好'));
+        $this->assertFalse(Str::endsWith('你好', '你'));
+        $this->assertFalse(Str::endsWith('你好', 'a'));
     }
 
     public function testStrBefore()


### PR DESCRIPTION
This PR makes `Str::startsWith` around 10% faster by using [`strncmp`](https://www.php.net/manual/en/function.strncmp.php).

There have been two PRs in the past that have tried to optimize this method using `strpos`: https://github.com/laravel/framework/pull/30952 and https://github.com/laravel/framework/pull/16761. Using `strpos` is not a good idea, [this comment on a previous PR](https://github.com/laravel/framework/pull/16761#issuecomment-266558361) explains why.

### Benchmark
<table>
<tr>
<th>Haystack</th>
<th>Needle</th>
<th>Time</th>
<th>%</th>
</tr>

<tr><td colspan="4">Rows below use the current <code>substr</code> implementation</td></tr>
<tr><td>test</td><td>te</td><td>1193</td><td></td></tr>
<tr><td>test</td><td>no</td><td>1250</td><td></td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('test', 20)</code></td><td>1368</td><td></td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('nope', 20)</code></td><td>1344</td><td></td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>test</td><td>1244</td><td></td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>nope</td><td>1260</td><td></td></tr>
<tr><td>test</td><td><code>str_repeat('test', 2000000)</code></td><td>1198</td><td></td></tr>


<tr><td colspan="4">Rows below use a <code>strpos</code> implementation</td></tr>
<tr><td>test</td><td>te</td><td>990</td><td>+17.0% :heavy_check_mark:</td></tr>
<tr><td>test</td><td>no</td><td>964</td><td>+22.9% :heavy_check_mark:</td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('test', 20)</code></td><td>2674</td><td>-95.4% :x: </td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('nope', 20)</code></td><td>7007</td><td>-421% :x: </td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>test</td><td>1018</td><td>+18.1% :heavy_check_mark: </td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>nope</td><td>99999+</td><td>-999% :x: </td></tr>
<tr><td>test</td><td><code>str_repeat('test', 2000000)</code></td><td>1003</td><td>+16.3% :heavy_check_mark:</td></tr>

<tr><td colspan="4">Rows below use the <code>strncmp</code> implementation proposed in this PR</td></tr>
<tr><td>test</td><td>te</td><td>1039</td><td>+12.9% :heavy_check_mark:</td></tr>
<tr><td>test</td><td>no</td><td>1082</td><td>+13.4% :heavy_check_mark:</td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('test', 20)</code></td><td>1192</td><td>+12.9% :heavy_check_mark:</td></tr>
<tr><td><code>str_repeat('test', 2000)</code></td><td><code>str_repeat('nope', 20)</code></td><td>1205</td><td>+10.3% :heavy_check_mark:</td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>test</td><td>1080</td><td>+13.2% :heavy_check_mark:</td></tr>
<tr><td><code>str_repeat('test', 2000000)</code></td><td>nope</td><td>1108</td><td>+12.1% :heavy_check_mark:</td></tr>
<tr><td>test</td><td><code>str_repeat('test', 2000000)</code></td><td>1181</td><td>+1.4% :heavy_check_mark:</td></tr>

</table>



### Benchmark code
```php
/** @test */
function benchmark_str_starts_with()
{
    $haystack = 'test';

    $needle = 'te';

    $speed = [];

    for ($times = 0; $times < 5; $times++) {
        $startedAt = microtime(true) * 1000;

        for ($i = 0; $i < 10000000; $i++) {
            Str::startsWith($haystack, $needle);
        }

        $speed[] = (microtime(true) * 1000) - $startedAt;
    }

    dump(
        'Haystack: '.Str::limit($haystack, 20),
        'Needle: '.Str::limit($needle, 20),
        $speed,
        'Average: '.(array_sum($speed) / count($speed))
    );
}
```
