### PR TITLE
[6.x] Fix assertion for forget with single indexed array

### DIFF
--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -363,6 +363,7 @@ class SupportCollectionTest extends TestCase
     {
         $c = new Collection(['foo', 'bar']);
         $c = $c->forget(0)->all();
+        $this->assertFalse(isset($c['foo']));
         $this->assertFalse(isset($c[0]));
         $this->assertTrue(isset($c[1]));
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -363,11 +363,13 @@ class SupportCollectionTest extends TestCase
     {
         $c = new Collection(['foo', 'bar']);
         $c = $c->forget(0)->all();
-        $this->assertFalse(isset($c['foo']));
+        $this->assertFalse(isset($c[0]));
+        $this->assertTrue(isset($c[1]));
 
         $c = new Collection(['foo' => 'bar', 'baz' => 'qux']);
         $c = $c->forget('foo')->all();
         $this->assertFalse(isset($c['foo']));
+        $this->assertTrue(isset($c['baz']));
     }
 
     public function testForgetArrayOfKeys()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`$this->assertFalse(isset($c['foo']));` will always be false for indexed arrays