### PR TITLE
[6.x] Update artisan property docblock to be nullable

### DIFF
--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -38,7 +38,7 @@ class Kernel implements KernelContract
     /**
      * The Artisan application instance.
      *
-     * @var \Illuminate\Console\Application
+     * @var \Illuminate\Console\Application|null
      */
     protected $artisan;
 


### PR DESCRIPTION
Since the `artisan` property doesn't have a default and isn't set in the constructor, technically it is nullable. That is why we use the `getArtisan` getter instead.

------
I'm considering this a bug, hence sending it to 6.x. The [Laravel Psalm Plugin](https://github.com/psalm/psalm-plugin-laravel) reports 

```
ERROR: PropertyNotSetInConstructor - app/Console/Kernel.php:8:7 - Property App\Console\Kernel::$artisan is not defined in constructor of App\Console\Kernel and in any methods called in the constructor (see https://psalm.dev/074)
class Kernel extends ConsoleKernel
```

Therefore all developers who are interested in using Psalm will also run into this warning
