### PR TITLE
[6.x] Use BindingResolutionException to signal problem with container resolution

### DIFF
--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Routing;
 
-use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Contracts\View\Factory as ViewFactoryContract;
@@ -144,7 +144,7 @@ class RoutingServiceProvider extends ServiceProvider
                 return (new DiactorosFactory)->createRequest($app->make('request'));
             }
 
-            throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
+            throw new BindingResolutionException('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
         });
     }
 
@@ -164,7 +164,7 @@ class RoutingServiceProvider extends ServiceProvider
                 return new ZendPsrResponse;
             }
 
-            throw new Exception('Unable to resolve PSR response. Please install nyholm/psr7.');
+            throw new BindingResolutionException('Unable to resolve PSR response. Please install nyholm/psr7.');
         });
     }
 


### PR DESCRIPTION
Same as https://github.com/laravel/framework/pull/32348 but targeting L6

As part of static analysis sometimes abstracts get resolved which aren't
resolvable => that's totally fine but it would help to use a common
exception to signal this.

I figured BindingResolutionException would be the correct one. For example,
it's caught in cases like `\Illuminate\Foundation\Exceptions\Handler::whoopsHandler`
and IMHO this would also benefit from a streamlined exception.
