### PR TITLE
Collection::random() returns an array

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -867,7 +867,7 @@ class Collection implements ArrayAccess, Enumerable
      * Get one or a specified number of items randomly from the collection.
      *
      * @param  int|null  $number
-     * @return static|mixed
+     * @return array
      *
      * @throws \InvalidArgumentException
      */


### PR DESCRIPTION
Correct PHPDoc type hinting for `Collection::random()` return type to be `array` instead of `mixed|static`.