### PR TITLE
[8.x] Fix model factories

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -18,7 +18,7 @@ class {{ model }}Factory extends Factory
     /**
      * Define the model's default state.
      *
-     * @return static
+     * @return array
      */
     public function definition()
     {

--- a/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
+++ b/src/Illuminate/Database/Eloquent/Factories/BelongsToManyRelationship.php
@@ -31,7 +31,7 @@ class BelongsToManyRelationship
      * Create a new attached relationship definition.
      *
      * @param  \Illuminate\Database\Eloquent\Factories\Factory  $factory
-     * @param  callable\array  $pivot
+     * @param  callable|array  $pivot
      * @param  string  $relationship
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -130,7 +130,7 @@ abstract class Factory
     /**
      * Define the model's default state.
      *
-     * @return static
+     * @return array
      */
     abstract public function definition();
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -491,7 +491,7 @@ abstract class Factory
      * @param  int  $count
      * @return static
      */
-    public function count(int $count)
+    public function count(?int $count)
     {
         return $this->newInstance(['count' => $count]);
     }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -488,7 +488,7 @@ abstract class Factory
     /**
      * Specify how many models should be generated.
      *
-     * @param  int  $count
+     * @param  int|null  $count
      * @return static
      */
     public function count(?int $count)

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -86,6 +86,9 @@ class DatabaseEloquentFactoryTest extends TestCase
         $user = FactoryTestUserFactory::new()->create();
         $this->assertInstanceOf(Eloquent::class, $user);
 
+        $user = FactoryTestUserFactory::new()->createOne();
+        $this->assertInstanceOf(Eloquent::class, $user);
+
         $user = FactoryTestUserFactory::new()->create(['name' => 'Taylor Otwell']);
         $this->assertInstanceOf(Eloquent::class, $user);
         $this->assertEquals('Taylor Otwell', $user->name);
@@ -96,6 +99,9 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_make_creates_unpersisted_model_instance()
     {
+        $user = FactoryTestUserFactory::new()->makeOne();
+        $this->assertInstanceOf(Eloquent::class, $user);
+
         $user = FactoryTestUserFactory::new()->make(['name' => 'Taylor Otwell']);
 
         $this->assertInstanceOf(Eloquent::class, $user);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Fixes some small mistakes :
- typo in docblock
- Factory::definition should return array accordingly to usage (https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Factories/Factory.php#L318)
- $count parameter of Factory::count() should be nullable (used with null in [createOne](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Factories/Factory.php#L167) and [makeOne](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Eloquent/Factories/Factory.php#L240))

