### PR TITLE
[7.x] Add set message to validation exception

### DIFF
--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -103,7 +103,7 @@ class ValidationException extends Exception
     /**
      * Set the message to be used for the response.
      *
-     * @param string $message
+     * @param  string  $message
      * @return $this
      */
     public function setMessage($message)

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -99,7 +99,7 @@ class ValidationException extends Exception
 
         return $this;
     }
-    
+
     /**
      * Set the message to be used for the response.
      *

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -99,6 +99,19 @@ class ValidationException extends Exception
 
         return $this;
     }
+    
+    /**
+     * Set the message to be used for the response.
+     *
+     * @param string $message
+     * @return $this
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+
+        return $this;
+    }
 
     /**
      * Set the error bag on the exception.


### PR DESCRIPTION
This is a compromise for adding a custom message to a validation error
Previous PRs (#26798,#22045,#28246,#21863, #22823) have added a translator to `ValidationException`

Now you can customize your message (localization or just your message)
```
public function render($request, Throwable $exception)
{
    if ($exception instanceof ValidationException) {
        $exception->setMessage(__('Lang error message'));
    }
    return parent::render($request, $exception);
}
```