### PR TITLE
[7.x] Changed $data to mixed in json() and jsonp() DocBlocks

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -37,7 +37,7 @@ interface ResponseFactory
     /**
      * Create a new JSON response instance.
      *
-     * @param  string|array|object  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options
@@ -49,7 +49,7 @@ interface ResponseFactory
      * Create a new JSONP response instance.
      *
      * @param  string  $callback
-     * @param  string|array|object  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options


### PR DESCRIPTION
Currently using `response()->json($data)` or `response()->jsonp($data)` can throw an error if `$data` type's not `string|array|object` (e.g. `null`, `boolean`, `int`, `float`) during static analysis.

[`ResponseFactory` interface](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Contracts/Routing/ResponseFactory.php#L40) uses `string|array|object` typehint for `$data`, but [`ResponseFactory` class](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/ResponseFactory.php#L91) uses `mixed` as typehint for `$data`.

This PR modifies `ResponseFactory` interface `$data` DocBlock typehint to match `ResponseFactory` class typehint.

```php
response()->json(true);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json() expects array|object|string, bool given.

response()->json(null);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json() expects array|object|string, null given.

response()->json(1);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json() expects array|object|string, int given.  
```