### PR TITLE
[7.x] Add new `Redirector::signedRoute()`, `Redirector::temporarySignedRoute()` methods

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -177,6 +177,36 @@ class Redirector
     }
 
     /**
+     * Create a new redirect response to a signed named route.
+     *
+     * @param  string  $route
+     * @param  mixed  $parameters
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function signedRoute($route, $parameters = [], $expiration = null, $status = 302, $headers = [])
+    {
+        return $this->to($this->generator->signedRoute($route, $parameters, $expiration), $status, $headers);
+    }
+
+    /**
+     * Create a new redirect response to a signed named route.
+     *
+     * @param  string  $route
+     * @param  \DateTimeInterface|\DateInterval|int|null  $expiration
+     * @param  mixed  $parameters
+     * @param  int  $status
+     * @param  array  $headers
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function temporarySignedRoute($route, $expiration, $parameters = [], $status = 302, $headers = [])
+    {
+        return $this->to($this->generator->temporarySignedRoute($route, $expiration, $parameters), $status, $headers);
+    }
+
+    /**
      * Create a new redirect response to a controller action.
      *
      * @param  string|array  $action

--- a/src/Illuminate/Support/Facades/Redirect.php
+++ b/src/Illuminate/Support/Facades/Redirect.php
@@ -12,6 +12,8 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Http\RedirectResponse away(string $path, int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse secure(string $path, int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse route(string $route, array $parameters = [], int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse signedRoute(string $name, array $parameters = [], \DateTimeInterface|\DateInterval|int $expiration = null, int $status = 302, array $headers = [])
+ * @method static \Illuminate\Http\RedirectResponse temporarySignedRoute(string $name, \DateTimeInterface|\DateInterval|int $expiration, array $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Http\RedirectResponse action(string $action, array $parameters = [], int $status = 302, array $headers = [])
  * @method static \Illuminate\Routing\UrlGenerator getUrlGenerator()
  * @method static void setSession(\Illuminate\Session\Store $session)

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -38,6 +38,7 @@ class RoutingRedirectorTest extends TestCase
         $this->url->shouldReceive('to')->with('login', [], null)->andReturn('http://foo.com/login');
         $this->url->shouldReceive('to')->with('http://foo.com/bar', [], null)->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('to')->with('/', [], null)->andReturn('http://foo.com/');
+        $this->url->shouldReceive('to')->with('http://foo.com/bar?signature=secret', [], null)->andReturn('http://foo.com/bar?signature=secret');
 
         $this->session = m::mock(Store::class);
 
@@ -159,6 +160,22 @@ class RoutingRedirectorTest extends TestCase
 
         $response = $this->redirect->home();
         $this->assertSame('http://foo.com/bar', $response->getTargetUrl());
+    }
+
+    public function testSignedRoute()
+    {
+        $this->url->shouldReceive('signedRoute')->with('home', [], null)->andReturn('http://foo.com/bar?signature=secret');
+
+        $response = $this->redirect->signedRoute('home');
+        $this->assertSame('http://foo.com/bar?signature=secret', $response->getTargetUrl());
+    }
+
+    public function testTemporarySignedRoute()
+    {
+        $this->url->shouldReceive('temporarySignedRoute')->with('home', 10, [])->andReturn('http://foo.com/bar?signature=secret');
+
+        $response = $this->redirect->temporarySignedRoute('home', 10);
+        $this->assertSame('http://foo.com/bar?signature=secret', $response->getTargetUrl());
     }
 
     public function testItSetsValidIntendedUrl()


### PR DESCRIPTION
This pull requests adds two new shortcut methods for redirecting to signed routes.

Currently, this can be achieved by:

```php
redirect()->to(URL::signedRoute(...));
```

but this can get hard to read and isn't as fluent as the other methods, such as `redirect()->route()`.

This PR adds support for the following:

```php
redirect()->signedRoute($route, $parameters, $expiration, $status, $headers);

// and

redirect()->temporarySignedRoute($route, $expiration, $parameters, $status, $headers);
```

Happy to implement these as macros in userland, but I don't see why they're not implemented in core.
