### PR TITLE
[7.x] Optimize Arr::set() method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -547,8 +547,12 @@ class Arr
 
         $keys = explode('.', $key);
 
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
+        foreach ($keys as $i => $key) {
+            if (count($keys) === 1) {
+                break;
+            }
+
+            unset($keys[$i]);
 
             // If the key doesn't exist at this depth, we will just create an empty array
             // to hold the next value, allowing us to create the arrays to hold final


### PR DESCRIPTION
Same idea as #32192 

> Replace `while:array_shift` with `foreach:unset`. This operation is 3.5x faster. It is arguably more readable as well.
> 
> In my isolation tests with 1000 iterations:
> 
> * While loop `1.969ms`
> * Foreach loop `0.527ms`

I made a small performance test and the result really surprised me. It is a significant performance difference that made me think there's something wrong with my test code.

```php
<?php

function testData() {
  return array_fill(0, 100000, 'TEST DATA');
}

$array = testData();
$start = microtime(true);
$storage = [];
while(count($array) > 1) {
  $element = array_shift($array);
  $storage[] = $element;
}
$whileLoopTime = round(microtime(true) - $start, 4);
$elements = count($storage);
echo "whileloop: {$whileLoopTime} | storage stores {$elements} elements\n";

$array = testData();
$start = microtime(true);
$storage = [];
foreach($array as $i => $element) {
  if(count($array) === 1) {
    break;
  }
  unset($array[$i]);
  $storage[] = $element;
}
$foreachTime = round(microtime(true) - $start, 4);
$elements = count($storage);
echo "foreach: {$foreachTime} | storage stores {$elements} elements\n";

?>
```
----

- 1st run

whileloop: `8.0251` | storage stores 99999 elements
foreach: `0.0145` | storage stores 99999 elements

- 2nd run

whileloop: `7.9512` | storage stores 99999 elements
foreach: `0.0154` | storage stores 99999 elements

- 3rd run

whileloop: `7.9988` | storage stores 99999 elements
foreach: `0.0132` | storage stores 99999 elements
