### PR TITLE
[8.x] Add pack and packAll to Collection

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1206,6 +1206,32 @@ class Collection implements ArrayAccess, Enumerable
         return new static($this->lazy()->takeWhile($value)->all());
     }
 
+    /*
+     * Get an item and pack it as another collection.
+     *
+     * @param  string  $key
+     * @param  array|null  $allowedKeys
+     * @return static
+     */
+    public function pack($key, array $allowedKeys = null)
+    {
+        return (new static($this->get($key)))->only($allowedKeys);
+    }
+
+    /**
+     * Get an array of items and pack them as individual collections.
+     *
+     * @param  string  $key
+     * @param  array|null  $allowedKeys
+     * @return static
+     */
+    public function packAll($key, array $allowedKeys = null)
+    {
+        return $this->pack($key)->map(function ($item) use ($key, $allowedKeys) {
+            return (new static($item))->only($allowedKeys);
+        });
+    }
+
     /**
      * Transform each item in the collection using a callback.
      *

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1666,6 +1666,79 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['taylor', 'dayle'], $data->all());
     }
 
+    public function testPackData()
+    {
+        $data = [
+            'settings' => [
+                'registrations' => 1,
+            ],
+        ];
+
+        $collection = new Collection($data);
+
+        $this->assertInstanceOf(Collection::class, $collection->pack('settings'));
+        $this->assertSame(['registrations' => 1], $collection->pack('settings')->all());
+    }
+
+    public function testPackDataWithSpecificKeys()
+    {
+        $data = [
+            'user' => [
+                'name' => 'Duilio',
+                'email' => 'duilio@example.com',
+                'is_admin' => 'true',
+            ],
+        ];
+
+        $collection = new Collection($data);
+
+        $expected = [
+            'name' => 'Duilio',
+            'email' => 'duilio@example.com',
+        ];
+        $this->assertSame($expected, $collection->pack('user', ['name', 'email'])->all());
+    }
+
+    public function testPackAllData()
+    {
+        $data = [
+            'posts' => [
+                ['title' => 'Laravel 8 released!'],
+                ['title' => 'New Collections component'],
+            ]
+        ];
+
+        $collection = new Collection($data);
+
+        $posts = $collection->packAll('posts');
+
+        $this->assertSame(['title' => 'Laravel 8 released!'], $posts->first()->all());
+        $this->assertSame(['title' => 'New Collections component'], $posts->last()->all());
+    }
+
+    public function testPackAllDataWithSpecificKeys()
+    {
+        $data = [
+            'posts' => [
+                [
+                    'id' => 123,
+                    'title' => 'Laravel 8 released!'
+                ],
+                [
+                    'title' => 'New Collections component',
+                    'status' => 'published'
+                ],
+            ]
+        ];
+
+        $collection = new Collection($data);
+
+        $posts = $collection->packAll('posts', ['title']);
+
+        $this->assertSame(['title' => 'Laravel 8 released!'], $posts->first()->all());
+        $this->assertSame(['title' => 'New Collections component'], $posts->last()->all());
+    }
+
     public function testPut()
     {
         $data = new Collection(['name' => 'taylor', 'email' => 'foo']);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1705,7 +1705,7 @@ class SupportCollectionTest extends TestCase
             'posts' => [
                 ['title' => 'Laravel 8 released!'],
                 ['title' => 'New Collections component'],
-            ]
+            ],
         ];
 
         $collection = new Collection($data);
@@ -1722,13 +1722,13 @@ class SupportCollectionTest extends TestCase
             'posts' => [
                 [
                     'id' => 123,
-                    'title' => 'Laravel 8 released!'
+                    'title' => 'Laravel 8 released!',
                 ],
                 [
                     'title' => 'New Collections component',
-                    'status' => 'published'
+                    'status' => 'published',
                 ],
-            ]
+            ],
         ];
 
         $collection = new Collection($data);


### PR DESCRIPTION
Allow a developer to get a sub-collection from an array of arrays:

```
$data = collect([
    'users' => [
        [
            'name' => 'Person 1',
            'email' => 'sample@example.com',
            'is_admin' => true,
        ]
    ],
    'settings' => [
         'registrations' => '1',
         'burn_server' => '1',
    ],
]);

$settings = $data->get('settings'); // returns a boring array 😞 
$settings = $data->pack('settings'); // returns a collection 👍 
$settings = $data->pack('settings', ['registrations']);
// returns a collection the specified keys 💃 

$users = $data->get('users'); // returns a plain array of arrays 😭 
$users = $data->packAll('users'); // returns a collection of collections 😄  
$users = $data->packAll('users', ['name', 'email']);
// returns a collection of collections with specific keys 🕺   
```

---

Following https://github.com/laravel/framework/pull/32379

This PR add two methods that should be very useful when dealing with nested validated data.

For example:

Assuming input looks like this:

```
$response = $this->post('/validate', [
    'users' => [
        [
            'name' => 'Person 1',
            'email' => 'sample@example.com',
            'is_admin' => true,
        ]
    ],
    'settings' => [
         'registrations' => '1',
         'burn_server' => '1',
    ],
]);
```

and validation looks like this:

```
$data = $request->validate([
        'users' => ['required', 'array'],
        'users.*' => ['required', 'array'],
        'users.*.name' => ['required'],
        'users.*.email' => ['required', 'email'],
        'users.*.password' => ['required', 'min:8'],
        'settings' => ['required', 'array:registrations'],
]);
```

`$data` will contain a `Validated` object that extends `Collection` but if we call `get` like this:

`$settings = $data->get('settings')` then `$settings` will be a plain array that cannot be passed to a model without `$fillable`.

But calling `$data->pack('settings')` will "pack" the underlying array as another instance of `Validated` that can be passed to a `Setting` model without fillable.

Furthermore, calling `$data->pack('settings', ['registrations', '...']);` will pack a new collection with whitelisted keys only.

Calling `$data->packAll('users')` will get a `Validated` collection containing `Validated` collections with users data.

Calling `$data->packAll('users', ['name', 'email', 'password'])` will get a `Validated` collection containing `Validated` collections of user data with *those 3 attributes only*.

The developer can choose whether to add more strict validation with:

`'users.*' => ['required', 'array:name,email,password'],` (https://github.com/laravel/framework/pull/32452)

or selecting specific keys just before "packing" the data to pass it to an Eloquent model or even to different Eloquent models!