### PR TITLE
[7.x] Add AuthenticationException on Gate

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -348,6 +348,7 @@ class Gate implements GateContract
      * @return mixed
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     public function raw($ability, $arguments = [])
     {
@@ -688,6 +689,8 @@ class Gate implements GateContract
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $arguments
      * @return mixed
+     * 
+     * @throws \Illuminate\Auth\AuthenticationException
      */
     protected function callPolicyMethod($policy, $method, $user, array $arguments)
     {
@@ -704,6 +707,10 @@ class Gate implements GateContract
 
         if ($this->canBeCalledWithUser($user, $policy, $method)) {
             return $policy->{$method}($user, ...$arguments);
+        }
+
+        if (!$user) {
+            throw new \Illuminate\Auth\AuthenticationException();
         }
     }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Auth\Access;
 
 use Exception;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
@@ -710,7 +711,7 @@ class Gate implements GateContract
         }
 
         if (! $user) {
-            throw new \Illuminate\Auth\AuthenticationException();
+            throw new AuthenticationException();
         }
     }
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -689,7 +689,7 @@ class Gate implements GateContract
      * @param  \Illuminate\Contracts\Auth\Authenticatable|null  $user
      * @param  array  $arguments
      * @return mixed
-     * 
+     *
      * @throws \Illuminate\Auth\AuthenticationException
      */
     protected function callPolicyMethod($policy, $method, $user, array $arguments)
@@ -709,7 +709,7 @@ class Gate implements GateContract
             return $policy->{$method}($user, ...$arguments);
         }
 
-        if (!$user) {
+        if (! $user) {
             throw new \Illuminate\Auth\AuthenticationException();
         }
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -121,7 +121,7 @@ class AuthAccessGateTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf(\Illuminate\Auth\AuthenticationException::class, $e);
         }
-        
+
         $this->assertTrue($_SERVER['__laravel.testBefore']);
 
         $gate = $this->getBasicGate();

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Auth;
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -119,7 +120,7 @@ class AuthAccessGateTest extends TestCase
         try {
             $gate->check('update', new AccessGateTestDummy);
         } catch (\Exception $e) {
-            $this->assertInstanceOf(\Illuminate\Auth\AuthenticationException::class, $e);
+            $this->assertInstanceOf(AuthenticationException::class, $e);
         }
 
         $this->assertTrue($_SERVER['__laravel.testBefore']);
@@ -148,7 +149,7 @@ class AuthAccessGateTest extends TestCase
         try {
             $gate->check('update', new AccessGateTestDummy);
         } catch (\Exception $e) {
-            $this->assertInstanceOf(\Illuminate\Auth\AuthenticationException::class, $e);
+            $this->assertInstanceOf(AuthenticationException::class, $e);
         }
         $this->assertFalse($_SERVER['__laravel.testBefore']);
 

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -116,7 +116,12 @@ class AuthAccessGateTest extends TestCase
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyThatAllowsGuests::class);
 
         $this->assertTrue($gate->check('edit', new AccessGateTestDummy));
-        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+        try {
+            $gate->check('update', new AccessGateTestDummy);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(\Illuminate\Auth\AuthenticationException::class, $e);
+        }
+        
         $this->assertTrue($_SERVER['__laravel.testBefore']);
 
         $gate = $this->getBasicGate();
@@ -140,7 +145,11 @@ class AuthAccessGateTest extends TestCase
         $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicyWithNonGuestBefore::class);
 
         $this->assertTrue($gate->check('edit', new AccessGateTestDummy));
-        $this->assertFalse($gate->check('update', new AccessGateTestDummy));
+        try {
+            $gate->check('update', new AccessGateTestDummy);
+        } catch (\Exception $e) {
+            $this->assertInstanceOf(\Illuminate\Auth\AuthenticationException::class, $e);
+        }
         $this->assertFalse($_SERVER['__laravel.testBefore']);
 
         unset($_SERVER['__laravel.testBefore']);

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Auth;
 
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\Access\Gate;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Container\Container;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
**Curently :**
When a user is not authenticated and is required in the policy an http response with 403 is return

**Now :**
When a user is not authenticated and is required in the policy an http response with 401 is return