### PR TITLE
[7.x] Prevent blade `$component` variable name conflicts

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -193,8 +193,8 @@ class ComponentTagCompiler
         }
 
         return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false).'])
-<?php $component->withName(\''.$component.'\'); ?>
-<?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
+<?php $__component->withName(\''.$component.'\'); ?>
+<?php $__component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -60,10 +60,10 @@ trait CompilesComponents
     public static function compileClassComponentOpening(string $component, string $data, string $hash)
     {
         return implode("\n", [
-            '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
-            '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
-            '<?php if ($component->shouldRender()): ?>',
-            '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
+            '<?php if (isset($__component)) { $__componentOriginal'.$hash.' = $__component; } ?>',
+            '<?php $__component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
+            '<?php if ($__component->shouldRender()): ?>',
+            '<?php $__env->startComponent($__component->resolveView(), $__component->data()); ?>',
         ]);
     }
 
@@ -78,7 +78,7 @@ trait CompilesComponents
 
         return implode("\n", [
             '<?php if (isset($__componentOriginal'.$hash.')): ?>',
-            '<?php $component = $__componentOriginal'.$hash.'; ?>',
+            '<?php $__component = $__componentOriginal'.$hash.'; ?>',
             '<?php unset($__componentOriginal'.$hash.'); ?>',
             '<?php endif; ?>',
             '<?php echo $__env->renderComponent(); ?>',

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -33,11 +33,11 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="foo" limit="5" @click="foo" required /><x-alert /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','required' => true]); ?>\n".
 "@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
 
@@ -46,8 +46,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
 
@@ -56,8 +56,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
-<?php \$component->withName('profile'); ?>
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$__component->withName('profile'); ?>
+<?php \$__component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonData()
@@ -65,8 +65,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1])
-<?php \$component->withName('profile'); ?>
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$__component->withName('profile'); ?>
+<?php \$__component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()
@@ -74,8 +74,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
-<?php \$component->withName('profile'); ?>
-<?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
+<?php \$__component->withName('profile'); ?>
+<?php \$__component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonNestedComponentParsing()
@@ -83,8 +83,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x-foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('foo:alert'); ?>
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$__component->withName('foo:alert'); ?>
+<?php \$__component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonStartingNestedComponentParsing()
@@ -92,8 +92,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['foo:alert' => TestAlertComponent::class]))->compileTags('<x:foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('foo:alert'); ?>
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$__component->withName('foo:alert'); ?>
+<?php \$__component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiled()
@@ -101,8 +101,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<div><x-alert/></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
 
@@ -141,8 +141,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
 '@endcomponentClass', trim($result));
     }
 
@@ -151,8 +151,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }
 
@@ -161,8 +161,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['profile' => TestProfileComponent::class]))->compileTags('<x-profile></x-profile>Words');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
-<?php \$component->withName('profile'); ?>
-<?php \$component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
+<?php \$__component->withName('profile'); ?>
+<?php \$__component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
     }
 
     public function testSelfClosingComponentsCanHaveAttachedWord()
@@ -170,8 +170,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert/>Words');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes([]); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes([]); ?>\n".
 '@endcomponentClass Words', trim($result));
     }
 
@@ -180,8 +180,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler(['alert' => TestAlertComponent::class]))->compileTags('<x-alert :title="$title" class="bar" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar']); ?>\n".
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes(['class' => 'bar']); ?>\n".
 '@endcomponentClass', trim($result));
     }
 
@@ -191,8 +191,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 </x-alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes([]); ?>
+<?php \$__component->withName('alert'); ?>
+<?php \$__component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
     }
 
@@ -208,8 +208,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = (new ComponentTagCompiler([]))->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withName('anonymous-component'); ?>
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+<?php \$__component->withName('anonymous-component'); ?>
+<?php \$__component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }
 

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -17,10 +17,10 @@ class BladeComponentsTest extends AbstractBladeTestCase
 
     public function testClassComponentsAreCompiled()
     {
-        $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
-<?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
-<?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
+        $this->assertSame('<?php if (isset($__component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $__component; } ?>
+<?php $__component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
+<?php if ($__component->shouldRender()): ?>
+<?php $__env->startComponent($__component->resolveView(), $__component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()
@@ -28,7 +28,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->compiler->newComponentHash('foo');
 
         $this->assertSame('<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
-<?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
+<?php $__component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
 <?php endif; ?>
 <?php echo $__env->renderComponent(); ?>', $this->compiler->compileString('@endcomponent'));
@@ -39,7 +39,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->compiler->newComponentHash('foo');
 
         $this->assertSame('<?php if (isset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33)): ?>
-<?php $component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
+<?php $__component = $__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33; ?>
 <?php unset($__componentOriginal0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33); ?>
 <?php endif; ?>
 <?php echo $__env->renderComponent(); ?>


### PR DESCRIPTION
When using a variable named `$component` within a blade component prop. The variable will be overwritten by the blade compiler. For example:

```
<x-alert :message="$component->message" :type="$component->type" />
```
will cause:

```
Undefined property: App\View\Components\Alert::$type
```

The first prop gets compiled correctly but, in the second prop, `$component` becomes a instance of `App\View\Components\Alert` instead whatever was initially stored to the variable.

I've added a `__` prefix to all `$component` variables within the blade component compiler to prevent this naming conflict.