### PR TITLE
[8.x] Don't leak engine instance as $this into views

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -86,14 +86,22 @@ class Filesystem
      * Get the returned value of a file.
      *
      * @param  string  $path
+     * @param  array  $data
      * @return mixed
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function getRequire($path)
+    public function getRequire($path, array $data = [])
     {
         if ($this->isFile($path)) {
-            return require $path;
+            $__path = $path;
+            $__data = $data;
+
+            return (static function () use ($__path, $__data) {
+                extract($__data, EXTR_SKIP);
+
+                return require $__path;
+            })();
         }
 
         throw new FileNotFoundException("File does not exist at path {$path}.");
@@ -102,12 +110,24 @@ class Filesystem
     /**
      * Require the given file once.
      *
-     * @param  string  $file
+     * @param  string  $path
+     * @param  array  $data
      * @return mixed
      */
-    public function requireOnce($file)
+    public function requireOnce($path, array $data = [])
     {
-        require_once $file;
+        if ($this->isFile($path)) {
+            $__path = $path;
+            $__data = $data;
+
+            return (static function () use ($__path, $__data) {
+                extract($__data, EXTR_SKIP);
+
+                return require_once $__path;
+            })();
+        }
+
+        throw new FileNotFoundException("File does not exist at path {$path}.");
     }
 
     /**

--- a/src/Illuminate/View/Engines/CompilerEngine.php
+++ b/src/Illuminate/View/Engines/CompilerEngine.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Engines;
 
 use ErrorException;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Throwable;
 
@@ -23,13 +24,15 @@ class CompilerEngine extends PhpEngine
     protected $lastCompiled = [];
 
     /**
-     * Create a new Blade view engine instance.
+     * Create a new compiler engine instance.
      *
+     * @param  \Illuminate\Filesystem\Filesystem  $filesystem
      * @param  \Illuminate\View\Compilers\CompilerInterface  $compiler
      * @return void
      */
-    public function __construct(CompilerInterface $compiler)
+    public function __construct(Filesystem $filesystem, CompilerInterface $compiler)
     {
+        parent::__construct($filesystem);
         $this->compiler = $compiler;
     }
 

--- a/src/Illuminate/View/Engines/FileEngine.php
+++ b/src/Illuminate/View/Engines/FileEngine.php
@@ -3,9 +3,28 @@
 namespace Illuminate\View\Engines;
 
 use Illuminate\Contracts\View\Engine;
+use Illuminate\Filesystem\Filesystem;
 
 class FileEngine implements Engine
 {
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new file engine instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $filesystem
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
     /**
      * Get the evaluated contents of the view.
      *
@@ -15,6 +34,6 @@ class FileEngine implements Engine
      */
     public function get($path, array $data = [])
     {
-        return file_get_contents($path);
+        return $this->filesystem->get($path);
     }
 }

--- a/src/Illuminate/View/Engines/PhpEngine.php
+++ b/src/Illuminate/View/Engines/PhpEngine.php
@@ -3,10 +3,29 @@
 namespace Illuminate\View\Engines;
 
 use Illuminate\Contracts\View\Engine;
+use Illuminate\Filesystem\Filesystem;
 use Throwable;
 
 class PhpEngine implements Engine
 {
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * Create a new file engine instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $filesystem
+     * @return void
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
     /**
      * Get the evaluated contents of the view.
      *
@@ -22,23 +41,21 @@ class PhpEngine implements Engine
     /**
      * Get the evaluated contents of the view at the given path.
      *
-     * @param  string  $__path
-     * @param  array  $__data
+     * @param  string  $path
+     * @param  array  $data
      * @return string
      */
-    protected function evaluatePath($__path, $__data)
+    protected function evaluatePath($path, $data)
     {
         $obLevel = ob_get_level();
 
         ob_start();
 
-        extract($__data, EXTR_SKIP);
-
         // We'll evaluate the contents of the view inside a try/catch block so we can
         // flush out any stray output that might get out before an error occurs or
         // an exception is thrown. This prevents any partial views from leaking.
         try {
-            include $__path;
+            $this->filesystem->getRequire($path, $data);
         } catch (Throwable $e) {
             $this->handleViewException($e, $obLevel);
         }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -121,7 +121,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerFileEngine($resolver)
     {
         $resolver->register('file', function () {
-            return new FileEngine;
+            return new FileEngine($this->app['files']);
         });
     }
 
@@ -134,7 +134,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerPhpEngine($resolver)
     {
         $resolver->register('php', function () {
-            return new PhpEngine;
+            return new PhpEngine($this->app['files']);
         });
     }
 
@@ -147,7 +147,7 @@ class ViewServiceProvider extends ServiceProvider
     public function registerBladeEngine($resolver)
     {
         $resolver->register('blade', function () {
-            return new CompilerEngine($this->app['blade.compiler']);
+            return new CompilerEngine($this->app['files'], $this->app['blade.compiler']);
         });
     }
 }

--- a/tests/View/ViewCompilerEngineTest.php
+++ b/tests/View/ViewCompilerEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Mockery as m;
@@ -40,6 +41,6 @@ class ViewCompilerEngineTest extends TestCase
 
     protected function getEngine()
     {
-        return new CompilerEngine(m::mock(CompilerInterface::class));
+        return new CompilerEngine(new Filesystem, m::mock(CompilerInterface::class));
     }
 }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Events\Dispatcher;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
@@ -337,7 +338,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/component.php');
-        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine);
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent('component', ['name' => 'Taylor']);
         $factory->slot('title');
@@ -488,7 +489,7 @@ class ViewFactoryTest extends TestCase
         $this->expectException(ErrorException::class);
         $this->expectExceptionMessage('section exception message');
 
-        $engine = new CompilerEngine(m::mock(CompilerInterface::class));
+        $engine = new CompilerEngine(new Filesystem, m::mock(CompilerInterface::class));
         $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
             return $path;
         });

--- a/tests/View/ViewPhpEngineTest.php
+++ b/tests/View/ViewPhpEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\View;
 
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Engines\PhpEngine;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +16,7 @@ class ViewPhpEngineTest extends TestCase
 
     public function testViewsMayBeProperlyRendered()
     {
-        $engine = new PhpEngine;
+        $engine = new PhpEngine(new Filesystem);
         $this->assertSame('Hello World
 ', $engine->get(__DIR__.'/fixtures/basic.php'));
     }


### PR DESCRIPTION
Currently, when views are loaded, `$this` is bound and available. I don't think that was intended (given that effort was made to make sure `$path` and `$data` were not bound). I propose we avoid this from happening by requiring files within a static closure. I've implemented this on the filesystem class, and made the view engines make calls to it.