### PR TITLE
[8.x] Allow app config to override package aliases

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
+++ b/src/Illuminate/Foundation/Bootstrap/RegisterFacades.php
@@ -22,8 +22,8 @@ class RegisterFacades
         Facade::setFacadeApplication($app);
 
         AliasLoader::getInstance(array_merge(
-            $app->make('config')->get('app.aliases', []),
-            $app->make(PackageManifest::class)->aliases()
+            $app->make(PackageManifest::class)->aliases(),
+            $app->make('config')->get('app.aliases', [])
         ))->register();
     }
 }


### PR DESCRIPTION
If you include two packages with the same alias defined, the rule will be that the last one will override the others (PackageManifest::config ->Collection::flatMap -> Arr::collapse). Which may be tricky to determine. Allowing the app to override the definition may be a good way to fix that kind of conflict. However that change can modify actual behavior where package overrides default aliases.