### PR TITLE
Translated ValidationException message

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -53,7 +53,7 @@ class ValidationException extends Exception
      */
     public function __construct($validator, $response = null, $errorBag = 'default')
     {
-        parent::__construct('The given data was invalid.');
+        parent::__construct(trans('The given data was invalid.'));
 
         $this->response = $response;
         $this->errorBag = $errorBag;


### PR DESCRIPTION
The default value (The given data was invalid.) has been passed to the translation function to be able to return this text in the different languages.