### PR TITLE
except method added to models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1211,6 +1211,23 @@ trait HasAttributes
     }
 
     /**
+     * Get a subset of the model's attributes.
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $results = $this->getAttributes();
+
+        foreach (is_array($attributes) ? $attributes : func_get_args() as $attribute) {
+            unset($results[$attribute]);
+        }
+
+        return $results;
+    }
+
+    /**
      * Sync the original attributes with the current.
      *
      * @return $this

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -201,6 +201,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->only(['first_name', 'last_name']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->except('project'));
+        $this->assertEquals(['project' => 'laravel'], $model->except('first_name', 'last_name'));
+        $this->assertEquals(['project' => 'laravel'], $model->except(['first_name', 'last_name']));
+    }
+
     public function testNewInstanceReturnsNewInstanceWithAttributesSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Except Method Added to HasAttributes class
I added an except method to `\Illuminate\Database\Eloquent\Concerns\HasAttributes` to compliment the `only()` method. For use on eloquent models

## Use Case
This is useful for when you want to get most of the attributes of a model but not all of them in an array. It's the compliment to the `only()` method.

```
$stub = new StubModel();
$stub->only(["first_name","last_name"]);
$stub->except(["middle_name","updated_at","created_at"]);
```
