### PR TITLE
[7.x] Add forceDeleted method to SoftDeletes

### DIFF
--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -157,6 +157,17 @@ trait SoftDeletes
     }
 
     /**
+     * Register a forceDeleted model event with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function forceDeleted($callback)
+    {
+        static::registerModelEvent('forceDeleted', $callback);
+    }
+
+    /**
      * Determine if the model is currently force deleting.
      *
      * @return bool


### PR DESCRIPTION
This PR adds the (missing?) forceDeleted method to SoftDeletes.

I stumbled upon this while looping on [getObservableEvents](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php#L100) and calling those events like so: ``static::$event(...);``

It appeared that ``static::forceDeleted()`` was the only one not defined.