### PR TITLE
[7.x] Add the build call to configure the Mailable instance properly in MailFake

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Testing\Fakes;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Mail\Factory;
 use Illuminate\Contracts\Mail\Mailable;
 use Illuminate\Contracts\Mail\Mailer;
@@ -322,7 +323,7 @@ class MailFake implements Factory, Mailer, MailQueue
     /**
      * Send a new message using a view.
      *
-     * @param  string|array  $view
+     * @param  \Illuminate\Contracts\Mail\Mailable|string|array  $view
      * @param  array  $data
      * @param  \Closure|string|null  $callback
      * @return void
@@ -341,6 +342,7 @@ class MailFake implements Factory, Mailer, MailQueue
             return $this->queue($view, $data);
         }
 
+        Container::getInstance()->call([$view, 'build']);
         $this->mailables[] = $view;
     }
 


### PR DESCRIPTION
The `Illuminate\Mail\Mailable` class let us to configure things with the build method. But because the `Illuminate\Support\Testing\Fakes\MailFake` doesn't call it, the Mailable instance doesn't get configured properly during test.

```php
class ExampleTest extends TestCase
{
    public function testTo()
    {
        Mail::fake();

        Mail::to('to@fake.com')->send(new FakeMailable());

        // This assertion passes as it's meant to
        Mail::assertSent(FakeMailable::class, function (Mailable $mailable) {
            return $mailable->hasTo('to@fake.com');
        });
    }

    public function testFrom()
    {
        Mail::fake();

        Mail::to('to@fake.com')->send(new FakeMailable());

        // This doesn't, since the mailable instance isn't configured properly
        Mail::assertSent(FakeMailable::class, function (Mailable $mailable) {
            return $mailable->hasFrom('from@fake.com');
        });
    }
}

class FakeMailable extends Mailable
{
    public function build()
    {
        return $this->from('from@fake.com');
    }
}
```
Anything like the `hasTo`, `hasFrom`, `hasBcc` or other methods, always return a false when the expected property is configured within the build method.

So this PR lets the configuration be done before the MailFake fakes the sending.

If I should write a test code too, please tell me 🙋‍♂️