### PR TITLE
[7.x] Define return type of connection method

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/Factory.php
+++ b/src/Illuminate/Contracts/Broadcasting/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a broadcaster implementation by name.
      *
      * @param  string|null  $name
-     * @return void
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
      */
     public function connection($name = null);
 }


### PR DESCRIPTION
This PR defines proper return type for method `connection` of `Factory` class in `Broadcasting` domain.

It allows better support from IDE.
