### PR TITLE
[8.x] Give MailMessage::data() setter functionality

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Mail\Markdown;
+use Illuminate\Support\Arr;
 use Traversable;
 
 class MailMessage extends SimpleMessage implements Renderable
@@ -267,13 +268,27 @@ class MailMessage extends SimpleMessage implements Renderable
     }
 
     /**
-     * Get the data array for the mail message.
+     * Get/set the data array for the mail message.
      *
-     * @return array
+     * If an array is passed as the key, we will assume you want to set an array of values.
+     *
+     * @param  array|string|null  $key
+     * @param  mixed  $value
+     * @return mixed
      */
-    public function data()
+    public function data($key = null, $value = null)
     {
-        return array_merge($this->toArray(), $this->viewData);
+        if (is_null($key)) {
+            return array_merge($this->toArray(), $this->viewData);
+        }
+
+        if (! is_array($key)) {
+            $key = [$key => $value];
+        }
+
+        foreach ($key as $arrayKey => $arrayValue) {
+            Arr::set($this->viewData, $arrayKey, $arrayValue);
+        }
     }
 
     /**

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -289,6 +289,7 @@ class MailMessage extends SimpleMessage implements Renderable
         foreach ($key as $arrayKey => $arrayValue) {
             Arr::set($this->viewData, $arrayKey, $arrayValue);
         }
+
         return $this;
     }
 

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -289,6 +289,7 @@ class MailMessage extends SimpleMessage implements Renderable
         foreach ($key as $arrayKey => $arrayValue) {
             Arr::set($this->viewData, $arrayKey, $arrayValue);
         }
+        return $this;
     }
 
     /**

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -87,10 +87,12 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame([$callback], $message->callbacks);
     }
 
-    public function testData() {
+    public function testData()
+    {
         $message = new MailMessage();
         $expect = $message->data();
-        $message->data('scalar', 'test');
+        $same = $message->data('scalar', 'test');
+        $this->assertSame($same, $message);
         $expect['scalar'] = 'test';
         $this->assertEquals($expect, $message->data());
 

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -86,4 +86,17 @@ class NotificationMailMessageTest extends TestCase
 
         $this->assertSame([$callback], $message->callbacks);
     }
+
+    public function testData() {
+        $message = new MailMessage();
+        $expect = $message->data();
+        $message->data('scalar', 'test');
+        $expect['scalar'] = 'test';
+        $this->assertEquals($expect, $message->data());
+
+        $message->data(['array1' => 1, 'array2' => 2]);
+        $expect['array1'] = 1;
+        $expect['array2'] = 2;
+        $this->assertEquals($expect, $message->data());
+    }
 }


### PR DESCRIPTION
This is a non-breaking change that allows applications to add information to a mail message that can then be passed to the view/render.

MailMessage currently only allows data to be passed in via view(), markdown(), or by setting the $viewData property directly. This change extends data() in a way that is fluent and consistent with similar functionality throughout the framework.
