### PR TITLE
[7.x] Added array to include Eloquent Model observers

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,6 +23,13 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
+     * Model observers to register.
+     *
+     * @var array
+     */
+    protected $observers = [];
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -39,6 +46,10 @@ class EventServiceProvider extends ServiceProvider
 
         foreach ($this->subscribe as $subscriber) {
             Event::subscribe($subscriber);
+        }
+
+        foreach ($this->observers as $model => $observers) {
+            $model::observe($observers);
         }
     }
 


### PR DESCRIPTION
Allows to add multiple Eloquent model observers in the `EventServiceProvider` instead of manually setting them in any Service Provider the user may have.

Changes in the docs are not included because this array is optional and empty by default, but would allow the user to use this simplistic approach to enable observers:

```php

class EventServiceProvider extends ServiceProvider
{
    /**
     * Model observers to register.
     *
     * @var array
     */
    protected $observers = [
        User::class => UserObserver::class,
        Schematic::class => SchematicObserver::class
    ];

    // ...

}
```

It also allows to have multiple observers since each array value is later converted as an array by the `observe` method of the Eloquent model.