### PR TITLE
[6.x] Set relation connection on eager loaded MorphTo

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -151,7 +151,11 @@ class MorphTo extends BelongsTo
     {
         $class = Model::getActualClassNameForMorph($type);
 
-        return new $class;
+        return tap(new $class, function ($instance) {
+            if (! $instance->getConnectionName()) {
+                $instance->setConnection($this->getConnection()->getName());
+            }
+        });
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1179,6 +1179,23 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertInstanceOf(EloquentTestItem::class, $item);
     }
 
+    public function testEagerLoadedMorphToRelationsOnAnotherDatabaseConnection()
+    {
+        EloquentTestPost::create(['id' => 1, 'name' => 'Default Connection Post', 'user_id' => 1]);
+        EloquentTestPhoto::create(['id' => 1, 'imageable_type' => EloquentTestPost::class, 'imageable_id' => 1, 'name' => 'Photo']);
+
+        EloquentTestPost::on('second_connection')
+            ->create(['id' => 1, 'name' => 'Second Connection Post', 'user_id' => 1]);
+        EloquentTestPhoto::on('second_connection')
+            ->create(['id' => 1, 'imageable_type' => EloquentTestPost::class, 'imageable_id' => 1, 'name' => 'Photo']);
+
+        $defaultConnectionPost = EloquentTestPhoto::with('imageable')->first()->imageable;
+        $secondConnectionPost = EloquentTestPhoto::on('second_connection')->with('imageable')->first()->imageable;
+
+        $this->assertEquals($defaultConnectionPost->name, 'Default Connection Post');
+        $this->assertEquals($secondConnectionPost->name, 'Second Connection Post');
+    }
+
     public function testBelongsToManyCustomPivot()
     {
         $john = EloquentTestUserWithCustomFriendPivot::create(['id' => 1, 'name' => 'John Doe', 'email' => 'johndoe@example.com']);


### PR DESCRIPTION
As a fix of bug described in issue #29935, this will pass the initial model's connection to the eager loaded MorphTo model that is using a default connection.