### PR TITLE
 [6.x] Add SSL SYSCALL EOF as a lost connection message

### DIFF
--- a/src/Illuminate/Database/DetectsLostConnections.php
+++ b/src/Illuminate/Database/DetectsLostConnections.php
@@ -44,6 +44,7 @@ trait DetectsLostConnections
             'running with the --read-only option so it cannot execute this statement',
             'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
             'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
+            'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
         ]);
     }
 }


### PR DESCRIPTION
From #32696, following @GrahamCampbell request :)

As Laravel get's deployed everywhere and to Clever Cloud, we started to get errors from long running workers trying to execute jobs having DB queries.
When a worker has not executed anything in a while, the first job fails with this error while the next ones runs fine.

`SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected (SQL: select * from "an_example_table")`

Our investigation shows that the connection is closed by the server because it was not used and we fixed it by adding these calls inspired by [Heroku's recommandations](https://devcenter.heroku.com/articles/forked-pg-connections):

```php
Queue::before(function (JobProcessing $event) {
    DB::connection()->reconnect();
});

Queue::after(function (JobProcessed $event) {
    DB::connection()->disconnect();
});

Queue::failing(function (JobFailed $event) {
    DB::connection()->disconnect();
});
```

But we tought that Laravel might consider this as a try again message.

PS: Maybe the message is too specific and should be more generic: `SSL SYSCALL error: EOF detected`.

Regards