### PR TITLE
[7.x] Use new line for route:list middleware

### DIFF
--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -172,7 +172,7 @@ class RouteListCommand extends Command
     {
         return collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
             return $middleware instanceof Closure ? 'Closure' : $middleware;
-        })->implode(',');
+        })->implode("\n");
     }
 
     /**


### PR DESCRIPTION
I think [this change](https://github.com/laravel/framework/commit/7ebd21193df520d78269d7abd740537a2fae889e) modified how route middleware is displayed. Routes groups are now displayed using all middleware class names, instead of say `web`. Because of this, the Middleware column is massive for routes that use `web`.

I recommend changing the join to new lines, so middleware is listed just like event listeners.

The below examples were generated using `php artisan route:list --path telescope/telescope-api/jobs`.

Examples with `,`:

```
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
| Domain | Method   | URI                                             | Name | Action                                                   | Middleware                                                                                                                              |
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
|        | POST     | telescope/telescope-api/jobs                    |      | Laravel\Telescope\Http\Controllers\QueueController@index | App\Http\Middleware\JsonMiddleware,Illuminate\Routing\Middleware\ThrottleRequests:60,1,Illuminate\Routing\Middleware\SubstituteBindings |
|        | GET|HEAD | telescope/telescope-api/jobs/{telescopeEntryId} |      | Laravel\Telescope\Http\Controllers\QueueController@show  | App\Http\Middleware\JsonMiddleware,Illuminate\Routing\Middleware\ThrottleRequests:60,1,Illuminate\Routing\Middleware\SubstituteBindings |
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```

Example with new line:

```
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------+
| Domain | Method   | URI                                             | Name | Action                                                   | Middleware                                          |
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------+
|        | POST     | telescope/telescope-api/jobs                    |      | Laravel\Telescope\Http\Controllers\QueueController@index | App\Http\Middleware\JsonMiddleware                  |
|        |          |                                                 |      |                                                          | Illuminate\Routing\Middleware\ThrottleRequests:60,1 |
|        |          |                                                 |      |                                                          | Illuminate\Routing\Middleware\SubstituteBindings    |
|        | GET|HEAD | telescope/telescope-api/jobs/{telescopeEntryId} |      | Laravel\Telescope\Http\Controllers\QueueController@show  | App\Http\Middleware\JsonMiddleware                  |
|        |          |                                                 |      |                                                          | Illuminate\Routing\Middleware\ThrottleRequests:60,1 |
|        |          |                                                 |      |                                                          | Illuminate\Routing\Middleware\SubstituteBindings    |
+--------+----------+-------------------------------------------------+------+----------------------------------------------------------+-----------------------------------------------------+
```