### PR TITLE
[8.x] Resolve component class with $attributes property

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -397,7 +397,7 @@ class ComponentTagCompiler
                                 ? "'{$attribute}' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute({$value})"
                                 : "'{$attribute}' => {$value}";
                 })
-                ->implode(',');
+                ->implode(', ');
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -189,7 +189,9 @@ class ComponentTagCompiler
 
             $class = AnonymousComponent::class;
         } else {
-            $parameters = $data->all();
+            $parameters = $data
+                ->put('attributes', '['.$this->attributesToString($attributes->all()).']')
+                ->all();
         }
 
         return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false).'])

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -32,30 +32,30 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="foo" limit="5" @click="foo" required /><x-alert /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>\n".
-"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+            "@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+            '@endcomponentClass </div>', trim($result));
     }
 
     public function testBasicComponentWithEmptyAttributesParsing()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => '','limit' => '','@click' => '','required' => true]])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+            '@endcomponentClass </div>', trim($result));
     }
 
     public function testDataCamelCasing()
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1','attributes' => []])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -64,7 +64,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1,'attributes' => []])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -73,7 +73,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['attributes' => ['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
     }
@@ -82,7 +82,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x-foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('foo:alert'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -91,7 +91,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x:foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('foo:alert'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -100,10 +100,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert/></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+            '@endcomponentClass </div>', trim($result));
     }
 
     public function testClassNamesCanBeGuessed()
@@ -140,27 +140,27 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
-'@endcomponentClass', trim($result));
+            '@endcomponentClass', trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiledWithDataAndAttributes()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo','attributes' => ['class' => 'bar','wire:model' => 'foo']])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
-'@endcomponentClass', trim($result));
+            '@endcomponentClass', trim($result));
     }
 
     public function testComponentsCanHaveAttachedWord()
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile></x-profile>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['attributes' => []])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
     }
@@ -169,20 +169,20 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert/>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass Words', trim($result));
+            '@endcomponentClass Words', trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiledWithBoundData()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert :title="$title" class="bar" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title,'attributes' => ['class' => 'bar']])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar']); ?>\n".
-'@endcomponentClass', trim($result));
+            '@endcomponentClass', trim($result));
     }
 
     public function testPairedComponentTags()
@@ -190,7 +190,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert>
 </x-alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
@@ -210,7 +210,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
 <?php \$component->withName('anonymous-component'); ?>
 <?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
-'@endcomponentClass', trim($result));
+            '@endcomponentClass', trim($result));
     }
 
     public function testAttributeSanitization()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -32,30 +32,30 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="foo" limit="5" @click="foo" required /><x-alert /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => 'foo', 'limit' => '5', '@click' => 'foo', 'required' => true]])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>\n".
-            "@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
+<?php \$component->withAttributes(['type' => 'foo', 'limit' => '5', '@click' => 'foo', 'required' => true]); ?>\n".
+"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-            '@endcomponentClass </div>', trim($result));
+'@endcomponentClass </div>', trim($result));
     }
 
     public function testBasicComponentWithEmptyAttributesParsing()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => '','limit' => '','@click' => '','required' => true]])
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['type' => '', 'limit' => '', '@click' => '', 'required' => true]])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
-            '@endcomponentClass </div>', trim($result));
+<?php \$component->withAttributes(['type' => '', 'limit' => '', '@click' => '', 'required' => true]); ?>\n".
+'@endcomponentClass </div>', trim($result));
     }
 
     public function testDataCamelCasing()
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1','attributes' => []])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1', 'attributes' => []])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -64,7 +64,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1,'attributes' => []])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1, 'attributes' => []])
 <?php \$component->withName('profile'); ?>
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
@@ -103,7 +103,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-            '@endcomponentClass </div>', trim($result));
+'@endcomponentClass </div>', trim($result));
     }
 
     public function testClassNamesCanBeGuessed()
@@ -140,20 +140,20 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => ['class' => 'bar', 'wire:model' => 'foo', 'x-on:click' => 'bar', '@click' => 'baz']])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
-            '@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['class' => 'bar', 'wire:model' => 'foo', 'x-on:click' => 'bar', '@click' => 'baz']); ?>\n".
+'@endcomponentClass', trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiledWithDataAndAttributes()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo','attributes' => ['class' => 'bar','wire:model' => 'foo']])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo', 'attributes' => ['class' => 'bar', 'wire:model' => 'foo']])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
-            '@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['class' => 'bar', 'wire:model' => 'foo']); ?>\n".
+'@endcomponentClass', trim($result));
     }
 
     public function testComponentsCanHaveAttachedWord()
@@ -172,17 +172,17 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['attributes' => []])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes([]); ?>\n".
-            '@endcomponentClass Words', trim($result));
+'@endcomponentClass Words', trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiledWithBoundData()
     {
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert :title="$title" class="bar" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title,'attributes' => ['class' => 'bar']])
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title, 'attributes' => ['class' => 'bar']])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar']); ?>\n".
-            '@endcomponentClass', trim($result));
+'@endcomponentClass', trim($result));
     }
 
     public function testPairedComponentTags()
@@ -207,10 +207,10 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = (new ComponentTagCompiler([]))->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component', 'data' => ['name' => 'Taylor', 'age' => 31, 'wire:model' => 'foo']])
 <?php \$component->withName('anonymous-component'); ?>
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
-            '@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'), 'age' => 31, 'wire:model' => 'foo']); ?>\n".
+'@endcomponentClass', trim($result));
     }
 
     public function testAttributeSanitization()


### PR DESCRIPTION
This small change allows one to type hint the $attributes parameter in the class constructor. This parameter contains an array of all attributes that were passed to this component.

```blade
<x-test-subject :foo="'bar'" baz="cookies" />
```
```php
<?php

namespace App\View\Components;

class TestSubject extends Base
{
    public function __construct($attributes)
    {
        dump($attributes); // contains ['foo' => 'bar', 'baz' => 'cookies']
    }
}

```

As this change reserves the `$attribute` parameter name it's technically breaking, although it's pretty small, so not sure whether this is major or minor feature.

I will adjust the tests if this PR gets a green light.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
