### PR TITLE
[7.x] Fix `userAgent()` return type

### DIFF
--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -294,7 +294,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     /**
      * Get the client user agent.
      *
-     * @return string
+     * @return string|null
      */
     public function userAgent()
     {


### PR DESCRIPTION
The `userAgent()` function may return `null`.