### PR TITLE
[6.x] Fix Faker Unique caching issue

### DIFF
--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -89,7 +89,7 @@ class DatabaseServiceProvider extends ServiceProvider
             }
 
             static::$fakers[$locale]->unique(true);
-            
+
             return static::$fakers[$locale];
         });
 

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -88,6 +88,8 @@ class DatabaseServiceProvider extends ServiceProvider
                 static::$fakers[$locale] = FakerFactory::create($locale);
             }
 
+            static::$fakers[$locale]->unique(true);
+            
             return static::$fakers[$locale];
         });
 


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/32700

I tested this change in my own codebase and it worked. The idea is somewhat simple: Assuming Faker is a **singleton**, the Container factory is executed only once per test. That means within a test, Faker will do it's job of ensuring uniqueness whenever asked.
As soon as the test finishes and the container is flushed, Laravel will start a container from scratch, which will run the container factory once again and it will clear the unique cache from faker by calling `$faker->unique(true)` (as suggested https://github.com/laravel/framework/issues/32700#issuecomment-624600631). 

The reason for this description is to pay extra attention in `$app->singleton()`. This is not something easy to catch on a unit test, after all we're testing if unique works across multiple tests. If somebody ever makes Faker a non-singleton, that would cause the factory to be executed on every instantiation of the class and would again break the unique().