### PR TITLE
[7.x] Fix mis-named variable in TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1263,7 +1263,7 @@ class TestResponse implements ArrayAccess
     public function offsetExists($offset)
     {
         return $this->responseHasView()
-                    ? isset($this->original->gatherData()[$key])
+                    ? isset($this->original->gatherData()[$offset])
                     : isset($this->json()[$offset]);
     }
 


### PR DESCRIPTION
Fixes a mis-named variable in the `offsetExists` method of `Illuminate\Testing\TestResponse`