### PR TITLE
[8.x] made redis cache flush all only by prefix

### DIFF
--- a/src/Illuminate/Cache/RedisStore.php
+++ b/src/Illuminate/Cache/RedisStore.php
@@ -214,7 +214,15 @@ class RedisStore extends TaggableStore implements LockProvider
      */
     public function flush()
     {
-        $this->connection()->flushdb();
+        $luaScript = <<<'LUA'
+local keys = redis.call('keys', ARGV[1]) 
+for i=1,#keys,5000 do
+    redis.call('del', unpack(keys, i, math.min(i+4999, #keys)))
+end
+return keys
+LUA;
+
+        $this->connection()->eval( $luaScript, 0, $this->prefix . '*');
 
         return true;
     }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

currently if you do `php artisan cache:clear` it will clear all the things that are stored in your redis db, 
this causes to loose user sessions from this redis db. What I want is to delete cache only and preserve user sessions.

I'm targeting 8.x because this is small but BC (for example if people really want to delete all redis cache)

I'll add/edit tests after see some feedback on this feature.