### PR TITLE
Removed unnecessary `array_filter` call

### DIFF
--- a/src/Illuminate/Database/Connection.php
+++ b/src/Illuminate/Database/Connection.php
@@ -904,12 +904,12 @@ class Connection implements ConnectionInterface
         if (is_null($this->doctrineConnection)) {
             $driver = $this->getDoctrineDriver();
 
-            $this->doctrineConnection = new DoctrineConnection(array_filter([
+            $this->doctrineConnection = new DoctrineConnection([
                 'pdo' => $this->getPdo(),
                 'dbname' => $this->getDatabaseName(),
                 'driver' => $driver->getName(),
                 'serverVersion' => $this->getConfig('server_version'),
-            ]), $driver);
+            ], $driver);
         }
 
         return $this->doctrineConnection;


### PR DESCRIPTION
Removed an unnecessary call to `array_filter` introduced in 8de4eb93942499012d6d927212c1d05d61ede432. Without a callback as second parameter, this does nothing.