### PR TITLE
[7.x] Add object helper function

### DIFF
--- a/src/Illuminate/Support/Obj.php
+++ b/src/Illuminate/Support/Obj.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Support;
+
+use ArrayAccess;
+use InvalidArgumentException;
+
+class Obj implements ArrayAccess
+{
+    use Traits\Macroable {
+        __call as macroCall;
+    }
+
+    /**
+     * The underlying array value.
+     *
+     * @var array
+     */
+    protected $value;
+
+    /**
+     * Construct a new object helper instance.
+     *
+     * @param array|object $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $this->ensureArray($value);
+    }
+
+    /**
+     * Ensure the given value is an array,
+     * or throw an exception if not possible.
+     *
+     * @param $value
+     */
+    protected function ensureArray($value)
+    {
+        if (is_array($value) && Arr::isAssoc($value)) {
+            return $value;
+        }
+
+        if (is_object($value) && $value instanceof ArrayAccess) {
+            return (array) $value;
+        }
+
+        throw new InvalidArgumentException('The value provided is not an array or an object that implements ArrayAccess');
+    }
+
+    /**
+     * Get the underlying value as an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Determine if an item exists at an offset.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function offsetExists($key)
+    {
+        return Arr::accessible($this->value) && Arr::exists($this->value, $key);
+    }
+
+    /**
+     * Get an item at a given offset.
+     *
+     * @param  mixed  $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return Arr::get($this->value, $key);
+    }
+
+    /**
+     * Set the item at a given offset.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function offsetSet($key, $value)
+    {
+        if (Arr::accessible($this->value)) {
+            $this->value[$key] = $value;
+        }
+    }
+
+    /**
+     * Unset the item at a given offset.
+     *
+     * @param  string  $key
+     * @return void
+     */
+    public function offsetUnset($key)
+    {
+        if (Arr::accessible($this->value)) {
+            unset($this->value[$key]);
+        }
+    }
+
+    /**
+     * Dynamically access the given property on the underlying value.
+     *
+     * @param string $name
+     * @return \Illuminate\Support\Obj|mixed
+     */
+    public function __get(string $name)
+    {
+        $value = $this->value[$name];
+
+        return is_array($value) && Arr::isAssoc($value)
+            ? new static($value) : $value;
+    }
+
+    /**
+     * Dynamically pass a method to the underlying value.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return $this->value[$method](...$parameters);
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Obj;
 use Illuminate\Contracts\Support\DeferringDisplayableValue;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
@@ -108,6 +109,19 @@ if (! function_exists('collect')) {
     function collect($value = null)
     {
         return new Collection($value);
+    }
+}
+
+if (! function_exists('object')) {
+    /**
+     * Create an object helper instance from the given value.
+     *
+     * @param  array|object  $value
+     * @return \Illuminate\Support\Obj
+     */
+    function object($value)
+    {
+        return new Obj($value);
     }
 }
 


### PR DESCRIPTION
**Note: I'm submitting this PR for discussion as I've found this to be quite a pain-point for me when writing PHP, and so maybe others experience the same. The solution made in this PR may not be ideal but it illustrates the sort of thing I'm going for.**

This PR adds a helper function `object()` and an `Obj` class. The basic idea is this: in PHP we have a short-hand for associate arrays, however, arrays aren't very ergonomic with how you drill into them.

It can be pretty tiresome and ugly to see things like this:
```php
$environments['production']['foo']['bar']
```

When ideally what you want to write is:
```php
$environments->production->foo->bar
```

Currently in PHP casting an array to an object using `(object)` only does a shallow cast - if you have a nested associative array then it won't be cast. And of course, the solution you'll find on Google is to encode and decode your array as JSON - which just feels terrible and a problem waiting to happen.

The solution this PR adds is an `Obj` class with some magic methods to access your array properties as if it were an object - however, the underlying value remains an array.

This is how you'd use it:
```php
$object = object([
    'foo' => [
        'bar' => 1,
        'func' => fn () => dd('hey'),
    ]
]);

// Get foo->bar
$object->foo->bar

// Get the underlying array back
$array = $object->toArray();

// Still retain array access
$object['foo']['bar']

// Works with functions too
$object->foo->func();

// It still counts as an object too
function acceptsObject(object $object) {
    return $object;
}

acceptsObject($object)
```

Naturally, this isn't a one-stop solution for complex objects - for that you'll be better off writing a set of classes to fit your use-case. But if all you want is an ergonomic way of drilling into a big array then this might fit the job.

Something else which could be cool but I'm not sure if possible would be to accept array arguments as objects, so for example, if you pass in an array but you'd prefer to work with an object in your method (but not impose that type), then 'some magical thing' could instantiate the `Obj` for it:

```php
function handle(Obj $payload) {
    return $payload->something;
}

handle(['something' => 123]);
```

As I write this though it is becoming more and more of a crazy solution, but I'm gonna submit this PR anyway and see what happens 🤷 