### PR TITLE
[7.x] Allow queue to be specified per channel

### DIFF
--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -189,11 +189,13 @@ class NotificationSender
                 if (! is_null($this->locale)) {
                     $notification->locale = $this->locale;
                 }
+                
+                $queue = (isset($notification->onQueues[$channel])) ? $notification->onQueues[$channel] : $notification->queue;
 
                 $this->bus->dispatch(
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
-                            ->onQueue($notification->queue)
+                            ->onQueue($queue)
                             ->delay($notification->delay)
                             ->through(
                                 array_merge(

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -189,13 +189,11 @@ class NotificationSender
                 if (! is_null($this->locale)) {
                     $notification->locale = $this->locale;
                 }
-                
-                $queue = (isset($notification->onQueues[$channel])) ? $notification->onQueues[$channel] : $notification->queue;
 
                 $this->bus->dispatch(
                     (new SendQueuedNotifications($notifiable, $notification, [$channel]))
                             ->onConnection($notification->connection)
-                            ->onQueue($queue)
+                            ->onQueue($notification->onQueues[$channel] ?? $notification->queue)
                             ->delay($notification->delay)
                             ->through(
                                 array_merge(


### PR DESCRIPTION
With this, notifications can optionally define a queue for each channel via `public $onQueues = ['mail' => 'emails', 'channel2' => 'queue2'];` -- it falls back to existing behavior of $notification->queue

My main purpose is to split the "mail" channel so it can be throttled separately.
