### PR TITLE
[7.x] Add tests for exceptions thrown by unsupported SQLite commands

### DIFF
--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -308,7 +308,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
     }
-    
+
     public function testItEnsuresDroppingMultipleColumnsIsAvailable()
     {
         $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -308,4 +308,43 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
     }
+    
+    public function testItEnsuresDroppingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->dropColumn('email');
+        });
+    }
+
+    public function testItEnsuresRenamingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->renameColumn('name', 'first_name');
+            $table->renameColumn('name2', 'last_name');
+        });
+    }
+
+    public function testItEnsuresRenamingAndDroppingMultipleColumnsIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->renameColumn('name2', 'last_name');
+        });
+    }
+
+    public function testItEnsuresDroppingForeignKeyIsAvailable()
+    {
+        $this->expectExceptionMessage("SQLite doesn't support dropping foreign keys (you would need to re-create the table).");
+
+        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+            $table->dropForeign('something');
+        });
+    }
 }


### PR DESCRIPTION
I wrote these tests while working on PR https://github.com/laravel/framework/pull/32583. The exceptions thrown when using unsupported SQLite commands in migrations are currently untested.