### PR TITLE
[8.x] Exponential backoffs

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -173,10 +173,11 @@ abstract class Queue
             return;
         }
 
-        $backoff = $job->backoff ?? $job->backoff();
-
-        return $backoff instanceof DateTimeInterface
-                        ? $this->secondsUntil($backoff) : $backoff;
+        return collect($job->backoff ?? $job->backoff())
+            ->map(function ($backoff) {
+                return $backoff instanceof DateTimeInterface
+                                ? $this->secondsUntil($backoff) : $backoff;
+            })->implode(',');
     }
 
     /**

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -502,7 +502,7 @@ class Worker
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @return int
      */
-    protected function calculateBackoff($job, WorkerOptions $options): int
+    protected function calculateBackoff($job, WorkerOptions $options)
     {
         $backoff = explode(',',
             method_exists($job, 'backoff') && ! is_null($job->backoff())


### PR DESCRIPTION
This PR adds the ability to set exponential backoff in on the worker command:

```
--backoff=1,5,10
```

And inside a job class:

```
$backoff = [1, 5, 10];

function backoff(){
    return [1, 5, 10];
}
```

This will instruct the worker to retry the job after 1 second on the first exception, on the second exception it'll be retried after 5 seconds, on the 3rd exception it'll be retried after 10 seconds, on any future exception it'll be retried after 10 seconds.