### PR TITLE
[7.x] Update testWhenEmpty for Stringable class

### DIFF
--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -62,7 +62,7 @@ class SupportStringableTest extends TestCase
     {
         tap($this->stringable(), function ($stringable) {
             $this->assertSame($stringable, $stringable->whenEmpty(function () {
-                return null;
+                //
             }));
         });
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -62,7 +62,7 @@ class SupportStringableTest extends TestCase
     {
         tap($this->stringable(), function ($stringable) {
             $this->assertSame($stringable, $stringable->whenEmpty(function () {
-                return;
+                return false;
             }));
         });
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -62,7 +62,7 @@ class SupportStringableTest extends TestCase
     {
         tap($this->stringable(), function ($stringable) {
             $this->assertSame($stringable, $stringable->whenEmpty(function () {
-                return false;
+                return null;
             }));
         });
 

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -60,6 +60,12 @@ class SupportStringableTest extends TestCase
 
     public function testWhenEmpty()
     {
+        tap($this->stringable(), function ($stringable) {
+            $this->assertSame($stringable, $stringable->whenEmpty(function () {
+                return;
+            }));
+        });
+
         $this->assertSame('empty', (string) $this->stringable()->whenEmpty(function () {
             return 'empty';
         }));


### PR DESCRIPTION
From the docs:

> If the Closure does not return a value, the fluent string instance will be returned

This PR adds an additional assertion to make sure the fluent string will be returned if the closure does not return a value.

Edit:
Returning `false` from the closure does not return the fluent string instance. Is this to be expected behavior?

I would say that the string instance should be returned when returning a `falsy` value from the closure.