### PR TITLE
Fixed mergeAttributesFromClassCasts eveytime when using getAttributes.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Concerns;
 use Carbon\CarbonInterface;
 use DateTimeInterface;
 use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\JsonEncodingException;
@@ -246,6 +247,8 @@ trait HasAttributes
      */
     protected function getArrayableAttributes()
     {
+        $this->mergeAttributesFromClassCasts();
+
         return $this->getArrayableItems($this->getAttributes());
     }
 
@@ -1067,7 +1070,7 @@ trait HasAttributes
      * Resolve the custom caster class for a given key.
      *
      * @param  string  $key
-     * @return mixed
+     * @return CastsInboundAttributes|CastsAttributes
      */
     protected function resolveCasterClass($key)
     {
@@ -1144,9 +1147,17 @@ trait HasAttributes
      */
     public function getAttributes()
     {
+        return $this->attributes;
+    }
+
+    /**
+     * @return $this
+     */
+    public function syncAttributes()
+    {
         $this->mergeAttributesFromClassCasts();
 
-        return $this->attributes;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
```
class User extends Model
{
    protected $casts = [
        'ext' => Ext::class
    ];
}

$user = User::find(1);

return [
    'id' => $user->id,
    'name' => $user->name,
    'ext' => $user->ext->toArray(),
]
```

Method `mergeAttributesFromClassCasts` will be called more tharn 1 time.

![image](https://user-images.githubusercontent.com/16648551/82118332-3a346180-97a9-11ea-96c5-4de3212856df.png)

Method mergeAttributesFromClassCasts before getAttributes only effect when I changed the value, and getAttributes to get the its underlying model values.

```
$model = new TestEloquentModelWithCustomCast;
$model->address = $address = new Address('110 Kingsbrook St.', 'My Childhood House');
$address->lineOne = '117 Spencer St.';
// $model->syncAttributes();
$this->assertSame('117 Spencer St.', $model->getAttributes()['address_line_one']);
```

So I think it not must to use in getAttributes.

If the model has many fields, and method `caster::set` will be called n times, if I fetch a list for model, it will be called n^2 times.