### PR TITLE
add expand method to Stringable class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -195,6 +195,22 @@ class Stringable
     }
 
     /**
+     * Expand the string into an array of Stringables.
+     *
+     * @param  string  $delimiter
+     * @param  int  $limit
+     * @return \Illuminate\Support\Collection
+     */
+    public function expand($delimiter, $limit = PHP_INT_MAX)
+    {
+        return collect(explode($delimiter, $this->value, $limit))
+            ->transform(function ($string) {
+                return Str::of($string);
+            });
+
+    }
+
+    /**
      * Split a string using a regular expression.
      *
      * @param  string  $pattern

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -484,4 +484,9 @@ class SupportStringableTest extends TestCase
         $this->assertSame(3, $this->stringable('laravelPHPFramework')->substrCount('a', 1, -2));
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
+
+    public function testExpand()
+    {
+        $this->assertInstanceOf(Stringable::class, $this->stringable('foo bar')->expand(' ')->first());
+    }
 }


### PR DESCRIPTION
<!--
In addition, please describe the benefit to end users; 
the reasons it does not break any existing features; 
how it makes building web applications easier, etc.
-->
More often than not, I find myself needing to do a bit more work on the collection of strings returned from the Str::explode() method. This will PR allow us to 'expand' a string into a collection of Stringables as opposed to a collection of strings.

So instead of exploding and transforming:
```
$stringable_collection = \Str::of('foo-bar')->explode('-')->transform(function($str){
    return Str::of($str);
});
```

We can expand:
```
$stringable_collection = \Str::of('foo-bar')->expand('-');
```

Operations on the collection will be that much more fluent as there is no need to use Str::of or Str::{method} to get access to the stringable class again. Once is enough.

```
$stringable_collection = \Str::of('foo-bar')
    ->expand('-')
    ->transform(function(Stringable $str){
        if($str->contains('oo')){
            return $str;
        }
        
        return $str->replace('r','z');
    });



```