### PR TITLE
[7.x] Fix mail content-type

### DIFF
--- a/src/Illuminate/Mail/Mailer.php
+++ b/src/Illuminate/Mail/Mailer.php
@@ -351,20 +351,25 @@ class Mailer implements MailerContract, MailQueueContract
      */
     protected function addContent($message, $view, $plain, $raw, $data)
     {
+        $header = $message->getContentType();
+
         if (isset($view)) {
-            $message->setBody($this->renderView($view, $data), 'text/html');
+            $message->setBody(
+                $this->renderView($view, $data),
+                $header && $header !== 'text/plain' ? $header : 'text/html'
+            );
         }
 
         if (isset($plain)) {
             $method = isset($view) ? 'addPart' : 'setBody';
 
-            $message->$method($this->renderView($plain, $data), 'text/plain');
+            $message->$method($this->renderView($plain, $data), $header ?: 'text/plain');
         }
 
         if (isset($raw)) {
             $method = (isset($view) || isset($plain)) ? 'addPart' : 'setBody';
 
-            $message->$method($raw, 'text/plain');
+            $message->$method($raw, $header ?: 'text/plain');
         }
     }
 

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -36,6 +36,7 @@ class MailMailerTest extends TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $message->shouldReceive('getContentType')->once()->andReturn('');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send('foo', ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
@@ -57,6 +58,7 @@ class MailMailerTest extends TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $message->shouldReceive('getContentType')->once()->andReturn('');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['html' => new HtmlString('rendered.view'), 'text' => new HtmlString('rendered.text')], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
@@ -77,6 +79,7 @@ class MailMailerTest extends TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $message->shouldReceive('getContentType')->once()->andReturn('');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->html('rendered.view', function ($m) {
             $_SERVER['__mailer.test'] = $m;
@@ -99,6 +102,7 @@ class MailMailerTest extends TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $message->shouldReceive('getContentType')->once()->andReturn('');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['foo', 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;
@@ -121,6 +125,7 @@ class MailMailerTest extends TestCase
         $message->shouldReceive('setFrom')->never();
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
+        $message->shouldReceive('getContentType')->once()->andReturn('');
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
         $mailer->send(['html' => 'foo', 'text' => 'bar'], ['data'], function ($m) {
             $_SERVER['__mailer.test'] = $m;


### PR DESCRIPTION
This fix solves https://github.com/laravel/framework/issues/29847. Originally https://github.com/laravel/framework/pull/22995 broke the previous behavior of empty email messages with attachments even though the intentions by the PR were fine. 

It basically boils down to the fact that we shouldn't overwrite the content type of an email message if it has already been set.