### PR TITLE
[7.x] Implement env and production Blade directives

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -48,6 +48,47 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the env statements into valid PHP.
+     *
+     * @param  string  $environment
+     * @return string
+     */
+    protected function compileEnv($environment)
+    {
+        return "<?php if(app()->environment{$environment}): ?>";
+    }
+
+    /**
+     * Compile the end-env statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndEnv()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
+     * Compile the production statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileProduction()
+    {
+        return "<?php if(app()->environment('production')): ?>";
+    }
+
+    /**
+     * Compile the end-env statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndProduction()
+    {
+        return '<?php endif; ?>';
+    }
+
+    /**
      * Compile the if-guest statements into valid PHP.
      *
      * @param  string|null  $guard

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -79,7 +79,7 @@ trait CompilesConditionals
     }
 
     /**
-     * Compile the end-env statements into valid PHP.
+     * Compile the end-production statements into valid PHP.
      *
      * @return string
      */

--- a/tests/View/Blade/BladeEnvironmentStatementsTest.php
+++ b/tests/View/Blade/BladeEnvironmentStatementsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeEnvironmentStatementsTest extends AbstractBladeTestCase
+{
+    public function testEnvStatementsAreCompiled()
+    {
+        $string = "@env('staging')
+breeze
+@else
+boom
+@endenv";
+        $expected = "<?php if(app()->environment('staging')): ?>
+breeze
+<?php else: ?>
+boom
+<?php endif; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testProductionStatementsAreCompiled()
+    {
+        $string = '@production
+breeze
+@else
+boom
+@endproduction';
+        $expected = "<?php if(app()->environment('production')): ?>
+breeze
+<?php else: ?>
+boom
+<?php endif; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}


### PR DESCRIPTION
I often find myself doing this:

```blade
@if (app()->environment('production'))
    <!-- Some tracking code here -->
@endif
```

This pr allows for:

```blade
@production
    <!-- Some tracking code here -->
@endproduction
```

And also for more granular environment checking if needed:
```blade
@env('staging')
    <!-- Some tracking code here -->
@endenv
```