### PR TITLE
[7.x] Add extendable relations for models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -415,7 +415,7 @@ trait HasAttributes
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key)) {
+        if (method_exists($this, $key) || isset(static::$relationResolvers[$key])) {
             return $this->getRelationshipFromMethod($key);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -415,7 +415,7 @@ trait HasAttributes
         // If the "attribute" exists as a method on the model, we will just assume
         // it is a relationship and will load and return results from the query
         // and hydrate the relationship's value on the "relationships" array.
-        if (method_exists($this, $key) || isset(static::$relationResolvers[$key])) {
+        if (method_exists($this, $key) || (static::$relationResolvers[static::class][$key] ?? null)) {
             return $this->getRelationshipFromMethod($key);
         }
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -61,7 +61,7 @@ trait HasRelationships
      */
     public static function resolveRelationUsing($name, Closure $callback)
     {
-        static::$relationResolvers[$name] = $callback;
+        static::$relationResolvers[static::class][$name] = $callback;
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -43,6 +44,25 @@ trait HasRelationships
     public static $manyMethods = [
         'belongsToMany', 'morphToMany', 'morphedByMany',
     ];
+
+    /**
+     * The relation resolver callbacks.
+     *
+     * @var array
+     */
+    protected static $relationResolvers = [];
+
+    /**
+     * Define a relation resolver.
+     *
+     * @param  string  $name
+     * @param  \Closure  $callback
+     * @return void
+     */
+    public static function resolveRelationUsing($name, Closure $callback)
+    {
+        static::$relationResolvers[$name] = $callback;
+    }
 
     /**
      * Define a one-to-one relationship.

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -61,7 +61,10 @@ trait HasRelationships
      */
     public static function resolveRelationUsing($name, Closure $callback)
     {
-        static::$relationResolvers[static::class][$name] = $callback;
+        static::$relationResolvers = array_replace_recursive(
+            static::$relationResolvers,
+            [static::class => [$name => $callback]]
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1725,8 +1725,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
-        if (isset(static::$relationResolvers[$method])) {
-            return static::$relationResolvers[$method]($this);
+        if ($resolver = static::$relationResolvers[static::class][$method] ?? null) {
+            return $resolver($this);
         }
 
         return $this->forwardCallTo($this->newQuery(), $method, $parameters);

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1725,6 +1725,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $this->$method(...$parameters);
         }
 
+        if (isset(static::$relationResolvers[$method])) {
+            return static::$relationResolvers[$method]($this);
+        }
+
         return $this->forwardCallTo($this->newQuery(), $method, $parameters);
     }
 

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -267,6 +267,20 @@ class DatabaseEloquentRelationTest extends TestCase
         $result = $relation->foo();
         $this->assertSame('foo', $result);
     }
+
+    public function testRelationResolvers()
+    {
+        $model = new EloquentRelationResetModelStub;
+        $builder = m::mock(Builder::class);
+        $builder->shouldReceive('getModel')->andReturn($model);
+
+        EloquentRelationResetModelStub::resolveRelationUsing('customer', function ($model) use ($builder) {
+            return new EloquentResolverRelationStub($builder, $model);
+        });
+
+        $this->assertInstanceOf(EloquentResolverRelationStub::class, $model->customer());
+        $this->assertSame(['key' => 'value'], $model->customer);
+    }
 }
 
 class EloquentRelationResetModelStub extends Model
@@ -328,4 +342,12 @@ class EloquentNoTouchingAnotherModelStub extends Model
     protected $attributes = [
         'id' => 2,
     ];
+}
+
+class EloquentResolverRelationStub extends EloquentRelationStub
+{
+    public function getResults()
+    {
+        return ['key' => 'value'];
+    }
 }


### PR DESCRIPTION
This PR introduces the `resolveRelationUsing` method, which allows defining relationships between models from "outside" of the classes. For example:

```php
Order::resolveRelationUsing('customer', function ($model) {
    return $model->belongsTo(Customer::class, 'customer_id');
});

$order->customer() // relation instance

$order->customer // related model instance / collection

$order->customer()->associate(...)

Order::whereHas('customer', function ($query) {
    //
});

Order::with('customer')->where(...);

// All should work as we would define the relation in the model class
```

This extension could be very handy when building multiple packages in the same ecosystem that may extend each other's functionality. Of course often extending models, using traits or writing query builder macros is enough, but all of them have limitations at some point.

-----

Keys should be passed explicitly when defining the relationship, to avoid automatically generated keys for a closure: `{closure}_id`.

By default, this should not be a breaking change, at least I could not find any. However, any defined resolvers will be triggered before the call is forwarded to the query builder. But by default, this should not affect any existing code, since the resolvers array is empty. 

Also, this would not affect any property or method that the class already has, they should have priority over the relation definitions.

-----

I found a related PR #22507, however, this approach tries to achieve to provide the same behavior as it would be a "native" relation definition. Also, the implementation of the two PRs are quite different.