### PR TITLE
[7.x] set/reset the select to from.* in cloneForPaginationCount

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2280,7 +2280,8 @@ class Builder
      */
     protected function cloneForPaginationCount()
     {
-        return $this->cloneWithout(['orders', 'limit', 'offset'])
+        return $this->select($this->from.'.*')
+                    ->cloneWithout(['orders', 'limit', 'offset'])
                     ->cloneWithoutBindings(['order']);
     }
 


### PR DESCRIPTION
In #32624 the pagination count query is now wrapped in a `select count(*) as aggregate` query for group by and havings, and the builder is used as a subquery.

If the builder has a join, but doesn't have a select, a duplicate column error is produced.

https://github.com/laravel/framework/pull/32624#issuecomment-624356274

This PR ensures the select is only from the primary table. As it is a subquery for a count, the columns in the subquery are irrelevant. 