### PR TITLE
[7.x] Use new static in Collection#mode()

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -135,7 +135,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $collection = isset($key) ? $this->pluck($key) : $this;
 
-        $counts = new self;
+        $counts = new static;
 
         $collection->each(function ($value) use ($counts) {
             $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1;


### PR DESCRIPTION
Changed to be consistent with the 61 other calls to `new static` in this class, the only other instance of `new self` being the one in `toBase()`.

As with all other methods, this now respects the ability of subclasses to override functionality of the Collection class.