### PR TITLE
[6.x] Fix QueueWorkTest cases asserting nothing

### DIFF
--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -59,19 +59,21 @@ class QueueWorkerTest extends TestCase
             $secondJob = new WorkerFakeJob,
         ]]);
 
-        $this->expectException(LoopBreakerException::class);
+        try {
+            $worker->daemon('default', 'queue', $workerOptions);
 
-        $worker->daemon('default', 'queue', $workerOptions);
+            $this->fail('Expected LoopBreakerException to be thrown.');
+        } catch (LoopBreakerException $e) {
+            $this->assertTrue($firstJob->fired);
 
-        $this->assertTrue($firstJob->fired);
+            $this->assertTrue($secondJob->fired);
 
-        $this->assertTrue($secondJob->fired);
+            $this->assertSame(0, $worker->stoppedWithStatus);
 
-        $this->assertSame(0, $worker->stoppedWithStatus);
+            $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessing::class))->twice();
 
-        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessing::class))->twice();
-
-        $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->twice();
+            $this->events->shouldHaveReceived('dispatch')->with(m::type(JobProcessed::class))->twice();
+        }
     }
 
     public function testJobCanBeFiredBasedOnPriority()
@@ -276,21 +278,23 @@ class QueueWorkerTest extends TestCase
 
         $maintenanceModeChecker = function () {
             if ($this->maintenanceFlags) {
-                return array_pop($this->maintenanceFlags);
+                return array_shift($this->maintenanceFlags);
             }
 
             throw new LoopBreakerException;
         };
 
-        $this->expectException(LoopBreakerException::class);
-
         $worker = $this->getWorker('default', ['queue' => [$firstJob, $secondJob]], $maintenanceModeChecker);
 
-        $worker->daemon('default', 'queue', $this->workerOptions());
+        try {
+            $worker->daemon('default', 'queue', $this->workerOptions());
 
-        $this->assertEquals($firstJob->attempts, 1);
+            $this->fail('Expected LoopBreakerException to be thrown');
+        } catch (LoopBreakerException $e) {
+            $this->assertSame(1, $firstJob->attempts);
 
-        $this->assertEquals($firstJob->attempts, 0);
+            $this->assertSame(0, $secondJob->attempts);
+        }
     }
 
     public function testJobDoesNotFireIfDeleted()
@@ -349,6 +353,7 @@ class QueueWorkerTest extends TestCase
 class InsomniacWorker extends Worker
 {
     public $sleptFor;
+    public $stopOnMemoryExceeded = false;
 
     public function sleep($seconds)
     {
@@ -365,6 +370,11 @@ class InsomniacWorker extends Worker
     public function daemonShouldRun(WorkerOptions $options, $connectionName, $queue)
     {
         return ! ($this->isDownForMaintenance)();
+    }
+
+    public function memoryExceeded($memoryLimit)
+    {
+        return $this->stopOnMemoryExceeded;
     }
 }
 


### PR DESCRIPTION
Retargeting https://github.com/laravel/framework/pull/32956 for 6.x.

While looking at https://github.com/laravel/framework/pull/32889 I saw some weird behavior in the queue worker tests. In two of the cases, PHPUnit's `$this->expectException(LoopBreakerException::class)` is setup, so `$worker->daemon()` that throws `LoopBreakerException` will cause all subsequent assertions to be skipped.

Fixing this shows `testJobRunsIfAppIsNotInMaintenanceMode()` actually never runs any jobs on the queue because it's discovering maintenance mode on the first loop iteration instead of the second.  And both of these assertions can't be true:

```php
$this->assertEquals($firstJob->attempts, 1);
$this->assertEquals($firstJob->attempts, 0);
```

This also fixes worker test brittleness when running the full framework test suite. Previous PHPUnit test cases use up memory and cause `Worker::memoryExceeded()` to sometimes return `true` so the queue is stopped and jobs won't run.

@fideloper: If this is merged, for https://github.com/laravel/framework/pull/32889 I setup the `InsomniacWorker::$stopOnMemoryExceeded` variable so adding `$worker->stopOnMemoryExceeded = true` in `testWorkerStopsWhenReachedMemoryLimit` can cause an `exit(12)` call.