### PR TITLE
[7.x] Check a request header with an array value

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -63,7 +63,7 @@ class Request implements ArrayAccess
     public function hasHeader($key, $value = null)
     {
         if (is_null($value)) {
-            return  ! empty($this->request->getHeaders()[$key]);
+            return ! empty($this->request->getHeaders()[$key]);
         }
 
         $value = is_array($value) ? $value : [$value];

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -62,9 +62,19 @@ class Request implements ArrayAccess
      */
     public function hasHeader($key, $value = null)
     {
-        return is_null($value)
-                    ? ! empty($this->request->getHeaders()[$key])
-                    : in_array($value, $this->headers()[$key]);
+        if (is_null($value)) {
+            return  ! empty($this->request->getHeaders()[$key]);
+        }
+        
+        $result = true;
+
+        $value = is_array($value) ? $value : [$value];
+        
+        foreach ($value as $headerValue) {
+            $result = $result && in_array($headerValue, $this->headers()[$key]);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -65,9 +65,9 @@ class Request implements ArrayAccess
         if (is_null($value)) {
             return  ! empty($this->request->getHeaders()[$key]);
         }
-        
+
         $value = is_array($value) ? $value : [$value];
-        
+
         return empty(array_diff($value, $this->headers()[$key]));
     }
 

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -66,15 +66,9 @@ class Request implements ArrayAccess
             return  ! empty($this->request->getHeaders()[$key]);
         }
         
-        $result = true;
-
         $value = is_array($value) ? $value : [$value];
         
-        foreach ($value as $headerValue) {
-            $result = $result && in_array($headerValue, $this->headers()[$key]);
-        }
-
-        return $result;
+        return empty(array_diff($value, $this->headers()[$key]));
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -59,6 +59,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->withHeaders([
             'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->post('http://foo.com/json', [
             'name' => 'Taylor',
         ]);
@@ -67,6 +68,7 @@ class HttpClientTest extends TestCase
             return $request->url() === 'http://foo.com/json' &&
                    $request->hasHeader('Content-Type', 'application/json') &&
                    $request->hasHeader('X-Test-Header', 'foo') &&
+                   $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']) &&
                    $request['name'] === 'Taylor';
         });
     }


### PR DESCRIPTION
This PR enables to check if a request has a header with a value of an array. Currently, if a header has a value of an array, it cannot be verified. For example, 
```
Http::withHeaders([
    'X-Foo'  => ['Bar', 'Baz'],
])->get('/');
```
```
Http::assertSent(function ($request) {
    return $request->hasHeader('X-Foo', ['Bar', 'Baz']); => false
});
```
This PR will enable to verify header values inside an array.
```
 $request->hasHeader('X-Foo', ['Bar', 'Baz']); => true.
 $request->hasHeader('X-Foo', 'Bar'); => true.
 $request->hasHeader('X-Foo', ['Bar']); => true.
```