### PR TITLE
[8.x] Add doesntHave method on the Collection & Lazy Collection classes

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -509,6 +509,25 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Determine if an item does not exist in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function doesntHave($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! $this->offsetExists($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -443,6 +443,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function has($key);
 
     /**
+     * Determine if an item does not exist in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function doesntHave($key);
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -516,6 +516,7 @@ class LazyCollection implements Enumerable
     public function doesntHave($key)
     {
         $keys = array_flip(is_array($key) ? $key : func_get_args());
+
         $count = count($keys);
 
         foreach ($this as $key => $value) {

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -508,6 +508,26 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Determine if an item does not exist in the collection by key.
+     *
+     * @param  mixed  $key
+     * @return bool
+     */
+    public function doesntHave($key)
+    {
+        $keys = array_flip(is_array($key) ? $key : func_get_args());
+        $count = count($keys);
+
+        foreach ($this as $key => $value) {
+            if (array_key_exists($key, $keys) && --$count == 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1681,6 +1681,18 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testDoesntHave($collection)
+    {
+        $data = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
+        $this->assertFalse($data->doesntHave('first'));
+        $this->assertTrue($data->doesntHave('third'));
+        $this->assertFalse($data->doesntHave(['first', 'second']));
+        $this->assertTrue($data->doesntHave(['third', 'first']));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);
@@ -4152,6 +4164,18 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($data->has('foo', 'bar', 1));
         $this->assertFalse($data->has('foo', 'bar', 1, 'baz'));
         $this->assertFalse($data->has('baz'));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDoesnHaveReturnsValidResults($collection)
+    {
+        $data = new $collection(['foo' => 'one', 'bar' => 'two', 1 => 'three']);
+        $this->assertFalse($data->doesntHave('foo'));
+        $this->assertFalse($data->doesntHave('foo', 'bar', 1));
+        $this->assertTrue($data->doesntHave('foo', 'bar', 1, 'baz'));
+        $this->assertTrue($data->doesntHave('baz'));
     }
 
     public function testPutAddsItemToCollection()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4169,7 +4169,7 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testDoesnHaveReturnsValidResults($collection)
+    public function testDoesntHaveReturnsValidResults($collection)
     {
         $data = new $collection(['foo' => 'one', 'bar' => 'two', 1 => 'three']);
         $this->assertFalse($data->doesntHave('foo'));


### PR DESCRIPTION
This PR adds `doesntHave()` method on the Collection & Lazy Collection classes.
The method is an inverse of the `has()` method.

The method aims to bring more human-like expression when checking for a key absence instead of doing it the typical PHP way: 
```php
<?php
$collection = collect(['id' => 1, 'first' => 'Hello', 'second' => 'World']);

if (! $collection->has('third')) {
...
```
With this PR you can do this:
```php
<?php
$collection = collect(['id' => 1, 'first' => 'Hello', 'second' => 'World']);

if ($collection->doesntHave('third')) {
...
```

The tests were run with the ` bin/test.sh` command contributed by @GrahamCampbell.
I've tried to follow the contribution guides as best as I can, but if I'm missing something do let me know.

As requested by @taylorotwell: https://github.com/laravel/framework/pull/32866#issuecomment-630253791