### PR TITLE
[7.x] Align docblock to support multiple choice questions assertion

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -103,7 +103,7 @@ class PendingCommand
      * Specify an expected choice question with expected answers that will be asked/shown when the command runs.
      *
      * @param  string  $question
-     * @param  string  $answer
+     * @param  string|array  $answer
      * @param  array  $answers
      * @param  bool  $strict
      * @return $this


### PR DESCRIPTION
This PR only aligns the docblock to give proper hint when testing console CHOICE with multiple options selected as an answer.

In reality we would do something like this:

**Only one chosen** works fine
```
Which toppings would you like? ['Pineapple']:
0 Cheese
1 Pineapple
2 Ham

> 1

// This can be tested as:
->expectsChoice('Which toppings would you like?', 'Pineapple')
```


**Multiple chosen** not entirely right
```
Which toppings would you like? ['Pineapple']:
0 Cheese
1 Pineapple
2 Ham

> 0,1,2

// This cannot be tested providing string as answer, since test will take it literally as one long answer:
->expectsChoice('Which toppings would you like?', 'Cheese,Pineapple,Ham')

// Instead we have to pass an array:
->expectsChoice('Which toppings would you like?', ['Cheese', 'Pineapple', 'Ham'])
```