### PR TITLE
[7.x] Revert "[7.x] HtmlString __toString() must always return a string"

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -51,6 +51,6 @@ class HtmlString implements Htmlable
      */
     public function __toString()
     {
-        return (string) $this->toHtml();
+        return $this->toHtml();
     }
 }


### PR DESCRIPTION
Reverts laravel/framework#32292