### PR TITLE
[6.x] Prevent timestamp update when pivot is not dirty

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -225,7 +225,7 @@ trait InteractsWithPivotTable
             $this->relatedPivotKey => $this->parseId($id),
         ], true);
 
-        $pivot->timestamps = in_array($this->updatedAt(), $this->pivotColumns);
+        $pivot->timestamps = $updated && in_array($this->updatedAt(), $this->pivotColumns);
 
         $pivot->fill($attributes)->save();
 


### PR DESCRIPTION
This will prevent the updated_at timestamp from being updated when the pivot isn't dirty during syncing.

Fixes https://github.com/laravel/framework/issues/30573