### PR TITLE
[7.x] Add containsAll collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -202,6 +202,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if all items exist in the collection, using strict comparison.
+     *
+     * @param  mixed $needles
+     *
+     * @return bool
+     */
+    public function containsAllStrict($needles)
+    {
+        foreach ($this->getArrayableItems($needles) as $needle) {
+            if (! $this->containsStrict($needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -184,6 +184,24 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if all items exist in the collection.
+     *
+     * @param  mixed $needles
+     *
+     * @return bool
+     */
+    public function containsAll($needles)
+    {
+        foreach ($this->getArrayableItems($needles) as $needle) {
+            if (! $this->contains($needle)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Cross join with the given lists, returning all possible permutations.
      *
      * @param  mixed  ...$lists

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -230,6 +230,18 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if all items exist in the collection.
+     *
+     * @param  mixed $needles
+     *
+     * @return bool
+     */
+    public function containsAll($needles)
+    {
+        return $this->collect()->containsAll($needles);
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @param  array  ...$arrays

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -242,6 +242,18 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if all items exist in the collection, using strict comparison.
+     *
+     * @param  mixed $needles
+     *
+     * @return bool
+     */
+    public function containsAllStrict($needles)
+    {
+        return $this->collect()->containsAllStrict($needles);
+    }
+
+    /**
      * Cross join the given iterables, returning all possible permutations.
      *
      * @param  array  ...$arrays

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -122,6 +122,24 @@ class DatabaseEloquentCollectionTest extends TestCase
         }));
     }
 
+    public function testContainsAll()
+    {
+        $mockModel = m::mock(Model::class);
+        $mockModel->shouldReceive('is')->with($mockModel)->andReturn(true);
+        $mockModel->shouldReceive('is')->andReturn(false)->times(3);
+        $mockModel2 = m::mock(Model::class);
+        $mockModel2->shouldReceive('is')->with($mockModel2)->andReturn(true)->twice();
+        $mockModel2->shouldReceive('is')->andReturn(false);
+        $mockModel3 = m::mock(Model::class);
+        $mockModel3->shouldNotReceive('is');
+        $c = new Collection([$mockModel, $mockModel2]);
+
+        $this->assertTrue($c->containsAll([$mockModel, $mockModel2]));
+        $this->assertTrue($c->containsAll([$mockModel2]));
+
+        $this->assertFalse($c->containsAll([$mockModel3]));
+    }
+
     public function testFindMethodFindsModelById()
     {
         $mockModel = m::mock(Model::class);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2750,6 +2750,41 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testContainsAll($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAll([1, 3]));
+        $this->assertTrue($c->containsAll([3, 5]));
+        $this->assertTrue($c->containsAll([1, 5]));
+        $this->assertTrue($c->containsAll(5));
+        $this->assertTrue($c->containsAll(true));
+
+        $this->assertFalse($c->containsAll([1, 2]));
+        $this->assertFalse($c->containsAll(2));
+        $this->assertFalse($c->containsAll(false));
+
+        $c = new $collection([0, 3, 5]);
+
+        $this->assertTrue($c->containsAll(['', 3]));
+        $this->assertTrue($c->containsAll([0, true]));
+        $this->assertTrue($c->containsAll([false, 5]));
+        $this->assertTrue($c->containsAll(true));
+        $this->assertTrue($c->containsAll(false));
+        $this->assertTrue($c->containsAll(''));
+
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+
+        $this->assertTrue($c->containsAll([['v' => 5], ['v' => 1], ['v' => 3]]));
+        $this->assertTrue($c->containsAll([['v' => 5], ['v' => 3]]));
+        $this->assertTrue($c->containsAll([['v' => 1], true]));
+
+        $this->assertFalse($c->containsAll(['v' => 3]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2785,6 +2785,41 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testContainsAllStrict($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertTrue($c->containsAllStrict([1, 3]));
+        $this->assertTrue($c->containsAllStrict([3, 5]));
+        $this->assertTrue($c->containsAllStrict([1, 5]));
+        $this->assertTrue($c->containsAllStrict(5));
+
+        $this->assertFalse($c->containsAllStrict([1, 2]));
+        $this->assertFalse($c->containsAllStrict(2));
+        $this->assertFalse($c->containsAllStrict(true));
+        $this->assertFalse($c->containsAllStrict(false));
+
+        $c = new $collection([0, 3, 5]);
+
+        $this->assertFalse($c->containsAllStrict(['', 3]));
+        $this->assertFalse($c->containsAllStrict([0, true]));
+        $this->assertFalse($c->containsAllStrict([false, 5]));
+        $this->assertFalse($c->containsAllStrict(true));
+        $this->assertFalse($c->containsAllStrict(false));
+        $this->assertFalse($c->containsAllStrict(''));
+
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+
+        $this->assertTrue($c->containsAllStrict([['v' => 5], ['v' => 1], ['v' => 3]]));
+        $this->assertTrue($c->containsAllStrict([['v' => 5], ['v' => 3]]));
+
+        $this->assertFalse($c->containsAllStrict(['v' => 3]));
+        $this->assertFalse($c->containsAllStrict([['v' => 1], true]));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);


### PR DESCRIPTION
A lot of the time I want to make sure a collection has certain items, I don't mind if it is in a particular order, just that they exist.

```php
$service->subscribeUsersToIssue($issue, $users);

// before
$this->assertTrue($issue->subscribers->contains($users[0]);
$this->assertTrue($issue->subscribers->contains($users[1]);
$this->assertTrue($issue->subscribers->contains($users[2]);

// after
$this->assertTrue($issue->subscribers->containsAll($users));
```

I've taken the naming from `Str::containsAll()`