### PR TITLE
[7.x] Throw exception on missing required parameter on Container call method

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -170,7 +170,7 @@ class BoundMethod
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
-        } elseif(! $parameter->isOptional() && ! array_key_exists($parameter->name, $parameters)) {
+        } elseif (! $parameter->isOptional() && ! array_key_exists($parameter->name, $parameters)) {
             $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
 
             throw new BindingResolutionException($message);

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -170,7 +170,7 @@ class BoundMethod
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
-        } elseif(!$parameter->isOptional() && !array_key_exists($parameter->name, $parameters)) {
+        } elseif(! $parameter->isOptional() && ! array_key_exists($parameter->name, $parameters)) {
             $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
 
             throw new BindingResolutionException($message);

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Container;
 
 use Closure;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -169,6 +170,10 @@ class BoundMethod
             $dependencies[] = $container->make($parameter->getClass()->name);
         } elseif ($parameter->isDefaultValueAvailable()) {
             $dependencies[] = $parameter->getDefaultValue();
+        } elseif(!$parameter->isOptional() && !array_key_exists($parameter->name, $parameters)) {
+            $message = "Unresolvable dependency resolving [$parameter] in class {$parameter->getDeclaringClass()->getName()}";
+
+            throw new BindingResolutionException($message);
         }
     }
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -175,7 +175,7 @@ class ContainerCallTest extends TestCase
         $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
 
         $container = new Container;
-        $container->call(ContainerTestCallStub::class . '@unresolvable');
+        $container->call(ContainerTestCallStub::class.'@unresolvable');
     }
 }
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Container;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use stdClass;
@@ -166,6 +167,15 @@ class ContainerCallTest extends TestCase
         $result = $container->call($callable);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertSame('jeffrey', $result[1]);
+    }
+
+    public function testCallWithoutRequiredParamsThrowsException()
+    {
+        $this->expectException(BindingResolutionException::class);
+        $this->expectExceptionMessage('Unresolvable dependency resolving [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerTestCallStub');
+
+        $container = new Container;
+        $container->call(ContainerTestCallStub::class . '@unresolvable');
     }
 }
 


### PR DESCRIPTION
Fixes #32438.

This is proposed solution to the aforementioned issue raised earlier with tests.