### PR TITLE
[7.x] Add 'loadMorph' and 'loadMorphCount' on Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -521,6 +521,22 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load relationships on the polymorphic relation of a model.
+     *
+     * @param  string $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorph($relation, $relations)
+    {
+        $className = get_class($this->{$relation});
+
+        $this->{$relation}->load($relations[$className] ?? []);
+
+        return $this;
+    }
+
+    /**
      * Eager load relations on the model if they are not already eager loaded.
      *
      * @param  array|string  $relations

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -567,6 +567,22 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
 
     /**
+     * Eager load relationship counts on the polymorphic relation of a model.
+     *
+     * @param  string $relation
+     * @param  array  $relations
+     * @return $this
+     */
+    public function loadMorphCount($relation, $relations)
+    {
+        $className = get_class($this->{$relation});
+
+        $this->{$relation}->loadCount($relations[$className] ?? []);
+
+        return $this;
+    }
+
+    /**
      * Increment a column's value by a given amount.
      *
      * @param  string  $column

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphCountLazyEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('likes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('post_id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $post = Post::create();
+
+        tap((new Like)->post()->associate($post))->save();
+        tap((new Like)->post()->associate($post))->save();
+
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function testLazyEagerLoading()
+    {
+        $comment = Comment::first();
+
+        $comment->loadMorphCount('commentable', [
+            Post::class => ['likes']
+        ]);
+
+        $this->assertTrue($comment->relationLoaded('commentable'));
+        $this->assertEquals(2, $comment->commentable->likes_count);
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+
+    public function likes()
+    {
+        return $this->hasMany(Like::class);
+    }
+}
+
+class Like extends Model
+{
+    public $timestamps = false;
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -44,7 +44,7 @@ class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
         $comment = Comment::first();
 
         $comment->loadMorphCount('commentable', [
-            Post::class => ['likes']
+            Post::class => ['likes'],
         ]);
 
         $this->assertTrue($comment->relationLoaded('commentable'));

--- a/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentMorphLazyEagerLoadingTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+/**
+ * @group integration
+ */
+class EloquentMorphLazyEagerLoadingTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->increments('post_id');
+            $table->unsignedInteger('user_id');
+        });
+
+        Schema::create('comments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('commentable_type');
+            $table->integer('commentable_id');
+        });
+
+        $user = User::create();
+
+        $post = tap((new Post)->user()->associate($user))->save();
+
+        (new Comment)->commentable()->associate($post)->save();
+    }
+
+    public function testLazyEagerLoading()
+    {
+        $comment = Comment::first();
+
+        $comment->loadMorph('commentable', [
+            Post::class => ['user'],
+        ]);
+
+        $this->assertTrue($comment->relationLoaded('commentable'));
+        $this->assertTrue($comment->commentable->relationLoaded('user'));
+    }
+}
+
+class Comment extends Model
+{
+    public $timestamps = false;
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}
+
+class Post extends Model
+{
+    public $timestamps = false;
+    protected $primaryKey = 'post_id';
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}
+
+class User extends Model
+{
+    public $timestamps = false;
+}


### PR DESCRIPTION
The `loadMorph` method already exists on Eloquent collection since v5.6 (https://github.com/laravel/framework/pull/23626).
I recently added the `loadMorphCount` method to the Eloquent collection (https://github.com/laravel/framework/pull/32739).

If you have a collection of Eloquent models, these methods work very well. But what if you only have one model? You have to write this kind of if-statements:

```php
$comment = Comment::first();

if ($comment->commentable instanceof Post) {
    $comment->commentable->load('likes');
    // or
    $comment->commentable->loadCount('likes');
} elseif ($comment->commentable instance Video) {
    $comment->commentable->load('views');
    // or
    $comment->commentable->loadCount('views');
}
```

By adding `loadMorph` and `loadMorphCount` methods to the Eloquent Model, this becomes a lot more elegant:

```php
$comment = Comment::first()

$comment->loadMorph('commentable', [
   Post::class => ['likes'],
   Video::class => ['views'],
]);

$comment->loadMorphCount('commentable', [
   Post::class => ['likes'],
   Video::class => ['views'],
]);
```