### PR TITLE
[6.x] Work around SQLite issue with columns

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -145,7 +145,7 @@ class Blueprint
                 // make separete dropColumn as one supportable array
                 $arrayColumns = [];
                 foreach ($this->commands as $key => $command) {
-                    if($command->name == 'dropColumn'){
+                    if($command->name == 'dropColumn') {
                         $arrayColumns[] = $command->columns;
                         unset($this->commands[$key]);
                     }
@@ -165,11 +165,11 @@ class Blueprint
             }
 
             // Fix new added not null columns to table
-            if(!$this->creating()){
+            if(!$this->creating()) {
                 foreach ($this->columns as $key => $column) {
-                    if(!isset($column['change'])){
-                        if(!isset($column['nullable'])){
-                            $this->columns[$key]['nullable'] =true;  
+                    if(!isset($column['change'])) {
+                        if(!isset($column['nullable'])) {
+                            $this->columns[$key]['nullable'] = true;  
                         }
                     }
                 }

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -140,12 +140,11 @@ class Blueprint
     protected function ensureCommandsAreValid(Connection $connection)
     {
         if ($connection instanceof SQLiteConnection) {
-
             if ($this->commandsNamed(['dropColumn'])->count() > 1) {
                 // make separete dropColumn as one supportable array
                 $arrayColumns = [];
                 foreach ($this->commands as $key => $command) {
-                    if($command->name == 'dropColumn') {
+                    if ($command->name == 'dropColumn') {
                         $arrayColumns[] = $command->columns;
                         unset($this->commands[$key]);
                     }
@@ -164,12 +163,12 @@ class Blueprint
                 return new Fluent();
             }
 
-            // Fix new added not null columns to table
-            if(!$this->creating()) {
+            // Fix Cannot add a NOT NULL column with default value NULL
+            if (!$this->creating()) {
                 foreach ($this->columns as $key => $column) {
-                    if(!isset($column['change'])) {
-                        if(!isset($column['nullable'])) {
-                            $this->columns[$key]['nullable'] = true;  
+                    if (!isset($column['change'])) {
+                        if (!isset($column['nullable'])) {
+                            $this->columns[$key]['nullable'] = true;
                         }
                     }
                 }
@@ -1327,7 +1326,8 @@ class Blueprint
         $index = $index ?: $this->createIndexName($type, $columns);
 
         return $this->addCommand(
-            $type, compact('index', 'columns', 'algorithm')
+            $type,
+            compact('index', 'columns', 'algorithm')
         );
     }
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -126,6 +126,42 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertFalse($schema->hasColumn('users', 'name'));
     }
 
+    public function testDropColumns()
+    {
+        if (! class_exists(SqliteSchemaManager::class)) {
+            $this->markTestSkipped('Doctrine should be installed to run dropColumn tests');
+        }
+
+        $db = new Manager;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => 'prefix_',
+        ]);
+
+        $schema = $db->getConnection()->getSchemaBuilder();
+
+        $schema->create('users', function (Blueprint $table) {
+            $table->string('email');
+            $table->string('name');
+            $table->string('gender');
+        });
+
+        
+        $this->assertTrue($schema->hasTable('users'));
+        $this->assertTrue($schema->hasColumn('users', 'name'));
+        $this->assertTrue($schema->hasColumn('users', 'gender'));
+
+        $schema->table('users', function (Blueprint $table) {
+            $table->dropColumn('name');
+            $table->dropColumn('gender');
+        });
+
+        $this->assertFalse($schema->hasColumn('users', 'name'));
+        $this->assertFalse($schema->hasColumn('users', 'gender'));
+    }
+
     public function testDropSpatialIndex()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
Sometimes we are dealing with an existing projects and we decide to add Unit Testing,
the issue is when we have a hundreds of migrations some of them are dropping columns and adding new columns to an existing tables also dropping foreign keys it become hard to maintain since we always prefer to use SQLite on memory or local file
The solution that provided is adding more test inside the migrations files like: 
 
```php
if (\DB::getDriverName() != 'sqlite') {
  $table->string('column');
}else{
  $table->string('column')->nullable();
}
```

or 
```php
if (\DB::getDriverName() != 'sqlite') {
   $table->dropColumn('column1');
   $table->dropColumn('column2');
}else{
   $table->dropColumn(['column1', 'column2']);
}
```

Or Create **separate migrations** or modify all the affected migrations by refactoring code to suit SQLite limitations.

It would be great to cover all SQLite limitation in new versions 