### PR TITLE
[6.x] Duplicated mailable in-memory data attachments with different names

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -814,7 +814,7 @@ class Mailable implements MailableContract, Renderable
         $this->rawAttachments = collect($this->rawAttachments)
                 ->push(compact('data', 'name', 'options'))
                 ->unique(function ($file) {
-                    return $file['data'].$file['name'];
+                    return $file['name'].$file['data'];
                 })->all();
 
         return $this;

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -813,8 +813,9 @@ class Mailable implements MailableContract, Renderable
     {
         $this->rawAttachments = collect($this->rawAttachments)
                 ->push(compact('data', 'name', 'options'))
-                ->unique('data')
-                ->all();
+                ->unique(function ($file) {
+                    return $file['data'].$file['name'];
+                })->all();
 
         return $this;
     }

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -101,6 +101,48 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasReplyTo('taylor@laravel.com'));
     }
 
+    public function testItIgnoresDuplicatedRawAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attachData('content1', 'report-1.txt');
+        $this->assertCount(1, $mailable->rawAttachments);
+
+        $mailable->attachData('content2', 'report-2.txt');
+        $this->assertCount(2, $mailable->rawAttachments);
+
+        $mailable->attachData('content1', 'report-1.txt');
+        $mailable->attachData('content2', 'report-2.txt');
+        $this->assertCount(2, $mailable->rawAttachments);
+
+        $mailable->attachData('content1', 'report-3.txt');
+        $mailable->attachData('content2', 'report-4.txt');
+        $this->assertCount(4, $mailable->rawAttachments);
+
+        $this->assertSame([
+            [
+                'data' => 'content1',
+                'name' => 'report-1.txt',
+                'options' => [],
+            ],
+            [
+                'data' => 'content2',
+                'name' => 'report-2.txt',
+                'options' => [],
+            ],
+            [
+                'data' => 'content1',
+                'name' => 'report-3.txt',
+                'options' => [],
+            ],
+            [
+                'data' => 'content2',
+                'name' => 'report-4.txt',
+                'options' => [],
+            ],
+        ], $mailable->rawAttachments);
+    }
+
     public function testMailableBuildsViewData()
     {
         $mailable = new WelcomeMailableStub;


### PR DESCRIPTION
I'm not sure what was the exact reason of fix in https://github.com/laravel/framework/commit/3c8ccc2fb4ec03572076e6df71608f6bbb7d71e1 but I think it should be possible to use same data as attachment if they have different name. 

Imagine such scenario - when you send daily or montly reports with some data in multiple files but sometimes some of those files can contain same data. At the moment some of files will be ignored and it can be really confusing both for developer and end-users why they won't receive some report files.

If approved I believe similar change should be done for disk attachments.