### PR TITLE
[6.x] Only restore common relations

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -557,7 +557,13 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getQueueableRelations()
     {
-        return $this->isNotEmpty() ? $this->first()->getQueueableRelations() : [];
+        if ($this->isEmpty()) {
+            return [];
+        }
+
+        return $this->map->getQueueableRelations()->reduce(function ($carry, $item) {
+            return array_intersect($carry ?? $item, $item);
+        });
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -557,9 +557,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getQueueableRelations()
     {
-        return $this->isEmpty() ? [] : $this->map->getQueueableRelations()->reduce(function ($carry, $item) {
-            return array_intersect($carry ?? $item, $item);
-        });
+        return $this->isEmpty() ? [] : array_intersect(...$this->map->getQueueableRelations()->all());
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -557,11 +557,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function getQueueableRelations()
     {
-        if ($this->isEmpty()) {
-            return [];
-        }
-
-        return $this->map->getQueueableRelations()->reduce(function ($carry, $item) {
+        return $this->isEmpty() ? [] : $this->map->getQueueableRelations()->reduce(function ($carry, $item) {
             return array_intersect($carry ?? $item, $item);
         });
     }

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -422,6 +422,24 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c->getQueueableClass();
     }
 
+    public function testQueueableRelationshipsReturnsOnlyRelationsCommonToAllModels()
+    {
+        // This is needed to prevent loading non-existing relationships on polymorphic model collections (#26126)
+        $c = new Collection([new class {
+            public function getQueueableRelations()
+            {
+                return ['user'];
+            }
+        }, new class {
+            public function getQueueableRelations()
+            {
+                return ['user', 'comments'];
+            }
+        }]);
+
+        $this->assertEquals(['user'], $c->getQueueableRelations());
+    }
+
     public function testEmptyCollectionStayEmptyOnFresh()
     {
         $c = new Collection;


### PR DESCRIPTION
Fixes #26126

We only want to restore relationships that are common amongst all models in the collection. Otherwise there will be errors be attempting to restore the collection.

One downside to this PR could be potential performance implications of getting the queueable relationships for each model in the collection. I did this in a collection of about 1000 models and it took 0.70ms on my local machine. 