### PR TITLE
[8.x] Allow purging connections of different components

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -190,6 +190,19 @@ class BroadcastManager implements FactoryContract
     }
 
     /**
+     * Disconnect the given disk and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?? $this->getDefaultDriver();
+
+        unset($this->drivers[$name]);
+    }
+
+    /**
      * Call a custom driver creator.
      *
      * @param  array  $config

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -354,6 +354,19 @@ class CacheManager implements FactoryContract
     }
 
     /**
+     * Disconnect the given driver and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?? $this->getDefaultDriver();
+
+        unset($this->stores[$name]);
+    }
+
+    /**
      * Register a custom driver creator Closure.
      *
      * @param  string  $driver

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -343,6 +343,19 @@ class FilesystemManager implements FactoryContract
     }
 
     /**
+     * Disconnect the given disk and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?? $this->getDefaultDriver();
+
+        unset($this->disks[$name]);
+    }
+
+    /**
      * Register a custom driver creator Closure.
      *
      * @param  string  $driver

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -135,6 +135,19 @@ class MailManager implements FactoryContract
     }
 
     /**
+     * Disconnect the given mailer and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?: $this->getDefaultDriver();
+
+        unset($this->mailers[$name]);
+    }
+
+    /**
      * Create the SwiftMailer instance for the given configuration.
      *
      * @param  array  $config

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -137,6 +137,19 @@ class RedisManager implements Factory
     }
 
     /**
+     * Disconnect the given connection and remove from local cache.
+     *
+     * @param  string|null  $name
+     * @return void
+     */
+    public function purge($name = null)
+    {
+        $name = $name ?: 'default';
+
+        unset($this->connections[$name]);
+    }
+
+    /**
      * Configure the given connection to prepare it for commands.
      *
      * @param  \Illuminate\Redis\Connections\Connection  $connection


### PR DESCRIPTION
We currently have the `DB::purge()` method to remove a database connection and delete it from local cache.

In this PR I'm adding the same method to different components.