### PR TITLE
[7.x] Add support for Arr::flatMap

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -228,6 +228,18 @@ class Arr
     }
 
     /**
+     * Map an array and flatten the result by a single level.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function flatMap($array, callable $callback)
+    {
+        return Collection::make($array)->flatMap($callback)->all();
+    }
+
+    /**
      * Remove one or many array items from a given array using "dot" notation.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -246,6 +246,18 @@ class SupportArrTest extends TestCase
         $this->assertEquals(['#foo', '#bar', ['#baz'], '#zap'], Arr::flatten($array, 2));
     }
 
+    public function testFlatMap()
+    {
+        $array = [
+            ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
+            ['name' => 'adam', 'hobbies' => ['music', 'powerlifting']],
+        ];
+        $hobbies = Arr::flatMap($array, function ($person) {
+            return $person['hobbies'];
+        });
+        $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $hobbies);
+    }
+
     public function testGet()
     {
         $array = ['products.desk' => ['price' => 100]];


### PR DESCRIPTION
Adds support for `Arr::flatMap`, uses existing collection flatMap.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->