### PR TITLE
[7.x] Fixes Http Client multipart request body params passed as key-value

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -467,7 +467,7 @@ class PendingRequest
                 foreach ($options[$this->bodyFormat] as $key => $value) {
                     $params[] = [
                         'name' => $key,
-                        'contents' => $value
+                        'contents' => $value,
                     ];
                 }
             }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
@@ -458,8 +459,21 @@ class PendingRequest
         $url = ltrim(rtrim($this->baseUrl, '/').'/'.ltrim($url, '/'), '/');
 
         if (isset($options[$this->bodyFormat])) {
+            $params = $options[$this->bodyFormat];
+
+            if ($this->bodyFormat === 'multipart' && Arr::isAssoc($params)) {
+                unset($params);
+
+                foreach ($options[$this->bodyFormat] as $key => $value) {
+                    $params[] = [
+                        'name' => $key,
+                        'contents' => $value
+                    ];
+                }
+            }
+
             $options[$this->bodyFormat] = array_merge(
-                $options[$this->bodyFormat], $this->pendingFiles
+                $params, $this->pendingFiles
             );
         }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -164,6 +164,21 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSenseMultipartDataWithSimplifiedParameters()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'data'
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo';
+        });
+    }
+
     public function testFilesCanBeAttached()
     {
         $this->factory->fake();

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -169,7 +169,7 @@ class HttpClientTest extends TestCase
         $this->factory->fake();
 
         $this->factory->asMultipart()->post('http://foo.com/multipart', [
-            'foo' => 'data'
+            'foo' => 'data',
         ]);
 
         $this->factory->assertSent(function (Request $request) {


### PR DESCRIPTION
This PR fixes #32058, full details to be found in the issue. 

In short, when the below code is run: 

```php
$photo = fopen(public_path('/storage/') . $this->photoPath, 'r');

$response = Http::withToken($this->token)
	->withHeaders([
		'X-Header' => $this->header
	])
	->attach('photo', $photo)
	->post($url, [
		'name' => 'test'
	]);
```

...it generates this error: 

> TypeError: Argument 2 passed to GuzzleHttp\Psr7\MultipartStream::addElement() must be of the type array, string given, called in /vendor/guzzlehttp/psr7/src/MultipartStream.php on line 70 in file /vendor/guzzlehttp/psr7/src/MultipartStream.php on line 79

This PR solves the above issue bye ensuring the proper array is passed to Guzzle options array.

------

My first PR in Laravel, open to all kinds of criticism/suggestions! 🤓
