### PR TITLE
[7.x] Update JSON attributes correctly after incrementing JSON value

### DIFF
--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1584,6 +1584,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(4, $model->foo);
         $this->assertEquals(1, $model->category);
         $this->assertTrue($model->isDirty('category'));
+
+        $model->inventory = ['quantity' => 4];
+        $model->publicIncrement('inventory->quantity', 6);
+        $this->assertEquals(10, $model->inventory['quantity']);
     }
 
     public function testRelationshipTouchOwnersIsPropagated()


### PR DESCRIPTION
This PR updates the JSON attributes of the model after incrementing one of its JSON attributes.

Currently, incrementing a JSON column on a model runs the query correctly, however, the attribute syncing throws a warning of a non-existing attribute key and does not update the value in the model itself. For example:

```php
$product->increment('quantity', 10); 
// works as expected

$product->increment('inventory->quantity', 10); 
// updates the value in the db, but not in the model instance
// No index: $model->original['inventory->quantity']
// Because it's: $model->original['inventory']['quantity']
```
This PR will search the subset value and update it with the incremented (or decremented) value. Then it syncs the modified attributes with the original attribues.