### PR TITLE
[6.x] Add return types to guard method

### DIFF
--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a guard instance by name.
      *
      * @param  string|null  $name
-     * @return  \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+     * @return \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null);
 

--- a/src/Illuminate/Contracts/Auth/Factory.php
+++ b/src/Illuminate/Contracts/Auth/Factory.php
@@ -8,7 +8,7 @@ interface Factory
      * Get a guard instance by name.
      *
      * @param  string|null  $name
-     * @return mixed
+     * @return  \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
      */
     public function guard($name = null);
 

--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
- * @method static mixed guard(string|null $name = null)
+ * @method static \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard guard(string|null $name = null)
  * @method static void shouldUse(string $name);
  * @method static bool check()
  * @method static bool guest()


### PR DESCRIPTION
reopening https://github.com/laravel/framework/pull/32772

[The implementation already has the correct docblock...](https://github.com/laravel/framework/blob/6.x/src/Illuminate/Auth/AuthManager.php#L62)
Here's a screenshot in case my links are being ignored

![image](https://user-images.githubusercontent.com/5747667/81847115-fec73800-9507-11ea-8397-e37ec232b058.png)


I've asked on slack and discord and others seem to be in agreement. 

Would you mind being more clear what file you are asking me to update? Is there another implementation in a different branch somewhere?
