### PR TITLE
[7.x] Allow queue to be specified per channel

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -189,11 +189,13 @@ class NotificationSender
                 if (! is_null($this->locale)) {
                     $notification->locale = $this->locale;
                 }
+                
+                $queue = (isset($notification->onQueues[$channel])) ? $notification->onQueues[$channel] : $notification->queue;
 
                 $this->bus->dispatch(
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
-                            ->onQueue($notification->queue)
+                            ->onQueue($queue)
                             ->delay($notification->delay)
                             ->through(
                                 array_merge(


### PR DESCRIPTION
Notification can optionally define queue for each channel via public $onQueues = ['mail' => 'emails', 'channel2' => 'queue2'] -- falls back to existing behavior:  $notification->queue

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
