### PR TITLE
[7.x] Fix unit test routes when base url has a trailing slash

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -490,7 +490,7 @@ trait MakesHttpRequests
         }
 
         if (! Str::startsWith($uri, 'http')) {
-            $uri = config('app.url').'/'.$uri;
+            $uri = rtrim(config('app.url'), '/').'/'.$uri;
         }
 
         return trim($uri, '/');


### PR DESCRIPTION
I ran a `composer update` today that updated the framework from `7.3.0` to `7.5.2`. This broke some of my unit tests.

Turns out the issue was that my `APP_URL` had a trailing slash: `http://st.test/`. Because only the URI is trimmed, and not the base url, this caused a double slash in my url: `http://st.test//tools`. This has never been a problem, but apparently this somehow broke between `7.3.0` and `7.5.2`.

The tests that broke looked something like this:
```php
$this->get('/tools')->assertStatus(301);
```
The routes couldn't be found anymore after the update, and returned a 404.
