### PR TITLE
[7.x] Add `skipUntil` and `skipWhile` methods to the collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -979,6 +979,28 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Skip items in the collection until the given condition is met.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public function skipUntil($value)
+    {
+        return new static($this->lazy()->skipUntil($value)->all());
+    }
+
+    /**
+     * Skip items in the collection while the given condition is met.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public function skipWhile($value)
+    {
+        return new static($this->lazy()->skipWhile($value)->all());
+    }
+
+    /**
      * Slice the underlying collection array.
      *
      * @param  int  $offset

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -948,6 +948,44 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Skip items in the collection until the given condition is met.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public function skipUntil($value)
+    {
+        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
+
+        return $this->skipWhile($this->negate($callback));
+    }
+
+    /**
+     * Skip items in the collection while the given condition is met.
+     *
+     * @param  mixed  $value
+     * @return static
+     */
+    public function skipWhile($value)
+    {
+        $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
+
+        return new static(function () use ($callback) {
+            $iterator = $this->getIterator();
+
+            while ($iterator->valid() && $callback($iterator->current(), $iterator->key())) {
+                $iterator->next();
+            }
+
+            while ($iterator->valid()) {
+                yield $iterator->key() => $iterator->current();
+
+                $iterator->next();
+            }
+        });
+    }
+
+    /**
      * Get a slice of items from the enumerable.
      *
      * @param  int  $offset

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1183,9 +1183,7 @@ class LazyCollection implements Enumerable
     {
         $callback = $this->useAsCallable($value) ? $value : $this->equality($value);
 
-        return $this->takeUntil(function ($item, $key) use ($callback) {
-            return ! $callback($item, $key);
-        });
+        return $this->takeUntil($this->negate($callback));
     }
 
     /**

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -965,13 +965,26 @@ trait EnumeratesValues
     /**
      * Make a function to check an item's equality.
      *
-     * @param  \Closure|mixed  $value
+     * @param  mixed  $value
      * @return \Closure
      */
     protected function equality($value)
     {
         return function ($item) use ($value) {
             return $item === $value;
+        };
+    }
+
+    /**
+     * Make a function using another function, by negating its result.
+     *
+     * @param  \Closure  $callback
+     * @return \Closure
+     */
+    protected function negate($callback)
+    {
+        return function (...$params) use ($callback) {
+            return ! $callback(...$params);
         };
     }
 }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Traits;
 
 use CachingIterator;
+use Closure;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
@@ -981,7 +982,7 @@ trait EnumeratesValues
      * @param  \Closure  $callback
      * @return \Closure
      */
-    protected function negate($callback)
+    protected function negate(Closure $callback)
     {
         return function (...$params) use ($callback) {
             return ! $callback(...$params);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -215,6 +215,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSkipUntil($collection)
+    {
+        $data = new $collection([1, 1, 2, 2, 3, 3, 4, 4]);
+
+        $data = $data->skipUntil(3)->values();
+
+        $this->assertSame([3, 3, 4, 4], $data->all());
+
+        $data = $data->skipUntil(function ($value, $key) {
+            return $value > 3;
+        })->values();
+
+        $this->assertSame([4, 4], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSkipWhile($collection)
+    {
+        $data = new $collection([1, 1, 2, 2, 3, 3, 4, 4]);
+
+        $data = $data->skipWhile(1)->values();
+
+        $this->assertSame([2, 2, 3, 3, 4, 4], $data->all());
+
+        $data = $data->skipWhile(function ($value, $key) {
+            return $value < 3;
+        })->values();
+
+        $this->assertSame([3, 3, 4, 4], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testGetArrayableItems($collection)
     {
         $data = new $collection;

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -850,6 +850,40 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testSkipUntilIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->skipUntil(INF);
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->skipUntil(10)->first();
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->skipUntil(function ($item) {
+                return $item === 10;
+            })->first();
+        });
+    }
+
+    public function testSkipWhileIsLazy()
+    {
+        $this->assertDoesNotEnumerate(function ($collection) {
+            $collection->skipWhile(1);
+        });
+
+        $this->assertEnumerates(2, function ($collection) {
+            $collection->skipWhile(1)->first();
+        });
+
+        $this->assertEnumerates(10, function ($collection) {
+            $collection->skipWhile(function ($item) {
+                return $item < 10;
+            })->first();
+        });
+    }
+
     public function testSliceIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
This is the counterpart of [`takeWhile` and `takeUntil`](https://github.com/laravel/framework/pull/32496).

---

Here's a sample usage, using [the log file example of my original `LazyCollection` PR (example 4)](https://github.com/laravel/framework/pull/29415#:~:text=Another%20use-case%20would%20be%20reading%20the%20lines%20of%20a%20multi-GB%20log%20file).

We'll skip all logs that are from previous years:

```php
function get_logs_from_this_year()
{
    $year = date("Y");

    return LazyCollection::make(function () {
        $handle = fopen('log.txt', 'r');

        while (($line = fgets($handle)) !== false) {
            yield $line;
        }
    })
    ->chunk(4)
    ->skipUntil(fn ($lines) => Str::startsWith($lines[0], $year))
    ->map(fn ($lines) => LogEntry::fromLines($lines));
}
```