### PR TITLE
[7.x] Added MailManager::forgetMailer()

### DIFF
--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -73,7 +73,9 @@ class MailManager implements FactoryContract
     }
 
     /**
-     * @param string $name
+     * Forget a mailer instance by name.
+     *
+     * @param  string  $name
      * @return void
      */
     public function forgetMailer($name)

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -73,6 +73,17 @@ class MailManager implements FactoryContract
     }
 
     /**
+     * @param string $name
+     * @return void
+     */
+    public function forgetMailer($name)
+    {
+        if(isset($this->mailers[$name])){
+            unset($this->mailers[$name]);
+        }
+    }
+
+    /**
      * Get a mailer driver instance.
      *
      * @param  string|null  $driver

--- a/tests/Mail/MailManagerTest.php
+++ b/tests/Mail/MailManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Mail;
 
+use Illuminate\Mail\MailManager;
 use Orchestra\Testbench\TestCase;
 
 class MailManagerTest extends TestCase
@@ -31,5 +32,31 @@ class MailManagerTest extends TestCase
         return [
             [null], [''], [' '],
         ];
+    }
+
+    public function testForgetMailer()
+    {
+        $this->app['config']->set('mail.mailers.custom_smtp', [
+            'transport' => "smtp",
+            'host' => "example.com",
+            'port' => "25",
+            'encryption' => "tls",
+            'username' => "username",
+            'password' => "password",
+            'timeout' => 10,
+        ]);
+
+        /** @var MailManager $mailManager */
+        $mailManager = $this->app['mail.manager'];
+        $mailManager->mailer("custom_smtp");
+
+        $mailersProperty = new \ReflectionProperty($mailManager, 'mailers');
+        $mailersProperty->setAccessible(true);
+
+        $this->assertArrayHasKey("custom_smtp", $mailersProperty->getValue($mailManager), "Mailer must exist in the \$mailers-property");
+
+        $mailManager->forgetMailer("custom_smtp");
+
+        $this->assertArrayNotHasKey("custom_smtp", $mailersProperty->getValue($mailManager), "Mailer must not exist in the \$mailers-property as it must have been removed with MailManager::forgetMailer()");
     }
 }


### PR DESCRIPTION
This enables the possibility to reset already resolved mailers. This helps especially when it comes to processing mails via worker on CLI to not re-use mailers on multi-tenant-systems.