### PR TITLE
Backport allowing ramsey/uuid 4.0 for laravel 5.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nesbot/carbon": "1.26.*",
         "psr/container": "~1.0",
         "psr/simple-cache": "^1.0",
-        "ramsey/uuid": "^3.7",
+        "ramsey/uuid": "^3.7|^4.0",
         "swiftmailer/swiftmailer": "~6.0",
         "symfony/console": "~4.0",
         "symfony/debug": "~4.0",


### PR DESCRIPTION
https://github.com/laravel/framework/pull/32086 for 5.6 🙏 

Is this possible to get a release of 5.6?