### PR TITLE
[8.x] Add extend option to Atomic Locks 

### DIFF
--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -47,7 +47,7 @@ class DynamoDbLock extends Lock
      */
     public function extend($seconds)
     {
-        $this->dynamo->
+        // to be implemented
     }
 
     /**

--- a/src/Illuminate/Cache/DynamoDbLock.php
+++ b/src/Illuminate/Cache/DynamoDbLock.php
@@ -40,6 +40,17 @@ class DynamoDbLock extends Lock
     }
 
     /**
+     * Extend the lock.
+     *
+     * @param int $seconds
+     * @return bool
+     */
+    public function extend($seconds)
+    {
+        $this->dynamo->
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -59,6 +59,14 @@ abstract class Lock implements LockContract
     abstract public function acquire();
 
     /**
+     * Extend the lock.
+     *
+     * @param int $seconds
+     * @return bool
+     */
+    abstract public function extend($seconds);
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/MemcachedLock.php
+++ b/src/Illuminate/Cache/MemcachedLock.php
@@ -40,6 +40,17 @@ class MemcachedLock extends Lock
     }
 
     /**
+     * Extend the lock.
+     *
+     * @param int $seconds
+     * @return bool
+     */
+    public function extend($seconds)
+    {
+        $this->memcached->touch($this->name, $this->seconds);
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool

--- a/src/Illuminate/Cache/MemcachedLock.php
+++ b/src/Illuminate/Cache/MemcachedLock.php
@@ -47,7 +47,7 @@ class MemcachedLock extends Lock
      */
     public function extend($seconds)
     {
-        $this->memcached->touch($this->name, $this->seconds);
+        return $this->memcached->touch($this->name, $this->seconds);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -42,13 +42,24 @@ class RedisLock extends Lock
     }
 
     /**
+     * Extend the lock.
+     *
+     * @param int $seconds
+     * @return bool
+     */
+    public function extend($seconds)
+    {
+        return $this->redis->command('expire', [$this->name]);
+    }
+
+    /**
      * Release the lock.
      *
      * @return bool
      */
     public function release()
     {
-        return (bool) $this->redis->eval(LuaScripts::releaseLock(), 1, $this->name, $this->owner);
+        return (bool)$this->redis->eval(LuaScripts::releaseLock(), 1, $this->name, $this->owner);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -49,7 +49,7 @@ class RedisLock extends Lock
      */
     public function extend($seconds)
     {
-        return $this->redis->command('expire', [$this->name]);
+        return (bool)$this->redis->expire($this->name);
     }
 
     /**


### PR DESCRIPTION
This PR adds support for extending existing atomic locks.

Adapters to implement:

- [x] Redis
- [x] Memcached
- [ ] DynamoDB

## Use case

Imagine a support system, where only one agent at a time, can work on a case.

When implementing this with atomic locks, you would want to lock a case for 30 seconds, and have the page poll every 15 seconds. That poll request should be able to extend the existing lock. 

When the agent leaves the page, the case will automatically be unlocked as soon as the lock expires.

## Help wanted
I'm not experiences with DynamoDB, so I can't figure out how to easily extend the TTL of a record. Perhaps someone else wishes to share their wisdom?