### PR TITLE
[8.x] Properly Inherit Parent Attributes

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Compilers\Concerns;
 
 use Illuminate\Support\Str;
+use Illuminate\View\ComponentAttributeBag;
 
 trait CompilesComponents
 {
@@ -167,7 +168,7 @@ trait CompilesComponents
     public static function sanitizeComponentAttribute($value)
     {
         return is_string($value) ||
-               (is_object($value) && method_exists($value, '__toString'))
+               (is_object($value) && ! $value instanceof ComponentAttributeBag && method_exists($value, '__toString'))
                         ? e($value)
                         : $value;
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -141,6 +141,15 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function setAttributes(array $attributes)
     {
+        if (isset($attributes['attributes']) &&
+            $attributes['attributes'] instanceof self) {
+            $parentBag = $attributes['attributes'];
+
+            unset($attributes['attributes']);
+
+            $attributes = $parentBag->merge($attributes);
+        }
+
         $this->attributes = $attributes;
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -5,7 +5,6 @@ namespace Illuminate\Tests\View\Blade;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Compilers\ComponentTagCompiler;
 use Illuminate\View\Component;

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Tests\View;
 
 use Illuminate\View\Component;
+use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
 
 class ViewComponentTest extends TestCase
@@ -16,6 +17,15 @@ class ViewComponentTest extends TestCase
         $this->assertEquals(10, $variables['votes']);
         $this->assertSame('world', $variables['hello']());
         $this->assertSame('taylor', $variables['hello']('taylor'));
+    }
+
+    public function testAttributeParentInheritance()
+    {
+        $component = new TestViewComponent;
+
+        $component->withAttributes(['class' => 'foo', 'attributes' => new ComponentAttributeBag(['class' => 'bar', 'type' => 'button'])]);
+
+        $this->assertEquals('class="foo bar" type="button"', (string) $component->attributes);
     }
 
     public function testPublicMethodsWithNoArgsAreConvertedToStringableCallablesInvokedAndNotCached()


### PR DESCRIPTION
Imagine you have two components: `button` and `danger-button`, where `danger-button` contains an instance of `button` with some additional classes. You are not able to proxy down any custom attributes to the `button` component using `$attributes`. For example, this will not work: 

```html
<!-- danger-button.blade.php -->

<x-button class="bg-red-200" {{ $attributes }}>
    {{ $slot }}
</x-button>
```

This also will not work as expected since the `button` component will end up with an attribute named `attribute`:

```html
<!-- danger-button.blade.php -->

<x-button class="bg-red-200" :attributes="$attributes">
    {{ $slot }}
</x-button>
```

This PR fixes this behavior by detecting any bound attribute bags and merging any other classes with them before setting them as the parent's attribute bag. So, the syntax above using `:attributes="$attributes"` will be handled properly.

It would be possible to handle the `{{ $attributes }}` passing syntax using some regular expressions to translate that syntax to `:attributes="$attributes"` for custom Blade tags but will leave that to someone with more regular expression knowledge.

Sending this to `master` since developers may already be working around this in more cumbersome ways that would be broken by this PR.