### PR TITLE
[8.x] Add ConfirmableTrait to ConfigCacheCommand

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -9,7 +9,7 @@ trait ConfirmableTrait
      *
      * @var string
      */
-    protected $environmentToConfirm = 'Production';
+    public $environmentToConfirm = 'Production';
 
     /**
      * Confirm before proceeding with the action.

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -5,6 +5,13 @@ namespace Illuminate\Console;
 trait ConfirmableTrait
 {
     /**
+     * The environment this command should be executed in.
+     *
+     * @var string
+     */
+    protected $environmentToConfirm = 'Production';
+
+    /**
      * Confirm before proceeding with the action.
      *
      * This method only asks for confirmation in production.
@@ -13,8 +20,12 @@ trait ConfirmableTrait
      * @param  \Closure|bool|null  $callback
      * @return bool
      */
-    public function confirmToProceed($warning = 'Application In Production!', $callback = null)
+    public function confirmToProceed($warning, $callback = null)
     {
+        if ($warning === null){
+            $warning = "Application In {$this->environmentToConfirm}!";
+        }
+
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;
 
         $shouldConfirm = value($callback);
@@ -46,7 +57,7 @@ trait ConfirmableTrait
     protected function getDefaultConfirmCallback()
     {
         return function () {
-            return $this->getLaravel()->environment() === 'production';
+            return $this->getLaravel()->environment() === strtolower($this->environmentToConfirm);
         };
     }
 }

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -20,9 +20,9 @@ trait ConfirmableTrait
      * @param  \Closure|bool|null  $callback
      * @return bool
      */
-    public function confirmToProceed($warning, $callback = null)
+    public function confirmToProceed($warning = null, $callback = null)
     {
-        if ($warning === null){
+        if ($warning === null) {
             $warning = "Application In {$this->environmentToConfirm}!";
         }
 

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -16,7 +16,7 @@ trait ConfirmableTrait
      *
      * This method only asks for confirmation in production.
      *
-     * @param  string  $warning
+     * @param  string|null  $warning
      * @param  \Closure|bool|null  $callback
      * @return bool
      */

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -23,7 +23,7 @@ trait ConfirmableTrait
     public function confirmToProceed($warning = null, $callback = null)
     {
         if ($warning === null) {
-            $warning = "Application In {$this->environmentToConfirm}!";
+        $warning = sprintf('Application In %s', ucfirst($this->environmentToConfirm));
         }
 
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -23,7 +23,7 @@ trait ConfirmableTrait
     public function confirmToProceed($warning = null, $callback = null)
     {
         if ($warning === null) {
-        $warning = sprintf('Application In %s', ucfirst($this->environmentToConfirm));
+            $warning = sprintf('Application In %s', ucfirst($this->environmentToConfirm));
         }
 
         $callback = is_null($callback) ? $this->getDefaultConfirmCallback() : $callback;

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -5,18 +5,24 @@ namespace Illuminate\Console;
 trait ConfirmableTrait
 {
     /**
+     * The environment this command should be executed in.
+     *
+     * @var string
+     */
+    public $environmentToConfirm = 'Production';
+
+    /**
      * Confirm before proceeding with the action.
      *
      * This method only asks for confirmation in production.
      *
-     * @param string             $warning
-     * @param \Closure|bool|null $callback
-     *
+     * @param  string  $warning
+     * @param  \Closure|bool|null  $callback
      * @return bool
      */
     public function confirmToProceed($warning, $callback = null)
     {
-        if ($warning === null) {
+        if ($warning === null){
             $warning = "Application In {$this->environmentToConfirm}!";
         }
 
@@ -33,7 +39,7 @@ trait ConfirmableTrait
 
             $confirmed = $this->confirm('Do you really wish to run this command?');
 
-            if (!$confirmed) {
+            if (! $confirmed) {
                 $this->comment('Command Canceled!');
 
                 return false;
@@ -50,10 +56,6 @@ trait ConfirmableTrait
      */
     protected function getDefaultConfirmCallback()
     {
-        if ($this->environmentToConfirm === null) {
-            $this->environmentToConfirm = 'Production';
-        }
-
         return function () {
             return $this->getLaravel()->environment() === strtolower($this->environmentToConfirm);
         };

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -57,7 +57,7 @@ trait ConfirmableTrait
     protected function getDefaultConfirmCallback()
     {
         return function () {
-            return $this->getLaravel()->environment() === strtolower($this->environmentToConfirm);
+            return $this->getLaravel()->environment() === $this->environmentToConfirm;
         };
     }
 }

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -9,7 +9,7 @@ trait ConfirmableTrait
      *
      * @var string
      */
-    public $environmentToConfirm = 'Production';
+    public $environmentToConfirm = 'production';
 
     /**
      * Confirm before proceeding with the action.

--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -5,24 +5,18 @@ namespace Illuminate\Console;
 trait ConfirmableTrait
 {
     /**
-     * The environment this command should be executed in.
-     *
-     * @var string
-     */
-    public $environmentToConfirm = 'Production';
-
-    /**
      * Confirm before proceeding with the action.
      *
      * This method only asks for confirmation in production.
      *
-     * @param  string  $warning
-     * @param  \Closure|bool|null  $callback
+     * @param string             $warning
+     * @param \Closure|bool|null $callback
+     *
      * @return bool
      */
     public function confirmToProceed($warning, $callback = null)
     {
-        if ($warning === null){
+        if ($warning === null) {
             $warning = "Application In {$this->environmentToConfirm}!";
         }
 
@@ -39,7 +33,7 @@ trait ConfirmableTrait
 
             $confirmed = $this->confirm('Do you really wish to run this command?');
 
-            if (! $confirmed) {
+            if (!$confirmed) {
                 $this->comment('Command Canceled!');
 
                 return false;
@@ -56,6 +50,10 @@ trait ConfirmableTrait
      */
     protected function getDefaultConfirmCallback()
     {
+        if ($this->environmentToConfirm === null) {
+            $this->environmentToConfirm = 'Production';
+        }
+
         return function () {
             return $this->getLaravel()->environment() === strtolower($this->environmentToConfirm);
         };

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -35,13 +35,6 @@ class ConfigCacheCommand extends Command
     protected $files;
 
     /**
-     * The environment this command should be executed in.
-     *
-     * @var string
-     */
-    public $environmentToConfirm = 'Local';
-
-    /**
      * Create a new config cache command instance.
      *
      * @param  \Illuminate\Filesystem\Filesystem  $files
@@ -52,6 +45,7 @@ class ConfigCacheCommand extends Command
         parent::__construct();
 
         $this->files = $files;
+        $this->environmentToConfirm = 'Local';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -39,7 +39,7 @@ class ConfigCacheCommand extends Command
      *
      * @var string
      */
-    protected $environmentToConfirm = 'Local';
+    public $environmentToConfirm = 'Local';
 
     /**
      * Create a new config cache command instance.

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -45,7 +45,7 @@ class ConfigCacheCommand extends Command
         parent::__construct();
 
         $this->files = $files;
-        $this->environmentToConfirm = 'Local';
+        $this->environmentToConfirm = 'local';
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -39,7 +39,7 @@ class ConfigCacheCommand extends Command
      *
      * @var string
      */
-    public $environmentToConfirm = 'Local';
+    protected $environmentToConfirm = 'Local';
 
     /**
      * Create a new config cache command instance.

--- a/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ConfigCacheCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
 use Illuminate\Filesystem\Filesystem;
 use LogicException;
@@ -10,6 +11,8 @@ use Throwable;
 
 class ConfigCacheCommand extends Command
 {
+    use ConfirmableTrait;
+
     /**
      * The console command name.
      *
@@ -30,6 +33,13 @@ class ConfigCacheCommand extends Command
      * @var \Illuminate\Filesystem\Filesystem
      */
     protected $files;
+
+    /**
+     * The environment this command should be executed in.
+     *
+     * @var string
+     */
+    protected $environmentToConfirm = 'Local';
 
     /**
      * Create a new config cache command instance.


### PR DESCRIPTION
We've had a few instances where `config:cache` has been ran, so then that is being used over the values in `phpunit`. So it's taken down a few databases unintentionally.

[I can see that this was added in 5.2 to increase throughput](https://github.com/laravel/framework/issues/13374#issuecomment-215699014), and [it's in the docs to not use this command locally](https://laravel.com/docs/7.x/configuration#configuration-caching). 
However we've still seen it happen (to myself personally also).

All this does is follow the same convention when running migrations on production.