### PR TITLE
[7.x] Add dump() and dd() to Stringable class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use Closure;
 use Illuminate\Support\Traits\Macroable;
+use Symfony\Component\VarDumper\VarDumper;
 
 class Stringable
 {
@@ -598,6 +599,30 @@ class Stringable
     public function words($words = 100, $end = '...')
     {
         return new static(Str::words($this->value, $words, $end));
+    }
+
+    /**
+     * Dump the string.
+     *
+     * @return $this
+     */
+    public function dump()
+    {
+        VarDumper::dump($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Dump the string and end the script.
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        $this->dump();
+
+        die(1);
     }
 
     /**


### PR DESCRIPTION
This PR adds `dump()` and `dd()` to the new fluent `Stringable` class, known from `Collection`.

## Usage
```php
Str::of('abc')
    ->replace('a','b')
    ->replace('c','a')
    ->dd() // 'bba' and die(1)
    ->replace('b','c');
```

```php
Str::of('abc')
    ->replace('a','b')
    ->dump() // 'bbc'
    ->replace('c','a')
    ->dump() // 'bba'
    ->replace('b','c');
```

## Realworld example
```php
Str::of($this->getStub())
    ->replace('DummyNamespace', config('factories-reloaded.factories_namespace'))
    ->replace('DummyFullModelClass', $this->modelClass)
    ->replace('DummyModelClass', class_basename($this->modelClass))
    ->replace('DummyFactory', $this->getTargetClassName())
    ->dd()
    ->replace('{{ uses }}', $this->uses)
    ->replace('{{ dummyData }}', $this->defaults)
    ->replace('{{ states }}', $this->withStates ? $this->states : '')
    ->replaceMatches('/(?P<imports>(?:use [^;]+;$\n?)+)/m', function($match) {
        return Str::of($match['imports'])->trim()->explode("\n")->sort()->implode("\n");
    });
```

It would be much easier to use our well-known `dd()` and `dump()` to debug the above code example (which is a compact version of `GeneratorCommand` stub replacement)

I hope you find it useful like it's for me.