### PR TITLE
[8.x] Dynamically load relationship counts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1505,7 +1505,7 @@ trait HasAttributes
      * Determine if the property being accessed is a relation count.
      *
      * @param  string  $key
-     * @return boolean
+     * @return bool
      */
     public function isRelationCount($key)
     {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -366,6 +366,12 @@ trait HasAttributes
             return;
         }
 
+        // If the attribute being accessed is a relation count we
+        // will run the withCount method and return the count.
+        if ($this->isRelationCount($key)) {
+            return $this->loadRelationCountAndReturnIt($key);
+        }
+
         return $this->getRelationValue($key);
     }
 
@@ -1493,5 +1499,29 @@ trait HasAttributes
         preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches);
 
         return $matches[1];
+    }
+
+    /**
+     * Determine if the property being accessed is a relation count.
+     *
+     * @param  string  $key
+     * @return boolean
+     */
+    public function isRelationCount($key)
+    {
+        return Str::endsWith($key, '_count') && ! method_exists(self::class, Str::before($key, '_count'));
+    }
+
+    /**
+     * Load a relationship count and returns it.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function loadRelationCountAndReturnIt($key)
+    {
+        $this->loadCount(Str::before($key, '_count'));
+
+        return $this->getAttribute($key);
     }
 }

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -90,6 +90,18 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
 
         $this->assertEquals(0, $model->deletedrelated_count);
     }
+
+    public function testCountCanBeAccessedAsProperty()
+    {
+        $model = BaseModel::first();
+
+        \DB::enableQueryLog();
+
+        $this->assertEquals(2, $model->related1_count);
+        $this->assertCount(1, \DB::getQueryLog());
+        $this->assertEquals(1, $model->related2_count);
+        $this->assertCount(2, \DB::getQueryLog());
+    }
 }
 
 class BaseModel extends Model

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -101,6 +101,10 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
         $this->assertCount(1, \DB::getQueryLog());
         $this->assertEquals(1, $model->related2_count);
         $this->assertCount(2, \DB::getQueryLog());
+
+        // to make sure we are not running a query again
+        $this->assertEquals(2, $model->related1_count);
+        $this->assertCount(2, \DB::getQueryLog());
     }
 }
 

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -74,21 +74,29 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
     {
         $model = BaseModel::first();
 
-        $this->assertEquals(null, $model->deletedrelated_count);
+        \DB::enableQueryLog();
 
         $model->loadCount('deletedrelated');
 
+        $this->assertCount(1, \DB::getQueryLog());
+
         $this->assertEquals(1, $model->deletedrelated_count);
+
+        \DB::disableQueryLog();
 
         DeletedRelated::first()->delete();
 
         $model = BaseModel::first();
 
-        $this->assertEquals(null, $model->deletedrelated_count);
+        \DB::enableQueryLog();
+
+        $this->assertEquals(0, $model->deletedrelated_count);
+        $this->assertCount(2, \DB::getQueryLog());
 
         $model->loadCount('deletedrelated');
 
         $this->assertEquals(0, $model->deletedrelated_count);
+        $this->assertCount(3, \DB::getQueryLog());
     }
 
     public function testCountCanBeAccessedAsProperty()


### PR DESCRIPTION
This PR enables relationship counts to be loaded dynamically. 

This is useful if you're checking counts in multiple places and you don't want to run multiple queries.

For instance, let's say you have an `Event` model with a `people_per_order` attribute and a `HasMany::Order` relationship. Now, if you need to display both the number of orders the event has and how many people are going, you could do something like this, but you'll run a count query twice. 

```
<td>{{ $event->orders()->count }}</td>
<td>{{ $event->orders()->count() * $event->people_per_order }}</td>
```  

In this case, sure, you could just load `orders` in-memory and run the count on the collection, but in more extreme cases that may become a hassle due to the load on the DB.   

Instead, with this PR, you could do:
```
<td>{{ $event->orders_count}}</td>
<td>{{ $event->orders_count * $event->people_per_order }}</td>
```

I'm very sorry but I wasn't completely sure where to put the test, and I also wasn't sure wether to throw an exception if someone tries to access the count of a relation that does not exist. 
I'm also setting the target branch as `master` because this is a breaking change IMO.

Thanks for the patience! :)