### PR TITLE
[7.x] Call named scope and consistent method naming

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1003,9 +1003,9 @@ class Builder
      */
     protected function callNamedScope($scope, array $parameters = [])
     {
-        return $this->callScope(function () use ($scope, $parameters) {
+        return $this->callScope(function (...$parameters) use ($scope) {
             return $this->model->callNamedScope($scope, $parameters);
-        });
+        }, $parameters);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -896,9 +896,9 @@ class Builder
      * @param  string  $name
      * @return bool
      */
-    public function hasScope($name)
+    public function hasNamedScope($name)
     {
-        return $this->model && $this->model->hasScope($name);
+        return $this->model && $this->model->hasNamedScope($name);
     }
 
     /**
@@ -1395,7 +1395,7 @@ class Builder
             return call_user_func_array(static::$macros[$method], $parameters);
         }
 
-        if ($this->hasScope($method)) {
+        if ($this->hasNamedScope($method)) {
             return $this->callNamedScope($method, $parameters);
         }
 

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -922,10 +922,7 @@ class Builder
             // Next we'll pass the scope callback to the callScope method which will take
             // care of grouping the "wheres" properly so the logical order doesn't get
             // messed up when adding scopes. Then we'll return back out the builder.
-            $builder = $builder->callScope(
-                [$this->model, 'scope'.ucfirst($scope)],
-                (array) $parameters
-            );
+            $builder = $builder->callNamedScope($scope, (array) $parameters);
         }
 
         return $builder;
@@ -976,7 +973,7 @@ class Builder
      * @param  array  $parameters
      * @return mixed
      */
-    protected function callScope(callable $scope, $parameters = [])
+    protected function callScope(callable $scope, array $parameters = [])
     {
         array_unshift($parameters, $this);
 
@@ -995,6 +992,20 @@ class Builder
         }
 
         return $result;
+    }
+
+    /**
+     * Apply the given named scope on the current builder instance.
+     *
+     * @param  string  $scope
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected function callNamedScope($scope, array $parameters = [])
+    {
+        return $this->callScope(function () use ($scope, $parameters) {
+            return $this->model->callNamedScope($scope, $parameters);
+        });
     }
 
     /**
@@ -1385,7 +1396,7 @@ class Builder
         }
 
         if ($this->hasScope($method)) {
-            return $this->callScope([$this->model, 'scope'.ucfirst($method)], $parameters);
+            return $this->callNamedScope($method, $parameters);
         }
 
         if (in_array($method, $this->passthru)) {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1114,7 +1114,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  string  $scope
      * @return bool
      */
-    public function hasScope($scope)
+    public function hasNamedScope($scope)
     {
         return method_exists($this, 'scope'.ucfirst($scope));
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1111,12 +1111,24 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Determine if the model has a given scope.
      *
-     * @param  string  $method
+     * @param  string  $scope
      * @return bool
      */
-    public function hasScope($method)
+    public function hasScope($scope)
     {
-        return method_exists($this, 'scope'.ucfirst($method));
+        return method_exists($this, 'scope'.ucfirst($scope));
+    }
+
+    /**
+     * Apply the given named scope if possible.
+     *
+     * @param  string  $scope
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function callNamedScope($scope, array $parameters = [])
+    {
+        return $this->{'scope'.ucfirst($scope)}(...$parameters);
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelScopeTest.php
+++ b/tests/Integration/Database/EloquentModelScopeTest.php
@@ -13,14 +13,14 @@ class EloquentModelScopeTest extends DatabaseTestCase
     {
         $model = new TestScopeModel1;
 
-        $this->assertTrue($model->hasScope('exists'));
+        $this->assertTrue($model->hasNamedScope('exists'));
     }
 
     public function testModelDoesNotHaveScope()
     {
         $model = new TestScopeModel1;
 
-        $this->assertFalse($model->hasScope('doesNotExist'));
+        $this->assertFalse($model->hasNamedScope('doesNotExist'));
     }
 }
 


### PR DESCRIPTION
1. The model is the source of truth for if a scope exists, but then the builder bypasses it to call the scope method. Instead, we should delegate to the model. This PR addresses this, and provides a reusable way to apply scopes.
2. https://github.com/laravel/framework/pull/32622 added `hasScope`, but the name `hasNamedScope` would be more consistent, since `callScope` expects a full on callable and `callNamedScope` expects the actual scope name.