### PR TITLE
[7.x] Disallow generation commands with reserved names

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -37,7 +37,7 @@ abstract class GeneratorCommand extends Command
         'declare', 'else', 'endforeach', 'exit', 'for', 'if', 'insteadof', 'new',
         'public', 'switch', 'use', 'as', 'class', 'default', 'elseif', 'endif',
         'extends', 'foreach', 'implements', 'interface', 'or', 'require', 'throw',
-        'var'
+        'var',
     ];
 
     /**
@@ -72,7 +72,7 @@ abstract class GeneratorCommand extends Command
         // First we will check whether the name can be found in the reserved names.
         // We have so called "reserved names" to ensure that no files are generated
         // using PHP keywords for example, because that would cause errors.
-        if($this->isReservedName($this->getNameInput())) {
+        if ($this->isReservedName($this->getNameInput())) {
             $this->error('The name "'.$this->getNameInput().'" is reserved. Please pick something else.');
 
             return false;


### PR DESCRIPTION
## What
This PR makes it so that an error is displayed to the user when they attempt to use a [reserved keyword](https://www.php.net/manual/en/reserved.keywords.php) in a generator command. For example:
```
php artisan make:model Case
```

## Why
Using PHP keywords as the name when using generation commands is not only bad practice, but it simply does not even work.

In my situation I wanted to create a model called `Case` (in the context of a "crime case").

<img src="https://i.imgur.com/qRQ81f1.png" width=400>

This will not work. A [context sensitive lexer](https://wiki.php.net/rfc/context_sensitive_lexer) was added in PHP 7, which allows you to use reserved keywords in method names. However, this does not go for class names.

Some could say:
> *"Developers should just be cautious and not use keywords when scaffolding."*

I partially agree, but when you use the following generation command for example:
```
php artisan make:model Case -a
```
It will successfully create a model class, factory, migration, seeder, and then... oops:

<img src="https://i.imgur.com/7tZY0Ds.png" width=500>

And now your project is polluted with a model class, factory, migration and seeder, while the model isn't usable in the first place. It would be much better to disallow the scaffolding immediately and prevent this.

## Screenshot
The error that is displayed when attempting to scaffold with a reserved name.
<img src="https://i.imgur.com/OENYuQn.png" width=500>