### PR TITLE
[8.x] Improved Rate Limiting

### DIFF
--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Cache;
 
-use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
@@ -30,6 +31,8 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
+
+        $this->app->singleton(RateLimiter::class);
     }
 
     /**
@@ -40,7 +43,7 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
     public function provides()
     {
         return [
-            'cache', 'cache.store', 'cache.psr6', 'memcached.connector',
+            'cache', 'cache.store', 'cache.psr6', 'memcached.connector', RateLimiter::class,
         ];
     }
 }

--- a/src/Illuminate/Cache/Limit.php
+++ b/src/Illuminate/Cache/Limit.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Cache;
+
+class Limit
+{
+    /**
+     * The rate limit signature key.
+     *
+     * @var mixed|string
+     */
+    public $key;
+
+    /**
+     * The maximum number of attempts allowed within the given number of minutes.
+     *
+     * @var int
+     */
+    public $maxAttempts;
+
+    /**
+     * The number of minutes until the rate limit is reset.
+     *
+     * @var int
+     */
+    public $decayMinutes;
+
+    /**
+     * Create a new limit instance.
+     *
+     * @param  mixed|string  $key
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return void
+     */
+    public function __construct($key, int $maxAttempts, int $decayMinutes = 1)
+    {
+        $this->key = $key;
+        $this->maxAttempts = $maxAttempts;
+        $this->decayMinutes = $decayMinutes;
+    }
+}

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -42,11 +42,22 @@ class RateLimiter
      * @param  \Closure  $callback
      * @return $this
      */
-    public function for($name, Closure $callback)
+    public function for(string $name, Closure $callback)
     {
         $this->limiters[$name] = $callback;
 
         return $this;
+    }
+
+    /**
+     * Get the given named rate limiter.
+     *
+     * @param  string  $name
+     * @return \Closure
+     */
+    public function limiter(string $name)
+    {
+        return $this->limiters[$name] ?? null;
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiter.php
+++ b/src/Illuminate/Cache/RateLimiter.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Cache;
 
+use Closure;
 use Illuminate\Contracts\Cache\Repository as Cache;
 use Illuminate\Support\InteractsWithTime;
 
@@ -17,6 +18,13 @@ class RateLimiter
     protected $cache;
 
     /**
+     * The configured limit object resolvers.
+     *
+     * @var array
+     */
+    protected $limiters = [];
+
+    /**
      * Create a new rate limiter instance.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $cache
@@ -25,6 +33,20 @@ class RateLimiter
     public function __construct(Cache $cache)
     {
         $this->cache = $cache;
+    }
+
+    /**
+     * Register a named limiter configuration.
+     *
+     * @param  string  $name
+     * @param  \Closure  $callback
+     * @return $this
+     */
+    public function for($name, Closure $callback)
+    {
+        $this->limiters[$name] = $callback;
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
+++ b/src/Illuminate/Cache/RateLimiting/GlobalLimit.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Cache\RateLimiting;
+
+class GlobalLimit extends Limit
+{
+    /**
+     * Create a new limit instance.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return void
+     */
+    public function __construct(int $maxAttempts, int $decayMinutes = 1)
+    {
+        parent::__construct('', $maxAttempts, $decayMinutes);
+    }
+}

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -33,10 +33,44 @@ class Limit
      * @param  int  $decayMinutes
      * @return void
      */
-    public function __construct($key, int $maxAttempts, int $decayMinutes = 1)
+    public function __construct($key = '', int $maxAttempts = 60, int $decayMinutes = 1)
     {
         $this->key = $key;
         $this->maxAttempts = $maxAttempts;
         $this->decayMinutes = $decayMinutes;
+    }
+
+    /**
+     * Create a new rate limit.
+     *
+     * @param  int  $maxAttempts
+     * @return static
+     */
+    public static function perMinute($maxAttempts)
+    {
+        return new static('', $maxAttempts);
+    }
+
+    /**
+     * Create a new unlimited rate limit.
+     *
+     * @return static
+     */
+    public static function none()
+    {
+        return new Unlimited;
+    }
+
+    /**
+     * Set the key of the rate limit.
+     *
+     * @param  string  $key
+     * @return $this
+     */
+    public function by($key)
+    {
+        $this->key = $key;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Cache;
+namespace Illuminate\Cache\RateLimiting;
 
 class Limit
 {

--- a/src/Illuminate/Cache/RateLimiting/Unlimited.php
+++ b/src/Illuminate/Cache/RateLimiting/Unlimited.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Illuminate\Cache\RateLimiting;
+
+class Unlimited extends GlobalLimit
+{
+    /**
+     * Create a new limit instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct(PHP_INT_MAX);
+    }
+}

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -204,8 +204,8 @@ class ThrottleRequests
                                   ?Response $response = null)
     {
         if ($response &&
-            $response->headers->get('X-RateLimit-Remaining') &&
-            $response->headers->get('X-RateLimit-Remaining') <= $remainingAttempts) {
+            ! is_null($response->headers->get('X-RateLimit-Remaining')) &&
+            (int) $response->headers->get('X-RateLimit-Remaining') <= (int) $remainingAttempts) {
             return [];
         }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -62,7 +62,7 @@ class ThrottleRequests
                     'key' => $prefix.$this->resolveRequestSignature($request),
                     'maxAttempts' => $this->resolveMaxAttempts($request, $maxAttempts),
                     'decayMinutes' => $decayMinutes,
-                ]
+                ],
             ]
         );
     }
@@ -95,7 +95,7 @@ class ThrottleRequests
                 return (object) [
                     'key' => md5($limiterName.$limit->key),
                     'maxAttempts' => $limit->maxAttempts,
-                    'decayMinutes' => $limit->decayMinutes
+                    'decayMinutes' => $limit->decayMinutes,
                 ];
             })->all()
         );

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing\Middleware;
 
 use Closure;
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
@@ -51,7 +52,11 @@ class ThrottleRequests
             && ! is_null($limiter = $this->limiter->limiter($maxAttempts))) {
             $limit = call_user_func($limiter, $request);
 
-            return $this->handleRequest(
+            if ($limit instanceof Response) {
+                return $limit;
+            }
+
+            return $limit instanceof Unlimited ? $next($request) : $this->handleRequest(
                 $request,
                 $next,
                 md5($maxAttempts.$limit->key),

--- a/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequestsWithRedis.php
@@ -17,18 +17,18 @@ class ThrottleRequestsWithRedis extends ThrottleRequests
     protected $redis;
 
     /**
-     * The timestamp of the end of the current duration.
+     * The timestamp of the end of the current duration by key.
      *
-     * @var int
+     * @var array
      */
-    public $decaysAt;
+    public $decaysAt = [];
 
     /**
-     * The number of remaining slots.
+     * The number of remaining slots by key.
      *
-     * @var int
+     * @var array
      */
-    public $remaining;
+    public $remaining = [];
 
     /**
      * Create a new request throttler.

--- a/src/Illuminate/Support/Facades/RateLimiter.php
+++ b/src/Illuminate/Support/Facades/RateLimiter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * @see \Illuminate\Cache\RateLimiter
+ */
+class RateLimiter extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'Illuminate\Cache\RateLimiter';
+    }
+}

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -2,6 +2,9 @@
 
 namespace Illuminate\Tests\Integration\Http;
 
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\GlobalLimit;
+use Illuminate\Container\Container;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Support\Carbon;
@@ -17,6 +20,7 @@ class ThrottleRequestsTest extends TestCase
     protected function tearDown(): void
     {
         parent::tearDown();
+
         Carbon::setTestNow(null);
     }
 
@@ -32,6 +36,44 @@ class ThrottleRequestsTest extends TestCase
         Route::get('/', function () {
             return 'yes';
         })->middleware(ThrottleRequests::class.':2,1');
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(1, $response->headers->get('X-RateLimit-Remaining'));
+
+        $response = $this->withoutExceptionHandling()->get('/');
+        $this->assertSame('yes', $response->getContent());
+        $this->assertEquals(2, $response->headers->get('X-RateLimit-Limit'));
+        $this->assertEquals(0, $response->headers->get('X-RateLimit-Remaining'));
+
+        Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 58));
+
+        try {
+            $this->withoutExceptionHandling()->get('/');
+        } catch (Throwable $e) {
+            $this->assertInstanceOf(ThrottleRequestsException::class, $e);
+            $this->assertEquals(429, $e->getStatusCode());
+            $this->assertEquals(2, $e->getHeaders()['X-RateLimit-Limit']);
+            $this->assertEquals(0, $e->getHeaders()['X-RateLimit-Remaining']);
+            $this->assertEquals(2, $e->getHeaders()['Retry-After']);
+            $this->assertEquals(Carbon::now()->addSeconds(2)->getTimestamp(), $e->getHeaders()['X-RateLimit-Reset']);
+        }
+    }
+
+    public function testLimitingUsingNamedLimiter()
+    {
+        $rateLimiter = Container::getInstance()->make(RateLimiter::class);
+
+        $rateLimiter->for('test', function ($request) {
+            return new GlobalLimit(2, 1);
+        });
+
+        Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 0));
+
+        Route::get('/', function () {
+            return 'yes';
+        })->middleware(ThrottleRequests::class.':test');
 
         $response = $this->withoutExceptionHandling()->get('/');
         $this->assertSame('yes', $response->getContent());


### PR DESCRIPTION
This improvement allows you to define named rate limiters that are more flexible and granular than what is possible to achieve currently. All existing throttle syntax is still supported. However, you may now define named rate limiters in your route service provider:

```php
use Illuminate\Cache\RateLimiting\Limit;
use Illuminate\Http\Request;
use Illuminate\Support\Facades\RateLimiter;

// Standard rate limit for the entire application users (sanity check...)
RateLimiter::for('global', function (Request $request) {
    return Limit::perMinute(1000);
});

// Limiting based on a custom key segment... such as IP address or anything else you want...
RateLimiter::for('uploads', function (Request $request) {
    Limit::perMinute(10)->by($request->ip()),
});

// Returning no rate limit for certain customers...
RateLimiter::for('podcasts', function (Request $request) {
    if ($request->user()->vipCustomer()) {
        return Limit::none();
    }

    Limit::perMinute(5)->by($request->ip()),
});

// Returning an array of rate limits the request must pass through...
RateLimiter::for('logins', function (Request $request) {
    return [
        Limit::perMinute(100),
        Limit::perMinute(3)->by($request->input('email')),
    ];
});
```

You can attach these named rate limiters to routes by passing their names to the throttle middleware:

```php
Route::middleware(['throttle:global'])->group(function () {
    Route::get('/', function () {
        return view('welcome');
    });

    Route::get('/upload', function () {
        return view('welcome');
    })->middleware('throttle:uploads');
});
```
