### PR TITLE
[6.x] Fix boolean value in assertSessionHasErrors

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1029,6 +1029,10 @@ class TestResponse implements ArrayAccess
             if (is_int($key)) {
                 PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
             } else {
+                if (is_bool($value)) {
+                    $value = (string) $value;
+                }
+
                 PHPUnit::assertContains($value, $errors->get($key, $format));
             }
         }

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -1029,11 +1029,7 @@ class TestResponse implements ArrayAccess
             if (is_int($key)) {
                 PHPUnit::assertTrue($errors->has($value), "Session missing error: $value");
             } else {
-                if (is_bool($value)) {
-                    $value = (string) $value;
-                }
-
-                PHPUnit::assertContains($value, $errors->get($key, $format));
+                PHPUnit::assertContains(is_bool($value) ? (string) $value : $value, $errors->get($key, $format));
             }
         }
 


### PR DESCRIPTION
PHPUnit 9 changes comparisons in `assertContains` to strict which means if you pass a boolean value it won't get matched against the converted `"1"` or `"0"` value. If we convert boolean values beforehand to strings (since we can only compare strings anyway here) we should be good.

Sent this to 6.x for the LTS support but the TestResponse class was moved to the new Testing component in 7.x so we'll need to make sure the fix also gets applied there after merging 6.x into the 7.x branch.

Fixes https://github.com/laravel/framework/issues/32541