### PR TITLE
[7.x] New method withSum for sum one or more columns for the relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1137,18 +1137,19 @@ class Builder
     protected function parseWithSumRelations(array $relations)
     {
         $results = [];
-        
+
         foreach ($relations as $name => $constraints) {
-            
+
             // If the "name" value is a numeric key, we can assume that no constraints
             // have been specified. We will just put an empty Closure there so that
             // we can treat these all the same while we are looping through them.
             if (is_numeric($name)) {
                 $name = $constraints;
 
-                [$name, $constraints] = [$name, static function () {}];
+                [$name, $constraints] = [$name, static function () {
+                }];
             }
-            
+
             $results[$name] = $constraints;
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1129,6 +1129,33 @@ class Builder
     }
 
     /**
+     * Parse a list of relations into individuals.
+     *
+     * @param  array  $relations
+     * @return array
+     */
+    protected function parseWithSumRelations(array $relations)
+    {
+        $results = [];
+        
+        foreach ($relations as $name => $constraints) {
+            
+            // If the "name" value is a numeric key, we can assume that no constraints
+            // have been specified. We will just put an empty Closure there so that
+            // we can treat these all the same while we are looping through them.
+            if (is_numeric($name)) {
+                $name = $constraints;
+
+                [$name, $constraints] = [$name, static function () {}];
+            }
+            
+            $results[$name] = $constraints;
+        }
+
+        return $results;
+    }
+
+    /**
      * Create a constraint to select the given columns for the relation.
      *
      * @param  string  $name

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -96,6 +96,38 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Load a set of relationship sum of column onto the collection.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadSum($relations)
+    {
+        if ($this->isEmpty()) {
+            return $this;
+        }
+
+        $models = $this->first()->newModelQuery()
+            ->whereKey($this->modelKeys())
+            ->select($this->first()->getKeyName())
+            ->withSum(...func_get_args())
+            ->get();
+
+        $attributes = Arr::except(
+            array_keys($models->first()->getAttributes()),
+            $models->first()->getKeyName()
+        );
+
+        $models->each(function ($model) use ($attributes) {
+            $this->find($model->getKey())->forceFill(
+                Arr::only($model->getAttributes(), $attributes)
+            )->syncOriginalAttributes($attributes);
+        });
+
+        return $this;
+    }
+
+    /**
      * Load a set of relationships onto the collection if they are not already eager loaded.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -440,7 +440,6 @@ trait QueriesRelationships
             // as a sub-select. First, we'll get the "has" query and use that to get the relation
             // sum query. We will normalize the relation name then append _{column}_sum as the name.
             foreach ($columns as $column) {
-
                 $query = $relation->getRelationExistenceSumQuery(
                     $relation->getRelated()->newQuery(), $this, $column
                 );

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -430,7 +430,6 @@ trait QueriesRelationships
         $relations = is_array($relations) ? $relations : func_get_args();
 
         foreach ($this->parseWithSumRelations($relations) as $name => $constraints) {
-
             $nameExplode = explode(':', $name);
             $name = $nameExplode[0];
             $columns = isset($nameExplode[1]) ? explode(',', $nameExplode[1]) : [];
@@ -441,7 +440,7 @@ trait QueriesRelationships
             // as a sub-select. First, we'll get the "has" query and use that to get the relation
             // sum query. We will normalize the relation name then append _{column}_sum as the name.
             foreach ($columns as $column) {
-                
+
                 $query = $relation->getRelationExistenceSumQuery(
                     $relation->getRelated()->newQuery(), $this, $column
                 );

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -78,6 +78,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     protected $withCount = [];
 
     /**
+     * The relationship sums that should be eager loaded on every query.
+     *
+     * @var array
+     */
+    protected $withSum = [];
+
+    /**
      * The number of models to return for pagination.
      *
      * @var int
@@ -543,6 +550,21 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         $relations = is_string($relations) ? func_get_args() : $relations;
 
         $this->newCollection([$this])->loadCount($relations);
+
+        return $this;
+    }
+
+    /**
+     * Eager load relation sums on the model.
+     *
+     * @param  array|string  $relations
+     * @return $this
+     */
+    public function loadSum($relations)
+    {
+        $relations = is_string($relations) ? func_get_args() : $relations;
+
+        $this->newCollection([$this])->loadSum($relations);
 
         return $this;
     }
@@ -1031,7 +1053,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         return $this->newModelQuery()
                     ->with($this->with)
-                    ->withCount($this->withCount);
+                    ->withCount($this->withCount)
+                    ->withSum($this->withSum);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -197,6 +197,20 @@ abstract class Relation
     }
 
     /**
+     * Add the constraints for a relationship sum of column query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $parentQuery
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function getRelationExistenceSumQuery(Builder $query, Builder $parentQuery, $column)
+    {
+        return $this->getRelationExistenceQuery(
+            $query, $parentQuery, new Expression('sum('.$column.')')
+        )->setBindings([], 'select');
+    }
+
+    /**
      * Add the constraints for an internal relationship existence query.
      *
      * Essentially, these queries compare on column names like whereColumn.


### PR DESCRIPTION
Added new method withSum for sum one or more columns for the relations without second sql query.

It's working like withCount. Three type:
1) Invoice::withSum('items:price,price2')->first(); where price, price2 are columns
2) $invoices = Invoice::first(); $invoices->loadSum('items:price');
3) $invoices = Invoice::withSum(['items:price,price2' => function (Builder $query) {
	  $query->where('id','<', 30);
   }])->get();

I often use this in my work and I hope it will be useful to you!