### PR TITLE
[8.x] Allow queue:work to shut down the framework when exiting

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -19,6 +19,10 @@ class Worker
 {
     use DetectsLostConnections;
 
+    const EXIT_SUCCESS = 0;
+    const EXIT_ERROR = 1;
+    const EXIT_MEMORY_LIMIT = 12;
+
     /**
      * The name of the worker.
      *
@@ -108,7 +112,7 @@ class Worker
      * @param  string  $connectionName
      * @param  string  $queue
      * @param  \Illuminate\Queue\WorkerOptions  $options
-     * @return void
+     * @return int
      */
     public function daemon($connectionName, $queue, WorkerOptions $options)
     {
@@ -123,7 +127,10 @@ class Worker
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.
             if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
-                $this->pauseWorker($options, $lastRestart);
+                $exitCode = $this->pauseWorker($options, $lastRestart);
+                if ($exitCode  !== false) {
+                    return $this->stop($exitCode);
+                }
 
                 continue;
             }
@@ -155,7 +162,10 @@ class Worker
             // Finally, we will check to see if we have exceeded our memory limits or if
             // the queue should restart based on other indications. If so, we'll stop
             // this worker and let whatever is "monitoring" it restart the process.
-            $this->stopIfNecessary($options, $lastRestart, $job);
+            $exitCode = $this->shouldStop($options, $lastRestart, $job);
+            if ($exitCode !== false) {
+                return $this->stop($exitCode);
+            }
         }
     }
 
@@ -178,7 +188,7 @@ class Worker
                 );
             }
 
-            $this->kill(1);
+            $this->kill(static::EXIT_ERROR);
         });
 
         pcntl_alarm(
@@ -226,15 +236,15 @@ class Worker
     /**
      * Pause the worker for the current loop.
      *
-     * @param  \Illuminate\Queue\WorkerOptions  $options
-     * @param  int  $lastRestart
-     * @return void
+     * @param \Illuminate\Queue\WorkerOptions $options
+     * @param int $lastRestart
+     * @return bool|int
      */
     protected function pauseWorker(WorkerOptions $options, $lastRestart)
     {
         $this->sleep($options->sleep > 0 ? $options->sleep : 1);
 
-        $this->stopIfNecessary($options, $lastRestart);
+        return $this->shouldStop($options, $lastRestart);
     }
 
     /**
@@ -243,19 +253,21 @@ class Worker
      * @param  \Illuminate\Queue\WorkerOptions  $options
      * @param  int  $lastRestart
      * @param  mixed  $job
-     * @return void
+     * @return int|bool
      */
-    protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $job = null)
+    protected function shouldStop(WorkerOptions $options, $lastRestart, $job = null)
     {
         if ($this->shouldQuit) {
-            $this->stop();
+            return static::EXIT_SUCCESS;
         } elseif ($this->memoryExceeded($options->memory)) {
-            $this->stop(12);
+            return static::EXIT_MEMORY_LIMIT;
         } elseif ($this->queueShouldRestart($lastRestart)) {
-            $this->stop();
+            return static::EXIT_SUCCESS;
         } elseif ($options->stopWhenEmpty && is_null($job)) {
-            $this->stop();
+            return static::EXIT_SUCCESS;
         }
+
+        return false;
     }
 
     /**
@@ -646,14 +658,14 @@ class Worker
     /**
      * Stop listening and bail out of the script.
      *
-     * @param  int  $status
-     * @return void
+     * @param int $status
+     * @return int
      */
     public function stop($status = 0)
     {
         $this->events->dispatch(new WorkerStopping($status));
 
-        exit($status);
+        return $status;
     }
 
     /**


### PR DESCRIPTION
## What

Following this discussion: [`app()->terminating()` not (always) called with `queue:work`](https://github.com/laravel/framework/discussions/32779), `queue:work` uses `exit($status)` when stopping the daemon. 

As a result, callbacks such as `app()->terminate()` are not called (and I assume other minor framework shutdown code, although given how long it's behaved like this, it may not be a big deal).

This PR allows the `Queue\Worker::daemon()` to return an exit code when breaking out of the `while (true)` loop, rather than exiting.

## Why

That means jobs that include code such as:

```php
app()->terminating(function() {
    Log::info("{$this->job->getJobId()} is running on app termination");
});
```

... will function when the queue is stopped.

## This is minor

This only matters when using `artisan queue:work` without `--once` (`queue:listen` doesn't require this).

Even then, it doesn't always make sense to register `app()->terminating(fn...)` callbacks in job context when you have no idea when a `queue:work` command will actually be stopped (and thus don't know when those callbacks will be used).

## Tests

One test was adjusted for this change, and one test was added to test out the memory limit exit code (`12`).

Testing `app()->terminate()` callbacks is tougher as the test environment `app()` is an instance of `Container` and doesn't have the `terminate()` callback methods.

Creating a new Laravel 8 app, applying this patch, does work. An example job:

```php
<?php

namespace App\Jobs;

use Illuminate\Support\Facades\Log;
use Illuminate\Bus\Queueable;
use Illuminate\Contracts\Queue\ShouldQueue;
use Illuminate\Foundation\Bus\Dispatchable;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Queue\SerializesModels;

class AddTerminatingThing implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    /**
     * Create a new job instance.
     *
     * @return void
     */
    public function __construct()
    {
        //
    }

    /**
     * Execute the job.
     *
     * @return void
     */
    public function handle()
    {
        app()->terminating(function() {
            Log::info('we are terminating');
        });
        sleep(1);
    }
}
```