### PR TITLE
[7.x] Cache::lock support for the database cache driver

### DIFF
--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -214,7 +214,11 @@ class CacheManager implements FactoryContract
 
         return $this->repository(
             new DatabaseStore(
-                $connection, $config['table'], $this->getPrefix($config)
+                $connection,
+                $config['table'],
+                $this->getPrefix($config),
+                $config['lock_table'] ?? 'cache_locks',
+                $config['lock_lottery'] ?? [2, 100],
             )
         );
     }

--- a/src/Illuminate/Cache/CacheManager.php
+++ b/src/Illuminate/Cache/CacheManager.php
@@ -218,7 +218,7 @@ class CacheManager implements FactoryContract
                 $config['table'],
                 $this->getPrefix($config),
                 $config['lock_table'] ?? 'cache_locks',
-                $config['lock_lottery'] ?? [2, 100],
+                $config['lock_lottery'] ?? [2, 100]
             )
         );
     }

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Illuminate\Cache;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\QueryException;
+
+class DatabaseLock extends Lock
+{
+    /**
+     * The database connection instance.
+     *
+     * @var \Illuminate\Database\Connection
+     */
+    protected $connection;
+
+    /**
+     * The database table name.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The prune probability odds.
+     *
+     * @var string
+     */
+    protected $lottery;
+
+    /**
+     * Create a new lock instance.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @param  string  $table
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @param  array  $lottery
+     * @return void
+     */
+    public function __construct(Connection $connection, $table, $name, $seconds, $owner = null, $lottery = [2, 100])
+    {
+        parent::__construct($name, $seconds, $owner);
+
+        $this->connection = $connection;
+        $this->table = $table;
+        $this->lottery = $lottery;
+    }
+
+    /**
+     * Attempt to acquire the lock.
+     *
+     * @return bool
+     */
+    public function acquire()
+    {
+        $acquired = false;
+
+        try {
+            $this->connection->table($this->table)->insert([
+                'id' => $this->name,
+                'owner' => $this->owner,
+                'expires_at' => $this->expiresAt()
+            ]);
+
+            $acquired = true;
+        } catch (QueryException $e) {
+            $updated = $this->connection->table($this->table)
+                ->where('id', $this->name)
+                ->where(function ($query) {
+                    return $query->where('owner', $this->owner)->orWhere('expires_at', '<=', time());
+                })->update([
+                'owner' => $this->owner,
+                'expires_at' => $this->expiresAt()
+            ]);
+
+            $acquired = $updated >= 1;
+        }
+
+        if (random_int(1, $this->lottery[1]) <= $this->lottery[0]) {
+            $this->connection->table($this->table)->where('expires_at', '<=', time())->delete();
+        }
+
+        return $acquired;
+    }
+
+    /**
+     * Get the UNIX timestamp indicating when the lock should expire.
+     *
+     * @return int
+     */
+    protected function expiresAt()
+    {
+        return $this->seconds > 0 ? time() + $this->seconds : now()->addDays(1)->getTimestamp();
+    }
+
+    /**
+     * Release the lock.
+     *
+     * @return bool
+     */
+    public function release()
+    {
+        if ($this->isOwnedByCurrentProcess()) {
+            $this->connection->table($this->table)
+                        ->where('id', $this->name)
+                        ->where('owner', $this->owner)
+                        ->delete();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Releases this lock in disregard of ownership.
+     *
+     * @return void
+     */
+    public function forceRelease()
+    {
+        $this->connection->table($this->table)
+                    ->where('id', $this->name)
+                    ->delete();
+    }
+
+    /**
+     * Returns the owner value written into the driver for this lock.
+     *
+     * @return string
+     */
+    protected function getCurrentOwner()
+    {
+        return optional($this->connection->table($this->table)->where('id', $this->name)->first())->token;
+    }
+}

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -24,7 +24,7 @@ class DatabaseLock extends Lock
     /**
      * The prune probability odds.
      *
-     * @var string
+     * @var array
      */
     protected $lottery;
 

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -133,6 +133,6 @@ class DatabaseLock extends Lock
      */
     protected function getCurrentOwner()
     {
-        return optional($this->connection->table($this->table)->where('id', $this->name)->first())->token;
+        return optional($this->connection->table($this->table)->where('id', $this->name)->first())->owner;
     }
 }

--- a/src/Illuminate/Cache/DatabaseLock.php
+++ b/src/Illuminate/Cache/DatabaseLock.php
@@ -61,7 +61,7 @@ class DatabaseLock extends Lock
             $this->connection->table($this->table)->insert([
                 'id' => $this->name,
                 'owner' => $this->owner,
-                'expires_at' => $this->expiresAt()
+                'expires_at' => $this->expiresAt(),
             ]);
 
             $acquired = true;
@@ -71,9 +71,9 @@ class DatabaseLock extends Lock
                 ->where(function ($query) {
                     return $query->where('owner', $this->owner)->orWhere('expires_at', '<=', time());
                 })->update([
-                'owner' => $this->owner,
-                'expires_at' => $this->expiresAt()
-            ]);
+                    'owner' => $this->owner,
+                    'expires_at' => $this->expiresAt(),
+                ]);
 
             $acquired = $updated >= 1;
         }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -36,18 +36,40 @@ class DatabaseStore implements Store
     protected $prefix;
 
     /**
+     * The name of the cache locks table.
+     *
+     * @var string
+     */
+    protected $lockTable;
+
+    /**
+     * A array representation of the lock lottery odds.
+     *
+     * @var string
+     */
+    protected $lockLottery;
+
+    /**
      * Create a new database store.
      *
      * @param  \Illuminate\Database\ConnectionInterface  $connection
      * @param  string  $table
      * @param  string  $prefix
+     * @param  string  $lockTable
+     * @param  array  $lockLottery
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, $table, $prefix = '')
+    public function __construct(ConnectionInterface $connection,
+                                $table,
+                                $prefix = '',
+                                $lockTable = 'cache_locks',
+                                $lockLottery = [2, 100])
     {
         $this->table = $table;
         $this->prefix = $prefix;
         $this->connection = $connection;
+        $this->lockTable = $lockTable;
+        $this->lockLottery = $lockLottery;
     }
 
     /**
@@ -203,6 +225,38 @@ class DatabaseStore implements Store
     public function forever($key, $value)
     {
         return $this->put($key, $value, 315360000);
+    }
+
+    /**
+     * Get a lock instance.
+     *
+     * @param  string  $name
+     * @param  int  $seconds
+     * @param  string|null  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function lock($name, $seconds = 0, $owner = null)
+    {
+        return new DatabaseLock(
+            $this->connection,
+            $this->lockTable,
+            $this->prefix.$name,
+            $seconds,
+            $owner,
+            $this->lockLottery
+        );
+    }
+
+    /**
+     * Restore a lock instance using the owner identifier.
+     *
+     * @param  string  $name
+     * @param  string  $owner
+     * @return \Illuminate\Contracts\Cache\Lock
+     */
+    public function restoreLock($name, $owner)
+    {
+        return $this->lock($name, 0, $owner);
     }
 
     /**

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -45,7 +45,7 @@ class DatabaseStore implements Store
     /**
      * A array representation of the lock lottery odds.
      *
-     * @var string
+     * @var array
      */
     protected $lockLottery;
 

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class DatabaseLockTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('owner');
+            $table->integer('expires_at');
+        });
+    }
+
+    public function testLockCanBeAcquired()
+    {
+        $lock = Cache::driver('database')->lock('foo');
+        $this->assertTrue($lock->get());
+
+        $otherLock = Cache::driver('database')->lock('foo');
+        $this->assertFalse($otherLock->get());
+
+        $lock->release();
+
+        $otherLock = Cache::driver('database')->lock('foo');
+        $this->assertTrue($otherLock->get());
+
+        $otherLock->release();
+    }
+
+    public function testLockCanBeForceReleased()
+    {
+        $lock = Cache::driver('database')->lock('foo');
+        $this->assertTrue($lock->get());
+
+        $otherLock = Cache::driver('database')->lock('foo');
+        $otherLock->forceRelease();
+        $this->assertTrue($otherLock->get());
+
+        $otherLock->release();
+    }
+
+    public function testExpiredLockCanBeRetrieved()
+    {
+        $lock = Cache::driver('database')->lock('foo');
+        $this->assertTrue($lock->get());
+        DB::table('cache_locks')->update(['expires_at' => now()->subDays(1)->getTimestamp()]);
+
+        $otherLock = Cache::driver('database')->lock('foo');
+        $this->assertTrue($otherLock->get());
+
+        $otherLock->release();
+    }
+}


### PR DESCRIPTION
This provides cache lock support for the database cache driver inspired by: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Lock/Store/PdoStore.php

Tests pending...