### PR TITLE
[7.x] Add alias as key of package's view components

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -115,8 +115,9 @@ abstract class ServiceProvider
     protected function loadViewComponentsAs($prefix, array $components)
     {
         $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
-            foreach ($components as $component) {
-                $blade->component($component, null, $prefix);
+            foreach ($components as $alias => $component) {
+                $alias = is_string($alias) ? $alias : NULL;
+                $blade->component($component, $alias, $prefix);
             }
         });
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -116,8 +116,7 @@ abstract class ServiceProvider
     {
         $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
             foreach ($components as $alias => $component) {
-                $alias = is_string($alias) ? $alias : null;
-                $blade->component($component, $alias, $prefix);
+                $blade->component($component, is_string($alias) ? $alias : null, $prefix);
             }
         });
     }

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -116,7 +116,7 @@ abstract class ServiceProvider
     {
         $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
             foreach ($components as $alias => $component) {
-                $alias = is_string($alias) ? $alias : NULL;
+                $alias = is_string($alias) ? $alias : null;
                 $blade->component($component, $alias, $prefix);
             }
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
When you register view component using ServiceProvider (loadViewComponentsAs), you can define key as a alias of component.
Example:
`$this->loadViewComponentsAs('courier', [
        'alert' => Alert::class,
        Button::class,
    ]);`