### PR TITLE
[7.x] Reset select bindings when setting select

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -225,6 +225,7 @@ class Builder
     public function select($columns = ['*'])
     {
         $this->columns = [];
+        $this->bindings['select'] = [];
 
         $columns = is_array($columns) ? $columns : func_get_args();
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3024,6 +3024,22 @@ SQL;
         $builder->selectSub(['foo'], 'sub');
     }
 
+    public function testSubSelectResetBindings()
+    {
+        $builder = $this->getPostgresBuilder();
+        $builder->from('one')->selectSub(function ($query) {
+            $query->from('two')->select('baz')->where('subkey', '=', 'subval');
+        }, 'sub');
+
+        $this->assertEquals('select (select "baz" from "two" where "subkey" = ?) as "sub" from "one"', $builder->toSql());
+        $this->assertEquals(['subval'], $builder->getBindings());
+
+        $builder->select('*');
+
+        $this->assertEquals('select * from "one"', $builder->toSql());
+        $this->assertEquals([], $builder->getBindings());
+    }
+
     public function testSqlServerWhereDate()
     {
         $builder = $this->getSqlServerBuilder();


### PR DESCRIPTION
fixes https://github.com/laravel/framework/issues/32526

---

This PR resets the select bindings when the select clause is set to something else.

Most operations on the Query Builder are additive: when you have an instance of it, and you call `->where('column', 'value')` on it, the clause is added to the underlying query.

This also works with sub-queries: bindings are merged into the query. Take for example this `orderBy()`:

```php
User::orderBy(
    Book::whereColumn('users.id', 'user_id')
        ->where('has_valid_isbn', true)
        ->select(DB::raw('count(*)'))
)->orderBy('created_at');

// select * from "users" 
// order by
//     (select count(*) from "books" where "users"."id" = "user_id" and "has_valid_isbn" = ?) asc, 
//     "created_at" asc"

// Bindings: [true]
```

Setting a select query, however, overwrites previous selects. (Use `addSelect()` when you want to add.)

```php
$builder = Book::select('title');
$builder->toSql(); //  select "title" from "books"
$builder->select('*');
$builder->toSql(); //  select * from "books"
$builder->addSelect('title');
$builder->toSql(); //  select *, "title" from "books"
```

When using a subquery in the select clause, registered bindings would currently stay in the query. MySQL 8.0 seems to be fine with that, but Postgres gives an error when this happens.

```php
>>> $query = App\User::withCount('books');
=> Illuminate\Database\Eloquent\Builder {#3013}
>>> $query->toSql();
=> "select "users".*, (select count(*) from "books" where "users"."id" = "books"."user_id" and "has_valid_isbn" = ?) as "books_count" from "users""
>>> $query->getBindings();
=> [
     true,
   ]
>>> $query->select('*')->toSql();
=> "select * from "users""
>>> $query->select('*')->getBindings();
=> [
     true,
   ]
>>> $query->select('*')->get();
Illuminate/Database/QueryException with message 'SQLSTATE[08P01]: <<Unknown error>>: 7 ERROR:  bind message supplies 1 parameters, but prepared statement "pdo_stmt_00000003" requires 0 (SQL: select * from "users")
```

This PR fixes that by setting the bindings for the select part of the queries to an empty array when an overwriting `->select()` call is made.