### PR TITLE
[8.x] Move contracts

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -4,10 +4,13 @@ namespace Illuminate\Collections;
 
 use ArrayAccess;
 use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Macroable\Macroable;
+use JsonSerializable;
 use stdClass;
 
-class Collection implements ArrayAccess, Enumerable
+class Collection implements Arrayable, ArrayAccess, Enumerable, Jsonable, JsonSerializable
 {
     use EnumeratesValues, Macroable;
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -3,12 +3,9 @@
 namespace Illuminate\Collections;
 
 use Countable;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Contracts\Support\Jsonable;
 use IteratorAggregate;
-use JsonSerializable;
 
-interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, JsonSerializable
+interface Enumerable extends Countable, IteratorAggregate
 {
     /**
      * Create a new collection instance if the value isn't one already.

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -4,11 +4,14 @@ namespace Illuminate\Collections;
 
 use ArrayIterator;
 use Closure;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Macroable\Macroable;
 use IteratorAggregate;
+use JsonSerializable;
 use stdClass;
 
-class LazyCollection implements Enumerable
+class LazyCollection implements Arrayable, Enumerable, Jsonable, JsonSerializable
 {
     use EnumeratesValues, Macroable;
 


### PR DESCRIPTION
It doesn't really makes sense that Enumerable is also array accesible or has anything to do with JSON manipulations. These interfaces should be defined on the implementing class.

It does makes sense however to keep Countable and IteratorAggregate as we're still talking about collections here. But we shouldn't force people to also implement ArrayAccess or also any JSON contracts.

Doing this on 8.x with the new collections component is a good moment to do this.

@JosephSilber does this seem reasonable to you?