### PR TITLE
[8.x] Add withViewErrors test helper

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Foundation\Testing\Concerns;
 
 use Illuminate\Support\Facades\View as ViewFacade;
+use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
+use Illuminate\Support\ViewErrorBag;
 use Illuminate\Testing\TestView;
 use Illuminate\View\View;
 
@@ -59,5 +61,21 @@ trait InteractsWithViews
         return $view instanceof View
                 ? new TestView($view->with($component->data()))
                 : new TestView(view($view, $component->data()));
+    }
+
+    /**
+     * Populate the view errors.
+     *
+     * @param  array  $errors
+     * @param  string  $key
+     * @return void
+     */
+    protected function withViewErrors(array $errors, $key = 'default')
+    {
+        $viewErrorBag = new ViewErrorBag();
+
+        $viewErrorBag->put($key, new MessageBag($errors));
+
+        ViewFacade::share('errors', $viewErrorBag);
     }
 }


### PR DESCRIPTION
While testing the new blade component and view test helpers I noticed that if you tried to render components which have the `@error` directive, the test would fail because the `$errors` variable was undefined. This is normal because we're not doing a full application cycle and thus the `ShareErrorsFromSession` middleware isn't run.

This PR adds a convenient helper method to populate the `ViewErrorBag` so components and views that are trying to render the `@error` directive can do so.

An example component:

```php
@error($field)
    <div {{ $attributes }}>
        {{ $message }}
    </div>
@enderror
```

An example test:

```php
/** @test */
public function the_component_can_be_rendered()
{
    $this->withViewErrors(['first_name' => 'Incorrect first name.'], $key = 'default');

    $expected = <<<HTML
<div class="text-red-500">
    Incorrect first name.
</div>
HTML;

    $this->assertComponentRenders(
        $expected,
        '<x-error field="first_name" class="text-red-500"/>'
    );
}
```