### PR TITLE
[7.x] Update Response.php

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -64,7 +64,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an object.
      *
-     * @return object
+     * @return object|array
      */
     public function object()
     {


### PR DESCRIPTION
Add array as return type as depending in the response body the result of `json_decode` will return an array or object, even when `assoc` is set to `false`.

```php
echo gettype(Http::get('https://www.bitstamp.net/api/v2/trading-pairs-info/')->object()); 
// Output: "array"
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
