### PR TITLE
[8.x] Remove elixir helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -406,46 +406,6 @@ if (! function_exists('dispatch_now')) {
     }
 }
 
-if (! function_exists('elixir')) {
-    /**
-     * Get the path to a versioned Elixir file.
-     *
-     * @param  string  $file
-     * @param  string  $buildDirectory
-     * @return string
-     *
-     * @throws \InvalidArgumentException
-     */
-    function elixir($file, $buildDirectory = 'build')
-    {
-        static $manifest = [];
-        static $manifestPath;
-
-        if (empty($manifest) || $manifestPath !== $buildDirectory) {
-            $path = public_path($buildDirectory.'/rev-manifest.json');
-
-            if (file_exists($path)) {
-                $manifest = json_decode(file_get_contents($path), true);
-                $manifestPath = $buildDirectory;
-            }
-        }
-
-        $file = ltrim($file, '/');
-
-        if (isset($manifest[$file])) {
-            return '/'.trim($buildDirectory.'/'.$manifest[$file], '/');
-        }
-
-        $unversioned = public_path($file);
-
-        if (file_exists($unversioned)) {
-            return '/'.trim($file, '/');
-        }
-
-        throw new InvalidArgumentException("File {$file} not defined in asset manifest.");
-    }
-}
-
 if (! function_exists('encrypt')) {
     /**
      * Encrypt the given value.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -43,21 +43,6 @@ class FoundationHelpersTest extends TestCase
         $this->assertSame('default', cache('baz', 'default'));
     }
 
-    public function testUnversionedElixir()
-    {
-        $file = 'unversioned.css';
-
-        app()->singleton('path.public', function () {
-            return __DIR__;
-        });
-
-        touch(public_path($file));
-
-        $this->assertSame('/'.$file, elixir($file));
-
-        unlink(public_path($file));
-    }
-
     public function testMixDoesNotIncludeHost()
     {
         $app = new Application;


### PR DESCRIPTION
Laravel 5.4  was shipped with Laravel Mix three years ago. Therefore I think most apps will be migrated from Laravel Elixir to Laravel Mix. So it may time to remove the `elixir()`helper.

For backward compatibility, we perhaps add that helper to the laravel\helpers repository like it was done for the `str_` and `arr_` helpers.
