### PR TITLE
[7.x] Add HTTP client response body as object

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -48,7 +48,7 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Get the JSON decoded body of the response.
+     * Get the JSON decoded body of the response as an array.
      *
      * @return array
      */
@@ -59,6 +59,16 @@ class Response implements ArrayAccess
         }
 
         return $this->decoded;
+    }
+
+    /**
+     * Get the JSON decoded body of the response as an object.
+     *
+     * @return object
+     */
+    public function object()
+    {
+        return json_decode($this->body(), false);
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -55,7 +55,7 @@ class Response implements ArrayAccess
     public function json()
     {
         if (! $this->decoded) {
-            $this->decoded = json_decode((string) $this->response->getBody(), true);
+            $this->decoded = json_decode($this->body(), true);
         }
 
         return $this->decoded;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -44,6 +44,8 @@ class HttpClientTest extends TestCase
         $this->assertIsArray($response->json());
         $this->assertSame(['foo' => 'bar'], $response->json()['result']);
         $this->assertSame(['foo' => 'bar'], $response['result']);
+        $this->assertIsObject($response->object());
+        $this->assertSame('bar', $response->object()->result->foo);
     }
 
     public function testUrlsCanBeStubbedByPath()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -31,6 +31,21 @@ class HttpClientTest extends TestCase
         $this->assertTrue($response->ok());
     }
 
+    public function testResponseBodyCasting()
+    {
+        $this->factory->fake([
+            '*' => ['result' => ['foo' => 'bar']],
+        ]);
+
+        $response = $this->factory->get('http://foo.com/api');
+
+        $this->assertSame('{"result":{"foo":"bar"}}', $response->body());
+        $this->assertSame('{"result":{"foo":"bar"}}', (string) $response);
+        $this->assertIsArray($response->json());
+        $this->assertSame(['foo' => 'bar'], $response->json()['result']);
+        $this->assertSame(['foo' => 'bar'], $response['result']);
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([


### PR DESCRIPTION
This PR lets you access the `Http` client response body as an `object`.

I also added tests to cover existing ways to access the response body.

## Current state
```php
// Current magic way - uses ->json() under the hood
$response = Http::get('some-api.wip');
$response['result'];

// Or with json()
$response = Http::get('some-api.wip')->json();
$response['result'];
```

Initially, I thought to pass a boolean to `json()` to tell if it should convert JSON as `array` or `object`.

But the fact that `json()` is used to implement `ArrayAccess`, and `json(true)` isn't verbose at all, I went with `object()`

## Usage
```php
// New option
$response = Http::get('some-api.wip')->object();
$response->result;
```

## Future
As most API's wrap there responses with `data` or `result`.

```php
// I thought it would be nice to do this
$response = Http::get('some-api.wip')->object('result');
```

But didn't implement it yet to keep it simple for now.

I hope you find it useful.
Happy Easter to everyone.