### PR TITLE
[7.x] Show a link to the files created by "make" commands

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -73,7 +73,7 @@ abstract class GeneratorCommand extends Command
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
 
-        $this->info($this->type.' created successfully.');
+        $this->info("Created {$this->type}: {$this->getLink($path)}");
     }
 
     /**
@@ -132,6 +132,19 @@ abstract class GeneratorCommand extends Command
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
         return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get a short link to the destination class path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    protected function getLink($path)
+    {
+        $link = Str::after($path, $this->laravel->basePath());
+
+        return Str::replaceFirst('/', '', $link);
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds information about the files created by commands that extend `GeneratorCommand`.

Before:
```
php artisan make:model Merch --all
Model created successfully.
Factory created successfully.
Created Migration: 2020_05_02_172056_create_merches_table
Seeder created successfully.
Controller created successfully.
```

With this PR:
```
php artisan make:model Merch --all
Created Model: app/Merch.php
Created Factory: database/factories/MerchFactory.php
Created Migration: 2020_05_02_172056_create_merches_table
Created Seeder: database/seeds/MerchSeeder.php
Created Controller: app/Http/Controllers/MerchController.php
```

Benefits:
The main benefit comes when using iTerm2, because the paths will be clickable saving developers a few clicks and a bit of scrolling. For beginners it will make it easier to locate the files created by the commands.

The output for `make:model * --all` will also look more consistent with the `make:migration` command. (The reason for the migration output being unchanged is that it doesn't extend `GeneratorCommand`.)

Breaking changes:
It will make tests fail for people extending `GeneratorCommand` and asserting its output. (If they didn't override the `handle()` method.)

Speaking about test:
The reason there are no tests included in this PR is because are no existing tests for `GeneratorCommand` or any class that extends `GeneratorCommand`. And I think adding these tests are outside the scope of this PR.