### PR TITLE
[7.x] Console command test output dumping

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -218,11 +218,11 @@ class PendingCommand
             );
         }
 
-        $this->verifyExpectations();
-
         if ($this->shouldDumpOutput) {
             dump($this->getActualOutput());
         }
+
+        $this->verifyExpectations();
 
         return $exitCode;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds the ability to dump the output of a console command after a test. As noted in https://github.com/laravel/ideas/issues/1656, it's currently difficult to determine the cause of console command test failures as there is no easy way to get at the output. This remedies that by adding a `dumpOutput()` method to the `PendingCommand` class to trigger a dump of the commands output after its execution.

An example of it's use:

    $this->artisan('inspire')
            ->expectsOutput('Simplicity is an acquired taste. - Katharine Gerould')
            ->assertExitCode(0)
            ->dumpOutput();

will yield something similar to:

    file:///.../src/Illuminate/Testing/PendingCommand.php#L222 array:13 [
        0 => "Well begun is half done. - Aristotle"
    ]

    Output "Simplicity is an acquired taste. - Katharine Gerould" was not printed.
    .../framework/src/Illuminate/Testing/PendingCommand.php:254
    .../framework/src/Illuminate/Testing/PendingCommand.php:225
    .../Testing/PendingCommand.php:331
    .../MyProject/tests/CommandTestCase.php:86


This is a non-breaking change as tests will perform as usual should the user not specify new `dumpOutput()` method in the assertion chain. Regarding tests, the PendingCommand test helper has no tests itself.