### PR TITLE
[7.x] Add a new helper to determine the true parent of a class.

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -75,6 +75,23 @@ if (! function_exists('class_basename')) {
     }
 }
 
+if (! function_exists('class_parent_initial')) {
+    /**
+     * Gets the initial parent class of another class.
+     *
+     * @param  string|object  $class
+     * @return string
+     */
+    function class_parent_initial($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        return Arr::last(class_parents($class), null, $class);
+    }
+}
+
 if (! function_exists('class_uses_recursive')) {
     /**
      * Returns all traits used by a class, its parent classes and trait of their traits.

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -33,6 +33,25 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('Baz', class_basename('Baz'));
     }
 
+    public function testClassParentInitial()
+    {
+        $expected = 'Illuminate\Database\Eloquent\Relations\Relation';
+
+        $this->assertSame($expected, class_parent_initial($expected));
+
+        $this->assertSame($expected, class_parent_initial(
+            'Illuminate\Database\Eloquent\Relations\HasMany'
+        ));
+
+        $this->assertSame($expected, class_parent_initial(
+            'Illuminate\Database\Eloquent\Relations\BelongsTo'
+        ));
+
+        $this->assertSame($expected, class_parent_initial(
+            'Illuminate\Database\Eloquent\Relations\HasOneOrMany'
+        ));
+    }
+
     public function testValue()
     {
         $this->assertSame('foo', value('foo'));


### PR DESCRIPTION
Some examples of use are:

```php
class_parent_initial(HasMany::class); // Returns Relation::class
class_parent_initial(HasOne::class); // Returns Relation::class
class_parent_initial(HasOneOrMany::class); // Returns Relation::class
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
