### PR TITLE
[6.x] Fix Filesystem tests failing in Windows

### DIFF
--- a/tests/Filesystem/FilesystemAdapterTest.php
+++ b/tests/Filesystem/FilesystemAdapterTest.php
@@ -236,8 +236,10 @@ class FilesystemAdapterTest extends TestCase
         $spy = m::spy($this->filesystem);
 
         $filesystemAdapter = new FilesystemAdapter($spy);
-        $stream = new Stream(fopen($this->tempDir.'/foo.txt', 'r'));
-        $filesystemAdapter->put('bar.txt', $stream);
+        $stream = fopen($this->tempDir.'/foo.txt', 'r');
+        $guzzleStream = new Stream($stream);
+        $filesystemAdapter->put('bar.txt', $guzzleStream);
+        fclose($stream);
 
         $spy->shouldHaveReceived('putStream');
         $this->assertEquals('some-data', $filesystemAdapter->get('bar.txt'));

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -43,8 +43,22 @@ class FilesystemTest extends TestCase
         $this->assertStringEqualsFile($this->tempDir.'/file.txt', 'Hello World');
     }
 
-    public function testReplaceStoresFiles()
+    public function testReplaceCreatesFile()
     {
+        $tempFile = "{$this->tempDir}/file.txt";
+
+        $filesystem = new Filesystem;
+
+        $filesystem->replace($tempFile, 'Hello World');
+        $this->assertStringEqualsFile($tempFile, 'Hello World');
+    }
+
+    public function testReplaceWhenUnixSymlinkExists()
+    {
+        if (windows_os()) {
+            $this->markTestSkipped('Skipping since operating system is Windows');
+        }
+
         $tempFile = "{$this->tempDir}/file.txt";
         $symlinkDir = "{$this->tempDir}/symlink_dir";
         $symlink = "{$symlinkDir}/symlink.txt";


### PR DESCRIPTION
This should be the last of it. All tests are now green in Windows.

### `FilesystemAdapterTest::testPutWithStreamInterface()`

https://github.com/laravel/framework/pull/30179 comments noted that `Storage::put()` implementation could leave a stream open by the PHP script. This has caused a chain of filesystem tests to fail in Windows because `FilesystemAdapterTest::tearDown()` can't delete the temp directory when a "foo.txt" temp file has an active `fopen()` stream.

* `GuzzleHttp\Psr7\Stream::__destruct()` is meant to gracefully `fclose($this->stream)` through `GuzzleHttp\Psr7\Stream::__close()`
* Having the framework call `GuzzleHttp\Psr7\Stream::detach()` to fetch stream content, the `close()` method now hits `$this->stream === null` so it's on userland to explicitly call `fclose()`.
  * https://laravel.com/docs/7.x/filesystem#storing-files

### `FilesystemTest::testReplaceStoresFiles()`

https://github.com/laravel/framework/pull/26254 added a test that only works in Linux/macOS. The `chmod()` / `umask()` write-permission changes have no effect on Windows and `symlink()` fails unless:

* the original file `"{$this->tempDir}/file.txt"` already exists.
* you're running PHPUnit using an Administrator role - at least this is true under Git Bash / MINGW64 shell.

So I've skipped adding the below Windows-only test as a counterpart to `testReplaceWhenUnixSymlinkExists`.

```php
    public function testReplaceWhenWindowsSymlinkExists()
    {
        if (! windows_os()) {
            $this->markTestSkipped('Skipping since operating system is not Windows');
        }

        $tempFile = "{$this->tempDir}/file.txt";
        file_put_contents($tempFile, 'Hello World');
        $symlinkDir = "{$this->tempDir}/symlink_dir";
        $symlink = "{$symlinkDir}/symlink.txt";

        mkdir($symlinkDir);
        symlink($tempFile, $symlink);

        $filesystem = new Filesystem;

        // Test replacing existing file.
        $filesystem->replace($tempFile, 'Something Else');
        $this->assertStringEqualsFile($tempFile, 'Something Else');

        // Test replacing symlinked file.
        $filesystem->replace($symlink, 'Yet Something Else Again');
        $this->assertStringEqualsFile($tempFile, 'Yet Something Else Again');
    }
```

![windows-tests](https://user-images.githubusercontent.com/823566/82935338-e705a000-9f5a-11ea-9288-84c0bf8806b8.png)