### PR TITLE
[7.x] Add $data param to assertDatabaseCount

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -56,7 +56,7 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseCount($table, int $count, array $data, $connection = null)
+    protected function assertDatabaseCount($table, int $count, array $data = [], $connection = null)
     {
         $this->assertThat(
             $table, new CountInDatabase($this->getConnection($connection), $count, $data)

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -56,10 +56,10 @@ trait InteractsWithDatabase
      * @param  string|null  $connection
      * @return $this
      */
-    protected function assertDatabaseCount($table, int $count, $connection = null)
+    protected function assertDatabaseCount($table, int $count, array $data, $connection = null)
     {
         $this->assertThat(
-            $table, new CountInDatabase($this->getConnection($connection), $count)
+            $table, new CountInDatabase($this->getConnection($connection), $count, $data)
         );
 
         return $this;

--- a/tests/Foundation/FoundationInteractsWithDatabaseTest.php
+++ b/tests/Foundation/FoundationInteractsWithDatabaseTest.php
@@ -110,6 +110,13 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->assertDatabaseCount($this->table, 1);
     }
 
+    public function testAssertTableEntriesCountWithData()
+    {
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount($this->table, 1, $this->data);
+    }
+
     public function testAssertTableEntriesCountWrong()
     {
         $this->expectException(ExpectationFailedException::class);
@@ -117,6 +124,16 @@ class FoundationInteractsWithDatabaseTest extends TestCase
         $this->mockCountBuilder(1);
 
         $this->assertDatabaseCount($this->table, 3);
+    }
+
+    public function testAssertTableEntriesCountWrongWithData()
+    {
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('Failed asserting that table [products] matches expected entries count of 0. Entries found: 1.');
+
+        $this->mockCountBuilder(1);
+
+        $this->assertDatabaseCount($this->table, 0, $this->data);
     }
 
     public function testAssertDeletedPassesWhenDoesNotFindResults()


### PR DESCRIPTION
This PR complete https://github.com/laravel/framework/pull/32597

It adds `$data` params to `assertDatabaseCount`

```php
MyCustomUserFactory::new()
    ->times(50)
    ->create(['name' => 'John']);

$this->assertDatabaseCount('users', 50, ['name' => 'John']);
```