### PR TITLE
[7.x] Add split() to Stringable class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -193,7 +193,7 @@ class Stringable
     {
         return collect(explode($delimiter, $this->value, $limit));
     }
-    
+
     /**
      * Split string by a regular expression.
      *
@@ -206,7 +206,7 @@ class Stringable
     {
         $keywords = preg_split($pattern, $this->value, $limit, $flags);
 
-        if(! $keywords) {
+        if (! $keywords) {
             return collect();
         }
 

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -193,6 +193,25 @@ class Stringable
     {
         return collect(explode($delimiter, $this->value, $limit));
     }
+    
+    /**
+     * Split string by a regular expression.
+     *
+     * @param  string  $pattern
+     * @param  int  $limit
+     * @param  int  $flags
+     * @return \Illuminate\Support\Collection
+     */
+    public function split($pattern, $limit = -1, $flags = 0)
+    {
+        $keywords = preg_split($pattern, $this->value, $limit, $flags);
+
+        if(! $keywords) {
+            return collect();
+        }
+
+        return collect($keywords);
+    }
 
     /**
      * Cap a string with a single instance of a given value.


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add a `split()` method to Stringable as a proxy to `preg_split()` to allow splitting by regex in addition of `explode()`

## Example
```php
Str::of('hypertext language, programming')
    ->split('/[\s,]+/');

/*
Illuminate\Support\Collection {#3523
     all: [
       "hypertext",
       "language",
       "programming",
     ],
   }

*/
```