### PR TITLE
[7.x] Artisan db:create command

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -61,7 +61,7 @@ class Connector
      * @param  array  $options
      * @return \PDO
      */
-    protected function createPdoConnection($dsn, $username, $password, $options)
+    public function createPdoConnection($dsn, $username, $password, $options)
     {
         if (class_exists(PDOConnection::class) && ! $this->isPersistentConnection($options)) {
             return new PDOConnection($dsn, $username, $password, $options);

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -90,7 +90,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
      * @param  array  $config
      * @return string
      */
-    protected function getDsn(array $config)
+    public function getDsn(array $config)
     {
         return $this->hasSocket($config)
                             ? $this->getSocketDsn($config)

--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -135,7 +135,7 @@ class PostgresConnector extends Connector implements ConnectorInterface
      * @param  array  $config
      * @return string
      */
-    protected function getDsn(array $config)
+    public function getDsn(array $config)
     {
         // First we will create the basic DSN setup as well as the port if it is in
         // in the configuration options. This will give us the basic DSN we will

--- a/src/Illuminate/Database/Console/CreateCommand.php
+++ b/src/Illuminate/Database/Console/CreateCommand.php
@@ -46,7 +46,7 @@ class CreateCommand extends Command
 
         $pdo = $connector->createPdoConnection($dsnWithoudDbName, $username, $password, $connector->getOptions($config));
 
-        $pdo->exec('CREATE DATABASE `' . $config['database'] .'`');
+        $pdo->exec('CREATE DATABASE `'.$config['database'].'`');
 
         $this->info('Database created successfully!');
     }

--- a/src/Illuminate/Database/Console/CreateCommand.php
+++ b/src/Illuminate/Database/Console/CreateCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Database\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+
+class CreateCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'db:create';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        $config = $this->laravel['db']->getConfig();
+
+        $connector = $this->laravel['db.factory']->createConnector($config);
+
+        [$username, $password] = [
+            $config['username'] ?? null, $config['password'] ?? null,
+        ];
+
+        $dsnWithoudDbName = str_replace("dbname={$config['database']}", '', $connector->getDsn($config));
+
+        $pdo = $connector->createPdoConnection($dsnWithoudDbName, $username, $password, $connector->getOptions($config));
+
+        $pdo->exec('CREATE DATABASE `' . $config['database'] .'`');
+
+        $this->info('Database created successfully!');
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Database\Console\CreateCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
@@ -83,6 +84,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'ConfigCache' => 'command.config.cache',
         'ConfigClear' => 'command.config.clear',
         'DbWipe' => 'command.db.wipe',
+        'DbCreate' => 'command.db.create',
         'Down' => 'command.down',
         'Environment' => 'command.environment',
         'EventCache' => 'command.event.cache',
@@ -317,6 +319,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.db.wipe', function () {
             return new WipeCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerDbCreateCommand()
+    {
+        $this->app->singleton('command.db.create', function () {
+            return new CreateCommand;
         });
     }
 


### PR DESCRIPTION
this PR adds **php artisan db:create** command to create new database .

i found with each new project i had to manually create DB and after that any new interaction with DB is done through migrations or models .

so by introducing **db:create** this will make the process from creating DB to the interaction with DB is done through the code.

also this command makes it **convenient** for other developers that are coming from **Rails  or Symfony background** . as both frameworks has **rake db:create** & **doctrine:database:create**

------------

for technicality. i thought about multiple approaches but only two has stood out

first i thought about using **doctrine/dbal** but i found it a little bit frustrating to install the package for only creating DB 

second one is using **PDO** . so by removing **dbname=** from PDO object configuration we can then execute SQL statement like creating DB without exception thrown that DB not found
