### PR TITLE
[7.x] Add dynamic 'column' key for foreign constraints

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -36,7 +36,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
      */
     public function constrained($table = null, $column = 'id')
     {
-        return $this->references($column)->on($table ?: Str::plural(Str::before($this->name, '_' . $column)));
+        return $this->references($column)->on($table ?: Str::plural(Str::before($this->name, '_'.$column)));
     }
 
     /**

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -28,7 +28,7 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     }
 
     /**
-     * Create a foreign key constraint on this column referencing the column of the conventionally related table.
+     * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
      *
      * @param  string|null  $table
      * @param  string  $column

--- a/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignIdColumnDefinition.php
@@ -28,14 +28,15 @@ class ForeignIdColumnDefinition extends ColumnDefinition
     }
 
     /**
-     * Create a foreign key constraint on this column referencing the "id" column of the conventionally related table.
+     * Create a foreign key constraint on this column referencing the column of the conventionally related table.
      *
      * @param  string|null  $table
+     * @param  string  $column
      * @return \Illuminate\Support\Fluent|\Illuminate\Database\Schema\ForeignKeyDefinition
      */
-    public function constrained($table = null)
+    public function constrained($table = null, $column = 'id')
     {
-        return $this->references('id')->on($table ?: Str::plural(Str::before($this->name, '_id')));
+        return $this->references($column)->on($table ?: Str::plural(Str::before($this->name, '_' . $column)));
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This change enables using the new (7.x) foreign key (`$table->foreignId('user_id')->constrained();`) syntax on tables not using 'id' as their primaryKey. Previously only the table could be specified.

As an example
```
    $table->foreignId('festival_year')->constrained('festivals', 'year');
```
would be the equivalent to the previous syntax of
```
    $table->unsignedBigInteger('festival_year');
    $table->foreign('festival_year')->references('year')->on('festivals');
```