### PR TITLE
[7.x] Fix Http client cookies method.

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -27,6 +27,13 @@ class Response implements ArrayAccess
     protected $decoded;
 
     /**
+     * Cookies of response.
+     *
+     * @var \GuzzleHttp\Cookie\CookieJarInterface
+     */
+    public $cookies;
+
+    /**
      * Create a new response instance.
      *
      * @param  \Psr\Http\Message\MessageInterface  $response
@@ -171,7 +178,7 @@ class Response implements ArrayAccess
      */
     public function cookies()
     {
-        return $this->cookies;
+        return array_column($this->cookies->toArray(), 'Value', 'Name');
     }
 
     /**


### PR DESCRIPTION
When I try to get the cookies returned by the response, what I get is actually an instance of `GuzzleHttp\Cookie\CookieJar`, not an array of key-value pairs. So I suggest to modify the cookies method to 
```php
public function cookies()
{
    return array_column($this->cookies->toArray(), 'Value', 'Name');
}
```
 to get the correct array.