### PR TITLE
[7.x] Fix route generation with custom binding field

### DIFF
--- a/src/Illuminate/Routing/RouteUri.php
+++ b/src/Illuminate/Routing/RouteUri.php
@@ -45,6 +45,7 @@ class RouteUri
 
         foreach ($matches[0] as $match) {
             if (strpos($match, ':') === false) {
+                $bindingFields[trim($match, '{}?')] = null;
                 continue;
             }
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -372,6 +372,23 @@ class RoutingUrlGeneratorTest extends TestCase
         $this->assertSame('/foo/test-slug', $url->route('routable', [$model], false));
     }
 
+    public function testRoutableInterfaceRoutingWithMultipleCustomBindingField()
+    {
+        $url = new UrlGenerator(
+            $routes = new RouteCollection,
+            Request::create('http://www.foo.com/')
+        );
+
+        $route = new Route(['GET'], 'foo/{foo}/{bar:slug}', ['as' => 'routable']);
+        $routes->add($route);
+
+        $model = new RoutableInterfaceStub;
+        $model->key = 'routable';
+
+        $this->assertSame('/foo/routable/test-slug', $url->route('routable', ['foo' => $model, 'bar' => $model], false));
+        $this->assertSame('/foo/routable/test-slug', $url->route('routable', [$model, $model], false));
+    }
+
     public function testRoutableInterfaceRoutingWithSingleParameter()
     {
         $url = new UrlGenerator(


### PR DESCRIPTION
Currently, the `route()` helper will not work with custom model binding when the route contains a model binding with a custom key after a model binding without a custom key.

## How to reproduce

Just create a simple route with a model binding without custom key and after a model binding with a custom key:
```php
Route::get('/users/{user}/posts/{post:slug}', function (User $user, Post $post) {
    dd($user, $post);
})->name('users.posts.show');
```

Then try to generate the url to this route with the `route()` helper: `route('users.posts.show', [$user, $post])`.

This will throw an `UrlGenerationException` with the message `Missing required parameters for [Route: users.posts.show] [URI: users/{user}/posts/{post}]`, instead of returning the
url.
