### PR TITLE
[7.x] Add 'morphWithCount' method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -45,6 +45,13 @@ class MorphTo extends BelongsTo
     protected $morphableEagerLoads = [];
 
     /**
+     * A map of relationship counts to load for each individual morph type.
+     *
+     * @var array
+     */
+    protected $morphableEagerLoadCounts = [];
+
+    /**
      * Create a new morph to relationship instance.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
@@ -121,7 +128,10 @@ class MorphTo extends BelongsTo
                             ->with(array_merge(
                                 $this->getQuery()->getEagerLoads(),
                                 (array) ($this->morphableEagerLoads[get_class($instance)] ?? [])
-                            ));
+                            ))
+                            ->withCount(
+                                (array) ($this->morphableEagerLoadCounts[get_class($instance)] ?? [])
+                            );
 
         $whereIn = $this->whereInMethod($instance, $ownerKey);
 
@@ -277,6 +287,21 @@ class MorphTo extends BelongsTo
     {
         $this->morphableEagerLoads = array_merge(
             $this->morphableEagerLoads, $with
+        );
+
+        return $this;
+    }
+
+    /**
+     * Specify which relationship counts to load for a given morph type.
+     *
+     * @param  array  $withCount
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function morphWithCount(array $withCount)
+    {
+        $this->morphableEagerLoadCounts = array_merge(
+            $this->morphableEagerLoadCounts, $withCount
         );
 
         return $this;

--- a/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphCountEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('views', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('video_id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('videos', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+        $video = Video::create();
+
+        tap((new Like)->post()->associate($post))->save();
+        tap((new Like)->post()->associate($post))->save();
+
+        tap((new View)->video()->associate($video))->save();
+
+        (new Comment)->commentable()->associate($post)->save();
+        (new Comment)->commentable()->associate($video)->save();
+    }
+
+    public function testWithMorphCountLoading()
+    {
+        $comments = Comment::query()
+            ->with(['commentable' => function (MorphTo $morphTo) {
+                $morphTo->morphWithCount([Post::class => ['likes']]);
+            }])
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertEquals(2, $comments[0]->commentable->likes_count);
+        $this->assertTrue($comments[1]->relationLoaded('commentable'));
+        $this->assertNull($comments[1]->commentable->views_count);
+    }
+
+    public function testWithMorphCountLoadingWithSingleRelation()
+    {
+        $comments = Comment::query()
+            ->with(['commentable' => function (MorphTo $morphTo) {
+                $morphTo->morphWithCount([Post::class => 'likes']);
+            }])
+            ->get();
+
+        $this->assertTrue($comments[0]->relationLoaded('commentable'));
+        $this->assertEquals(2, $comments[0]->commentable->likes_count);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
+}
+
+class Video extends Model
+{
+    public $timestamps = false;
+
+    public function views()
+    {
+        return $this->hasMany(View::class);
+    }
+}
+
+class Like extends Model
+{
+    public $timestamps = false;
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}
+
+class View extends Model
+{
+    public $timestamps = false;
+
+    public function video()
+    {
+        return $this->belongsTo(Video::class);
+    }
+}


### PR DESCRIPTION
The `morphWith` method was added by PR #28647. It allows you to eager load relations on morphed models.

This PR adds a `morphWithCount` method that allows you to eager load relationship counts on morphed models. It uses the same syntax as the `morphWith` method.

An example:

```php
Comment::query()
    ->with(['commentable' => function (MorphTo $morphTo) {
        $morphTo->morphWithCount([Post::class => ['likes']]);
    }])
    ->get();
```

