### PR TITLE
[7.x] Allow disabling of global middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -136,7 +136,7 @@ class Kernel implements KernelContract
 
         return (new Pipeline($this->app))
                     ->send($request)
-                    ->through($this->app->shouldSkipMiddleware() ? [] : $this->middleware)
+                    ->through($this->gatherGlobalMiddleware($request))
                     ->then($this->dispatchToRouter());
     }
 
@@ -207,6 +207,25 @@ class Kernel implements KernelContract
                 $instance->terminate($request, $response);
             }
         }
+    }
+
+    /**
+     * Gather the glboal route middleware for the given request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    protected function gatherGlobalMiddleware($request)
+    {
+        if ($this->app->shouldSkipMiddleware()) {
+            return [];
+        }
+
+        if ($route = $this->router->getRoutes()->match($request)) {
+            return array_diff($this->middleware, $route->excludedMiddleware());
+        }
+
+        return $this->middleware;
     }
 
     /**

--- a/tests/Integration/Http/DisablesGlobalMiddlewareTest.php
+++ b/tests/Integration/Http/DisablesGlobalMiddlewareTest.php
@@ -2,13 +2,11 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
-use Illuminate\Foundation\Http\Kernel as BaseKernel;
+use Closure;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Contracts\Routing\Registrar;
-use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Http\Kernel as BaseKernel;
 use Orchestra\Testbench\TestCase;
-use Closure;
 
 /**
  * @group integration
@@ -28,13 +26,15 @@ class DisablesGlobalMiddlewareTest extends TestCase
 
     public function testItCanDisableGlobalMiddleware()
     {
-        $action = function () {return response('route-response');};
-        
+        $action = function () {
+            return response('route-response');
+        };
+
         $router = $this->app->make(Registrar::class);
-        
-        $router->get('foo-route', $action); 
+
+        $router->get('foo-route', $action);
         $router->get('bar-route', $action)->withoutMiddleware(DummyMiddleware::class);
-        
+
         $this->get('foo-route')->assertSee('middleware-response');
         $this->get('bar-route')->assertSee('route-response');
     }
@@ -65,6 +65,6 @@ class DummyKernel extends BaseKernel
      * @var array
      */
     protected $middleware = [
-        DummyMiddleware::class
+        DummyMiddleware::class,
     ];
 }

--- a/tests/Integration/Http/DisablesGlobalMiddlewareTest.php
+++ b/tests/Integration/Http/DisablesGlobalMiddlewareTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http;
+
+use Illuminate\Foundation\Http\Kernel as BaseKernel;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Closure;
+
+/**
+ * @group integration
+ */
+class DisablesGlobalMiddlewareTest extends TestCase
+{
+    /**
+     * Resolve application HTTP Kernel implementation.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function resolveApplicationHttpKernel($app)
+    {
+        $app->singleton(Kernel::class, DummyKernel::class);
+    }
+
+    public function testItCanDisableGlobalMiddleware()
+    {
+        $action = function () {return response('route-response');};
+        
+        $router = $this->app->make(Registrar::class);
+        
+        $router->get('foo-route', $action); 
+        $router->get('bar-route', $action)->withoutMiddleware(DummyMiddleware::class);
+        
+        $this->get('foo-route')->assertSee('middleware-response');
+        $this->get('bar-route')->assertSee('route-response');
+    }
+}
+
+class DummyMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next)
+    {
+        return response('middleware-response');
+    }
+}
+
+class DummyKernel extends BaseKernel
+{
+    /**
+     * The application's middleware stack.
+     *
+     * @var array
+     */
+    protected $middleware = [
+        DummyMiddleware::class
+    ];
+}


### PR DESCRIPTION
This PR aims to fix issue [#32384](https://github.com/laravel/framework/issues/32384), and is supplementary to PR [#32347](https://github.com/laravel/framework/pull/32347) by @dsazup , after discussion with @driesvints.

At time of writing global middleware doesn't support access to routes, because the route matching process is done after the global middleware stack has run. As a result, accessing the current route on `Illuminate\Foundation\Http\Kernel` works for terminable (global) middleware, but not for regular middleware.

I've moved the global middleware stack check to its own method, and manually match there now, but obviously there's a performance consideration there. The obvious solution is marking the `findRoute` method of `Illuminate\Routing\Router` as public and caching the actual lookup, but that'd be a breaking change in the contract. I'm open for thoughts on this.