### PR TITLE
WIP: [7.x] Fix double slash inconsistency in the routing system (#32228)

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -140,7 +140,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function path()
     {
-        $pattern = trim($this->getPathInfo(), '/');
+        $pattern = rtrim($this->getPathInfo(), '/');
 
         return $pattern == '' ? '/' : $pattern;
     }

--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,7 +16,7 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        $path = $request->path() === '/' ? '/' : '/'.$request->path();
+        $path = $request->path();
 
         return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -377,7 +377,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function hasCorrectSignature(Request $request, $absolute = true)
     {
-        $url = $absolute ? $request->url() : '/'.$request->path();
+        $url = $absolute ? $request->url() : $request->path();
 
         $original = rtrim($url.'?'.Arr::query(
             Arr::except($request->query(), 'signature')


### PR DESCRIPTION
Try to fix inconsistency between routes collection and cached routes collection.

Having a `foo` route, `http://127.0.0.1//foo` will not match with or without cached routes (it was matching without cached routes).

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
