### PR TITLE
[7.x] Add alias get() method to Stringable

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -214,7 +214,7 @@ class Stringable
     {
         return $this->__toString();
     }
-    
+
     /**
      * Determine if a given string matches a given pattern.
      *

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -206,6 +206,16 @@ class Stringable
     }
 
     /**
+     * Get the raw string value.
+     *
+     * @return string
+     */
+    public function get()
+    {
+        return $this->__toString();
+    }
+    
+    /**
      * Determine if a given string matches a given pattern.
      *
      * @param  string|array  $pattern

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -484,9 +484,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame(3, $this->stringable('laravelPHPFramework')->substrCount('a', 1, -2));
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
-    
+
     public function testGet()
     {
         $this->assertEquals('Laravel', $this->stringable('Laravel')->get());
-    }    
+    }
 }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -484,4 +484,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame(3, $this->stringable('laravelPHPFramework')->substrCount('a', 1, -2));
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
+    
+    public function testGet()
+    {
+        $this->assertEquals('Laravel', $this->stringable('Laravel')->get());
+    }    
 }


### PR DESCRIPTION
This PR adds a `get()` alias method to `Illuminate\Support\Stringable`, which simply defers to the already present `__toString()` method.

```php
// Before
(string) Str::of('Laravel')->append(' 7');
Str::of('Laravel')->append(' 7')->__toString();

// After
Str::of('Laravel')->append(' 7')->get();
```

My reasoning for this, is that it's a little awkward to have to write code that either needs to cast the instance to a string or use `__toString()`, which kind of *feels* like an internal method.

Also, since Laravel developers are so used to using `get()` on chainable classes e.g. collections, query builders etc. adding it to `Stringable` seems like an easy win.