### PR TITLE
[7.x] Fixed isEmpty implementation

### DIFF
--- a/src/Illuminate/Support/HtmlString.php
+++ b/src/Illuminate/Support/HtmlString.php
@@ -41,7 +41,7 @@ class HtmlString implements Htmlable
      */
     public function isEmpty()
     {
-        return empty($this->html);
+        return $this->html === '';
     }
 
     /**


### PR DESCRIPTION
Do we really want `'0'` to be treated as an empty html string?

I don't even understand why `isEmpty` was added. Why not just compare its value with the empty string. In particular, this method is not present on the htmlable contract, so cannot usually be safely called anyway...

I'd actually vote for just entirely removing this method.