### PR TITLE
[8.x] Add ability to test blade components

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -45,7 +45,7 @@ trait InteractsWithViews
     /**
      * Create a new TestView from the given view component.
      *
-     * @param  string  $view
+     * @param  string  $viewComponent
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @return \Illuminate\Testing\TestView
      */

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -41,4 +41,23 @@ trait InteractsWithViews
 
         return new TestView(view(Str::before(basename($tempFile), '.blade.php'), $data));
     }
+
+    /**
+     * Create a new TestView from the given view component.
+     *
+     * @param  string  $view
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
+     * @return \Illuminate\Testing\TestView
+     */
+    protected function component(string $viewComponent, array $data = [])
+    {
+        $component = $this->app->make($viewComponent, $data);
+        $view = $component->resolveView();
+
+        if ($view instanceof \Illuminate\View\View) {
+            return new TestView($view->with($component->data()));
+        }
+
+        return new TestView(view($view, $component->data()));
+    }
 }


### PR DESCRIPTION
Similar to what was added in #31378, this PR allows testing of view components.

```php
public function testComponent()
    {
        $this->component(Alert::class, ['type' => 'danger', 'message' => 'Hello'])
            ->assertSee('alert-danger');
    }
```

While the same could be achieved using the "raw blade" testing, I think this provides a nicer API for testing component classes. Especially when you need to pass in data - so you do not need to build a blade string yourself.