### PR TITLE
[8.x] Support for closure-based routes caching

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -227,7 +227,7 @@ class BoundMethod
             ]));
         }
 
-        $closure = SerializedClosure::toClosure($serialized);
+        $closure = SerializedClosure::fromString($serialized);
 
         return static::callBoundMethod($container, $closure, function () use ($container, $closure, $parameters) {
             return call_user_func_array(

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -5,6 +5,7 @@ namespace Illuminate\Container;
 use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use InvalidArgumentException;
+use Opis\Closure\SerializableClosure;
 use ReflectionFunction;
 use ReflectionMethod;
 
@@ -24,6 +25,10 @@ class BoundMethod
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
+        if (static::isSerializedClosure($callback)) {
+            return static::callSerializedClosure($container, $callback, $parameters);
+        }
+
         if (static::isCallableWithAtSign($callback) || $defaultMethod) {
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }
@@ -186,5 +191,48 @@ class BoundMethod
     protected static function isCallableWithAtSign($callback)
     {
         return is_string($callback) && strpos($callback, '@') !== false;
+    }
+
+    /**
+     * Determine if the given string is in a serialized Closure syntax.
+     *
+     * @param  mixed  $callback
+     * @return bool
+     */
+    protected static function isSerializedClosure($callback)
+    {
+        return static::isCallableWithAtSign($callback)
+            && explode('@', $callback)[0] === SerializedClosure::class;
+    }
+
+    /**
+     * Call a string reference to a serialized Closure syntax.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @param  string  $callback
+     * @param  array  $parameters
+     * @return mixed
+     */
+    protected static function callSerializedClosure($container, $callback, array $parameters = [])
+    {
+        $serialized = explode('@', $callback)[1] ?? '';
+
+        if (empty($serialized)) {
+            throw new InvalidArgumentException(vsprintf(
+                'Serialized Closure expected in [%s@SERIALIZED] format, with SERIALIZED coming from %s. Given: [%s]',
+                [
+                    SerializedClosure::class,
+                    SerializableClosure::class,
+                    $callback,
+            ]));
+        }
+
+        $closure = SerializedClosure::toClosure($serialized);
+
+        return static::callBoundMethod($container, $closure, function () use ($container, $closure, $parameters) {
+            return call_user_func_array(
+                $closure, static::getMethodDependencies($container, $closure, $parameters)
+            );
+        });
     }
 }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -224,7 +224,8 @@ class BoundMethod
                     SerializedClosure::class,
                     SerializableClosure::class,
                     $callback,
-            ]));
+                ]
+            ));
         }
 
         $closure = SerializedClosure::fromString($serialized);

--- a/src/Illuminate/Container/SerializedClosure.php
+++ b/src/Illuminate/Container/SerializedClosure.php
@@ -9,10 +9,12 @@ use Opis\Closure\SerializableClosure;
 class SerializedClosure
 {
     /**
+     * Parse serialized string into callable Closure.
+     *
      * @param string $serializedClosure
      * @return Closure
      */
-    public static function toClosure($serializedClosure)
+    public static function fromString($serializedClosure)
     {
         $serializableClosure = unserialize($serializedClosure);
 
@@ -21,5 +23,16 @@ class SerializedClosure
         }
 
         throw new InvalidArgumentException('Provided value is not a valid SerializableClosure');
+    }
+
+    /**
+     * Serialize callable Closure into string.
+     *
+     * @param Closure $closure
+     * @return string
+     */
+    public static function toString($closure)
+    {
+        return self::class . '@' . serialize(new SerializableClosure($closure));
     }
 }

--- a/src/Illuminate/Container/SerializedClosure.php
+++ b/src/Illuminate/Container/SerializedClosure.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Illuminate\Container;
+
+use Closure;
+use InvalidArgumentException;
+use Opis\Closure\SerializableClosure;
+
+class SerializedClosure
+{
+    /**
+     * @param string $serializedClosure
+     * @return Closure
+     */
+    public static function toClosure($serializedClosure)
+    {
+        $serializableClosure = unserialize($serializedClosure);
+
+        if ($serializableClosure instanceof SerializableClosure) {
+            return $serializableClosure->getClosure();
+        }
+
+        throw new InvalidArgumentException('Provided value is not a valid SerializableClosure');
+    }
+}

--- a/src/Illuminate/Container/SerializedClosure.php
+++ b/src/Illuminate/Container/SerializedClosure.php
@@ -33,6 +33,6 @@ class SerializedClosure
      */
     public static function toString($closure)
     {
-        return self::class . '@' . serialize(new SerializableClosure($closure));
+        return self::class.'@'.serialize(new SerializableClosure($closure));
     }
 }

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -4,6 +4,7 @@ namespace Illuminate\Routing;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Container\SerializedClosure;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
@@ -1137,7 +1138,7 @@ class Route
     public function prepareForSerialization()
     {
         if ($this->action['uses'] instanceof Closure) {
-            throw new LogicException("Unable to prepare route [{$this->uri}] for serialization. Uses Closure.");
+            $this->action['uses'] = SerializedClosure::toString($this->action['uses']);
         }
 
         $this->compileRoute();

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -6,7 +6,6 @@ use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Container\SerializedClosure;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Foundation\Application;
 use InvalidArgumentException;
 use Opis\Closure\SerializableClosure;
 use PHPUnit\Framework\TestCase;
@@ -199,7 +198,7 @@ class ContainerCallTest extends TestCase
             return $param;
         };
         $container = new Container;
-        $callable = SerializedClosure::class . '@' . serialize(new SerializableClosure($closure));
+        $callable = SerializedClosure::class.'@'.serialize(new SerializableClosure($closure));
         $result = $container->call($callable);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
     }
@@ -211,7 +210,7 @@ class ContainerCallTest extends TestCase
                                       'with SERIALIZED coming from Opis\Closure\SerializableClosure. Given: [Illuminate\Container\SerializedClosure@]');
 
         $container = new Container;
-        $callable = SerializedClosure::class . '@';
+        $callable = SerializedClosure::class.'@';
         $container->call($callable);
     }
 }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -4,7 +4,11 @@ namespace Illuminate\Tests\Container;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Container\SerializedClosure;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Foundation\Application;
+use InvalidArgumentException;
+use Opis\Closure\SerializableClosure;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use stdClass;
@@ -187,6 +191,28 @@ class ContainerCallTest extends TestCase
         $foo = $container->call(function ($foo, $bar = 'default') {
             return $foo;
         });
+    }
+
+    public function testCallWithSerializedClosure()
+    {
+        $closure = function (ContainerCallConcreteStub $param) {
+            return $param;
+        };
+        $container = new Container;
+        $callable = SerializedClosure::class . '@' . serialize(new SerializableClosure($closure));
+        $result = $container->call($callable);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+    }
+
+    public function testCallWithInvalidSerializedClosureThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Serialized Closure expected in [Illuminate\Container\SerializedClosure@SERIALIZED] format, '.
+                                      'with SERIALIZED coming from Opis\Closure\SerializableClosure. Given: [Illuminate\Container\SerializedClosure@]');
+
+        $container = new Container;
+        $callable = SerializedClosure::class . '@';
+        $container->call($callable);
     }
 }
 

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\SerializedClosure;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+
+class RouteTest extends TestCase
+{
+    public function testRouteClosureIsProperlySerialized()
+    {
+        $closure = function () {
+            return 'OK';
+        };
+        $route = new Route('GET', 'closure-route', $closure);
+        $route->prepareForSerialization();
+        $this->assertSame(SerializedClosure::toString($closure), $route->action['uses']);
+    }
+}


### PR DESCRIPTION
Introducing closure-based routes caching.

In order to cache the routes we're extending IoC so it supports `calling` serialized closures.
Implementation aims to be as simple as possible with `@` callable syntax on top of `Opis\Closure\SerializableClosure` which we already use in the `queue` component.

Example cached route:

```php
...
'serialized-route' => 
array (
  'methods' => array (
    0 => 'GET',
    1 => 'HEAD',
  ),
  'uri' => 'genie',
  'action' => array (
    'uses' => 'Illuminate\\Container\\SerializedClosure@C:32:"Opis\\Closure\\SerializableClosure":970:{@IFD1EnJFrI3ZYePnRGDKf6yrbATMCi8bZTCZQeRiU8o=.a:5:{s:3:"use";a:0:{}s:8:"function";s:800:"function (\\Illuminate\\Http\\Request $request) { ... }";s:5:"scope";N;s:4:"this";N;s:4:"self";s:32:"0000000045201a3c000000001cce6179";}}',
    'as' => 'serialized-route',
  ),
  'fallback' => false,
  'defaults' => array (),
  'wheres' => array (),
  'bindingFields' => array (),
  'lockSeconds' => NULL,
  'waitSeconds' => NULL,
),
```

---

The change is backward-compatible in principle, so should be good to merge to `7.x`, but as we know... 😂


![image](https://user-images.githubusercontent.com/6928818/82754424-62ead580-9dff-11ea-8aff-d3e8b00d0ae2.png)
