### PR TITLE
[7.x] Allow the programmer to specify preserve keys when chunking collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1029,11 +1029,14 @@ class Collection implements ArrayAccess, Enumerable
 
     /**
      * Chunk the collection into chunks of the given size.
+     * If the $preserveKeys parameter is set to false, the returned
+     * collection will not contain the keys of the original collection.
      *
      * @param  int  $size
+     * @param bool $preserveKeys
      * @return static
      */
-    public function chunk($size)
+    public function chunk($size, $preserveKeys=true)
     {
         if ($size <= 0) {
             return new static;
@@ -1041,7 +1044,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $chunks = [];
 
-        foreach (array_chunk($this->items, $size, true) as $chunk) {
+        foreach (array_chunk($this->items, $size, $preserveKeys) as $chunk) {
             $chunks[] = new static($chunk);
         }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1036,7 +1036,7 @@ class Collection implements ArrayAccess, Enumerable
      * @param bool $preserveKeys
      * @return static
      */
-    public function chunk($size, $preserveKeys=true)
+    public function chunk($size, $preserveKeys = true)
     {
         if ($size <= 0) {
             return new static;


### PR DESCRIPTION
It is not a big change, but I find that it would be better if the programmer can specify if he/she wants to preserve the keys when chunking an array. I found myself using the array_chunk() php method to do chunking because I didn't want to preserve the keys. 
If this feature is added to the collections, I think it would be better. Also since the default value for the $preserveKey parameter is set to true, it is fully backward compatible.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
