### PR TITLE
[8.x] Allow dependencies to be injected into migrations constructor

### DIFF
--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -78,7 +78,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton('migrator', function ($app) {
             $repository = $app['migration.repository'];
 
-            return new Migrator($repository, $app['db'], $app['files'], $app['events']);
+            return new Migrator($app, $repository, $app['db'], $app['files'], $app['events']);
         });
     }
 

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -78,7 +78,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->singleton('migrator', function ($app) {
             $repository = $app['migration.repository'];
 
-            return new Migrator($app, $repository, $app['db'], $app['files'], $app['events']);
+            return new Migrator($repository, $app['db'], $app['files'], $app['events'], $app);
         });
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -19,25 +19,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Migrator
 {
     /**
-     * The container implementation.
-     *
-     * @var \Illuminate\Contracts\Container\Container|null
-     */
-    protected $container;
-
-    /**
-     * The event dispatcher instance.
-     *
-     * @var \Illuminate\Contracts\Events\Dispatcher
-     */
-    protected $events;
-
-    /**
      * The migration repository implementation.
      *
      * @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
      */
     protected $repository;
+
+    /**
+     * The connection resolver instance.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
 
     /**
      * The filesystem instance.
@@ -47,11 +40,18 @@ class Migrator
     protected $files;
 
     /**
-     * The connection resolver instance.
+     * The event dispatcher instance.
      *
-     * @var \Illuminate\Database\ConnectionResolverInterface
+     * @var \Illuminate\Contracts\Events\Dispatcher
      */
-    protected $resolver;
+    protected $events;
+
+    /**
+     * The container implementation.
+     *
+     * @var \Illuminate\Contracts\Container\Container|null
+     */
+    protected $container;
 
     /**
      * The name of the default connection.
@@ -88,12 +88,12 @@ class Migrator
                                 Resolver $resolver,
                                 Filesystem $files,
                                 Dispatcher $dispatcher = null,
-                                ?Container $container = null)
+                                Container $container = null)
     {
+        $this->repository = $repository;
+        $this->resolver = $resolver;
         $this->files = $files;
         $this->events = $dispatcher;
-        $this->resolver = $resolver;
-        $this->repository = $repository;
         $this->container = $container;
     }
 

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Migrations;
 
 use Illuminate\Collections\Arr;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Database\Events\MigrationEnded;
@@ -17,6 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Migrator
 {
+    /**
+     * The container implementation.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
+    protected $container;
+
     /**
      * The event dispatcher instance.
      *
@@ -69,17 +77,20 @@ class Migrator
     /**
      * Create a new migrator instance.
      *
+     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(MigrationRepositoryInterface $repository,
+    public function __construct(Container $container,
+                                MigrationRepositoryInterface $repository,
                                 Resolver $resolver,
                                 Filesystem $files,
                                 Dispatcher $dispatcher = null)
     {
+        $this->container = $container;
         $this->files = $files;
         $this->events = $dispatcher;
         $this->resolver = $resolver;
@@ -450,7 +461,7 @@ class Migrator
     {
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
 
-        return new $class;
+        return $this->container->make($class);
     }
 
     /**

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -21,7 +21,7 @@ class Migrator
     /**
      * The container implementation.
      *
-     * @var \Illuminate\Contracts\Container\Container
+     * @var \Illuminate\Contracts\Container\Container|null
      */
     protected $container;
 
@@ -77,24 +77,24 @@ class Migrator
     /**
      * Create a new migrator instance.
      *
-     * @param  \Illuminate\Contracts\Container\Container  $container
      * @param  \Illuminate\Database\Migrations\MigrationRepositoryInterface  $repository
      * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
      * @param  \Illuminate\Filesystem\Filesystem  $files
      * @param  \Illuminate\Contracts\Events\Dispatcher|null  $dispatcher
+     * @param  \Illuminate\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container,
-                                MigrationRepositoryInterface $repository,
+    public function __construct(MigrationRepositoryInterface $repository,
                                 Resolver $resolver,
                                 Filesystem $files,
-                                Dispatcher $dispatcher = null)
+                                Dispatcher $dispatcher = null,
+                                ?Container $container = null)
     {
-        $this->container = $container;
         $this->files = $files;
         $this->events = $dispatcher;
         $this->resolver = $resolver;
         $this->repository = $repository;
+        $this->container = $container;
     }
 
     /**
@@ -460,6 +460,10 @@ class Migrator
     public function resolve($file)
     {
         $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+
+        if (is_null($this->container)) {
+            return new $class;
+        }
 
         return $this->container->make($class);
     }

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -45,6 +45,7 @@ class DatabaseMigratorIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
 
         $this->migrator = new Migrator(
+            $container,
             $repository = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations'),
             $db->getDatabaseManager(),
             new Filesystem

--- a/tests/Database/DatabaseMigratorIntegrationTest.php
+++ b/tests/Database/DatabaseMigratorIntegrationTest.php
@@ -45,7 +45,6 @@ class DatabaseMigratorIntegrationTest extends TestCase
         Facade::setFacadeApplication($container);
 
         $this->migrator = new Migrator(
-            $container,
             $repository = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations'),
             $db->getDatabaseManager(),
             new Filesystem


### PR DESCRIPTION
In some cases you might need access to the container to ensure the proper update of your data structure. This could be necessary to update relations with some specific logic or to create new entities.

```php
class CreateDemoTable extends Migration
{
    public function __construct(TenantManagerInterface $tenantManager)
    {
        $this->tenantManager = $tenantManager;
    }

    public function up(): void
    {
    }
}
```

This question was raised many times before:
- #30590 L6.x
- #25038 L5.7
- #21999 L5.5
- #13069 L5.3
- #6784 L5.0
- #4259 L4.1