### PR TITLE
[7.x] Dynamic firstWhere

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3113,6 +3113,12 @@ class Builder
             return $this->dynamicWhere($method, $parameters);
         }
 
+        if (Str::startsWith($method, 'firstWhere')) {
+            $method = Str::of($method)->after('first', $method)->lcfirst();
+
+            return $this->dynamicWhere($method, $parameters)->first();
+        }
+
         static::throwBadMethodCallException($method);
     }
 }

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -674,6 +674,17 @@ class Str
     }
 
     /**
+     * Make a string's first character lowercase.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public static function lcfirst($string)
+    {
+        return static::lower(static::substr($string, 0, 1)).static::substr($string, 1);
+    }
+
+    /**
      * Generate a UUID (version 4).
      *
      * @return \Ramsey\Uuid\UuidInterface

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -586,6 +586,16 @@ class Stringable
     }
 
     /**
+     * Make a string's first character lowercase.
+     *
+     * @return static
+     */
+    public function lcfirst()
+    {
+        return new static(Str::lcfirst($this->value));
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2848,6 +2848,19 @@ SQL;
         $this->assertCount(2, $builder->wheres);
     }
 
+    public function testDynamicFirstWhere()
+    {
+        $builder = $this->getMockQueryBuilder();
+
+        $builder->getConnection()->shouldReceive('select');
+        $builder->getProcessor()->shouldReceive('processSelect')->andReturn([]);
+        $builder->shouldReceive('first')->andReturn(['foo' => 'bar']);
+        $result = $builder->firstWhereFooAndBar('baz', 'qux');
+
+        $this->assertCount(2, $builder->wheres);
+        $this->assertEquals(['foo' => 'bar'], $result);
+    }
+
     public function testBuilderThrowsExpectedExceptionWithUndefinedMethod()
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -446,6 +446,14 @@ class SupportStrTest extends TestCase
         $this->assertSame('Мама мыла раму', Str::ucfirst('мама мыла раму'));
     }
 
+    public function testLcfirst()
+    {
+        $this->assertSame('laravel', Str::lcfirst('Laravel'));
+        $this->assertSame('laravel Framework', Str::lcfirst('Laravel Framework'));
+        $this->assertSame('mAMA', Str::lcfirst('MAMA'));
+        $this->assertSame('mама мыла раму', Str::lcfirst('Mама мыла раму'));
+    }
+
     public function testUuid()
     {
         $this->assertInstanceOf(UuidInterface::class, Str::uuid());


### PR DESCRIPTION
Hey! 

I'm a huge fan of dynamic where methods. Most often only the first value is needed, so need to call `->first()`. This PR adds `firstWhereSomething` dynamic method.  
E.g `User::whereGithubId($id)->first()` could be written as `User::firstWhereGithubId($id)`

In addition, it also adds `lcfirst()` method to `Str` and `Stringable`. I'm not sure if this is an overkill, but I thought since there is ucfirst, why not have lcfirst. Although if you think otherwise I can remove it. 

Is this something you would be interested in merging to the core? Thanks.