### PR TITLE
[7.x] Add getGrammar into passthru in Eloquent builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -74,7 +74,7 @@ class Builder
      */
     protected $passthru = [
         'insert', 'insertOrIgnore', 'insertGetId', 'insertUsing', 'getBindings', 'toSql', 'dump', 'dd',
-        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw',
+        'exists', 'doesntExist', 'count', 'min', 'max', 'avg', 'average', 'sum', 'getConnection', 'raw', 'getGrammar',
     ];
 
     /**

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -640,6 +640,11 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('raw')->once()->with('bar')->andReturn('foo');
 
         $this->assertSame('foo', $builder->raw('bar'));
+
+        $builder = $this->getBuilder();
+        $grammar = new Grammar();
+        $builder->getQuery()->shouldReceive('getGrammar')->once()->andReturn($grammar);
+        $this->assertSame($grammar, $builder->getGrammar());
     }
 
     public function testQueryScopes()


### PR DESCRIPTION
This fix a bug when getGrammar() is called on the Eloquent builder which should be passed thru but not.