### PR TITLE
[7.x] Add hasScope function to the Base Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1329,7 +1329,7 @@ class Builder
 
     /**
      * Determine if the given model has a scope.
-     * 
+     *
      * @param string $method
      * @return bool
      */
@@ -1385,7 +1385,7 @@ class Builder
         }
 
         if ($this->hasScope($method)) {
-            return $this->callScope([$this->model, 'scope' . ucfirst($method)], $parameters);
+            return $this->callScope([$this->model, 'scope'.ucfirst($method)], $parameters);
         }
 
         if (in_array($method, $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1328,6 +1328,17 @@ class Builder
     }
 
     /**
+     * Determine if the given model has a scope.
+     * 
+     * @param string $method
+     * @return bool
+     */
+    public function hasScope(string $name)
+    {
+        return $this->model->hasScope($name);
+    }
+
+    /**
      * Dynamically access builder proxies.
      *
      * @param  string  $key
@@ -1373,7 +1384,7 @@ class Builder
             return call_user_func_array(static::$macros[$method], $parameters);
         }
 
-        if ($this->model->hasScope($method)) {
+        if ($this->hasScope($method)) {
             return $this->callScope([$this->model, 'scope' . ucfirst($method)], $parameters);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1330,10 +1330,10 @@ class Builder
     /**
      * Determine if the given model has a scope.
      *
-     * @param string $method
+     * @param  string  $name
      * @return bool
      */
-    public function hasScope(string $name)
+    public function hasScope($name)
     {
         return $this->model && $this->model->hasScope($name);
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1335,7 +1335,7 @@ class Builder
      */
     public function hasScope(string $name)
     {
-        return $this->model->hasScope($name);
+        return $this->model && $this->model->hasScope($name);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1373,8 +1373,8 @@ class Builder
             return call_user_func_array(static::$macros[$method], $parameters);
         }
 
-        if (method_exists($this->model, $scope = 'scope'.ucfirst($method))) {
-            return $this->callScope([$this->model, $scope], $parameters);
+        if ($this->model->hasScope($method)) {
+            return $this->callScope([$this->model, 'scope' . ucfirst($method)], $parameters);
         }
 
         if (in_array($method, $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -334,10 +334,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Determine if the given model has a scope.
      *
-     * @param string $method
+     * @param  string  $method
      * @return bool
      */
-    public function hasScope(string $method)
+    public function hasScope($method)
     {
         return method_exists($this, 'scope'.ucfirst($method));
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -333,13 +333,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
     /**
      * Determine if the given model has a scope.
-     * 
+     *
      * @param string $method
      * @return bool
      */
     public function hasScope(string $method)
     {
-        return method_exists($this, 'scope' . ucfirst($method));
+        return method_exists($this, 'scope'.ucfirst($method));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -332,6 +332,17 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if the given model has a scope.
+     * 
+     * @param string $method
+     * @return bool
+     */
+    public function hasScope(string $method)
+    {
+        return method_exists($this, 'scope' . ucfirst($method));
+    }
+
+    /**
      * Fill the model with an array of attributes.
      *
      * @param  array  $attributes

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @group integration
+ */
+class EloquentModelScopeTest extends DatabaseTestCase
+{
+    public function testModelHasScope()
+    {
+        $model = new TestModel1;
+
+        $this->assertTrue($model->hasScope("exists"));
+    }
+
+    public function testModelDoesNotHaveScope()
+    {
+        $model = new TestModel1;
+
+        $this->assertFalse($model->hasScope("doesNotExist"));
+    }
+}
+
+class TestModel1 extends Model
+{
+    public function scopeExists()
+    {
+        return true;
+    }
+}

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -11,20 +11,20 @@ class EloquentModelScopeTest extends DatabaseTestCase
 {
     public function testModelHasScope()
     {
-        $model = new TestModel1;
+        $model = new TestScopeModel1;
 
         $this->assertTrue($model->hasScope("exists"));
     }
 
     public function testModelDoesNotHaveScope()
     {
-        $model = new TestModel1;
+        $model = new TestScopeModel1;
 
         $this->assertFalse($model->hasScope("doesNotExist"));
     }
 }
 
-class TestModel1 extends Model
+class TestScopeModel1 extends Model
 {
     public function scopeExists()
     {

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -13,14 +13,14 @@ class EloquentModelScopeTest extends DatabaseTestCase
     {
         $model = new TestScopeModel1;
 
-        $this->assertTrue($model->hasScope("exists"));
+        $this->assertTrue($model->hasScope('exists'));
     }
 
     public function testModelDoesNotHaveScope()
     {
         $model = new TestScopeModel1;
 
-        $this->assertFalse($model->hasScope("doesNotExist"));
+        $this->assertFalse($model->hasScope('doesNotExist'));
     }
 }
 


### PR DESCRIPTION
This `hasScope` method cleans up checking if a scope exists in a dynamic way.

The use case for this is requests containing an array of filters to be applied (via scopes), the code is more expressive with:

```
public function index(Request $request)
    {
        $post = Post::query();

        foreach ($request->get('filters', []) as $filter) {
            if ($post->hasScope($filter)) {
                $post->{$filter}();
            }
        }

        return $post->paginate();
    }
```