### PR TITLE
[6.x] Set FileStore file permissions only once

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -102,7 +102,8 @@ class FileStore implements Store
      * @param  string  $path
      * @return void
      */
-    protected function ensureCorrectPermissions($path){
+    protected function ensureCorrectPermissions($path)
+    {
         if (is_null($this->filePermission)) {
             return;
         }

--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -75,9 +75,7 @@ class FileStore implements Store
         );
 
         if ($result !== false && $result > 0) {
-            if (! is_null($this->filePermission)) {
-                $this->files->chmod($path, $this->filePermission);
-            }
+            $this->ensureCorrectPermissions($path);
 
             return true;
         }
@@ -96,6 +94,24 @@ class FileStore implements Store
         if (! $this->files->exists(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0777, true, true);
         }
+    }
+
+    /**
+     * Set file permission if required.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function ensureCorrectPermissions($path){
+        if (is_null($this->filePermission)) {
+            return;
+        }
+
+        if (intval($this->files->chmod($path), 8) == $this->filePermission) {
+            return;
+        }
+
+        $this->files->chmod($path, $this->filePermission);
     }
 
     /**

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -6,6 +6,7 @@ use Illuminate\Cache\FileStore;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Carbon;
+use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class CacheFileStoreTest extends TestCase
@@ -77,6 +78,27 @@ class CacheFileStoreTest extends TestCase
         $files->expects($this->once())->method('put')->with($this->equalTo(__DIR__.'/'.$cache_dir.'/'.$hash), $this->equalTo($contents))->willReturn(strlen($contents));
         $result = $store->put('foo', 'Hello World', 10);
         $this->assertTrue($result);
+    }
+
+    public function testStoreItemProperlySetsPermissions()
+    {
+        $files = m::mock(Filesystem::class);
+        $files->shouldIgnoreMissing();
+        $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0644])->getMock();
+        $hash = sha1('foo');
+        $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
+        $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {
+            return strlen($value);
+        });
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash])->andReturnValues(["0600", "0644"])->times(3);
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, 0644])->andReturn([true])->once();
+        $result = $store->put('foo', 'foo', 10);
+        $this->assertTrue($result);
+        $result = $store->put('foo', 'bar', 10);
+        $this->assertTrue($result);
+        $result = $store->put('foo', 'baz', 10);
+        $this->assertTrue($result);
+        m::close();
     }
 
     public function testForeversAreStoredWithHighTimestamp()

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -90,7 +90,7 @@ class CacheFileStoreTest extends TestCase
         $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {
             return strlen($value);
         });
-        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash])->andReturnValues(["0600", "0644"])->times(3);
+        $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash])->andReturnValues(['0600', '0644'])->times(3);
         $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, 0644])->andReturn([true])->once();
         $result = $store->put('foo', 'foo', 10);
         $this->assertTrue($result);


### PR DESCRIPTION
Follow up to #32841:

> This modifies some of the behaviour in 61b5aa1
> From pull request #31579
> 
> That change was intended to make it easier for multiple OS users to read/write the same cached values when using the FileStore driver. However, the change introduced a subtle bug. Suppose we have the following situation:
> 
> One user (say www-data) puts a value in the cache.
> 2 Some time later but before the value from (1) has expired, another user (say ubuntu) attempts to update the value written in (1).
> This will fail irrespective of what $filePermission value is configured for FileStore because:
> 
> after (1), the owner of the file on disk is www-data
> FileStore will attempt to call FileSystem#chmod on this file
> FileSystem#chmod will fail because the OS will prevent ubuntu from changing the file permissions of a file owned by www-data
> In short, the $filePermission option is not working as intended when two users try to write to the same cache key.

This PR solves the problem by checking the permissions first so it only tries to set it once. As a bonus on multiple writes the check first aproach is significantly faster (only the chmod was measured).