### PR TITLE
[6.x] Fix assertJsonCount not accepting falsey keys

### DIFF
--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -684,7 +684,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonCount(int $count, $key = null)
     {
-        if ($key) {
+        if ($key !== null) {
             PHPUnit::assertCount(
                 $count, data_get($this->json(), $key),
                 "Failed to assert that the response count matched the expected {$count}"

--- a/src/Illuminate/Foundation/Testing/TestResponse.php
+++ b/src/Illuminate/Foundation/Testing/TestResponse.php
@@ -684,7 +684,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonCount(int $count, $key = null)
     {
-        if ($key !== null) {
+        if (! is_null($key)) {
             PHPUnit::assertCount(
                 $count, data_get($this->json(), $key),
                 "Failed to assert that the response count matched the expected {$count}"

--- a/tests/Foundation/FoundationTestResponseTest.php
+++ b/tests/Foundation/FoundationTestResponseTest.php
@@ -484,6 +484,9 @@ class FoundationTestResponseTest extends TestCase
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
+        // With falsey key
+        $response->assertJsonCount(1, '0');
+
         // With simple key
         $response->assertJsonCount(3, 'bars');
 
@@ -918,6 +921,7 @@ class JsonSerializableMixedResourcesStub implements JsonSerializable
                 'foobar_foo' => 'foo',
                 'foobar_bar' => 'bar',
             ],
+            '0' => ['foo'],
             'bars' => [
                 ['bar' => 'foo 0', 'foo' => 'bar 0'],
                 ['bar' => 'foo 1', 'foo' => 'bar 1'],


### PR DESCRIPTION
This fixes the issue described in #32651, where assertJsonCount does not accept the key '0' due to a boolean comparison instead of a strict null comparison.

I can open another PR with the same changes for the 7.x branch if necessary (both files have been renamed between 6.x and 7.x so they cannot be merged).