### PR TITLE
[7.x] Allow postgresql to store blob (bytea) files when contains special characters

### DIFF
--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database;
 
+use PDO;
 use Doctrine\DBAL\Driver\PDOPgSql\Driver as DoctrineDriver;
 use Illuminate\Database\Query\Grammars\PostgresGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\PostgresProcessor;

--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -63,4 +63,21 @@ class PostgresConnection extends Connection
     {
         return new DoctrineDriver;
     }
+
+    /**
+     * Bind values to their parameters in the given statement.
+     *
+     * @param  \PDOStatement $statement
+     * @param  array  $bindings
+     * @return void
+     */
+    public function bindValues($statement, $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            $statement->bindValue(
+                is_string($key) ? $key : $key + 1, $value,
+                is_int($value) ? PDO::PARAM_INT : ctype_print($value) ? PDO::PARAM_STR : PDO::PARAM_LOB
+            );
+        }
+    }
 }


### PR DESCRIPTION
Hi, I need store bytea files into database. When file (binary format of file, not content) contains non printable characters (like pdf file), pdo failed. After this fix, everything working fine. When you are storing files like txt, which not contains non printable characters, it is storing bytea as PDO::PARAM_STR (because ctype_print return true), but in this situation there is no problem.
Edit: If you storing non printable chars into varchar field, there is no problem too (in this situation storing value into varchar with PDO::PARAM_LOB working without problem).
