### PR TITLE
Create idx helper function

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -558,3 +558,27 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (!function_exists('idx')) {
+    /**
+     * @param ArrayAccess|array|null $arr
+     * @param mixed      $index
+     * @param mixed|null $default
+     *
+     * @return mixed|null
+     */
+    function idx($arr, $index, $default = null)
+    {
+        if ($index === null) {
+            return $default;
+        }
+
+        if (is_array($arr) && array_key_exists($index, $arr)) {
+            return $arr[$index];
+        } elseif ($arr instanceof ArrayAccess && $arr->offsetExists($index)) {
+            return $arr[$index];
+        }
+
+        return $default;
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -559,7 +559,7 @@ if (! function_exists('with')) {
     }
 }
 
-if (!function_exists('idx')) {
+if (! function_exists('idx')) {
     /**
      * @param ArrayAccess|array|null $arr
      * @param mixed      $index

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -564,6 +564,26 @@ class SupportHelpersTest extends TestCase
         }));
     }
 
+    public function testIdx()
+    {
+        $this->assertEquals('foo', idx(null, null, 'foo'));
+        $this->assertEquals('foo', idx(null, 'key', 'foo'));
+
+        $test = ['item', 'one' => 'test', 'two' => null];
+        $this->assertEquals('item', idx($test, 0));
+        $this->assertEquals('test', idx($test, 'one'));
+        $this->assertNull(idx($test, 'two', 'foo'));
+        $this->assertEquals('foo', idx($test, 'bad_key', 'foo'));
+        $this->assertEquals('foo', idx($test, null, 'foo'));
+
+        $test = collect($test);
+        $this->assertEquals('item', idx($test, 0));
+        $this->assertEquals('test', idx($test, 'one'));
+        $this->assertNull(idx($test, 'two', 'foo'));
+        $this->assertEquals('foo', idx($test, 'bad_key', 'foo'));
+        $this->assertEquals('foo', idx($test, null, 'foo'));
+    }
+
     public function testEnv()
     {
         $_SERVER['foo'] = 'bar';


### PR DESCRIPTION
Adding idx function to helper functions. This function simplifies the common pattern of checking for an index in an array and selecting a default value if it does not exist.

This is something I used a lot when I was using Hacklang, and I missed it so I reimplemented it in our own helpers.  I thought it might be useful to more people

The Hacklang documentation gives a good description https://docs.hhvm.com/hack/reference/function/HH.idx/