### PR TITLE
[7.x] Eloquent\Builder::with() support for closures

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1075,12 +1075,17 @@ class Builder
     /**
      * Set the relationships that should be eager loaded.
      *
-     * @param  mixed  $relations
+     * @param  string|array  $relations
+     * @param  string|\Closure|null  $callback
      * @return $this
      */
-    public function with($relations)
+    public function with($relations, $callback = null)
     {
-        $eagerLoad = $this->parseWithRelations(is_string($relations) ? func_get_args() : $relations);
+        if ($callback instanceof Closure) {
+            $eagerLoad = $this->parseWithRelations([$relations => $callback]);
+        } else {
+            $eagerLoad = $this->parseWithRelations(is_string($relations) ? func_get_args() : $relations);
+        }
 
         $this->eagerLoad = array_merge($this->eagerLoad, $eagerLoad);
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -607,6 +607,16 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf(Closure::class, $eagers['orders']);
         $this->assertNull($eagers['orders']());
         $this->assertSame('foo', $eagers['orders.lines']());
+
+        $builder = $this->getBuilder();
+        $builder->with('orders.lines', function () {
+            return 'foo';
+        });
+        $eagers = $builder->getEagerLoads();
+
+        $this->assertInstanceOf(Closure::class, $eagers['orders']);
+        $this->assertNull($eagers['orders']());
+        $this->assertSame('foo', $eagers['orders.lines']());
     }
 
     public function testQueryPassThru()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
# Eloquent\Builder::with() support for closures
Provides support for an alternative, more elegant syntax for eager loading relationships with constraints. 

To not introduce any breaking changes this still supports all currently possible method calls of: 
- single string (`->with('foo')`)
- list of strings (`->with('foo', 'bar')`)
- [not-associative] array of strings (`->with(['foo', 'bar'])`)
- associative array of string keys and closure values (`->with(['foo' => function () {}])`)

This will introduce support for closures as a second argument as demonstrated below:
```php
// single relationship
$query->with('foo', function ($query) {
    $query->where('status', 'active');
});

// multi relationship
$query->with('foo', function ($query) {
    $query->where('status', 'active');
})->with('bar', function ($query) {
    $query->where(...);
});
```

The alternative, and current, syntax to this would be to use an associative array, as demonstrated below:
```php
// single relationship
$query->with([
    'foo' => function ($query) {
       $query->where('status', 'active');
     },
]);

// multi relationship
$query->with([
    'foo' => function ($query) {
       $query->where('status', 'active');
     },
    'bar' => function ($query) {
        $query->where(...);
    }
]);
```

Arguably this is easier to read, write and reason about. More importantly, though, this follows a convention already seen in many other methods within the framework and on the `Builder` class specifically such as the `Builder::where` method which can take either an array or single set of column, operand, and value.