### PR TITLE
[7.x] Console command test output dumping

### DIFF
--- a/src/Illuminate/Testing/OutputRecorder.php
+++ b/src/Illuminate/Testing/OutputRecorder.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Illuminate\Testing;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OutputRecorder extends Output
+{
+    /**
+     * The output target to be recorded.
+     *
+     * @var OutputInterface
+     */
+    protected $target;
+
+    /**
+     * The recorded output.
+     * 
+     * @var string
+     */
+    protected $recording = '';
+
+    /**
+     * @param OutputInterface               $target The output target to record
+     * @param int                           $verbosity The verbosity level (one of the VERBOSITY constants in OutputInterface)
+     * @param bool                          $decorated Whether to decorate messages
+     * @param OutputFormatterInterface|null $formatter Output formatter target (null to use default OutputFormatter)
+     */
+    public function __construct(
+        OutputInterface $target,
+        ?int $verbosity = self::VERBOSITY_NORMAL,
+        bool $decorated = false,
+        OutputFormatterInterface $formatter = null
+    ) {
+        $this->target = $target;
+
+        parent::__construct($verbosity, $decorated, $formatter);
+    }
+
+    /**
+     * Get the underlying output target.
+     *
+     * @return OutputInterface
+     */
+    public function target()
+    {
+        return $this->target;
+    }
+
+    /**
+     * Get the recorded output.
+     * 
+     * @return string
+     */
+    public function getRecording()
+    {
+        return $this->recording;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWrite(string $message, bool $newline)
+    {
+        $this->recording .= $message;
+
+        if ($newline) {
+            $this->recording .= PHP_EOL;
+        }
+
+        $this->target->doWrite($message, $newline);
+    }
+}

--- a/src/Illuminate/Testing/OutputRecorder.php
+++ b/src/Illuminate/Testing/OutputRecorder.php
@@ -17,7 +17,7 @@ class OutputRecorder extends Output
 
     /**
      * The recorded output.
-     * 
+     *
      * @var string
      */
     protected $recording = '';
@@ -51,7 +51,7 @@ class OutputRecorder extends Output
 
     /**
      * Get the recorded output.
-     * 
+     *
      * @return string
      */
     public function getRecording()

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -154,11 +154,13 @@ class PendingCommand
     /**
      * Dump the output after execution.
      *
-     * @return void
+     * @return $this
      */
     public function dumpOutput()
     {
         dump($this->getOutput());
+
+        return $this;
     }
 
     /**

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -168,7 +168,7 @@ class PendingCommand
      */
     public function getOutput()
     {
-        if (!$this->hasExecuted) {
+        if (! $this->hasExecuted) {
             $this->run();
         }
 
@@ -243,7 +243,7 @@ class PendingCommand
 
         if (count($this->test->expectedOutput)) {
             $failureMessage = 'Output "'.Arr::first($this->test->expectedOutput).'" was not printed.';
-            $failureMessage .= ' The output of the command was:' . "\r\n\r\n" . $this->recorder->getRecording();
+            $failureMessage .= ' The output of the command was:'."\r\n\r\n".$this->recorder->getRecording();
             $this->test->fail($failureMessage);
         }
     }


### PR DESCRIPTION
A rework of my original PR #32658, this allows retrieval/dumping of a commands output after test execution and additionally automatically dumps the output of a command on expectation failure.

As noted in laravel/ideas#1656, it's currently difficult to determine the cause of console command test failures as there is no easy way to get at the output. This remedies that by adding getOutput() and dumpOutput() methods to the PendingCommand class to trigger a dump of the commands output after its execution.

An example:

    $this->artisan('inspire')
        ->expectsOutput('Life is like riding a bicycle. To keep your balance, you must keep moving.')
        ->assertExitCode(0);

will yield something similar to:

    Output "Life is like riding a bicycle. To keep your balance, you must keep moving." was not printed. The output of the command was:

    The only way to do great work is to love what you do. - Steve Jobs

    .../framework/src/Illuminate/Testing/PendingCommand.php:254
    .../framework/src/Illuminate/Testing/PendingCommand.php:225
    .../Testing/PendingCommand.php:331
    .../MyProject/tests/CommandTestCase.php:86

Or force the dumping of the output to the console even after a successful outcome:

    $this->artisan('inspire')
        ->expectsOutput('Success is not final, failure is not fatal: it is the courage to continue that counts.')
        ->assertExitCode(0)
        ->dumpOutput();

You can also retrieve the output and then test using regular helpers allowing more complex output assertions.

    $output = $this->artisan('inspire')
        ->expectsOutput('Life is like riding a bicycle. To keep your balance, you must keep moving.')
        ->assertExitCode(0)
        ->getOutput();

    $this->assertStringContainsString('Life is like riding a bicycle.', $output);