### PR TITLE
[6.x] Fix phpdoc for \Illuminate\Database\Query\Builder::orderBy $column parameter

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1809,7 +1809,7 @@ class Builder
     /**
      * Add an "order by" clause to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $column
+     * @param  \Closure|\Illuminate\Database\Query\Builder|\Illuminate\Database\Query\Expression|string  $column
      * @param  string  $direction
      * @return $this
      *


### PR DESCRIPTION
The $column also supports passing \Illuminate\Database\Query\Expression directly.

There _is_ an `orderByRaw` but it's different (takes string + bindings),
whereas `orderBy` accepting an Expression + order direction.

In fact the first part of the method actually converts the $column to such an expression object (unless it's already one):
```php
        if ($this->isQueryable($column)) {
            [$query, $bindings] = $this->createSub($column);

            $column = new Expression('('.$query.')');

            $this->addBinding($bindings, $this->unions ? 'unionOrder' : 'order');
        }
```

I checked master, still the same phpdoc
