### PR TITLE
[6.x] Remove 'as' keyword

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -482,7 +482,7 @@ class Builder
     {
         [$query, $bindings] = $this->createSub($query);
 
-        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+        $expression = '('.$query.') '.$this->grammar->wrapTable($as);
 
         $this->addBinding($bindings, 'join');
 


### PR DESCRIPTION
with Oracle 11g, table or sub query result aliasing name with 'as' keyword returns exception. But any sql query doesn't need 'as' right?

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
