### PR TITLE
[7.x] `File::guessedExtension()` method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -7,6 +7,7 @@ use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Traits\Macroable;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Mime\MimeTypes;
 
 class Filesystem
 {
@@ -310,6 +311,17 @@ class Filesystem
     public function extension($path)
     {
         return pathinfo($path, PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Guess the file extension from the mime-type of a given file.
+     *
+     * @param  string  $path
+     * @return string|null
+     */
+    public function guessedExtension($path)
+    {
+        return (new MimeTypes)->getExtensions($this->mimeType($path))[0] ?? null;
     }
 
     /**


### PR DESCRIPTION
This PR provides a `File::guessedExtension()` method which could be useful in case we want to know the extension of the file which actually doesn't have one.

```php
>>> File::name(public_path('image.png'))
=> "image"
>>> File::extension(public_path('image.png'))
=> "png"
>>> File::guessedExtension(public_path('image.png'))
=> "png"
>>> File::copy(public_path('image.png'), public_path('image'))
=> true
>>> File::name(public_path('image'))
=> "image"
>>> File::extension(public_path('image'))
=> ""
>>> File::guessedExtension(public_path('image'))
=> "png"
```

Under the hood, it guesses the extension by the mime-type.

> It this PR gets approved, I'll provide tests.