### PR TITLE
[8.x] Use "sync" queue in Bus::dispatchNow()

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Bus;
 
 use Closure;
-use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -79,11 +79,13 @@ class Dispatcher implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
+     * Queuable jobs will be dispatched to the "sync" queue.
+     *
      * @param  mixed  $command
      * @param  mixed  $handler
      * @return mixed
      */
-    public function dispatchNow($command, $handler = null)
+    public function dispatchSync($command, $handler = null)
     {
         if ($this->queueResolver &&
             $this->commandShouldBeQueued($command) &&
@@ -91,7 +93,7 @@ class Dispatcher implements QueueingDispatcher
             return $this->dispatchToQueue($command->onConnection('sync'));
         }
 
-        return $this->dispatchDirectly($command, $handler);
+        return $this->dispatchNow($command, $handler);
     }
 
     /**
@@ -101,7 +103,7 @@ class Dispatcher implements QueueingDispatcher
      * @param  mixed  $handler
      * @return mixed
      */
-    public function dispatchDirectly($command, $handler = null)
+    public function dispatchNow($command, $handler = null)
     {
         $uses = class_uses_recursive($command);
 

--- a/src/Illuminate/Contracts/Bus/Dispatcher.php
+++ b/src/Illuminate/Contracts/Bus/Dispatcher.php
@@ -15,6 +15,17 @@ interface Dispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
+     * Queuable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $command
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    public function dispatchSync($command, $handler = null);
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
      * @param  mixed  $command
      * @param  mixed  $handler
      * @return mixed

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -46,6 +46,18 @@ trait Dispatchable
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
+     * Queuable jobs will be dispatched to the "sync" queue.
+     *
+     * @return mixed
+     */
+    public static function dispatchSync()
+    {
+        return app(Dispatcher::class)->dispatchSync(new static(...func_get_args()));
+    }
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
      * @return mixed
      */
     public static function dispatchNow()

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -79,7 +79,7 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
-                    return $this->dispatcher->dispatchDirectly(
+                    return $this->dispatcher->dispatchNow(
                         $command, $this->resolveHandler($job, $command)
                     );
                 });

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -79,7 +79,7 @@ class CallQueuedHandler
         return (new Pipeline($this->container))->send($command)
                 ->through(array_merge(method_exists($command, 'middleware') ? $command->middleware() : [], $command->middleware ?? []))
                 ->then(function ($command) use ($job) {
-                    return $this->dispatcher->dispatchNow(
+                    return $this->dispatcher->dispatchDirectly(
                         $command, $this->resolveHandler($job, $command)
                     );
                 });

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -240,6 +240,24 @@ class BusFake implements QueueingDispatcher
     /**
      * Dispatch a command to its appropriate handler in the current process.
      *
+     * Queuable jobs will be dispatched to the "sync" queue.
+     *
+     * @param  mixed  $command
+     * @param  mixed  $handler
+     * @return mixed
+     */
+    public function dispatchSync($command, $handler = null)
+    {
+        if ($this->shouldFakeJob($command)) {
+            $this->commands[get_class($command)][] = $command;
+        } else {
+            return $this->dispatcher->dispatchSync($command, $handler);
+        }
+    }
+
+    /**
+     * Dispatch a command to its appropriate handler in the current process.
+     *
      * @param  mixed  $command
      * @param  mixed  $handler
      * @return mixed


### PR DESCRIPTION
This PR fixes two issues. First, it fixes an issue where job middleware are not run when doing something like `ProcessPodcast::dispatchNow()`. This can be fixed by dispatching this job through the `sync` queue instead of invoking it directly from the command bus.

The second problem it fixes is currently any jobs dispatched using `dispatchNow` do not have have access to the `$this->job` property, even though they use `InteractsWithQueue`. The `$this->job` variable will just be `null`. This is awkward because you may have a job that is sometimes dispatched using the normal `dispatch` method and sometimes using `dispatchNow` and the `$this->job` variable is only going to be available when dispatched using `dispatch`. So, you would have to put `null` checks within your job to work around this. This PR solves this by setting a `SyncJob` on the job if one is not already set.

Added a new `dispatchDirectly` method to execute a job directly within the command bus without using the sync queue or job middleware (basically the old `dispatchNow` behavior).

**Alternative:**

One alternative to this is to leave `dispatchNow` as it is and add a new `dispatchSync` method (or some similar name) that dispatches the job using the `sync` queue.