### PR TITLE
[7.x] Add the ability to makeMany (create many without saving)

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -60,7 +60,7 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
-     * Create and return an un-saved instances of the related models
+     * Create and return an un-saved instances of the related models.
      *
      * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -60,6 +60,23 @@ abstract class HasOneOrMany extends Relation
     }
 
     /**
+     * Create and return an un-saved instances of the related models
+     *
+     * @param  iterable  $records
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function makeMany(iterable $records)
+    {
+        $instances = $this->related->newCollection();
+
+        foreach ($records as $record) {
+            $instances->push($this->make($record));
+        }
+
+        return $instances;
+    }
+
+    /**
      * Set the base constraints on the relation query.
      *
      * @return void

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -65,7 +65,7 @@ abstract class HasOneOrMany extends Relation
      * @param  iterable  $records
      * @return \Illuminate\Database\Eloquent\Collection
      */
-    public function makeMany(iterable $records)
+    public function makeMany($records)
     {
         $instances = $this->related->newCollection();
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -26,6 +26,27 @@ class DatabaseEloquentHasManyTest extends TestCase
         $this->assertEquals($instance, $relation->make(['name' => 'taylor']));
     }
 
+    public function testMakeManyCreatesARelatedModelForEachRecord()
+    {
+        $records = [
+            'taylor' => ['name' => 'taylor'],
+            'colin' => ['name' => 'colin'],
+        ];
+
+        $relation = $this->getRelation();
+        $relation->getRelated()->shouldReceive('newCollection')->once()->andReturn(new Collection);
+
+        $taylor = $this->expectNewModel($relation, ['name' => 'taylor']);
+        $taylor->expects($this->never())->method('save');
+        $colin = $this->expectNewModel($relation, ['name' => 'colin']);
+        $colin->expects($this->never())->method('save');
+
+        $instances = $relation->makeMany($records);
+        $this->assertInstanceOf(Collection::class, $instances);
+        $this->assertEquals($taylor, $instances[0]);
+        $this->assertEquals($colin, $instances[1]);
+    }
+
     public function testCreateMethodProperlyCreatesNewModel()
     {
         $relation = $this->getRelation();


### PR DESCRIPTION
when adding many records to a one to many relation I found that I had to use one of two methods 
- createMany($models)
- saveMany($models)
but each of them, execute count($models) queries

I found that I had to use the query builder insert method which takes an array of arrays and executes a single query but then I have to explicitly attach the foreign key first

so I thought what if there is a like (make) function but make a collection of instances instead of a single one and every instance has the parent id attached to it under the hood.

I used it in my project as a macro but I thought it could be useful.

```
public function orderTickets(string $email, int $ticket_quantity)
{
    $order = $this->orders()->create(['email' => $email]);

    $order->tickets()->insert($order->tickets()->makeMany(collect()->pad($ticket_quantity, []))->toArray());

    return $order;
}
```
