### PR TITLE
[7.x] Add whenKeyExists method

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -210,6 +210,34 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve a value if the key exists.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenKeyExists($key, $value = null, $default = null)
+    {
+        if (func_num_args() < 3) {
+            $default = new MissingValue;
+        }
+
+        if (! array_key_exists(
+            $key,
+            (is_array($this->resource) ? $this->resource : $this->resource->toArray())
+        )) {
+            return value($default);
+        }
+
+        if (func_num_args() === 1) {
+            $value = $this->resource->{$key};
+        }
+
+        return value($value);
+    }
+
+    /**
      * Transform the given value if it is present.
      *
      * @param  mixed  $value


### PR DESCRIPTION
This PR adds a method which allows filtering JsonResource to include only queried fields. e.g. when query has the select()/addSelect() methods or when specifying the columns in get() or paginate().

see https://github.com/laravel/framework/issues/32662