### PR TITLE
[7.x] Add 'loadMorphCount' method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -190,6 +190,27 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Load a set of relationship counts onto the mixed relationship collection.
+     *
+     * @param  string  $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorphCount($relation, $relations)
+    {
+        $this->pluck($relation)
+            ->filter()
+            ->groupBy(function ($model) {
+                return get_class($model);
+            })
+            ->each(function ($models, $className) use ($relations) {
+                static::make($models)->loadCount($relations[$className] ?? []);
+            });
+
+        return $this;
+    }
+
+    /**
      * Determine if a key exists in the collection.
      *
      * @param  mixed  $key

--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -292,6 +292,20 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Load a set of relationship counts onto the mixed relationship collection.
+     *
+     * @param  string  $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorphCount($relation, $relations)
+    {
+        $this->getCollection()->loadMorphCount($relation, $relations);
+
+        return $this;
+    }
+
+    /**
      * Get the slice of items being paginated.
      *
      * @return array

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -137,6 +137,31 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
         $this->assertTrue($likes[1]->likeable->relationLoaded('comments'));
     }
 
+    public function testItLoadsNestedMorphRelationshipCountsOnDemand()
+    {
+        $this->seedData();
+
+        TestPost::first()->likes()->create([]);
+        TestComment::first()->likes()->create([]);
+
+        $likes = TestLike::with('likeable.owner')->get()->loadMorphCount('likeable', [
+            TestComment::class => ['likes'],
+            TestPost::class => 'comments',
+        ]);
+
+        $this->assertTrue($likes[0]->relationLoaded('likeable'));
+        $this->assertTrue($likes[0]->likeable->relationLoaded('owner'));
+        $this->assertEquals(2, $likes[0]->likeable->likes_count);
+
+        $this->assertTrue($likes[1]->relationLoaded('likeable'));
+        $this->assertTrue($likes[1]->likeable->relationLoaded('owner'));
+        $this->assertEquals(1, $likes[1]->likeable->comments_count);
+
+        $this->assertTrue($likes[2]->relationLoaded('likeable'));
+        $this->assertTrue($likes[2]->likeable->relationLoaded('owner'));
+        $this->assertEquals(2, $likes[2]->likeable->likes_count);
+    }
+
     /**
      * Helpers...
      */

--- a/tests/Pagination/PaginatorLoadMorphCountTest.php
+++ b/tests/Pagination/PaginatorLoadMorphCountTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Pagination;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\AbstractPaginator;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class PaginatorLoadMorphCountTest extends TestCase
+{
+    public function testCollectionLoadMorphCountCanChainOnThePaginator()
+    {
+        $relations = [
+            'App\\User' => 'photos',
+            'App\\Company' => ['employees', 'calendars'],
+        ];
+
+        $items = m::mock(Collection::class);
+        $items->shouldReceive('loadMorphCount')->once()->with('parentable', $relations);
+
+        $p = (new class extends AbstractPaginator {
+            //
+        })->setCollection($items);
+
+        $this->assertSame($p, $p->loadMorphCount('parentable', $relations));
+    }
+}


### PR DESCRIPTION
The `loadMorph` method was added way back in v5.6 by PR #23626.

Because I created a PR for a `morphWithCount` method, I thought it would be a good idea to add an appropriate load-method.

```php
$comments = Comment::all();

$comments->loadMorphCount('commentable', [
    Post::class => ['likes'],
]);
```

I also added a proxy method to the paginator, as is the case with loadMorph-method.