### PR TITLE
[7.x] Cleanup integration tests

### DIFF
--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -4,12 +4,12 @@ namespace Illuminate\Tests\Integration\Cache;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Tests\Integration\IntegrationTest;
+use Orchestra\Testbench\TestCase;
 
 /**
  * @group integration
  */
-class RedisStoreTest extends IntegrationTest
+class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -7,11 +7,14 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Arr;
-use Illuminate\Tests\Integration\IntegrationTest;
+use Orchestra\Testbench\TestCase;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class CompiledRouteCollectionTest extends IntegrationTest
+/**
+ * @group integration
+ */
+class CompiledRouteCollectionTest extends TestCase
 {
     /**
      * @var \Illuminate\Routing\RouteCollection

--- a/tests/Integration/Routing/SimpleRouteTest.php
+++ b/tests/Integration/Routing/SimpleRouteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Integration;
+namespace Illuminate\Tests\Integration\Routing;
 
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 /**
  * @group integration
  */
-class IntegrationTest extends TestCase
+class SimpleRouteTest extends TestCase
 {
     public function testSimpleRouteThroughTheFramework()
     {


### PR DESCRIPTION
Remove the base integration test and extend correct Orchestra test case. I noticed that otherwise some tests ran the one from IntegrationTestCase twice.