### PR TITLE
[7.x] Updated observer.stub to handle all model events

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -6,6 +6,29 @@ use NamespacedDummyModel;
 
 class DummyClass
 {
+
+    /**
+     * Handle the DocDummyModel "retrieved" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function retrieved(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Handle the DocDummyModel "creating" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function creating(DummyModel $dummyModel)
+    {
+        //
+    }
+
     /**
      * Handle the DocDummyModel "created" event.
      *
@@ -13,6 +36,17 @@ class DummyClass
      * @return void
      */
     public function created(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Handle the DocDummyModel "updating" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function updating(DummyModel $dummyModel)
     {
         //
     }
@@ -29,12 +63,56 @@ class DummyClass
     }
 
     /**
+     * Handle the DocDummyModel "saving" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saving(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Handle the DocDummyModel "saved" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function saved(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Handle the DocDummyModel "deleting" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function deleting(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
      * Handle the DocDummyModel "deleted" event.
      *
      * @param  \NamespacedDummyModel  $dummyModel
      * @return void
      */
     public function deleted(DummyModel $dummyModel)
+    {
+        //
+    }
+
+    /**
+     * Handle the DocDummyModel "restoring" event.
+     *
+     * @param  \NamespacedDummyModel  $dummyModel
+     * @return void
+     */
+    public function restoring(DummyModel $dummyModel)
     {
         //
     }

--- a/src/Illuminate/Foundation/Console/stubs/observer.stub
+++ b/src/Illuminate/Foundation/Console/stubs/observer.stub
@@ -6,7 +6,6 @@ use NamespacedDummyModel;
 
 class DummyClass
 {
-
     /**
      * Handle the DocDummyModel "retrieved" event.
      *


### PR DESCRIPTION
Updated the observer.stub that is created when a model class is provided to handle all model events

- retrieved (new)
- creating (new)
- created
- updating (new)
- updated
- saving (new)
- saved (new)
- deleting (new)
- deleted
- restoring (new)
- restored
- force deleted

If the user is already in a position to creating a observer for there model class, they should have access to all model events within the observer, this will stop the user adding them manually later 
- especially for new users, who aren't aware what events are available for them, or how to go about it.
