### PR TITLE
[7.x] Deprecate `until`

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -731,6 +731,8 @@ trait EnumeratesValues
      *
      * @param  mixed  $key
      * @return static
+     *
+     * @deprecated Use the "takeUntil" method directly.
      */
     public function until($value)
     {


### PR DESCRIPTION
People should be using the [`takeUntil`](https://github.com/laravel/framework/pull/32496) method directly.