### PR TITLE
[7.x] Add if_null helper function to the list of helper functions

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -558,3 +558,21 @@ if (! function_exists('with')) {
         return is_null($callback) ? $value : $callback($value);
     }
 }
+
+if (! function_exists('if_null')) {
+    /**
+     * Return the given if not null, otherwise return the value from the given callback.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $callback
+     * @return mixed
+     */
+    function if_null($value, callable $callback = null)
+    {
+        if (!is_null($value)) {
+            return $value;
+        }
+        
+        return is_null($callback) ? $value : $callback();
+    }
+}

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -561,7 +561,7 @@ if (! function_exists('with')) {
 
 if (! function_exists('if_null')) {
     /**
-     * Return the given if not null, otherwise return the value from the given callback.
+     * Return the given value if not null, otherwise return the value from the given callback.
      *
      * @param  mixed  $value
      * @param  callable|null  $callback

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -569,10 +569,10 @@ if (! function_exists('if_null')) {
      */
     function if_null($value, callable $callback = null)
     {
-        if (!is_null($value)) {
+        if (! is_null($value)) {
             return $value;
         }
-        
+
         return is_null($callback) ? $value : $callback();
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Description
This PULL REQUEST adds a function `if_null()` function to the list of helpers in `Illuminate/Support/helpers.php` file. This function is inspired by the `get()` and `rememberForever()` methods of `Cache` implementation that looks like this:

```php
$value = Cache::get('key', function () {
    return DB::table(...)->get();
});

$value = Cache::rememberForever('users', function () {
    return DB::table('users')->get();
});
```

As can be seen, when these values don't exist, then the closure is executed and the value returned is saved and returned. But `if_null` just returns the result from the callback when the `$value` is null.

#### How about `with()` and `optional()`?

The implementation of `with()` function focuses on the callback first, as can be seen below:

```php
function with($value, callable $callback = null)
{
    return is_null($callback) ? $value : $callback($value);
}
```

And `optional()` also considers the callback first.

```php
    function optional($value = null, callable $callback = null)
    {
        if (is_null($callback)) { //still considers `$callback` first
            return new Optional($value);
        } elseif (! is_null($value)) {
            return $callback($value);
        }
    }
```

`transform()` is the closest but because of the usage of `filled()` function which checks false, empty array etc. But this `is_null()` function checks specifically if the `$value` is null especially when you also expect `falsity` value.

### Usage

Serves as default value/closure value from any result.
Here:

```php
$value = if_null(Cred::whereNotNull('key')->value('key'), function() {
    return config()->get('credentials.default.key');
});
```
When the credentials is null from the db, then it is retrieved from the config file :)

### Closest native alternative: 
In the latest php versions, there is `??` and even `?:` operator which enables doing similar thing:

```php
$value = Cred::whereNotNull('key')->value('key') ?? config()->get('credentials.default.key');
```

The only issue is if you need to work on multiple lines then using `??` becomes complex and unreadable. So this simple `if_null()` simplifies this call like `optional()` and `with()` does.

### Backward compatibility
This  function does not add any non-backward compatibility changes to the core code rather a new feature that can be released in upcoming minor version of `Laravel 7.x`.

### Tests

I didn't find tests for helper functions. Someone could point me to it.