### PR TITLE
[7.x] Fix 'loadCount' method to ensure count is set on all models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -87,9 +87,11 @@ class Collection extends BaseCollection implements QueueableCollection
         );
 
         $models->each(function ($model) use ($attributes) {
-            $this->find($model->getKey())->forceFill(
-                Arr::only($model->getAttributes(), $attributes)
-            )->syncOriginalAttributes($attributes);
+            $this->where($this->first()->getKeyName(), $model->getKey())
+                ->each
+                ->forceFill(Arr::only($model->getAttributes(), $attributes))
+                ->each
+                ->syncOriginalAttributes($attributes);
         });
 
         return $this;

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -57,6 +57,20 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
         $this->assertSame('2', $posts[0]->getOriginal('comments_count'));
     }
 
+    public function testLoadCountWithSameModels()
+    {
+        $posts = Post::all()->push(Post::first());
+
+        DB::enableQueryLog();
+
+        $posts->loadCount('comments');
+
+        $this->assertCount(1, DB::getQueryLog());
+        $this->assertSame('2', $posts[0]->comments_count);
+        $this->assertSame('0', $posts[1]->comments_count);
+        $this->assertSame('2', $posts[2]->comments_count);
+    }
+
     public function testLoadCountOnDeletedModels()
     {
         $posts = Post::all()->each->delete();


### PR DESCRIPTION
If a model is present multiple times in a collection, all models should get the relationship count set, instead of only the first occurence of that model in the collection.

```php
$posts = Post::where('id', 1)->get()->push(Post::where('id', 1)->get());

$posts[0]->comments_count; // is set
$posts[1]->comments_count; // is not set (bug)
```

I discovered this bug while I was creating PR #32739 that adds `loadMorphCount` method. That method uses the `loadCount` method. The temporary collection that calls the `loadCount` method, can contain duplicates (e.g. 2 comments can morph to the same post)