### PR TITLE
Add StartCase to Str & Stringable

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -603,13 +603,10 @@ class Str
 
     public static function startCase($value)
     {
-        //       return Str::of($input)
-        // ->studly()
-        // ->replaceMatches("([A-Z])", " $0")
-        // ->trim()
-        // ->__toString();
         $value = static::studly($value);
-        $value = preg_replace("([A-Z])", " $0", $value, -1);
+
+        $value = preg_replace('([A-Z])', ' $0', $value, -1);
+        
         $value = trim($value);
 
         return $value;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -595,6 +595,27 @@ class Str
     }
 
     /**
+     * Convert a string to start case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+
+    public static function startCase($value)
+    {
+        //       return Str::of($input)
+        // ->studly()
+        // ->replaceMatches("([A-Z])", " $0")
+        // ->trim()
+        // ->__toString();
+        $value = static::studly($value);
+        $value = preg_replace("([A-Z])", " $0", $value, -1);
+        $value = trim($value);
+
+        return $value;
+    }
+
+    /**
      * Determine if a given string starts with a given substring.
      *
      * @param  string  $haystack

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -459,6 +459,17 @@ class Stringable
     }
 
     /**
+     * Convert the given string to start case.
+     *
+     * @param  string  $prefix
+     * @return static
+     */
+    public function startCase()
+    {
+        return new static(Str::startCase($this->value));
+    }
+
+    /**
      * Convert the given string to upper-case.
      *
      * @return static

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -409,6 +409,19 @@ class SupportStrTest extends TestCase
         $this->assertSame('fooBarBaz', Str::camel('foo-bar_baz'));
     }
 
+    public function testStartCase()
+    {
+        $this->assertSame('Laravel Php Framework', Str::startCase('Laravel_php_framework'));
+        $this->assertSame('Laravel Php Framework', Str::startCase('Laravel-php-framework'));
+        $this->assertSame('Laravel Php Framework', Str::startCase('Laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('Foo Bar', Str::startCase('FooBar'));
+        $this->assertSame('Foo Bar', Str::startCase('foo_bar'));
+        $this->assertSame('Foo Bar', Str::startCase('foo_bar')); // test cache
+        $this->assertSame('Foo Bar Baz', Str::startCase('Foo-barBaz'));
+        $this->assertSame('Foo Bar Baz', Str::startCase('foo-bar_baz'));
+    }
+
     public function testSubstr()
     {
         $this->assertSame('Ё', Str::substr('БГДЖИЛЁ', -1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -353,7 +353,8 @@ class SupportStringableTest extends TestCase
 
     public function testLimit()
     {
-        $this->assertSame('Laravel is...',
+        $this->assertSame(
+            'Laravel is...',
             (string) $this->stringable('Laravel is a free, open source PHP web application framework.')->limit(10)
         );
         $this->assertSame('这是一...', (string) $this->stringable('这是一段中文')->limit(6));
@@ -454,6 +455,19 @@ class SupportStringableTest extends TestCase
         $this->assertSame('fooBar', (string) $this->stringable('foo_bar')->camel()); // test cache
         $this->assertSame('fooBarBaz', (string) $this->stringable('Foo-barBaz')->camel());
         $this->assertSame('fooBarBaz', (string) $this->stringable('foo-bar_baz')->camel());
+    }
+
+    public function testStartCase()
+    {
+        $this->assertSame('Laravel Php Framework', (string) $this->stringable('Laravel_Php_framework')->startCase());
+        $this->assertSame('Laravel Php Framework', (string) $this->stringable('Laravel_php_framework')->startCase());
+        $this->assertSame('Laravel Php Framework', (string) $this->stringable('Laravel-php_framework')->startCase());
+        $this->assertSame('Laravel Php Framework', (string) $this->stringable('Laravel  -_-  php   -_-   framework   ')->startCase());
+
+        $this->assertSame('Foo Bar', (string) $this->stringable('FooBar')->startCase());
+        $this->assertSame('Foo Bar', (string) $this->stringable('foo_bar')->startCase());
+        $this->assertSame('Foo Bar Baz', (string) $this->stringable('Foo-barBaz')->startCase());
+        $this->assertSame('Foo Bar Baz', (string) $this->stringable('foo-bar_baz')->startCase());
     }
 
     public function testSubstr()


### PR DESCRIPTION
Adds ```Str:startCase()``` and Stringable ```->startCase()``` functionality to the helpers.

This allows for users to convert a cased string (studly, camel, etc.) to Start Case.
It differs slightly from Title case in two ways. https://en.wikipedia.org/wiki/Letter_case#Stylistic_or_specialised_usage

- Title case does & should not convert from kebab, camel, studly cases
- Title case should not capitalize all words where Start Case should (this may be something that needs implementing in ```title()``` in future)

This functionality is really useful for converting a class name 'FooBar' to a nice string for display 'Foo Bar'.

I have been needing this a lot in Nova to generate nice resource names from a class in a Select. 
Originally I was using lodash's ```_.startCase()``` and building custom fields.
Now the values can be provided much cleaner using ```->options()``` directly.

It is an addition only and does not change any existing functionality. 

If accepted I will also PR the necessary changes to the docs repo.