### PR TITLE
[8.x] Add a `doesntHave` method to collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -443,6 +443,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function has($key);
 
     /**
+     * Determine if an item does not exist in the collection by key.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function doesntHave($key);
+
+    /**
      * Concatenate values of a given key as a string.
      *
      * @param  string  $value

--- a/src/Illuminate/Collections/EnumeratesValues.php
+++ b/src/Illuminate/Collections/EnumeratesValues.php
@@ -649,6 +649,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Determine if an item does not exist in the collection by key.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function doesntHave($key)
+    {
+        return ! $this->has($key);
+    }
+
+    /**
      * Pass the collection to the given callback and return the result.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1681,6 +1681,18 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testDoesntHave($collection)
+    {
+        $data = new $collection(['first' => 'Hello', 'second' => 'World']);
+        $this->assertFalse($data->doesntHave('first'));
+        $this->assertFalse($data->doesntHave('second'));
+        $this->assertTrue($data->doesntHave('third'));
+        $this->assertTrue($data->doesntHave(1));
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testImplode($collection)
     {
         $data = new $collection([['name' => 'taylor', 'email' => 'foo'], ['name' => 'dayle', 'email' => 'bar']]);

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -202,6 +202,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
         });
     }
 
+    public function testDoesntHaveIsLazy()
+    {
+        $this->assertEnumerates(1, function ($collection) {
+            $collection->doesntHave(0);
+        });
+
+        $this->assertEnumerates(11, function ($collection) {
+            $collection->doesntHave(10);
+        });
+
+        $this->assertEnumeratesOnce(function ($collection) {
+            $collection->doesntHave('missing-key');
+        });
+    }
+
     public function testDuplicatesIsLazy()
     {
         $this->assertDoesNotEnumerate(function ($collection) {


### PR DESCRIPTION
In #32873, @andresayej introduced a new `doesntHave` method to the collections.

This was subsequently reverted, because its behavior was unintuitive when passed multiple keys.

This PR reintroduces the `doesntHave` method, but only with a single key.