### PR TITLE
[7.x]  Allow developers to specify accepted keys in array rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -317,11 +317,20 @@ trait ValidatesAttributes
      *
      * @param  string  $attribute
      * @param  mixed  $value
+     * @param  array  $parameters
      * @return bool
      */
-    public function validateArray($attribute, $value)
+    public function validateArray($attribute, $value, $parameters)
     {
-        return is_array($value);
+        if (! is_array($value)) {
+            return false;
+        }
+
+        if (empty($parameters)) {
+            return true;
+        }
+
+        return empty(array_diff_key($value, array_fill_keys($parameters, '')));
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -320,7 +320,7 @@ trait ValidatesAttributes
      * @param  array  $parameters
      * @return bool
      */
-    public function validateArray($attribute, $value, $parameters)
+    public function validateArray($attribute, $value, $parameters = [])
     {
         if (! is_array($value)) {
             return false;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -672,6 +672,23 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->passes());
     }
 
+    public function testValidateArrayKeys()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $rules = ['user' => 'array:name,username'];
+
+        $v = new Validator($trans, ['user' => ['name' => 'Duilio', 'username' => 'duilio']], $rules);
+        $this->assertTrue($v->passes());
+
+        // The array is valid if there's a missing key.
+        $v = new Validator($trans, ['user' => ['name' => 'Duilio']], $rules);
+        $this->assertTrue($v->passes());
+
+        // But it's not valid if there's an unexpected key.
+        $v = new Validator($trans, ['user' => ['name' => 'Duilio', 'username' => 'duilio', 'is_admin' => true]], $rules);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateFilled()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
I'm trying to come up with a solution for the problem @mnabialek mentioned here https://github.com/laravel/framework/pull/32379:

---

I'm sending such data in test:

```
$response = $this->post('/validate', [
    'users' => [
        [
            'name' => 'Person 1',
            'email' => 'sample@example.com',
            'is_admin' => true,
        ]
    ],
    'anything' => 'else',
]);
```

And my controller method looks like this:

```
$validated = $this->validate(request(), [
    'users' => ['required', 'array'],
    'users.*' => ['required', 'array'],
    'users.*.name' => ['required', 'string'],
    'users.*.email' => ['required', 'email'],
]);
```

`dd($validated);` returns:

```
array:1 [
  "users" => array:1 [
    0 => array:3 [
      "name" => "Person 1"
      "email" => "sample@example.com"
      "is_admin" => true
    ]
  ]
]
```

Although `is_admin` flag shouldn't be there.

---

In cases like this the validation could be changed slightly, specifying the keys that are accepted in any given array:

```
$validated = $this->validate(request(), [
    'users' => ['required', 'array'],
    'users.*' => ['required', 'array:name,email'],
    'users.*.name' => ['required', 'string'],
    'users.*.email' => ['required', 'email'],
]);
```

In this case both keys happened to be required and therefore they have their own validated rules, but that is not always going to be the case.

I was also trying to limit the amount of data in the `validated` array when more nested rules are specified but that's turning out to be a bit more difficult and also a breaking change, so I'm sending this rule option in the meantime as a way to whitelist the accepted keys in associative arrays.