### PR TITLE
[7.x] HtmlString __toString() must always return a string

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -41,6 +41,6 @@ class HtmlString implements Htmlable
      */
     public function __toString()
     {
-        return $this->toHtml();
+        return (string) $this->toHtml();
     }
 }


### PR DESCRIPTION
Fixes:

```
PHP Error:  Method Illuminate/Support/HtmlString::__toString() must return a string value
```