### PR TITLE
[7.x] Fix Console expectation assertion order

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
-use Illuminate\Support\Arr;
 use Illuminate\Testing\PendingCommand;
 
 trait InteractsWithConsole
@@ -49,28 +48,6 @@ trait InteractsWithConsole
         if (! $this->mockConsoleOutput) {
             return $this->app[Kernel::class]->call($command, $parameters);
         }
-
-        $this->beforeApplicationDestroyed(function () {
-            if (count($this->expectedQuestions)) {
-                $this->fail('Question "'.Arr::first($this->expectedQuestions)[0].'" was not asked.');
-            }
-
-            if (count($this->expectedChoices) > 0) {
-                foreach ($this->expectedChoices as $question => $answers) {
-                    $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
-
-                    $this->{$assertion}(
-                        $answers['expected'],
-                        $answers['actual'],
-                        'Question "'.$question.'" has different options.'
-                    );
-                }
-            }
-
-            if (count($this->expectedOutput)) {
-                $this->fail('Output "'.Arr::first($this->expectedOutput).'" was not printed.');
-            }
-        });
 
         return new PendingCommand($this, $this->app, $command, $parameters);
     }

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -188,7 +188,7 @@ class PendingCommand
     }
 
     /**
-     * Verify if expected questions/choices/outputs aren't fulfilled.
+     * Determine if expected questions / choices / outputs are fulfilled.
      *
      * @return void
      */

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -5,6 +5,7 @@ namespace Illuminate\Testing;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
@@ -181,7 +182,37 @@ class PendingCommand
             );
         }
 
+        $this->verifyExpectations();
+
         return $exitCode;
+    }
+
+    /**
+     * Verify if expected questions/choices/outputs aren't fulfilled.
+     *
+     * @return void
+     */
+    protected function verifyExpectations()
+    {
+        if (count($this->test->expectedQuestions)) {
+            $this->test->fail('Question "'.Arr::first($this->test->expectedQuestions)[0].'" was not asked.');
+        }
+
+        if (count($this->test->expectedChoices) > 0) {
+            foreach ($this->test->expectedChoices as $question => $answers) {
+                $assertion = $answers['strict'] ? 'assertEquals' : 'assertEqualsCanonicalizing';
+
+                $this->test->{$assertion}(
+                    $answers['expected'],
+                    $answers['actual'],
+                    'Question "'.$question.'" has different options.'
+                );
+            }
+        }
+
+        if (count($this->test->expectedOutput)) {
+            $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
+        }
     }
 
     /**


### PR DESCRIPTION
This PR solves the ordering bug when using command and other assertions in the same test.

Please find more detailed information in issue #32256


## Current State

Laravel command assertions (expectations) are being run before the application gets destroyes.
This is why command assertions `always`run at the end of the test and not in the provided order inside the test.

## Solution

This PR changes the implementation so that the command assertions run immediately after defining them.
Fixes #32256.
