### PR TITLE
[7.x] Added check to avoid endless loop in MailManager::createTransport

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -162,22 +162,13 @@ class MailManager implements FactoryContract
         // Here we will check if the "transport" key exists and if it doesn't we will
         // assume an application is still using the legacy mail configuration file
         // format and use the "mail.driver" configuration option instead for BC.
-        $transport = $config['transport'] ??
-            $this->app['config']['mail.driver'];
+        $transport = (string) $config['transport'] ?? $this->app['config']['mail.driver'];
 
         if (isset($this->customCreators[$transport])) {
             return call_user_func($this->customCreators[$transport], $config);
         }
 
-        // Check whether $transport is empty or not to avoid calling createTransport() again in an endless loop in
-        // case of misconfiguration a user can do when he/she forgets to set `transport` correctly
-        if(empty(trim((string) $transport))){
-            throw new InvalidArgumentException(
-                "Empty value for \"transport\"-key in \"mail.mailers\"-config found. " .
-                "Please check that every mailer in your config/mail.php has a \"transport\"-key.");
-        }
-
-        if (! method_exists($this, $method = 'create'.ucfirst($transport).'Transport')) {
+        if (trim($transport) === '' || ! method_exists($this, $method = 'create'.ucfirst($transport).'Transport')) {
             throw new InvalidArgumentException("Unsupported mail transport [{$config['transport']}].");
         }
 

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -169,6 +169,14 @@ class MailManager implements FactoryContract
             return call_user_func($this->customCreators[$transport], $config);
         }
 
+        // Check whether $transport is empty or not to avoid calling createTransport() again in an endless loop in
+        // case of misconfiguration a user can do when he/she forgets to set `transport` correctly
+        if(empty(trim((string) $transport))){
+            throw new InvalidArgumentException(
+                "Empty value for \"transport\"-key in \"mail.mailers\"-config found. " .
+                "Please check that every mailer in your config/mail.php has a \"transport\"-key.");
+        }
+
         if (! method_exists($this, $method = 'create'.ucfirst($transport).'Transport')) {
             throw new InvalidArgumentException("Unsupported mail transport [{$config['transport']}].");
         }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -162,7 +162,7 @@ class MailManager implements FactoryContract
         // Here we will check if the "transport" key exists and if it doesn't we will
         // assume an application is still using the legacy mail configuration file
         // format and use the "mail.driver" configuration option instead for BC.
-        $transport = (string) $config['transport'] ?? $this->app['config']['mail.driver'];
+        $transport = $config['transport'] ?? $this->app['config']['mail.driver'];
 
         if (isset($this->customCreators[$transport])) {
             return call_user_func($this->customCreators[$transport], $config);

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Mail;
+
+use Illuminate\Mail\MailManager;
+use Orchestra\Testbench\TestCase;
+
+class MailManagerTest extends TestCase
+{
+
+    /**
+     * @dataProvider emptyTransportConfigDataProvider
+     * @covers \Illuminate\Mail\MailManager::createTransport
+     */
+    public function testEmptyTransportConfig(?string $transport)
+    {
+        $this->app['config']->set('mail.mailers.custom_smtp', [
+            'transport' => $transport,
+            'host' => null,
+            'port' => null,
+            'encryption' => null,
+            'username' => null,
+            'password' => null,
+            'timeout' => null,
+        ]);
+
+        /** @var MailManager $mailManager */
+        $mailManager = app('mail.manager');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Empty value for \"transport\"-key in \"mail.mailers\"-config found. Please check that every mailer in your config/mail.php has a \"transport\"-key.");
+        $mailManager->mailer("custom_smtp");
+    }
+
+    public function emptyTransportConfigDataProvider() : array
+    {
+        return [
+          [null], [""], [" "]
+        ];
+    }
+}

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -7,12 +7,10 @@ use Orchestra\Testbench\TestCase;
 
 class MailManagerTest extends TestCase
 {
-
     /**
      * @dataProvider emptyTransportConfigDataProvider
-     * @covers \Illuminate\Mail\MailManager::createTransport
      */
-    public function testEmptyTransportConfig(?string $transport)
+    public function testEmptyTransportConfig($transport)
     {
         $this->app['config']->set('mail.mailers.custom_smtp', [
             'transport' => $transport,
@@ -24,18 +22,15 @@ class MailManagerTest extends TestCase
             'timeout' => null,
         ]);
 
-        /** @var MailManager $mailManager */
-        $mailManager = app('mail.manager');
-
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Empty value for \"transport\"-key in \"mail.mailers\"-config found. Please check that every mailer in your config/mail.php has a \"transport\"-key.");
-        $mailManager->mailer("custom_smtp");
+        $this->expectExceptionMessage('Unsupported mail transport []');
+        $this->app['mail.manager']->mailer("custom_smtp");
     }
 
-    public function emptyTransportConfigDataProvider() : array
+    public function emptyTransportConfigDataProvider()
     {
         return [
-          [null], [""], [" "]
+            [null], [""], [" "]
         ];
     }
 }

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -23,7 +23,7 @@ class MailManagerTest extends TestCase
         ]);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unsupported mail transport []');
+        $this->expectExceptionMessage("Unsupported mail transport [{$transport}]");
         $this->app['mail.manager']->mailer("custom_smtp");
     }
 


### PR DESCRIPTION
When upgrading to Laravel 7 I found out that a misconfiguration of the new `mail.mailers.*` config can lead to an endless loop in `MailManager::createTransport()` which is caused by an empty `transport`-key in `mail.mailers.{ANY_MAILER}`.

This happed to us when we were migrating or multi-tenant SMTP configuration to new mailers pattern and as we used `driver` instead of `transport` in the configuration ran into a memory overflow due to the described endless loop.

This MR adds a check, as well as tests for it, to ensure that `transport`-key in `$config` in `MailManager::createTransport()` is not empty, where not empty means unequal to `null`, `""` and `" "`.

This MR points the user to the right place of misconfiguration and does not break any existing features.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
