### PR TITLE
[6.x] Allow null for query columns

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -54,7 +54,7 @@ class Grammar extends BaseGrammar
         // can build the query and concatenate all the pieces together as one.
         $original = $query->columns;
 
-        if (is_null($query->columns)) {
+        if (empty($query->columns)) {
             $query->columns = ['*'];
         }
 

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -45,6 +45,9 @@ class DatabaseQueryBuilderTest extends TestCase
             $this->assertSame('select * from "users"', $sql);
         });
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
+            $this->assertSame('select * from "users"', $sql);
+        });
+        $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
             $this->assertSame('select "foo", "bar" from "users"', $sql);
         });
         $builder->getConnection()->shouldReceive('select')->once()->andReturnUsing(function ($sql) {
@@ -52,6 +55,9 @@ class DatabaseQueryBuilderTest extends TestCase
         });
 
         $builder->from('users')->get();
+        $this->assertNull($builder->columns);
+
+        $builder->from('users')->get(null);
         $this->assertNull($builder->columns);
 
         $builder->from('users')->get(['foo', 'bar']);


### PR DESCRIPTION
Allow `null` for query columns as in Laravel 5.
If `null` is specified, it behaves as if omitted.
Currently, it is a syntax error.

```php
// when $columns may be null
App\User::get($columns); 

// or when $columns may be undefined
App\User::get($columns ?? null);
```

After the change, if columns are `null` or undefined, the following query is executed:
```sql
select * from "users"
```

Currently, if columns are `null` or undefined, the following syntax error occurs:
```
Illuminate/Database/QueryException with message 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'from `users`' at line 1 (SQL: select  from `users`)'
```

I think it's more helpful for users to use it without knowing the default argument `['*']`.