### PR TITLE
[7.x] Set component alias name

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -193,6 +193,7 @@ class ComponentTagCompiler
         }
 
         return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false).'])
+<?php $component->withName(\''.$component.'\'); ?>
 <?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
     }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -33,6 +33,13 @@ abstract class Component
     protected $except = [];
 
     /**
+     * The component alias name.
+     *
+     * @var string
+     */
+    public $componentName;
+
+    /**
      * The component attributes.
      *
      * @var \Illuminate\View\ComponentAttributeBag
@@ -206,6 +213,19 @@ abstract class Component
             'view',
             'withAttributes',
         ], $this->except);
+    }
+
+    /**
+     * Set the component alias name.
+     *
+     * @param  string  $name
+     * @return $this
+     */
+    public function withName($name)
+    {
+        $this->componentName = $name;
+
+        return $this;
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -33,8 +33,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="foo" limit="5" @click="foo" required /><x-alert /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>\n".
 "@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -44,6 +46,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -53,6 +56,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
+<?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -61,6 +65,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1])
+<?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -69,6 +74,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+<?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
     }
 
@@ -77,6 +83,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x-foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('foo:alert'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -85,6 +92,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x:foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('foo:alert'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -93,6 +101,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert/></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -132,6 +141,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -141,6 +151,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -150,6 +161,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile></x-profile>Words');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+<?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
     }
 
@@ -158,6 +170,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert/>Words');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass Words', trim($result));
     }
@@ -167,6 +180,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert :title="$title" class="bar" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -177,6 +191,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 </x-alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+<?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
     }
@@ -193,6 +208,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler([]))->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+<?php \$component->withName('anonymous-component'); ?>
 <?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }


### PR DESCRIPTION
I have a use case where I want to conditionally render the contents of a component based on its alias name. For example, when you have an `Svg` component and use `<x:heroicon-o-bell/>` which is aliased to the component as follows:

```php
Blade::component(Svg::class, 'heroicon-o-bell');
```

This is much cleaner than having to do `<x:svg name="heroicon-o-bell"/>`. Adding the alias name to the `Component` class will open up many new use cases and possibilities for Blade components 🌟

Fyi: I picked `$componentName` rather than `$name` to not clash with component attributes using `$name` already.