### PR TITLE
[6.x] Fix brittle tests failing on Windows

### DIFF
--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -14,22 +14,54 @@ class EventTest extends TestCase
         m::close();
     }
 
-    public function testBuildCommand()
+    public function testBuildCommandUsingUnix()
     {
-        $isWindows = DIRECTORY_SEPARATOR == '\\';
-        $quote = ($isWindows) ? '"' : "'";
+        if (windows_os()) {
+            $this->markTestSkipped('Skipping since operating system is Windows');
+        }
 
         $event = new Event(m::mock(EventMutex::class), 'php -i');
 
-        $defaultOutput = ($isWindows) ? 'NUL' : '/dev/null';
-        $this->assertSame("php -i > {$quote}{$defaultOutput}{$quote} 2>&1", $event->buildCommand());
+        $this->assertSame("php -i > '/dev/null' 2>&1", $event->buildCommand());
+    }
+
+    public function testBuildCommandUsingWindows()
+    {
+        if (! windows_os()) {
+            $this->markTestSkipped('Skipping since operating system is not Windows');
+        }
+
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+
+        $this->assertSame('php -i > "NUL" 2>&1', $event->buildCommand());
+    }
+
+    public function testBuildCommandInBackgroundUsingUnix()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Skipping since operating system is Windows');
+        }
 
         $event = new Event(m::mock(EventMutex::class), 'php -i');
         $event->runInBackground();
 
-        $commandSeparator = ($isWindows ? '&' : ';');
         $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
-        $this->assertSame("(php -i > {$quote}{$defaultOutput}{$quote} 2>&1 {$commandSeparator} {$quote}".PHP_BINARY."{$quote} artisan schedule:finish {$scheduleId} \"$?\") > {$quote}{$defaultOutput}{$quote} 2>&1 &", $event->buildCommand());
+
+        $this->assertSame("(php -i > '/dev/null' 2>&1 ; '".PHP_BINARY."' artisan schedule:finish {$scheduleId} \"$?\") > '/dev/null' 2>&1 &", $event->buildCommand());
+    }
+
+    public function testBuildCommandInBackgroundUsingWindows()
+    {
+        if (! windows_os()) {
+            $this->markTestSkipped('Skipping since operating system is not Windows');
+        }
+
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->runInBackground();
+
+        $scheduleId = '"framework'.DIRECTORY_SEPARATOR.'schedule-eeb46c93d45e928d62aaf684d727e213b7094822"';
+
+        $this->assertSame('start /b cmd /c "(php -i & "'.PHP_BINARY.'" artisan schedule:finish '.$scheduleId.' "%errorlevel%") > "NUL" 2>&1"', $event->buildCommand());
     }
 
     public function testBuildCommandSendOutputTo()

--- a/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
+++ b/tests/Foundation/Bootstrap/LoadEnvironmentVariablesTest.php
@@ -11,6 +11,9 @@ class LoadEnvironmentVariablesTest extends TestCase
 {
     protected function tearDown(): void
     {
+        unset($_ENV['FOO']);
+        unset($_SERVER['FOO']);
+        putenv('FOO');
         m::close();
     }
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -359,11 +359,12 @@ class FoundationApplicationTest extends TestCase
     {
         $app = new Application('/base/path');
 
-        $this->assertSame('/base/path/bootstrap/cache/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/base/path/bootstrap/cache/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/base/path/bootstrap/cache/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/base/path/bootstrap/cache/routes.php', $app->getCachedRoutesPath());
-        $this->assertSame('/base/path/bootstrap/cache/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path'.$ds.'bootstrap'.$ds.'cache/events.php', $app->getCachedEventsPath());
     }
 
     public function testEnvPathsAreUsedForCachePathsWhenSpecified()
@@ -375,6 +376,7 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_ROUTES_CACHE'] = '/absolute/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = '/absolute/path/events.php';
 
+        $ds = DIRECTORY_SEPARATOR;
         $this->assertSame('/absolute/path/services.php', $app->getCachedServicesPath());
         $this->assertSame('/absolute/path/packages.php', $app->getCachedPackagesPath());
         $this->assertSame('/absolute/path/config.php', $app->getCachedConfigPath());
@@ -399,11 +401,12 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
 
-        $this->assertSame('/base/path/relative/path/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/base/path/relative/path/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/base/path/relative/path/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/base/path/relative/path/routes.php', $app->getCachedRoutesPath());
-        $this->assertSame('/base/path/relative/path/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame('/base/path'.$ds.'relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame('/base/path'.$ds.'relative/path/events.php', $app->getCachedEventsPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],
@@ -423,11 +426,12 @@ class FoundationApplicationTest extends TestCase
         $_SERVER['APP_ROUTES_CACHE'] = 'relative/path/routes.php';
         $_SERVER['APP_EVENTS_CACHE'] = 'relative/path/events.php';
 
-        $this->assertSame('/relative/path/services.php', $app->getCachedServicesPath());
-        $this->assertSame('/relative/path/packages.php', $app->getCachedPackagesPath());
-        $this->assertSame('/relative/path/config.php', $app->getCachedConfigPath());
-        $this->assertSame('/relative/path/routes.php', $app->getCachedRoutesPath());
-        $this->assertSame('/relative/path/events.php', $app->getCachedEventsPath());
+        $ds = DIRECTORY_SEPARATOR;
+        $this->assertSame($ds.'relative/path/services.php', $app->getCachedServicesPath());
+        $this->assertSame($ds.'relative/path/packages.php', $app->getCachedPackagesPath());
+        $this->assertSame($ds.'relative/path/config.php', $app->getCachedConfigPath());
+        $this->assertSame($ds.'relative/path/routes.php', $app->getCachedRoutesPath());
+        $this->assertSame($ds.'relative/path/events.php', $app->getCachedEventsPath());
 
         unset(
             $_SERVER['APP_SERVICES_CACHE'],

--- a/tests/Integration/Mail/RenderingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/RenderingMailWithLocaleTest.php
@@ -31,14 +31,14 @@ class RenderingMailWithLocaleTest extends TestCase
     {
         $mail = new RenderedTestMail;
 
-        $this->assertStringContainsString('name'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString('name', $mail->render());
     }
 
     public function testMailableRendersInSelectedLocale()
     {
         $mail = (new RenderedTestMail)->locale('es');
 
-        $this->assertStringContainsString('nombre'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString('nombre', $mail->render());
     }
 
     public function testMailableRendersInAppSelectedLocale()
@@ -47,7 +47,7 @@ class RenderingMailWithLocaleTest extends TestCase
 
         $mail = new RenderedTestMail;
 
-        $this->assertStringContainsString('nombre'.PHP_EOL, $mail->render());
+        $this->assertStringContainsString('nombre', $mail->render());
     }
 }
 

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -67,6 +67,7 @@ class RedisQueueIntegrationTest extends TestCase
 
     /**
      * @dataProvider redisDriverProvider
+     * @requires extension pcntl
      *
      * @param  mixed  $driver
      *
@@ -74,7 +75,12 @@ class RedisQueueIntegrationTest extends TestCase
      */
     public function testBlockingPop($driver)
     {
+        if (! function_exists('pcntl_fork')) {
+            $this->markTestSkipped('Skipping since the pcntl extension is not available');
+        }
+
         $this->tearDownRedis();
+
         if ($pid = pcntl_fork() > 0) {
             $this->setUpRedis();
             $this->setQueue($driver, 'default', null, 60, 10);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -492,7 +492,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertTrue(microtime(true) - $startTime >= 0.1);
+        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.01);
     }
 
     public function testRetryWithPassingWhenCallback()
@@ -513,7 +513,7 @@ class SupportHelpersTest extends TestCase
         $this->assertEquals(2, $attempts);
 
         // Make sure we waited 100ms for the first attempt
-        $this->assertTrue(microtime(true) - $startTime >= 0.1);
+        $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.01);
     }
 
     public function testRetryWithFailingWhenCallback()


### PR DESCRIPTION
Fix tests currently failing in Windows environments that Linux CI output doesn't give feedback for.

* `RenderingMailWithLocaleTest`
  These mailable tests were affected by Blade changes. https://github.com/laravel/framework/pull/27621/files changed `\n` assertions to `PHP_EOL` but 7.x https://github.com/laravel/framework/pull/32026/files now enforces Blade templates _always_ generate `\n`. The mailable tests don't care about newlines. Just look for the translation phrase.
* `RedisQueueIntegrationTest::testBlockingPop()`
  Same as `FilesystemTest::testSharedGet()`, ensure the `pcntl` extension is installed for the `pcntl_fork()` call. This extension is unavailable on Windows.
* `LoadEnvironmentVariablesTest` / `SupportHelpersTest::testEnv()`
  Windows environment variable `"FOO=BAR"` set by `LoadEnvironmentVariablesTest::testCanLoad()` was leaking global state into the `env()` helper unit tests.
* `SupportHelpersTest::testRetry()`
  `retry()` calls `usleep()` which has rounding issues on Windows. From: https://www.php.net/usleep

  > It should be noted that Windows machines have a resolution of either 10 mS or 15 mS... when using the Sleep() function in kernel32.dll.  This means that your average error will be either 5 or 7.5 mS.

  Some `retry(..., 100)` durations:
  * 0.10040688514709
  * 0.09948515892028
  * 0.10079598426819
  * 0.10021185874939
  * 0.09946084022522

  `assertEqualsWithDelta(0.1, ..., 0.01)` for `>= 0.09` should cover it.
* `Illuminate\Tests\Console\Scheduling\EventTest`
  https://github.com/laravel/framework/pull/29826 changed how Windows background commands are generated but it didn't adjust the tests. I've split the god test (that looks like it needs its own unit tests) into 4 cases.

  * (1) Unix foreground command
  * (2) Unix daemon scheduler
  * (3) Windows foreground command
  * (4) Windows daemon scheduler

  CI will only run 1 & 2. Local test runs on Windows will execute 3 & 4.
* `FoundationApplicationTest`
  Backport https://github.com/laravel/framework/pull/32002 to the 6.x branch