### PR TITLE
[7.x] Optimize Arr::forget() method

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -257,8 +257,12 @@ class Arr
             // clean up before each pass
             $array = &$original;
 
-            while (count($parts) > 1) {
-                $part = array_shift($parts);
+            foreach ($parts as $i => $part) {
+                if (count($parts) === 1) {
+                    break;
+                }
+
+                unset($parts[$i]);
 
                 if (isset($array[$part]) && is_array($array[$part])) {
                     $array = &$array[$part];
@@ -267,7 +271,7 @@ class Arr
                 }
             }
 
-            unset($array[array_shift($parts)]);
+            unset($array[current($parts)]);
         }
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -271,7 +271,7 @@ class Arr
                 }
             }
 
-            unset($array[current($parts)]);
+            unset($array[reset($parts)]);
         }
     }
 


### PR DESCRIPTION
This PR replaces `while:array_shift` with  `foreach:unset` just like the other two PRs did  #32192 & #32282