### PR TITLE
[6.x] Depreciate the elixir function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -416,6 +416,8 @@ if (! function_exists('elixir')) {
      * @return string
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated Use Laravel Mix instead.
      */
     function elixir($file, $buildDirectory = 'build')
     {


### PR DESCRIPTION
This should give Laravel LTS and Laravel Stable users a heads up that this function will be removed in the next major upgrade they do.