### PR TITLE
[7.x] Fixed increment bug that changes expiration to forever

### DIFF
--- a/src/Illuminate/Cache/ArrayStore.php
+++ b/src/Illuminate/Cache/ArrayStore.php
@@ -93,7 +93,7 @@ class ArrayStore extends TaggableStore implements LockProvider
      */
     public function increment($key, $value = 1)
     {
-        if ($existing = $this->get($key)) {
+        if (! is_null($existing = $this->get($key))) {
             return tap(((int) $existing) + $value, function ($incremented) use ($key) {
                 $value = $this->serializesValues ? serialize($incremented) : $incremented;
 


### PR DESCRIPTION
A bug was introduced recently when changing:

```
if (! isset($this->storage[$key])) {
```

to

```
if ($existing = $this->get($key)) {
```

When attempting to increment a value that starts from zero (0), before it worked correctly when evaluating if the item was in the cache. However, now when `$this->get($key)` returns 0 since we are incrementing from 0 (the item has a value of 0), it evaluates as false and thus changes expiration to "forever". This causes issues for testing rate limiting because nothing ever "expires".

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
