### PR TITLE
[7.x] Fix HttpClientTest test case failing on Windows

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -250,7 +250,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');
-        $this->assertSame('This is a story about something that happened long ago when your grandfather was a child.'.PHP_EOL, $response->body());
+        $this->assertSame("This is a story about something that happened long ago when your grandfather was a child.\n", $response->body());
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');


### PR DESCRIPTION
https://github.com/laravel/framework/pull/31692 shouldn't have changed `HttpClientTest::testSequenceBuilder()`. Factory file `tests/Http/Fixtures/test.txt` is being read and it always has a `\n` line ending.