### PR TITLE
[7.x] Lock support for cache file driver

### DIFF
--- a/src/Illuminate/Cache/FileLock.php
+++ b/src/Illuminate/Cache/FileLock.php
@@ -61,6 +61,7 @@ class FileLock extends Lock
     /**
      * Write the lock file.
      *
+     * @param  \Illuminate\Support\Carbon $now
      * @return bool
      */
     private function writeLockFile($now)

--- a/src/Illuminate/Cache/FileLock.php
+++ b/src/Illuminate/Cache/FileLock.php
@@ -41,7 +41,7 @@ class FileLock extends Lock
         parent::__construct($name, $seconds, $owner);
 
         $this->store = $store;
-        $this->path = $this->store->getDirectory() . '/' . $this->name . $this->extension;
+        $this->path = $this->store->getDirectory().'/'.$this->name.$this->extension;
     }
 
     /**
@@ -54,8 +54,6 @@ class FileLock extends Lock
         if ($this->exists()) {
             return json_decode($this->store->getFilesystem()->get($this->path));
         }
-
-        return null;
     }
 
     /**

--- a/src/Illuminate/Cache/FileLock.php
+++ b/src/Illuminate/Cache/FileLock.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Support\Carbon;
+
+class FileLock extends Lock
+{
+    /**
+     * The parent array file store.
+     *
+     * @var \Illuminate\Cache\FileStore
+     */
+    protected $store;
+
+    /**
+     * The lock file path.
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * The extension that will be used for lock files.
+     *
+     * @var string
+     */
+    protected $extension = '.lock';
+
+    /**
+     * Create a new lock instance.
+     *
+     * @param  \Illuminate\Cache\FileStore  $store
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return void
+     */
+    public function __construct($store, $name, $seconds, $owner = null)
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->store = $store;
+        $this->path = $this->store->getDirectory() . '/' . $this->name . $this->extension;
+    }
+
+    /**
+     * Get file content if exists.
+     *
+     * @return string|null
+     */
+    private function getLockFileContent()
+    {
+        if ($this->exists()) {
+            return json_decode($this->store->getFilesystem()->get($this->path));
+        }
+
+        return null;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        $now = Carbon::now();
+        $content = $this->getLockFileContent();
+        $expiration = is_null($content) || is_null($content->expiresAt) ? $now->copy() : Carbon::parse($content->expiresAt);
+
+        if ($expiration->isFuture()) {
+            return false;
+        }
+
+        $this->store->getFilesystem()->put($this->path, json_encode([
+            'owner' => $this->owner,
+            'expiresAt' => $this->seconds === 0 ? null : $now->copy()->addSeconds($this->seconds),
+        ]), true);
+
+        return true;
+    }
+
+    /**
+     * Determine if the current lock exists.
+     *
+     * @return bool
+     */
+    protected function exists()
+    {
+        return $this->store->getFilesystem()->exists($this->path);
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        if (! $this->exists()) {
+            return false;
+        }
+
+        if (! $this->isOwnedByCurrentProcess()) {
+            return false;
+        }
+
+        $this->forceRelease();
+
+        return true;
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return string
+     */
+    protected function getCurrentOwner()
+    {
+        $content = $this->getLockFileContent();
+
+        return $content->owner;
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        $this->store->getFilesystem()->delete($this->path);
+    }
+}

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Cache;
 
 use Exception;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\InteractsWithTime;
 
-class FileStore implements Store
+class FileStore implements Store, LockProvider
 {
     use InteractsWithTime, RetrievesMultipleKeys;
 
@@ -136,6 +137,31 @@ class FileStore implements Store
     public function forever($key, $value)
     {
         return $this->put($key, $value, 0);
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new FileLock($this, $name, $seconds, $owner);
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
     }
 
     /**

--- a/tests/Cache/CacheFileLockTest.php
+++ b/tests/Cache/CacheFileLockTest.php
@@ -4,22 +4,26 @@ namespace Illuminate\Tests\Cache;
 
 use Illuminate\Cache\FileStore;
 use Illuminate\Cache\FileLock;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class CacheFileLockTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->directory = sys_get_temp_dir();
+        $this->filesystem = new Filesystem();
+    }
+
     public function testLockCanBeAcquired()
     {
-        $name = uniqid();
         $owner = 'owner';
         $seconds = 2;
-        $directory = sys_get_temp_dir();
-        $filesystem = new Filesystem();
-        $store = new FileStore($filesystem, $directory);
-        $lock = new FileLock($store, $name, $seconds, $owner);
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = new FileLock($store, uniqid(), $seconds, $owner);
 
         // Lock can be acquired since it does not exist
         $this->assertTrue($lock->acquire());
@@ -35,5 +39,91 @@ class CacheFileLockTest extends TestCase
 
         // Lock should be should be available after a release
         $this->assertTrue($lock->acquire());
+
+        // Release the lock at the end of the test
+        $lock->release();
+    }
+
+    public function testCannotAcquireLockTwice()
+    {
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = $store->lock(uniqid(), 10);
+
+        $this->assertTrue($lock->acquire());
+        $this->assertFalse($lock->acquire());
+    }
+
+    public function testCanAcquireLockAgainAfterExpiry()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = $store->lock(uniqid(), 10);
+        $lock->acquire();
+        Carbon::setTestNow(Carbon::now()->addSeconds(10));
+
+        $this->assertTrue($lock->acquire());
+
+        $lock->release();
+    }
+
+    public function testLockExpirationLowerBoundary()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = $store->lock(uniqid(), 10);
+        $lock->acquire();
+        Carbon::setTestNow(Carbon::now()->addSeconds(10)->subMicrosecond());
+
+        $this->assertFalse($lock->acquire());
+
+        $lock->release();
+    }
+
+    public function testLockWithNoExpirationNeverExpires()
+    {
+        Carbon::setTestNow(Carbon::now());
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = $store->lock(uniqid());
+        $lock->acquire();
+        Carbon::setTestNow(Carbon::now()->addYears(100));
+
+        $this->assertFalse($lock->acquire());
+
+        $lock->release();
+    }
+
+    public function testCanAcquireLockAfterRelease()
+    {
+        $store = new FileStore($this->filesystem, $this->directory);
+        $lock = $store->lock(uniqid(), 10);
+        $lock->acquire();
+
+        $this->assertTrue($lock->release());
+        $this->assertTrue($lock->acquire());
+
+        $lock->release();
+    }
+
+    public function testAnotherOwnerCannotReleaseLock()
+    {
+        $name = uniqid();
+        $store = new FileStore($this->filesystem, $this->directory);
+        $owner = $store->lock($name, 10);
+        $wannabeOwner = $store->lock($name, 10);
+        $owner->acquire();
+
+        $this->assertFalse($wannabeOwner->release());
+    }
+
+    public function testAnotherOwnerCanForceReleaseALock()
+    {
+        $name = uniqid();
+        $store = new FileStore($this->filesystem, $this->directory);
+        $owner = $store->lock($name, 10);
+        $wannabeOwner = $store->lock($name, 10);
+        $owner->acquire();
+        $wannabeOwner->forceRelease();
+
+        $this->assertTrue($wannabeOwner->acquire());
     }
 }

--- a/tests/Cache/CacheFileLockTest.php
+++ b/tests/Cache/CacheFileLockTest.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Tests\Cache;
 
-use Illuminate\Cache\FileStore;
 use Illuminate\Cache\FileLock;
+use Illuminate\Cache\FileStore;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\TestCase;

--- a/tests/Cache/CacheFileLockTest.php
+++ b/tests/Cache/CacheFileLockTest.php
@@ -37,7 +37,7 @@ class CacheFileLockTest extends TestCase
         // Release the lock
         $lock->release();
 
-        // Lock should be should be available after a release
+        // Lock should be available after a release
         $this->assertTrue($lock->acquire());
 
         // Release the lock at the end of the test

--- a/tests/Cache/CacheFileLockTest.php
+++ b/tests/Cache/CacheFileLockTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\FileStore;
+use Illuminate\Cache\FileLock;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class CacheFileLockTest extends TestCase
+{
+    public function testLockCanBeAcquired()
+    {
+        $name = uniqid();
+        $owner = 'owner';
+        $seconds = 2;
+        $directory = sys_get_temp_dir();
+        $filesystem = new Filesystem();
+        $store = new FileStore($filesystem, $directory);
+        $lock = new FileLock($store, $name, $seconds, $owner);
+
+        // Lock can be acquired since it does not exist
+        $this->assertTrue($lock->acquire());
+
+        // Simulate long process
+        sleep($seconds);
+
+        // Lock cannot be acquired before it is released
+        $this->assertFalse($lock->acquire());
+
+        // Release the lock
+        $lock->release();
+
+        // Lock should be should be available after a release
+        $this->assertTrue($lock->acquire());
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

Also, please describe the benefit to end-users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Hello,

[Atomic locks](https://laravel.com/docs/7.x/cache#atomic-locks) are currently supported for `memcached`, `dynamodb`, and `redis` cache drivers.

This PR aims to implement this functionality for `file` cache driver, which is useful for environments that cannot use the other ones.

Thank you.