### PR TITLE
[7.x] Added missing doc comment for lock and restoreLock

### DIFF
--- a/src/Illuminate/Support/Facades/Cache.php
+++ b/src/Illuminate/Support/Facades/Cache.php
@@ -17,6 +17,8 @@ namespace Illuminate\Support\Facades;
  * @method static mixed sear(string $key, \Closure $callback)
  * @method static mixed rememberForever(string $key, \Closure $callback)
  * @method static bool forget(string $key)
+ * @method static \Illuminate\Contracts\Cache\Lock lock(string $name, int $seconds = 0, mixed $owner = null)
+ * @method static \Illuminate\Contracts\Cache\Lock restoreLock(string $name, string $owner)
  * @method static \Illuminate\Contracts\Cache\Store getStore()
  *
  * @see \Illuminate\Cache\CacheManager


### PR DESCRIPTION
Added missing lock and restoreLock doc comments to the cache facade.