### PR TITLE
[7.x] Make MakesHttpRequests::prepareUrlForRequest method simpler

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -485,11 +485,7 @@ trait MakesHttpRequests
      */
     protected function prepareUrlForRequest($uri)
     {
-        if (Str::startsWith($uri, '/')) {
-            $uri = substr($uri, 1);
-        }
-
-        return trim(url($uri), '/');
+        return url(trim($uri, '/'));
     }
 
     /**


### PR DESCRIPTION
Recently @taylorotwell changed `Illuminate\Foundation\Testing\Concerns::prepareUrlForRequest` method: https://github.com/laravel/framework/commit/5608c22e28f71cd3484af08d0ebf315bb95e9445

It seems it might be even more simpler. We don't need to look for the `/` character and substring it, we could just trim it from the both sides of the `$uri` variable.