### PR TITLE
[6.x] Fix firstWhere behavior for relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -575,6 +575,20 @@ class BelongsToMany extends Relation
     }
 
     /**
+     * Add a basic where clause to the query, and return the first result.
+     *
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->first();
+    }
+
+    /**
      * Execute the query and get the first result.
      *
      * @param  array  $columns

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -247,6 +247,20 @@ class HasManyThrough extends Relation
     }
 
     /**
+     * Add a basic where clause to the query, and return the first result.
+     *
+     * @param  \Closure|string|array  $column
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @param  string  $boolean
+     * @return \Illuminate\Database\Eloquent\Model|static
+     */
+    public function firstWhere($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        return $this->where($column, $operator, $value, $boolean)->first();
+    }
+
+    /**
      * Execute the query and get the first related model.
      *
      * @param  array  $columns

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -629,6 +629,22 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
         $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
     }
 
+    public function testFirstWhere()
+    {
+        $tag = Tag::create(['name' => 'foo']);
+        $post = Post::create(['title' => Str::random()]);
+
+        DB::table('posts_tags')->insert([
+            ['post_id' => $post->id, 'tag_id' => $tag->id, 'flag' => 'foo'],
+        ]);
+
+        $relationTag = $post->tags()->firstWhere('name', 'foo');
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+
+        $relationTag = $post->tags()->firstWhere('name', '=', 'foo');
+        $this->assertEquals($relationTag->getAttributes(), $tag->getAttributes());
+    }
+
     public function testWherePivotOnBoolean()
     {
         $tag = Tag::create(['name' => Str::random()]);

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -50,13 +50,25 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
         $team1 = Team::create(['id' => 10, 'owner_id' => $user->id]);
         $team2 = Team::create(['owner_id' => $user->id]);
 
-        $mate1 = User::create(['name' => Str::random(), 'team_id' => $team1->id]);
-        $mate2 = User::create(['name' => Str::random(), 'team_id' => $team2->id]);
+        $mate1 = User::create(['name' => 'John', 'team_id' => $team1->id]);
+        $mate2 = User::create(['name' => 'Jack', 'team_id' => $team2->id, 'slug' => null]);
 
         User::create(['name' => Str::random()]);
 
         $this->assertEquals([$mate1->id, $mate2->id], $user->teamMates->pluck('id')->toArray());
         $this->assertEquals([$user->id], User::has('teamMates')->pluck('id')->toArray());
+
+        $result = $user->teamMates()->first();
+        $this->assertEquals(
+            $mate1->refresh()->getAttributes() + ['laravel_through_key' => '1'],
+            $result->getAttributes()
+        );
+
+        $result = $user->teamMates()->firstWhere('name', 'Jack');
+        $this->assertEquals(
+            $mate2->refresh()->getAttributes() + ['laravel_through_key' => '1'],
+            $result->getAttributes()
+        );
     }
 
     public function testGlobalScopeColumns()


### PR DESCRIPTION
This PR fixes the `firstWhere` behavior for `BelongsToMany` relations and `HasManyThrough`. Previous behavior caused attributes from the pivot table to also be placed on the retrieved model and subsequently overwrite attributes.

Fixes https://github.com/laravel/framework/issues/32464