### PR TITLE
[7.x] Fix Stringable isEmpty

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -233,7 +233,7 @@ class Stringable
      */
     public function isEmpty()
     {
-        return empty($this->value);
+        return $this->value === '';
     }
 
     /**

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -24,6 +24,7 @@ class SupportStringableTest extends TestCase
 
     public function testIsEmpty()
     {
+        $this->assertTrue($this->stringable('')->isEmpty());
         $this->assertFalse($this->stringable('A')->isEmpty());
         $this->assertFalse($this->stringable('0')->isEmpty());
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -22,6 +22,12 @@ class SupportStringableTest extends TestCase
         $this->assertFalse($this->stringable('ù')->isAscii());
     }
 
+    public function testIsEmpty()
+    {
+        $this->assertFalse($this->stringable('A')->isEmpty());
+        $this->assertFalse($this->stringable('0')->isEmpty());
+    }
+
     public function testPluralStudly()
     {
         $this->assertSame('LaraCon', (string) $this->stringable('LaraCon')->pluralStudly(1));


### PR DESCRIPTION
The `Stringable` class `isEmpty` method uses the `empty` function.

As a result a string of `'0'` will be evaluated as empty.
This PR fixes this. Added a test as well.