### PR TITLE
[8.x] Deprecate old collection and macroable objects

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support;
 
 use Illuminate\Collections\Arr as BaseArr;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 class Arr extends BaseArr
 {
     //

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support;
 
 use Illuminate\Collections\Collection as BaseCollection;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 class Collection extends BaseCollection
 {
     /**

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support;
 
 use Illuminate\Collections\Enumerable as BaseEnumerable;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 interface Enumerable extends BaseEnumerable
 {
     //

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -5,6 +5,9 @@ namespace Illuminate\Support;
 use Closure;
 use Illuminate\Collections\LazyCollection as BaseLazyCollection;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 class LazyCollection extends BaseLazyCollection
 {
     /**

--- a/src/Illuminate/Support/Traits/Macroable.php
+++ b/src/Illuminate/Support/Traits/Macroable.php
@@ -4,6 +4,9 @@ namespace Illuminate\Support\Traits;
 
 use Illuminate\Macroable\Macroable as BaseMacroable;
 
+/**
+ * @deprecated Will be removed in a future Laravel version.
+ */
 trait Macroable
 {
     use BaseMacroable;


### PR DESCRIPTION
We should definitely keep the objects around for a couple of major versions but we should push people to use the newer classes so we can eventually get rid of the duplicate ones.