### PR TITLE
[7.x] Updated user model var name

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -103,6 +103,7 @@ class PolicyMakeCommand extends GeneratorCommand
             'DummyUser' => $dummyUser,
             '{{ user }}' => $dummyUser,
             '{{user}}' => $dummyUser,
+            '$user' => '$'.Str::camel($dummyUser),
         ];
 
         $stub = str_replace(


### PR DESCRIPTION
This PR is just changing the variable name used in a policy.

Say i have `App\Teacher` set as user in the `config/auth.php` file.

When i create a policy like `php artisan make:policy --model=Subject`  the policy methods are currently having $user as var name eg.
```php
public function view(Teacher $user, Subject $subject){}
```

This PR changes the variable name to $teacher
```php
public function view(Teacher $teacher, Subject $subject){}
```