### PR TITLE
[8.x] Ignore fillable protection when passing 'Validated' data

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -758,7 +758,7 @@ class Builder
     /**
      * Save a new model and return the instance.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
     public function create($attributes = [])
@@ -1083,7 +1083,7 @@ class Builder
     /**
      * Create a new instance of the model being queried.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function newModelInstance($attributes = [])

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -758,10 +758,10 @@ class Builder
     /**
      * Save a new model and return the instance.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @return \Illuminate\Database\Eloquent\Model|$this
      */
-    public function create(array $attributes = [])
+    public function create($attributes = [])
     {
         return tap($this->newModelInstance($attributes), function ($instance) {
             $instance->save();
@@ -1083,7 +1083,7 @@ class Builder
     /**
      * Create a new instance of the model being queried.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @return \Illuminate\Database\Eloquent\Model|static
      */
     public function newModelInstance($attributes = [])

--- a/src/Illuminate/Database/Eloquent/Fillable.php
+++ b/src/Illuminate/Database/Eloquent/Fillable.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Illuminate\Database\Eloquent;
-
-interface Fillable
-{
-    public function all();
-}

--- a/src/Illuminate/Database/Eloquent/Fillable.php
+++ b/src/Illuminate/Database/Eloquent/Fillable.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+interface Fillable
+{
+    public function all();
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\ApprovedBag;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Str;
@@ -157,7 +158,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @return void
      */
     public function __construct($attributes = [])
@@ -332,17 +333,15 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Fill the model with an array of attributes.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
     public function fill($attributes)
     {
-        if ($attributes instanceof Fillable) {
-            $this->forceFill($attributes->all());
-
-            return $this;
+        if ($attributes instanceof ApprovedBag) {
+            return $this->forceFill($attributes->all());
         }
 
         $totallyGuarded = $this->totallyGuarded();
@@ -408,20 +407,16 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Create a new instance of the given model.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @param  bool  $exists
      * @return static
      */
     public function newInstance($attributes = [], $exists = false)
     {
-        if ($attributes === null) {
-            $attributes = [];
-        }
-
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static($attributes);
+        $model = new static($attributes ?: []);
 
         $model->exists = $exists;
 
@@ -628,7 +623,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Update the model in the database.
      *
-     * @param  array|Fillable  $attributes
+     * @param  array|\Illuminate\Support\ApprovedBag  $attributes
      * @param  array  $options
      * @return bool
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -157,10 +157,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Create a new Eloquent model instance.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @return void
      */
-    public function __construct(array $attributes = [])
+    public function __construct($attributes = [])
     {
         $this->bootIfNotBooted();
 
@@ -332,13 +332,19 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Fill the model with an array of attributes.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @return $this
      *
      * @throws \Illuminate\Database\Eloquent\MassAssignmentException
      */
-    public function fill(array $attributes)
+    public function fill($attributes)
     {
+        if ($attributes instanceof Fillable) {
+            $this->forceFill($attributes->all());
+
+            return $this;
+        }
+
         $totallyGuarded = $this->totallyGuarded();
 
         foreach ($this->fillableFromArray($attributes) as $key => $value) {
@@ -402,16 +408,20 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Create a new instance of the given model.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @param  bool  $exists
      * @return static
      */
     public function newInstance($attributes = [], $exists = false)
     {
+        if ($attributes === null) {
+            $attributes = [];
+        }
+
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static((array) $attributes);
+        $model = new static($attributes);
 
         $model->exists = $exists;
 
@@ -618,11 +628,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Update the model in the database.
      *
-     * @param  array  $attributes
+     * @param  array|Fillable  $attributes
      * @param  array  $options
      * @return bool
      */
-    public function update(array $attributes = [], array $options = [])
+    public function update($attributes = [], array $options = [])
     {
         if (! $this->exists) {
             return false;

--- a/src/Illuminate/Support/ApprovedBag.php
+++ b/src/Illuminate/Support/ApprovedBag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Support;
+
+interface ApprovedBag
+{
+    /**
+     * Get all the data in the approved bag.
+     *
+     * @return array
+     */
+    public function all();
+}

--- a/src/Illuminate/Validation/Validated.php
+++ b/src/Illuminate/Validation/Validated.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Validation;
+
+use Illuminate\Database\Eloquent\Fillable;
+
+class Validated implements Fillable
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function all()
+    {
+        return $this->data;
+    }
+}

--- a/src/Illuminate/Validation/Validated.php
+++ b/src/Illuminate/Validation/Validated.php
@@ -7,5 +7,4 @@ use Illuminate\Support\Collection;
 
 class Validated extends Collection implements Fillable
 {
-
 }

--- a/src/Illuminate/Validation/Validated.php
+++ b/src/Illuminate/Validation/Validated.php
@@ -3,21 +3,9 @@
 namespace Illuminate\Validation;
 
 use Illuminate\Database\Eloquent\Fillable;
+use Illuminate\Support\Collection;
 
-class Validated implements Fillable
+class Validated extends Collection implements Fillable
 {
-    /**
-     * @var array
-     */
-    private $data;
 
-    public function __construct(array $data)
-    {
-        $this->data = $data;
-    }
-
-    public function all()
-    {
-        return $this->data;
-    }
 }

--- a/src/Illuminate/Validation/Validated.php
+++ b/src/Illuminate/Validation/Validated.php
@@ -2,9 +2,9 @@
 
 namespace Illuminate\Validation;
 
-use Illuminate\Database\Eloquent\Fillable;
+use Illuminate\Support\ApprovedBag;
 use Illuminate\Support\Collection;
 
-class Validated extends Collection implements Fillable
+class Validated extends Collection implements ApprovedBag
 {
 }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -399,7 +399,7 @@ class Validator implements ValidatorContract
     /**
      * Get the attributes and values that were validated.
      *
-     * @return array
+     * @return Validated
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -421,7 +421,7 @@ class Validator implements ValidatorContract
             }
         }
 
-        return $results;
+        return new Validated($results);
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Validation\ImplicitRule;
 use Illuminate\Contracts\Validation\Rule as RuleContract;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
@@ -364,7 +365,7 @@ class Validator implements ValidatorContract
     /**
      * Run the validator's rules against its data.
      *
-     * @return array
+     * @return \Illuminate\Validation\Validated
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -381,7 +382,7 @@ class Validator implements ValidatorContract
      * Run the validator's rules against its data.
      *
      * @param  string  $errorBag
-     * @return array
+     * @return \Illuminate\Validation\Validated
      *
      * @throws \Illuminate\Validation\ValidationException
      */
@@ -399,13 +400,13 @@ class Validator implements ValidatorContract
     /**
      * Get the attributes and values that were validated.
      *
-     * @return Validated
+     * @return \Illuminate\Validation\Validated
      *
      * @throws \Illuminate\Validation\ValidationException
      */
     public function validated()
     {
-        if ($this->invalid()) {
+        if ($this->invalid()->isNotEmpty()) {
             throw new ValidationException($this);
         }
 
@@ -732,7 +733,7 @@ class Validator implements ValidatorContract
     /**
      * Returns the data which was valid.
      *
-     * @return array
+     * @return \Illuminate\Validation\Validated
      */
     public function valid()
     {
@@ -740,15 +741,15 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        return array_diff_key(
+        return new Validated(array_diff_key(
             $this->data, $this->attributesThatHaveMessages()
-        );
+        ));
     }
 
     /**
      * Returns the data which was invalid.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function invalid()
     {
@@ -768,7 +769,7 @@ class Validator implements ValidatorContract
             Arr::set($result, $key, $failure);
         }
 
-        return $result;
+        return new Collection($result);
     }
 
     /**
@@ -866,7 +867,7 @@ class Validator implements ValidatorContract
     /**
      * Get the data under validation.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function attributes()
     {
@@ -876,11 +877,11 @@ class Validator implements ValidatorContract
     /**
      * Get the data under validation.
      *
-     * @return array
+     * @return \Illuminate\Support\Collection
      */
     public function getData()
     {
-        return $this->data;
+        return new Collection($this->data);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Fillable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
@@ -22,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Support\ApprovedBag;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\InteractsWithTime;
@@ -956,9 +956,9 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('bar', $model->age);
     }
 
-    public function testFillableInterface()
+    public function testApprovedBag()
     {
-        $fillable = new class implements Fillable {
+        $approved = new class implements ApprovedBag {
             public function all()
             {
                 return ['name' => 'foo', 'age' => 'bar'];
@@ -966,7 +966,7 @@ class DatabaseEloquentModelTest extends TestCase
         };
 
         $model = new EloquentModelStub;
-        $model->fill($fillable);
+        $model->fill($approved);
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
     }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Fillable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
@@ -951,6 +952,21 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $model->fillable(['name', 'age']);
         $model->fill(['name' => 'foo', 'age' => 'bar']);
+        $this->assertSame('foo', $model->name);
+        $this->assertSame('bar', $model->age);
+    }
+
+    public function testFillableInterface()
+    {
+        $fillable = new class implements Fillable {
+            public function all()
+            {
+                return ['name' => 'foo', 'age' => 'bar'];
+            }
+        };
+
+        $model = new EloquentModelStub;
+        $model->fill($fillable);
         $this->assertSame('foo', $model->name);
         $this->assertSame('bar', $model->age);
     }

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -34,7 +34,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals(['name' => 'specified'], $request->validated());
+        $this->assertEquals(['name' => 'specified'], $request->validated()->all());
     }
 
     public function testValidatedMethodReturnsTheValidatedDataNestedRules()
@@ -45,7 +45,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $request->validated());
+        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $request->validated()->all());
     }
 
     public function testValidatedMethodReturnsTheValidatedDataNestedChildRules()
@@ -56,7 +56,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals(['nested' => ['foo' => 'bar']], $request->validated());
+        $this->assertEquals(['nested' => ['foo' => 'bar']], $request->validated()->all());
     }
 
     public function testValidatedMethodReturnsTheValidatedDataNestedArrayRules()
@@ -67,7 +67,7 @@ class FoundationFormRequestTest extends TestCase
 
         $request->validateResolved();
 
-        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated());
+        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $request->validated()->all());
     }
 
     public function testValidatedMethodNotValidateTwice()

--- a/tests/Integration/Validation/RequestValidationTest.php
+++ b/tests/Integration/Validation/RequestValidationTest.php
@@ -17,7 +17,7 @@ class RequestValidationTest extends TestCase
 
         $validated = $request->validate(['name' => 'string']);
 
-        $this->assertSame(['name' => 'Taylor'], $validated);
+        $this->assertSame(['name' => 'Taylor'], $validated->all());
     }
 
     public function testValidateMacroWhenItFails()
@@ -35,7 +35,7 @@ class RequestValidationTest extends TestCase
 
         $validated = $request->validateWithBag('some_bag', ['name' => 'string']);
 
-        $this->assertSame(['name' => 'Taylor'], $validated);
+        $this->assertSame(['name' => 'Taylor'], $validated->all());
     }
 
     public function testValidateWithBagMacroWhenItFails()

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -22,7 +22,7 @@ class ValidationFactoryTest extends TestCase
         $factory = new Factory($translator);
         $validator = $factory->make(['foo' => 'bar'], ['baz' => 'boom']);
         $this->assertEquals($translator, $validator->getTranslator());
-        $this->assertEquals(['foo' => 'bar'], $validator->getData());
+        $this->assertEquals(['foo' => 'bar'], $validator->getData()->all());
         $this->assertEquals(['baz' => ['boom']], $validator->getRules());
 
         $presence = m::mock(PresenceVerifierInterface::class);
@@ -90,7 +90,7 @@ class ValidationFactoryTest extends TestCase
 
         $this->assertTrue($_SERVER['__validator.factory']);
         $this->assertEquals($translator, $validator->getTranslator());
-        $this->assertEquals(['foo' => 'bar'], $validator->getData());
+        $this->assertEquals(['foo' => 'bar'], $validator->getData()->all());
         $this->assertEquals(['baz' => ['boom']], $validator->getRules());
         unset($_SERVER['__validator.factory']);
     }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4385,70 +4385,63 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans,
-            [
-                ['name' => 'John'],
-                ['name' => null],
-                ['name' => ''],
-            ],
-            [
-                '*.name' => 'required',
-            ]);
+        $v = new Validator($trans, [
+            ['name' => 'John'],
+            ['name' => null],
+            ['name' => ''],
+        ], [
+            '*.name' => 'required',
+        ]);
 
-        $this->assertEquals($v->invalid(), [
+        $expected = [
             1 => ['name' => null],
             2 => ['name' => ''],
-        ]);
+        ];
+        $this->assertEquals($expected, $v->invalid()->all());
 
-        $v = new Validator($trans,
-            [
-                'name' => '',
-            ],
-            [
-                'name' => 'required',
-            ]);
-
-        $this->assertEquals($v->invalid(), [
+        $v = new Validator($trans, [
             'name' => '',
+        ], [
+            'name' => 'required',
         ]);
+
+        $this->assertEquals(['name' => ''], $v->invalid()->all());
     }
 
     public function testValidMethod()
     {
         $trans = $this->getIlluminateArrayTranslator();
 
-        $v = new Validator($trans,
-            [
-                ['name' => 'John'],
-                ['name' => null],
-                ['name' => ''],
-                ['name' => 'Doe'],
-            ],
-            [
-                '*.name' => 'required',
-            ]);
+        $v = new Validator($trans, [
+            ['name' => 'John'],
+            ['name' => null],
+            ['name' => ''],
+            ['name' => 'Doe'],
+        ], [
+            '*.name' => 'required',
+        ]);
 
-        $this->assertEquals($v->valid(), [
+        $expected = [
             0 => ['name' => 'John'],
             3 => ['name' => 'Doe'],
+        ];
+        $this->assertEquals($expected, $v->valid()->all());
+
+        $v = new Validator($trans, [
+            'name' => 'Carlos',
+            'age' => 'unknown',
+            'gender' => 'male',
+        ], [
+            'name' => 'required',
+            'gender' => 'in:male,female',
+            'age' => 'required|int',
         ]);
 
-        $v = new Validator($trans,
-            [
-                'name' => 'Carlos',
-                'age' => 'unknown',
-                'gender' => 'male',
-            ],
-            [
-                'name' => 'required',
-                'gender' => 'in:male,female',
-                'age' => 'required|int',
-            ]);
-
-        $this->assertEquals($v->valid(), [
+        $expected = [
             'name' => 'Carlos',
             'gender' => 'male',
-        ]);
+        ];
+        $this->assertEquals($expected, $v->valid()->all());
     }
 
     public function testNestedInvalidMethod()
@@ -4471,12 +4464,14 @@ class ValidationValidatorTest extends TestCase
                 'regex:/[A-F]{3}[0-9]{3}/',
             ],
         ]);
-        $this->assertEquals($v->invalid(), [
+
+        $expected = [
             'testinvalid' => '',
             'records' => [
                 3 => 'ADCD23',
             ],
-        ]);
+        ];
+        $this->assertEquals($expected, $v->invalid()->all());
     }
 
     public function testMultipleFileUploads()
@@ -5195,8 +5190,8 @@ class ValidationValidatorTest extends TestCase
         );
         $this->assertTrue($validator->passes());
         $this->assertSame(['cat' => 'Tom'], $validator->validated()->all());
-        $this->assertSame(['cat' => 'Tom'], $validator->valid());
-        $this->assertSame([], $validator->invalid());
+        $this->assertSame(['cat' => 'Tom'], $validator->valid()->all());
+        $this->assertSame([], $validator->invalid()->all());
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
@@ -5204,8 +5199,8 @@ class ValidationValidatorTest extends TestCase
             ['cat' => 'required|string', 'mouse' => 'exclude_if:cat,Felix|required|string']
         );
         $this->assertTrue($validator->fails());
-        $this->assertSame(['cat' => 'Tom'], $validator->valid());
-        $this->assertSame(['mouse' => null], $validator->invalid());
+        $this->assertSame(['cat' => 'Tom'], $validator->valid()->all());
+        $this->assertSame(['mouse' => null], $validator->invalid()->all());
     }
 
     public function testValidateFailsWithAsterisksAsDataKeys()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4683,7 +4683,7 @@ class ValidationValidatorTest extends TestCase
         });
         $data = $v->validate();
 
-        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
+        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data->all());
     }
 
     public function testValidateReturnsValidatedDataNestedRules()
@@ -4698,7 +4698,7 @@ class ValidationValidatorTest extends TestCase
         });
         $data = $v->validate();
 
-        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $data);
+        $this->assertEquals(['nested' => ['foo' => 'bar'], 'array' => [1, 2]], $data->all());
     }
 
     public function testValidateReturnsValidatedDataNestedChildRules()
@@ -4711,7 +4711,7 @@ class ValidationValidatorTest extends TestCase
         });
         $data = $v->validate();
 
-        $this->assertEquals(['nested' => ['foo' => 'bar']], $data);
+        $this->assertEquals(['nested' => ['foo' => 'bar']], $data->all());
     }
 
     public function testValidateReturnsValidatedDataNestedArrayRules()
@@ -4724,7 +4724,7 @@ class ValidationValidatorTest extends TestCase
         });
         $data = $v->validate();
 
-        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data);
+        $this->assertEquals(['nested' => [['bar' => 'baz'], ['bar' => 'baz2']]], $data->all());
     }
 
     public function testValidateAndValidatedData()
@@ -4738,8 +4738,8 @@ class ValidationValidatorTest extends TestCase
         $data = $v->validate();
         $validatedData = $v->validated();
 
-        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
-        $this->assertEquals($data, $validatedData);
+        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data->all());
+        $this->assertEquals($data->all(), $validatedData->all());
     }
 
     public function testValidatedNotValidateTwiceData()
@@ -4754,7 +4754,7 @@ class ValidationValidatorTest extends TestCase
         $data = $v->validate();
         $v->validated();
 
-        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data);
+        $this->assertEquals(['first' => 'john', 'preferred' => 'john'], $data->all());
         $this->assertEquals(1, $validateCount);
     }
 
@@ -5036,7 +5036,7 @@ class ValidationValidatorTest extends TestCase
 
         $this->assertTrue($passes, $message ?? '');
 
-        $this->assertSame($expectedValidatedData, $validator->validated());
+        $this->assertSame($expectedValidatedData, $validator->validated()->all());
     }
 
     public function providesFailingExcludeIfData()
@@ -5159,7 +5159,7 @@ class ValidationValidatorTest extends TestCase
             ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
         );
         $this->assertTrue($validator->passes());
-        $this->assertSame(['cat' => 'Felix'], $validator->validated());
+        $this->assertSame(['cat' => 'Felix'], $validator->validated()->all());
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
@@ -5167,7 +5167,7 @@ class ValidationValidatorTest extends TestCase
             ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
         );
         $this->assertTrue($validator->passes());
-        $this->assertSame(['cat' => 'Felix'], $validator->validated());
+        $this->assertSame(['cat' => 'Felix'], $validator->validated()->all());
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
@@ -5175,7 +5175,7 @@ class ValidationValidatorTest extends TestCase
             ['cat' => 'required|string', 'mouse' => 'exclude_unless:cat,Tom|required|string']
         );
         $this->assertTrue($validator->passes());
-        $this->assertSame(['cat' => 'Tom', 'mouse' => 'Jerry'], $validator->validated());
+        $this->assertSame(['cat' => 'Tom', 'mouse' => 'Jerry'], $validator->validated()->all());
 
         $validator = new Validator(
             $this->getIlluminateArrayTranslator(),
@@ -5194,7 +5194,7 @@ class ValidationValidatorTest extends TestCase
             ['cat' => 'required|string', 'mouse' => 'exclude_if:cat,Tom|required|string']
         );
         $this->assertTrue($validator->passes());
-        $this->assertSame(['cat' => 'Tom'], $validator->validated());
+        $this->assertSame(['cat' => 'Tom'], $validator->validated()->all());
         $this->assertSame(['cat' => 'Tom'], $validator->valid());
         $this->assertSame([], $validator->invalid());
 


### PR DESCRIPTION
This is a proof of concept that could settle the `fillable` dilemma. Currently there seems to be 2 options:

1. *Use `$fillable` to set the attributes that can be mass assigned from the controller:* the problem here is that sometimes the fillable attributes are context dependent: we'd like certain attributes to be fillable in one module of the app (i.e. the users profile) but different attributes in another module (i.e. the users module in the admin panel). 

2. *Unguard all the attributes and be careful about what we pass to our modules:* this is the approach I prefer, but I've found scenarios where one developer in the team forgets about this and leaves a potential vulnerability in the app.

The problem with mass assigning attributes to Eloquent models since to arise mainly from the following scenario:

`new User($request->all())`

If we are passing validated attributes, that shouldn't be a problem, or at least it's more explicit:

```
        $data = $request->validate([
            'name' => ['required'],
            'email' => ['required', 'email'],
            'password' => ['required', 'min:8'],
        ]);

        User::create($data);
```

But since both the `validate` and the `all` methods return an `array`, it's impossible for Eloquent to know how the data is passed from the "controller".

---

I propose we implement a "Fillable" interface that can ignore the fillable protection.

An additional advantage of returning a "Validated" object from the `validate` method instead of a plain array is that we could add extra methods like "only", "except", "transform", to grab or change parts of the validated data, then pass it to multiple models, etc.

I'd like to know what you think.