### PR TITLE
[7.x] Allow store resource into postgresql bytea

### DIFF
--- a/src/Illuminate/Database/PostgresConnection.php
+++ b/src/Illuminate/Database/PostgresConnection.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Query\Grammars\PostgresGrammar as QueryGrammar;
 use Illuminate\Database\Query\Processors\PostgresProcessor;
 use Illuminate\Database\Schema\Grammars\PostgresGrammar as SchemaGrammar;
 use Illuminate\Database\Schema\PostgresBuilder;
+use PDO;
 
 class PostgresConnection extends Connection
 {
@@ -62,5 +63,32 @@ class PostgresConnection extends Connection
     protected function getDoctrineDriver()
     {
         return new DoctrineDriver;
+    }
+
+    /**
+     * Bind values to their parameters in the given statement.
+     *
+     * @param  \PDOStatement  $statement
+     * @param  array  $bindings
+     * @return void
+     */
+    public function bindValues($statement, $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            $pdoParam = null;
+
+            if (is_int($value)) {
+                $pdoParam = PDO::PARAM_INT;
+            } elseif (is_resource($value)) {
+                $pdoParam = PDO::PARAM_LOB;
+            } else {
+                $pdoParam = PDO::PARAM_STR;
+            }
+
+            $statement->bindValue(
+                is_string($key) ? $key : $key + 1, $value,
+                $pdoParam
+            );
+        }
     }
 }


### PR DESCRIPTION
Allowing store files into postgresql database with bytea column type. You can simple use:
```php
\DB::table('table')->insert([ 'bytea_column' => fopen('filename', 'r') ]);
```
You can simple storing files from user upload etc...