### PR TITLE
[7.x] Re-use `Router::newRoute()` inside `CompiledRouteCollection`

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -297,9 +297,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
-            ->setBindingFields($attributes['bindingFields'])
-            ->setRouter($this->router)
-            ->setContainer($this->container);
+            ->setBindingFields($attributes['bindingFields']);
     }
 
     /**

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -293,7 +293,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ), '/');
         }
 
-        return (new Route($attributes['methods'], $baseUri == '' ? '/' : $baseUri, $attributes['action']))
+        return $this->router->newRoute($attributes['methods'], $baseUri == '' ? '/' : $baseUri, $attributes['action'])
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -544,7 +544,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  mixed  $action
      * @return \Illuminate\Routing\Route
      */
-    protected function newRoute($methods, $uri, $action)
+    public function newRoute($methods, $uri, $action)
     {
         return (new Route($methods, $uri, $action))
                     ->setRouter($this)


### PR DESCRIPTION
Fixes #32415 

Re-use `Router::newRoute()` inside `CompiledRouteCollection`, allow to use single place for the custom route definition.