### PR TITLE
[5.8] Backport support for Composer 2.x

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -113,7 +113,9 @@ class PackageManifest
         $packages = [];
 
         if ($this->files->exists($path = $this->vendorPath.'/composer/installed.json')) {
-            $packages = json_decode($this->files->get($path), true);
+            $installed = json_decode($this->files->get($path), true);
+
+            $packages = $installed['packages'] ?? $installed;
         }
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());


### PR DESCRIPTION
Composer 2.0.0 is due to be released very shortly, but Laravel doesn't support the new `installed.json` format. Because Composer 1.x is actually going to stop working in the future, Laravel should backport this fix to allow people to continue to deploy their existing apps.