### PR TITLE
[8.x] Add exception for undefined cast

### DIFF
--- a/src/Illuminate/Database/Eloquent/CastNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/CastNotFoundException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Illuminate\Database\Eloquent;
+
+use RuntimeException;
+
+class CastNotFoundException extends RuntimeException
+{
+    /**
+     * The name of the affected Eloquent model.
+     *
+     * @var string
+     */
+    public $model;
+
+    /**
+     * The name of the column.
+     *
+     * @var string
+     */
+    public $column;
+
+    /**
+     * The name of the cast type.
+     *
+     * @var string
+     */
+    public $castType;
+
+    /**
+     * Create a new exception instance.
+     *
+     * @param  mixed  $model
+     * @param  string  $column
+     * @param  string  $castType
+     * @return static
+     */
+    public static function make($model, $column, $castType)
+    {
+        $class = get_class($model);
+
+        $instance = new static("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");
+
+        $instance->model = $model;
+        $instance->column = $column;
+        $instance->castType = $castType;
+
+        return $instance;
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -8,7 +8,7 @@ use Illuminate\Collections\Arr;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\CastNotFoundException;
+use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
@@ -1065,7 +1065,7 @@ trait HasAttributes
             return true;
         }
 
-        throw CastNotFoundException::make($this->getModel(), $key, $castType);
+        throw InvalidCastException::make($this->getModel(), $key, $castType);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -4,12 +4,12 @@ namespace Illuminate\Database\Eloquent;
 
 use RuntimeException;
 
-class CastNotFoundException extends RuntimeException
+class InvalidCastException extends RuntimeException
 {
     /**
      * The name of the affected Eloquent model.
      *
-     * @var string
+     * @var object
      */
     public $model;
 
@@ -30,7 +30,7 @@ class CastNotFoundException extends RuntimeException
     /**
      * Create a new exception instance.
      *
-     * @param  mixed  $model
+     * @param  object  $model
      * @param  string  $column
      * @param  string  $castType
      * @return static

--- a/src/Illuminate/Database/Eloquent/InvalidCastException.php
+++ b/src/Illuminate/Database/Eloquent/InvalidCastException.php
@@ -9,7 +9,7 @@ class InvalidCastException extends RuntimeException
     /**
      * The name of the affected Eloquent model.
      *
-     * @var object
+     * @var string
      */
     public $model;
 
@@ -41,7 +41,7 @@ class InvalidCastException extends RuntimeException
 
         $instance = new static("Call to undefined cast [{$castType}] on column [{$column}] in model [{$class}].");
 
-        $instance->model = $model;
+        $instance->model = $class;
         $instance->column = $column;
         $instance->castType = $castType;
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Database\Eloquent\CastNotFoundException;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -141,6 +142,24 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $this->assertInstanceOf(ValueObject::class, $model->value_object_caster_with_caster_instance);
     }
+
+    public function testGetFromUndefinedCast()
+    {
+        $this->expectException(CastNotFoundException::class);
+
+        $model = new TestEloquentModelWithCustomCast;
+        $model->undefined_cast_column;
+    }
+
+    public function testSetToUndefinedCast()
+    {
+        $this->expectException(CastNotFoundException::class);
+
+        $model = new TestEloquentModelWithCustomCast;
+        $this->assertTrue($model->hasCast('undefined_cast_column'));
+
+        $model->undefined_cast_column = 'Glāžšķūņu rūķīši';
+    }
 }
 
 class TestEloquentModelWithCustomCast extends Model
@@ -166,6 +185,7 @@ class TestEloquentModelWithCustomCast extends Model
         'value_object_with_caster' => ValueObject::class,
         'value_object_caster_with_argument' => ValueObject::class.':argument',
         'value_object_caster_with_caster_instance' => ValueObjectWithCasterInstance::class,
+        'undefined_cast_column' => UndefinedCast::class,
     ];
 }
 

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -5,7 +5,7 @@ namespace Illuminate\Tests\Integration\Database;
 use Illuminate\Contracts\Database\Eloquent\Castable;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Database\Eloquent\CastNotFoundException;
+use Illuminate\Database\Eloquent\InvalidCastException;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -145,7 +145,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
     public function testGetFromUndefinedCast()
     {
-        $this->expectException(CastNotFoundException::class);
+        $this->expectException(InvalidCastException::class);
 
         $model = new TestEloquentModelWithCustomCast;
         $model->undefined_cast_column;
@@ -153,7 +153,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
     public function testSetToUndefinedCast()
     {
-        $this->expectException(CastNotFoundException::class);
+        $this->expectException(InvalidCastException::class);
 
         $model = new TestEloquentModelWithCustomCast;
         $this->assertTrue($model->hasCast('undefined_cast_column'));


### PR DESCRIPTION
Currently casting to an undefined type silently skips the cast.

These currently leave the value uncasted:

```php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class MyModel extends Model 
{
	protected $casts = [
		'a_number' => 'intger',  // typo 
		'custom' => MyCast,      // missing import
	];
}
```

This PR adds an exception that is thrown on such cases to inform developer about the error.
