### PR TITLE
[8.x] Disable transaction events in DatabaseTransactions trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
+++ b/src/Illuminate/Foundation/Testing/DatabaseTransactions.php
@@ -14,14 +14,22 @@ trait DatabaseTransactions
         $database = $this->app->make('db');
 
         foreach ($this->connectionsToTransact() as $name) {
-            $database->connection($name)->beginTransaction();
+            $connection = $database->connection($name);
+            $dispatcher = $connection->getEventDispatcher();
+
+            $connection->unsetEventDispatcher();
+            $connection->beginTransaction();
+            $connection->setEventDispatcher($dispatcher);
         }
 
         $this->beforeApplicationDestroyed(function () use ($database) {
             foreach ($this->connectionsToTransact() as $name) {
                 $connection = $database->connection($name);
+                $dispatcher = $connection->getEventDispatcher();
 
-                $connection->rollBack();
+                $connection->unsetEventDispatcher();
+                $connection->rollback();
+                $connection->setEventDispatcher($dispatcher);
                 $connection->disconnect();
             }
         });


### PR DESCRIPTION
This follows commit deafaa70e5bb9e86e30585a50e7872814a7af53e
which already added this for RefreshDatabase.

It's for the exact same reason as outlined in https://github.com/laravel/framework/pull/23832 :
> This is motivated by the fact that in tests, when using the RefreshDatabase trait, transactions events are dispatched and may interfer with the application testing itself when it relies on events like these ( for further info, see https://github.com/laravel/ideas/issues/1094 ).

As to not have custom handling of transaction events interfere with the
test suite itself, this simply disables this.

Again, the same change was added to `RefreshDatabase` and is still
present; this PR merely keeps the behaviour of them in sync in regards
to the handling of events in transactions: https://github.com/laravel/framework/blob/4d7eeb71b3c0bd3f65b895611175634631f5e290/src/Illuminate/Foundation/Testing/RefreshDatabase.php#L75-L94

Thanks