### PR TITLE
[7.x] Add expectsOutputContains method

### DIFF
--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -6,12 +6,12 @@ use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Illuminate\Support\Str;
 
 class PendingCommand
 {
@@ -58,7 +58,7 @@ class PendingCommand
     protected $hasExecuted = false;
 
     /**
-     * Keep track of expected output containing strings
+     * Keep track of expected output containing strings.
      *
      * @var array
      */


### PR DESCRIPTION
This PR introduces the `expectsOutputContains()` method, in addition to the `expectsOutput()` method, which expects an exact match on line basis. `expectsOutputContains()` asserts whether any of the output lines *contains* the string passed to the method.

```
        $this->artisan('task:list')
            ->expectsOutputContains('Wash the car')
            ->assertExitCode(0);
```

```
  Tests:  1 failed, 5 passed

  Output did not contain "Wash the car"

  at vendor/illuminate/testing/PendingCommand.php:239
    235|             $this->test->fail('Output "'.Arr::first($this->test->expectedOutput).'" was not printed.');
    236|         }
    237| 
    238|         if (count($this->expectedOutputContains)) {
  > 239|             $this->test->fail('Output did not contain "'.Arr::first($this->expectedOutputContains).'"');
    240|         }
    241|     }
    242| 
    243|     /**

```
