### PR TITLE
Allow Eloquent Model can self Morphology without pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait SelfMorphModel {
+    protected static $morphTypes = [];
+
+    /**
+     * register a morph type to a class
+     */
+    public static function registerMorph($alias) {
+        self::$morphTypes[$alias] = static::class;
+    }
+
+    /**
+     * find the class morph type(from class name to alias)
+     */
+    public static function getMorphType($className = null) {
+        $className = $className ? $className : static::class;
+        return array_search($className, self::$morphTypes);
+    }
+
+    /**
+     * get all morph types(alias)
+     */
+    public static function getMorphTypes() {
+        return array_keys(self::$morphTypes);
+    }
+
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+        $morphType = $attributes['morph_type'] ?? false;
+        if ($morphType && isset(self::$morphTypes[$morphType])) {
+            $class = self::$morphTypes[$morphType];
+            return new $class($fillAttributes ? $attributes : []);
+        }
+        return new static($fillAttributes ? $attributes : []);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -4,20 +4,23 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 
-trait SelfMorphModel {
+trait SelfMorphModel 
+{
     protected static $morphTypes = [];
 
     /**
      * register a morph type to a class
      */
-    public static function registerMorph($alias) {
+    public static function registerMorph($alias) 
+    {
         self::$morphTypes[$alias] = static::class;
     }
 
     /**
      * find the class morph type(from class name to alias)
      */
-    public static function getMorphType($className = null) {
+    public static function getMorphType($className = null) 
+    {
         $className = $className ? $className : static::class;
         return array_search($className, self::$morphTypes);
     }
@@ -25,11 +28,13 @@ trait SelfMorphModel {
     /**
      * get all morph types(alias)
      */
-    public static function getMorphTypes() {
+    public static function getMorphTypes() 
+    {
         return array_keys(self::$morphTypes);
     }
 
-    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) 
+    {
         $morphType = $attributes['morph_type'] ?? false;
         if ($morphType && isset(self::$morphTypes[$morphType])) {
             $class = self::$morphTypes[$morphType];

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -407,14 +407,15 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @param  array  $attributes
      * @param  bool  $exists
+     * @param  bool  $fillWithAttributes if true will fill with $attributes
      * @return static
      */
-    public function newInstance($attributes = [], $exists = false)
+    public function newInstance($attributes = [], $exists = false, $fillAttributes = true)
     {
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static((array) $attributes);
+        $model = $this->newMorphInstance((array) $attributes, $fillAttributes);
 
         $model->exists = $exists;
 
@@ -430,6 +431,17 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Create a new instance of the given model. 
+     *
+     * @param  array  $attributes
+     * @param  bool  $fillWithAttributes if true will fill with $attributes
+     * @return static
+     */
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+        return new static($fillAttributes ? $attributes : []);
+    }
+
+    /**
      * Create a new model instance that is existing.
      *
      * @param  array  $attributes
@@ -438,7 +450,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function newFromBuilder($attributes = [], $connection = null)
     {
-        $model = $this->newInstance([], true);
+        $model = $this->newInstance($attributes, true, false);
 
         $model->setRawAttributes((array) $attributes, true);
 


### PR DESCRIPTION

### How to use Self Morph Model Trait

Sometimes we need an eloquent model can self morph by the database table config.

#### 1. Base class

```php
<?php
use Illuminate\Database\Eloquent\Concerns\SelfMorphModel;

class Product extends \Illuminate\Database\Eloquent\Model {
use SelfMorphModel;
}

class SimpleProduct extends Product {
}

class BundleProduct extends Product {
}
```



#### 2. Register in Provider class
```
<?php

//on Provider class to register
class Provider extends \Illuminate\Support\ServiceProvider {
   public function register() {
      SimpleProduct::registerMorph('simple');
      BundleProduct::registerMorph('bundle');
   }
}
```

#### 3. Prepare database table 'products'
> //products table
id morph_type name
1  simple.        simpleproductname1
2  bundle.       bundleproductname1

#### 4. Self Morph result
```
Product::find(1).    will return an instance of SimpleProduct
Product::find(2).    will return an instance of BundleProduct
```

