### PR TITLE
[7.x] Fix BuildsQueries::tap() return type

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -166,7 +166,7 @@ trait BuildsQueries
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
-     * @return \Illuminate\Database\Query\Builder
+     * @return mixed|$this
      */
     public function tap($callback)
     {


### PR DESCRIPTION
This changes the documented return type of `BuildsQueries::tap()` to `$this`, which makes it so `Eloquent\Builder::tap()` doesn't report it's return type as `Query\Builder`. The reported return type will now be the exact same as `BuildsQueries::when()` which this method proxies.