### PR TITLE
[7.x] Fix error message in TestResponse::assertStatus

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -181,8 +181,8 @@ class TestResponse implements ArrayAccess
         $actual = $this->getStatusCode();
 
         PHPUnit::assertSame(
-            $actual, $status,
-            "Expected status code {$status} but received {$actual}."
+            $status, $actual,
+            "Response status code [{$actual}] does not match expected {$status} status code."
         );
 
         return $this;


### PR DESCRIPTION
Currently the expected vs actual arguments are swapped resulting in somewhat conflicting error messages.
![image](https://user-images.githubusercontent.com/8465957/80085039-02464f80-8558-11ea-962f-2aa84473e65b.png)

This PR will bring the error message in line with other helpers such as `assertUnauthorized()`.