### PR TITLE
[7.x] Add `takeUntil` and `takeWhile` collection methods

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -737,17 +737,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Take items in the collection until the given condition is met.
-     *
-     * @param  mixed  $key
-     * @return static
-     */
-    public function until($value)
-    {
-        return new static($this->lazy()->until($value)->all());
-    }
-
-    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -1194,6 +1183,28 @@ class Collection implements ArrayAccess, Enumerable
         }
 
         return $this->slice(0, $limit);
+    }
+
+    /**
+     * Take items in the collection until the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function takeUntil($value)
+    {
+        return new static($this->lazy()->takeUntil($value)->all());
+    }
+
+    /**
+     * Take items in the collection while the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function takeWhile($value)
+    {
+        return new static($this->lazy()->takeWhile($value)->all());
     }
 
     /**

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -738,27 +738,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Take items in the collection until the given condition is met.
-     *
-     * @param  mixed  $key
-     * @return static
-     */
-    public function until($value)
-    {
-        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
-
-        return new static(function () use ($callback) {
-            foreach ($this as $key => $item) {
-                if ($callback($item, $key)) {
-                    break;
-                }
-
-                yield $key => $item;
-            }
-        });
-    }
-
-    /**
      * Create a new collection consisting of every n-th element.
      *
      * @param  int  $step
@@ -1132,6 +1111,42 @@ class LazyCollection implements Enumerable
                     $iterator->next();
                 }
             }
+        });
+    }
+
+    /**
+     * Take items in the collection until the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function takeUntil($value)
+    {
+        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
+
+        return new static(function () use ($callback) {
+            foreach ($this as $key => $item) {
+                if ($callback($item, $key)) {
+                    break;
+                }
+
+                yield $key => $item;
+            }
+        });
+    }
+
+    /**
+     * Take items in the collection while the given condition is met.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function takeWhile($value)
+    {
+        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
+
+        return $this->takeUntil(function ($item, $key) use ($callback) {
+            return ! $callback($item, $key);
         });
     }
 

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -65,6 +65,8 @@ trait EnumeratesValues
         'sortBy',
         'sortByDesc',
         'sum',
+        'takeUntil',
+        'takeWhile',
         'unique',
         'until',
     ];
@@ -720,6 +722,19 @@ trait EnumeratesValues
     public function uniqueStrict($key = null)
     {
         return $this->unique($key, true);
+    }
+
+    /**
+     * Take items in the collection until the given condition is met.
+     *
+     * This is an alias to the "takeUntil" method.
+     *
+     * @param  mixed  $key
+     * @return static
+     */
+    public function until($value)
+    {
+        return $this->takeUntil($value);
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1724,6 +1724,131 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testTakeUntilUsingValue($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $data = $data->takeUntil(3);
+
+        $this->assertSame([1, 2], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeUntilUsingCallback($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $data = $data->takeUntil(function ($item) {
+            return $item >= 3;
+        });
+
+        $this->assertSame([1, 2], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeUntilReturnsAllItemsForUnmetValue($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $actual = $data->takeUntil(99);
+
+        $this->assertSame($data->toArray(), $actual->toArray());
+
+        $actual = $data->takeUntil(function ($item) {
+            return $item >= 99;
+        });
+
+        $this->assertSame($data->toArray(), $actual->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeUntilCanBeProxied($collection)
+    {
+        $data = new $collection([
+            new TestSupportCollectionHigherOrderItem('Adam'),
+            new TestSupportCollectionHigherOrderItem('Taylor'),
+            new TestSupportCollectionHigherOrderItem('Jason'),
+        ]);
+
+        $actual = $data->takeUntil->is('Jason');
+
+        $this->assertCount(2, $actual);
+        $this->assertSame('Adam', $actual->get(0)->name);
+        $this->assertSame('Taylor', $actual->get(1)->name);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeWhileUsingValue($collection)
+    {
+        $data = new $collection([1, 1, 2, 2, 3, 3]);
+
+        $data = $data->takeWhile(1);
+
+        $this->assertSame([1, 1], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeWhileUsingCallback($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $data = $data->takeWhile(function ($item) {
+            return $item < 3;
+        });
+
+        $this->assertSame([1, 2], $data->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeWhileReturnsNoItemsForUnmetValue($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $actual = $data->takeWhile(2);
+
+        $this->assertSame([], $actual->toArray());
+
+        $actual = $data->takeWhile(function ($item) {
+            return $item == 99;
+        });
+
+        $this->assertSame([], $actual->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testTakeWhileCanBeProxied($collection)
+    {
+        $data = new $collection([
+            new TestSupportCollectionHigherOrderItem('Adam'),
+            new TestSupportCollectionHigherOrderItem('Adam'),
+            new TestSupportCollectionHigherOrderItem('Taylor'),
+            new TestSupportCollectionHigherOrderItem('Taylor'),
+        ]);
+
+        $actual = $data->takeWhile->is('Adam');
+
+        $this->assertCount(2, $actual);
+        $this->assertSame('Adam', $actual->get(0)->name);
+        $this->assertSame('Adam', $actual->get(1)->name);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMacroable($collection)
     {
         // Foo() macro : unique values starting with A
@@ -4092,68 +4217,6 @@ class SupportCollectionTest extends TestCase
             'b' => 2,
             'c' => 3,
         ], $data->all());
-    }
-
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testUntilUsingValue($collection)
-    {
-        $data = new $collection([1, 2, 3, 4]);
-
-        $data = $data->until(3);
-
-        $this->assertSame([1, 2], $data->toArray());
-    }
-
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testUntilUsingCallback($collection)
-    {
-        $data = new $collection([1, 2, 3, 4]);
-
-        $data = $data->until(function ($item) {
-            return $item >= 3;
-        });
-
-        $this->assertSame([1, 2], $data->toArray());
-    }
-
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testUntilReturnsAllItemsForUnmetValue($collection)
-    {
-        $data = new $collection([1, 2, 3, 4]);
-
-        $actual = $data->until(99);
-
-        $this->assertSame($data->toArray(), $actual->toArray());
-
-        $actual = $data->until(function ($item) {
-            return $item >= 99;
-        });
-
-        $this->assertSame($data->toArray(), $actual->toArray());
-    }
-
-    /**
-     * @dataProvider collectionClassProvider
-     */
-    public function testUntilCanBeProxied($collection)
-    {
-        $data = new $collection([
-            new TestSupportCollectionHigherOrderItem('Adam'),
-            new TestSupportCollectionHigherOrderItem('Taylor'),
-            new TestSupportCollectionHigherOrderItem('Jason'),
-        ]);
-
-        $actual = $data->until->is('Jason');
-
-        $this->assertCount(2, $actual);
-        $this->assertSame('Adam', $actual->get(0)->name);
-        $this->assertSame('Taylor', $actual->get(1)->name);
     }
 
     /**

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -989,6 +989,40 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testTakeUntilIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->takeUntil(INF);
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->takeUntil(10)->all();
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->takeUntil(function ($item) {
+                return $item === 10;
+            })->all();
+        });
+    }
+
+    public function testTakeWhileIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->takeWhile(0);
+        });
+
+        $this->assertEnumerates(1, function ($collection) {
+            $collection->takeWhile(0)->all();
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->takeWhile(function ($item) {
+                return $item < 10;
+            })->all();
+        });
+    }
+
     public function testTapDoesNotEnumerate()
     {
         $this->assertDoesNotEnumerate(function ($collection) {
@@ -1097,23 +1131,6 @@ class SupportLazyCollectionIsLazyTest extends TestCase
             $collection->unlessNotEmpty(function ($collection) {
                 // Silence is golden!
             });
-        });
-    }
-
-    public function testUntilIsLazy()
-    {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->until(INF);
-        });
-
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->until(10)->all();
-        });
-
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->until(function ($item) {
-                return $item === 10;
-            })->all();
         });
     }
 


### PR DESCRIPTION
In #32262, we added an `until` collection method.

That naming is quite unfortunate, given that `takeWhile` is practically an industry standard. It's used by Rails, Python, Haskell, Lodash, RxJS, Java, Kotlin, C#/LINQ and countless others.

In most cases, there are both `takeWhile` and `takeUntil` variants.

---

This PR introduces two new methods: `takeWhile` and `takeUntil`. The existing `until` method is now just an alias to `takeUntil`.

---

I would also propose marking `until` as deprecated, and switch the docs to only show `takeUntil` and `takeWhile`.