### PR TITLE
[7.x] Fix setting component name and attributes

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -203,8 +203,8 @@ class ComponentTagCompiler
             $parameters = $data->all();
         }
 
-        return " @component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false)."])
-<?php \$component->withAttributes([".$this->attributesToString($attributes->all()).']); ?>';
+        return " @component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false).'])
+<?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -203,7 +203,7 @@ class ComponentTagCompiler
             $parameters = $data->all();
         }
 
-        return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false)."], '{$component}')
+        return " @component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false)."])
 <?php \$component->withAttributes([".$this->attributesToString($attributes->all()).']); ?>';
     }
 

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -203,9 +203,8 @@ class ComponentTagCompiler
             $parameters = $data->all();
         }
 
-        return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false).'])
-<?php $component->withName(\''.$component.'\'); ?>
-<?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
+        return " @component('{$class}', [".$this->attributesToString($parameters, $escapeBound = false)."], '{$component}')
+<?php \$component->withAttributes([".$this->attributesToString($attributes->all()).']); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -21,7 +21,7 @@ trait CompilesComponents
      */
     protected function compileComponent($expression)
     {
-        [$component, $data, $alias] = strpos($expression, ',') !== false
+        [$component, $alias, $data] = strpos($expression, ',') !== false
                     ? array_map('trim', explode(',', trim($expression, '()'), 3)) + ['', '', '']
                     : [trim($expression, '()'), '', ''];
 

--- a/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesComponents.php
@@ -21,16 +21,16 @@ trait CompilesComponents
      */
     protected function compileComponent($expression)
     {
-        [$component, $data] = strpos($expression, ',') !== false
-                    ? array_map('trim', explode(',', trim($expression, '()'), 2))
-                    : [trim($expression, '()'), ''];
+        [$component, $data, $alias] = strpos($expression, ',') !== false
+                    ? array_map('trim', explode(',', trim($expression, '()'), 3)) + ['', '', '']
+                    : [trim($expression, '()'), '', ''];
 
         $component = trim($component, '\'"');
 
         $hash = static::newComponentHash($component);
 
         if (Str::contains($component, ['::class', '\\'])) {
-            return static::compileClassComponentOpening($component, $data, $hash);
+            return static::compileClassComponentOpening($component, $data, $hash, $alias);
         }
 
         return "<?php \$__env->startComponent{$expression}; ?>";
@@ -53,15 +53,17 @@ trait CompilesComponents
      * Compile a class component opening.
      *
      * @param  string  $component
+     * @param  string  $alias
      * @param  string  $data
      * @param  string  $hash
      * @return string
      */
-    public static function compileClassComponentOpening(string $component, string $data, string $hash)
+    public static function compileClassComponentOpening(string $component, string $data, string $hash, string $alias)
     {
         return implode("\n", [
             '<?php if (isset($component)) { $__componentOriginal'.$hash.' = $component; } ?>',
             '<?php $component = $__env->getContainer()->make('.Str::finish($component, '::class').', '.($data ?: '[]').'); ?>',
+            '<?php $component->withName('.$alias.'); ?>',
             '<?php if ($component->shouldRender()): ?>',
             '<?php $__env->startComponent($component->resolveView(), $component->data()); ?>',
         ]);

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -32,9 +32,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
-"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -43,7 +43,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -52,7 +52,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'], 'profile')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => '1'])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -60,7 +60,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1], 'profile')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -68,7 +68,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [], 'profile')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
 <?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
     }
 
@@ -76,7 +76,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x-foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'foo:alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -84,7 +84,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x:foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'foo:alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -92,7 +92,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert/></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -131,7 +131,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -140,7 +140,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'], 'alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -149,7 +149,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile></x-profile>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [], 'profile')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
 <?php \$component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
     }
 
@@ -157,7 +157,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert/>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass Words', trim($result));
     }
@@ -166,7 +166,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert :title="$title" class="bar" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title], 'alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => \$title])
 <?php \$component->withAttributes(['class' => 'bar']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -176,7 +176,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert>
 </x-alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
     }
@@ -192,7 +192,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']], 'anonymous-component')
+        $this->assertSame("@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
 <?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -32,11 +32,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
-"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -45,8 +43,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -55,8 +52,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'])
-<?php \$component->withName('profile'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => '1'], 'profile')
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -64,8 +60,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1])
-<?php \$component->withName('profile'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', ['userId' => 1], 'profile')
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -73,8 +68,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
-<?php \$component->withName('profile'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [], 'profile')
 <?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
     }
 
@@ -82,8 +76,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x-foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('foo:alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'foo:alert')
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -91,8 +84,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x:foo:alert></x-foo:alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('foo:alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'foo:alert')
 <?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
     }
 
@@ -100,8 +92,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert/></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass </div>', trim($result));
     }
@@ -140,8 +131,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -150,8 +140,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'], 'alert')
 <?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -160,8 +149,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile></x-profile>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
-<?php \$component->withName('profile'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [], 'profile')
 <?php \$component->withAttributes([]); ?> @endcomponentClass Words", trim($result));
     }
 
@@ -169,8 +157,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert/>Words');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes([]); ?>\n".
 '@endcomponentClass Words', trim($result));
     }
@@ -179,8 +166,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert :title="$title" class="bar" />');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => \$title], 'alert')
 <?php \$component->withAttributes(['class' => 'bar']); ?>\n".
 '@endcomponentClass', trim($result));
     }
@@ -190,8 +176,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert>
 </x-alert>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', [], 'alert')
 <?php \$component->withAttributes([]); ?>
  @endcomponentClass", trim($result));
     }
@@ -207,8 +192,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
-        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withName('anonymous-component'); ?>
+        $this->assertSame("@component('Illuminate\View\AnonymousComponent', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']], 'anonymous-component')
 <?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
 '@endcomponentClass', trim($result));
     }

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -11,11 +11,6 @@ class BladeComponentsTest extends AbstractBladeTestCase
         $this->assertSame('<?php $__env->startComponent(\'foo\'); ?>', $this->compiler->compileString('@component(\'foo\')'));
     }
 
-    public function testExtraAttributesCanBePassedToComponents()
-    {
-        $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"], ["foo" => "bar"]); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"], ["foo" => "bar"])'));
-    }
-
     public function testClassComponentsAreCompiled()
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -6,7 +6,6 @@ class BladeComponentsTest extends AbstractBladeTestCase
 {
     public function testComponentsAreCompiled()
     {
-        $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"], \'baz\'); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"], \'baz\')'));
         $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"])'));
         $this->assertSame('<?php $__env->startComponent(\'foo\'); ?>', $this->compiler->compileString('@component(\'foo\')'));
     }
@@ -17,7 +16,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
 <?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"], \'test\')'));
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', \'test\', ["foo" => "bar"])'));
     }
 
     public function testEndComponentsAreCompiled()

--- a/tests/View/Blade/BladeComponentsTest.php
+++ b/tests/View/Blade/BladeComponentsTest.php
@@ -6,6 +6,7 @@ class BladeComponentsTest extends AbstractBladeTestCase
 {
     public function testComponentsAreCompiled()
     {
+        $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"], \'baz\'); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"], \'baz\')'));
         $this->assertSame('<?php $__env->startComponent(\'foo\', ["foo" => "bar"]); ?>', $this->compiler->compileString('@component(\'foo\', ["foo" => "bar"])'));
         $this->assertSame('<?php $__env->startComponent(\'foo\'); ?>', $this->compiler->compileString('@component(\'foo\')'));
     }
@@ -19,8 +20,9 @@ class BladeComponentsTest extends AbstractBladeTestCase
     {
         $this->assertSame('<?php if (isset($component)) { $__componentOriginal35bda42cbf6f9717b161c4f893644ac7a48b0d98 = $component; } ?>
 <?php $component = $__env->getContainer()->make(Test::class, ["foo" => "bar"]); ?>
+<?php $component->withName(\'test\'); ?>
 <?php if ($component->shouldRender()): ?>
-<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"])'));
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>', $this->compiler->compileString('@component(\'Test::class\', ["foo" => "bar"], \'test\')'));
     }
 
     public function testEndComponentsAreCompiled()


### PR DESCRIPTION
This PR fixes setting the component alias and attributes so they can be used within the `render` method of a component.