### PR TITLE
[7.x] Added CastMake command

### DIFF
--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Foundation\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class CastMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:cast';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new custom cast class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Cast';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/cast.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Casts';
+    }
+}

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -3,9 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
-use Illuminate\Foundation\Inspiring;
-use Illuminate\Support\Str;
-use Symfony\Component\Console\Input\InputOption;
 
 class CastMakeCommand extends GeneratorCommand
 {

--- a/src/Illuminate/Foundation/Console/CastMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/CastMakeCommand.php
@@ -18,7 +18,7 @@ class CastMakeCommand extends GeneratorCommand
      *
      * @var string
      */
-    protected $description = 'Create a new custom cast class';
+    protected $description = 'Create a new custom Eloquent cast class';
 
     /**
      * The type of class being generated.

--- a/src/Illuminate/Foundation/Console/stubs/cast.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.stub
@@ -17,7 +17,7 @@ class DummyClass implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        // Cast the given value
+        return $value;
     }
 
     /**
@@ -31,6 +31,6 @@ class DummyClass implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        // Prepare the given value for storage.
+        return $value;
     }
 }

--- a/src/Illuminate/Foundation/Console/stubs/cast.stub
+++ b/src/Illuminate/Foundation/Console/stubs/cast.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class DummyClass implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        // Cast the given value
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  array  $value
+     * @param  array  $attributes
+     * @return string
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        // Prepare the given value for storage.
+    }
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Console\Factories\FactoryMakeCommand;
 use Illuminate\Database\Console\Seeds\SeedCommand;
 use Illuminate\Database\Console\Seeds\SeederMakeCommand;
 use Illuminate\Database\Console\WipeCommand;
+use Illuminate\Foundation\Console\CastMakeCommand;
 use Illuminate\Foundation\Console\ChannelMakeCommand;
 use Illuminate\Foundation\Console\ClearCompiledCommand;
 use Illuminate\Foundation\Console\ComponentMakeCommand;
@@ -118,6 +119,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected $devCommands = [
         'CacheTable' => 'command.cache.table',
+        'CastMake' => 'command.cast.make',
         'ChannelMake' => 'command.channel.make',
         'ComponentMake' => 'command.component.make',
         'ConsoleMake' => 'command.console.make',
@@ -209,6 +211,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.cache.table', function ($app) {
             return new CacheTableCommand($app['files'], $app['composer']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerCastMakeCommand()
+    {
+        $this->app->singleton('command.cast.make', function ($app) {
+            return new CastMakeCommand($app['files']);
         });
     }
 


### PR DESCRIPTION
It appeared to me that there is no artisan command to easily create a new cast class.

So I've added `artisan make:cast` which is very simple. It just takes the name of the cast as a parameter and saves it in `app\Casts`.

Let me know if anything could be done better!