### PR TITLE
[7.x] Adding "between" clauses for BelongsToMany pivot columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -358,6 +358,57 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Set a "where between" clause for a pivot table column.
+     *
+     * @param   string  $column
+     * @param   array   $values
+     * @param   string  $boolean
+     * @param   bool    $not
+     * @return  BelongsToMany
+     */
+    public function wherePivotBetween($column, array $values, $boolean = 'and', $not = false)
+    {
+        return $this->whereBetween($this->table.'.'.$column, $values, $boolean, $not);
+    }
+
+    /**
+     * Set a "or where between" clause for a pivot table column.
+     *
+     * @param   string  $column
+     * @param   array   $values
+     * @return BelongsToMany
+     */
+    public function orWherePivotBetween($column, array $values)
+    {
+        return $this->wherePivotBetween($column, $values, 'or');
+    }
+
+    /**
+     * Set a "where pivot not between" clause for a pivot table column.
+     *
+     * @param $column
+     * @param array $values
+     * @param string $boolean
+     * @return BelongsToMany
+     */
+    public function wherePivotNotBetween($column, array $values, $boolean = 'and')
+    {
+        return $this->wherePivotBetween($column, $values, $boolean, true);
+    }
+
+    /**
+     * Set a "or where not between" clause for a pivot table column.
+     *
+     * @param   string  $column
+     * @param   array   $values
+     * @return BelongsToMany
+     */
+    public function orWherePivotNotBetween($column, array $values)
+    {
+        return $this->wherePivotBetween($column, $values, 'or', true);
+    }
+
+    /**
      * Set a "where in" clause for a pivot table column.
      *
      * @param  string  $column

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -360,11 +360,11 @@ class BelongsToMany extends Relation
     /**
      * Set a "where between" clause for a pivot table column.
      *
-     * @param   string  $column
-     * @param   array   $values
-     * @param   string  $boolean
-     * @param   bool    $not
-     * @return  BelongsToMany
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @param  bool  $not
+     * @return $this
      */
     public function wherePivotBetween($column, array $values, $boolean = 'and', $not = false)
     {
@@ -374,9 +374,9 @@ class BelongsToMany extends Relation
     /**
      * Set a "or where between" clause for a pivot table column.
      *
-     * @param   string  $column
-     * @param   array   $values
-     * @return BelongsToMany
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
      */
     public function orWherePivotBetween($column, array $values)
     {
@@ -386,10 +386,10 @@ class BelongsToMany extends Relation
     /**
      * Set a "where pivot not between" clause for a pivot table column.
      *
-     * @param $column
-     * @param array $values
-     * @param string $boolean
-     * @return BelongsToMany
+     * @param  string  $column
+     * @param  array  $values
+     * @param  string  $boolean
+     * @return $this
      */
     public function wherePivotNotBetween($column, array $values, $boolean = 'and')
     {
@@ -399,9 +399,9 @@ class BelongsToMany extends Relation
     /**
      * Set a "or where not between" clause for a pivot table column.
      *
-     * @param   string  $column
-     * @param   array   $values
-     * @return BelongsToMany
+     * @param  string  $column
+     * @param  array  $values
+     * @return $this
      */
     public function orWherePivotNotBetween($column, array $values)
     {


### PR DESCRIPTION
Pretty short and simple. This adds the ability to add 'where between' query clauses to pivot columns.

More or less syntactic sugar, but it allows to more consistency between the normal "where" clauses and the "wherePivot" methods.