### PR TITLE
[8.x] Support for closure-based routes caching

### DIFF
--- a/src/Illuminate/Container/SerializedClosure.php
+++ b/src/Illuminate/Container/SerializedClosure.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Container;
+
+use Closure;
+use InvalidArgumentException;
+use Opis\Closure\SerializableClosure;
+
+class SerializedClosure
+{
+    /**
+     * Parse serialized string into callable Closure.
+     *
+     * @param string $serializedClosure
+     * @return Closure
+     */
+    public static function fromString($serializedClosure)
+    {
+        if (BoundMethod::isSerializedClosure($serializedClosure)) {
+            $serializedClosure = explode('@', $serializedClosure, 2)[1];
+        }
+
+        $serializableClosure = unserialize($serializedClosure);
+
+        if ($serializableClosure instanceof SerializableClosure) {
+            return $serializableClosure->getClosure();
+        }
+
+        throw new InvalidArgumentException('Provided value is not a valid SerializableClosure');
+    }
+
+    /**
+     * Serialize callable Closure into string.
+     *
+     * @param Closure $closure
+     * @return string
+     */
+    public static function toString($closure)
+    {
+        return self::class.'@'.serialize(new SerializableClosure($closure));
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -211,7 +211,7 @@ class Route
      */
     protected function isControllerAction()
     {
-        return is_string($this->action['uses']) && !BoundMethod::isSerializedClosure($this->action['uses']);
+        return is_string($this->action['uses']) && ! BoundMethod::isSerializedClosure($this->action['uses']);
     }
 
     /**

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -4,7 +4,10 @@ namespace Illuminate\Tests\Container;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Container\SerializedClosure;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use InvalidArgumentException;
+use Opis\Closure\SerializableClosure;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use stdClass;
@@ -187,6 +190,28 @@ class ContainerCallTest extends TestCase
         $foo = $container->call(function ($foo, $bar = 'default') {
             return $foo;
         });
+    }
+
+    public function testCallWithSerializedClosure()
+    {
+        $closure = function (ContainerCallConcreteStub $param) {
+            return $param;
+        };
+        $container = new Container;
+        $callable = SerializedClosure::class.'@'.serialize(new SerializableClosure($closure));
+        $result = $container->call($callable);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result);
+    }
+
+    public function testCallWithInvalidSerializedClosureThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Serialized Closure expected in [Illuminate\Container\SerializedClosure@SERIALIZED] format, '.
+                                      'with SERIALIZED coming from Opis\Closure\SerializableClosure. Given: [Illuminate\Container\SerializedClosure@]');
+
+        $container = new Container;
+        $callable = SerializedClosure::class.'@';
+        $container->call($callable);
     }
 }
 

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Illuminate\Tests\Routing;
+
+use Illuminate\Container\SerializedClosure;
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\TestCase;
+
+class RouteTest extends TestCase
+{
+    public function testRouteClosureIsProperlySerialized()
+    {
+        $closure = function () {
+            return 'OK';
+        };
+        $route = new Route('GET', 'closure-route', $closure);
+        $route->prepareForSerialization();
+        $this->assertSame(SerializedClosure::toString($closure), $route->action['uses']);
+    }
+}


### PR DESCRIPTION
Introducing closure-based routes caching.

In order to cache the routes we're extending IoC so it supports `calling` serialized closures.
Implementation aims to be as simple as possible with `@` callable syntax on top of `Opis\Closure\SerializableClosure` which we already use in the `queue` component.

Example cached route:

```php
...
'serialized-route' => 
array (
  'methods' => array (
    0 => 'GET',
    1 => 'HEAD',
  ),
  'uri' => 'genie',
  'action' => array (
    'uses' => 'Illuminate\\Container\\SerializedClosure@C:32:"Opis\\Closure\\SerializableClosure":970:{@IFD1EnJFrI3ZYePnRGDKf6yrbATMCi8bZTCZQeRiU8o=.a:5:{s:3:"use";a:0:{}s:8:"function";s:800:"function (\\Illuminate\\Http\\Request $request) { ... }";s:5:"scope";N;s:4:"this";N;s:4:"self";s:32:"0000000045201a3c000000001cce6179";}}',
    'as' => 'serialized-route',
  ),
  'fallback' => false,
  'defaults' => array (),
  'wheres' => array (),
  'bindingFields' => array (),
  'lockSeconds' => NULL,
  'waitSeconds' => NULL,
),
```

---

The PR introduces new functionality, doesn't change existing behavior except for unhandled path throwing error in the past, and thus is fully backward-compatible.
Should be good to merge to `7.x`, however targeting master as we know that... 😂


![image](https://user-images.githubusercontent.com/6928818/82754424-62ead580-9dff-11ea-8aff-d3e8b00d0ae2.png)
