### PR TITLE
[7.x] Update Http Facade attach docblock to be accurate

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Client\Factory;
 /**
  * @method static \Illuminate\Http\Client\PendingRequest asJson()
  * @method static \Illuminate\Http\Client\PendingRequest asForm()
- * @method static \Illuminate\Http\Client\PendingRequest attach(string $name, string $contents, string|null $filename = null, array $headers)
+ * @method static \Illuminate\Http\Client\PendingRequest attach(string $name, string $contents, string|null $filename = null, array $headers = [])
  * @method static \Illuminate\Http\Client\PendingRequest asMultipart()
  * @method static \Illuminate\Http\Client\PendingRequest bodyFormat(string $format)
  * @method static \Illuminate\Http\Client\PendingRequest contentType(string $contentType)


### PR DESCRIPTION
Currently, the Http client facade has a typo that says the `$headers` parameter in the `attach` function is necessary and doesn't have a default. In the actual code (and in the documentation) it is clear that this parameter is not actually necessary and has a default value of an empty array.

This typo causes confusion in IDEs like PHPStorm, where if you leave out the `$headers` parameter it complains that you are using the function incorrectly, even though during runtime everything works fine.
