### PR TITLE
[7.x] Fix method return type in docblock

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 /**
  * @method array validate(array $rules, ...$params)
  * @method array validateWithBag(string $errorBag, array $rules, ...$params)
- * @method string hasValidSignature(bool $absolute = true)
+ * @method bool hasValidSignature(bool $absolute = true)
  */
 class Request extends SymfonyRequest implements Arrayable, ArrayAccess
 {


### PR DESCRIPTION
This PR fixed the method `hasValidSignature` return type - added in the Request class docblock - to match its `UrlGenerator` counterpart.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
