### PR TITLE
[7.x] Support for FILTER_FLAG_EMAIL_UNICODE via "email:filter_unicode"

### DIFF
--- a/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
+++ b/src/Illuminate/Validation/Concerns/FilterEmailValidation.php
@@ -8,6 +8,31 @@ use Egulias\EmailValidator\Validation\EmailValidation;
 class FilterEmailValidation implements EmailValidation
 {
     /**
+     * @var int
+     */
+    protected $flags;
+
+    /**
+     * Create a new instance which allows any unicode characters in local-part.
+     *
+     * @return static
+     */
+    public static function unicode()
+    {
+        return new static(FILTER_FLAG_EMAIL_UNICODE);
+    }
+
+    /**
+     * FilterEmailValidation constructor.
+     *
+     * @param int $flags
+     */
+    public function __construct($flags = 0)
+    {
+        $this->flags = $flags;
+    }
+
+    /**
      * Returns true if the given email is valid.
      *
      * @param  string  $email
@@ -16,7 +41,7 @@ class FilterEmailValidation implements EmailValidation
      */
     public function isValid($email, EmailLexer $emailLexer)
     {
-        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+        return filter_var($email, FILTER_VALIDATE_EMAIL, $this->flags) !== false;
     }
 
     /**

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -654,6 +654,8 @@ trait ValidatesAttributes
                     return new SpoofCheckValidation();
                 } elseif ($validation === 'filter') {
                     return new FilterEmailValidation();
+                } elseif ($validation === 'filter_unicode') {
+                    return FilterEmailValidation::unicode();
                 }
             })
             ->values()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -2353,6 +2353,32 @@ class ValidationValidatorTest extends TestCase
     {
         $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@bar'], ['x' => 'email:filter']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example@example.com'], ['x' => 'email:filter']);
+        $this->assertTrue($v->passes());
+
+        // Unicode characters are not allowed
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'exämple@example.com'], ['x' => 'email:filter']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'exämple@exämple.com'], ['x' => 'email:filter']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateEmailWithFilterUnicodeCheck()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@bar'], ['x' => 'email:filter_unicode']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'example@example.com'], ['x' => 'email:filter_unicode']);
+        $this->assertTrue($v->passes());
+
+        // Any unicode characters are allowed only in local-part
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'exämple@example.com'], ['x' => 'email:filter_unicode']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'exämple@exämple.com'], ['x' => 'email:filter_unicode']);
+        $this->assertFalse($v->passes());
     }
 
     /**


### PR DESCRIPTION
# Overview

This PR enables us to validate email with `FILTER_FLAG_EMAIL_UNICODE` flag. It allows any unicode characters in local-part.

| | Unicode in local-part | Unicode in domain-part |
|:---|:---:|:---:|
| `rfc` | ✅| ✅|
| `filter` | :x: | :x: |
| **`filter_unicode`** | ✅| :x: |

I decided to submit this PR according to the following reason:

- `egulias/EmailValidator` has some **[bugs](https://github.com/egulias/EmailValidator/issues?q=is%3Aissue+is%3Aopen+label%3Abug)**. Our service is in trouble because the number of wrong registrations is increasing due to them.
- We don't want to directly allow unicode characters in domain-part. We encode them using Punycode, such as `xn--***`.

# Links

- [Email addresses can contain unicode nowadays · Issue #23239 · laravel/framework](https://github.com/laravel/framework/issues/23239)