### PR TITLE
[8.x] Allow seeding the database when refreshing

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -37,7 +37,9 @@ trait RefreshDatabase
      */
     protected function refreshInMemoryDatabase()
     {
-        $this->artisan('migrate');
+        $this->artisan('migrate', [
+            '--seed' => $this->shouldSeed(),
+        ]);
 
         $this->app[Kernel::class]->setArtisan(null);
     }
@@ -53,6 +55,7 @@ trait RefreshDatabase
             $this->artisan('migrate:fresh', [
                 '--drop-views' => $this->shouldDropViews(),
                 '--drop-types' => $this->shouldDropTypes(),
+                '--seed' => $this->shouldSeed(),
             ]);
 
             $this->app[Kernel::class]->setArtisan(null);
@@ -125,5 +128,16 @@ trait RefreshDatabase
     {
         return property_exists($this, 'dropTypes')
                             ? $this->dropTypes : false;
+    }
+
+    /**
+     * Determine if the seed task should be run when refreshing the database.
+     *
+     * @return bool
+     */
+    protected function shouldSeed()
+    {
+        return property_exists($this, 'seed')
+                            ? $this->seed : false;
     }
 }


### PR DESCRIPTION
When using the [`RefreshDatabase` trait](https://laravel.com/docs/7.x/database-testing#resetting-the-database-after-each-test) along with the [`seed` method](https://laravel.com/docs/7.x/database-testing#using-seeds), the seeds are ran inside of the database transaction that gets rolled back at the end of the test, so you need to re-run them for every single test.

If you want to use all the seeds for every test this is unnecessarily slow -- it would be a lot faster to run the seeds once when the database is migrated, rather than running the same seeds for every test.

This PR adds the ability to enable the `--seed` flag for `migrate:fresh`, which runs the seeds once for the entire test suite.

It's impossible to accomplish this in your own code without overriding the `RefreshDatabase::refreshTestDatabase` method -- you would need to run the seeders between the [`migrate:fresh` call](https://github.com/laravel/framework/blob/4a5aa7d071c546247b15ee3eff70a186b0529ba6/src/Illuminate/Foundation/Testing/RefreshDatabase.php#L53) and the [beginDatabaseTransaction call](https://github.com/laravel/framework/blob/4a5aa7d071c546247b15ee3eff70a186b0529ba6/src/Illuminate/Foundation/Testing/RefreshDatabase.php#L63), and those calls both happen in the `refreshTestDatabase` method.

I made this PR to the master branch since it's technically a breaking change if you have defined a `seed` property or `shouldSeed` method in your feature tests.

No tests because I didn't see any existing tests for the `RefreshDatabase` trait but I'm happy to add some if needed.