### PR TITLE
[7.x] Use relative links by default

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\HttpFoundation\Request;
 
 class StorageLinkCommand extends Command
 {
@@ -11,7 +12,7 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:link';
+    protected $signature = 'storage:link {--absolute : Create links using absolute paths}';
 
     /**
      * The console command description.
@@ -31,6 +32,11 @@ class StorageLinkCommand extends Command
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {
+                if (! $this->option('absolute') && DIRECTORY_SEPARATOR == '/') {
+                    // Utilize Symfony's Request to find the relative path
+                    $target = Request::create($link)->getRelativeUriForPath($target);
+                }
+
                 $this->laravel->make('files')->link($target, $link);
 
                 $this->info("The [$link] link has been connected to [$target].");


### PR DESCRIPTION
A small change to `StorageLinkCommand` to create links using  _relative_ paths, when feasible.

The relative path is computed using `getRelativeUriForPath` in Symfony's `Request`. For this reason, relative links are only attempted when `DIRECTORY_SEPARATOR ` is `/` (although Windows does actually support relative links).

```
$ php artisan storage:link
The [/path/project/public/storage] link has been connected to [../storage/app/public].
The links have been created.
```

Absolute links can be forced with the `--absolute` option:

```
$ php artisan storage:link --absolute
The [/path/project/public/storage] link has been connected to [/path/project/storage/app/public].
The links have been created.
```

Proposed before as #28970, but much simpler this time.