### PR TITLE
[8.x] Throw an exception when trying to add a foreign key to an existing SQLite database

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -156,6 +156,12 @@ class Blueprint
                     "SQLite doesn't support dropping foreign keys (you would need to re-create the table)."
                 );
             }
+
+            if (! $this->creating() && $this->commandsNamed(['foreign'])->count() > 0) {
+                throw new BadMethodCallException(
+                    "SQLite doesn't support adding foreign keys to existing tables."
+                );
+            }
         }
     }
 

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -308,4 +308,52 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
     }
+
+    public function testItEnsuresDroppingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->dropColumn('email');
+        });
+    }
+
+    public function testItEnsuresRenamingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->renameColumn('name', 'first_name');
+            $table->renameColumn('name2', 'last_name');
+        });
+    }
+
+    public function testItEnsuresRenamingAndDroppingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->renameColumn('name2', 'last_name');
+        });
+    }
+
+    public function testItEnsuresDroppingForeignKeyIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support dropping foreign keys (you would need to re-create the table).");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropForeign('something');
+        });
+    }
+
+    public function testItAddingForeignKeysIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support adding foreign keys to existing tables.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->foreign('company_id')->references('id')->on('companies')->onDelete('set null');
+        });
+    }
 }


### PR DESCRIPTION
I just spent an hour trying to figure out why a foreign key constraint wasn't working in one of my tests. As it turns out, [SQLite doesn't support adding foreign keys to existing databases](https://stackoverflow.com/questions/1884818/how-do-i-add-a-foreign-key-to-an-existing-sqlite-table/1884841#1884841). Doing this in a migration doesn't throw an exception, you'll only notice your foreign key constraints aren't working when you start seeing weird behavior in your code (such as `ON DELETE CASCADE` not working).

What makes this issue even harder to debug, is that when you look up "SQLite foreign key constraints not working", all the answers you find will say "foreign keys are disabled by default, you should enable them manually". Laravel has been enabling foreign keys for SQLite since https://github.com/laravel/framework/pull/26298, so all these answers aren't useful. You have to specifically look up "add foreign key to SQLite table" to figure out why it isn't working.

This PR makes it so that an exception is thrown if you try to add a foreign key to an existing SQLite database. It also adds tests for the exceptions that are thrown when you try to run commands that aren't available for SQLite.

I'm targeting 8.x because this change will likely break some users their migrations.
