### PR TITLE
[6.x] Use a map to prevent unnecessary array access

### DIFF
--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -25,7 +25,9 @@ class PaginatedResourceResponse extends ResourceResponse
             ),
             $this->calculateStatus()
         ), function ($response) use ($request) {
-            $response->original = $this->resource->resource->pluck('resource');
+            $response->original = $this->resource->resource->map(function ($item) {
+                return $item->resource;
+            });
 
             $this->resource->withResponse($request, $response);
         });


### PR DESCRIPTION
I'm sure I'll get the "resources are an eloquent feature" response, but it's so great for us to use without needing to reinvent any wheels, and this is a tiny change so I thought it's worth a shot.

[This change](https://github.com/laravel/framework/commit/dbb3b8c7f503f872d63b0fd8aecfcc60b1a19ca8#diff-051f4207f04389c85d22b75ab28c71a6L53) introduced a while back broke paginated API resources where people weren't using Eloquent models.

There are a bunch of issues #29858, #29916, #31703, #31704 (probably others) related to it.

This PR fixes the root cause for most of them. By changing from pluck to map, we avoid an array access call to the Eloquent model (or non-Eloquent model in our cases) that happens further down the stack trace. It'll let those of us who still want to use Resources to avoid [ugly workarounds](https://github.com/laravel/framework/issues/29916#issuecomment-538999045).