### PR TITLE
[7.x] Http Client multipart request #32058

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -635,7 +635,6 @@ class PendingRequest
         return $this;
     }
 
-
     /**
      * Parse multipart form data to allow for ['key' => 'value'] post data.
      *

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -217,7 +217,6 @@ class HttpClientTest extends TestCase
                 $request[1]['contents'] === 'data' &&
                 $request[1]['headers']['X-Test-Header'] === 'foo';
         });
-
     }
 
     public function testItCanSendToken()

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -179,6 +179,47 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testCanSendMultipartDataWithSimplifiedParameters()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo' &&
+                $request[0]['contents'] === 'bar';
+        });
+    }
+
+    public function testCanSendMultipartDataWithBothSimplifiedAndExtendedParameters()
+    {
+        $this->factory->fake();
+
+        $this->factory->asMultipart()->post('http://foo.com/multipart', [
+            'foo' => 'bar',
+            [
+                'name' => 'foobar',
+                'contents' => 'data',
+                'headers' => ['X-Test-Header' => 'foo'],
+            ],
+        ]);
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/multipart' &&
+                Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
+                $request[0]['name'] === 'foo' &&
+                $request[0]['contents'] === 'bar' &&
+                $request[1]['name'] === 'foobar' &&
+                $request[1]['contents'] === 'data' &&
+                $request[1]['headers']['X-Test-Header'] === 'foo';
+        });
+
+    }
+
     public function testItCanSendToken()
     {
         $this->factory->fake();


### PR DESCRIPTION
This PR fixes https://github.com/laravel/framework/issues/32058.

The issue has been raised because currently multipart requests can only be sent with the full multipart form parameters, like below:

```php
<?php

use Illuminate\Support\Facades\Http;

Http::asMultipart()->post($url, [
   ['name' => 'key', 'contents' => 'value']
]);
```

This is not currently in line with the sending post requests via another `bodyFormat`, so this PR allows for both possibilities.

```php
<?php

use Illuminate\Support\Facades\Http;

$file = fopen($path_to_file, 'r');

Http::attach('file', $file)->post($url, [
   ['name' => 'key', 'contents' => 'value'],
   'another_key' => 'value'
]);

```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
