### PR TITLE
[7.x] Fix compiled route actions without a namespace

### DIFF
--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -210,7 +210,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
     {
         $attributes = collect($this->attributes)->first(function (array $attributes) use ($action) {
             if (isset($attributes['action']['controller'])) {
-                return $attributes['action']['controller'] === $action;
+                return trim($attributes['action']['controller'], '\\') === $action;
             }
 
             return $attributes['action']['uses'] === $action;

--- a/tests/Integration/Routing/CompiledRouteCollectionTest.php
+++ b/tests/Integration/Routing/CompiledRouteCollectionTest.php
@@ -407,6 +407,15 @@ class CompiledRouteCollectionTest extends TestCase
         $this->assertSame('foo/bar', $route->uri());
     }
 
+    public function testRouteWithoutNamespaceIsFound()
+    {
+        $this->routeCollection->add($this->newRoute('GET', 'foo/bar', ['controller' => '\App\FooController']));
+
+        $route = $this->collection()->getByAction('App\FooController');
+
+        $this->assertSame('foo/bar', $route->uri());
+    }
+
     public function testGroupPrefixAndRoutePrefixAreProperlyHandled()
     {
         $this->routeCollection->add($this->newRoute('GET', 'foo/bar', ['uses' => 'FooController@index', 'prefix' => '{locale}'])->prefix('pre'));


### PR DESCRIPTION
Currently when using invokeable controllers in actions, using compiled routes will not work properly.

For example

```
action(\Spatie\MailcoachSesFeedback\SesWebhookController::class)
```

Will look in the compiled routes for a controller `Spatie\MailcoachSesFeedback\SesWebhookController` because of the `trim` here https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/UrlGenerator.php#L480

But inside the compiled routes, the route gets saved as `\Spatie\MailcoachSesFeedback\SesWebhookController`

So to correctly match the compiled routes against the action we want, we also have to trim that backslash when comparing.