### PR TITLE
[8.x] Fix Jobs Batching progress percentage

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -174,11 +174,11 @@ class Batch implements JsonSerializable
     /**
      * Get the percentage of jobs that have been processed.
      *
-     * @return float
+     * @return int
      */
     public function progress()
     {
-        return $this->totalJobs > 0 ? round($this->processedJobs() / $this->totalJobs, 2) * 100 : 0;
+        return $this->totalJobs > 0 ? round($this->processedJobs() / $this->totalJobs) * 100 : 0;
     }
 
     /**

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -178,7 +178,7 @@ class Batch implements JsonSerializable
      */
     public function progress()
     {
-        return $this->totalJobs > 0 ? round($this->processedJobs() / $this->totalJobs, 2) : 0;
+        return $this->totalJobs > 0 ? round($this->processedJobs() / $this->totalJobs, 2) * 100 : 0;
     }
 
     /**

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -112,7 +112,7 @@ class BusBatchTest extends TestCase
         $batch->pendingJobs = 4;
 
         $this->assertEquals(6, $batch->processedJobs());
-        $this->assertEquals(0.6, $batch->progress());
+        $this->assertEquals(60, $batch->progress());
     }
 
     public function test_successful_jobs_can_be_recorded()


### PR DESCRIPTION
If we have 4 jobs processed out of 10. 

I noticed the tests were expecting 0.6 but I have no idea why its like that!

Before this PR
```php
$batch->progress() // 0.4
```

This PR
```php
$batch->progress() // 40.0
```

