### PR TITLE
[6.x] Fix typo/copy-paste error in SupportCollectionTest

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2284,7 +2284,7 @@ class SupportCollectionTest extends TestCase
 
     public function sortByUrl(array $value)
     {
-        return $value['rating'];
+        return $value['url'];
     }
 
     /**


### PR DESCRIPTION
Noticed small error in test for https://github.com/laravel/framework/pull/32471.