### PR TITLE
[master] to solve the Oracle issue: auto-convert field to uppercase

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2243,7 +2243,7 @@ class Builder
         } elseif (! isset($results[0])) {
             return 0;
         } elseif (is_object($results[0])) {
-            return (int) $results[0]->aggregate;
+            return (int) (property_exists($results[0], 'aggregate') ? $results[0]->aggregate : $results[0]->AGGREGATE);   // to solve the Oracle issue: auto-convert field to uppercase 
         }
 
         return (int) array_change_key_case((array) $results[0])['aggregate'];


### PR DESCRIPTION
I find a a issue that Laravel `paginate` won't work with Oracle connections because of its naming conventions.

The Oracle statement _`SELECT COUNT(1) AS aggregate FROM TABLE`_, for instance, will return a column named **`AGGREGATE`**.

Unless the column name is enclosed within double quotes, such as _`SELECT COUNT(1) AS "aggregate" FROM TABLE`_.

Since the `aggregate` field will be converted to `AGGREGATE` in Oracle connections, I think we should also check whether `AGGREGATE` property exists.