### PR TITLE
[7.x] Fix HtmlString

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -19,9 +19,9 @@ class HtmlString implements Htmlable
      * @param  string  $html
      * @return void
      */
-    public function __construct($html)
+    public function __construct($html = '')
     {
-        $this->html = $html;
+        $this->html = (string) $html;
     }
 
     /**
@@ -31,7 +31,7 @@ class HtmlString implements Htmlable
      */
     public function toHtml()
     {
-        return $this->html;
+        return (string) $this->html;
     }
 
     /**

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 class HtmlString implements Htmlable
 {
     /**
-     * The HTML string.
+     * The underlying string value.
      *
      * @var string
      */
@@ -16,7 +16,7 @@ class HtmlString implements Htmlable
     /**
      * Create a new HTML string instance.
      *
-     * @param  string  $html
+     * @param  string  $value
      * @return void
      */
     public function __construct($value = '')
@@ -25,7 +25,7 @@ class HtmlString implements Htmlable
     }
 
     /**
-     * Get the HTML string.
+     * Get the raw string value.
      *
      * @return string
      */
@@ -35,7 +35,7 @@ class HtmlString implements Htmlable
     }
 
     /**
-     * Get the HTML string.
+     * Get the raw string value.
      *
      * @return string
      */

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -11,7 +11,7 @@ class HtmlString implements Htmlable
      *
      * @var string
      */
-    protected $html;
+    protected $value;
 
     /**
      * Create a new HTML string instance.
@@ -19,9 +19,9 @@ class HtmlString implements Htmlable
      * @param  string  $html
      * @return void
      */
-    public function __construct($html = '')
+    public function __construct($value = '')
     {
-        $this->html = (string) $html;
+        $this->value = (string) $value;
     }
 
     /**
@@ -31,7 +31,7 @@ class HtmlString implements Htmlable
      */
     public function toHtml()
     {
-        return (string) $this->html;
+        return (string) $this->value;
     }
 
     /**

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -7,17 +7,22 @@ use PHPUnit\Framework\TestCase;
 
 class SupportHtmlStringTest extends TestCase
 {
+    /**
+     * @param  string  $string
+     * @return \Illuminate\Support\HtmlString
+     */
+    protected function htmlstring($string = '')
+    {
+        return new HtmlString($string);
+    }
+
     public function testToHtml()
     {
-        $str = '<h1>foo</h1>';
-        $html = new HtmlString('<h1>foo</h1>');
-        $this->assertEquals($str, $html->toHtml());
+        $this->assertSame('<h1>foo</h1>', $this->htmlstring('<h1>foo</h1>')->toHtml());
     }
 
     public function testToString()
     {
-        $str = '<h1>foo</h1>';
-        $html = new HtmlString('<h1>foo</h1>');
-        $this->assertEquals($str, (string) $html);
+        $this->assertSame('<h1>foo</h1>', (string) $this->htmlstring('<h1>foo</h1>'));
     }
 }

--- a/tests/Support/SupportHtmlStringTest.php
+++ b/tests/Support/SupportHtmlStringTest.php
@@ -16,6 +16,11 @@ class SupportHtmlStringTest extends TestCase
         return new HtmlString($string);
     }
 
+    public function testConstruct()
+    {
+        $this->assertSame('', (string) new HtmlString());
+    }
+
     public function testToHtml()
     {
         $this->assertSame('<h1>foo</h1>', $this->htmlstring('<h1>foo</h1>')->toHtml());


### PR DESCRIPTION
Currently it is possible to instatiate a new `HtmlString` class with a `null` value.

This will result in an error:

```php
echo new HtmlString(null);
```
`HtmlString::__toString() must return a string value`

This PR fixes this, and makes it possible to instantiate an empty `HtmlString` object.

- Refactored the test
- Changed `$html` to `$value` to be more in line with the `Stringable` class, updated the docblocks as well