### PR TITLE
[6.x] Allows multiple OS users to share values cached in file store

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -76,7 +76,7 @@ class FileStore implements Store
 
         if ($result !== false && $result > 0) {
             if (! is_null($this->filePermission)) {
-                $this->files->chmod($path, $this->filePermission);
+                $this->files->chmod($path, $this->filePermission, true);
             }
 
             return true;

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -194,10 +194,8 @@ class Filesystem
      */
     public function chmod($path, $mode = null, $ensureOwnership = false)
     {
-        if ($mode)
-        {
-            if ($ensureOwnership && extension_loaded("posix") && fileowner($path) !== posix_getuid())
-            {
+        if ($mode) {
+            if ($ensureOwnership && extension_loaded('posix') && fileowner($path) !== posix_getuid()) {
                 return false;
             }
 

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -192,9 +192,15 @@ class Filesystem
      * @param  int|null  $mode
      * @return mixed
      */
-    public function chmod($path, $mode = null)
+    public function chmod($path, $mode = null, $ensureOwnership = false)
     {
-        if ($mode) {
+        if ($mode)
+        {
+            if ($ensureOwnership && extension_loaded("posix") && fileowner($path) !== posix_getuid())
+            {
+                return false;
+            }
+
             return chmod($path, $mode);
         }
 

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -79,6 +79,21 @@ class CacheFileStoreTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testStoreUpdatesFilePermissions()
+    {
+        $filePermissions = 0755;
+        $files = $this->mockFilesystem();
+        $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__, $filePermissions])->getMock();
+        $store->expects($this->once())->method('expiration')->with($this->equalTo(10))->willReturn(1111111111);
+        $contents = '1111111111'.serialize('Hello World');
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
+        $files->expects($this->once())->method('chmod')->with(__DIR__.'/'.$cache_dir.'/'.$hash, $filePermissions);
+        $result = $store->put('foo', 'Hello World', 10);
+        $this->assertTrue($result);
+    }
+
     public function testForeversAreStoredWithHighTimestamp()
     {
         $files = $this->mockFilesystem();

--- a/tests/Cache/FileCacheIntegrationTest.php
+++ b/tests/Cache/FileCacheIntegrationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Illuminate\Tests\Cache;
+
+use Illuminate\Cache\FileStore;
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+
+class FileCacheIntegrationTest extends TestCase
+{
+    public function testStoreWorksForDifferentUsers()
+    {
+        if (!extension_loaded('posix')) {
+            $this->markTestSkipped("This test only applies when the posix extension is present");
+
+        } else if (posix_getuid() === 0) {
+            $this->markTestSkipped("This test must run as a non-root user");
+        }
+
+        $dir = sys_get_temp_dir();
+        $store = new FileStore(new Filesystem(), $dir, 0666);
+        $store->flush();
+
+        // Write a cache file (as non-root)
+        $store->forever("foo", "bar");
+
+        // Change ownership of the cache file to root (user id 0)
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $cache_file = $dir . '/' . $cache_dir . '/' . $hash;
+        exec("sudo chown root \"" . $dir.'/'.$cache_dir.'/'.$hash . "\"", $output, $exitCode);
+        if ($exitCode !== 0)
+        {
+            $this->markTestSkipped("This test must run as a user with sudo access");
+        }
+
+        // Clear ownership information cached by PHP
+        clearstatcache($cache_file);
+
+        // Attempt to overwrite the cache file as non-root
+        $this->assertTrue($store->forever("foo", "bar"));
+    }
+}

--- a/tests/Cache/FileCacheIntegrationTest.php
+++ b/tests/Cache/FileCacheIntegrationTest.php
@@ -10,11 +10,10 @@ class FileCacheIntegrationTest extends TestCase
 {
     public function testStoreWorksForDifferentUsers()
     {
-        if (!extension_loaded('posix')) {
-            $this->markTestSkipped("This test only applies when the posix extension is present");
-
-        } else if (posix_getuid() === 0) {
-            $this->markTestSkipped("This test must run as a non-root user");
+        if (! extension_loaded('posix')) {
+            $this->markTestSkipped('This test only applies when the posix extension is present');
+        } elseif (posix_getuid() === 0) {
+            $this->markTestSkipped('This test must run as a non-root user');
         }
 
         $dir = sys_get_temp_dir();
@@ -22,22 +21,21 @@ class FileCacheIntegrationTest extends TestCase
         $store->flush();
 
         // Write a cache file (as non-root)
-        $store->forever("foo", "bar");
+        $store->forever('foo', 'bar');
 
         // Change ownership of the cache file to root (user id 0)
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $cache_file = $dir . '/' . $cache_dir . '/' . $hash;
-        exec("sudo chown root \"" . $dir.'/'.$cache_dir.'/'.$hash . "\"", $output, $exitCode);
-        if ($exitCode !== 0)
-        {
-            $this->markTestSkipped("This test must run as a user with sudo access");
+        $cache_file = $dir.'/'.$cache_dir.'/'.$hash;
+        exec('sudo chown root "'.$dir.'/'.$cache_dir.'/'.$hash.'"', $output, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('This test must run as a user with sudo access');
         }
 
         // Clear ownership information cached by PHP
         clearstatcache($cache_file);
 
         // Attempt to overwrite the cache file as non-root
-        $this->assertTrue($store->forever("foo", "bar"));
+        $this->assertTrue($store->forever('foo', 'bar'));
     }
 }

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -92,6 +92,24 @@ class FilesystemTest extends TestCase
         $this->assertEquals($expectedPermissions, $filePermission);
     }
 
+    public function testSetChmodWithOwnershipCheck()
+    {
+        if (!extension_loaded('posix'))
+        {
+            $this->markTestSkipped("This test only applies when the posix extension is present");
+        }
+
+        file_put_contents($this->tempDir.'/file.txt', 'Hello World');
+        exec("sudo chown root " . $this->tempDir.'/file.txt', $output, $exitCode);
+        if ($exitCode !== 0)
+        {
+            $this->markTestSkipped("This test must run as a user with sudo access");
+        }
+
+        $files = new Filesystem;
+        $this->assertFalse($files->chmod($this->tempDir.'/file.txt', 0755, true));
+    }
+
     public function testGetChmod()
     {
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -94,16 +94,14 @@ class FilesystemTest extends TestCase
 
     public function testSetChmodWithOwnershipCheck()
     {
-        if (!extension_loaded('posix'))
-        {
-            $this->markTestSkipped("This test only applies when the posix extension is present");
+        if (! extension_loaded('posix')) {
+            $this->markTestSkipped('This test only applies when the posix extension is present');
         }
 
         file_put_contents($this->tempDir.'/file.txt', 'Hello World');
-        exec("sudo chown root " . $this->tempDir.'/file.txt', $output, $exitCode);
-        if ($exitCode !== 0)
-        {
-            $this->markTestSkipped("This test must run as a user with sudo access");
+        exec('sudo chown root '.$this->tempDir.'/file.txt', $output, $exitCode);
+        if ($exitCode !== 0) {
+            $this->markTestSkipped('This test must run as a user with sudo access');
         }
 
         $files = new Filesystem;


### PR DESCRIPTION
This modifies some of the behaviour in 61b5aa1
From pull request #31579

That change was intended to make it easier for multiple OS users to read/write the same cached values when using the FileStore driver. However, the change introduced a subtle bug. Suppose we have the following situation:

1. One user (say `www-data`) puts a value in the cache.
2 Some time later but before the value from (1) has expired, another user (say `ubuntu`) attempts to update the value written in (1).

This will fail irrespective of what $filePermission value is configured for FileStore because:
* after (1), the owner of the file on disk is `www-data`
* FileStore will attempt to call FileSystem#chmod on this file
* FileSystem#chmod will fail because the OS will prevent `ubuntu` from changing the file permissions of a file owned by `www-data`

In short, the $filePermission option is not working as intended when two users try to write to the same cache key.