### PR TITLE
[7.x] Add InteractsWithScheduler trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/InteractsWithScheduler.php
+++ b/src/Illuminate/Foundation/Testing/InteractsWithScheduler.php
@@ -24,7 +24,7 @@ trait InteractsWithScheduler
     {
         $event = $this->getScheduledCommand($commandSignature);
 
-        if (!is_null($event)) {
+        if (! is_null($event)) {
             Assert::fail("Command $commandSignature is scheduled");
         }
 

--- a/src/Illuminate/Foundation/Testing/InteractsWithScheduler.php
+++ b/src/Illuminate/Foundation/Testing/InteractsWithScheduler.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\App;
+use Illuminate\Testing\Assert;
+
+trait InteractsWithScheduler
+{
+    private function assertCommandIsScheduled(string $commandSignature): void
+    {
+        $event = $this->getScheduledCommand($commandSignature);
+
+        if (is_null($event)) {
+            Assert::fail("Command $commandSignature is not scheduled");
+        }
+
+        Assert::assertNotNull($event);
+    }
+
+    private function assertCommandIsNotScheduled(string $commandSignature): void
+    {
+        $event = $this->getScheduledCommand($commandSignature);
+
+        if (!is_null($event)) {
+            Assert::fail("Command $commandSignature is scheduled");
+        }
+
+        Assert::assertNull($event);
+    }
+
+    private function getScheduledCommand(string $commandSignature): ?Event
+    {
+        App::forgetInstance(Schedule::class);
+
+        $schedule = app()->make(Schedule::class);
+
+        return collect($schedule->events())->first(function ($event) use ($commandSignature) {
+            return strpos($event->command, $commandSignature);
+        });
+    }
+}


### PR DESCRIPTION
**History** https://twitter.com/jorenvanhocht/status/1263208759163314179

**What am I trying to accomplish?**
Applications that I work on regularly  conditionally schedule commands. I want to make sure this conditional works as intended and the command is actually scheduled or not.

**The solution**
A trait `InteractsWithScheduler` that can be used in tests. We get the events from the scheduler and check against the command signature.

**Usage**

```php
<?php

namespace Tests\Feature;

use Tests\TestCase;
use Tests\Traits\InteractsWithScheduler;

class SchedulerTest extends TestCase
{
    use InteractsWithScheduler;

    /** @test */
    public function it_only_schedules_my_command_when_enabled()
    {
        config()->set('settings.schedule.my_command', true);
        $this->assertCommandIsScheduled('my-command-signature');

        config()->set('settings.schedule.my_command', false);
        $this->assertCommandIsNotScheduled('my-command-signature');
    }
}

```

This PR is still a work in progress, the trait works in my application but might need some more work to work within core. I already created this PR to check if this approach is going into the right direction.
I'm currently having a hard time finding a way to test this trait, so if somebody would like to pair program with me on this let me know so that we can schedule something.

If it's nog light weight enough that's fine as well, then I will probably package it up.