### PR TITLE
[7.x] Parameterless Component Methods Invokable With & Without Parens

### DIFF
--- a/src/Illuminate/Contracts/Support/DeferringDisplayableValue.php
+++ b/src/Illuminate/Contracts/Support/DeferringDisplayableValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\Contracts\Support;
+
+interface DeferringDisplayableValue
+{
+    /**
+     * Resolve the displayable value that the class is deferring.
+     *
+     * @return mixed
+     */
+    public function resolveDisplayableValue();
+}

--- a/src/Illuminate/Contracts/Support/DeferringDisplayableValue.php
+++ b/src/Illuminate/Contracts/Support/DeferringDisplayableValue.php
@@ -7,7 +7,7 @@ interface DeferringDisplayableValue
     /**
      * Resolve the displayable value that the class is deferring.
      *
-     * @return mixed
+     * @return \Illuminate\Contracts\Support\Htmlable|string
      */
     public function resolveDisplayableValue();
 }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -250,6 +251,10 @@ if (! function_exists('e')) {
      */
     function e($value, $doubleEncode = true)
     {
+        if ($value instanceof DeferringDisplayableValue) {
+            $value = $value->resolveDisplayableValue();
+        }
+
         if ($value instanceof Htmlable) {
             return $value->toHtml();
         }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -245,7 +245,7 @@ if (! function_exists('e')) {
     /**
      * Encode HTML special characters in a string.
      *
-     * @param  \Illuminate\Contracts\Support\Htmlable|string  $value
+     * @param  \Illuminate\Contracts\Support\DeferringDisplayableValue|\Illuminate\Contracts\Support\Htmlable|string  $value
      * @param  bool  $doubleEncode
      * @return string
      */

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -219,6 +219,7 @@ abstract class Component
             {
                 return (string) $this->__invoke();
             }
+
         };
     }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -182,8 +183,43 @@ abstract class Component
     protected function createVariableFromMethod(ReflectionMethod $method)
     {
         return $method->getNumberOfParameters() === 0
-                        ? $this->{$method->getName()}()
+                        ? $this->createInvokableVariable($method->getName())
                         : Closure::fromCallable([$this, $method->getName()]);
+    }
+
+    /**
+     * Create an invokable, toStringable variable for the given component method.
+     *
+     * @param  string  $method
+     * @return object
+     */
+    protected function createInvokableVariable(string $method)
+    {
+        return new class(function () use ($method) {
+            return $this->{$method}();
+        }) implements DeferringDisplayableValue {
+            protected $callable;
+
+            public function __construct(Closure $callable)
+            {
+                $this->callable = $callable;
+            }
+
+            public function resolveDisplayableValue()
+            {
+                return $this->__invoke();
+            }
+
+            public function __invoke()
+            {
+                return call_user_func($this->callable);
+            }
+
+            public function __toString()
+            {
+                return (string) $this->__invoke();
+            }
+        };
     }
 
     /**

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -18,19 +18,20 @@ class ViewComponentTest extends TestCase
         $this->assertSame('taylor', $variables['hello']('taylor'));
     }
 
-    public function testPublicMethodsWithNoArgsAreEagerlyInvokedAndNotCached()
+    public function testPublicMethodsWithNoArgsAreConvertedToStringableCallablesInvokedAndNotCached()
     {
         $component = new TestSampleViewComponent;
 
         $this->assertEquals(0, $component->counter);
         $variables = $component->data();
-        $this->assertEquals(1, $component->counter);
+        $this->assertEquals(0, $component->counter);
 
-        $this->assertSame('noArgs val', $variables['noArgs']);
+        $this->assertSame('noArgs val', $variables['noArgs']());
+        $this->assertSame('noArgs val', (string) $variables['noArgs']);
         $this->assertEquals(0, $variables['counter']);
 
         // make sure non-public members are not invoked nor counted.
-        $this->assertEquals(1, $component->counter);
+        $this->assertEquals(2, $component->counter);
         $this->assertArrayHasKey('publicHello', $variables);
         $this->assertArrayNotHasKey('protectedHello', $variables);
         $this->assertArrayNotHasKey('privateHello', $variables);
@@ -38,12 +39,12 @@ class ViewComponentTest extends TestCase
         $this->assertArrayNotHasKey('protectedCounter', $variables);
         $this->assertArrayNotHasKey('privateCounter', $variables);
 
-        // test each time we invoke data(), the non-argument methods are invoked
-        $this->assertEquals(1, $component->counter);
+        // test each time we invoke data(), the non-argument methods aren't invoked
+        $this->assertEquals(2, $component->counter);
         $component->data();
         $this->assertEquals(2, $component->counter);
         $component->data();
-        $this->assertEquals(3, $component->counter);
+        $this->assertEquals(2, $component->counter);
     }
 
     public function testItIgnoresExceptedMethodsAndProperties()


### PR DESCRIPTION
This change allows parameterless Blade component methods to be invoked using no parameters or using parameters:

```php
{{ $foo }}

{{ $foo() }}
```

It's easy to forget that these methods currently are not able to called with parentheses. I have stumbled on this myself. This should be backward compatible since both ways of echoing the value are supported.