### PR TITLE
[7.x] Support retryAfter method option on Queued Listeners

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -525,7 +525,7 @@ class Dispatcher implements DispatcherContract
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
             $job->retryAfter = method_exists($listener, 'retryAfter')
-                ? $listener->retryAfter() :  ($listener->retryAfter ?? null);
+                ? $listener->retryAfter() : ($listener->retryAfter ?? null);
             $job->timeout = $listener->timeout ?? null;
             $job->timeoutAt = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -524,7 +524,8 @@ class Dispatcher implements DispatcherContract
     {
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
-            $job->retryAfter = $listener->retryAfter ?? null;
+            $job->retryAfter = method_exists($listener, 'retryAfter')
+                ? $listener->retryAfter() :  ($listener->retryAfter ?? null);
             $job->timeout = $listener->timeout ?? null;
             $job->timeoutAt = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -525,7 +525,7 @@ class Dispatcher implements DispatcherContract
         return tap($job, function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
             $job->retryAfter = method_exists($listener, 'retryAfter')
-                ? $listener->retryAfter() : ($listener->retryAfter ?? null);
+                                ? $listener->retryAfter() : ($listener->retryAfter ?? null);
             $job->timeout = $listener->timeout ?? null;
             $job->timeoutAt = method_exists($listener, 'retryUntil')
                                 ? $listener->retryUntil() : null;


### PR DESCRIPTION
The current framework only supports property level declaration for `retryAfter`. However, my company requires to do more complicated `retryAfter` logic so that a method level support is essential for us. This PR is adding the missing support for `retryAfter` method

Related PRs:
https://github.com/laravel/framework/pull/30743