### PR TITLE
Add support for the new composer installed.json format

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -122,7 +122,9 @@ class PackageManifest
         $packages = [];
 
         if ($this->files->exists($path = $this->vendorPath.'/composer/installed.json')) {
-            $packages = json_decode($this->files->get($path), true);
+            $installed = json_decode($this->files->get($path), true);
+
+            $packages = $installed['packages'] ?? $installed;
         }
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());


### PR DESCRIPTION
The format of vendor/composer/installed.json was changed in the latest snapshot version of composer breaking the package discovery. This PR fixes that with backwards compatibility with older versions of composer.
