### PR TITLE
[7.x] Allow overriding the MySQL server version for strict mode

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -147,7 +147,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
             $this->setCustomModes($connection, $config);
         } elseif (isset($config['strict'])) {
             if ($config['strict']) {
-                $connection->prepare($this->strictMode($connection))->execute();
+                $connection->prepare($this->strictMode($connection, $config))->execute();
             } else {
                 $connection->prepare("set session sql_mode='NO_ENGINE_SUBSTITUTION'")->execute();
             }
@@ -172,14 +172,29 @@ class MySqlConnector extends Connector implements ConnectorInterface
      * Get the query to enable strict mode.
      *
      * @param  \PDO  $connection
+     * @param  array  $config
      * @return string
      */
-    protected function strictMode(PDO $connection)
+    protected function strictMode(PDO $connection, $config)
     {
-        if (version_compare($connection->getAttribute(PDO::ATTR_SERVER_VERSION), '8.0.11') >= 0) {
+        $version = $this->getServerVersion($connection, $config);
+
+        if (version_compare($version, '8.0.11') >= 0) {
             return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 
         return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+    }
+
+    /**
+     * Get the server version of the given connection.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return string
+     */
+    protected function getServerVersion(PDO $connection, array $config)
+    {
+        return $config['version'] ?? $connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 }

--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -177,24 +177,12 @@ class MySqlConnector extends Connector implements ConnectorInterface
      */
     protected function strictMode(PDO $connection, $config)
     {
-        $version = $this->getServerVersion($connection, $config);
+        $version = $config['version'] ?? $connection->getAttribute(PDO::ATTR_SERVER_VERSION);
 
         if (version_compare($version, '8.0.11') >= 0) {
             return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 
         return "set session sql_mode='ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
-    }
-
-    /**
-     * Get the server version of the given connection.
-     *
-     * @param  \PDO  $connection
-     * @param  array  $config
-     * @return string
-     */
-    protected function getServerVersion(PDO $connection, array $config)
-    {
-        return $config['version'] ?? $connection->getAttribute(PDO::ATTR_SERVER_VERSION);
     }
 }


### PR DESCRIPTION
A PR in response to https://github.com/laravel/framework/issues/32681.

When working with managed MySQL servers from Azure there's quite a peculiar catch: the database servers are behind a proxy and these don't know in advance which version you're connecting to while handshaking.

As a consequence `$connection->getAttribute(PDO::ATTR_SERVER_VERSION)` will always yield `5.6.42.0` regardless of the actual MySQL version (like 8.0.x!), and Laravel is unable to set the correct modes.

Since there's no way to circumvent the spoofed server version, a simple `version` config -if present- seemed like the cleanest approach to me.