### PR TITLE
[7.x] Allow doing truth-test assertions with just a closure

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -5,10 +5,13 @@ namespace Illuminate\Support\Testing\Fakes;
 use Closure;
 use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class BusFake implements QueueingDispatcher
 {
+    use ReflectsClosures;
+
     /**
      * The original Bus dispatcher implementation.
      *
@@ -60,6 +63,10 @@ class BusFake implements QueueingDispatcher
      */
     public function assertDispatched($command, $callback = null)
     {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstParameterType($command), $command];
+        }
+
         if (is_numeric($callback)) {
             return $this->assertDispatchedTimes($command, $callback);
         }
@@ -98,6 +105,10 @@ class BusFake implements QueueingDispatcher
      */
     public function assertNotDispatched($command, $callback = null)
     {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstParameterType($command), $command];
+        }
+
         PHPUnit::assertTrue(
             $this->dispatched($command, $callback)->count() === 0 &&
             $this->dispatchedAfterResponse($command, $callback)->count() === 0,
@@ -114,6 +125,10 @@ class BusFake implements QueueingDispatcher
      */
     public function assertDispatchedAfterResponse($command, $callback = null)
     {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstParameterType($command), $command];
+        }
+
         if (is_numeric($callback)) {
             return $this->assertDispatchedAfterResponseTimes($command, $callback);
         }
@@ -150,6 +165,10 @@ class BusFake implements QueueingDispatcher
      */
     public function assertNotDispatchedAfterResponse($command, $callback = null)
     {
+        if ($command instanceof Closure) {
+            [$command, $callback] = [$this->firstParameterType($command), $command];
+        }
+
         PHPUnit::assertCount(
             0, $this->dispatchedAfterResponse($command, $callback),
             "The unexpected [{$command}] job was dispatched for after sending the response."

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -57,7 +57,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Assert if a job was dispatched based on a truth-test callback.
      *
-     * @param  string  $command
+     * @param  string|\Closure  $command
      * @param  callable|int|null  $callback
      * @return void
      */
@@ -99,7 +99,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Determine if a job was dispatched based on a truth-test callback.
      *
-     * @param  string  $command
+     * @param  string|\Closure  $command
      * @param  callable|null  $callback
      * @return void
      */
@@ -119,7 +119,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Assert if a job was dispatched after the response was sent based on a truth-test callback.
      *
-     * @param  string  $command
+     * @param  string|\Closure  $command
      * @param  callable|int|null  $callback
      * @return void
      */
@@ -159,7 +159,7 @@ class BusFake implements QueueingDispatcher
     /**
      * Determine if a job was dispatched based on a truth-test callback.
      *
-     * @param  string  $command
+     * @param  string|\Closure  $command
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -5,10 +5,13 @@ namespace Illuminate\Support\Testing\Fakes;
 use Closure;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class EventFake implements Dispatcher
 {
+    use ReflectsClosures;
+
     /**
      * The original event dispatcher.
      *
@@ -53,6 +56,10 @@ class EventFake implements Dispatcher
      */
     public function assertDispatched($event, $callback = null)
     {
+        if ($event instanceof Closure) {
+            [$event, $callback] = [$this->firstParameterType($event), $event];
+        }
+
         if (is_int($callback)) {
             return $this->assertDispatchedTimes($event, $callback);
         }
@@ -89,6 +96,10 @@ class EventFake implements Dispatcher
      */
     public function assertNotDispatched($event, $callback = null)
     {
+        if ($event instanceof Closure) {
+            [$event, $callback] = [$this->firstParameterType($event), $event];
+        }
+
         PHPUnit::assertCount(
             0, $this->dispatched($event, $callback),
             "The unexpected [{$event}] event was dispatched."

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -50,7 +50,7 @@ class EventFake implements Dispatcher
     /**
      * Assert if an event was dispatched based on a truth-test callback.
      *
-     * @param  string  $event
+     * @param  string|\Closure  $event
      * @param  callable|int|null  $callback
      * @return void
      */
@@ -90,7 +90,7 @@ class EventFake implements Dispatcher
     /**
      * Determine if an event was dispatched based on a truth-test callback.
      *
-     * @param  string  $event
+     * @param  string|\Closure  $event
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -2,15 +2,19 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Closure;
 use Illuminate\Contracts\Mail\Factory;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
 use Illuminate\Contracts\Mail\MailQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class MailFake implements Factory, Mailer, MailQueue
 {
+    use ReflectsClosures;
+
     /**
      * The mailer currently being used to send a message.
      *
@@ -41,6 +45,10 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertSent($mailable, $callback = null)
     {
+        if ($mailable instanceof Closure) {
+            [$mailable, $callback] = [$this->firstParameterType($mailable), $mailable];
+        }
+
         if (is_numeric($callback)) {
             return $this->assertSentTimes($mailable, $callback);
         }
@@ -112,6 +120,10 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertQueued($mailable, $callback = null)
     {
+        if ($mailable instanceof Closure) {
+            [$mailable, $callback] = [$this->firstParameterType($mailable), $mailable];
+        }
+
         if (is_numeric($callback)) {
             return $this->assertQueuedTimes($mailable, $callback);
         }

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -39,7 +39,7 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Assert if a mailable was sent based on a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|int|null  $callback
      * @return void
      */
@@ -114,7 +114,7 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Assert if a mailable was queued based on a truth-test callback.
      *
-     * @param  string  $mailable
+     * @param  string|\Closure  $mailable
      * @param  callable|int|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -35,7 +35,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * Assert if a notification was sent based on a truth-test callback.
      *
      * @param  mixed  $notifiable
-     * @param  string  $notification
+     * @param  string|\Closure  $notification
      * @param  callable|null  $callback
      * @return void
      *
@@ -91,7 +91,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * Determine if a notification was sent based on a truth-test callback.
      *
      * @param  mixed  $notifiable
-     * @param  string  $notification
+     * @param  string|\Closure  $notification
      * @param  callable|null  $callback
      * @return void
      *

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -55,9 +55,9 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             return;
         }
 
-       if ($notification instanceof Closure) {
-           [$notification, $callback] = [$this->firstParameterType($notification), $notification];
-       }
+        if ($notification instanceof Closure) {
+            [$notification, $callback] = [$this->firstParameterType($notification), $notification];
+        }
 
         if (is_numeric($callback)) {
             return $this->assertSentToTimes($notifiable, $notification, $callback);

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Support\Testing\Fakes;
 
+use Closure;
 use Exception;
 use Illuminate\Contracts\Notifications\Dispatcher as NotificationDispatcher;
 use Illuminate\Contracts\Notifications\Factory as NotificationFactory;
@@ -9,11 +10,12 @@ use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
+use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class NotificationFake implements NotificationDispatcher, NotificationFactory
 {
-    use Macroable;
+    use Macroable, ReflectsClosures;
 
     /**
      * All of the notifications that have been sent.
@@ -52,6 +54,10 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
 
             return;
         }
+
+       if ($notification instanceof Closure) {
+           [$notification, $callback] = [$this->firstParameterType($notification), $notification];
+       }
 
         if (is_numeric($callback)) {
             return $this->assertSentToTimes($notifiable, $notification, $callback);
@@ -103,6 +109,10 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             }
 
             return;
+        }
+
+        if ($notification instanceof Closure) {
+            [$notification, $callback] = [$this->firstParameterType($notification), $notification];
         }
 
         PHPUnit::assertCount(

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -3,12 +3,16 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use BadMethodCallException;
+use Closure;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Traits\ReflectsClosures;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class QueueFake extends QueueManager implements Queue
 {
+    use ReflectsClosures;
+
     /**
      * All of the jobs that have been pushed.
      *
@@ -25,6 +29,10 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertPushed($job, $callback = null)
     {
+        if ($job instanceof Closure) {
+            [$job, $callback] = [$this->firstParameterType($job), $job];
+        }
+
         if (is_numeric($callback)) {
             return $this->assertPushedTimes($job, $callback);
         }
@@ -62,6 +70,10 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertPushedOn($queue, $job, $callback = null)
     {
+        if ($job instanceof Closure) {
+            [$job, $callback] = [$this->firstParameterType($job), $job];
+        }
+
         return $this->assertPushed($job, function ($job, $pushedQueue) use ($callback, $queue) {
             if ($pushedQueue !== $queue) {
                 return false;
@@ -180,6 +192,10 @@ class QueueFake extends QueueManager implements Queue
      */
     public function assertNotPushed($job, $callback = null)
     {
+        if ($job instanceof Closure) {
+            [$job, $callback] = [$this->firstParameterType($job), $job];
+        }
+
         PHPUnit::assertCount(
             0, $this->pushed($job, $callback),
             "The unexpected [{$job}] job was pushed."

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -23,7 +23,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Assert if a job was pushed based on a truth-test callback.
      *
-     * @param  string  $job
+     * @param  string|\Closure  $job
      * @param  callable|int|null  $callback
      * @return void
      */
@@ -64,7 +64,7 @@ class QueueFake extends QueueManager implements Queue
      * Assert if a job was pushed based on a truth-test callback.
      *
      * @param  string  $queue
-     * @param  string  $job
+     * @param  string|\Closure  $job
      * @param  callable|null  $callback
      * @return void
      */
@@ -186,7 +186,7 @@ class QueueFake extends QueueManager implements Queue
     /**
      * Determine if a job was pushed based on a truth-test callback.
      *
-     * @param  string  $job
+     * @param  string|\Closure  $job
      * @param  callable|null  $callback
      * @return void
      */

--- a/src/Illuminate/Support/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Support/Traits/ReflectsClosures.php
@@ -23,7 +23,7 @@ trait ReflectsClosures
 
         return array_map(function (ReflectionParameter $parameter) {
             if ($parameter->isVariadic()) {
-                return null;
+                return;
             }
 
             return $parameter->getClass()->name ?? null;

--- a/src/Illuminate/Support/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Support/Traits/ReflectsClosures.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Support\Traits;
+
+use Closure;
+use ReflectionFunction;
+use ReflectionParameter;
+
+trait ReflectsClosures
+{
+    /**
+     * Get the class types of the parameters of the given closure.
+     *
+     * @param  Closure  $closure
+     * @return array
+     *
+     * @throws \ReflectionException
+     */
+    protected function closureParameterTypes(Closure $closure)
+    {
+        $reflection = new ReflectionFunction($closure);
+
+        return array_map(function (ReflectionParameter $parameter) {
+            if ($parameter->isVariadic()) {
+                return null;
+            }
+
+            return $parameter->getClass()->name ?? null;
+        }, $reflection->getParameters());
+    }
+}

--- a/src/Illuminate/Support/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Support/Traits/ReflectsClosures.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Traits;
 use Closure;
 use ReflectionFunction;
 use ReflectionParameter;
+use RuntimeException;
 
 trait ReflectsClosures
 {
@@ -16,7 +17,7 @@ trait ReflectsClosures
      *
      * @throws \ReflectionException
      */
-    protected function closureParameterTypes(Closure $closure)
+    protected function parameterTypes(Closure $closure)
     {
         $reflection = new ReflectionFunction($closure);
 
@@ -27,5 +28,28 @@ trait ReflectsClosures
 
             return $parameter->getClass()->name ?? null;
         }, $reflection->getParameters());
+    }
+
+    /**
+     * Get the class of the first parameter of the given closure.
+     *
+     * @param  Closure  $closure
+     * @return string
+     *
+     * @throws \ReflectionException|\RunTimeException
+     */
+    protected function firstParameterType(Closure $closure)
+    {
+        $types = $this->parameterTypes($closure);
+
+        if (! $types) {
+            throw new RunTimeException('The given closure has no parameters');
+        }
+
+        if ($types[0] === null) {
+            throw new RunTimeException('The first parameter of the given closure has no class type hint');
+        }
+
+        return $types[0];
     }
 }

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -37,6 +37,33 @@ class SupportReflectsClosuresTest extends TestCase
         });
     }
 
+    public function testItReturnsTheFirstParameterType()
+    {
+        $type = ReflectsClosuresClass::reflectFirst(function (ExampleParameter $a) {
+            //
+        });
+
+        $this->assertInstanceOf($type, new ExampleParameter);
+    }
+
+    public function testItThrowsWhenNoParameters()
+    {
+        $this->expectException(RuntimeException::class);
+
+        ReflectsClosuresClass::reflectFirst(function () {
+            //
+        });
+    }
+
+    public function testItThrowsWhenNoFirstParameterType()
+    {
+        $this->expectException(RuntimeException::class);
+
+        ReflectsClosuresClass::reflectFirst(function ($a, ExampleParameter $b) {
+            //
+        });
+    }
+
     private function assertParameterTypes($expected, $closure)
     {
         $types = ReflectsClosuresClass::reflect($closure);
@@ -51,7 +78,12 @@ class ReflectsClosuresClass
 
     public static function reflect($closure)
     {
-        return (new static)->closureParameterTypes($closure);
+        return (new static)->parameterTypes($closure);
+    }
+
+    public static function reflectFirst($closure)
+    {
+        return (new static)->firstParameterType($closure);
     }
 }
 

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Traits\ReflectsClosures;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SupportReflectsClosuresTest extends TestCase
+{
+    public function testReflectsClosures()
+    {
+        $this->assertParameterTypes([ExampleParameter::class], function (ExampleParameter $one) {
+            // assert the Closure isn't actually executed
+            throw new RunTimeException();
+        });
+
+        $this->assertParameterTypes([], function () {
+            //
+        });
+
+        $this->assertParameterTypes([null], function ($one) {
+            //
+        });
+
+        $this->assertParameterTypes([null, ExampleParameter::class], function ($one, ExampleParameter $two = null) {
+            //
+        });
+
+        $this->assertParameterTypes([null, ExampleParameter::class], function (string $one, ?ExampleParameter $two) {
+            //
+        });
+
+        // Because the parameter is variadic, the closure will always receive an array.
+        $this->assertParameterTypes([null], function (ExampleParameter ...$vars) {
+            //
+        });
+    }
+
+    private function assertParameterTypes($expected, $closure)
+    {
+        $types = ReflectsClosuresClass::reflect($closure);
+
+        $this->assertSame($expected, $types);
+    }
+}
+
+class ReflectsClosuresClass
+{
+    use ReflectsClosures;
+
+    public static function reflect($closure)
+    {
+        return (new static)->closureParameterTypes($closure);
+    }
+}
+
+class ExampleParameter
+{
+    //
+}

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -40,6 +40,15 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->assertDispatched(BusJobStub::class);
     }
 
+    public function testAssertDispatchedWithClosure()
+    {
+        $this->fake->dispatch(new BusJobStub);
+
+        $this->fake->assertDispatched(function (BusJobStub $job) {
+            return true;
+        });
+    }
+
     public function testAssertDispatchedAfterResponse()
     {
         try {
@@ -52,6 +61,18 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->dispatchAfterResponse(new BusJobStub);
 
         $this->fake->assertDispatchedAfterResponse(BusJobStub::class);
+    }
+
+    public function testAssertDispatchedAfterResponseClosure()
+    {
+        try {
+            $this->fake->assertDispatchedAfterResponse(function (BusJobStub $job) {
+                return true;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\BusJobStub] job was not dispatched for after sending the response.'));
+        }
     }
 
     public function testAssertDispatchedNow()
@@ -182,6 +203,21 @@ class SupportTestingBusFakeTest extends TestCase
         }
     }
 
+    public function testAssertNotDispatchedWithClosure()
+    {
+        $this->fake->dispatch(new BusJobStub);
+        $this->fake->dispatchNow(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatched(function (BusJobStub $job) {
+                return true;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched.'));
+        }
+    }
+
     public function testAssertNotDispatchedAfterResponse()
     {
         $this->fake->assertNotDispatchedAfterResponse(BusJobStub::class);
@@ -190,6 +226,20 @@ class SupportTestingBusFakeTest extends TestCase
 
         try {
             $this->fake->assertNotDispatchedAfterResponse(BusJobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched for after sending the response.'));
+        }
+    }
+
+    public function testAssertNotDispatchedAfterResponseClosure()
+    {
+        $this->fake->dispatchAfterResponse(new BusJobStub);
+
+        try {
+            $this->fake->assertNotDispatchedAfterResponse(function (BusJobStub $job) {
+                return true;
+            });
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\BusJobStub] job was dispatched for after sending the response.'));

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -31,6 +31,15 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->assertDispatched(EventStub::class);
     }
 
+    public function testAssertDispatchedWithClosure()
+    {
+        $this->fake->dispatch(new EventStub);
+
+        $this->fake->assertDispatched(function (EventStub $event) {
+            return true;
+        });
+    }
+
     public function testAssertDispatchedWithCallbackInt()
     {
         $this->fake->dispatch(EventStub::class);
@@ -69,6 +78,20 @@ class SupportTestingEventFakeTest extends TestCase
 
         try {
             $this->fake->assertNotDispatched(EventStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.'));
+        }
+    }
+
+    public function testAssertNotDispatchedWithClosure()
+    {
+        $this->fake->dispatch(new EventStub);
+
+        try {
+            $this->fake->assertNotDispatched(function (EventStub $event) {
+                return true;
+            });
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\EventStub] event was dispatched.'));

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -154,6 +154,24 @@ class SupportTestingMailFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The following mailables were queued unexpectedly: Illuminate\Tests\Support\MailableStub'));
         }
     }
+
+    public function testAssertQueuedWithClosure()
+    {
+        $this->fake->to($user = new LocalizedRecipientStub)->queue($this->mailable);
+
+        $this->fake->assertQueued(function (MailableStub $mail) use ($user) {
+            return $mail->hasTo($user);
+        });
+    }
+
+    public function testAssertSentWithClosure()
+    {
+        $this->fake->to($user = new LocalizedRecipientStub)->send($this->mailable);
+
+        $this->fake->assertSent(function (MailableStub $mail) use ($user) {
+            return $mail->hasTo($user);
+        });
+    }
 }
 
 class MailableStub extends Mailable implements MailableContract

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -51,6 +51,15 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->assertSentTo($this->user, NotificationStub::class);
     }
 
+    public function testAssertSentToClosure()
+    {
+        $this->fake->send($this->user, new NotificationStub);
+
+        $this->fake->assertSentTo($this->user, function (NotificationStub $notification) {
+            return true;
+        });
+    }
+
     public function testAssertNotSentTo()
     {
         $this->fake->assertNotSentTo($this->user, NotificationStub::class);
@@ -59,6 +68,20 @@ class SupportTestingNotificationFakeTest extends TestCase
 
         try {
             $this->fake->assertNotSentTo($this->user, NotificationStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.'));
+        }
+    }
+
+    public function testAssertNotSentToClosure()
+    {
+        $this->fake->send($this->user, new NotificationStub);
+
+        try {
+            $this->fake->assertNotSentTo($this->user, function (NotificationStub $notification) {
+                return true;
+            });
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\NotificationStub] notification was sent.'));

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -43,6 +43,15 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->assertPushed(JobStub::class);
     }
 
+    public function testAssertPushedWithClosure()
+    {
+        $this->fake->push($this->job);
+
+        $this->fake->assertPushed(function (JobStub $job) {
+            return true;
+        });
+    }
+
     public function testQueueSize()
     {
         $this->assertEquals(0, $this->fake->size());
@@ -54,12 +63,26 @@ class SupportTestingQueueFakeTest extends TestCase
 
     public function testAssertNotPushed()
     {
+        $this->fake->push($this->job);
+
+        try {
+            $this->fake->assertNotPushed(JobStub::class);
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\JobStub] job was pushed.'));
+        }
+    }
+
+    public function testAssertNotPushedWithClosure()
+    {
         $this->fake->assertNotPushed(JobStub::class);
 
         $this->fake->push($this->job);
 
         try {
-            $this->fake->assertNotPushed(JobStub::class);
+            $this->fake->assertNotPushed(function (JobStub $job) {
+                return true;
+            });
             $this->fail();
         } catch (ExpectationFailedException $e) {
             $this->assertThat($e, new ExceptionMessage('The unexpected [Illuminate\Tests\Support\JobStub] job was pushed.'));
@@ -78,6 +101,24 @@ class SupportTestingQueueFakeTest extends TestCase
         }
 
         $this->fake->assertPushedOn('foo', JobStub::class);
+    }
+
+    public function testAssertPushedOnWithClosure()
+    {
+        $this->fake->push($this->job, '', 'foo');
+
+        try {
+            $this->fake->assertPushedOn('bar', function (JobStub $job) {
+                return true;
+            });
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was not pushed.'));
+        }
+
+        $this->fake->assertPushedOn('foo', function (JobStub $job) {
+            return true;
+        });
     }
 
     public function testAssertPushedTimes()


### PR DESCRIPTION
Currently, for all the truth-test assertions, you have to first pass in a class, then a closure. If you want your editor to assist you with auto-completion, you have to type the class twice. Once as the first argument for the `assertQueued` method, and once as the type hint for the parameter of the closure.
```php
Mail::assertQueued(SubpictureFinishedEmail::class, function (SubpictureFinishedEmail $email) use ($user) {
    return $email->user->id === $user->id;
});

// or with a short closure

Mail::assertQueued(SubpictureFinishedEmail::class, fn (SubpictureFinishedEmail $email) => $email->user->id === $user->id);
```

This PR, using a little reflection magic, infers the type from the parameter of the closure. This removes the duplication, and allows you to write the assertions like this instead:

```php
Mail::assertQueued(function (SubpictureFinishedEmail $email) use ($user) {
    return $email->user->id === $user->id;
});

// or with a short closure

Mail::assertQueued(fn (SubpictureFinishedEmail $email) => $email->user->id === $user->id);
```

This isn't a breaking change, all modified methods will currently throw an exception if you give them a closure as the first argument.
