### PR TITLE
[7.x] Add assertResource for TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -6,7 +6,6 @@ use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -1153,10 +1152,10 @@ class TestResponse implements ArrayAccess
     /**
      * Assert that the response is a given resource.
      *
-     * @param JsonResource $resource
+     * @param \Illuminate\Http\Resources\Json\JsonResource $resource
      * @return $this
      */
-    public function assertResource(JsonResource $resource)
+    public function assertResource(\Illuminate\Http\Resources\Json\JsonResource $resource)
     {
         return $this->assertJson($resource->response()->getData(true));
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -1155,7 +1156,7 @@ class TestResponse implements ArrayAccess
      * @param \Illuminate\Http\Resources\Json\JsonResource $resource
      * @return $this
      */
-    public function assertResource(\Illuminate\Http\Resources\Json\JsonResource $resource)
+    public function assertResource(JsonResource $resource)
     {
         return $this->assertJson($resource->response()->getData(true));
     }

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -6,6 +6,7 @@ use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -1147,6 +1148,17 @@ class TestResponse implements ArrayAccess
         }
 
         return $this;
+    }
+
+    /**
+     * Assert that the response is a given resource.
+     *
+     * @param JsonResource $resource
+     * @return $this
+     */
+    public function assertResource(JsonResource $resource)
+    {
+        return $this->assertJson($resource->response()->getData(true));
     }
 
     /**

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -68,6 +68,43 @@ class ResourceTest extends TestCase
         $this->assertSame('{"id":5,"title":"Test Title","custom":true}', $resource->toJson());
     }
 
+    public function testResponseContainsResource()
+    {
+        $resource = new PostResource(new Post([
+            'id' => 5,
+            'title' => 'Test Title',
+            'abstract' => 'Test abstract',
+        ]));
+
+        Route::get('/', function () use ($resource) {
+            return $resource;
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertResource($resource);
+    }
+
+    public function testResponseContainsCollection()
+    {
+        $collection = PostResource::collection(collect([
+            new Post(['id' => 1, 'title' => 'Test title 1']),
+            new Post(['id' => 2, 'title' => 'Test title 2']),
+        ]));
+
+        Route::get('/', function () use ($collection) {
+            return $collection;
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertResource($collection);
+    }
+
     public function testAnObjectsMayBeConvertedToJson()
     {
         Route::get('/', function () {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use JsonSerializable;
@@ -856,6 +857,15 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonMissingValidationErrors('bar', 'data');
+    }
+
+    public function testAssertResource()
+    {
+        $resource = new JsonResource(['foo' => 'bar']);
+
+        $response = TestResponse::fromBaseResponse(new Response($resource));
+
+        $response->assertResource($resource);
     }
 
     public function testMacroable()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use JsonSerializable;
@@ -857,15 +856,6 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonMissingValidationErrors('bar', 'data');
-    }
-
-    public function testAssertResource()
-    {
-        $resource = new JsonResource(['foo' => 'bar']);
-
-        $response = TestResponse::fromBaseResponse(new Response($resource));
-
-        $response->assertResource($resource);
     }
 
     public function testMacroable()


### PR DESCRIPTION
This PR adds a new assertion to the TestResponse class called assertResource. Here is an example:

```php
$item = factory(Item::class)->create();

$response = $this->get(route('items.show'));

// for single resource
$response->assertResource(new ItemResource($item));

// for collection
$response->assertResource(ItemResource::collection($items));

```


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
