### PR TITLE
[7.x] Add assertSentCount HTTP client assertion

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -219,6 +219,17 @@ class Factory
     }
 
     /**
+     * Assert how many requests have been recorded.
+     *
+     * @param $count
+     * @return void
+     */
+    public function assertSentCount($count)
+    {
+        PHPUnit::assertCount($count, $this->recorded);
+    }
+
+    /**
      * Assert that every created response sequence is empty.
      *
      * @return void

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -127,6 +127,24 @@ class HttpClientTest extends TestCase
         $this->factory->assertNothingSent();
     }
 
+    public function testRequestCount()
+    {
+        $this->factory->fake();
+        $this->factory->assertSentCount(0);
+
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Taylor',
+        ]);
+
+        $this->factory->assertSentCount(1);
+
+        $this->factory->post('http://foo.com/form', [
+            'name' => 'Jim',
+        ]);
+
+        $this->factory->assertSentCount(2);
+    }
+
     public function testCanSendMultipartData()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR adds a new HTTP client assertion called `assertSentCount`.

Next to the given assertions, it is also useful to count the recorded requests. This way you can make sure your code only sends `x` amount of requests and you do not have to be more specific how they look like. Here is an example:

```php
$this->factory->fake();

$this->factory->assertSentCount(0);

$this->factory->post('http://foo.com/form', [
       'name' => 'Taylor',
]);

$this->factory->assertSentCount(1);

$this->factory->post('http://foo.com/form', [
       'name' => 'Jim',
]);

$this->factory->assertSentCount(2);
```
