### PR TITLE
[7.x] Fix double slashes with cached routes (#32228)

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -157,7 +157,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
         $parts = explode('?', $request->server->get('REQUEST_URI'), 2);
 
         $trimmedRequest->server->set(
-            'REQUEST_URI', rtrim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')
+            'REQUEST_URI', trim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')
         );
 
         return $trimmedRequest;

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -478,6 +478,20 @@ class CompiledRouteCollectionTest extends IntegrationTest
         $this->assertSame('foo', $this->collection()->match($request)->getName());
     }
 
+    public function testRootTrailingSlashIsTrimmedWhenMatchingCachedRoutes()
+    {
+        $this->routeCollection->add(
+            $this->newRoute('GET', 'foo', ['uses' => 'FooController@index', 'as' => 'foo'])
+        );
+
+        $request = Request::create('http://example.com//foo');
+
+        // Access to request path info before matching route
+        $request->getPathInfo();
+
+        $this->assertSame('foo', $this->collection()->match($request)->getName());
+    }
+
     /**
      * Create a new Route object.
      *


### PR DESCRIPTION
Fix discrepancy between routes and cached routes (#32228).

With this fix, url with many slashes at the begin (like http://127.0.0.1:8000//foo) will work consistently with routes cached or not.