### PR TITLE
[7.x] Fix merging boolean or null attributes in Blade components

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -111,6 +111,10 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $attributes = [];
 
         $attributeDefaults = array_map(function ($value) {
+            if (is_null($value) || is_bool($value)) {
+                return $value;
+            }
+
             return e($value);
         }, $attributeDefaults);
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -43,21 +43,21 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $bag = (new ComponentAttributeBag)
             ->merge([
-            'test-escaped' => '<tag attr="attr">'
-        ]);
+                'test-escaped' => '<tag attr="attr">'
+            ]);
 
         $this->assertSame('test-escaped="&lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);
 
         $bag = (new ComponentAttributeBag)
             ->merge([
-            'test-string' => 'ok',
-            'test-null' => null,
-            'test-false' => false,
-            'test-true' => true,
-            'test-0' => 0,
-            'test-0-string' => '0',
-            'test-empty-string' => '',
-        ]);
+                'test-string' => 'ok',
+                'test-null' => null,
+                'test-false' => false,
+                'test-true' => true,
+                'test-0' => 0,
+                'test-0-string' => '0',
+                'test-empty-string' => '',
+            ]);
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -43,7 +43,7 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $bag = (new ComponentAttributeBag)
             ->merge([
-                'test-escaped' => '<tag attr="attr">'
+                'test-escaped' => '<tag attr="attr">',
             ]);
 
         $this->assertSame('test-escaped="&lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -40,5 +40,25 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
+
+        $bag = (new ComponentAttributeBag)
+            ->merge([
+            'test-escaped' => '<tag attr="attr">'
+        ]);
+
+        $this->assertSame('test-escaped="&lt;tag attr=&quot;attr&quot;&gt;"', (string) $bag);
+
+        $bag = (new ComponentAttributeBag)
+            ->merge([
+            'test-string' => 'ok',
+            'test-null' => null,
+            'test-false' => false,
+            'test-true' => true,
+            'test-0' => 0,
+            'test-0-string' => '0',
+            'test-empty-string' => '',
+        ]);
+
+        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }
 }


### PR DESCRIPTION
The fix to escape merged attributes with `e` creates an unexpected behaviour when merging attributes with `null` or boolean values, for example:

```
        $bag = new ComponentAttributeBag([]);
        
        echo $bag->merge([
            'required' => false,
            'readonly' => null,
            'disabled' => true,
        ]));
```

Will print `required="" readonly="" disabled="1"` instead of `disabled="disabled"`

This is also inconsistent with the result that we'd get if we create a new instance of `ComponentAttributeBag` passing the same array as the first argument of the constructor:

```
new ComponentAttributeBag([
    'required' => false,
    'readonly' => null,
    'disabled' => true,
])
```

Will print `disabled="disabled"` and I think this is the right result.

Therefore I'm submitting this PR to avoid escaping boolean or `null` values so we get the same result in both cases.