### PR TITLE
[7.x] Add until Collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1333,4 +1333,30 @@ class Collection implements ArrayAccess, Enumerable
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Take items in the collection until condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function until($value)
+    {
+        $passed = [];
+
+        $callback = $this->useAsCallable($value) ? $value :
+            function ($item) use ($value) {
+                return $item === $value;
+            };
+
+        foreach ($this as $key => $item) {
+            if ($callback($item, $key)) {
+                break;
+            }
+
+            $passed[$key] = $item;
+        }
+
+        return new static($passed);
+    }
 }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1333,30 +1333,4 @@ class Collection implements ArrayAccess, Enumerable
     {
         unset($this->items[$key]);
     }
-
-    /**
-     * Take items in the collection until condition is met.
-     *
-     * @param  mixed  $key
-     * @return static
-     */
-    public function until($value)
-    {
-        $passed = [];
-
-        $callback = $this->useAsCallable($value) ? $value :
-            function ($item) use ($value) {
-                return $item === $value;
-            };
-
-        foreach ($this as $key => $item) {
-            if ($callback($item, $key)) {
-                break;
-            }
-
-            $passed[$key] = $item;
-        }
-
-        return new static($passed);
-    }
 }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -36,6 +36,7 @@ use Traversable;
  * @property-read HigherOrderCollectionProxy $sortByDesc
  * @property-read HigherOrderCollectionProxy $sum
  * @property-read HigherOrderCollectionProxy $unique
+ * @property-read HigherOrderCollectionProxy $until
  */
 trait EnumeratesValues
 {
@@ -47,7 +48,7 @@ trait EnumeratesValues
     protected static $proxies = [
         'average', 'avg', 'contains', 'each', 'every', 'filter', 'first',
         'flatMap', 'groupBy', 'keyBy', 'map', 'max', 'min', 'partition',
-        'reject', 'some', 'sortBy', 'sortByDesc', 'sum', 'unique',
+        'reject', 'some', 'sortBy', 'sortByDesc', 'sum', 'unique', 'until',
     ];
 
     /**
@@ -701,6 +702,32 @@ trait EnumeratesValues
     public function uniqueStrict($key = null)
     {
         return $this->unique($key, true);
+    }
+
+    /**
+     * Take items in the collection until condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function until($value)
+    {
+        $passed = [];
+
+        $callback = $this->useAsCallable($value) ? $value :
+            function ($item) use ($value) {
+                return $item === $value;
+            };
+
+        foreach ($this as $key => $item) {
+            if ($callback($item, $key)) {
+                break;
+            }
+
+            $passed[$key] = $item;
+        }
+
+        return new static($passed);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4070,18 +4070,24 @@ class SupportCollectionTest extends TestCase
         ], $data->all());
     }
 
-    public function testUntilUsingValue()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUntilUsingValue($collection)
     {
-        $data = new Collection([1, 2, 3, 4]);
+        $data = new $collection([1, 2, 3, 4]);
 
         $data = $data->until(3);
 
         $this->assertSame([1, 2], $data->toArray());
     }
 
-    public function testUntilUsingCallback()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUntilUsingCallback($collection)
     {
-        $data = new Collection([1, 2, 3, 4]);
+        $data = new $collection([1, 2, 3, 4]);
 
         $data = $data->until(function ($item) {
             return $item >= 3;
@@ -4090,9 +4096,12 @@ class SupportCollectionTest extends TestCase
         $this->assertSame([1, 2], $data->toArray());
     }
 
-    public function testUntilReturnsAllItemsForUnmetValue()
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUntilReturnsAllItemsForUnmetValue($collection)
     {
-        $data = new Collection([1, 2, 3, 4]);
+        $data = new $collection([1, 2, 3, 4]);
 
         $actual = $data->until(99);
 
@@ -4103,6 +4112,24 @@ class SupportCollectionTest extends TestCase
         });
 
         $this->assertSame($data->toArray(), $actual->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testUntilCanBeProxied($collection)
+    {
+        $data = new $collection([
+            new TestSupportCollectionHigherOrderItem('Adam'),
+            new TestSupportCollectionHigherOrderItem('Taylor'),
+            new TestSupportCollectionHigherOrderItem('Jason'),
+        ]);
+
+        $actual = $data->until->is('Jason');
+
+        $this->assertCount(2, $actual);
+        $this->assertSame('Adam', $actual->get(0)->name);
+        $this->assertSame('Taylor', $actual->get(1)->name);
     }
 
     /**
@@ -4131,6 +4158,11 @@ class TestSupportCollectionHigherOrderItem
     public function uppercase()
     {
         return $this->name = strtoupper($this->name);
+    }
+
+    public function is($name)
+    {
+        return $this->name === $name;
     }
 }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4070,6 +4070,41 @@ class SupportCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testUntilUsingValue()
+    {
+        $data = new Collection([1, 2, 3, 4]);
+
+        $data = $data->until(3);
+
+        $this->assertSame([1, 2], $data->toArray());
+    }
+
+    public function testUntilUsingCallback()
+    {
+        $data = new Collection([1, 2, 3, 4]);
+
+        $data = $data->until(function ($item) {
+            return $item >= 3;
+        });
+
+        $this->assertSame([1, 2], $data->toArray());
+    }
+
+    public function testUntilReturnsAllItemsForUnmetValue()
+    {
+        $data = new Collection([1, 2, 3, 4]);
+
+        $actual = $data->until(99);
+
+        $this->assertSame($data->toArray(), $actual->toArray());
+
+        $actual = $data->until(function ($item) {
+            return $item >= 99;
+        });
+
+        $this->assertSame($data->toArray(), $actual->toArray());
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
This introduces a new `until` Collection method. It is similar to the `take_while` method in Ruby.

While this functionality may be achieved using combinations of the existing Collection methods or with custom logic, the code clarity provided by this single method brings value.

For example:

```php
[$before, $after] = $primes->partition(function ($item) {
    return $item < 11;
});
$before->dump();
```

May simply be written as:

```php
$primes->until(11)->dump();
```


This would be useful as a _higher order_ method as well.