### PR TITLE
[7.x] Restore app()->getCached*Path() absolute '/' behavior in Windows

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -152,7 +152,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var array
      */
-    protected $absoluteCachePathPrefixes = [DIRECTORY_SEPARATOR];
+    protected $absoluteCachePathPrefixes = ['/', '\\'];
 
     /**
      * Create a new Illuminate application instance.


### PR DESCRIPTION
Fixes: https://github.com/laravel/framework/issues/32960

`testEnvPathsAreUsedForCachePathsWhenSpecified` is currently failing when run in Windows environments.

7.2.1 started enforcing `DIRECTORY_SEPARATOR` (https://github.com/laravel/framework/pull/31985) as the path prefix to be treated as absolute. For a point release, this breaks Windows environments in existing apps that use environment variables to set absolute `'/'`-prefixed paths.

```php
$_SERVER['APP_CONFIG_CACHE'] = '/ext/cache/config.php';
echo app()->getCachedConfigPath();
// C:\Users\Foo\projects\blog\/ext/cache/config.php
```

This should still be `'/ext/cache/config.php'` which PHP will likely resolve to `'C:\ext\cache\config.php'`.