### PR TITLE
[7.x] Add the ability to create indexes as expressions

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
@@ -519,6 +520,18 @@ class Blueprint
     public function spatialIndex($columns, $name = null)
     {
         return $this->indexCommand('spatialIndex', $columns, $name);
+    }
+
+    /**
+     * Specify a raw index for the table.
+     *
+     * @param  string  $expression
+     * @param  string  $name
+     * @return \Illuminate\Support\Fluent
+     */
+    public function rawIndex($expression, $name)
+    {
+        return $this->index([new Expression($expression)], $name);
     }
 
     /**

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -363,6 +363,16 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `geo` add spatial index `geo_coordinates_spatialindex`(`coordinates`)', $statements[1]);
     }
 
+    public function testAddingRawIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawIndex('(function(column))', 'raw_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add index `raw_index`((function(column)))', $statements[0]);
+    }
+
     public function testAddingForeignKey()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -268,6 +268,16 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
         $this->assertSame('create index "geo_coordinates_spatialindex" on "geo" using gist ("coordinates")', $statements[1]);
     }
 
+    public function testAddingRawIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawIndex('(function(column))', 'raw_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -252,6 +252,16 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->toSql($this->getConnection(), $this->getGrammar());
     }
 
+    public function testAddingRawIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawIndex('(function(column))', 'raw_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -277,6 +277,16 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
         $this->assertSame('create spatial index "geo_coordinates_spatialindex" on "geo" ("coordinates")', $statements[1]);
     }
 
+    public function testAddingRawIndex()
+    {
+        $blueprint = new Blueprint('users');
+        $blueprint->rawIndex('(function(column))', 'raw_index');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('create index "raw_index" on "users" ((function(column)))', $statements[0]);
+    }
+
     public function testAddingIncrementingID()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
This PR adds the ability to create indexes as expressions. Previously (to the best of my knowledge), the only way to do this was using `DB::statement()`. For example:

```php
public function up()
{
    Schema::create('users', function (Blueprint $table) {
        $table->id();
        $table->string('name');
        $table->date('birth_date')->nullable();
        $table->timestamps();
    });

    DB::statement('ALTER TABLE users ADD INDEX birthday_index ((date_format(birth_date, "%m-%d")))');
}
```

Not only does this look awful, it also doesn't take advantage of any platform specific grammar (should the expressions themselves be cross platform, of course).

This PR adds a new `rawIndex()` method to the `Blueprint` class, which allows for a much more Laravel-style syntax for creating expression indexes. For example:

```php
public function up()
{
    Schema::create('users', function (Blueprint $table) {
        $table->id();
        $table->string('name');
        $table->date('birth_date')->nullable();
        $table->timestamps();

        $table->rawIndex('(date_format(birth_date, "%m-%d"))', 'birthday_index');
    });
}
```

The other method name I considered was `$table->expressionIndex()`, but I felt this was probably more appropriate, since it's essentially using a raw expression under the hood.

This method requires an index name as the second argument, since there isn't a nice way to autogenerate the name.

I've tested this on MySQL, Postgres, and SQLite, and it works great. I haven't tested on it on SQL Server (no access to it), but I'm pretty confident it will work.

Compatibility:

- Postgres has had functional index support since version [7.2 - (2002)](https://www.postgresql.org/docs/7.2/indexes-functional.html).
- SQLite has had functional index support since version [3.9.0 - (2015)](https://www.sqlite.org/expridx.html).
- MySQL has had functional index support since version [8.0.13 - (2018)](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-13.html).
