### PR TITLE
[6.x] Add return types to guard method

### DIFF
--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a guard instance by name.
      *
      * @param  string|null  $name
-     * @return  \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null);
 

--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a guard instance by name.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return  \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null);
 

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static mixed guard(string|null $name = null)
+ * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
  * @method static void shouldUse(string $name);
  * @method static bool check()
  * @method static bool guest()


### PR DESCRIPTION
Rather than relying on `mixed`, we can narrow down the return type of `Auth::guard` to be a union of `Guard` and `StatefulGuard`. This is what is currently documented as the return type for `AuthManager::guard`

------
I'm considering this a bug, hence sending it to 6.x. The [Laravel Psalm Plugin](https://github.com/psalm/psalm-plugin-laravel) reports 

```
MixedMethodCall | Cannot determine the type of the object on the left hand side of this expression
```

Therefore all developers who are interested in using Psalm will also run into this warning
