### PR TITLE
[7.x] Fix #32722 - shouldQueue() returning false not taking effect

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -445,12 +445,18 @@ class Dispatcher implements DispatcherContract
     protected function createQueuedHandlerCallable($class, $method)
     {
         return function () use ($class, $method) {
-            $arguments = array_map(function ($a) {
-                return is_object($a) ? clone $a : $a;
-            }, func_get_args());
+            $arguments = func_get_args();
 
             if ($this->handlerWantsToBeQueued($class, $arguments)) {
+                $arguments = array_map(function ($a) {
+                    return is_object($a) ? clone $a : $a;
+                }, $arguments);
+
                 $this->queueHandler($class, $method, $arguments);
+            } else {
+                call_user_func_array(
+                    [$this->container->make($class), $method], $arguments
+                );
             }
         };
     }

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -41,6 +41,11 @@ class QueuedListenersTestEvent
 
 class QueuedListenersTestListenerShouldQueue implements ShouldQueue
 {
+    public function handle()
+    {
+        //
+    }
+
     public function shouldQueue()
     {
         return true;
@@ -49,6 +54,11 @@ class QueuedListenersTestListenerShouldQueue implements ShouldQueue
 
 class QueuedListenersTestListenerShouldNotQueue implements ShouldQueue
 {
+    public function handle()
+    {
+        //
+    }
+
     public function shouldQueue()
     {
         return false;


### PR DESCRIPTION
Fixes #32722

The only modification I did apart from adding behavior is moving the `array_map()` for arguments into the `if ($this->handlerWantsToBeQueued($class, $arguments)) {` scope, but all tests are passing so this didn't break anything.

Proof of regression test working:
![Screenshot from 2020-05-08 21-48-25](https://user-images.githubusercontent.com/33033094/81443620-08eade80-9176-11ea-9031-5dadddbb5d84.png)

And the test passes if I uncomment my additions:
![Screenshot from 2020-05-08 21-48-14](https://user-images.githubusercontent.com/33033094/81443652-16a06400-9176-11ea-8981-37e8b5e4cdf0.png)

