### PR TITLE
[6.x] Fix testing commands that do not resolve 'OutputStyle::class' from the container

### DIFF
--- a/src/Illuminate/Foundation/Testing/PendingCommand.php
+++ b/src/Illuminate/Foundation/Testing/PendingCommand.php
@@ -131,10 +131,10 @@ class PendingCommand
     {
         $this->hasExecuted = true;
 
-        $this->mockConsoleOutput();
+        $mock = $this->mockConsoleOutput();
 
         try {
-            $exitCode = $this->app[Kernel::class]->call($this->command, $this->parameters);
+            $exitCode = $this->app[Kernel::class]->call($this->command, $this->parameters, $mock);
         } catch (NoMatchingExpectationException $e) {
             if ($e->getMethodName() === 'askQuestion') {
                 $this->test->fail('Unexpected question "'.$e->getActualArguments()[0]->getQuestion().'" was asked.');
@@ -156,7 +156,7 @@ class PendingCommand
     /**
      * Mock the application's console output.
      *
-     * @return void
+     * @return \Mockery\MockInterface
      */
     protected function mockConsoleOutput()
     {
@@ -181,6 +181,8 @@ class PendingCommand
         $this->app->bind(OutputStyle::class, function () use ($mock) {
             return $mock;
         });
+
+        return $mock;
     }
 
     /**


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Tests that look for output (via `expectsOutput`) from commands that do not resolve `OutputStyle` from the application container fail unexpectedly. 

An example of this is the default Symfony 'list' command, this command is not a descendant of `Illuminate\Console\Command` and therefore doesn't resolve its output interface from the container.

You can verify the behaviour by adding the following test to the stock FeatureTest:

    public function testList()
    {
        $this->artisan('list')
            ->expectsOutput("Available commands:")
            ->assertExitCode(0);
    }

This tests the `list` command, which will fail if run against the current codebase but pass against this fix.

This shouldn't break anything as we're simply passing the mock directly to the kernels call method as opposed to relying on it being resolved.

If accepted, I'm guessing this can also be merged up?