### PR TITLE
[7.x] Option to preserve keys of reversed collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -919,9 +919,9 @@ class Collection implements ArrayAccess, Enumerable
      *
      * @return static
      */
-    public function reverse()
+    public function reverse($preserve = true)
     {
-        return new static(array_reverse($this->items, true));
+        return new static(array_reverse($this->items, $preserve));
     }
 
     /**


### PR DESCRIPTION
Reversing a collection preserves the underlying array keys. This is due to the underlying implementation in the Collection class. 

```
    public function reverse()
    {
        return new static(array_reverse($this->items, true));
    }
```

This change gives the developer the option to choose whether they want the keys preserved or not.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
