### PR TITLE
[8.x] Renamed 'salutation' to 'valediction' in the mail notifications

### DIFF
--- a/src/Illuminate/Notifications/Messages/SimpleMessage.php
+++ b/src/Illuminate/Notifications/Messages/SimpleMessage.php
@@ -29,11 +29,11 @@ class SimpleMessage
     public $greeting;
 
     /**
-     * The notification's salutation.
+     * The notification's valediction.
      *
      * @var string
      */
-    public $salutation;
+    public $valediction;
 
     /**
      * The "intro" lines of the notification.
@@ -127,14 +127,14 @@ class SimpleMessage
     }
 
     /**
-     * Set the salutation of the notification.
+     * Set the valediction of the notification.
      *
-     * @param  string  $salutation
+     * @param  string  $valediction
      * @return $this
      */
-    public function salutation($salutation)
+    public function valediction($valediction)
     {
-        $this->salutation = $salutation;
+        $this->valediction = $valediction;
 
         return $this;
     }
@@ -214,7 +214,7 @@ class SimpleMessage
             'level' => $this->level,
             'subject' => $this->subject,
             'greeting' => $this->greeting,
-            'salutation' => $this->salutation,
+            'valediction' => $this->valediction,
             'introLines' => $this->introLines,
             'outroLines' => $this->outroLines,
             'actionText' => $this->actionText,

--- a/src/Illuminate/Notifications/resources/views/email.blade.php
+++ b/src/Illuminate/Notifications/resources/views/email.blade.php
@@ -39,9 +39,9 @@
 
 @endforeach
 
-{{-- Salutation --}}
-@if (! empty($salutation))
-{{ $salutation }}
+{{-- Valediction --}}
+@if (! empty($valediction))
+{{ $valediction }}
 @else
 @lang('Regards'),<br>
 {{ config('app.name') }}


### PR DESCRIPTION
This is a simple pull request that just replaces all occurrences of ``` salutation ``` to ``` valediction ``` in the mail notifications.

My reasoning for this is that a salutation is usually the opening part of a letter/email and the valediction is at the end (or at least that's my understanding). I got a little bit confused while trying to modify a mail message and had to start delving into the mail template to find out how to update the valediction in the message. I'm guessing other people might have had the same issue?

I've added this a breaking change because all occurrences of ``` ->salutation() ``` will need to be updated to ``` ->valediction() ``` in the notifications. Any existing mail templates that have been published will likely also need to be updated to match this change as well.

Hopefully, this is all okay? 