### PR TITLE
[7.x] Fix Validator, getPrimaryAttribute returns wrong attribute

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -553,7 +553,7 @@ class Validator implements ValidatorContract
     protected function getPrimaryAttribute($attribute)
     {
         foreach ($this->implicitAttributes as $unparsed => $parsed) {
-            if (in_array($attribute, $parsed)) {
+            if (in_array($attribute, $parsed, true)) {
                 return $unparsed;
             }
         }


### PR DESCRIPTION
When I want the primary attribute for "1.10", I receive "\*.1" and not the expected "\*.10". It  can be solved with the parameter `strict=true` of the function `in_array`.

**Here is the testcase :**

Parameter $attribute: 1.10

Return: *.1 
Expected return:  *.10


$this->implicitAttribute: 

Array
(
    [*.0] => Array
        (
            [0] => 1.0
            [1] => 2.0
        )

    [*.1] => Array
        (
            [0] => 1.1
            [1] => 2.1
        )

    [*.2] => Array
        (
            [0] => 1.2
            [1] => 2.2
        )

    [*.3] => Array
        (
            [0] => 1.3
            [1] => 2.3
        )

    [*.4] => Array
        (
            [0] => 1.4
            [1] => 2.4
        )

    [*.5] => Array
        (
            [0] => 1.5
            [1] => 2.5
        )

    [*.6] => Array
        (
            [0] => 1.6
            [1] => 2.6
        )

    [*.7] => Array
        (
            [0] => 1.7
            [1] => 2.7
        )

    [*.8] => Array
        (
            [0] => 1.8
            [1] => 2.8
        )

    [*.9] => Array
        (
            [0] => 1.9
            [1] => 2.9
        )

    [*.10] => Array
        (
            [0] => 1.10
            [1] => 2.10
        )

    [*.11] => Array
        (
            [0] => 1.11
            [1] => 2.11
        )
)
