### PR TITLE
[7.x] Add isEmpty() method to HtmlString

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -25,16 +25,6 @@ class HtmlString implements Htmlable
     }
 
     /**
-     * Determine if the given HTML string is empty.
-     *
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return empty($this->html);
-    }
-
-    /**
      * Get the HTML string.
      *
      * @return string
@@ -43,6 +33,17 @@ class HtmlString implements Htmlable
     {
         return $this->html;
     }
+
+
+    /**
+     * Determine if the given HTML string is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->html);
+    }    
 
     /**
      * Get the HTML string.

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -34,7 +34,6 @@ class HtmlString implements Htmlable
         return $this->html;
     }
 
-
     /**
      * Determine if the given HTML string is empty.
      *

--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -25,6 +25,16 @@ class HtmlString implements Htmlable
     }
 
     /**
+     * Determine if the given HTML string is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->html);
+    }
+
+    /**
      * Get the HTML string.
      *
      * @return string


### PR DESCRIPTION
This PR adds an `isEmpty` method to the `\Illuminate\Support\HtmlString` class just like the `Stringable` class has.

```php
$string = new \Illuminate\Support\HtmlString(''); 

if ($string->isEmpty())

// vs

if (empty($string->toHtml()))
```