### PR TITLE
[6.x] Duplicated mailable storage attachments with different names

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -795,7 +795,7 @@ class Mailable implements MailableContract, Renderable
             'name' => $name ?? basename($path),
             'options' => $options,
         ])->unique(function ($file) {
-            return $file['disk'].$file['path'];
+            return $file['name'].$file['disk'].$file['path'];
         })->all();
 
         return $this;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -143,6 +143,61 @@ class MailMailableTest extends TestCase
         ], $mailable->rawAttachments);
     }
 
+    public function testItIgnoresDuplicateStorageAttachments()
+    {
+        $mailable = new WelcomeMailableStub;
+
+        $mailable->attachFromStorageDisk('disk1', 'sample/file.txt');
+        $this->assertCount(1, $mailable->diskAttachments);
+
+        $mailable->attachFromStorageDisk('disk1', 'sample/file2.txt');
+        $this->assertCount(2, $mailable->diskAttachments);
+
+        $mailable->attachFromStorageDisk('disk1',  'sample/file.txt', 'file.txt');
+        $mailable->attachFromStorageDisk('disk1', 'sample/file2.txt');
+        $this->assertCount(2, $mailable->diskAttachments);
+
+        $mailable->attachFromStorageDisk('disk2',  'sample/file.txt', 'file.txt');
+        $mailable->attachFromStorageDisk('disk2', 'sample/file2.txt');
+        $this->assertCount(4, $mailable->diskAttachments);
+
+        $mailable->attachFromStorageDisk('disk1',  'sample/file.txt', 'custom.txt');
+        $this->assertCount(5, $mailable->diskAttachments);
+
+        $this->assertSame([
+            [
+                'disk' => 'disk1',
+                'path' => 'sample/file.txt',
+                'name' => 'file.txt',
+                'options' => [],
+            ],
+            [
+                'disk' => 'disk1',
+                'path' => 'sample/file2.txt',
+                'name' => 'file2.txt',
+                'options' => [],
+            ],
+            [
+                'disk' => 'disk2',
+                'path' => 'sample/file.txt',
+                'name' => 'file.txt',
+                'options' => [],
+            ],
+            [
+                'disk' => 'disk2',
+                'path' => 'sample/file2.txt',
+                'name' => 'file2.txt',
+                'options' => [],
+            ],
+            [
+                'disk' => 'disk1',
+                'path' => 'sample/file.txt',
+                'name' => 'custom.txt',
+                'options' => [],
+            ],
+        ], $mailable->diskAttachments);
+    }
+
     public function testMailableBuildsViewData()
     {
         $mailable = new WelcomeMailableStub;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -153,15 +153,15 @@ class MailMailableTest extends TestCase
         $mailable->attachFromStorageDisk('disk1', 'sample/file2.txt');
         $this->assertCount(2, $mailable->diskAttachments);
 
-        $mailable->attachFromStorageDisk('disk1',  'sample/file.txt', 'file.txt');
+        $mailable->attachFromStorageDisk('disk1', 'sample/file.txt', 'file.txt');
         $mailable->attachFromStorageDisk('disk1', 'sample/file2.txt');
         $this->assertCount(2, $mailable->diskAttachments);
 
-        $mailable->attachFromStorageDisk('disk2',  'sample/file.txt', 'file.txt');
+        $mailable->attachFromStorageDisk('disk2', 'sample/file.txt', 'file.txt');
         $mailable->attachFromStorageDisk('disk2', 'sample/file2.txt');
         $this->assertCount(4, $mailable->diskAttachments);
 
-        $mailable->attachFromStorageDisk('disk1',  'sample/file.txt', 'custom.txt');
+        $mailable->attachFromStorageDisk('disk1', 'sample/file.txt', 'custom.txt');
         $this->assertCount(5, $mailable->diskAttachments);
 
         $this->assertSame([


### PR DESCRIPTION
This is similar to https://github.com/laravel/framework/pull/32392 but this time for storage attachments.