### PR TITLE
[7.x] Add `withFragmentIdentifier` and `withoutFragmentIdentifier` methods to RedirectResponse

### DIFF
--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -159,7 +159,7 @@ class RedirectResponse extends BaseRedirectResponse
         // Strip superfluous "#" from the beginning of the fragment identifier
         $fragmentIdentifier = preg_replace('/^#/', '', $fragmentIdentifier);
 
-        return $this->setTargetUrl($this->getTargetUrl() . "#$fragmentIdentifier");
+        return $this->setTargetUrl($this->getTargetUrl()."#$fragmentIdentifier");
     }
 
     /**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -157,7 +157,7 @@ class RedirectResponse extends BaseRedirectResponse
         $this->withoutFragmentIdentifier();
 
         // Strip superfluous "#" from the beginning of the fragment identifier
-        $fragmentIdentifier = preg_replace('/^#/', '', $fragmentIdentifier);
+        $fragmentIdentifier = Str::after($fragmentIdentifier, '#');
 
         return $this->setTargetUrl($this->getTargetUrl()."#$fragmentIdentifier");
     }
@@ -169,7 +169,7 @@ class RedirectResponse extends BaseRedirectResponse
      */
     public function withoutFragmentIdentifier()
     {
-        return $this->setTargetUrl(explode('#', $this->getTargetUrl(), 2)[0]);
+        return $this->setTargetUrl(Str::before($this->getTargetUrl(), '#'));
     }
 
     /**

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -148,10 +148,10 @@ class RedirectResponse extends BaseRedirectResponse
     /**
      * Add fragment identifier to the url.
      *
-     * @param  string $fragmentIdentifier
+     * @param  string  $fragmentIdentifier
      * @return $this
      */
-    public function withFragmentIdentifier(string $fragmentIdentifier)
+    public function withFragmentIdentifier($fragmentIdentifier)
     {
         // Remove any existing fragment identifier
         $this->withoutFragmentIdentifier();

--- a/src/Illuminate/Http/RedirectResponse.php
+++ b/src/Illuminate/Http/RedirectResponse.php
@@ -146,6 +146,33 @@ class RedirectResponse extends BaseRedirectResponse
     }
 
     /**
+     * Add fragment identifier to the url.
+     *
+     * @param  string $fragmentIdentifier
+     * @return $this
+     */
+    public function withFragmentIdentifier(string $fragmentIdentifier)
+    {
+        // Remove any existing fragment identifier
+        $this->withoutFragmentIdentifier();
+
+        // Strip superfluous "#" from the beginning of the fragment identifier
+        $fragmentIdentifier = preg_replace('/^#/', '', $fragmentIdentifier);
+
+        return $this->setTargetUrl($this->getTargetUrl() . "#$fragmentIdentifier");
+    }
+
+    /**
+     * Remove any fragment identifier from the response url.
+     *
+     * @return $this
+     */
+    public function withoutFragmentIdentifier()
+    {
+        return $this->setTargetUrl(explode('#', $this->getTargetUrl(), 2)[0]);
+    }
+
+    /**
      * Parse the given errors into an appropriate value.
      *
      * @param  \Illuminate\Contracts\Support\MessageProvider|array|string  $provider

--- a/tests/Http/HttpRedirectResponseTest.php
+++ b/tests/Http/HttpRedirectResponseTest.php
@@ -52,6 +52,20 @@ class HttpRedirectResponseTest extends TestCase
         $this->assertSame('bar', $cookies[0]->getValue());
     }
 
+    public function testFragmentIdentifierOnRedirect()
+    {
+        $response = new RedirectResponse('foo.bar');
+
+        $response->withFragmentIdentifier('foo');
+        $this->assertSame('foo', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+
+        $response->withFragmentIdentifier('#bar');
+        $this->assertSame('bar', parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+
+        $response->withoutFragmentIdentifier();
+        $this->assertNull(parse_url($response->getTargetUrl(), PHP_URL_FRAGMENT));
+    }
+
     public function testInputOnRedirect()
     {
         $response = new RedirectResponse('foo.bar');


### PR DESCRIPTION
The _fragment identifier_ is the optional last part of a URL that comes after **#** (hash mark). It is often added to a URL to jump immediately to a particular section of the page.

This PR adds the methods `withFragmentIdentifier` and `withoutFragmentIdentifier` to `RedirectResponse` to make it easy to add, edit or remove the fragment identifier for a redirect.

This is useful if you need to redirect back to a particular section of a page:

```PHP
Route::post('user/profile', function () {
    // Handle the request

    return redirect('user')->withFragmentIdentifier('profile');
});
``` 

The fragment identifier may be given with or without a leading hash mark. That is, `withFragmentIdentifier('#profile')` is equivalent to `withFragmentIdentifier('profile')`.

The method name _withFragmentIdentifier_ may be problematic. Currently, calling that same method will flash session data with key "fragmentIdentifier". If that's an issue, we can perhaps change the name to something that doesn't start with "with". I chose that name as it conforms with the other fluent methods `withCookies`, `withInput`, `withErrors`, etc.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
