### PR TITLE
[7.x] Fixed deprecated "Doctrine/Common/Inflector/Inflector" class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/inflector": "^1.1",
+        "doctrine/inflector": "^2.0",
         "dragonmantank/cron-expression": "^2.0",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -2,7 +2,11 @@
 
 namespace Illuminate\Support;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\CachedWordInflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\Rules\English;
+use Doctrine\Inflector\RulesetInflector;
+use Illuminate\Validation\Rules\In;
 
 class Pluralizer
 {
@@ -70,7 +74,7 @@ class Pluralizer
             return $value;
         }
 
-        $plural = Inflector::pluralize($value);
+        $plural = static::inflector()->pluralize($value);
 
         return static::matchCase($plural, $value);
     }
@@ -83,7 +87,7 @@ class Pluralizer
      */
     public static function singular($value)
     {
-        $singular = Inflector::singularize($value);
+        $singular = static::inflector()->singularize($value);
 
         return static::matchCase($singular, $value);
     }
@@ -117,5 +121,17 @@ class Pluralizer
         }
 
         return $value;
+    }
+
+    protected static function inflector()
+    {
+        return new Inflector(
+            new CachedWordInflector(new RulesetInflector(
+                English\Rules::getSingularRuleset()
+            )),
+            new CachedWordInflector(new RulesetInflector(
+                English\Rules::getPluralRuleset()
+            ))
+        );
     }
 }

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -6,7 +6,6 @@ use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\Rules\English;
 use Doctrine\Inflector\RulesetInflector;
-use Illuminate\Validation\Rules\In;
 
 class Pluralizer
 {


### PR DESCRIPTION
> **The Inflector class is deprecated, use Doctrine\Common\Inflector\Inflector from doctrine/inflector package instead,**

New class is non-static [Doctrine\Inflector\Inflector::class](https://github.com/doctrine/inflector/blob/master/lib/Doctrine/Inflector/Inflector.php)