### PR TITLE
[7.x] Warn when laravel/ui is not installed

### DIFF
--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Support\Facades;
 
+use Laravel\Ui\UiServiceProvider;
+use LogicException;
+
 /**
  * @method static mixed guard(string|null $name = null)
  * @method static void shouldUse(string $name);
@@ -49,6 +52,10 @@ class Auth extends Facade
      */
     public static function routes(array $options = [])
     {
+        if (! array_key_exists(UiServiceProvider::class, static::$app->getLoadedProviders())) {
+            throw new LogicException('Please install the laravel/ui package in order to use the Route::auth() method.');
+        }
+
         static::$app->make('router')->auth($options);
     }
 }

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -53,7 +53,7 @@ class Auth extends Facade
     public static function routes(array $options = [])
     {
         if (! array_key_exists(UiServiceProvider::class, static::$app->getLoadedProviders())) {
-            throw new LogicException('Please install the laravel/ui package in order to use the Route::auth() method.');
+            throw new LogicException('Please install the laravel/ui package in order to use the Auth::routes() method.');
         }
 
         static::$app->make('router')->auth($options);

--- a/tests/Integration/Support/AuthFacadeTest.php
+++ b/tests/Integration/Support/AuthFacadeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Support;
+
+use Illuminate\Support\Facades\Auth;
+use LogicException;
+use Orchestra\Testbench\TestCase;
+
+class AuthFacadeTest extends TestCase
+{
+    public function testItFailsIfTheUiPackageIsMissing()
+    {
+        $this->expectExceptionObject(new LogicException(
+            'Please install the laravel/ui package in order to use the Route::auth() method.'
+        ));
+
+        Auth::routes();
+    }
+}

--- a/tests/Integration/Support/AuthFacadeTest.php
+++ b/tests/Integration/Support/AuthFacadeTest.php
@@ -11,7 +11,7 @@ class AuthFacadeTest extends TestCase
     public function testItFailsIfTheUiPackageIsMissing()
     {
         $this->expectExceptionObject(new LogicException(
-            'Please install the laravel/ui package in order to use the Route::auth() method.'
+            'Please install the laravel/ui package in order to use the Auth::routes() method.'
         ));
 
         Auth::routes();


### PR DESCRIPTION
This is an attempt at solving the issue where people who are using `Auth::routes()` will get a better and more readable message when they haven't yet installed the laravel/ui package.