### PR TITLE
[7.x] Use isDefaultValueAvailable() instead of isOptional()

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -951,7 +951,7 @@ class Container implements ArrayAccess, ContainerContract
         // is optional, and if it is we will return the optional parameter value as
         // the value of the dependency, similarly to how we do this with scalars.
         catch (BindingResolutionException $e) {
-            if ($parameter->isOptional()) {
+            if ($parameter->isDefaultValueAvailable()) {
                 return $parameter->getDefaultValue();
             }
 


### PR DESCRIPTION
The only difference between these two methods is that the `isDefaultValueAvailable()` only works on user-defined functions while the `isOptional()` method works on user-defined functions **AND** internal functions (PHP core).

Since the purpose of checking is for getting the parameter's default value, trying to get the default value of an internal function's parameter will throw:

> Fatal error: Uncaught ReflectionException: Cannot determine default value for internal functions

Using `isDefaultValueAvailable()` is safer because it _always_ return **false** when the function is _not_ an user-defined function: 

https://github.com/php/php-src/blob/1b6f61e7c4330b0f7abcc29c80f3c94bc6d13ce5/ext/reflection/php_reflection.c#L2627-L2630

This prevent us from trying to get the default value of an internal function's parameter.

Credit: https://stackoverflow.com/a/23775053/7932059

