### PR TITLE
[6.x] Fix *scan methods for phpredis

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -295,6 +295,77 @@ class PhpRedisConnection extends Connection implements ConnectionContract
     }
 
     /**
+     * Scans the all keys based on options.
+     *
+     * @param mixed $cursor
+     * @param array $options
+     * @return mixed
+     */
+    public function scan($cursor, $options = [])
+    {
+        $result = $this->client->scan($cursor,
+            $options['match'] ?? '*',
+            $options['count'] ?? 10
+        );
+
+        return empty($result) ? $result : [$cursor, $result];
+    }
+
+    /**
+     * Scans the given set for all values based on options.
+     *
+     * @param string $key
+     * @param mixed $cursor
+     * @param array $options
+     * @return mixed
+     */
+    public function zscan($key, $cursor, $options = [])
+    {
+        $result = $this->client->zscan($key, $cursor,
+            $options['match'] ?? '*',
+            $options['count'] ?? 10
+        );
+
+        return $result === false ? [0, []] : [$cursor, $result];
+    }
+
+    /**
+     * Scans the given set for all values based on options.
+     *
+     * @param string $key
+     * @param mixed $cursor
+     * @param array $options
+     * @return mixed
+     */
+    public function hscan($key, $cursor, $options = [])
+    {
+        $result = $this->client->hscan($key, $cursor,
+            $options['match'] ?? '*',
+            $options['count'] ?? 10
+        );
+
+        return $result === false ? [0, []] : [$cursor, $result];
+    }
+
+    /**
+     * Scans the given set for all values based on options.
+     *
+     * @param string $key
+     * @param mixed $cursor
+     * @param array $options
+     * @return mixed
+     */
+    public function sscan($key, $cursor, $options = [])
+    {
+        $result = $this->client->sscan($key, $cursor,
+            $options['match'] ?? '*',
+            $options['count'] ?? 10
+        );
+
+        return $result === false ? [0, []] : [$cursor, $result];
+    }
+
+    /**
      * Execute commands in a pipeline.
      *
      * @param  callable|null  $callback

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -592,7 +592,7 @@ class RedisConnectionTest extends TestCase
             do {
                 [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
 
-                if (!is_array($returnedMembers)) {
+                if (! is_array($returnedMembers)) {
                     $returnedMembers = [$returnedMembers];
                 }
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -577,6 +577,119 @@ class RedisConnectionTest extends TestCase
         }
     }
 
+    public function testItZscansForKeys()
+    {
+        foreach ($this->connections() as $redis) {
+            $members = [100 => 'test:zscan:1', 200 => 'test:zscan:2'];
+
+            foreach ($members as $score => $member) {
+                $redis->zadd('set', $score, $member);
+            }
+
+            $iterator = null;
+            $result = [];
+
+            do {
+                [$iterator, $returnedMembers] = $redis->zscan('set', $iterator);
+
+                if (!is_array($returnedMembers)) {
+                    $returnedMembers = [$returnedMembers];
+                }
+
+                foreach ($returnedMembers as $member => $score) {
+                    $this->assertArrayHasKey((int) $score, $members);
+                    $this->assertContains($member, $members);
+                }
+
+                $result += $returnedMembers;
+            } while ($iterator > 0);
+
+            $this->assertCount(2, $result);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->zscan('set', $iterator, ['match' => 'test:unmatch:*']);
+            $this->assertEmpty($returned);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->zscan('set', $iterator, ['count' => 5]);
+            $this->assertCount(2, $returned);
+
+            $redis->flushAll();
+        }
+    }
+
+    public function testItHscansForKeys()
+    {
+        foreach ($this->connections() as $redis) {
+            $fields = ['name' => 'mohamed', 'hobby' => 'diving'];
+
+            foreach ($fields as $field => $value) {
+                $redis->hset('hash', $field, $value);
+            }
+
+            $iterator = null;
+            $result = [];
+
+            do {
+                [$iterator, $returnedFields] = $redis->hscan('hash', $iterator);
+
+                foreach ($returnedFields as $field => $value) {
+                    $this->assertArrayHasKey($field, $fields);
+                    $this->assertContains($value, $fields);
+                }
+
+                $result += $returnedFields;
+            } while ($iterator > 0);
+
+            $this->assertCount(2, $result);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['match' => 'test:unmatch:*']);
+            $this->assertEmpty($returned);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->hscan('hash', $iterator, ['count' => 5]);
+            $this->assertCount(2, $returned);
+
+            $redis->flushAll();
+        }
+    }
+
+    public function testItSscansForKeys()
+    {
+        foreach ($this->connections() as $redis) {
+            $members = ['test:sscan:1', 'test:sscan:2'];
+
+            foreach ($members as $member) {
+                $redis->sadd('set', $member);
+            }
+
+            $iterator = null;
+            $result = [];
+
+            do {
+                [$iterator, $returnedMembers] = $redis->sscan('set', $iterator);
+
+                foreach ($returnedMembers as $member) {
+                    $this->assertContains($member, $members);
+                    array_push($result, $member);
+                }
+            } while ($iterator > 0);
+
+            $this->assertCount(2, $result);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->sscan('set', $iterator, ['match' => 'test:unmatch:*']);
+            $this->assertEmpty($returned);
+
+            $iterator = null;
+            [$iterator, $returned] = $redis->sscan('set', $iterator, ['count' => 5]);
+            $this->assertCount(2, $returned);
+
+            $redis->flushAll();
+        }
+    }
+
     public function testPhpRedisScanOption()
     {
         foreach ($this->connections() as $redis) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR fixes #24222, previously fixed in #24313 but reverted by broken test.
hscan, zscan, sscan problem on phpredis that it can't iterate sets with cursor still occurs 6.x, 7.x branch so I requested this pr. If something is wrong with pull request process, please let me know.

This PR fixes *scan methods for phpredis and add missing *scan tests to redis connection.

## Current Behaviour

Redis Facade set phpredis as client returns no cursor with same results on every *scan call. So it can not iterate sets that has many members.
![image](https://user-images.githubusercontent.com/1641039/79041051-ab6f7a80-7c27-11ea-85fe-934aad20d36b.png)

## Fixed Behaviour
Returns cursor with results on *scan methods for phpredis. This behaviour is compatible with predis adapter. 
It can iterate over sets until all member has been returned.
![image](https://user-images.githubusercontent.com/1641039/79042209-9ba86400-7c30-11ea-9e8d-15bd4b628d6b.png)