### PR TITLE
[7.x] Remove order clauses where it is invalid in SQL server

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2047,7 +2047,6 @@ class Builder
 
     /**
      * Determine if a "limit" or "offset" clause is specified
-     * @param $query
      * @return bool
      */
     protected function isLimitOrOffsetSpecified() : bool {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2046,10 +2046,12 @@ class Builder
     }
 
     /**
-     * Determine if a "limit" or "offset" clause is specified
+     * Determine if a "limit" or "offset" clause is specified.
+     *
      * @return bool
      */
-    protected function isLimitOrOffsetSpecified() : bool {
+    protected function isLimitOrOffsetSpecified()
+    {
         return $this->unions
             ? isset($this->unionLimit) || isset($this->unionOffset)
             : isset($this->limit) || isset($this->offset);

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2058,7 +2058,8 @@ class Builder
     }
 
     /**
-     * Remove "order" clauses in order to make the query usable as a subquery in SQL server
+     * Remove "order" clauses in order to make the query usable as a subquery in SQL server.
+     *
      * @return $this
      */
     protected function removeSubqueryOrderOnSqlServer()


### PR DESCRIPTION
In SQL Server, "order by" clauses are invalid in subqueries unless TOP, OFFSET or FOR XML is also specified. This will cause errors when a query containing an "order by" are passed as subqueries in the query builder, for example, the following fail when there is a global scope with order defined on Course:

    CourseUser::whereIn('course_id', Course::where('title', '>=', 'N')->select('id'))->get();
    Course::where('id', '<', 50)->union(Course::where('id', '>', 100))->get();
    DB::query()->fromSub(Course::select(['id', 'title']), 'data')->get();

This pull request automatically removes invalid "order by" queries when it is used as a subquery, including subqueries in "select", "from", "join", "where", "order by", "insert", "union" to make the above work.