### PR TITLE
[7.X] Refactor getJobRetryDelay() method

### DIFF
--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -169,7 +169,7 @@ abstract class Queue
      * @param  mixed  $job
      * @return int
      */
-    public function getJobRetryDelay($job): int
+    public function getJobRetryDelay($job)
     {
         // If no retry information is provided, will return no delay.
         if (! method_exists($job, 'retryAfter') && ! isset($job->retryAfter)) {

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -163,11 +163,11 @@ abstract class Queue
 
     /**
      * Get the retry delay for an object-based queue handler.
-     * 
+     *
      * Method 'retryAfter()' will have precedence over attribute 'retryAfter'.
      *
      * @param  mixed  $job
-     * @return integer
+     * @return int
      */
     public function getJobRetryDelay($job): int
     {
@@ -185,7 +185,7 @@ abstract class Queue
         }
 
         // Returns delay.
-        return ($delay instanceof DateTimeInterface ? $this->secondsUntil($delay) : $delay);
+        return $delay instanceof DateTimeInterface ? $this->secondsUntil($delay) : $delay;
     }
 
     /**

--- a/src/Illuminate/Queue/Queue.php
+++ b/src/Illuminate/Queue/Queue.php
@@ -163,20 +163,29 @@ abstract class Queue
 
     /**
      * Get the retry delay for an object-based queue handler.
+     * 
+     * Method 'retryAfter()' will have precedence over attribute 'retryAfter'.
      *
      * @param  mixed  $job
-     * @return mixed
+     * @return integer
      */
-    public function getJobRetryDelay($job)
+    public function getJobRetryDelay($job): int
     {
+        // If no retry information is provided, will return no delay.
         if (! method_exists($job, 'retryAfter') && ! isset($job->retryAfter)) {
-            return;
+            return 0;
         }
 
-        $delay = $job->retryAfter ?? $job->retryAfter();
+        // Collects retrying delay from Job.
+        // We'll use the attribute's value by default, but if retryAfter() method is defined,
+        // we'll use its return value instead.
+        $delay = $job->retryAfter;
+        if (method_exists($job, 'retryAfter')) {
+            $delay = $job->retryAfter();
+        }
 
-        return $delay instanceof DateTimeInterface
-                        ? $this->secondsUntil($delay) : $delay;
+        // Returns delay.
+        return ($delay instanceof DateTimeInterface ? $this->secondsUntil($delay) : $delay);
     }
 
     /**


### PR DESCRIPTION
Improved documentation, datatype hinting and mechanics of `getJobRetryDelay()` method in Queue:
- Made `retryAfter()`'s method have precedence over `retryAfter`'s class attribute.
- This will allow better implementation of _exponential backoff strategies_ for individual Jobs.

Example of "_basic_" override implementation:
```
public $retryAfter = 3;

public function retryAfter(): int
{
    return $this->retryAfter;
}
```

Example of simple Exponential backoff strategy (_method over attribute precedence_):
```
public $retryAfter = 3;

public function retryAfter(): int
{
    return ($this->retryAfter * (2 ** ($this->attempts() - 1)));
}
```
In the last example, we could still use "_native_" `$this->retryAfter` attribute in the strategy.
This will produce the following delays `[3, 6, 9, 12, 15, ...]` until `maxTries()` is achieved.

*Note:* If no `retryAfter()` method is defined, default `$this->retryAfter` attribute will still be used.