### PR TITLE
[8.x] Add option to include table data when using schema:dump

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -19,7 +19,8 @@ class DumpCommand extends Command
     protected $signature = 'schema:dump
                 {--database= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
-                {--prune : Delete all existing migration files}';
+                {--prune : Delete all existing migration files}
+                {--include-data : Includes data with the schema dump}';
 
     /**
      * The console command description.
@@ -37,7 +38,7 @@ class DumpCommand extends Command
     {
         $this->schemaState(
             $connection = $connections->connection($database = $this->input->getOption('database'))
-        )->dump($path = $this->path($connection));
+        )->dump($path = $this->path($connection), $this->option('include-data'));
 
         $dispatcher->dispatch(new SchemaDumped($connection, $path));
 
@@ -45,7 +46,8 @@ class DumpCommand extends Command
 
         if ($this->option('prune')) {
             (new Filesystem)->deleteDirectory(
-                database_path('migrations'), $preserve = false
+                database_path('migrations'),
+                $preserve = false
             );
 
             $this->info('Migrations pruned successfully.');

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -8,19 +8,25 @@ class MySqlSchemaState extends SchemaState
      * Dump the database's schema into a file.
      *
      * @param  string  $path
+     * @param  bool  $includeData
      * @return void
      */
-    public function dump($path)
+    public function dump($path, bool $includeData = false)
     {
         $this->makeProcess(
-            $this->baseDumpCommand().' --routines --result-file=$LARAVEL_LOAD_PATH --no-data'
-        )->mustRun($this->output, array_merge($this->baseVariables($this->connection->getConfig()), [
-            'LARAVEL_LOAD_PATH' => $path,
-        ]));
+            $this->baseDumpCommand($includeData) . ' --routines --result-file=$LARAVEL_LOAD_PATH',
+            )->mustRun(
+                $this->output,
+                array_merge($this->baseVariables($this->connection->getConfig()), [
+                'LARAVEL_LOAD_PATH' => $path,
+            ]),
+                );
 
-        $this->removeAutoIncrementingState($path);
+        if (!$includeData) {
+            $this->removeAutoIncrementingState($path);
 
-        $this->appendMigrationData($path);
+            $this->appendMigrationData($path, $includeData);
+        }
     }
 
     /**
@@ -31,11 +37,7 @@ class MySqlSchemaState extends SchemaState
      */
     protected function removeAutoIncrementingState(string $path)
     {
-        $this->files->put($path, preg_replace(
-            '/\s+AUTO_INCREMENT=[0-9]+/iu',
-            '',
-            $this->files->get($path)
-        ));
+        $this->files->put($path, preg_replace('/\s+AUTO_INCREMENT=[0-9]+/iu', '', $this->files->get($path)));
     }
 
     /**
@@ -46,11 +48,17 @@ class MySqlSchemaState extends SchemaState
      */
     protected function appendMigrationData(string $path)
     {
-        with($process = $this->makeProcess(
-            $this->baseDumpCommand().' migrations --no-create-info --skip-extended-insert --skip-routines --compact'
-        ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
-            //
-        ]));
+        with(
+            $process = $this->makeProcess(
+                $this->baseDumpCommand(true) .
+                    ' migrations --no-create-info --skip-extended-insert --skip-routines --compact',
+                ),
+            )->mustRun(
+                null,
+                array_merge($this->baseVariables($this->connection->getConfig()), [
+                //
+            ]),
+                );
 
         $this->files->append($path, $process->getOutput());
     }
@@ -63,21 +71,34 @@ class MySqlSchemaState extends SchemaState
      */
     public function load($path)
     {
-        $process = $this->makeProcess('mysql --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD --database=$LARAVEL_LOAD_DATABASE < $LARAVEL_LOAD_PATH');
+        $process = $this->makeProcess(
+            'mysql --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD --database=$LARAVEL_LOAD_DATABASE < $LARAVEL_LOAD_PATH',
+            );
 
-        $process->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
-            'LARAVEL_LOAD_PATH' => $path,
-        ]));
+        $process->mustRun(
+            null,
+            array_merge($this->baseVariables($this->connection->getConfig()), [
+                'LARAVEL_LOAD_PATH' => $path,
+            ]),
+            );
     }
 
     /**
      * Get the base dump command arguments for MySQL as a string.
      *
+     * @param  bool  $includeData
      * @return string
      */
-    protected function baseDumpCommand()
+    protected function baseDumpCommand(bool $includeData)
     {
-        return 'mysqldump --set-gtid-purged=OFF --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD $LARAVEL_LOAD_DATABASE';
+        $cmd =
+            'mysqldump --set-gtid-purged=OFF --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD $LARAVEL_LOAD_DATABASE';
+
+        if (!$includeData) {
+            $cmd .= ' --no-data';
+        }
+
+        return $cmd;
     }
 
     /**

--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -63,9 +63,10 @@ abstract class SchemaState
      * Dump the database's schema into a file.
      *
      * @param  string  $path
+     * @param  bool    $includeData
      * @return void
      */
-    abstract public function dump($path);
+    abstract public function dump($path, bool $includeData);
 
     /**
      * Load the given schema file into the database.


### PR DESCRIPTION
This PR adds an option to include table data when using the new `schema:dump` command.

We have static data stored in our database that needs to be deployed in parallel with code changes. An example of this is permissions.

Another use case is you can make pre-seeded test suites which can dramatically improve the test suite runtime.

Here are a couple GIFs demonstrating the new option to ensure our static permission data is included with the schema dump:

Before:

![2020-04-12 21 35 34](https://user-images.githubusercontent.com/791222/79090104-ce705c00-7d05-11ea-90f3-fb3d84c1e784.gif)

After, with new option set:

![2020-04-12 21 36 02](https://user-images.githubusercontent.com/791222/79090133-de883b80-7d05-11ea-9cd0-3d25a256c079.gif)

I couldn't find any tests for this new command, but if they're in there somewhere, please point me in the right direction and I can add test coverage.

There's some code formatting changes from my editor, but I think StyleCI should fix them, if not, I can clean them up.