### PR TITLE
[7.x] Support PostgreSQL operator containing a question mark using PHP 7.4

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -753,9 +753,9 @@ class Builder
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-		if (strpos($operator, '?') > -1) {
-			$operator = str_replace('?', '??', $operator);
-		}
+        if (strpos($operator, '?') > -1) {
+            $operator = str_replace('?', '??', $operator);
+        }
 
         return [$value, $operator];
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -753,7 +753,11 @@ class Builder
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, str_replace('?', '??', $operator)];
+		if (strpos($operator, '?') > -1) {
+			$operator = str_replace('?', '??', $operator);
+		}
+
+        return [$value, $operator];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -753,7 +753,7 @@ class Builder
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        if (strpos($operator, '?') > -1) {
+        if (strpos($operator, '?') !== false) {
             $operator = str_replace('?', '??', $operator);
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -753,7 +753,7 @@ class Builder
             throw new InvalidArgumentException('Illegal operator and value combination.');
         }
 
-        return [$value, $operator];
+        return [$value, str_replace('?', '??', $operator)];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -17,7 +17,7 @@ class PostgresGrammar extends Grammar
         '=', '<', '>', '<=', '>=', '<>', '!=',
         'like', 'not like', 'between', 'ilike', 'not ilike',
         '~', '&', '|', '#', '<<', '>>', '<<=', '>>=',
-        '&&', '@>', '<@', '?', '?|', '?&', '||', '-', '-', '#-',
+        '&&', '@>', '<@', '??', '??|', '??&', '||', '-', '-', '#-',
         'is distinct from', 'is not distinct from',
     ];
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3626,8 +3626,8 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
-	public function testFromQuestionMarkOperatorOnPostgresqlServer()
-	{
+    public function testFromQuestionMarkOperatorOnPostgresqlServer()
+    {
         $operators = ['?' => '??', '?|' => '??|', '?&' => '??&'];
 
         foreach ($operators as $raw => $operator) {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3626,6 +3626,18 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
+	public function testFromQuestionMarkOperatorOnPostgresqlServer()
+	{
+        $operators = ['?' => '??', '?|' => '??|', '?&' => '??&'];
+
+        foreach ($operators as $raw => $operator) {
+            $builder = $this->getPostgresBuilder();
+            $builder->where('hstore_name', $raw, 'hstore_key');
+
+            $this->assertSame("select * where \"hstore_name\" {$operator} ?", $builder->toSql());
+        }
+    }
+
     protected function getBuilder()
     {
         $grammar = new Grammar;


### PR DESCRIPTION
Since the arrival of PHP 7.4, it is now possible to use special PostgreSQL operators such as `?`, `?|` or `?&`. This PR, therefore, includes the use of these operators by doubling the question mark.

```php
\App\User::where('roles', '?', 'admin')->get();

// ->toSql()       select * from "users" where "roles" ?? ?
// ->getBindings() ['admin']
```

For PHP < 7.4, operators don't work anyway, the use of operator functions is mandatory.

---

- https://wiki.php.net/rfc/pdo_escape_placeholders ;