### PR TITLE
Give MailMessage::data() setter functionality.

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -286,11 +286,7 @@ class MailMessage extends SimpleMessage implements Renderable
         }
 
         foreach ($key as $arrayKey => $arrayValue) {
-            if (method_exists($this, $arrayKey)) {
-                $this->{$arrayKey}($arrayValue);
-            } else {
-                Arr::set($this->data, $arrayKey, $arrayValue);
-            }
+            Arr::set($this->data, $arrayKey, $arrayValue);
         }
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -267,13 +267,31 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
-     * Get the data array for the mail message.
+     * Get/set the data array for the mail message.
      *
-     * @return array
+     * If an array is passed as the key, we will assume you want to set an array of values.
+     *
+     * @param  array|string|null  $key
+     * @param  mixed  $value
+     * @return mixed
      */
-    public function data()
+    public function data($key = null, $value = null)
     {
-        return array_merge($this->toArray(), $this->viewData);
+        if (is_null($key)) {
+            return array_merge($this->toArray(), $this->viewData);
+        }
+
+        if (! is_array($key)) {
+            $key = [$key => $value];
+        }
+
+        foreach ($key as $arrayKey => $arrayValue) {
+            if (method_exists($this, $arrayKey)) {
+                $this->{$arrayKey}($arrayValue);
+            } else {
+                Arr::set($this->data, $arrayKey, $arrayValue);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This is a non-breaking change that allows applications to add information to a mail message that can then be passed to the view/render.

MailMessage currently only allows data to be passed in via view(), markdown(), or by setting the $viewData property directly. This change extends data() in a way that is fluent and consistent with similar functionality throughout the framework.
