### PR TITLE
[7.x] Make active_url validation rule support IDNs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "symfony/http-foundation": "^5.0",
         "symfony/http-kernel": "^5.0",
         "symfony/mime": "^5.0",
+        "symfony/polyfill-intl-idn": "^1.11",
         "symfony/process": "^5.0",
         "symfony/routing": "^5.0",
         "symfony/var-dumper": "^5.0",

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -57,7 +57,7 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return (bool) dns_get_record(
+                return (bool) @dns_get_record(
                     idn_to_ascii($url, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46),
                     DNS_A | DNS_AAAA
                 );

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -57,7 +57,10 @@ trait ValidatesAttributes
 
         if ($url = parse_url($value, PHP_URL_HOST)) {
             try {
-                return count(dns_get_record($url, DNS_A | DNS_AAAA)) > 0;
+                return (bool) dns_get_record(
+                    idn_to_ascii($url, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46),
+                    DNS_A | DNS_AAAA
+                );
             } catch (Exception $e) {
                 return false;
             }

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -22,7 +22,8 @@
         "illuminate/support": "^7.0",
         "illuminate/translation": "^7.0",
         "symfony/http-foundation": "^5.0",
-        "symfony/mime": "^5.0"
+        "symfony/mime": "^5.0",
+        "symfony/polyfill-intl-idn": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2630,6 +2630,12 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['x' => ['fdsfs', 'fdsfds']], ['x' => 'active_url']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['x' => 'http://invalid.invalid'], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://invalid/invalid'], ['x' => 'active_url']);
+        $this->assertFalse($v->passes());
+
         $v = new Validator($trans, ['x' => 'http://google.com'], ['x' => 'active_url']);
         $this->assertTrue($v->passes());
 
@@ -2637,6 +2643,12 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['x' => 'http://www.google.com/about'], ['x' => 'active_url']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://täst.de'], ['x' => 'active_url']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['x' => 'http://öbb.at/en'], ['x' => 'active_url']);
         $this->assertTrue($v->passes());
     }
 


### PR DESCRIPTION
This PR adds support for IDN (Internationalized Domain Name) when using `active_url` validation rule. The hostname is converted to IDNA ASCII form using `idn_to_ascii` PHP function before being passed to `dns_get_record`.

Alternatively, it avoids throwing an exception in case of `dns_get_record` fails and returns false instead of an array and causes `count(false) > 0` throw an exception (that try/catch finally catches).