### PR TITLE
Allow action classes to be invoked by qualified class name

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -510,7 +510,7 @@ class Router implements BindingRegistrar, RegistrarContract
         // Here we'll merge any group "uses" statement if necessary so that the action
         // has the proper clause for this property. Then we can simply set the name
         // of the controller on the action and return the action array for usage.
-        if ($this->hasGroupStack()) {
+        if ($this->hasGroupStack() && ! method_exists($action['uses'], '__invoke')) {
             $action['uses'] = $this->prependGroupNamespace($action['uses']);
         }
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1717,6 +1717,23 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
     }
 
+    public function testGroupNamespaceCanBeIgnoredForActionClasses()
+    {
+        $router = $this->getRouter();
+
+        $router->namespace('App\Http\Controllers')->group(function ($router) {
+            $router->get('foo/bar', ActionStub::class);
+        });
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->namespace('Illuminate\Tests\Routing')->group(function ($router) {
+            $router->get('foo/bar2', 'ActionStub');
+        });
+
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
+    }
+
     public function testResponseIsReturned()
     {
         $router = $this->getRouter();


### PR DESCRIPTION
This PR adds the ability to add action classes to a route group without having to use the array syntax, it allows for there to be a default namespace in the RouteServiceProvider and allowing it to be overriden when needed.

For example the current syntax is:

```
use App\Http\Controllers\Example\ActionClass;

Route::get('/action', [ActionClass::class, '__invoke']);
```

This PR would allow for the following:

```
use App\Http\Controllers\Example\ActionClass;

Route::get('/action', ActionClass::class);
```

It also still works if there is a namespace set for the group and a string is passed for the action class name:

```
Route::namespace('Example')->group(function () {
    Route::get('/action', 'ActionClass');
});
```

This PR currently contains a basic test but I am happy to add more if needed.