### PR TITLE
[7.x] Add assertDatabaseCount assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
+use Illuminate\Testing\Constraints\CountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
 use PHPUnit\Framework\Constraint\LogicalNot as ReverseConstraint;
@@ -43,6 +44,23 @@ trait InteractsWithDatabase
         );
 
         $this->assertThat($table, $constraint);
+
+        return $this;
+    }
+
+    /**
+     * Assert the count of table entries.
+     *
+     * @param  string  $table
+     * @param  int  $count
+     * @param  string|null  $connection
+     * @return $this
+     */
+    protected function assertDatabaseCount($table, int $count, $connection = null)
+    {
+        $this->assertThat(
+            $table, new CountInDatabase($this->getConnection($connection), $count)
+        );
 
         return $this;
     }

--- a/src/Illuminate/Testing/Constraints/CountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/CountInDatabase.php
@@ -2,13 +2,12 @@
 
 namespace Illuminate\Testing\Constraints;
 
-use ReflectionClass;
 use Illuminate\Database\Connection;
 use PHPUnit\Framework\Constraint\Constraint;
+use ReflectionClass;
 
 class CountInDatabase extends Constraint
 {
-
     /**
      * The database connection.
      *

--- a/src/Illuminate/Testing/Constraints/CountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/CountInDatabase.php
@@ -34,7 +34,6 @@ class CountInDatabase extends Constraint
      *
      * @param  \Illuminate\Database\Connection  $database
      * @param  int  $expectedCount
-     *
      * @return void
      */
     public function __construct(Connection $database, int $expectedCount)
@@ -54,7 +53,7 @@ class CountInDatabase extends Constraint
     {
         $this->actualCount = $this->database->table($table)->count();
 
-        return  $this->actualCount === $this->expectedCount;
+        return $this->actualCount === $this->expectedCount;
     }
 
     /**

--- a/src/Illuminate/Testing/Constraints/CountInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/CountInDatabase.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Testing\Constraints;
+
+use ReflectionClass;
+use Illuminate\Database\Connection;
+use PHPUnit\Framework\Constraint\Constraint;
+
+class CountInDatabase extends Constraint
+{
+
+    /**
+     * The database connection.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $database;
+
+    /**
+     * The expected table entries count that will be checked against the actual count.
+     *
+     * @var int
+     */
+    protected $expectedCount;
+
+    /**
+     * The actual table entries count that will be checked against the expected count.
+     *
+     * @var int
+     */
+    protected $actualCount;
+
+    /**
+     * Create a new constraint instance.
+     *
+     * @param  \Illuminate\Database\Connection  $database
+     * @param  int  $expectedCount
+     *
+     * @return void
+     */
+    public function __construct(Connection $database, int $expectedCount)
+    {
+        $this->expectedCount = $expectedCount;
+
+        $this->database = $database;
+    }
+
+    /**
+     * Check if the expected and actual count are equal.
+     *
+     * @param  string  $table
+     * @return bool
+     */
+    public function matches($table): bool
+    {
+        $this->actualCount = $this->database->table($table)->count();
+
+        return  $this->actualCount === $this->expectedCount;
+    }
+
+    /**
+     * Get the description of the failure.
+     *
+     * @param  string  $table
+     * @return string
+     */
+    public function failureDescription($table): string
+    {
+        return sprintf(
+            "table [%s] matches expected entries count of %s. Entries found: %s.\n",
+            $table, $this->expectedCount, $this->actualCount
+        );
+    }
+
+    /**
+     * Get a string representation of the object.
+     *
+     * @param  int  $options
+     * @return string
+     */
+    public function toString($options = 0): string
+    {
+        return (new ReflectionClass($this))->name;
+    }
+}

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -103,6 +103,22 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseMissing($this->table, $this->data);
     }
 
+    public function testAssertTableEntriesCount()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount($this->table, 1);
+    }
+
+    public function testAssertTableEntriesCountWrong()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.');
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount($this->table, 3);
+    }
+
     public function testAssertDeletedPassesWhenDoesNotFindResults()
     {
         $this->mockCountBuilder(0);


### PR DESCRIPTION
This PR adds a new database assertion called `assertDatabaseCount($count)`.

Next to the given `assertDatabaseHas` or `assertDatabaseMissing` assertions, it is often useful to just check the number of entries in a database table. This is possible in different workarounds already, but it would be more convenient to provide a simple helper through Laravel as well.

Here is an example of how to use it inside a test:

```php
MyCustomUserFactory::new()
    ->times(50)
    ->create();

$this->assertDatabaseCount('users', 50);
```

And this is how a failure message would look like:

`Failed asserting that table [products] matches expected entries count of 3. Entries found: 1.`