### PR TITLE
[7.x] Performance improvements

### DIFF
--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -309,6 +309,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
         foreach ($this->messages as $key => $message) {
             $attributes[explode('.', $key)[0]] = $key;
         }
+
         return $attributes;
     }
 

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -299,6 +299,20 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     }
 
     /**
+     * Generate an array of all attributes that have messages.
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        $attributes = [];
+        foreach ($this->messages as $key => $message) {
+            $attributes[explode('.', $key)[0]] = $key;
+        }
+        return $attributes;
+    }
+
+    /**
      * Get the default message format.
      *
      * @return string

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -180,6 +180,7 @@ class ValidationRuleParser
             foreach ((array) $attribute as $innerAttribute => $innerRules) {
                 $all[$innerRules] = head($this->explodeRules([$innerRules]));
             }
+
             return $all;
         }
 

--- a/src/Illuminate/Validation/ValidationRuleParser.php
+++ b/src/Illuminate/Validation/ValidationRuleParser.php
@@ -133,7 +133,9 @@ class ValidationRuleParser
                 foreach ((array) $rules as $rule) {
                     $this->implicitAttributes[$attribute][] = strval($key);
 
-                    $results = $this->mergeRules($results, $key, $rule);
+                    foreach ($this->getRules($key, $rule) as $rKey => $rVal) {
+                        $results[$rKey] = $rVal;
+                    }
                 }
             }
         }
@@ -162,6 +164,26 @@ class ValidationRuleParser
         return $this->mergeRulesForAttribute(
             $results, $attribute, $rules
         );
+    }
+
+    /**
+     * Get rules of a given attribute(s).
+     *
+     * @param  string|array  $attribute
+     * @param  string|array  $rules
+     * @return array
+     */
+    public function getRules($attribute, $rules = [])
+    {
+        if (is_array($attribute)) {
+            $all = [];
+            foreach ((array) $attribute as $innerAttribute => $innerRules) {
+                $all[$innerRules] = head($this->explodeRules([$innerRules]));
+            }
+            return $all;
+        }
+
+        return [$attribute => head($this->explodeRules([$rules]))];
     }
 
     /**


### PR DESCRIPTION
This PR improve asymptotic algorithmic complexity of validation, the speed-up is more than a constant number and it depends on the input size.

Validation tests are passed in my system. I don't know if they break anything. It should be backported to LTS versions. I don't regard this as a breaking change, but you may decide to choose portion of it for version 7, 6, and 5.5.
The performance may still be poor in some cases. But other improvements may require breaking changes or bigger changes.