### PR TITLE
[7.x] Fix cookies method to return array

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -13,6 +13,13 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Cookies of response.
+     *
+     * @var \GuzzleHttp\Cookie\CookieJarInterface
+     */
+    public $cookies;
+
+    /**
      * The underlying PSR response.
      *
      * @var \Psr\Http\Message\ResponseInterface
@@ -171,7 +178,7 @@ class Response implements ArrayAccess
      */
     public function cookies()
     {
-        return $this->cookies;
+        return $this->cookies->toArray();
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -252,10 +252,9 @@ class HttpClientTest extends TestCase
             ['foo' => 'bar'], 'https://laravel.com'
         )->get('https://laravel.com');
 
-        $this->assertCount(1, $response->cookies()->toArray());
+        $this->assertCount(1, $response->cookies());
 
-        /** @var \GuzzleHttp\Cookie\CookieJarInterface $responseCookies */
-        $responseCookie = $response->cookies()->toArray()[0];
+        $responseCookie = $response->cookies()[0];
 
         $this->assertSame('foo', $responseCookie['Name']);
         $this->assertSame('bar', $responseCookie['Value']);


### PR DESCRIPTION
The data type returned in the `cookies` comment is array, but actually the instance of `GuzzleHttp\Cookie\CookieJar` is returned, which is also defined in the test file. So modified the cookies method to return the array.