### PR TITLE
Fix deadlock handling

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -717,6 +717,12 @@ class Connection implements ConnectionInterface
      */
     protected function handleQueryException(QueryException $e, $query, $bindings, Closure $callback)
     {
+    	if ($this->causedByDeadlock($e)) {
+    		$this->transactions = 0;
+
+    		throw $e;
+		}
+
         if ($this->transactions >= 1) {
             throw $e;
         }

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -139,12 +139,14 @@ interface ConnectionInterface
      */
     public function commit();
 
-    /**
-     * Rollback the active database transaction.
-     *
-     * @return void
-     */
-    public function rollBack();
+	/**
+	 * Rollback the active database transaction.
+	 *
+	 * @param int|null $toLevel
+	 *
+	 * @return void
+	 */
+    public function rollBack(int $toLevel = null);
 
     /**
      * Get the number of active transactions.

--- a/src/Illuminate/Database/DetectsConcurrencyErrors.php
+++ b/src/Illuminate/Database/DetectsConcurrencyErrors.php
@@ -16,22 +16,40 @@ trait DetectsConcurrencyErrors
      */
     protected function causedByConcurrencyError(Throwable $e)
     {
-        if ($e instanceof PDOException && $e->getCode() === '40001') {
+        if ($this->causedByDeadlock($e)) {
             return true;
         }
 
         $message = $e->getMessage();
 
         return Str::contains($message, [
-            'Deadlock found when trying to get lock',
-            'deadlock detected',
             'The database file is locked',
             'database is locked',
             'database table is locked',
             'A table in the database is locked',
-            'has been chosen as the deadlock victim',
             'Lock wait timeout exceeded; try restarting transaction',
-            'WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction',
         ]);
     }
+
+	/**
+	 * Determine if the given exception was caused by a deadlock.
+	 *
+	 * @param  \Throwable  $e
+	 * @return bool
+	 */
+	protected function causedByDeadlock(Throwable $e)
+	{
+		if ($e instanceof PDOException && $e->getCode() === '40001') {
+			return true;
+		}
+
+		$message = $e->getMessage();
+
+		return Str::contains($message, [
+			'Deadlock found when trying to get lock',
+			'deadlock detected',
+			'has been chosen as the deadlock victim',
+			'WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction',
+		]);
+	}
 }

--- a/src/Illuminate/Database/Transaction.php
+++ b/src/Illuminate/Database/Transaction.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Illuminate\Database;
+
+/**
+ * Database connection transaction with guarantee of proper commit/roll back level.
+ */
+class Transaction
+{
+	/**
+	 * Connection this transaction is created on.
+	 *
+	 * @var ConnectionInterface
+	 */
+	private $connection;
+
+	/**
+	 * Transaction level of the connection after transaction was began.
+	 *
+	 * @var int
+	 */
+	private $level;
+
+	/**
+	 * Whether transaction has already begun.
+	 *
+	 * @var bool
+	 */
+	private $hasBegun = false;
+
+	/**
+	 * Whether transaction is closed (committed or rolled back).
+	 *
+	 * @var bool
+	 */
+	private $isClosed = false;
+
+	public function __construct(ConnectionInterface $connection)
+	{
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Begin the transaction.
+	 *
+	 * May not be began twice.
+	 *
+	 * @return void
+	 */
+	public function begin(): void
+	{
+		assert(!$this->hasBegun, 'Transaction may not be began twice.');
+
+		$this->connection->beginTransaction();
+
+		$this->level = $this->connection->transactionLevel();
+		$this->hasBegun = true;
+	}
+
+	/**
+	 * Commit the transaction.
+	 *
+	 * May not be committed twice or after rollback.
+	 *
+	 * @return void
+	 */
+	public function commit(): void
+	{
+		$this->assertNotClosed();
+		assert($this->connection->transactionLevel() >= $this->level, 'Transaction has already been committed or rolled back.');
+
+		$this->connection->commit();
+
+		$this->close();
+	}
+
+	/**
+	 * Rollback the transaction.
+	 *
+	 * May not be rolled back twice or after commit.
+	 *
+	 * @return void
+	 */
+	public function rollBack(): void
+	{
+		$this->assertNotClosed();
+
+		// Rollback to level that was before starting a transaction.
+		// If current level is lower or equal to what we want - we don't care, it's already rolled back.
+		// If current level is higher - Laravel will rollback to the level we need.
+		$this->connection->rollBack($this->level - 1);
+
+		$this->close();
+	}
+
+	/**
+	 * Assert it hasn't been closed yet.
+	 *
+	 * @return void
+	 */
+	private function assertNotClosed(): void
+	{
+		assert(!$this->isClosed, 'Transaction is already closed - either committed or rolled back.');
+	}
+
+	/**
+	 * Close the transaction, disallowing any following commits or rollbacks.
+	 *
+	 * @return void
+	 */
+	private function close(): void
+	{
+		$this->isClosed = true;
+	}
+}

--- a/src/Illuminate/Database/Transaction.php
+++ b/src/Illuminate/Database/Transaction.php
@@ -94,6 +94,14 @@ class Transaction
 	}
 
 	/**
+	 * Level of this transaction.
+	 */
+	public function level(): int
+	{
+		return $this->level;
+	}
+
+	/**
 	 * Assert it hasn't been closed yet.
 	 *
 	 * @return void

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -276,7 +276,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
-        $pdo->expects($this->exactly(0))->method('rollBack');
+        $pdo->expects($this->exactly(3))->method('rollBack');
         $pdo->expects($this->never())->method('commit');
         $mock->transaction(function () use ($mock) {
         	$transactions = (new ReflectionObject($mock))->getProperty('transactions');

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -22,6 +22,7 @@ use PDOException;
 use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionObject;
 use stdClass;
 
 class DatabaseConnectionTest extends TestCase
@@ -275,9 +276,13 @@ class DatabaseConnectionTest extends TestCase
         $pdo = $this->getMockBuilder(DatabaseConnectionTestMockPDO::class)->setMethods(['beginTransaction', 'commit', 'rollBack'])->getMock();
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->exactly(3))->method('beginTransaction');
-        $pdo->expects($this->exactly(3))->method('rollBack');
+        $pdo->expects($this->exactly(0))->method('rollBack');
         $pdo->expects($this->never())->method('commit');
-        $mock->transaction(function () {
+        $mock->transaction(function () use ($mock) {
+        	$transactions = (new ReflectionObject($mock))->getProperty('transactions');
+        	$transactions->setAccessible(true);
+        	$transactions->setValue($mock, 0);
+
             throw new QueryException('', [], new Exception('Deadlock found when trying to get lock'));
         }, 3);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Resolves https://github.com/laravel/framework/issues/32543

Idea is described in the issue itself: https://github.com/laravel/framework/issues/32543#issuecomment-620499341

In short, this PR introduces couple of changes:
 - deadlocks are now handled on connection level, meaning connection's transaction level is always in sync with database's level
 - `Connection::newTransaction()` method which creates a transaction that throws if it can no longer be committed and ignores rollback errors where possible (as described in the issue)