### PR TITLE
[7.x] Fix `whereNull`/`whereNotNull` for json in MySQL

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -245,7 +245,8 @@ class MySqlGrammar extends Grammar
         return 'json_extract('.$field.$path.')';
     }
 
-    protected function whereNull(Builder $query, $where) {
+    protected function whereNull(Builder $query, $where)
+    {
         if ($this->isJsonSelector($where['column'])) {
             // In MySQL json_extract() returns different values
             // * key not exist => SQL NULL
@@ -264,7 +265,8 @@ class MySqlGrammar extends Grammar
         return parent::whereNull($query, $where);
     }
 
-    protected function whereNotNull(Builder $query, $where) {
+    protected function whereNotNull(Builder $query, $where)
+    {
         if ($this->isJsonSelector($where['column'])) {
             [$field, $path] = $this->wrapJsonFieldAndPath($where['column']);
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1012,6 +1012,18 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
+    public function testJsonWhereNullMysql() {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNull('items->id');
+        $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is null OR json_type(json_extract(`items`, \'$."id"\')) = \'NULL\')', $builder->toSql());
+    }
+
+    public function testJsonWhereNotNullMysql() {
+        $builder = $this->getMySqlBuilder();
+        $builder->select('*')->from('users')->whereNotNull('items->id');
+        $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is not null AND json_type(json_extract(`items`, \'$."id"\')) != \'NULL\')', $builder->toSql());
+    }
+
     public function testArrayWhereNulls()
     {
         $builder = $this->getBuilder();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1012,13 +1012,15 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertEquals([0 => 1], $builder->getBindings());
     }
 
-    public function testJsonWhereNullMysql() {
+    public function testJsonWhereNullMysql()
+    {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereNull('items->id');
         $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is null OR json_type(json_extract(`items`, \'$."id"\')) = \'NULL\')', $builder->toSql());
     }
 
-    public function testJsonWhereNotNullMysql() {
+    public function testJsonWhereNotNullMysql()
+    {
         $builder = $this->getMySqlBuilder();
         $builder->select('*')->from('users')->whereNotNull('items->id');
         $this->assertSame('select * from `users` where (json_extract(`items`, \'$."id"\') is not null AND json_type(json_extract(`items`, \'$."id"\')) != \'NULL\')', $builder->toSql());

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -95,15 +95,14 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
     public function jsonWhereNullDataProvider(): array
     {
         return [
-            //                                  exists?    key                  json
-            'key not exists'                 => [true,     'invalid'],
-            'key exists and null'            => [true,     'value',             ['value' => null]],
-            'key exists and "null"'          => [false,    'value',             ['value' => 'null']],
-            'key exists and not null'        => [false,    'value',             ['value' => false]],
-            'nested key not exists'          => [true,     'nested->invalid'],
-            'nested key exists and null'     => [true,     'nested->value',     ['nested' => ['value' => null]]],
-            'nested key exists and "null"'   => [false,    'nested->value',     ['nested' => ['value' => 'null']]],
-            'nested key exists and not null' => [false,    'nested->value',     ['nested' => ['value' => false]]],
+            'key not exists' => [true, 'invalid'],
+            'key exists and null' => [true, 'value', ['value' => null]],
+            'key exists and "null"' => [false, 'value', ['value' => 'null']],
+            'key exists and not null' => [false, 'value', ['value' => false]],
+            'nested key not exists' => [true, 'nested->invalid'],
+            'nested key exists and null' => [true, 'nested->value', ['nested' => ['value' => null]]],
+            'nested key exists and "null"' => [false, 'nested->value', ['nested' => ['value' => 'null']]],
+            'nested key exists and not null' => [false, 'nested->value', ['nested' => ['value' => false]]],
         ];
     }
 }

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -89,7 +89,7 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
     {
         DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
 
-        $this->assertSame(!$expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL.'->'.$key)->exists());
+        $this->assertSame(! $expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL.'->'.$key)->exists());
     }
 
     public function jsonWhereNullDataProvider(): array

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -71,4 +71,39 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
 
         $this->assertEquals(self::FLOAT_VAL, DB::table(self::TABLE)->value(self::FLOAT_COL));
     }
+
+    /**
+     * @dataProvider jsonWhereNullDataProvider
+     */
+    public function testJsonWhereNull(bool $expected, string $key, array $value = ['value' => 123]): void
+    {
+        DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
+
+        $this->assertSame($expected, DB::table(self::TABLE)->whereNull(self::JSON_COL.'->'.$key)->exists());
+    }
+
+    /**
+     * @dataProvider jsonWhereNullDataProvider
+     */
+    public function testJsonWhereNotNull(bool $expected, string $key, array $value = ['value' => 123]): void
+    {
+        DB::table(self::TABLE)->insert([self::JSON_COL => json_encode($value)]);
+
+        $this->assertSame(!$expected, DB::table(self::TABLE)->whereNotNull(self::JSON_COL.'->'.$key)->exists());
+    }
+
+    public function jsonWhereNullDataProvider(): array
+    {
+        return [
+            //                                  exists?    key                  json
+            'key not exists'                 => [true,     'invalid'],
+            'key exists and null'            => [true,     'value',             ['value' => null]],
+            'key exists and "null"'          => [false,    'value',             ['value' => 'null']],
+            'key exists and not null'        => [false,    'value',             ['value' => false]],
+            'nested key not exists'          => [true,     'nested->invalid'],
+            'nested key exists and null'     => [true,     'nested->value',     ['nested' => ['value' => null]]],
+            'nested key exists and "null"'   => [false,    'nested->value',     ['nested' => ['value' => 'null']]],
+            'nested key exists and not null' => [false,    'nested->value',     ['nested' => ['value' => false]]],
+        ];
+    }
 }


### PR DESCRIPTION
This PR fixes #31473, please see issue for more details, in short:

```sql
set @a='{"value":null}';

select
-- Actual behavior whereNull/whereNotNull
json_unquote(json_extract(@a, '$."value"')) is null,     -- false but should be true because value = null
json_unquote(json_extract(@a, '$."value"')) is not null, -- true  but should be false 

-- Expected
(json_extract(@a, '$."value"') is null     OR  json_type(json_extract(@a, '$."value"')) = 'NULL'),  -- true, ok
(json_extract(@a, '$."value"') is not null AND json_type(json_extract(@a, '$."value"')) != 'NULL')  -- false, ok
;
```

_PS: I tested it only for MySQL, probably would be good also test for MariaDB and Percona._
