### PR TITLE
[7.x] Added new Stringable::leftTrim() and Stringable::rightTrim() methods

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -535,7 +535,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function leftTrim($characters = null)
+    public function ltrim($characters = null)
     {
         return new static(ltrim(...array_merge([$this->value], func_get_args())));
     }
@@ -546,7 +546,7 @@ class Stringable
      * @param  string  $characters
      * @return static
      */
-    public function rightTrim($characters = null)
+    public function rtrim($characters = null)
     {
         return new static(rtrim(...array_merge([$this->value], func_get_args())));
     }

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -530,6 +530,28 @@ class Stringable
     }
 
     /**
+     * Left trim the string of the given characters.
+     *
+     * @param  string  $characters
+     * @return static
+     */
+    public function leftTrim($characters = null)
+    {
+        return new static(ltrim(...array_merge([$this->value], func_get_args())));
+    }
+
+    /**
+     * Right trim the string of the given characters.
+     *
+     * @param  string  $characters
+     * @return static
+     */
+    public function rightTrim($characters = null)
+    {
+        return new static(rtrim(...array_merge([$this->value], func_get_args())));
+    }
+
+    /**
      * Make a string's first character uppercase.
      *
      * @return static

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -51,6 +51,16 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo', (string) $this->stringable(' foo ')->trim());
     }
 
+    public function testLeftTrim()
+    {
+        $this->assertSame('foo ', (string) $this->stringable(' foo ')->leftTrim());
+    }
+
+    public function testRightTrim()
+    {
+        $this->assertSame(' foo', (string) $this->stringable(' foo ')->rightTrim());
+    }
+
     public function testCanBeLimitedByWords()
     {
         $this->assertSame('Taylor...', (string) $this->stringable('Taylor Otwell')->words(1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -51,14 +51,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame('foo', (string) $this->stringable(' foo ')->trim());
     }
 
-    public function testLeftTrim()
+    public function testLtrim()
     {
-        $this->assertSame('foo ', (string) $this->stringable(' foo ')->leftTrim());
+        $this->assertSame('foo ', (string) $this->stringable(' foo ')->ltrim());
     }
 
-    public function testRightTrim()
+    public function testRtrim()
     {
-        $this->assertSame(' foo', (string) $this->stringable(' foo ')->rightTrim());
+        $this->assertSame(' foo', (string) $this->stringable(' foo ')->rtrim());
     }
 
     public function testCanBeLimitedByWords()


### PR DESCRIPTION
A `trim()` method already existed, but the neighbouring `leftTrim()` and `rightTrim()` methods were missing.

If they're not wanted in the framework, I can always macro them in but I think there would be quite a few use cases where you only want to trim from one end of the string, not both.