### PR TITLE
[7.x] Add usingConnection method to DatabaseManager

### DIFF
--- a/src/Illuminate/Database/DatabaseManager.php
+++ b/src/Illuminate/Database/DatabaseManager.php
@@ -246,6 +246,22 @@ class DatabaseManager implements ConnectionResolverInterface
     }
 
     /**
+     * Set the database connection for the callback execution.
+     *
+     * @param  string  $name
+     * @param  callable  $callback
+     * @return void
+     */
+    public function usingConnection(string $name, callable $callback)
+    {
+        $previousName = $this->getDefaultConnection();
+
+        $this->setDefaultConnection($name);
+        $callback();
+        $this->setDefaultConnection($previousName);
+    }
+
+    /**
      * Refresh the PDO connections on a given connection.
      *
      * @param  string  $name


### PR DESCRIPTION
This PR adds `usingConnection` method to `Illuminate\Database\DatabaseManager`.

It is useful when you want to execute some actions in one connection and then switch back to the original connection.

```php
// Some logic performed on tenant connection

$this->databaseManager->usingConnection('landlord', function () {
    // Some logic performed on landlord connection
});

// Some logic performed on tenant connection
```