### PR TITLE
[7.x] Improve return type that may be null

### DIFF
--- a/src/Illuminate/Cookie/CookieJar.php
+++ b/src/Illuminate/Cookie/CookieJar.php
@@ -119,7 +119,7 @@ class CookieJar implements JarContract
      * @param  string  $key
      * @param  mixed  $default
      * @param  string|null  $path
-     * @return \Symfony\Component\HttpFoundation\Cookie
+     * @return \Symfony\Component\HttpFoundation\Cookie|null
      */
     public function queued($key, $default = null, $path = null)
     {

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -348,7 +348,7 @@ class Route
      *
      * @param  string  $name
      * @param  mixed  $default
-     * @return string|object
+     * @return string|object|null
      */
     public function parameter($name, $default = null)
     {
@@ -360,7 +360,7 @@ class Route
      *
      * @param  string  $name
      * @param  mixed  $default
-     * @return string
+     * @return string|null
      */
     public function originalParameter($name, $default = null)
     {


### PR DESCRIPTION
When using the IDE, I can get a hint for the return type.
<img width="943" alt="IDE" src="https://user-images.githubusercontent.com/9360694/80359904-1c15c880-88b1-11ea-9fa5-16d21e0448f1.png">

The hint here will only return a string, I might write code like the following.
```php
if ($user_id !== '') {

}
```
In fact, null may be returned [here](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Routing/Route.php#L367), my correct code should be like this.
```php
if ($user_id !== '' && $user_id !== null) {

}
```
So I submitted this PR.
Thanks.