### PR TITLE
[7.x] Add excludes method to Collection

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -52,6 +52,7 @@ trait EnumeratesValues
         'contains',
         'each',
         'every',
+        'excludes',
         'filter',
         'first',
         'flatMap',
@@ -131,6 +132,19 @@ trait EnumeratesValues
     public function some($key, $operator = null, $value = null)
     {
         return $this->contains(...func_get_args());
+    }
+
+    /**
+     * Determine if an item does not exist in the collection.
+     *
+     * @param  mixed  $key
+     * @param  mixed  $operator
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function excludes($key, $operator = null, $value = null)
+    {
+        return ! $this->contains(...func_get_args());
     }
 
     /**

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2750,6 +2750,38 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testExcludes($collection)
+    {
+        $c = new $collection([1, 3, 5]);
+
+        $this->assertFalse($c->excludes(1));
+        $this->assertFalse($c->excludes('1'));
+        $this->assertTrue($c->excludes(2));
+        $this->assertTrue($c->excludes('2'));
+
+        $c = new $collection([0]);
+
+        $this->assertFalse($c->excludes(function ($value) {
+            return $value < 5;
+        }));
+        $this->assertTrue($c->excludes(function ($value) {
+            return $value > 5;
+        }));
+
+        $c = new $collection([['v' => 1], ['v' => 3], ['v' => 5]]);
+
+        $this->assertFalse($c->excludes('v', 1));
+        $this->assertTrue($c->excludes('v', 2));
+
+        $c = new $collection([['a' => false, 'b' => false], ['a' => true, 'b' => false]]);
+
+        $this->assertFalse($c->excludes->a);
+        $this->assertTrue($c->excludes->b);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSome($collection)
     {
         $c = new $collection([1, 3, 5]);


### PR DESCRIPTION
I think the `contains` method is one of the most used feature of the Collection class. And in quite a handful of scenarios, I find the need of an inverse.

For example, a real example that I used to work with:

```php
if (! $email->tags->contains('name', 'ATTACHMENTS_DOWNLOADED')) {
    $email->attachments->each->download();
    $email->tag('ATTACHMENTS_DOWNLOADED');
}
```
That could be changed to:

```php
if ($email->tags->excludes('name', 'ATTACHMENTS_DOWNLOADED')) {
    $email->attachments->each->download();
    $email->tag('ATTACHMENTS_DOWNLOADED');
}
```

A different example could be:
```php
if ($freeShippingPostcodes->excludes($address->postcode)) {
    // Go on to charge normal shipping costs.
}
```