### PR TITLE
[7.x] Add container support for variadic constructor arguments

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -57,7 +57,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
     /**
      * Define the implementation for the contextual binding.
      *
-     * @param  \Closure|string  $implementation
+     * @param  \Closure|string|array  $implementation
      * @return void
      */
     public function give($implementation)

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -231,9 +231,84 @@ class ContextualBindingTest extends TestCase
         );
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->implTwo->impl);
     }
+
+    public function testContextualBindingWorksForVariadicDependencies()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->give(function ($c) {
+            return [
+                $c->make(ContainerContextImplementationStub::class),
+                $c->make(ContainerContextImplementationStubTwo::class),
+            ];
+        });
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadic::class);
+
+        $this->assertCount(2, $resolvedInstance->stubs);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
+    }
+
+    public function testContextualBindingWorksForVariadicDependenciesWithNothingBound()
+    {
+        $container = new Container;
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadic::class);
+
+        $this->assertCount(0, $resolvedInstance->stubs);
+    }
+
+    public function testContextualBindingWorksForVariadicAfterNonVariadicDependencies()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectVariadicAfterNonVariadic::class)->needs(IContainerContextContractStub::class)->give(function ($c) {
+            return [
+                $c->make(ContainerContextImplementationStub::class),
+                $c->make(ContainerContextImplementationStubTwo::class),
+            ];
+        });
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadicAfterNonVariadic::class);
+
+        $this->assertCount(2, $resolvedInstance->stubs);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
+    }
+
+    public function testContextualBindingWorksForVariadicAfterNonVariadicDependenciesWithNothingBound()
+    {
+        $container = new Container;
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadicAfterNonVariadic::class);
+
+        $this->assertCount(0, $resolvedInstance->stubs);
+    }
+
+    public function testContextualBindingWorksForVariadicDependenciesWithoutFactory()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->give([
+            ContainerContextImplementationStub::class,
+            ContainerContextImplementationStubTwo::class,
+        ]);
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadic::class);
+
+        $this->assertCount(2, $resolvedInstance->stubs);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
+    }
 }
 
 interface IContainerContextContractStub
+{
+    //
+}
+
+class ContainerContextNonContractStub
 {
     //
 }
@@ -307,5 +382,27 @@ class ContainerTestContextWithOptionalInnerDependency
     public function __construct(ContainerTestContextInjectOne $inner = null)
     {
         $this->inner = $inner;
+    }
+}
+
+class ContainerTestContextInjectVariadic
+{
+    public $stubs;
+
+    public function __construct(IContainerContextContractStub ...$stubs)
+    {
+        $this->stubs = $stubs;
+    }
+}
+
+class ContainerTestContextInjectVariadicAfterNonVariadic
+{
+    public $other;
+    public $stubs;
+
+    public function __construct(ContainerContextNonContractStub $other, IContainerContextContractStub ...$stubs)
+    {
+        $this->other = $other;
+        $this->stubs = $stubs;
     }
 }


### PR DESCRIPTION
This PR adds container support for variadic constructor arguments.

See these Twitter discussions for the catalysts for this PR:

 * https://twitter.com/nikolaposa/status/1251942141619769344 (April 19th, 2020)
 * https://twitter.com/i/status/1204182301430681600 (December, 2019)
 * https://twitter.com/beausimensen/status/1189903429054992384 (October, 2019)
 * https://twitter.com/beausimensen/status/1187016380979339264 (October, 2019)

## The Problem

There is currently no way to support classes that have variadic constructor arguments without breaking out and providing a full factory for a class.

For example:

```php
interface Logger { }

class MyLogger implements Logger { }

interface Filter { }

class NullFilter implements Filter { }
class ProfanityFilter implements Filter { }
class TooLongFilter implements Filter { }

class Firewall
{
    public $logger;
    public $filters;

    public function __construct(Logger $logger, Filter ...$filters)
    {
        $this->logger = $logger;
        $this->filters = $filters;
    }
}
```

The only way to do this currently:

```php
app()->singleton(Logger::class, MyLogger::class);
app()->bind(Firewall::class, function ($c) {
    return new Firewall(
        $c->make(Logger::class),
        ...[
            $c->make(NullFilter::class),
            $c->make(ProfanityFilter::class),
            $c->make(TooLongFilter::class),
        ]
    );
});
```

It feels heavy handed since we have to manually `make` all four dependencies for `Firewall` when all of them should be able to be autowired. Likewise, add another constructor argument, and the container configuration needs to change, even if the new constructor argument could be autowired.

----

## The Solution

My ideal situation is to configure classes like this using contextual binding. I only want to specify the dependencies that cannot be autowired.

To me, that looks like this:

```php
app()->singleton(Logger::class, MyLogger::class);
app()
    ->when(Firewall::class)
    ->needs(Filter::class)
    ->give(function ($c) {
        return [
            $c->make(NullFilter::class),
            $c->make(ProfanityFilter::class),
            $c->make(TooLongFilter::class),
        ];
    });
```

Or... better yet...

```php
app()->singleton(Logger::class, MyLogger::class);
app()
    ->when(Firewall::class)
    ->needs(Filter::class)
    ->give([
        NullFilter::class,
        ProfanityFilter::class,
        TooLongFilter::class,
    ]);
```

This PR makes both of these last two configuration styles possible.

----

## Notable Changes

 * `Container::getContextualConcrete` can now return an `array` (only a doc change, but changed expectation)
 * `Container::resolveClass` can now return an `array` (docs already have it returning `mixed`, but changed expectation)
 * `Container::resolveClass` will now return an empty array (`[]`) if a value is not defined (better fits with how PHP handles variadic functions when no variadic values are actually passed)
 * `ContextualBindingBuilder::give` can now accept an array (only a doc change, but changed expectation)

----

## Other Thoughts on Implementation

 * Unclear if reusing `needs`/`give` is best vs adding `needsVariadic`/`givesVariadic` or something along those lines. This looks cleanest and probably easiest to adopt, but happy to discuss this.
 * Unclear if there are performance impact on some of the places I changed the code. I'm most worried about `Container::resolveClass`. I started down `resolveVariadic` but quickly scaled back as it was duplicating a *lot* of code and wasn't sure it was worth it.
 * Unclear what other impacts there might be by adding the option to return an array in some of these cases. The tests all pass, but it *is* changing some expected behavior...

----

Related to #26950.