### PR TITLE
[6.x] Add putFile doc block to storage facade

### DIFF
--- a/src/Illuminate/Support/Facades/Storage.php
+++ b/src/Illuminate/Support/Facades/Storage.php
@@ -10,6 +10,7 @@ use Illuminate\Filesystem\Filesystem;
  * @method static string get(string $path)
  * @method static resource|null readStream(string $path)
  * @method static bool put(string $path, string|resource $contents, mixed $options = [])
+ * @method static string|false putFile(string $path, \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string $file, mixed $options = [])
  * @method static bool writeStream(string $path, resource $resource, array $options = [])
  * @method static string getVisibility(string $path)
  * @method static bool setVisibility(string $path, string $visibility)


### PR DESCRIPTION
This pull requests adds a doc block for `Storage::putFile()` allowing IDEs to autcomplete it