### PR TITLE
[8.x] Add tests to ensure `doesntHave` is actually lazy

### DIFF
--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -202,6 +202,25 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testDoesntHaveIsLazy()
+    {
+        $this->assertEnumerates(1, function ($collection) {
+            $collection->doesntHave(0);
+        });
+
+        $this->assertEnumerates(11, function ($collection) {
+            $collection->doesntHave(5, 10);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->doesntHave('missing-key');
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->doesntHave(0, 'missing-key');
+        });
+    }
+
     public function testDuplicatesIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
In #32873 we added the `doesntHave` method to the `LazyCollection`, without the required tests ensuring that it's actually lazy.

This PR adds those tests.