### PR TITLE
[7.x] Allow configuring the auth_mode for SMTP mail driver

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -232,6 +232,10 @@ class MailManager implements FactoryContract
             $transport->setTimeout($config['timeout']);
         }
 
+        if (isset($config['auth_mode'])) {
+            $transport->setAuthMode($config['auth_mode']);
+        }
+
         return $transport;
     }
 


### PR DESCRIPTION
Hi!

This PR adds the `auth_mode` for SMTP mail driver as new option.
Sometimes it's useful to set explicit the auth_mode when you do not want to handle it by itself.

Possible values are: `null`, `plain`, `login` or `cram-md5` ([Docs](https://symfony.com/doc/current/reference/configuration/swiftmailer.html#auth-mode))

After this PR is merged, I will create one on laravel/laravel.