### PR TITLE
[7.x] Allow Eloquent Model can self Morphology without pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+
+trait SelfMorphModel {
+    protected static $morphTypes = [];
+
+    /**
+     * register a morph type to a class
+     */
+    public static function registerMorph($alias) {
+        self::$morphTypes[$alias] = static::class;
+    }
+
+    /**
+     * find the class morph type(from class name to alias)
+     */
+    public static function getMorphType($className = null) {
+        $className = $className ? $className : static::class;
+        return array_search($className, self::$morphTypes);
+    }
+
+    /**
+     * get all morph types(alias)
+     */
+    public static function getMorphTypes() {
+        return array_keys(self::$morphTypes);
+    }
+
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+        $morphType = $attributes['morph_type'] ?? false;
+        if ($morphType && isset(self::$morphTypes[$morphType])) {
+            $class = self::$morphTypes[$morphType];
+            return new $class($fillAttributes ? $attributes : []);
+        }
+        return new static($fillAttributes ? $attributes : []);
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -4,20 +4,23 @@ namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 
-trait SelfMorphModel {
+trait SelfMorphModel 
+{
     protected static $morphTypes = [];
 
     /**
      * register a morph type to a class
      */
-    public static function registerMorph($alias) {
+    public static function registerMorph($alias) 
+    {
         self::$morphTypes[$alias] = static::class;
     }
 
     /**
      * find the class morph type(from class name to alias)
      */
-    public static function getMorphType($className = null) {
+    public static function getMorphType($className = null) 
+    {
         $className = $className ? $className : static::class;
         return array_search($className, self::$morphTypes);
     }
@@ -25,11 +28,13 @@ trait SelfMorphModel {
     /**
      * get all morph types(alias)
      */
-    public static function getMorphTypes() {
+    public static function getMorphTypes() 
+    {
         return array_keys(self::$morphTypes);
     }
 
-    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) 
+    {
         $morphType = $attributes['morph_type'] ?? false;
         if ($morphType && isset(self::$morphTypes[$morphType])) {
             $class = self::$morphTypes[$morphType];

--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -7,7 +7,10 @@ trait SelfMorphModel
     protected static $morphTypes = [];
 
     /**
-     * register a morph type to a class.
+     * Register a morph type to a class.
+     *
+     * @param  string  $alias
+     * @return void
      */
     public static function registerMorph($alias)
     {
@@ -15,7 +18,10 @@ trait SelfMorphModel
     }
 
     /**
-     * find the class morph type(from class name to alias).
+     * Find the class morph type(from class name to alias).
+     *
+     * @param  string|null  $className
+     * @return string|null
      */
     public static function getMorphType($className = null)
     {
@@ -25,13 +31,22 @@ trait SelfMorphModel
     }
 
     /**
-     * get all morph types(alias).
+     * Get all morph types(alias).
+     *
+     * @return array
      */
     public static function getMorphTypes()
     {
         return array_keys(self::$morphTypes);
     }
 
+    /**
+     * Create a new instance base on morph_type in $attributes.
+     *
+     * @param  array  $attributes
+     * @param  bool  $fillWithAttributes if true will fill with $attributes
+     * @return \Illuminate\Database\Eloquent\Model
+     */
     protected function newMorphInstance(array $attributes, $fillAttributes = true)
     {
         $morphType = $attributes['morph_type'] ?? false;

--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -20,7 +20,7 @@ trait SelfMorphModel
     public static function getMorphType($className = null)
     {
         $className = $className ? $className : static::class;
-        
+
         return array_search($className, self::$morphTypes);
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/SelfMorphModel.php
@@ -2,44 +2,45 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Database\Eloquent\Model;
-
-trait SelfMorphModel 
+trait SelfMorphModel
 {
     protected static $morphTypes = [];
 
     /**
-     * register a morph type to a class
+     * register a morph type to a class.
      */
-    public static function registerMorph($alias) 
+    public static function registerMorph($alias)
     {
         self::$morphTypes[$alias] = static::class;
     }
 
     /**
-     * find the class morph type(from class name to alias)
+     * find the class morph type(from class name to alias).
      */
-    public static function getMorphType($className = null) 
+    public static function getMorphType($className = null)
     {
         $className = $className ? $className : static::class;
+        
         return array_search($className, self::$morphTypes);
     }
 
     /**
-     * get all morph types(alias)
+     * get all morph types(alias).
      */
-    public static function getMorphTypes() 
+    public static function getMorphTypes()
     {
         return array_keys(self::$morphTypes);
     }
 
-    protected function newMorphInstance(array $attributes, $fillAttributes = true) 
+    protected function newMorphInstance(array $attributes, $fillAttributes = true)
     {
         $morphType = $attributes['morph_type'] ?? false;
         if ($morphType && isset(self::$morphTypes[$morphType])) {
             $class = self::$morphTypes[$morphType];
+
             return new $class($fillAttributes ? $attributes : []);
         }
+
         return new static($fillAttributes ? $attributes : []);
     }
 }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -410,7 +410,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  bool  $fillWithAttributes if true will fill with $attributes
      * @return static
      */
-    public function newInstance($attributes = [], $exists = false, $fillAttributes = true)
+    protected function newInstanceFillWithAttributes($attributes = [], $exists = false, $fillAttributes = true)
     {
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
@@ -443,6 +443,18 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Create a new instance of the given model.
+     *
+     * @param  array  $attributes
+     * @param  bool  $exists
+     * @return static
+     */
+    public function newInstance($attributes = [], $exists = false)
+    {
+        return $this->newInstanceFillWithAttributes($attributes, $exists, true);
+    }
+
+    /**
      * Create a new model instance that is existing.
      *
      * @param  array  $attributes
@@ -451,7 +463,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function newFromBuilder($attributes = [], $connection = null)
     {
-        $model = $this->newInstance($attributes, true, false);
+        $model = $this->newInstanceFillWithAttributes($attributes, true, false);
 
         $model->setRawAttributes((array) $attributes, true);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -407,14 +407,15 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @param  array  $attributes
      * @param  bool  $exists
+     * @param  bool  $fillWithAttributes if true will fill with $attributes
      * @return static
      */
-    public function newInstance($attributes = [], $exists = false)
+    public function newInstance($attributes = [], $exists = false, $fillAttributes = true)
     {
         // This method just provides a convenient way for us to generate fresh model
         // instances of this current model. It is particularly useful during the
         // hydration of new objects via the Eloquent query builder instances.
-        $model = new static((array) $attributes);
+        $model = $this->newMorphInstance((array) $attributes, $fillAttributes);
 
         $model->exists = $exists;
 
@@ -430,6 +431,17 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Create a new instance of the given model. 
+     *
+     * @param  array  $attributes
+     * @param  bool  $fillWithAttributes if true will fill with $attributes
+     * @return static
+     */
+    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+        return new static($fillAttributes ? $attributes : []);
+    }
+
+    /**
      * Create a new model instance that is existing.
      *
      * @param  array  $attributes
@@ -438,7 +450,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function newFromBuilder($attributes = [], $connection = null)
     {
-        $model = $this->newInstance([], true);
+        $model = $this->newInstance($attributes, true, false);
 
         $model->setRawAttributes((array) $attributes, true);
 

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -431,13 +431,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
-     * Create a new instance of the given model. 
+     * Create a new instance of the given model.
      *
      * @param  array  $attributes
      * @param  bool  $fillWithAttributes if true will fill with $attributes
      * @return static
      */
-    protected function newMorphInstance(array $attributes, $fillAttributes = true) {
+    protected function newMorphInstance(array $attributes, $fillAttributes = true)
+    {
         return new static($fillAttributes ? $attributes : []);
     }
 


### PR DESCRIPTION

### How to use Self Morph Model Trait

Sometime we need an eloquent model can self morph by the database table config.

#### 1. Base class

```php
<?php
use Illuminate\Database\Eloquent\Concerns\SelfMorphModel;

class Product extends \Illuminate\Database\Eloquent\Model 
{
use SelfMorphModel;
}

class SimpleProduct extends Product 
{
}

class BundleProduct extends Product 
{
}
```



#### 2. Register in Provider class
```
<?php

//on Provider class to register
class Provider extends \Illuminate\Support\ServiceProvider 
{
   public function register() 
   {
      SimpleProduct::registerMorph('simple');
      BundleProduct::registerMorph('bundle');
   }
}
```

#### 3. Prepare database table 'products'
> //products table
id morph_type name
1  simple.        simpleproductname1
2  bundle.       bundleproductname1

#### 4. Self Morph result
```
Product::find(1).    will return instance of SimpleProduct
Product::find(2).    will return instance of BundleProduct
```

