### PR TITLE
[7.x] Add `dumpJson` to TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1180,7 +1180,7 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * dump the json content from the response
+     * Dump the json content from the response.
      *
      * @param null $key
      *

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1180,6 +1180,20 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * dump the json content from the response
+     *
+     * @param null $key
+     *
+     * @return $this
+     */
+    public function dumpJson($key = null)
+    {
+        dump($this->json($key));
+
+        return $this;
+    }
+
+    /**
      * Dump the headers from the response.
      *
      * @return $this


### PR DESCRIPTION
From time to time during API development There is a need to see the debug the actual JSON that returns from your request.

**Before**

```PHP
$jsonResponse = $this->getJson('/user')
  ->assertSuccessful()
  ->assertJsonCount(2, 'data')
  ->json();

dump($jsonResponse);
```

**After**
```PHP
$this->getJson('/user')
  ->assertSuccessful()
  ->assertJsonCount(2, 'data')
  ->dumpJson();
```

No test was written because I didn't saw any test to another "dump" method.