### PR TITLE
[6.x] Remove wasted file read when loading package manifest

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -106,8 +106,6 @@ class PackageManifest
             $this->build();
         }
 
-        $this->files->get($this->manifestPath);
-
         return $this->manifest = file_exists($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
     }


### PR DESCRIPTION
See #32645

This PR removes an unused `file_get_contents` of the packages manifest file.

**How / Why**
I was optimizing an application to have zero disk accesses, but I noticed the package manifest was read on every request, even though it is a PHP file and it should be cached by opcache.

I dug into the code and I find out there's a get of the manifest file before requiring it:
https://github.com/laravel/framework/blob/407372de8bb0031ba8364d303cd74bf306a11441/src/Illuminate/Foundation/PackageManifest.php#L109
This translates to always reading the file into memory, and then throwing away the result.

`$this->files->get` was introduced in commit 683637a5c0d8ee0049e9067785175f9a291e824e as a locking mechanism to prevent partial reads of the manifest file.
In commit 633a907bf974d303a2ee19eef070efdc6150ca2c the locking was substituted by an atomic rename-based file write. The get called survived the refactor, resulting a no-op `file_get_contents` that just trashes the output.

**Behavior Differences**
When the build function is not capable of creating the file, the filesystem get would have thrown a `FileNotFoundException`. After this changes, an empty manifest is returned instead.
I don't think there is a way for build to silently fail a write, and the following line is explicitly checking the existence of the file. Hence I believe this is the intended behavior.
