### PR TITLE
[7.x] Add support for adding attribute bag to component

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -98,7 +98,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes\s?\}\}
+                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
                             )
                             |
                             (?:
@@ -151,7 +151,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes\s?\}\}
+                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
                             )
                             |
                             (?:
@@ -398,7 +398,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
         (?:^|\s+)     # start of the string or whitespace between attributes
-        \{\{\s?(\\\$attributes)\s?\}\} # exact match of attributes being echoed
+        \{\{\s?(\\\$attributes(?:.*[\)])?)\s?\}\} # exact match of attributes being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -96,18 +96,26 @@ class ComponentTagCompiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.@]+
-                        (
-                            =
+                        (?:
                             (?:
-                                \\\"[^\\\"]*\\\"
-                                |
-                                \'[^\']*\'
-                                |
-                                [^\'\\\"=<>]+
+                                \{\{\s?\\\$attributes\s?\}\}
+                            )
+                            |
+                            (?:
+                                [\w\-:.@]+
+                                (
+                                    =
+                                    (?:
+                                        \\\"[^\\\"]*\\\"
+                                        |
+                                        \'[^\']*\'
+                                        |
+                                        [^\'\\\"=<>]+
+                                    )
+                                )?
                             )
                         )
-                    ?)*
+                    )*
                     \s*
                 )
                 (?<![\/=\-])
@@ -141,17 +149,25 @@ class ComponentTagCompiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.@]+
-                        (
-                            =
+                        (?:
                             (?:
-                                \\\"[^\\\"]*\\\"
-                                |
-                                \'[^\']*\'
-                                |
-                                [^\'\\\"=<>]+
+                                \{\{\s?\\\$attributes\s?\}\}
                             )
-                        )?
+                            |
+                            (?:
+                                [\w\-:.@]+
+                                (
+                                    =
+                                    (?:
+                                        \\\"[^\\\"]*\\\"
+                                        |
+                                        \'[^\']*\'
+                                        |
+                                        [^\'\\\"=<>]+
+                                    )
+                                )?
+                            )
+                        )
                     )*
                     \s*
                 )
@@ -324,6 +340,8 @@ class ComponentTagCompiler
      */
     protected function getAttributesFromAttributeString(string $attributeString)
     {
+        $attributeString = $this->parseAttributeBag($attributeString);
+
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
@@ -368,6 +386,22 @@ class ComponentTagCompiler
 
             return [$attribute => $value];
         })->toArray();
+    }
+
+    /**
+     * Parse the attribute bag in a given attribute string into it's fully-qualified syntax.
+     *
+     * @param  string  $attributeString
+     * @return string
+     */
+    protected function parseAttributeBag(string $attributeString)
+    {
+        $pattern = "/
+        (?:^|\s+)     # start of the string or whitespace between attributes
+        \{\{\s?(\\\$attributes)\s?\}\} # exact match of attributes being echoed
+        /x";
+
+        return preg_replace($pattern, ' :attributes="$1"', $attributeString);
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -157,6 +157,28 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endcomponentClass', trim($result));
     }
 
+    public function testComponentCanReceiveAttributeBag()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile class="bar" {{ $attributes }} wire:model="foo"></x-profile>');
+
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+<?php \$component->withName('profile'); ?>
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?> @endcomponentClass", trim($result));
+    }
+
+    public function testSelfClosingComponentCanReceiveAttributeBag()
+    {
+        $this->mockViewFactory();
+
+        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes }} wire:model="foo" /></div>');
+
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
+<?php \$component->withName('alert'); ?>
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
+            "@endcomponentClass </div>", trim($result));
+    }
+
     public function testComponentsCanHaveAttachedWord()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile></x-profile>Words');

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -171,11 +171,11 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $this->mockViewFactory();
 
-        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes }} wire:model="foo" /></div>');
+        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes->merge([\'class\' => \'test\']) }} wire:model="foo" /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>\n".
             '@endcomponentClass </div>', trim($result));
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -176,7 +176,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
-            "@endcomponentClass </div>", trim($result));
+            '@endcomponentClass </div>', trim($result));
     }
 
     public function testComponentsCanHaveAttachedWord()


### PR DESCRIPTION
Currently if you have a base component and another component that wraps around the base component you can't add the attribute bag to the component using
```php
<x-button {{ $attributes }}>
```

Instead you have to use
```php
<x-button :attributes="$attributes">
```

This adds support for this so it is consistent with how you add the attributes to html tags.

For example, it would be used when you have x-primary-button and x-secondary-button components that may add styles or other actions to and wrap around x-button component.