### PR TITLE
[7.x] Provide psr/container-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,9 @@
         "predis/predis": "^1.1.1",
         "symfony/cache": "^5.0"
     },
+    "provide": {
+        "psr/container-implementation": "1.0"
+    },
     "conflict": {
         "tightenco/collect": "<5.5.33"
     },

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -18,6 +18,9 @@
         "illuminate/contracts": "^7.0",
         "psr/container": "^1.0"
     },
+    "provide": {
+        "psr/container-implementation": "1.0"
+    },
     "autoload": {
         "psr-4": {
             "Illuminate\\Container\\": ""


### PR DESCRIPTION
See https://github.com/laravel/ideas/issues/2241.

As [recommended in PSR-11](https://www.php-fig.org/psr/psr-11/#2-package), this declares that `illuminate/container` provides the `psr/container-implementation` virtual package.