### PR TITLE
[7.x] Add subquery support for aggregate functions

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2486,7 +2486,7 @@ class Builder
     /**
      * Retrieve the "count" result of the query.
      *
-     * @param  array|Closure|\Illuminate\Database\Query\Builder|string  $columns
+     * @param  array|\Closure|\Illuminate\Database\Query\Builder|string  $columns
      * @return int
      */
     public function count($columns = '*')
@@ -2497,7 +2497,7 @@ class Builder
     /**
      * Retrieve the minimum value of a given column.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return mixed
      */
     public function min($column)
@@ -2508,7 +2508,7 @@ class Builder
     /**
      * Retrieve the maximum value of a given column.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return mixed
      */
     public function max($column)
@@ -2519,7 +2519,7 @@ class Builder
     /**
      * Retrieve the sum of the values of a given column.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return mixed
      */
     public function sum($column)
@@ -2532,7 +2532,7 @@ class Builder
     /**
      * Retrieve the average of the values of a given column.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return mixed
      */
     public function avg($column)
@@ -2543,7 +2543,7 @@ class Builder
     /**
      * Alias for the "avg" method.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return mixed
      */
     public function average($column)
@@ -2626,7 +2626,7 @@ class Builder
     /**
      * Add an aggregate column to the query.
      *
-     * @param  Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
      * @return void
      */
     protected function addAggregate($column)


### PR DESCRIPTION
This PR adds the ability to use subqueries in aggregate methods like `count()`, `sum()`, `min()`, `max()`, `avg()`, and `average()`.

Here are a few examples:

### How many users are logged in actually

```php
$activeUsers = User::count(function () {
    $expiration = now()->subMinutes(config('session.lifetime'));

    Login::selectRaw(1)
          ->where('created_at', '>', $expiration)
          ->whereColumn('user_id', 'users.id')
          ->limit(1);
});
```

#### Generated SQL:
```sql
select count(
    select 1 from `logins`
    where `logins`.`created_at` = ?
    and `user_id` = `users`.`id`
    limit 1
) as aggregate from `users`
```

### Say we want to know the number of views for the videos for the top user

```php
$mostViewsByUser = User::max(function ($query) {
    $query->selectRaw('sum(views)')
        ->from('videos')
        ->whereColumn('user_id', 'users.id');
});
```

#### Generated SQL:

```sql
select max(
    select sum(`views`) from `videos`
    where `user_id` = `users`.`id`
) as aggregate from `users`
```

### Say we want to know the average number of videos the users have published this year

```php
$yearlyAverageVideosByUser = User::avg(function ($query) {
    $query->selectRaw('count(*)')
        ->from('videos')
        ->whereYear('published_at', 2020)
        ->whereColumn('user_id', 'users.id');
});
```

#### Generated SQL:

```sql
select avg(
    select count(*) from `videos`
    where year(`published_at`) = ?
    and `user_id` = `users`.`id`
) as aggregate from `users`
```

These methods accept `Closure`, `Illuminate\Database\Eloquent\Builder`, `Illuminate\Database\Query\Builder`, `Illuminate\Database\Query\Expression` instances as well as strings.

Passing `Expression` instances was still possible before but it was never tested.

Could @reinink or @staudenmeir check if this is looking good?