### PR TITLE
[7.x] Added head method to PendingRequest class

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -388,6 +388,20 @@ class PendingRequest
     }
 
     /**
+     * Issue a HEAD request to the given URL.
+     *
+     * @param  string  $url
+     * @param  array|string|null  $query
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function head(string $url, $query = null)
+    {
+        return $this->send('HEAD', $url, [
+            'query' => $query,
+        ]);
+    }
+
+    /**
      * Issue a POST request to the given URL.
      *
      * @param  string  $url

--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -25,6 +25,7 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\PendingRequest withOptions(array $options)
  * @method static \Illuminate\Http\Client\PendingRequest beforeSending(callable $callback)
  * @method static \Illuminate\Http\Client\Response get(string $url, array $query = [])
+ * @method static \Illuminate\Http\Client\Response head(string $url, array $query = [])
  * @method static \Illuminate\Http\Client\Response post(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response patch(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response put(string $url, array $data = [])


### PR DESCRIPTION
Currently it is only possible to send a HEAD request through the send method which works just fine. However it is not a sleek as using the get, post, delete methods.

This pull request adds a dedicated method called head to send a HEAD request with the same arguments as the current get method. 