### PR TITLE
[7.x] Add support for Arr::map

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -390,6 +390,22 @@ class Arr
     }
 
     /**
+     * Run a map over each of the items.
+     *
+     * @param  array  $array
+     * @param  callable  $callback
+     * @return array
+     */
+    public static function map($array, callable $callback)
+    {
+        $keys = array_keys($array);
+
+        $items = array_map($callback, $array, $keys);
+
+        return array_combine($keys, $items);
+    }
+
+    /**
      * Get a subset of the items from the given array.
      *
      * @param  array  $array

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -633,11 +633,7 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function map(callable $callback)
     {
-        $keys = array_keys($this->items);
-
-        $items = array_map($callback, $this->items, $keys);
-
-        return new static(array_combine($keys, $items));
+        return new static(Arr::map($this->items, $callback));
     }
 
     /**

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -424,6 +424,15 @@ class SupportArrTest extends TestCase
         $this->assertFalse(Arr::isAssoc(['a', 'b']));
     }
 
+    public function testMap()
+    {
+        $array = ['first' => 'taylor', 'last' => 'otwell'];
+        $array = Arr::map($array, function ($item, $key) {
+            return $key.'-'.strrev($item);
+        });
+        $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $array);
+    }
+
     public function testOnly()
     {
         $array = ['name' => 'Desk', 'price' => 100, 'orders' => 10];


### PR DESCRIPTION
Standard `array_map` doesn't provide access to keys within it's callback, forcing the usage of collections, loops or awkward core function combos if you want to use the key, this moves the `Collection` map functionality over to `Arr`.