### PR TITLE
[7.x] Adds notification stub from project stubs

### DIFF
--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -85,8 +85,21 @@ class NotificationMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return $this->option('markdown')
-                        ? __DIR__.'/stubs/markdown-notification.stub'
-                        : __DIR__.'/stubs/notification.stub';
+            ? $this->resolveStubPath('/stubs/markdown-notification.stub')
+            : $this->resolveStubPath('/stubs/notification.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
     }
 
     /**


### PR DESCRIPTION
Allows for custom stubs to be added to a project for Notifications. My projects, like I'm sure a few peoples will, uses custom logic in notifications which becomes a part of the boiler plate each time so it would be really useful to have the ability to customise per project.

I've not added the stub to the `stubs:publish` command but am happy to do so if required.
