### PR TITLE
[7.x] Fix ResponseFactory interface DocBlock to match class

### DIFF
--- a/src/Illuminate/Contracts/Routing/ResponseFactory.php
+++ b/src/Illuminate/Contracts/Routing/ResponseFactory.php
@@ -37,7 +37,7 @@ interface ResponseFactory
     /**
      * Create a new JSON response instance.
      *
-     * @param  string|array|object  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options
@@ -49,7 +49,7 @@ interface ResponseFactory
      * Create a new JSONP response instance.
      *
      * @param  string  $callback
-     * @param  string|array|object  $data
+     * @param  mixed  $data
      * @param  int  $status
      * @param  array  $headers
      * @param  int  $options


### PR DESCRIPTION
This PR fixes the DocBlock typehints of `ResponseFactory` interface to match the DocBlock of implementation class.

<br>

**Explanation:**

Class `Illuminate\Http\JsonResponse` typehints  **`$data`** as **`mixed`**
```php
/**
 * @param  mixed  $data
 */
public function __construct($data = null, $status = 200, $headers = [], $options = 0)
```

Class `Illuminate\Routing\ResponseFactory` typehints **`$data`** as **`mixed`** _(since it returns a `JsonResponse` instance)_
```php
/**
 * @param  mixed  $data
 */
public function json($data = [], $status = 200, array $headers = [], $options = 0)
```

Interface `Illuminate\Contracts\Routing\ResponseFactory` **incorrectly** typehints **`$data`** as **`string|array|object`** _(it should typehint `mixed`)_
```php
/**
 * @param  string|array|object  $data
 */
public function json($data = [], $status = 200, array $headers = [], $options = 0);
```

<br>
<br>

**Effects of this bug (static analysis):**
```php
response()->json(1);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json()
// expects array|object|string, int given.

response()->json(1.0);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json()
// expects array|object|string, float given.

response()->json(true);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json()
// expects array|object|string, bool given.

response()->json(null);
// Parameter #1 $data of method Illuminate\Contracts\Routing\ResponseFactory::json()
// expects array|object|string, null given.
```
