### PR TITLE
[8.x] Unify Model $dates property with $casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -80,13 +80,6 @@ trait HasAttributes
     ];
 
     /**
-     * The attributes that should be mutated to dates.
-     *
-     * @var array
-     */
-    protected $dates = [];
-
-    /**
      * The storage format of the model's date columns.
      *
      * @var string
@@ -972,8 +965,8 @@ trait HasAttributes
         ];
 
         return $this->usesTimestamps()
-                    ? array_unique(array_merge($this->dates, $defaults))
-                    : $this->dates;
+                    ? $defaults
+                    : [];
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -33,7 +33,9 @@ trait SoftDeletes
      */
     public function initializeSoftDeletes()
     {
-        $this->dates[] = $this->getDeletedAtColumn();
+        if (! isset($this->casts[$this->getDeletedAtColumn()])) {
+            $this->casts[$this->getDeletedAtColumn()] = 'datetime';
+        }
     }
 
     /**

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -1738,7 +1738,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 class EloquentTestUser extends Eloquent
 {
     protected $table = 'users';
-    protected $dates = ['birthday'];
+    protected $casts = ['birthday' => 'datetime'];
     protected $guarded = [];
 
     public function friends()

--- a/tests/Database/DatabaseSoftDeletingTest.php
+++ b/tests/Database/DatabaseSoftDeletingTest.php
@@ -9,23 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseSoftDeletingTest extends TestCase
 {
-    public function testDeletedAtIsAddedToDateCasts()
+    public function testDeletedAtIsAddedToCastsAsDefaultType()
     {
         $model = new SoftDeletingModel;
 
-        $this->assertContains('deleted_at', $model->getDates());
-    }
-
-    public function testDeletedAtIsUniqueWhenAlreadyExists()
-    {
-        $model = new class extends SoftDeletingModel {
-            protected $dates = ['deleted_at'];
-        };
-        $entries = array_filter($model->getDates(), function ($attribute) {
-            return $attribute === 'deleted_at';
-        });
-
-        $this->assertCount(1, $entries);
+        $this->assertArrayHasKey('deleted_at', $model->getCasts());
+        $this->assertSame('datetime', $model->getCasts()['deleted_at']);
     }
 
     public function testDeletedAtIsCastToCarbonInstance()

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -43,7 +43,6 @@ class TestModel1 extends Model
     public $table = 'test_model1';
     public $timestamps = false;
     protected $guarded = ['id'];
-    protected $dates = ['date_field', 'datetime_field'];
 
     public $casts = [
         'date_field' => 'date:Y-m',

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -76,7 +76,7 @@ class TestModel1 extends Model
     public $table = 'test_model1';
     public $timestamps = false;
     protected $guarded = ['id'];
-    protected $dates = ['nullable_date'];
+    protected $casts = ['nullable_date' => 'datetime'];
 }
 
 class TestModel2 extends Model

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -156,5 +156,5 @@ class TestUpdateModel3 extends Model
 
     public $table = 'test_model3';
     protected $fillable = ['counter'];
-    protected $dates = ['deleted_at'];
+    protected $casts = ['deleted_at' => 'datetime'];
 }


### PR DESCRIPTION
This removes the Model `$dates` property as it has become antiquated by the `$casts` property.

Laravel as well as other community packages have adopted using `casts` directly for _dates_. Unifying these properties will remove ambiguity and give developers a single place for casting their _date_ attributes, as well as other attributes.

**Before**
```php
class Person extends Model
{
    protected $casts = [
        'age' => 'integer',
    ];

    protected $dates = ['birthday'];

    // ...
}
```

**After**
```php
class Person extends Model
{
    protected $casts = [
        'age' => 'integer',
        'birthday' => 'datetime',
    ];

    // ...
}
```