### PR TITLE
workaround for bug in is_writable

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -180,8 +180,7 @@ class PackageManifest
             $fullPath = $sPath.'test.file';
             $isOK = false;
             $fp = @fopen($fullPath, "w");
-            if($fp !== false)
-            {
+            if($fp !== false) {
                 $isOK = true;
             }
             @fclose($fp);
@@ -191,8 +190,7 @@ class PackageManifest
 
         }
 
-        if(!isWritablePath(dirname($this->manifestPath)))
-        {
+        if(!isWritablePath(dirname($this->manifestPath))) {
             throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
         }
 

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -175,7 +175,24 @@ class PackageManifest
      */
     protected function write(array $manifest)
     {
-        if (! is_writable(dirname($this->manifestPath))) {
+        function isWritablePath($sPath)
+        {
+            $fullPath = $sPath.'test.file';
+            $isOK = false;
+            $fp = @fopen($fullPath, "w");
+            if($fp !== false)
+            {
+                $isOK = true;
+            }
+            @fclose($fp);
+            @unlink($fullPath);
+
+            return $isOK;
+
+        }
+
+        if(!isWritablePath(dirname($this->manifestPath)))
+        {
             throw new Exception('The '.dirname($this->manifestPath).' directory must be present and writable.');
         }
 


### PR DESCRIPTION
If you create a new Laravel application on windows on a mounted Linux drive whith ACL, this exception will be thrown:
```
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi
In PackageManifest.php line 179:
  The R:\path\to\laravel\bootstrap\cache directory must be present and writable.
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```
Problem is the `is_writable` function returns false although the cache directory is present and writable. The `fileperms` function resolves the permissions as `40777`. It is possible to create files in the user/group constellation in php.

To be sure whether the directory is writable you have to write in it. If it is successful you may proceed. Because I'm not sure where to put the equivalent of the [wordpress ](https://developer.wordpress.org/reference/functions/win_is_writable/) function I'd add it to the same function where I had the problem.

I'm open to alternatives.
