### PR TITLE
[7.x] array_key_first function used to get first credential key

### DIFF
--- a/src/Illuminate/Auth/EloquentUserProvider.php
+++ b/src/Illuminate/Auth/EloquentUserProvider.php
@@ -139,9 +139,7 @@ class EloquentUserProvider implements UserProvider
      */
     protected function firstCredentialKey(array $credentials)
     {
-        foreach ($credentials as $key => $value) {
-            return $key;
-        }
+        return array_key_first($credentials) ?? null;
     }
 
     /**


### PR DESCRIPTION
When login is attempted and only password key is passed then a function `firstCredentialKey` is called in `src\Illuminate\Auth\EloquentUserProvider.php` which is used to get first key from passed credentials array. 

In this PR i have removed that **foreach** loop which returns the first key from credentials array. Instead of that i used `array_key_first` function.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
