### PR TITLE
[8.x] Add parameter support to value helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -513,11 +513,12 @@ if (! function_exists('value')) {
      * Return the default value of the given value.
      *
      * @param  mixed  $value
+     * @param  array  $parameters
      * @return mixed
      */
-    function value($value)
+    function value($value, ...$parameters)
     {
-        return $value instanceof Closure ? $value() : $value;
+        return $value instanceof Closure ? $value(...$parameters) : $value;
     }
 }
 

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -39,6 +39,9 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('foo', value(function () {
             return 'foo';
         }));
+        $this->assertSame('foo', value(function ($f = 'F', $o = 'O') {
+            return $f.$o.$o;
+        }, 'f', 'o'));
     }
 
     public function testObjectGet()


### PR DESCRIPTION
This pull request allows passing additional parameters to the value helper which will be passed to value resolution when its a closure. The current behaviors of the value helper is unaffected only a new one is introduced.

This is probably not a breaking change since the helper functions cannot be extended or overriden, I made the pull request against the master branch to be sure bu I can change it to 7.x.

Example:
```php
function number($value){
    return value($value, 12);
}

echo number(5); // 5
echo number(fn() => rand()); // random number
echo number(fn($x) => $x * 3); // 36
```