### PR TITLE
[6.x] Fix Cache Dependencies of Composer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-php-${{ matrix.php }}-${{ matrix.stability }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
The cache dependencies key should include the stability (prefer-lowest or prefer-stable).

Otherwise, some of the dependencies in the prefer-lowest build seem to be re-downloaded every time - unless the lowest version happen to match the stable one.
