### PR TITLE
[6.x] Fixed deprecated "Doctrine/Common/Inflector/Inflector" class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "doctrine/inflector": "^1.1",
+        "doctrine/inflector": "^1.4|^2.0",
         "dragonmantank/cron-expression": "^2.0",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -122,6 +122,11 @@ class Pluralizer
         return $value;
     }
 
+    /**
+     * Get the inflector instance.
+     *
+     * @return \Doctrine\Inflector\Inflector
+     */
     public static function inflector()
     {
         static $inflector;

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -122,15 +122,21 @@ class Pluralizer
         return $value;
     }
 
-    protected static function inflector()
+    public static function inflector()
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                English\Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                English\Rules::getPluralRuleset()
-            ))
-        );
+        static $inflector;
+
+        if ($inflector === null) {
+            $inflector = new Inflector(
+                new CachedWordInflector(new RulesetInflector(
+                    English\Rules::getSingularRuleset()
+                )),
+                new CachedWordInflector(new RulesetInflector(
+                    English\Rules::getPluralRuleset()
+                ))
+            );
+        }
+
+        return $inflector;
     }
 }

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Support;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\CachedWordInflector;
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\Rules\English;
+use Doctrine\Inflector\RulesetInflector;
 
 class Pluralizer
 {
@@ -70,7 +73,7 @@ class Pluralizer
             return $value;
         }
 
-        $plural = Inflector::pluralize($value);
+        $plural = static::inflector()->pluralize($value);
 
         return static::matchCase($plural, $value);
     }
@@ -83,7 +86,7 @@ class Pluralizer
      */
     public static function singular($value)
     {
-        $singular = Inflector::singularize($value);
+        $singular = static::inflector()->singularize($value);
 
         return static::matchCase($singular, $value);
     }
@@ -117,5 +120,17 @@ class Pluralizer
         }
 
         return $value;
+    }
+
+    protected static function inflector()
+    {
+        return new Inflector(
+            new CachedWordInflector(new RulesetInflector(
+                English\Rules::getSingularRuleset()
+            )),
+            new CachedWordInflector(new RulesetInflector(
+                English\Rules::getPluralRuleset()
+            ))
+        );
     }
 }

--- a/src/Illuminate/Support/Pluralizer.php
+++ b/src/Illuminate/Support/Pluralizer.php
@@ -131,7 +131,7 @@ class Pluralizer
     {
         static $inflector;
 
-        if ($inflector === null) {
+        if (is_null($inflector)) {
             $inflector = new Inflector(
                 new CachedWordInflector(new RulesetInflector(
                     English\Rules::getSingularRuleset()

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -17,7 +17,7 @@
         "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "doctrine/inflector": "^1.1",
+        "doctrine/inflector": "^1.4|^2.0",
         "illuminate/contracts": "^6.0",
         "nesbot/carbon": "^2.0"
     },


### PR DESCRIPTION
> **The Inflector class is deprecated, use Doctrine\Common\Inflector\Inflector from doctrine/inflector package instead,**

New class is non-static [Doctrine\Inflector\Inflector::class](https://github.com/doctrine/inflector/blob/master/lib/Doctrine/Inflector/Inflector.php)

I also changed the minimum version for `doctrine/inflector` package because the earlier `1.1` supports php 5.6 and higher, while Laravel 6.x supports 7.2+.
Package version `1.4` supports php 7.2+.

Also see #32730