### PR TITLE
[7.x] Add uuid change support in migrations

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -159,6 +159,9 @@ class ChangeColumn
             case 'binary':
                 $type = 'blob';
                 break;
+            case 'uuid':
+                $type = 'guid';
+                break;
         }
 
         return Type::getType($type);


### PR DESCRIPTION
Hi,

For now, we can't use `change()` for an uuid column:
```
Unknown column type "uuid" requested.
```

Actually this is just because DBAL reference this type as `guid`:
https://www.doctrine-project.org/projects/doctrine-dbal/en/2.10/reference/types.html#guid

I've added the conversion in the dedicated method, and this works like a charm.

If you're ok with that, I'll be happy to add tests for all grammars.

Thanks.