### PR TITLE
[8.x] Serialize Batch entity to array

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -361,11 +361,11 @@ class Batch implements JsonSerializable
     }
 
     /**
-     * Get the JSON serializable representation of the object.
+     * Convert the batch to an array.
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function toArray()
     {
         return [
             'id' => $this->id,
@@ -378,5 +378,15 @@ class Batch implements JsonSerializable
             'cancelledAt' => $this->cancelledAt,
             'finishedAt' => $this->finishedAt,
         ];
+    }
+
+    /**
+     * Get the JSON serializable representation of the object.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
     }
 }


### PR DESCRIPTION
This PR adds array serialization support. casting `(array) $batch` does not provide `processedJobs()` and `progress()`. 

ex: The PR makes it easier to use with livewire when exporting the batch to render method and have the whole properties including `processed_jobs` and `progress()`. 