### PR TITLE
[7.x] Fixed wrong return type in PHPDoc in case multiple answers are possible for command

### DIFF
--- a/src/Illuminate/Console/Concerns/InteractsWithIO.php
+++ b/src/Illuminate/Console/Concerns/InteractsWithIO.php
@@ -200,7 +200,7 @@ trait InteractsWithIO
      * @param  string|null  $default
      * @param  mixed|null  $attempts
      * @param  bool  $multiple
-     * @return string
+     * @return string|array
      */
     public function choice($question, array $choices, $default = null, $attempts = null, $multiple = false)
     {


### PR DESCRIPTION
In case $multiple is true for Command->choice an array is returned rather than a string. The PHPDoc though suggests only a string to be returned.
