### PR TITLE
Feature: Add a str() helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,11 +1,12 @@
 <?php
 
-use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
-use Illuminate\Support\HigherOrderTapProxy;
+use Illuminate\Support\Str;
 use Illuminate\Support\Optional;
+use Illuminate\Support\Collection;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HigherOrderTapProxy;
 
 if (! function_exists('append_config')) {
     /**
@@ -551,5 +552,18 @@ if (! function_exists('with')) {
     function with($value, callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
+    }
+}
+
+if (! function_exists('str')) {
+    /**
+     * Create a new Str instance
+     *
+     * @param  string  $string
+     * @return \Illuminate\Support\Stringable
+     */
+    function str($string)
+    {
+        return Str::of($string);
     }
 }

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -10,6 +10,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use stdClass;
+use Illuminate\Support\Str;
 
 class SupportHelpersTest extends TestCase
 {
@@ -562,6 +563,13 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(10, with(5, function ($five) {
             return $five + 5;
         }));
+    }
+
+    public function testStr()
+    {
+        $this->assertEquals(Str::of('string'), str('string'));
+
+        $this->assertEquals(Str::of('string')->plural(), str('string')->plural());
     }
 
     public function testEnv()


### PR DESCRIPTION
This PR adds a global `str()` helper. 
It works as `Str::of()` and adding it, benefits users by making them write less code. 
It's also easier and more expressive to write `{{str('feature')->plural()}}` rather than `{{Str::of('feature')->plural()}}`.


