### PR TITLE
[8.x] Remove helper from Eloquent factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factory.php
@@ -58,13 +58,11 @@ class Factory implements ArrayAccess
      * Create a new factory container.
      *
      * @param  \Faker\Generator  $faker
-     * @param  string|null  $pathToFactories
+     * @param  string  $pathToFactories
      * @return static
      */
-    public static function construct(Faker $faker, $pathToFactories = null)
+    public static function construct(Faker $faker, $pathToFactories)
     {
-        $pathToFactories = $pathToFactories ?: database_path('factories');
-
         return (new static($faker))->load($pathToFactories);
     }
 


### PR DESCRIPTION
Usage of a foundation helper here is discouraged because the package can be used outside the framework. It's also best to explicitly passing the factories location which is already done from the service provider.

Sent to master because of the breaking change of removing the fallback even though I don't believe people are using it like that.

Fixes https://github.com/laravel/framework/issues/32071