### PR TITLE
[7.x] Add cloud() to Storage phpdoc

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 
 /**
  * @method static \Illuminate\Contracts\Filesystem\Filesystem disk(string $name = null)
+ * @method static \Illuminate\Contracts\Filesystem\Filesystem cloud()
  * @method static bool exists(string $path)
  * @method static string get(string $path)
  * @method static resource|null readStream(string $path)


### PR DESCRIPTION
Add the `cloud()` phpdoc so editors can autocomplete `Storage::cloud()`.