### PR TITLE
[6.x] Align Tap & When method

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -166,7 +166,7 @@ trait BuildsQueries
      * Pass the query to a given callback.
      *
      * @param  callable  $callback
-     * @return \Illuminate\Database\Query\Builder
+     * @return $this
      */
     public function tap($callback)
     {


### PR DESCRIPTION
The `tap` method is returning `when`, which has a different signature. Moreover, when using static analyser against code that uses `tap`, it leads to false positive because the return can either be `Eloquent\Builder` or `Query\Builder`. In fact, it will be whatever the original object instance referred to.