### PR TITLE
[7.x] Add PDOException's try again as a lost connection message

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -43,6 +43,7 @@ trait DetectsLostConnections
             'Connection refused',
             'running with the --read-only option so it cannot execute this statement',
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
+            'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
         ]);
     }
 }


### PR DESCRIPTION
Since switching to AWS Fargate, we started to encounter the error below time to time when connecting to the databases. It just suddenly comes out from nowhere and disappears in a second or so.
```
SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again (SQL: select * from this_is_an_example)
```

Of course we are investigating what's going on under there, but at the same time, I feel that Laravel should retry to create connection since it's saying "try again".

I added the whole message including `SQLSTATE[HY000] [2002]` since there was a discussion taken place before, claiming there was a side effect when the message was too general.
( added here https://github.com/laravel/framework/pull/25289, but reverted here https://github.com/laravel/framework/issues/27053 )