### PR TITLE
[7.x] Check ability in controller

### DIFF
--- a/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
+++ b/src/Illuminate/Foundation/Auth/Access/AuthorizesRequests.php
@@ -41,6 +41,20 @@ trait AuthorizesRequests
     }
 
     /**
+     * Check if a given action allowed for the current user.
+     *
+     * @param  mixed  $ability
+     * @param  mixed|array  $arguments
+     * @return bool
+     */
+    public function check($ability, $arguments = [])
+    {
+        [$ability, $arguments] = $this->parseAbilityAndArguments($ability, $arguments);
+
+        return app(Gate::class)->check($ability, $arguments);
+    }
+
+    /**
      * Guesses the ability's name if it wasn't provided.
      *
      * @param  mixed  $ability

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -29,9 +29,11 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
             return true;
         });
 
-        $response = (new FoundationTestAuthorizeTraitClass)->authorize('baz');
+        $authorizeResponse = (new FoundationTestAuthorizeTraitClass)->authorize('baz');
+        $checkResponse = (new FoundationTestAuthorizeTraitClass)->check('baz');
 
-        $this->assertInstanceOf(Response::class, $response);
+        $this->assertInstanceOf(Response::class, $authorizeResponse);
+        $this->assertTrue($checkResponse);
         $this->assertTrue($_SERVER['_test.authorizes.trait']);
     }
 


### PR DESCRIPTION
Checking ability in controller required, for example, for hiding buttons when action is forbidden for current user.

Example usage:

```
public function get(Request $request, $object)
{
     return [
          'id' => $object->id
          'editable' => $this->check('edit', $object),
     ];
}

public function edit(Request $request, $object)
{
     $this->authorize('edit', $object);
     $object->doSomething();
}
```