### PR TITLE
[7.x] Run pagination count as subquery for group by and havings

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2256,9 +2256,11 @@ class Builder
     protected function runPaginationCountQuery($columns = ['*'])
     {
         if ($this->groups || $this->havings) {
+            $clone = $this->cloneForPaginationCount();
+
             return [(object) ['aggregate' => $this->newQuery()
-                        ->from(new Expression('('.$this->cloneForPaginationCount()->toSql().') as '.$this->grammar->wrap('aggregate_table')))
-                        ->mergeBindings($this)
+                        ->from(new Expression('('.$clone->toSql().') as '.$this->grammar->wrap('aggregate_table')))
+                        ->mergeBindings($clone)
                         ->count(['*']), ]];
         }
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2259,7 +2259,7 @@ class Builder
             return [(object) ['aggregate' => $this->newQuery()
                         ->from(new Expression('('.$this->toSql().') as '.$this->grammar->wrap('aggregate_table')))
                         ->mergeBindings($this)
-                        ->count(['*'])]];
+                        ->count(['*']), ]];
         }
 
         $without = $this->unions ? ['orders', 'limit', 'offset'] : ['columns', 'orders', 'limit', 'offset'];

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2257,7 +2257,7 @@ class Builder
     {
         if ($this->groups || $this->havings) {
             return [(object) ['aggregate' => $this->newQuery()
-                        ->from(new Expression('('.$this->toSql().') as '.$this->grammar->wrap('aggregate_table')))
+                        ->from(new Expression('('.$this->cloneForPaginationCount()->toSql().') as '.$this->grammar->wrap('aggregate_table')))
                         ->mergeBindings($this)
                         ->count(['*']), ]];
         }
@@ -2268,6 +2268,17 @@ class Builder
                     ->cloneWithoutBindings($this->unions ? ['order'] : ['select', 'order'])
                     ->setAggregate('count', $this->withoutSelectAliases($columns))
                     ->get()->all();
+    }
+
+    /**
+     * Clone the existing query instance for usage in a pagination subquery.
+     *
+     * @return self
+     */
+    protected function cloneForPaginationCount()
+    {
+        return $this->cloneWithout(['orders', 'limit', 'offset'])
+                    ->cloneWithoutBindings(['order']);
     }
 
     /**


### PR DESCRIPTION
Paginating queries with `groupBy` or `having` statements is a long-standing issue in Laravel going back to the very beginning of the framework with literal dozens of raised issues:

#1892, #2761, #3105, #4306, #6985, #7372, #9567, #10632, #14123, #16320, #17406, #22883, #28931

This solution was suggested @acasar years ago but I wrote it off at the time - but honestly I think it's a lot better than what we have now so I'm bringing it up again for consideration.

👀