### PR TITLE
[7.x] Make LazyCollection@until actually be lazy

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -737,6 +737,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Take items in the collection until the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function until($value)
+    {
+        return new static($this->lazy()->until($value)->all());
+    }
+
+    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -738,6 +738,27 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Take items in the collection until the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function until($value)
+    {
+        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
+
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $item) {
+                if ($callback($item, $key)) {
+                    break;
+                }
+
+                yield $key => $item;
+            }
+        });
+    }
+
+    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -723,31 +723,6 @@ trait EnumeratesValues
     }
 
     /**
-     * Take items in the collection until condition is met.
-     *
-     * @param  mixed  $key
-     * @return static
-     */
-    public function until($value)
-    {
-        $passed = [];
-
-        $callback = $this->useAsCallable($value) ? $value : function ($item) use ($value) {
-            return $item === $value;
-        };
-
-        foreach ($this as $key => $item) {
-            if ($callback($item, $key)) {
-                break;
-            }
-
-            $passed[$key] = $item;
-        }
-
-        return new static($passed);
-    }
-
-    /**
      * Collect the values into a collection.
      *
      * @return \Illuminate\Support\Collection

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -969,4 +969,17 @@ trait EnumeratesValues
             return data_get($item, $value);
         };
     }
+
+    /**
+     * Make a function to check an item's equality.
+     *
+     * @param  \Closure|mixed  $value
+     * @return \Closure
+     */
+    protected function equality($value)
+    {
+        return function ($item) use ($value) {
+            return $item === $value;
+        };
+    }
 }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -1100,6 +1100,23 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testUntilIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->until(INF);
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->until(10)->all();
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->until(function ($item) {
+                return $item === 10;
+            })->all();
+        });
+    }
+
     public function testUnwrapEnumeratesOne()
     {
         $this->assertEnumeratesOnce(function ($collection) {


### PR DESCRIPTION
In #32262, we added an `until` method to the lazy collection that isn't actually lazy :cry: 

This PR makes it lazy, and adds tests ensuring that it is indeed lazy.