### PR TITLE
[7.x] Using an indexed array as the limit modifier for zrangebyscore

### DIFF
--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Redis\Connections;
 
 use Closure;
 use Illuminate\Contracts\Redis\Connection as ConnectionContract;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Redis;
 use RedisCluster;
@@ -240,7 +241,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zrangebyscore($key, $min, $max, $options = [])
     {
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && Arr::isAssoc($options['limit'])) {
             $options['limit'] = [
                 $options['limit']['offset'],
                 $options['limit']['count'],
@@ -261,7 +262,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function zrevrangebyscore($key, $min, $max, $options = [])
     {
-        if (isset($options['limit'])) {
+        if (isset($options['limit']) && Arr::isAssoc($options['limit'])) {
             $options['limit'] = [
                 $options['limit']['offset'],
                 $options['limit']['count'],

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -329,6 +329,10 @@ class RedisConnectionTest extends TestCase
                     'count' => 2,
                 ],
             ]));
+            $this->assertEquals(['matt' => 5, 'taylor' => 10], $redis->zrangebyscore('set', 0, 11, [
+                'withscores' => true,
+                'limit' => [1, 2],
+            ]));
 
             $redis->flushall();
         }
@@ -345,6 +349,10 @@ class RedisConnectionTest extends TestCase
                     'offset' => 1,
                     'count' => 2,
                 ],
+            ]));
+            $this->assertEquals(['matt' => 5, 'jeffrey' => 1], $redis->ZREVRANGEBYSCORE('set', 10, 0, [
+                'withscores' => true,
+                'limit' => [1, 2],
             ]));
 
             $redis->flushall();


### PR DESCRIPTION
The `LIMIT` modifier for `ZRANGEBYSCORE` can be specified using either:
- an indexed array: `array($offset, $count)`
- an associative array: `array('offset' => $offset, 'count' => $count)`