### PR TITLE
[7.x] Add Callbacks with Output to Console Schedule

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -499,6 +499,83 @@ class Event
     }
 
     /**
+     * Register a callback that uses the output after the job runs.
+     *
+     * @param  Closure $callback
+     * @param  bool  $onlyIfOutputExists
+     * @return $this
+     */
+    public function thenWithOutput(Closure $callback, $onlyIfOutputExists = false)
+    {
+        $this->ensureOutputIsBeingCaptured();
+
+        return $this->then($this->withOutputCallback($callback, $onlyIfOutputExists));
+    }
+
+    /**
+     * Register a callback that uses the output after the job runs if the given condition is true.
+     *
+     * @param  bool  $value
+     * @param  Closure $callback
+     * @param  bool  $onlyIfOutputExists
+     * @return $this
+     */
+    public function thenIfWithOutput($value, Closure $callback, $onlyIfOutputExists = false)
+    {
+        $this->ensureOutputIsBeingCaptured();
+
+        return $value ? $this->then($this->withOutputCallback($callback, $onlyIfOutputExists)) : $this;
+    }
+
+    /**
+     * Register a callback that uses the output if the operation succeeds.
+     *
+     * @param  Closure $callback
+     * @param  bool  $onlyIfOutputExists
+     * @return $this
+     */
+    public function onSuccessWithOutput(Closure $callback, $onlyIfOutputExists = false)
+    {
+        $this->ensureOutputIsBeingCaptured();
+
+        return $this->onSuccess($this->withOutputCallback($callback, $onlyIfOutputExists));
+    }
+
+    /**
+     * Register a callback that uses the output if the operation fails.
+     *
+     * @param  Closure $callback
+     * @param  bool  $onlyIfOutputExists
+     * @return $this
+     */
+    public function onFailureWithOutput(Closure $callback, $onlyIfOutputExists = false)
+    {
+        $this->ensureOutputIsBeingCaptured();
+
+        return $this->onFailure($this->withOutputCallback($callback, $onlyIfOutputExists));
+    }
+
+    /**
+     * Get the callback that provides output.
+     *
+     * @param  Closure $callback
+     * @param  bool  $onlyIfOutputExists
+     * @return Closure
+     */
+    protected function withOutputCallback(Closure $callback, $onlyIfOutputExists = false)
+    {
+        return function () use ($callback, $onlyIfOutputExists) {
+            $text = file_exists($this->output) ? file_get_contents($this->output) : '';
+
+            if ($onlyIfOutputExists && empty($text)) {
+                return;
+            }
+
+            return $callback($text);
+        };
+    }
+
+    /**
      * Register a callback to ping a given URL before the job runs.
      *
      * @param  string  $url

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -501,7 +501,7 @@ class Event
     /**
      * Register a callback that uses the output after the job runs.
      *
-     * @param  Closure $callback
+     * @param  \Closure  $callback
      * @param  bool  $onlyIfOutputExists
      * @return $this
      */
@@ -516,7 +516,7 @@ class Event
      * Register a callback that uses the output after the job runs if the given condition is true.
      *
      * @param  bool  $value
-     * @param  Closure $callback
+     * @param  \Closure  $callback
      * @param  bool  $onlyIfOutputExists
      * @return $this
      */
@@ -530,7 +530,7 @@ class Event
     /**
      * Register a callback that uses the output if the operation succeeds.
      *
-     * @param  Closure $callback
+     * @param  \Closure  $callback
      * @param  bool  $onlyIfOutputExists
      * @return $this
      */
@@ -544,7 +544,7 @@ class Event
     /**
      * Register a callback that uses the output if the operation fails.
      *
-     * @param  Closure $callback
+     * @param  \Closure  $callback
      * @param  bool  $onlyIfOutputExists
      * @return $this
      */
@@ -558,9 +558,9 @@ class Event
     /**
      * Get the callback that provides output.
      *
-     * @param  Closure $callback
+     * @param  \Closure  $callback
      * @param  bool  $onlyIfOutputExists
-     * @return Closure
+     * @return \Closure
      */
     protected function withOutputCallback(Closure $callback, $onlyIfOutputExists = false)
     {


### PR DESCRIPTION
Our health check provider allows POSTing output logs. Currently there's no built in way to do this. Instead of trying to figure out a one-size-fits-all to POST, my proposal is to use callbacks. This way you can use any kind of HTTP library you want, attach additional data, filter the output, etc.

I took the `$onlyIfOutputExists` argument from the `emailOutputTo()` command, so you can optionally only run the callback if an output was generated.

There are 4 callable methods, similar to the ping URL methods:
- `thenWithOutput()`
- `thenIfWithOutput()`
- `onSuccessWithOutput()`
- `onFailureWithOutput()`

Example:
```
$schedule->command('inspire')
    ->onSuccessWithOutput(function ($text) {
        Http::send('POST', 'https://healthcheckservice.test/abc123', [
            'body' => $text,
        ]);
    })
    ->daily();
```