### PR TITLE
[8.x] Fix Queued MessageSent Listener With Attachments

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -631,7 +631,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
 
         if ($this->fireModelEvent('updating') === false) {
             return false;
-        };
+        }
 
         return tap($query->where(
             $this->getKeyName(), $this->getKey()

--- a/src/Illuminate/Mail/Events/MessageSent.php
+++ b/src/Illuminate/Mail/Events/MessageSent.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Mail\Events;
 
+use Swift_Attachment;
+
 class MessageSent
 {
     /**
@@ -29,5 +31,44 @@ class MessageSent
     {
         $this->data = $data;
         $this->message = $message;
+    }
+
+    /**
+     * Get the serializable representation of the object.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $hasAttachments = collect($this->message->getChildren())
+                                ->whereInstanceOf(Swift_Attachment::class)
+                                ->isNotEmpty();
+
+        return $hasAttachments ? [
+            'message' => base64_encode(serialize($this->message)),
+            'data' => base64_encode(serialize($this->data)),
+            'hasAttachments' => true,
+        ] : [
+            'message' => $this->message,
+            'data' => $this->data,
+            'hasAttachments' => false,
+        ];
+    }
+
+    /**
+     * Marshal the object from its serialized data.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function __unserialize(array $data)
+    {
+        if (isset($data['hasAttachments']) && $data['hasAttachments'] === true) {
+            $this->message = unserialize(base64_decode($data['message']));
+            $this->data = unserialize(base64_decode($data['data']));
+        } else {
+            $this->message = $data['message'];
+            $this->data = $data['data'];
+        }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/laravel/framework/issues/28847 by using `base64_encode` on the serialized message if attachments are present. 

This uses the new `__serialize` and `__unserialize` methods available in PHP 7.4+.