### PR TITLE
[7.x] Add default value to HtmlString constructor

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -19,7 +19,7 @@ class HtmlString implements Htmlable
      * @param  string  $html
      * @return void
      */
-    public function __construct($html)
+    public function __construct($html = '')
     {
         $this->html = $html;
     }


### PR DESCRIPTION
This PR adds a default value to the `Illuminate\Support\HtmlString` constructor.

```php
new HtmlString;

// vs

new HtmlString('');
```

Example use case:
```php
public function getContent(): HtmlString
{
    if (empty($this->attribute) {
        return new HtmlString;
        // vs
        return new HtmlString('');
    }

    return new HtmlString($this->attribute);
}
```
