### PR TITLE
[6.x] Add boolean to types that don't need character options

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
+++ b/src/Illuminate/Database/Schema/Grammars/ChangeColumn.php
@@ -189,6 +189,7 @@ class ChangeColumn
         return in_array($type, [
             'bigInteger',
             'binary',
+            'boolean',
             'date',
             'decimal',
             'double',


### PR DESCRIPTION
I was glad to see #30539 got fixed by fccdf7c, but after I updated Laravel to 7.10.3 my issue was still present. I was changing a varchar to a boolean and that one is missing from the list of types that don't need character options. This PR adds it to that list!