### PR TITLE
[8.x] Allow Route::view() helper to set headers

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -265,13 +265,19 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  string  $uri
      * @param  string  $view
      * @param  array  $data
+     * @param  int|array  $status
+     * @param  array  $headers
      * @return \Illuminate\Routing\Route
      */
-    public function view($uri, $view, $data = [])
+    public function view($uri, $view, $data = [], $status = 200, array $headers = [])
     {
         return $this->match(['GET', 'HEAD'], $uri, '\Illuminate\Routing\ViewController')
-                ->defaults('view', $view)
-                ->defaults('data', $data);
+                ->setDefaults([
+                    'view' => $view,
+                    'data' => $data,
+                    'status' => is_array($status) ? 200 : $status,
+                    'headers' => is_array($status) ? $status : $headers,
+                ]);
     }
 
     /**

--- a/src/Illuminate/Routing/ViewController.php
+++ b/src/Illuminate/Routing/ViewController.php
@@ -2,38 +2,38 @@
 
 namespace Illuminate\Routing;
 
-use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\Routing\ResponseFactory;
 
 class ViewController extends Controller
 {
     /**
-     * The view factory implementation.
+     * The response factory implementation.
      *
-     * @var \Illuminate\Contracts\View\Factory
+     * @var \Illuminate\Contracts\Routing\ResponseFactory
      */
-    protected $view;
+    protected $response;
 
     /**
      * Create a new controller instance.
      *
-     * @param  \Illuminate\Contracts\View\Factory  $view
+     * @param  \Illuminate\Contracts\Routing\ResponseFactory  $response
      * @return void
      */
-    public function __construct(ViewFactory $view)
+    public function __construct(ResponseFactory $response)
     {
-        $this->view = $view;
+        $this->response = $response;
     }
 
     /**
      * Invoke the controller method.
      *
      * @param  array  $args
-     * @return \Illuminate\Contracts\View\View
+     * @return \Illuminate\Http\Response
      */
     public function __invoke(...$args)
     {
-        [$view, $data] = array_slice($args, -2);
+        [$view, $data, $status, $headers] = array_slice($args, -4);
 
-        return $this->view->make($view, $data);
+        return $this->response->view($view, $data, $status, $headers);
     }
 }

--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -29,7 +29,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Router|\Illuminate\Routing\RouteRegistrar group(\Closure|string|array $attributes, \Closure|string $routes)
  * @method static \Illuminate\Routing\Route redirect(string $uri, string $destination, int $status = 302)
  * @method static \Illuminate\Routing\Route permanentRedirect(string $uri, string $destination)
- * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [])
+ * @method static \Illuminate\Routing\Route view(string $uri, string $view, array $data = [], int $status = 200, array $headers = [])
  * @method static void bind(string $key, string|callable $binder)
  * @method static void model(string $key, string $class, \Closure|null $callback = null)
  * @method static \Illuminate\Routing\Route current()

--- a/tests/Integration/Routing/RouteViewTest.php
+++ b/tests/Integration/Routing/RouteViewTest.php
@@ -18,6 +18,7 @@ class RouteViewTest extends TestCase
         View::addLocation(__DIR__.'/Fixtures');
 
         $this->assertStringContainsString('Test bar', $this->get('/route')->getContent());
+        $this->assertSame(200, $this->get('/route')->status());
     }
 
     public function testRouteViewWithParams()
@@ -28,5 +29,32 @@ class RouteViewTest extends TestCase
 
         $this->assertStringContainsString('Test bar', $this->get('/route/value1/value2')->getContent());
         $this->assertStringContainsString('Test bar', $this->get('/route/value1')->getContent());
+    }
+
+    public function testRouteViewWithStatus()
+    {
+        Route::view('route', 'view', ['foo' => 'bar'], 418);
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $this->assertSame(418, $this->get('/route')->status());
+    }
+
+    public function testRouteViewWithHeaders()
+    {
+        Route::view('route', 'view', ['foo' => 'bar'], 418, ['Framework' => 'Laravel']);
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $this->assertSame('Laravel', $this->get('/route')->headers->get('Framework'));
+    }
+
+    public function testRouteViewOverloadingStatusWithHeaders()
+    {
+        Route::view('route', 'view', ['foo' => 'bar'], ['Framework' => 'Laravel']);
+
+        View::addLocation(__DIR__.'/Fixtures');
+
+        $this->assertSame('Laravel', $this->get('/route')->headers->get('Framework'));
     }
 }


### PR DESCRIPTION
## Example...

```php
// routes/api.php

Route::view('seat-map.svg', 'seat-map', ['Content-type' => 'image/svg+xml']);
```

## Why? My use case

In my current project, I'm manipulating an SVG on the fly within a blade component based on some query parameters, in order to highlight specific parts of the SVG.

```svg
<!-- resources/views/seat-map.blade.php -->
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600">
    <defs>
        <style>
            #section-{{ request()->query('section') }}-bg {
                fill: #482640;
            }
            #section-{{ request()->query('section') }}-number {
                fill: #482640;
            }
        </style>
    </defs>
    <!-- static SVG definition -->
</svg>
```

I thought, great I don't need a controller I can just use the `Route::view()` helper to bypass that. Unfortunately I did have to setup the boilerplate controller in order to attach the Content-type headers.

I had assumed that the `Route::view()` helper was a proxy to the more full featured `response()->view($view, $data, $status, $headers)` method, however it is currently proxy to the `view($view, $data)`.

## Other potential use cases

Of course *my* use case is hyper specific to my project, however I can see this feature being useful to developer who are creating endpoints for things like IP lists.

Example: https://www.cloudflare.com/ips-v4

```php
Route::view('ips', 'ips', ['Content-type' => 'text/plain']);

// https://my.app/ips
// https://my.app/ips?v=4
// https://my.app/ips?v=6
```

Or for exposing scripts via a URL where only the request query / user information is needed to make manipulations.

## Status though?

I can't think of a situation myself where it would be handy to change the status on a route like this, however to keep it consistent with the `response()->view()` method I've left the `$status` in there. I have, however, overloaded `$status` so you can bypass it and just send through the headers. Thus...

```php
// routes/api.php

// this...
Route::view('seat-map.svg', 'seat-map', 200, ['Content-type' => 'image/svg+xml']);

// is equivalent to...
Route::view('seat-map.svg', 'seat-map', ['Content-type' => 'image/svg+xml']);
```