### PR TITLE
[6.x] Allow using Container::wrap for strings

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -566,11 +566,11 @@ class Container implements ArrayAccess, ContainerContract
     /**
      * Wrap the given closure such that its dependencies will be injected when executed.
      *
-     * @param  \Closure  $callback
+     * @param  callable|string  $callback
      * @param  array  $parameters
      * @return \Closure
      */
-    public function wrap(Closure $callback, array $parameters = [])
+    public function wrap($callback, array $parameters = [])
     {
         return function () use ($callback, $parameters) {
             return $this->call($callback, $parameters);

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -157,6 +157,12 @@ class ContainerCallTest extends TestCase
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertSame('taylor', $result[1]);
+
+        $wrapped = $container->wrap(ContainerTestCallStub::class.'@work', ['test' => 'me']);
+        $result = $wrapped();
+
+        $this->assertInstanceOf(Closure::class, $wrapped);
+        $this->assertSame('me', $result[0]);
     }
 
     public function testCallWithCallableObject()


### PR DESCRIPTION
Hi,

I would like to suggest changes that will allow `\Illuminate\Container\Container::wrap` to accept not only `\Closure`, but also any `string` like `RandomService@method` since it simply wraps over `$callback` and then calls `\Illuminate\Container\Container::call`.

Reason for proposed changes:

I think it will make container use a little easier.

It seems to me that it is a bit more convenient to use
```php
return $app->wrap('RandomService@method', ['param' => 'value']);
```
rather 
```php
return function () {
    $app->call('RandomService@method', ['param' => 'value']);
};
```

