### PR TITLE
[7.x] Add IrreversibleMigrationException to prevent migrate:rollback

### DIFF
--- a/src/Illuminate/Database/Migrations/IrreversibleMigrationException.php
+++ b/src/Illuminate/Database/Migrations/IrreversibleMigrationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Database\Migrations;
+
+use Exception;
+
+/**
+ * Exception to be thrown in the down() methods of migrations that signifies it
+ * is an irreversible migration and stops execution.
+ */
+class IrreversibleMigrationException extends Exception
+{
+}

--- a/src/Illuminate/Database/Migrations/Migration.php
+++ b/src/Illuminate/Database/Migrations/Migration.php
@@ -27,4 +27,18 @@ abstract class Migration
     {
         return $this->connection;
     }
+
+    /**
+     * @param string|null $message
+     *
+     * @throws IrreversibleMigrationException
+     */
+    protected function throwIrreversibleMigrationException($message = null)
+    {
+        if ($message === null) {
+            $message = 'This migration is irreversible and cannot be reverted.';
+        }
+
+        throw new IrreversibleMigrationException($message);
+    }
 }


### PR DESCRIPTION
It is a good practice to only migrate up in databases.

This exception is a little helper to say developers that migration could not be reverted. Then `php artisan migrate:rollback` command can not be executed. If you leave `down` method empty - rollback command will delete migration record from the database like it was reverted without any issues, what leads to wrong state of the database.

All the migrations might look like this:

```php
class CreateDemoTable extends Migration
{
    public function up(): void
    {
        // Migrate up
    }

    public function down(): void
    {
        $this->throwIrreversibleMigrationException();
    }
}
```

Adding `throwIrreversibleMigrationException` method is optional. My main proposal to have some kind of specialized exception in framework core build.