### PR TITLE
[7.x] Add withToken() helper method

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -93,6 +93,19 @@ trait MakesHttpRequests
     }
 
     /**
+     * Add a bearer token to the request headers.
+     *
+     * @param  string  $value
+     * @return $this
+     */
+    public function withBearerToken(string $value)
+    {
+        $this->defaultHeaders['Authorization'] = 'Bearer '.$value;
+
+        return $this;
+    }
+
+    /**
      * Define a set of server variables to be sent with the requests.
      *
      * @param  array  $server

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -96,12 +96,12 @@ trait MakesHttpRequests
      * Add an authorization token for the request.
      *
      * @param  string  $token
-     * @param  string  $type
+     * @param  string|null  $type
      * @return $this
      */
-    public function withToken(string $token, string $type = 'Bearer')
+    public function withToken(string $token, string $type = null)
     {
-        $this->defaultHeaders['Authorization'] = trim($type.' '.$token);
+        $this->defaultHeaders['Authorization'] = sprintf('%s %s', $type ?? 'Bearer', $token);
 
         return $this;
     }

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -93,14 +93,15 @@ trait MakesHttpRequests
     }
 
     /**
-     * Add a bearer token to the request headers.
+     * Add an authorization token for the request.
      *
-     * @param  string  $value
+     * @param  string  $token
+     * @param  string  $type
      * @return $this
      */
-    public function withBearerToken(string $value)
+    public function withToken(string $token, string $type = 'Bearer')
     {
-        $this->defaultHeaders['Authorization'] = 'Bearer '.$value;
+        $this->defaultHeaders['Authorization'] = trim($type.' '.$token);
 
         return $this;
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -14,6 +14,13 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('previous/url', $this->app['session']->previousUrl());
     }
 
+    public function testBearerTokenSetsHeader()
+    {
+        $this->withBearerToken('foobar');
+
+        $this->assertSame('Bearer foobar', $this->defaultHeaders['Authorization']);
+    }
+
     public function testWithoutAndWithMiddleware()
     {
         $this->assertFalse($this->app->has('middleware.disable'));

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -14,11 +14,13 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('previous/url', $this->app['session']->previousUrl());
     }
 
-    public function testBearerTokenSetsHeader()
+    public function testWithTokenSetsAuthorizationHeader()
     {
-        $this->withBearerToken('foobar');
-
+        $this->withToken('foobar');
         $this->assertSame('Bearer foobar', $this->defaultHeaders['Authorization']);
+
+        $this->withToken('foobar', 'Basic');
+        $this->assertSame('Basic foobar', $this->defaultHeaders['Authorization']);
     }
 
     public function testWithoutAndWithMiddleware()


### PR DESCRIPTION
This PR adds a small helper method for tests using Authorization Bearer tokens as part of request headers. It was inspired by the existing `$request->bearerToken()` method on the `Illuminate\Http\Request` class, which is also really useful.

I feel this allows requests inside tests to read a little nicer, as well as helps against typos when writing "Authorization" and "Bearer" over and over, and instead IDEs can autocomplete the method.

```
$response = $this->withHeader('Authorization', 'Bearer test_token')->postJson('/some-endpoint');

$response = $this->withBearerToken('test_token')->postJson('/some-endpoint');
```

There are no breaking changes, and I've added a small test to verify everything works as expected. 

Happy to make changes if there's any feedback!