### PR TITLE
[7.x] Add JobQueued event

### DIFF
--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Pipeline\Pipeline;
+use Illuminate\Queue\Events\JobQueued;
 use RuntimeException;
 
 class Dispatcher implements QueueingDispatcher
@@ -70,7 +71,9 @@ class Dispatcher implements QueueingDispatcher
     public function dispatch($command)
     {
         if ($this->queueResolver && $this->commandShouldBeQueued($command)) {
-            return $this->dispatchToQueue($command);
+            return tap($this->dispatchToQueue($command), function ($jobId) use ($command) {
+                $this->raiseJobQueuedEvent($command, $jobId);
+            });
         }
 
         return $this->dispatchNow($command);
@@ -220,5 +223,17 @@ class Dispatcher implements QueueingDispatcher
         $this->handlers = array_merge($this->handlers, $map);
 
         return $this;
+    }
+
+    /**
+     * Raise the job queued event.
+     *
+     * @param mixed $command
+     * @param mixed $jobId
+     * @return void
+     */
+    protected function raiseJobQueuedEvent($command, $jobId)
+    {
+        $this->container->make('events')->dispatch(new JobQueued($command, $jobId));
     }
 }

--- a/src/Illuminate/Queue/Events/JobQueued.php
+++ b/src/Illuminate/Queue/Events/JobQueued.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Illuminate\Queue\Events;
+
+class JobQueued
+{
+    /**
+     * @var mixed
+     */
+    public $command;
+
+    /**
+     * @var mixed
+     */
+    public $jobId;
+
+    /**
+     * JobQueued constructor.
+     *
+     * @param mixed $command
+     * @param mixed $jobId
+     * @return void
+     */
+    public function __construct($command, $jobId)
+    {
+        $this->command = $command;
+        $this->jobId = $jobId;
+    }
+}

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -8,6 +8,7 @@ use Illuminate\Config\Repository as Config;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\InteractsWithQueue;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -23,9 +24,22 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueued()
     {
         $container = new Container;
+        $container->singleton('events', function () {
+            $mock = m::mock(\Illuminate\Events\Dispatcher::class);
+            $mock->shouldReceive('dispatch')->withArgs(function ($jobQueued) {
+                $this->assertInstanceOf(JobQueued::class, $jobQueued);
+                $this->assertInstanceOf(ShouldQueue::class, $jobQueued->command);
+                $this->assertSame($jobQueued->jobId, 'job_id');
+
+                return true;
+            })->once();
+
+            return $mock;
+        });
+
         $dispatcher = new Dispatcher($container, function () {
             $mock = m::mock(Queue::class);
-            $mock->shouldReceive('push')->once();
+            $mock->shouldReceive('push')->once()->andReturn('job_id');
 
             return $mock;
         });
@@ -36,6 +50,19 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;
+        $container->singleton('events', function () {
+            $mock = m::mock(\Illuminate\Events\Dispatcher::class);
+            $mock->shouldReceive('dispatch')->withArgs(function ($jobQueued) {
+                $this->assertInstanceOf(JobQueued::class, $jobQueued);
+                $this->assertInstanceOf(ShouldQueue::class, $jobQueued->command);
+                $this->assertNull($jobQueued->jobId);
+
+                return true;
+            })->once();
+
+            return $mock;
+        });
+
         $dispatcher = new Dispatcher($container, function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
@@ -49,6 +76,19 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
     {
         $container = new Container;
+        $container->singleton('events', function () {
+            $mock = m::mock(\Illuminate\Events\Dispatcher::class);
+            $mock->shouldReceive('dispatch')->withArgs(function ($jobQueued) {
+                $this->assertInstanceOf(JobQueued::class, $jobQueued);
+                $this->assertInstanceOf(ShouldQueue::class, $jobQueued->command);
+                $this->assertNull($jobQueued->jobId);
+
+                return true;
+            })->once();
+
+            return $mock;
+        });
+
         $dispatcher = new Dispatcher($container, function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class));
@@ -98,6 +138,18 @@ class BusDispatcherTest extends TestCase
                     ],
                 ],
             ]);
+        });
+        $container->singleton('events', function () {
+            $mock = m::mock(\Illuminate\Events\Dispatcher::class);
+            $mock->shouldReceive('dispatch')->withArgs(function ($jobQueued) {
+                $this->assertInstanceOf(JobQueued::class, $jobQueued);
+                $this->assertInstanceOf(ShouldQueue::class, $jobQueued->command);
+                $this->assertNull($jobQueued->jobId);
+
+                return true;
+            })->once();
+
+            return $mock;
         });
 
         $dispatcher = new Dispatcher($container, function () {


### PR DESCRIPTION
This PR aims to add a new `JobQueued` event dispatched when a job is added to a queue.

The main reason for this is to complete the existing events list: `JobProcessing`, `JobProcessed`, `JobFailed` and `JobExceptionOccurred` which let users track the jobs.

Looking for packages or tutorials to track queued job status will give for example: https://github.com/imTigger/laravel-job-status or https://blog.rafter.app/tracking-queued-job-chains-in-laravel/ .

In both cases the trick is made by creating the tracking record to the database inside the job's constructor. 

Having a `JobQueue` event aims to remove this DB call from the job's constructor.

So to track a job a simple `EventSubscriber` class could be created as: 
```
public function subscribe(Dispatcher $dispatcher) {
    $dispatcher->listen(JobQueued::class, /* Handler */);
    $dispatcher->listen(JobProcessing::class, /* Handler */);
    $dispatcher->listen(JobProcessed::class, /* Handler */ );
    $dispatcher->listen(JobFailed::class, /* Handler */);
    $dispatcher->listen(JobExceptionOccurred::class, /* Handler */);
}
```