### PR TITLE
[7.x] Fix getQueueableRelations() for filtered collections

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -577,7 +577,7 @@ class Collection extends BaseCollection implements QueueableCollection
         if (count($relations) === 0 || $relations === [[]]) {
             return [];
         } elseif (count($relations) === 1) {
-            return $relations[0];
+            return reset($relations);
         } else {
             return array_intersect(...$relations);
         }


### PR DESCRIPTION
If the Eloquent Collection has been filtered and the keys retained, `$relations[0]` will result in an undefined index error. Using `reset()` will get the first item regardless of its key in the array.

Introduced in 7b32469420258e9e52b24b2ffa7f491e79a3a870

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
