### PR TITLE
[7.x] Fix: Lazyload PackageManifest

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -195,9 +195,11 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->instance(Container::class, $this);
         $this->singleton(Mix::class);
 
-        $this->instance(PackageManifest::class, new PackageManifest(
-            new Filesystem, $this->basePath(), $this->getCachedPackagesPath()
-        ));
+        $this->singleton(PackageManifest::class, function () {
+            return  new PackageManifest(
+                new Filesystem, $this->basePath(), $this->getCachedPackagesPath()
+            );
+        });
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -196,7 +196,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         $this->singleton(Mix::class);
 
         $this->singleton(PackageManifest::class, function () {
-            return  new PackageManifest(
+            return new PackageManifest(
                 new Filesystem, $this->basePath(), $this->getCachedPackagesPath()
             );
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Im making this pull request to fix bug with PackageManifest class binding to early.
When i deploy my app in google app engine composer script post-autoload-dump failed  because `PackageManifest::$manifestPath` is referencing wrong path.

Expected: `/tmp/packages.php`
Actual: `path/to/app/bootstrap/cache/packages.php`
