### PR TITLE
[7.X] Throws exceptions when limit is not a positive int

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1981,10 +1981,12 @@ class Builder
     public function limit($value)
     {
         $property = $this->unions ? 'unionLimit' : 'limit';
-
-        if ($value >= 0) {
-            $this->$property = $value;
+        
+        if ($value < 0 || !is_numeric($value)) {
+            throw new RuntimeException('You must use positive integer for limit parameter.');
         }
+
+        $this->$property = (int) $value;
 
         return $this;
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1981,7 +1981,7 @@ class Builder
     public function limit($value)
     {
         $property = $this->unions ? 'unionLimit' : 'limit';
-        
+
         if ($value < 0 || !is_numeric($value)) {
             throw new RuntimeException('You must use positive integer for limit parameter.');
         }


### PR DESCRIPTION
Today if you use negative numbers ou not numeric values as parameter the builder will ignore the limit parameters and all data will be fetched. With this a runtime exception will be throwed.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
