### PR TITLE
[7.x] Add ability to check for multiple request headers when using HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -91,7 +91,7 @@ class Request implements ArrayAccess
         }
 
         foreach ($headers as $key => $value) {
-            if (! $this -> hasHeader($key, $value)) {
+            if (! $this->hasHeader($key, $value)) {
                 return false;
             }
         }

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -79,6 +79,27 @@ class Request implements ArrayAccess
     }
 
     /**
+     * Determine if the request has the given headers.
+     *
+     * @param  array|string  $headers
+     * @return bool
+     */
+    public function hasHeaders($headers)
+    {
+        if (is_string($headers)) {
+            $headers = [$headers => null];
+        }
+
+        foreach ($headers as $key => $value) {
+            if (! $this -> hasHeader($key, $value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get the values for the header with the given name.
      *
      * @param  string  $key

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -394,4 +394,37 @@ class HttpClientTest extends TestCase
                 && $request['foo;bar; space test'] === 'laravel';
         });
     }
+
+    public function testCanConfirmManyHeaders()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders([
+                       'X-Test-Header' => 'foo',
+                       'X-Test-ArrayHeader' => ['bar', 'baz'],
+                   ]);
+        });
+    }
+
+    public function testCanConfirmManyHeadersUsingAString()
+    {
+        $this->factory->fake();
+
+        $this->factory->withHeaders([
+            'X-Test-Header' => 'foo',
+            'X-Test-ArrayHeader' => ['bar', 'baz'],
+        ])->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                   $request->hasHeaders('X-Test-Header');
+        });
+    }
 }


### PR DESCRIPTION
This PR adds a `hasHeaders()` method to `Illuminate/Http/Client/Request.php`, and may be used to more succinctly check if an `array` of headers is present when [inspecting requests](https://laravel.com/docs/master/http-client#inspecting-requests). Under the hood, the `hasHeaders` method simply defers to the already present `hasHeader` method.

Before:

```php
Http:withHeaders([
    'X-Test-Header' => 'foo',
    'X-Test-ArrayHeader' => ['bar', 'baz'],
]);

Http:assertSent(function ($request) {
    return $request->hasHeader('X-Test-Header', 'foo') &&
           $request->hasHeader('X-Test-ArrayHeader', ['bar', 'baz']);
});
```

After

```php
Http:withHeaders($headers = [
    'X-Test-Header' => 'foo',
    'X-Test-ArrayHeader' => ['bar', 'baz'],
]);

Http:assertSent(function ($request) {
    return $request->hasHeaders($headers);
});

// or with PHP 7.4 arrow functions...

Http:assertSent(fn ($request) => $request->hasHeaders($headers));
```