### PR TITLE
[7.x] Adds ddc() global helper function

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -961,3 +961,27 @@ if (! function_exists('view')) {
         return $factory->make($view, $data, $mergeData);
     }
 }
+
+if (! function_exists('ddc')) {
+    /**
+     * Dumps variables n times before it dies.
+     *
+     * @param  int  $count
+     * @param  mixed  ...$vars
+     * @return void
+     */
+    function ddc($count, ...$vars)
+    {
+        static $c = 0;
+        $c++;
+        $offset = 0;
+
+        if (is_array($count)) {
+            [$offset, $count] = $count;
+        }
+
+        if ($c > $offset) {
+            ($count == $c) ? dd(...$vars) : dump(...$vars);
+        }
+    }
+}


### PR DESCRIPTION
ddc stands for: die dump count

There are a lot of time where we want to dump variables in loop but not all of them.
This helper function can be called n times and then it dies.

```php
<?php

$i = 0;
while (true) {
    $i++;
    ddc(4, $i);         // dumps 1, 2, 3, 4 then dies
    ddc([0, 4], $i);    // same as ddc(4, $i); 
}

$i = 0;
while (true) {
    $i++;
    ddc([2,4], $i);   // dumps 3, 4 (skips 1, 2)
}
```
