### PR TITLE
[7.x] Relative symlinks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/console": "^5.0",
         "symfony/error-handler": "^5.0",
+        "symfony/filesystem": "^5.0",
         "symfony/finder": "^5.0",
         "symfony/http-foundation": "^5.0",
         "symfony/http-kernel": "^5.0",

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 class StorageLinkCommand extends Command
 {
@@ -32,9 +32,8 @@ class StorageLinkCommand extends Command
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {
-                if (! $this->option('absolute') && DIRECTORY_SEPARATOR == '/') {
-                    // Utilize Symfony's Request to find the relative path
-                    $target = Request::create($link)->getRelativeUriForPath($target);
+                if (! $this->option('absolute')) {
+                    $target = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
                 }
 
                 $this->laravel->make('files')->link($target, $link);

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\HttpFoundation\Request;
 
 class StorageLinkCommand extends Command
 {
@@ -11,7 +12,7 @@ class StorageLinkCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'storage:link';
+    protected $signature = 'storage:link {--absolute : Create links using absolute paths}';
 
     /**
      * The console command description.
@@ -31,6 +32,11 @@ class StorageLinkCommand extends Command
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {
+                if (! $this->option('absolute') && DIRECTORY_SEPARATOR == '/') {
+                    // Utilize Symfony's Request to find the relative path
+                    $target = Request::create($link)->getRelativeUriForPath($target);
+                }
+
                 $this->laravel->make('files')->link($target, $link);
 
                 $this->info("The [$link] link has been connected to [$target].");


### PR DESCRIPTION
Cleaned up implementation of #32430, for your consideration.

Relative paths for links are determined by `makePathRelative` from Symfony's `Filesystem`, which handles Windows paths as well. 
