### PR TITLE
[7.x] Fix double slashes matching in UriValidator (fix inconsistencies between cached and none cached routes)

### DIFF
--- a/src/Illuminate/Routing/Matching/UriValidator.php
+++ b/src/Illuminate/Routing/Matching/UriValidator.php
@@ -16,7 +16,7 @@ class UriValidator implements ValidatorInterface
      */
     public function matches(Route $route, Request $request)
     {
-        $path = $request->path() === '/' ? '/' : '/'.$request->path();
+        $path = rtrim($request->getPathInfo(), '/') ?: '/';
 
         return preg_match($route->getCompiled()->getRegex(), rawurldecode($path));
     }

--- a/tests/Routing/RouteCollectionTest.php
+++ b/tests/Routing/RouteCollectionTest.php
@@ -3,10 +3,12 @@
 namespace Illuminate\Tests\Routing;
 
 use ArrayIterator;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use LogicException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RouteCollectionTest extends TestCase
 {
@@ -261,5 +263,22 @@ class RouteCollectionTest extends TestCase
         $this->expectException(LogicException::class);
 
         $this->routeCollection->compile();
+    }
+
+    public function testRouteCollectionDontMatchNonMatchingDoubleSlashes()
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->routeCollection->add(new Route('GET', 'foo', [
+            'uses' => 'FooController@index',
+            'as' => 'foo_index',
+        ]));
+
+        $request = Request::create('', 'GET');
+        // We have to set uri in REQUEST_URI otherwise Request uses parse_url() which trim the slashes
+        $request->server->set(
+            'REQUEST_URI', '//foo'
+        );
+        $this->routeCollection->match($request);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Sorry to open a new PR but the other one was closed, I think there were some misunderstanding.
The goal of this PR is to **not** match routes when we have double slashes and also fix the misleading 405 error with cached route collection when we have a double slash.

**Before the PR**
URL | Not cached | Cached
-- | -- | --
http://127.0.0.1/foo | foo | foo
http://127.0.0.1/foo/bar | bar | bar
http://127.0.0.1//foo ⚠️ | **foo** | **405**
http://127.0.0.1//foo/bar ⚠️ | **bar** | **405**
http://127.0.0.1/foo//bar | 404 | 404
http://127.0.0.1//foo/bar | 404 | 404

**With this PR**
URL | Not cached | Cached
-- | -- | --
http://127.0.0.1/foo | foo | foo
http://127.0.0.1/foo/bar | bar | bar
http://127.0.0.1//foo | **404** | **404**
http://127.0.0.1//foo/bar | **404** | **404**
http://127.0.0.1/foo//bar | 404 | 404
http://127.0.0.1//foo/bar | 404 | 404

The problem is that _`UriValidator`_ uses `$request->path()` which use the trimmed path but _`CompiledRouteCollection`_ uses:

```php
    $parts = explode('?', $request->server->get('REQUEST_URI'), 2);

    $trimmedRequest->server->set(
        'REQUEST_URI', rtrim($parts[0], '/').(isset($parts[1]) ? '?'.$parts[1] : '')
    );
```
with `rtrim`, which creates the discrepancy.

What do you think ? Please let me know if you want me to fix it differently, I just want to fix this inconsistency.