### PR TITLE
[6.x] Fix `refresh()` to support `AsPivot` trait

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
@@ -1151,7 +1152,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         );
 
         $this->load(collect($this->relations)->reject(function ($relation) {
-            return $relation instanceof Pivot;
+            return $relation instanceof Pivot
+                || in_array(AsPivot::class, class_uses_recursive($relation), true);
         })->keys()->all());
 
         $this->syncOriginal();

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\Integration\Database\EloquentModelRefreshTest;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -57,6 +58,23 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
         $this->assertSame('patrick', $post->getOriginal('title'));
     }
+
+    public function testAsPivot()
+    {
+        Schema::create('post_posts', function (Blueprint $table) {
+            $table->bigInteger('foreign_id');
+            $table->bigInteger('related_id');
+        });
+
+        $post  = AsPivotPost::create(['title' => 'parent']);
+        $child = AsPivotPost::create(['title' => 'child']);
+
+        $post->children()->attach($child->getKey());
+
+        $this->assertEquals(1, $post->children->count());
+
+        $post->children->first()->refresh();
+    }
 }
 
 class Post extends Model
@@ -75,4 +93,21 @@ class Post extends Model
             $query->where('title', '!=', 'mohamed');
         });
     }
+}
+
+class AsPivotPost extends Post
+{
+    public function children() 
+    {
+        return $this
+            ->belongsToMany(static::class, (new AsPivotPostPivot())->getTable(), 'foreign_id', 'related_id')
+            ->using(AsPivotPostPivot::class);
+    }
+}
+
+class AsPivotPostPivot extends Model
+{
+    use AsPivot;
+
+    protected $table = 'post_posts';
 }

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -66,7 +66,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
             $table->bigInteger('related_id');
         });
 
-        $post  = AsPivotPost::create(['title' => 'parent']);
+        $post = AsPivotPost::create(['title' => 'parent']);
         $child = AsPivotPost::create(['title' => 'child']);
 
         $post->children()->attach($child->getKey());
@@ -97,7 +97,7 @@ class Post extends Model
 
 class AsPivotPost extends Post
 {
-    public function children() 
+    public function children()
     {
         return $this
             ->belongsToMany(static::class, (new AsPivotPostPivot())->getTable(), 'foreign_id', 'related_id')


### PR DESCRIPTION
The regression was introduced in #31125 - all custom pivot models that uses [`AsPivot`](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php) trait are broken now due to this line:

https://github.com/laravel/framework/blob/898f24ec56d5a2859a28f4dc0cc98ae967eec456/src/Illuminate/Database/Eloquent/Model.php#L1154

In other words `$model->refresh()` will throw error "Call to undefined relationship [pivot] on model" if `$model` has relations that uses `AsPivot` trait instead extending `Pivot` model.

This PR fixes it and closes #31811 (please also see it for more details).