### PR TITLE
[7.x] Add ArrayAccess support for Http client get requests

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
 class PendingRequest
@@ -466,8 +467,22 @@ class PendingRequest
 
         return retry($this->tries ?? 1, function () use ($method, $url, $options) {
             try {
+                $laravelData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
+
+                // Attempt to parse query string on url if no request data found
+                $urlStr = Str::of($url);
+                if (! $laravelData && $method === 'GET' && $urlStr->contains('?')) {
+                    $laravelData = (string) $urlStr->after('?');
+                }
+
+                // If found data is a string then treat it as query parameters and parse them to an array
+                if (is_string($laravelData)) {
+                    parse_str($laravelData, $parsedData);
+                    $laravelData = is_array($parsedData) ? $parsedData : [];
+                }
+
                 return tap(new Response($this->buildClient()->request($method, $url, $this->mergeOptions([
-                    'laravel_data' => $options[$this->bodyFormat] ?? [],
+                    'laravel_data' => $laravelData,
                     'on_stats' => function ($transferStats) {
                         $this->transferStats = $transferStats;
                     },

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Client;
 
 use ArrayAccess;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use LogicException;
 
@@ -66,9 +67,15 @@ class Request implements ArrayAccess
             return ! empty($this->request->getHeaders()[$key]);
         }
 
+        $headers = $this->headers();
+
+        if (! Arr::has($headers, $key)) {
+            return false;
+        }
+
         $value = is_array($value) ? $value : [$value];
 
-        return empty(array_diff($value, $this->headers()[$key]));
+        return empty(array_diff($value, $headers[$key]));
     }
 
     /**
@@ -79,7 +86,7 @@ class Request implements ArrayAccess
      */
     public function header($key)
     {
-        return $this->headers()[$key];
+        return Arr::get($this->headers(), $key, [null]);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -269,7 +269,8 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get', ['foo' => 'bar']);
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo=bar';
+            return $request->url() === 'http://foo.com/get?foo=bar'
+                && $request['foo'] === 'bar';
         });
     }
 
@@ -280,7 +281,8 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get', 'foo=bar');
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo=bar';
+            return $request->url() === 'http://foo.com/get?foo=bar'
+                && $request['foo'] === 'bar';
         });
     }
 
@@ -291,7 +293,9 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get?foo=bar&page=1');
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo=bar&page=1';
+            return $request->url() === 'http://foo.com/get?foo=bar&page=1'
+                && $request['foo'] === 'bar'
+                && $request['page'] === '1';
         });
     }
 
@@ -302,7 +306,10 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get?foo;bar;1;5;10&page=1');
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1';
+            return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
+                && ! isset($request['foo'])
+                && ! isset($request['bar'])
+                && $request['page'] === '1';
         });
     }
 
@@ -313,7 +320,8 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']);
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?hello=world';
+            return $request->url() === 'http://foo.com/get?hello=world'
+                && $request['hello'] === 'world';
         });
     }
 
@@ -324,7 +332,8 @@ class HttpClientTest extends TestCase
         $this->factory->get('http://foo.com/get', ['foo;bar; space test' => 'laravel']);
 
         $this->factory->assertSent(function (Request $request) {
-            return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel';
+            return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel'
+                && $request['foo;bar; space test'] === 'laravel';
         });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/32398.

**TL;DR**
Fixes an `Undefined index: Content-Type` exception and allows access to get request params via array access `$request['foo']` and in turn allows you to make assertions such as `$request['foo'] === 'bar'`.

### Description:
I was writing a test similar to the below and when running it was greeted with an `ErrorException` of `Undefined index: Content-Type`. 

```php
public function testGet()
{
    \Http::fake(['*' => \Http::response(['response' =>'Test return data'], 200)]);

    \Http::acceptJson()
        ->get('https://google.com', ['apikey' => 'aaa-bbb-ccc'])
        ->json()

    \Http::assertSent(function (Request $request) {
        $this->assertStringStartsWith('https://google.com', $request->url());
        $this->assertSame('aaa-bbb-ccc', $request['apikey']); // Undefined index: Content-Type
        return true;
    });
}
```

### Cause
Looking at the line causing the error it seems it just needs to check if the key it is searching for exists in the headers array before trying to access it:

**Illuminate/Http/Client/Request.php:**
```php
public function isForm()
{
    return $this->hasHeader('Content-Type', 'application/x-www-form-urlencoded');
}

public function hasHeader($key, $value = null)
{
    ...
    // Added an Arr::has($headers, $key) here. This ⬇️ was causing the error. 
    return empty(array_diff($value, $this->headers()[$key]));
}
```

### Initial fix & New error found
So I initially set out to fix `hasHeader` so that it checks the `$key` exists in the `array` returned by `$this->headers()` and I ran the tests and got the same error `Undefined index: Content-Type` but from a different location:

**Illuminate/Http/Client/Request.php:**
```php
public function isJson()
{
    return Str::contains($this->header('Content-Type')[0], 'json');
}

public function header($key)
{
    // Caused by this line ⬇️ 
    return $this->headers()[$key];
}
```

### Adding ArrayAccess Support
I then added `Arr::get` check in the `header($key)` method and then discovered that there is not any existing support for accessing get query parameters via `$request` and was met with another `Undefined index: foo` in the below test:

```php
public function testGetWithArrayQueryParam()
{
    $this->factory->fake();

    $this->factory->get('http://foo.com/get', ['foo' => 'bar']);

    $this->factory->assertSent(function (Request $request) {
        return $request->url() === 'http://foo.com/get?foo=bar'
            && $request['foo'] === 'bar'; // Undefined index: foo
    });
}
```

So this change gets the query parameters either from `$options['query']` or by extracting them from the `$url`. It handles the below with the tests adjusted to prove it. 

```php
Http::get('http://foo.com');
Http::get('http://foo.com?foo=bar');
Http::get('http://foo.com', ['foo' => 'bar']);
Http::get('http://foo.com', 'foo=bar');
Http::get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']); // Hello world overwrites params
Http::get('http://foo.com', ['foo;bar; space test' => 'laravel']);
```
Then you can do assertions on the `$request` data:

```php
Http::assertSent(function (Request $request) {
    return $request->url() === 'http://foo.com/get?foo=bar'
        && $request['foo'] === 'bar';
});
```