### PR TITLE
[7.x] Fix hasParameters behavior in the Route class

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -325,7 +325,7 @@ class Route
      */
     public function hasParameters()
     {
-        return isset($this->parameters);
+        return ! empty($this->parameters);
     }
 
     /**


### PR DESCRIPTION
The `$parameters` property exists in the class and `isset` always returns true even if the route has no parameters.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
