### PR TITLE
[7.x] Add additinal translation helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -881,6 +881,37 @@ if (! function_exists('trans_choice')) {
     }
 }
 
+if (! function_exists('lang')) {
+    /**
+     * Translate the given message.
+     *
+     * @param  string|null  $key
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @return \Illuminate\Contracts\Translation\Translator|string|array|null
+     */
+    function lang($key = null, $replace = [], $locale = null)
+    {
+        return trans($key, $replace, $locale);
+    }
+}
+
+if (! function_exists('lang_choice')) {
+    /**
+     * Translates the given message based on a count.
+     *
+     * @param  string  $key
+     * @param  \Countable|int|array  $number
+     * @param  array  $replace
+     * @param  string|null  $locale
+     * @return string
+     */
+    function lang_choice($key, $number, array $replace = [], $locale = null)
+    {
+        return trans_choice($key, $number, $replace, $locale);
+    }
+}
+
 if (! function_exists('__')) {
     /**
      * Translate the given message.

--- a/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesTranslations.php
@@ -32,6 +32,27 @@ trait CompilesTranslations
     }
 
     /**
+     * Compile the trans statements into valid PHP.
+     *
+     * @param  string|null  $expression
+     * @return string
+     */
+    protected function compileTrans($expression)
+    {
+        return $this->compileLang($expression);
+    }
+
+    /**
+     * Compile the end-trans statements into valid PHP.
+     *
+     * @return string
+     */
+    protected function compileEndtrans()
+    {
+        return $this->compileEndlang();
+    }
+
+    /**
      * Compile the choice statements into valid PHP.
      *
      * @param  string  $expression

--- a/tests/View/Blade/BladeExpressionTest.php
+++ b/tests/View/Blade/BladeExpressionTest.php
@@ -14,5 +14,6 @@ class BladeExpressionTest extends AbstractBladeTestCase
         $this->assertSame('<html <?php echo e($foo); ?>>', $this->compiler->compileString('<html {{ $foo }}>'));
         $this->assertSame('<html<?php echo e($foo); ?>>', $this->compiler->compileString('<html{{ $foo }}>'));
         $this->assertSame('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @lang(\'foo\')>'));
+        $this->assertSame('<html <?php echo e($foo); ?> <?php echo app(\'translator\')->get(\'foo\'); ?>>', $this->compiler->compileString('<html {{ $foo }} @trans(\'foo\')>'));
     }
 }

--- a/tests/View/Blade/BladeTransTest.php
+++ b/tests/View/Blade/BladeTransTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeTransTest extends AbstractBladeTestCase
+{
+    public function testStatementThatContainsNonConsecutiveParenthesisAreCompiled()
+    {
+        $string = "Foo @trans(function_call('foo(blah)')) bar";
+        $expected = "Foo <?php echo app('translator')->get(function_call('foo(blah)')); ?> bar";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testTranslationIsCompiled()
+    {
+        $this->assertSame('<?php echo app(\'translator\')->get(\'foo\'); ?>', $this->compiler->compileString("@trans('foo')"));
+    }
+}


### PR DESCRIPTION
This PR adds additional helper functions and blade directives for translations.

In Blade you currently have the possibility to translate a string via the `@lang` directive, whereas in in PHP you can only access the translation helpers via `trans()`.

This is very confusing, as you mistype this fairly often when switching between Blade und PHP.


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
