### PR TITLE
[8.x] Add component attribute bag short syntax

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -101,7 +101,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes\s?\}\}
+                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
                             )
                             |
                             (?:
@@ -154,7 +154,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes\s?\}\}
+                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
                             )
                             |
                             (?:
@@ -400,7 +400,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
         (?:^|\s+)     # start of the string or whitespace between attributes
-        \{\{\s?(\\\$attributes)\s?\}\} # exact match of attributes being echoed
+        \{\{\s?(\\\$attributes(?:.*[\)])?)\s?\}\} # exact match of attributes being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -99,18 +99,26 @@ class ComponentTagCompiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.@]+
-                        (
-                            =
+                        (?:
                             (?:
-                                \\\"[^\\\"]*\\\"
-                                |
-                                \'[^\']*\'
-                                |
-                                [^\'\\\"=<>]+
+                                \{\{\s?\\\$attributes\s?\}\}
+                            )
+                            |
+                            (?:
+                                [\w\-:.@]+
+                                (
+                                    =
+                                    (?:
+                                        \\\"[^\\\"]*\\\"
+                                        |
+                                        \'[^\']*\'
+                                        |
+                                        [^\'\\\"=<>]+
+                                    )
+                                )?
                             )
                         )
-                    ?)*
+                    )*
                     \s*
                 )
                 (?<![\/=\-])
@@ -144,17 +152,25 @@ class ComponentTagCompiler
                 (?<attributes>
                     (?:
                         \s+
-                        [\w\-:.@]+
-                        (
-                            =
+                        (?:
                             (?:
-                                \\\"[^\\\"]*\\\"
-                                |
-                                \'[^\']*\'
-                                |
-                                [^\'\\\"=<>]+
+                                \{\{\s?\\\$attributes\s?\}\}
                             )
-                        )?
+                            |
+                            (?:
+                                [\w\-:.@]+
+                                (
+                                    =
+                                    (?:
+                                        \\\"[^\\\"]*\\\"
+                                        |
+                                        \'[^\']*\'
+                                        |
+                                        [^\'\\\"=<>]+
+                                    )
+                                )?
+                            )
+                        )
                     )*
                     \s*
                 )
@@ -326,6 +342,8 @@ class ComponentTagCompiler
      */
     protected function getAttributesFromAttributeString(string $attributeString)
     {
+        $attributeString = $this->parseAttributeBag($attributeString);
+
         $attributeString = $this->parseBindAttributes($attributeString);
 
         $pattern = '/
@@ -370,6 +388,22 @@ class ComponentTagCompiler
 
             return [$attribute => $value];
         })->toArray();
+    }
+
+    /**
+     * Parse the attribute bag in a given attribute string into it's fully-qualified syntax.
+     *
+     * @param  string  $attributeString
+     * @return string
+     */
+    protected function parseAttributeBag(string $attributeString)
+    {
+        $pattern = "/
+        (?:^|\s+)     # start of the string or whitespace between attributes
+        \{\{\s?(\\\$attributes)\s?\}\} # exact match of attributes being echoed
+        /x";
+
+        return preg_replace($pattern, ' :attributes="$1"', $attributeString);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -101,7 +101,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
+                                \{\{\s?\\\$attributes(?:[^}]+?)?\s?\}\}
                             )
                             |
                             (?:
@@ -154,7 +154,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes(?:.*[\)])?\s?\}\}
+                                \{\{\s?\\\$attributes(?:[^}]+?)?\s?\}\}
                             )
                             |
                             (?:
@@ -400,7 +400,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
         (?:^|\s+)     # start of the string or whitespace between attributes
-        \{\{\s?(\\\$attributes(?:.*[\)])?)\s?\}\} # exact match of attributes being echoed
+        \{\{\s?(\\\$attributes(?:[^}]+?(?<!\s))?)\s?\}\} # exact match of attributes being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -400,7 +400,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
         (?:^|\s+)     # start of the string or whitespace between attributes
-        \{\{\s*(\\\$attributes(?:[^}]+?(?<!\s))?)\s*\}\} # exact match of attributes being echoed
+        \{\{\s*(\\\$attributes(?:[^}]+?(?<!\s))?)\s*\}\} # exact match of attributes variable being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -101,7 +101,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes(?:[^}]+?)?\s?\}\}
+                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
                             (?:
@@ -154,7 +154,7 @@ class ComponentTagCompiler
                         \s+
                         (?:
                             (?:
-                                \{\{\s?\\\$attributes(?:[^}]+?)?\s?\}\}
+                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
                             (?:
@@ -400,7 +400,7 @@ class ComponentTagCompiler
     {
         $pattern = "/
         (?:^|\s+)     # start of the string or whitespace between attributes
-        \{\{\s?(\\\$attributes(?:[^}]+?(?<!\s))?)\s?\}\} # exact match of attributes being echoed
+        \{\{\s*(\\\$attributes(?:[^}]+?(?<!\s))?)\s*\}\} # exact match of attributes being echoed
         /x";
 
         return preg_replace($pattern, ' :attributes="$1"', $attributeString);

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -164,7 +164,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
 <?php \$component->withName('alert'); ?>
 <?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
-            "@endcomponentClass </div>", trim($result));
+            '@endcomponentClass </div>', trim($result));
     }
 
     public function testComponentsCanHaveAttachedWord()

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -150,8 +150,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->mockViewFactory();
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile class="bar" {{ $attributes }} wire:model="foo"></x-profile>');
 
-        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
-<?php \$component->withName('profile'); ?>
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
 <?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?> @endcomponentClass", trim($result));
     }
 
@@ -161,8 +160,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes->merge([\'class\' => \'test\']) }} wire:model="foo" /></div>');
 
-        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
-<?php \$component->withName('alert'); ?>
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
 <?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>\n".
             '@endcomponentClass </div>', trim($result));
     }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -159,11 +159,11 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
     {
         $this->mockViewFactory();
 
-        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes }} wire:model="foo" /></div>');
+        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes->merge([\'class\' => \'test\']) }} wire:model="foo" /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
 <?php \$component->withName('alert'); ?>
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>\n".
             '@endcomponentClass </div>', trim($result));
     }
 

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -145,6 +145,28 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endcomponentClass', trim($result));
     }
 
+    public function testComponentCanReceiveAttributeBag()
+    {
+        $this->mockViewFactory();
+        $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile class="bar" {{ $attributes }} wire:model="foo"></x-profile>');
+
+        $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', [])
+<?php \$component->withName('profile'); ?>
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?> @endcomponentClass", trim($result));
+    }
+
+    public function testSelfClosingComponentCanReceiveAttributeBag()
+    {
+        $this->mockViewFactory();
+
+        $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes }} wire:model="foo" /></div>');
+
+        $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', ['title' => 'foo'])
+<?php \$component->withName('alert'); ?>
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>\n".
+            "@endcomponentClass </div>", trim($result));
+    }
+
     public function testComponentsCanHaveAttachedWord()
     {
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile></x-profile>Words');


### PR DESCRIPTION
Currently if you have a base component and another component that wraps around the base component you can't add the attribute bag to the component using the short syntax.
```php
<x-button {{ $attributes }}>
```
Instead you have to use
```php
<x-button :attributes="$attributes">
```
This adds support for this so it is consistent with how you add the attribute bag to html tags.

Original PR here #32565 

Regular expression has been improved so it is more robust.

Sending to master as it goes with PR #32576 