### PR TITLE
[7.x] Same-session ID request concurrency limiting

### DIFF
--- a/src/Illuminate/Cache/Lock.php
+++ b/src/Illuminate/Cache/Lock.php
@@ -33,6 +33,13 @@ abstract class Lock implements LockContract
     protected $owner;
 
     /**
+     * The number of milliseconds to wait before re-attempting to acquire a lock while blocking.
+     *
+     * @var int
+     */
+    protected $sleepMilliseconds = 250;
+
+    /**
      * Create a new lock instance.
      *
      * @param  string  $name
@@ -107,7 +114,7 @@ abstract class Lock implements LockContract
         $starting = $this->currentTime();
 
         while (! $this->acquire()) {
-            usleep(250 * 1000);
+            usleep($this->sleepMilliseconds * 1000);
 
             if ($this->currentTime() - $seconds >= $starting) {
                 throw new LockTimeoutException;
@@ -143,5 +150,18 @@ abstract class Lock implements LockContract
     protected function isOwnedByCurrentProcess()
     {
         return $this->getCurrentOwner() === $this->owner;
+    }
+
+    /**
+     * Specify the number of milliseconds to sleep in between blocked lock aquisition attempts.
+     *
+     * @param  int  $milliseconds
+     * @return $this
+     */
+    public function betweenBlockedAttemptsSleepFor($milliseconds)
+    {
+        $this->sleepMilliseconds = $milliseconds;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -144,6 +144,8 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
                 'defaults' => $route->defaults,
                 'wheres' => $route->wheres,
                 'bindingFields' => $route->bindingFields(),
+                'lockSeconds' => $route->locksFor(),
+                'waitSeconds' => $route->waitsFor(),
             ];
         }
 

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -297,7 +297,8 @@ class CompiledRouteCollection extends AbstractRouteCollection
             ->setFallback($attributes['fallback'])
             ->setDefaults($attributes['defaults'])
             ->setWheres($attributes['wheres'])
-            ->setBindingFields($attributes['bindingFields']);
+            ->setBindingFields($attributes['bindingFields'])
+            ->block($attributes['lockSeconds'] ?? null, $attributes['waitSeconds'] ?? null);
     }
 
     /**

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -93,6 +93,20 @@ class Route
     protected $originalParameters;
 
     /**
+     * Indicates the maximum number of seconds the route should acquire a session lock for.
+     *
+     * @var int|null
+     */
+    protected $lockSeconds;
+
+    /**
+     * Indicates the maximum number of seconds the route should wait while attempting to acquire a session lock.
+     *
+     * @var int|null
+     */
+    protected $waitSeconds;
+
+    /**
      * The computed gathered middleware.
      *
      * @var array|null
@@ -970,6 +984,51 @@ class Route
     public function excludedMiddleware()
     {
         return (array) ($this->action['excluded_middleware'] ?? []);
+    }
+
+    /**
+     * Specify that the route should not allow concurrent requests from the same session.
+     *
+     * @param  int|null  $lockSeconds
+     * @param  int|null  $waitSeconds
+     * @return $this
+     */
+    public function block($lockSeconds = 10, $waitSeconds = 10)
+    {
+        $this->lockSeconds = $lockSeconds;
+        $this->waitSeconds = $waitSeconds;
+
+        return $this;
+    }
+
+    /**
+     * Specify that the route should allow concurrent requests from the same session.
+     *
+     * @return $this
+     */
+    public function withoutBlocking()
+    {
+        return $this->block(null, null);
+    }
+
+    /**
+     * Get the maximum number of seconds the route's session lock should be held for.
+     *
+     * @return int|null
+     */
+    public function locksFor()
+    {
+        return $this->lockSeconds;
+    }
+
+    /**
+     * Get the maximum number of seconds to wait while attempting to acquire a session lock.
+     *
+     * @return int|null
+     */
+    public function waitsFor()
+    {
+        return $this->waitSeconds;
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Session\Middleware;
 
 use Closure;
-use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Http\Request;
 use Illuminate\Session\SessionManager;

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -71,7 +71,7 @@ class StartSession
                         ? $request->route()->locksFor()
                         : 10;
 
-        $lock = $this->cache->driver()
+        $lock = $this->cache->driver($this->manager->blockDriver())
                     ->lock('session:'.$session->getId(), $lockFor)
                     ->betweenBlockedAttemptsSleepFor(50);
 

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -203,6 +203,16 @@ class SessionManager extends Manager
     }
 
     /**
+     * Determine if requests for the same session should wait for each to finish before executing.
+     *
+     * @return bool
+     */
+    public function shouldBlock()
+    {
+        return $this->config->get('session.block', false);
+    }
+
+    /**
      * Get the session configuration.
      *
      * @return array

--- a/src/Illuminate/Session/SessionManager.php
+++ b/src/Illuminate/Session/SessionManager.php
@@ -213,6 +213,16 @@ class SessionManager extends Manager
     }
 
     /**
+     * Get the name of the cache store / driver that should be used to acquire session locks.
+     *
+     * @return string|null
+     */
+    public function blockDriver()
+    {
+        return $this->config->get('session.block_store');
+    }
+
+    /**
      * Get the session configuration.
      *
      * @return array

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Session;
 
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\ServiceProvider;
 
@@ -18,7 +19,11 @@ class SessionServiceProvider extends ServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton(StartSession::class);
+        $this->app->singleton(StartSession::class, function () {
+            return new StartSession($this->app->make(SessionManager::class), function () {
+                return $this->app->make(CacheFactory::class);
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
This PR implements a long requested feature (since basically the beginning of Laravel) for blocking concurrency requests from the same session until previous requests have finished. The basic use case being prevention of concurrent requests writing conflicting data to the session and data being lost.

There are many issues and StackOverflow / Laracasts / etc. threads about this but here is the most recent and the only one that still remains unclosed: https://github.com/laravel/framework/issues/18187

Implementing this doesn't seem particularly hard since Laravel offers atomic lock functionality out the box. If the `session.block` configuration variable is set to `true`, we attempt to obtain a lock on the a cache key matching `session:{session-id}`. Once we obtain one we process the request through the middleware and release the lock. If `session.block` is `false` there is no behavior change in session handling.

Route level blocking is implemented using a new `block` method on individual routes: `Route::post(...)->block()`

### This is a proof of concept and there are several things that need to be discussed:

It would be nice to ship locking support for the database cache driver. This seems possible (see: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Lock/Store/PdoStore.php). Offering this would open this feature up to a wider range of developers that may not have access to the currently supported `memcached`, `redis`, or `dynamodb` drivers.

### Caveats

This feature will not work with the `cookie` session driver.

Must be using `memcached`, `redis`, or `dynamodb` as a cache. As noted, would like to add `database` lock support.

### Remaining items summary:

- [x] Configurable block time at global and possibly route level
- [x] Ability to opt-in to blocking at route level only
- [x] Configurable cache driver to be used for session blocking
- [x] Database lock support
