### PR TITLE
[7.x] Add action helper to base controller to generate route action

### DIFF
--- a/src/Illuminate/Routing/Controller.php
+++ b/src/Illuminate/Routing/Controller.php
@@ -55,6 +55,17 @@ abstract class Controller
     }
 
     /**
+     * Return the controllers class and action as an array.
+     *
+     * @param string $action
+     * @return array
+     */
+    public static function action($action)
+    {
+        return [static::class, $action];
+    }
+
+    /**
      * Handle calls to missing methods on the controller.
      *
      * @param  string  $method

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Routing;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Illuminate\Routing\Exceptions\UrlGenerationException;
 use Illuminate\Routing\Route;
 use Illuminate\Routing\RouteCollection;
@@ -681,6 +682,14 @@ class RoutingUrlGeneratorTest extends TestCase
 
         Request::create($url->signedRoute('foo', ['signature' => 'bar']));
     }
+
+    public function testControllerActionHelper()
+    {
+        list($class, $action) = DummyController::action('index');
+
+        $this->assertEquals('Illuminate\\Tests\\Routing\\DummyController', $class);
+        $this->assertEquals('index', $action);
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable
@@ -714,5 +723,13 @@ class InvokableActionStub
     public function __invoke()
     {
         return 'hello';
+    }
+}
+
+class DummyController extends Controller
+{
+    public function index()
+    {
+        // empty
     }
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -685,7 +685,7 @@ class RoutingUrlGeneratorTest extends TestCase
 
     public function testControllerActionHelper()
     {
-        list($class, $action) = DummyController::action('index');
+        [$class, $action] = DummyController::action('index');
 
         $this->assertEquals('Illuminate\\Tests\\Routing\\DummyController', $class);
         $this->assertEquals('index', $action);


### PR DESCRIPTION
This PR adds an `action` helper to the base controller, to generate the controller+action name.

This allows you to do the following:

```php
Route::get('posts', PostController::action('index'));

// instead of 

Route::get('posts', [PostController::class, 'index']);
```

This might only look like a minor change, but the action helper feels much more natural to me. 
The array syntax has always bugged me a bit.

The helper method does not validate if the action method actually exists on the controllre, since the router will already do that when a request comes in.