### PR TITLE
[7.x] Added appends($attributes) method to Eloquent collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -399,6 +399,17 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Append an attribute across the entire collection.
+     *
+     * @param $attributes
+     * @return $this
+     */
+    public function append($attributes)
+    {
+        return $this->each->append($attributes);
+    }
+
+    /**
      * Get a dictionary keyed by primary keys.
      *
      * @param  \ArrayAccess|array|null  $items

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -399,6 +399,16 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Append an attribute across the entire collection.
+     * @param $attributes
+     * @return mixed
+     */
+    public function append($attributes)
+    {
+        return $this->each->append($attributes);
+    }
+
+    /**
      * Get a dictionary keyed by primary keys.
      *
      * @param  \ArrayAccess|array|null  $items

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -401,7 +401,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Append an attribute across the entire collection.
      *
-     * @param $attributes
+     * @param  array|string  $attributes
      * @return $this
      */
     public function append($attributes)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -399,16 +399,6 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Append an attribute across the entire collection.
-     * @param $attributes
-     * @return mixed
-     */
-    public function append($attributes)
-    {
-        return $this->each->append($attributes);
-    }
-
-    /**
      * Get a dictionary keyed by primary keys.
      *
      * @param  \ArrayAccess|array|null  $items

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -387,6 +387,15 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
+    public function testAppendsAddsTestOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->makeVisible('test');
+        $c = $c->append('test');
+
+        $this->assertEquals(['test' => 'test'], $c[0]->toArray());
+    }
+
     public function testNonModelRelatedMethods()
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
@@ -434,4 +443,9 @@ class TestEloquentCollectionModel extends Model
 {
     protected $visible = ['visible'];
     protected $hidden = ['hidden'];
+
+    public function getTestAttribute()
+    {
+        return 'test';
+    }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -12,7 +12,7 @@ use stdClass;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         m::close();
     }
@@ -26,13 +26,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testGettingMaxItemsFromCollection()
     {
-        $c = new Collection([(object)['foo' => 10], (object)['foo' => 20]]);
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(20, $c->max('foo'));
     }
 
     public function testGettingMinItemsFromCollection()
     {
-        $c = new Collection([(object)['foo' => 10], (object)['foo' => 20]]);
+        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
     }
 
@@ -114,12 +114,10 @@ class DatabaseEloquentCollectionTest extends TestCase
         $mockModel2->shouldReceive('getKey')->andReturn(2);
         $c = new Collection([$mockModel1, $mockModel2]);
 
-        $this->assertTrue($c->contains(function ($model)
-        {
+        $this->assertTrue($c->contains(function ($model) {
             return $model->getKey() < 2;
         }));
-        $this->assertFalse($c->contains(function ($model)
-        {
+        $this->assertFalse($c->contains(function ($model) {
             return $model->getKey() > 2;
         }));
     }
@@ -211,8 +209,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->map(function ($item)
-        {
+        $cAfterMap = $c->map(function ($item) {
             return $item;
         });
 
@@ -225,8 +222,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $one = m::mock(Model::class);
         $two = m::mock(Model::class);
 
-        $c = (new Collection([$one, $two]))->map(function ($item)
-        {
+        $c = (new Collection([$one, $two]))->map(function ($item) {
             return 'not-a-model';
         });
 
@@ -391,16 +387,6 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
-    public function testAppendsAddsTestOnEntireCollection()
-    {
-        $c = new Collection([new TestEloquentCollectionModel]);
-        $c = $c->makeVisible('test');
-        $c = $c->append('test');
-
-        $this->assertEquals(['test' => 'test'], $c[0]->toArray());
-
-    }
-
     public function testNonModelRelatedMethods()
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
@@ -433,7 +419,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
 
-        $c = new Collection([new TestEloquentCollectionModel, (object)['id' => 'something']]);
+        $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
         $c->getQueueableClass();
     }
 
@@ -448,9 +434,4 @@ class TestEloquentCollectionModel extends Model
 {
     protected $visible = ['visible'];
     protected $hidden = ['hidden'];
-
-    public function getTestAttribute()
-    {
-        return "test";
-    }
 }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -12,7 +12,7 @@ use stdClass;
 
 class DatabaseEloquentCollectionTest extends TestCase
 {
-    protected function tearDown(): void
+    protected function tearDown() : void
     {
         m::close();
     }
@@ -26,13 +26,13 @@ class DatabaseEloquentCollectionTest extends TestCase
 
     public function testGettingMaxItemsFromCollection()
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new Collection([(object)['foo' => 10], (object)['foo' => 20]]);
         $this->assertEquals(20, $c->max('foo'));
     }
 
     public function testGettingMinItemsFromCollection()
     {
-        $c = new Collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
+        $c = new Collection([(object)['foo' => 10], (object)['foo' => 20]]);
         $this->assertEquals(10, $c->min('foo'));
     }
 
@@ -114,10 +114,12 @@ class DatabaseEloquentCollectionTest extends TestCase
         $mockModel2->shouldReceive('getKey')->andReturn(2);
         $c = new Collection([$mockModel1, $mockModel2]);
 
-        $this->assertTrue($c->contains(function ($model) {
+        $this->assertTrue($c->contains(function ($model)
+        {
             return $model->getKey() < 2;
         }));
-        $this->assertFalse($c->contains(function ($model) {
+        $this->assertFalse($c->contains(function ($model)
+        {
             return $model->getKey() > 2;
         }));
     }
@@ -209,7 +211,8 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->map(function ($item) {
+        $cAfterMap = $c->map(function ($item)
+        {
             return $item;
         });
 
@@ -222,7 +225,8 @@ class DatabaseEloquentCollectionTest extends TestCase
         $one = m::mock(Model::class);
         $two = m::mock(Model::class);
 
-        $c = (new Collection([$one, $two]))->map(function ($item) {
+        $c = (new Collection([$one, $two]))->map(function ($item)
+        {
             return 'not-a-model';
         });
 
@@ -387,6 +391,16 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->assertEquals([], $c[0]->getHidden());
     }
 
+    public function testAppendsAddsTestOnEntireCollection()
+    {
+        $c = new Collection([new TestEloquentCollectionModel]);
+        $c = $c->makeVisible('test');
+        $c = $c->append('test');
+
+        $this->assertEquals(['test' => 'test'], $c[0]->toArray());
+
+    }
+
     public function testNonModelRelatedMethods()
     {
         $a = new Collection([['foo' => 'bar'], ['foo' => 'baz']]);
@@ -419,7 +433,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Queueing collections with multiple model types is not supported.');
 
-        $c = new Collection([new TestEloquentCollectionModel, (object) ['id' => 'something']]);
+        $c = new Collection([new TestEloquentCollectionModel, (object)['id' => 'something']]);
         $c->getQueueableClass();
     }
 
@@ -434,4 +448,9 @@ class TestEloquentCollectionModel extends Model
 {
     protected $visible = ['visible'];
     protected $hidden = ['hidden'];
+
+    public function getTestAttribute()
+    {
+        return "test";
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Much like the `makeVisible($attributes)` and `makeHidden($attributes)` methods, `appends($attributes)` allows the developer to utilize Laravel's accessors to append specific attributes across an entire eloquent collection.

```php
$collection->append($attribute);
```

If you wan't to achieve something similar right now, you would have to do something like this:
```php
$collection->each(function($model) {
    $model->append($attribute)
});
```

Otherwise your only option is to specify the attributes to be appended directly within the model, where it will be appended every time.

The downside here is that you'd have to remove/unset/hide the attribute whenever you don't need that specific one.

As an end user, this method allows me to more quickly choose when certain attributes should be appended.

The method has simply been added to the Collections.php class and should not cause any breaking changes.