### PR TITLE
[7.x] Ability to skip a middleware from route registration

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -932,7 +932,7 @@ class Route
     }
 
     /**
-     * Set which middleware(s) to skip
+     * Set which middleware(s) to skip.
      *
      * @param  array|string|null $middleware
      * @return $this|array

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -932,6 +932,29 @@ class Route
     }
 
     /**
+     * Set which middleware(s) to skip
+     *
+     * @param  array|string|null $middleware
+     * @return $this|array
+     */
+    public function skipMiddleware($middleware = null)
+    {
+        if (is_null($middleware)) {
+            return (array) ($this->action['skip_middleware'] ?? []);
+        }
+
+        if (is_string($middleware)) {
+            $middleware = func_get_args();
+        }
+
+        $this->action['skip_middleware'] = array_merge(
+            (array) ($this->action['skip_middleware'] ?? []), $middleware
+        );
+
+        return $this;
+    }
+
+    /**
      * Get the middleware for the route's controller.
      *
      * @return array

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -697,7 +697,7 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten()->reject(function($name) use ($route) {
+        })->flatten()->reject(function ($name) use ($route) {
             return in_array($name, $route->skipMiddleware(), true);
         });
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -697,7 +697,9 @@ class Router implements BindingRegistrar, RegistrarContract
     {
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten();
+        })->flatten()->reject(function($name) use ($route) {
+            return in_array($name, $route->getAction()['skip_middleware'] ?? [], true);
+        });
 
         return $this->sortMiddleware($middleware);
     }

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -698,7 +698,7 @@ class Router implements BindingRegistrar, RegistrarContract
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
         })->flatten()->reject(function($name) use ($route) {
-            return in_array($name, $route->getAction()['skip_middleware'] ?? [], true);
+            return in_array($name, $route->skipMiddleware(), true);
         });
 
         return $this->sortMiddleware($middleware);

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -60,6 +60,17 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['seven'], $this->getRoute()->middleware());
     }
 
+    public function testSkipMiddlewareRegistration()
+    {
+        $this->router->middleware(['one', 'two'])->get('users', function () {
+            return 'all-users';
+        })->skipMiddleware('one');
+
+        $this->seeResponse('all-users', Request::create('users', 'GET'));
+
+        $this->assertEquals(['one'], $this->getRoute()->skipMiddleware());
+    }
+
     public function testCanRegisterGetRouteWithClosureAction()
     {
         $this->router->middleware('get-middleware')->get('users', function () {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -193,6 +193,18 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testMiddlewareCanBeSkipped()
+    {
+        $router = $this->getRouter();
+        $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
+
+        $router->get('foo/bar', ['middleware' => 'web', function () {
+            return 'hello';
+        }])->skipMiddleware(RoutingTestMiddlewareGroupTwo::class);
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
     public function testMiddlewareWorksIfControllerThrowsHttpResponseException()
     {
         // Before calling controller


### PR DESCRIPTION
Hello. Quite a few times I needed to skip a specific middleware for just one route. The current approach seems to be `$except` property in the middleware and then skipping it if the URL matches. This mostly works, but sometimes we do not know the exact URL, or we do not know the name of the route so that is not always the best solution.

I would like to propose `skipMiddleware` method, which would be used like:
* `Route::get('/something')->skipMiddleware(VerifyCsrfToken::class)`
* `Route::get('/teams/create')->skipMiddleware(VerifyUserHasTeam::class)`

Quite simple, but solves an annoying problem. Hopefully, I am not the only one running into this so I'd love to see this in the core. Please consider it and let me know if there is anything I need to change. 

Thanks!  
