### PR TITLE
[7.x] Update items when making calls into the collection of a paginator

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -686,7 +686,9 @@ abstract class AbstractPaginator implements Htmlable
      */
     public function __call($method, $parameters)
     {
-        return $this->forwardCallTo($this->getCollection(), $method, $parameters);
+        $result = $this->forwardCallTo($this->getCollection(), $method, $parameters);
+
+        return $result instanceof Collection ? $this->setCollection($result) : $result;
     }
 
     /**


### PR DESCRIPTION
Using the paginate method would return the paginator instance.

```php
return User::paginate();
// Illuminate\Pagination\LengthAwarePaginator
```

Before this PR, when using paginate and then making calls into the collection would result in returning the collection instance and losing the paginator.

```php
return User::paginate()->map(function () {
    // your code here
});
// Illuminate\Database\Eloquent\Collection
```

After the PR

```php
return User::paginate()->map(function () {
    // your code here
});
// Illuminate\Pagination\LengthAwarePaginator
```

If you called a method on the collection that does not return a collection like count() or first(), it will return the result of the method called.

```php
return User::paginate()->count();
// The number of items in the collection
```

This will help when using collection methods to transform items in the collection of the paginator.