### PR TITLE
[8.x] Allow naming workers and customizing how to pick jobs

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -21,6 +21,7 @@ class WorkCommand extends Command
      */
     protected $signature = 'queue:work
                             {connection? : The name of the queue connection to work}
+                            {--name=default : The name of the worker}
                             {--queue= : The names of the queues to work}
                             {--daemon : Run the worker in daemon mode (Deprecated)}
                             {--once : Only process the next job on the queue}
@@ -108,6 +109,8 @@ class WorkCommand extends Command
     protected function runWorker($connection, $queue)
     {
         $this->worker->setCache($this->cache);
+
+        $this->worker->setName($this->option('name'));
 
         return $this->worker->{$this->option('once') ? 'runNextJob' : 'daemon'}(
             $connection, $queue, $this->gatherWorkerOptions()

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -297,7 +297,7 @@ class Worker
 
         try {
             if (isset(static::$jobPickerCallbacks[$this->name])) {
-                return (static::$jobPickerCallbacks[$this->name])($popJobCallback);
+                return (static::$jobPickerCallbacks[$this->name])($popJobCallback, $queue);
             }
 
             foreach (explode(',', $queue) as $queue) {

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -733,7 +733,7 @@ class Worker
     public static function pickJobsUsing($workerName, $callback)
     {
         if (is_null($callback)) {
-            static::$jobPickerCallbacks = [];
+            unset(static::$jobPickerCallbacks[$workerName]);
         } else {
             static::$jobPickerCallbacks[$workerName] = $callback;
         }

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -20,7 +20,7 @@ class Worker
     use DetectsLostConnections;
 
     /**
-     * The name of the worker;
+     * The name of the worker.
      *
      * @var string
      */

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -337,7 +337,7 @@ class QueueWorkerTest extends TestCase
         $this->assertFalse($defaultJob->fired);
         $this->assertTrue($customJob->fired);
 
-        Worker::pickJobsUsing(null);
+        Worker::pickJobsUsing('myworker', null);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -336,6 +336,8 @@ class QueueWorkerTest extends TestCase
 
         $this->assertFalse($defaultJob->fired);
         $this->assertTrue($customJob->fired);
+
+        Worker::pickJobsUsing(null);
     }
 
     /**

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -309,6 +309,35 @@ class QueueWorkerTest extends TestCase
         $this->assertTrue($job->isDeleted());
     }
 
+    public function testWorkerPicksJobUsingCustomCallbacks()
+    {
+        $worker = $this->getWorker('default', [
+            'default' => [$defaultJob = new WorkerFakeJob], 'custom' => [$customJob = new WorkerFakeJob],
+        ]);
+
+        $worker->runNextJob('default', 'default', new WorkerOptions);
+        $worker->runNextJob('default', 'default', new WorkerOptions);
+
+        $this->assertTrue($defaultJob->fired);
+        $this->assertFalse($customJob->fired);
+
+        $worker2 = $this->getWorker('default', [
+            'default' => [$defaultJob = new WorkerFakeJob], 'custom' => [$customJob = new WorkerFakeJob],
+        ]);
+
+        $worker2->setName('myworker');
+
+        Worker::pickJobsUsing('myworker', function ($pop) {
+            return $pop('custom');
+        });
+
+        $worker2->runNextJob('default', 'default', new WorkerOptions);
+        $worker2->runNextJob('default', 'default', new WorkerOptions);
+
+        $this->assertFalse($defaultJob->fired);
+        $this->assertTrue($customJob->fired);
+    }
+
     /**
      * Helpers...
      */


### PR DESCRIPTION
This PR allows naming a worker:

```
php artisan queue:work --name=niceworker
```

With the worker having a name, we can now customize how it can pick jobs by registering a callback to override the default behaviour. So, in the boot method of a service provider we can add:

```php
Worker::pickJobsUsing('niceworker', function ($pop) {
    $queues = time()->atNight() 
        ? ['mail', 'webhooks'] 
        : ['push-notifications', 'sms', 'mail', 'webhooks'];

    foreach ($queues as $queue) {
        if (! is_null($job = $pop($queue))) {
            return $job;
        }
    }
});
```

This worker will only pick jobs from the `mail` and `webhooks` queues at night, and in the morning it'll pick jobs from all queues.