### PR TITLE
[7.x] Using Implicit Binding Custom Key with JSON type column

### DIFF
--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -39,7 +39,7 @@ class RouteUri
      */
     public static function parse($uri)
     {
-        preg_match_all('/\{([\w\:]+?)\??\}/', $uri, $matches);
+        preg_match_all('/\{([\w\:\->]+?)\??\}/', $uri, $matches);
 
         $bindingFields = [];
 

--- a/tests/Routing/RouteUriTest.php
+++ b/tests/Routing/RouteUriTest.php
@@ -32,5 +32,21 @@ class RouteUriTest extends TestCase
         $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug?}/{test:id?}');
         $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
         $this->assertEquals(['qux' => 'slug', 'test' => 'id'], $parsed->bindingFields);
+
+        $parsed = RouteUri::parse('/foo/{bar:slug->en}');
+        $this->assertSame('/foo/{bar}', $parsed->uri);
+        $this->assertEquals(['bar' => 'slug->en'], $parsed->bindingFields);
+
+        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug->en}');
+        $this->assertSame('/foo/{bar}/baz/{qux}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug->en'], $parsed->bindingFields);
+
+        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug->en?}');
+        $this->assertSame('/foo/{bar}/baz/{qux?}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug->en'], $parsed->bindingFields);
+
+        $parsed = RouteUri::parse('/foo/{bar}/baz/{qux:slug->en?}/{test:id?}');
+        $this->assertSame('/foo/{bar}/baz/{qux?}/{test?}', $parsed->uri);
+        $this->assertEquals(['qux' => 'slug->en', 'test' => 'id'], $parsed->bindingFields);
     }
 }


### PR DESCRIPTION
I changed the regex to accept also the '->' for JSON type column.

I'm using a lot of JSON type columns for multilang purposes but the implicit binding with custom key doesn't work with JSON type.

With this pull request you can use implicit binding with custom JSON key like this : 
`Route::get('posts/{post:slug->en}',function(\App\Post $post){
    // Your code
});`




