### PR TITLE
[7.x] Ability to skip middleware from resource routes

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Routing;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\Macroable;
 
 class PendingResourceRegistration
@@ -149,6 +150,21 @@ class PendingResourceRegistration
     public function middleware($middleware)
     {
         $this->options['middleware'] = $middleware;
+
+        return $this;
+    }
+
+    /**
+     * Specify middleware that should be removed from the resource routes.
+     *
+     * @param  array|string $middleware
+     * @return $this|array
+     */
+    public function withoutMiddleware($middleware)
+    {
+        $this->options['excluded_middleware'] = array_merge(
+            (array) ($this->options['excluded_middleware'] ?? []), Arr::wrap($middleware)
+        );
 
         return $this;
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -389,6 +389,10 @@ class ResourceRegistrar
             $action['middleware'] = $options['middleware'];
         }
 
+        if (isset($options['excluded_middleware'])) {
+            $action['excluded_middleware'] = $options['excluded_middleware'];
+        }
+
         return $action;
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -513,6 +513,18 @@ class RouteRegistrarTest extends TestCase
         $this->seeMiddleware(RouteRegistrarMiddlewareStub::class);
     }
 
+    public function testResourceWithoutMiddlewareRegistration()
+    {
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->only('index')
+                     ->middleware(['one', 'two'])
+                     ->withoutMiddleware('one');
+
+        $this->seeResponse('controller', Request::create('users', 'GET'));
+
+        $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -205,6 +205,18 @@ class RoutingRouteTest extends TestCase
         $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
+    public function testMiddlewareCanBeSkippedFromResources()
+    {
+        $router = $this->getRouter();
+        $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
+
+        $router->resource('foo', RouteTestControllerMiddlewareGroupStub::class)
+            ->middleware('web')
+            ->withoutMiddleware(RoutingTestMiddlewareGroupTwo::class);
+
+        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+    }
+
     public function testMiddlewareWorksIfControllerThrowsHttpResponseException()
     {
         // Before calling controller


### PR DESCRIPTION
This PR adds the ability to skip specific middleware from resources routes. This is similar to #32347. This is handy when having middleware groups with many resourceful routes but you need to exclude some middleware from a specific resource.

Example:
```php
<?php
Route::middleware(['auth', 'verified'])->group(function () {
    Route::resource('photo', 'PhotosController')->withoutMiddleware('verified');
});
```