### PR TITLE
[8.x] Disable download progress for composer update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         uses: niden/actions-memcached@v7
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose


### PR DESCRIPTION
`--no-progress` makes the `Install dependencies` step in GitHub Actions more readable by no longer displaying empty squares which indicate the download progress for each installed pacakge.