### PR TITLE
[8.x] Always attempt to gracefully exit queue:worker

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -73,7 +73,7 @@ class WorkCommand extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int|null
      */
     public function handle()
     {
@@ -94,7 +94,7 @@ class WorkCommand extends Command
         // connection being run for the queue operation currently being executed.
         $queue = $this->getQueue($connection);
 
-        $this->runWorker(
+        return $this->runWorker(
             $connection, $queue
         );
     }
@@ -104,7 +104,7 @@ class WorkCommand extends Command
      *
      * @param  string  $connection
      * @param  string  $queue
-     * @return array
+     * @return int|null
      */
     protected function runWorker($connection, $queue)
     {

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Orchestra\Testbench\TestCase;
+use Queue;
+
+/**
+ * @group integration
+ */
+class WorkCommandTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', 'true');
+
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['db']->connection()->getSchemaBuilder()->create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue');
+            $table->longText('payload');
+            $table->tinyInteger('attempts')->unsigned();
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+            $table->index(['queue', 'reserved_at']);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        $this->app['db']->connection()->getSchemaBuilder()->drop('jobs');
+
+        parent::tearDown();
+
+        FirstJob::$ran = false;
+        SecondJob::$ran = false;
+    }
+
+    public function testRunningOneJob()
+    {
+        Queue::connection('database')->push(new FirstJob);
+        Queue::connection('database')->push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--once' => true,
+            '--memory' => 1024,
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, Queue::connection('database')->size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
+
+    public function testDaemon()
+    {
+        Queue::connection('database')->push(new FirstJob);
+        Queue::connection('database')->push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 1024,
+        ])->assertExitCode(0);
+
+        $this->assertSame(0, Queue::connection('database')->size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertTrue(SecondJob::$ran);
+    }
+
+    public function testMemoryExceeded()
+    {
+        Queue::connection('database')->push(new FirstJob);
+        Queue::connection('database')->push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--memory' => 0.1,
+        ])->assertExitCode(12);
+
+        // Memory limit isn't checked until after the first job is attempted.
+        $this->assertSame(1, Queue::connection('database')->size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
+}
+
+class FirstJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}
+
+class SecondJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        static::$ran = true;
+    }
+}


### PR DESCRIPTION
This completes the implementation of https://github.com/laravel/framework/pull/32889 with some additional end-to-end test coverage to run a complete `php artisan queue:work` command.

This may fix https://github.com/laravel/telescope/issues/577 since a 'terminating' hook is registered in `Laravel\Telescope\ListensForStorageOpportunities@storeEntriesBeforeTermination()` to save Telescope entries. Job event listeners should cover entries being saved but I think the below cases may leave gaps when Telescope storage is skipped.

`App::terminating()` callbacks don't get called in some cases when `queue:worker` is shutdown:

* memory limit exceeded
* `php artisan queue:restart` has been called
* the database connection is lost
* `--stop-when-empty` option is enabled
* on `SIGTERM` interruption

Instead of immediately calling `exit()`, bubble a PHP script exit code up to `WorkCommand@handle()`. Gracefully exiting allows Laravel's application state to be cleaned up.

* `SIGALRM` interruptions still call `exit()` (and won't invoke `App::terminating()`) since it's run asynchronously and doesn't allow the current job to complete.
* I'm not sure why `WorkCommand@runWorker()` was annotated `@return array` since the call stack would always return `null`.