### PR TITLE
[7.x] Add support for instantiated middleware objects

### DIFF
--- a/src/Illuminate/Routing/Middleware.php
+++ b/src/Illuminate/Routing/Middleware.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Routing;
+
+abstract class Middleware
+{
+    public static function __set_state($data)
+    {
+        return new static(...array_values($data));
+    }
+}

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -23,6 +23,10 @@ class MiddlewareNameResolver
             return $name;
         }
 
+        if (is_object($name)) {
+            return $name;
+        }
+
         if (isset($map[$name]) && $map[$name] instanceof Closure) {
             return $map[$name];
         }

--- a/src/Illuminate/Routing/MiddlewareNameResolver.php
+++ b/src/Illuminate/Routing/MiddlewareNameResolver.php
@@ -23,7 +23,7 @@ class MiddlewareNameResolver
             return $name;
         }
 
-        if (is_object($name)) {
+        if ($name instanceof Middleware) {
             return $name;
         }
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -700,7 +700,13 @@ class Router implements BindingRegistrar, RegistrarContract
         })->flatten()->values()->all();
 
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
-            return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
+            $resolvedMiddleware = MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
+
+            if (is_array($resolvedMiddleware)) {
+                return $resolvedMiddleware;
+            }
+
+            return [$resolvedMiddleware];
         })->flatten()->reject(function ($name) use ($route, $excluded) {
             return in_array($name, $excluded, true);
         })->values();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -19,6 +19,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
+use Illuminate\Routing\Middleware;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Routing\ResourceRegistrar;
 use Illuminate\Routing\Route;
@@ -2282,7 +2283,7 @@ class ExampleMiddleware implements ExampleMiddlewareContract
     }
 }
 
-class ExampleMiddlewareWithConstructorParam
+class ExampleMiddlewareWithConstructorParam extends Middleware
 {
     private $testParam;
 


### PR DESCRIPTION
Proof of concept for https://github.com/laravel/ideas/issues/2194

To be discussed:

### Array casting of middlewares

We cannot use an array cast in `(array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);` anymore, because when an object is returned, it gets cast to an array, instead of wrapped in one. There's either my suggested solution of explicitly checking whether the resolvedMiddleware is already an array or not, or we could wrap the object in an array within `MiddlewareNameResolver`, like so:

```php
if (is_object($name)) {
    return [$name];
}
```

### Middleware interface vs `is_object`

My personal preference would be to introduce an interface for middlewares that support direct instantiated, and check on that interface in `MiddlewareNameResolver`. I deliberately didn't add that in this PR, because I wanted to hear opinions on this first.

Personally I prefer to use stricter types, because it's explicit and would help with IDE autocompletion; but I know Laravel likes to keep things open and extensible, so it's up for discussion. 

For reference, an interface would look like this:

```php
interface Middleware
{
    public function handle(Request $request, Closure $next): Response;
}
```

And the check in `MiddlewareNameResolver` would be changed like so:

```php
if ($name instanceof Middleware) {
    return [$name];
}
```