### PR TITLE
[7.x] Allow setting the event handler queue via a getQueue() method

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -489,7 +489,7 @@ class Dispatcher implements DispatcherContract
             $listener->connection ?? null
         );
 
-        $queue = $listener->queue ?? null;
+        $queue = method_exists($listener, 'getQueue') ? $listener->getQueue() : $listener->queue ?? null;
 
         isset($listener->delay)
                     ? $connection->laterOn($queue, $listener->delay, $job)

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -99,7 +99,8 @@ class TestDispatcherGetQueue implements ShouldQueue
         //
     }
 
-    public function getQueue(): string {
+    public function getQueue()
+    {
         return 'some_other_queue';
     }
 }

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -50,6 +50,22 @@ class QueuedEventsTest extends TestCase
 
         $fakeQueue->assertPushedOn('my_queue', CallQueuedListener::class);
     }
+
+    public function testQueueIsSetByGetQueue()
+    {
+        $d = new Dispatcher;
+
+        $fakeQueue = new QueueFake(new Container());
+
+        $d->setQueueResolver(function () use ($fakeQueue) {
+            return $fakeQueue;
+        });
+
+        $d->listen('some.event', TestDispatcherGetQueue::class.'@handle');
+        $d->dispatch('some.event', ['foo', 'bar']);
+
+        $fakeQueue->assertPushedOn('some_other_queue', CallQueuedListener::class);
+    }
 }
 
 class TestDispatcherQueuedHandler implements ShouldQueue
@@ -71,5 +87,19 @@ class TestDispatcherConnectionQueuedHandler implements ShouldQueue
     public function handle()
     {
         //
+    }
+}
+
+class TestDispatcherGetQueue implements ShouldQueue
+{
+    public $queue = 'my_queue';
+
+    public function handle()
+    {
+        //
+    }
+
+    public function getQueue(): string {
+        return 'some_other_queue';
     }
 }


### PR DESCRIPTION
Using queued event listeners, it is possible to set the queue the resulting job should be executed on using the `$queue` attribute. This attribute is then adopted by the dispatcher. 

However, it is not possible to set the queue name from the config, the environment or otherwise programatically, because the listener instance is created without invoking the constructor in `Dispatcher::createListenerAndJob()`. Thus, trying to set the queue name in the constructor or anywhere else in the Listener has no effect.

This pull request proposes a non-breaking change to the Dispatcher class that allows a user to set the queue name by defining a `getQueue()` method within the Listener, as it is already done with `retryAfter` and `retryUntil` methods. 

If no getQueue method is defined, the code falls back to use the `$queue` attribute or null, as it was before.

The benefit of this change is to provide developers with a flexible way to influence the target queues instead of having to hard code them.