### PR TITLE
[7.x] Added client or server error definition in the Http

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -145,6 +145,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response indicates a client or server error occurred.
+     *
+     * @return bool
+     */
+    public function failed()
+    {
+        return $this->serverError() || $this->clientError();
+    }
+
+    /**
      * Determine if the response indicates a client error occurred.
      *
      * @return bool
@@ -162,16 +172,6 @@ class Response implements ArrayAccess
     public function serverError()
     {
         return $this->status() >= 500;
-    }
-
-    /**
-     * Determine if the response indicates a client or server error occurred.
-     *
-     * @return bool
-     */
-    public function failed()
-    {
-        return $this->serverError() || $this->clientError();
     }
 
     /**

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -165,6 +165,16 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Determine if the response indicates a client or server error occurred.
+     *
+     * @return bool
+     */
+    public function failed()
+    {
+        return $this->serverError() || $this->clientError();
+    }
+
+    /**
      * Get the response cookies.
      *
      * @return \GuzzleHttp\Cookie\CookieJar


### PR DESCRIPTION
The Http facade has method `successful`, the return status of a successful request. But in case you need to determine the error, you have to use one of the following options:
```php
if (! $response->successful()) { }
// or
if ($response->clientError() || serverError()) { }
```

Therefore, I propose adding method `failed`, which makes it possible to more clearly identify errors:
```php
if ($response->failed()) { }
```