### PR TITLE
[7.x] Provide syntactic sugar for contextually binding tagged services

### DIFF
--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -66,4 +66,19 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
             $this->container->addContextualBinding($concrete, $this->needs, $implementation);
         }
     }
+
+    /**
+     * Define tagged services to be used as the implementation for the contextual binding.
+     *
+     * @param  string  $tag
+     * @return void
+     */
+    public function giveTagged($tag)
+    {
+        $this->give(function ($container) use ($tag) {
+            $taggedServices = $container->tagged($tag);
+
+            return is_array($taggedServices) ? $taggedServices : iterator_to_array($taggedServices);
+        });
+    }
 }

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -301,6 +301,64 @@ class ContextualBindingTest extends TestCase
         $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
         $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
     }
+
+    public function testContextualBindingGivesTagsForArrayWithNoTagsDefined()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectArray::class)->needs('$stubs')->giveTagged('stub');
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectArray::class);
+
+        $this->assertCount(0, $resolvedInstance->stubs);
+    }
+
+    public function testContextualBindingGivesTagsForVariadicWithNoTagsDefined()
+    {
+        $container = new Container;
+
+        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->giveTagged('stub');
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadic::class);
+
+        $this->assertCount(0, $resolvedInstance->stubs);
+    }
+
+    public function testContextualBindingGivesTagsForArray()
+    {
+        $container = new Container;
+
+        $container->tag([
+            ContainerContextImplementationStub::class,
+            ContainerContextImplementationStubTwo::class,
+        ], ['stub']);
+
+        $container->when(ContainerTestContextInjectArray::class)->needs('$stubs')->giveTagged('stub');
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectArray::class);
+
+        $this->assertCount(2, $resolvedInstance->stubs);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
+    }
+
+    public function testContextualBindingGivesTagsForVariadic()
+    {
+        $container = new Container;
+
+        $container->tag([
+            ContainerContextImplementationStub::class,
+            ContainerContextImplementationStubTwo::class,
+        ], ['stub']);
+
+        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->giveTagged('stub');
+
+        $resolvedInstance = $container->make(ContainerTestContextInjectVariadic::class);
+
+        $this->assertCount(2, $resolvedInstance->stubs);
+        $this->assertInstanceOf(ContainerContextImplementationStub::class, $resolvedInstance->stubs[0]);
+        $this->assertInstanceOf(ContainerContextImplementationStubTwo::class, $resolvedInstance->stubs[1]);
+    }
 }
 
 interface IContainerContextContractStub
@@ -382,6 +440,16 @@ class ContainerTestContextWithOptionalInnerDependency
     public function __construct(ContainerTestContextInjectOne $inner = null)
     {
         $this->inner = $inner;
+    }
+}
+
+class ContainerTestContextInjectArray
+{
+    public $stubs;
+
+    public function __construct(array $stubs)
+    {
+        $this->stubs = $stubs;
     }
 }
 


### PR DESCRIPTION
Handling tagged services feels heavier than it needs to be.

Currently, we can use primitive binding for primitive (`array`) constructor arguments to avoid having to use a factory for the whole class. That's a plus.

However, they almost always look the same:

```php
$this->app->when(WantFactory::class)
    ->needs('$wantConfigurers')
    ->give(function ($container) {
        return iterator_to_array($container->tagged('want_configurer'));
    });
```

There are some weird oddities with `Container::tagged`, though. So, even if one figures out they can use `iterator_to_array` to convert the response into something that can be consumed of the receiving object's constructor, it might not *always* work.

This is because `Container::tagged` returns an array early if nothing has been tagged with the tag in question:

```php
if (! isset($this->tags[$tag])) {
    return [];
}
```

So, to be safe, one would need to be more specific by doing something like this:

```php
$this->app->when(WantFactory::class)
    ->needs('$wantConfigurers')
    ->give(function ($container) {
        $services = $container->tagged('want_configurer');

        return is_array($services) ? $services : iterator_to_array($services);
    });
```

It is easy to get it wrong. It is easy to end up in a situation where it works until it doesn't.

It could be easier.

----

Tagged services are baked into the Container as first-class citizens. By extending the Contextual Binding Builder with a bit of sugar, we can simplify this common task:

```php
$this->app->when(WantFactory::class)
    ->needs('$wantConfigurers') // primitive binding w/ array type
    ->giveTagged('want_configurer');
```

Building on the new variadic constructor argument support, this can also be used to satisfy typed variadic constructor arguments as well:

```php
$this->app->when(WantFactory::class)
    ->needs(WantConfigurer::class) // variadic binding w/ WantConfigurer type
    ->giveTagged('want_configurer');
```

If you are using a variadic constructor argument and are using the type as a tag (something I've started to do more often) you can do this:

```php
$this->app->when(WantFactory::class)
    ->needs(WantConfigurer::class) // variadic binding w/ WantConfigurer type
    ->giveTagged(WantConfigurer::class);
```

~~Taking it to the next level, if someone wants to `giveTagged` and haven't set a `needs`, we can use the tag as the assumed abstract. That looks like this:~~

> ~~$this->app->when(WantFactory::class)->giveTagged(WantConfigurer::class); ~~

This PR makes these last ~~four~~ three configuration options possible.

----

~~`When -> Needs -> Gives` reads so nicely. `When -> Gives`, not so much. As such, I'm not sold on the inclusion of the last configuration option presented. Which is why it is in an isolated commit in this PR. :) Easy to drop if the rest is acceptable.~~

