### PR TITLE
Added only() method to the Eloquent\Builder class

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1328,6 +1328,17 @@ class Builder
     }
 
     /**
+     * Execute the query and get the result only if one record is found.
+     *
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Model|object|static|null
+     */
+    public function only($columns = ['*'])
+    {
+        return $this->count() === 1 ? $this->take(1)->get($columns)->first() : null;
+    }
+
+    /**
      * Get the given global macro by name.
      *
      * @param  string  $name

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -180,6 +180,35 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('bar', $result);
     }
 
+    public function testOnlyMethodWithLessThanOneRecord()
+    {
+        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('count')->times(1)->andReturn(0);
+
+        $result = $builder->only();
+        $this->assertSame(null, $result);
+    }
+
+    public function testOnlyMethodWithMoreThanOneRecord()
+    {
+        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('count')->times(1)->andReturn(2);
+
+        $result = $builder->only();
+        $this->assertSame(null, $result);
+    }
+
+    public function testOnlyMethodWithOneRecord()
+    {
+        $builder = m::mock(Builder::class.'[get,take]', [$this->getMockQueryBuilder()]);
+        $builder->shouldReceive('count')->times(1)->andReturn(1);
+        $builder->shouldReceive('take')->with(1)->andReturnSelf();
+        $builder->shouldReceive('get')->with(['*'])->andReturn(new Collection(['bar']));
+
+        $result = $builder->only();
+        $this->assertSame('bar', $result);
+    }
+
     public function testQualifyColumn()
     {
         $builder = new Builder(m::mock(BaseBuilder::class));


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

At the moment Eloquent offers two methods to finding a single record:
- the `first()` method which gets the first record from the list of records matching the given criteria
- the `find()` method which gets an ID and returns that particular record by ID. 

Often during development, I saw the need that I want to get a single record and want to make sure that there is only one row matching the criteria. The `first()` method does not ensure if the query criteria is matching exactly one row. It just gets the first record even if the criteria matches 100 rows. If, as a user (developer) you want to make sure that there is only one matching record for your query criteria, you first use the Builder's `count()` method and then call the `first()` method. The `only()` method simplifies this and encapsulates this logic.

At the moment, the `only()` method returns `null` if the number of records matching the query criteria is anything other than one. I had two options: either throw  an exception in case the number of records matching the criteria is anything other than one, or return null. I went with returning null as from an API point of view as the expectation from client is that it would know in advance that `only()` would return null even if there are more than one records matching the criteria.

Your feedback is welcome. Thanks.