### PR TITLE
[7.x] Ability to define the name of the timestamps through the database configuration

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,7 +11,6 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
@@ -276,7 +275,7 @@ class Builder
     public function latest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? Config::get('database.timestamps.created_at', 'created_at');
+            $column = $this->model->getCreatedAtColumn() ?? config('database.timestamps.created_at', 'created_at');
         }
 
         $this->query->latest($column);
@@ -293,7 +292,7 @@ class Builder
     public function oldest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? Config::get('database.timestamps.created_at', 'created_at');
+            $column = $this->model->getCreatedAtColumn() ?? config('database.timestamps.created_at', 'created_at');
         }
 
         $this->query->oldest($column);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use ReflectionClass;
@@ -275,7 +276,7 @@ class Builder
     public function latest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+            $column = $this->model->getCreatedAtColumn() ?? Config::get('app.timestamps.created_at', 'created_at');
         }
 
         $this->query->latest($column);
@@ -292,7 +293,7 @@ class Builder
     public function oldest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? 'created_at';
+            $column = $this->model->getCreatedAtColumn() ?? Config::get('app.timestamps.created_at', 'created_at');
         }
 
         $this->query->oldest($column);

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -276,7 +276,7 @@ class Builder
     public function latest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? Config::get('app.timestamps.created_at', 'created_at');
+            $column = $this->model->getCreatedAtColumn() ?? Config::get('database.timestamps.created_at', 'created_at');
         }
 
         $this->query->latest($column);
@@ -293,7 +293,7 @@ class Builder
     public function oldest($column = null)
     {
         if (is_null($column)) {
-            $column = $this->model->getCreatedAtColumn() ?? Config::get('app.timestamps.created_at', 'created_at');
+            $column = $this->model->getCreatedAtColumn() ?? Config::get('database.timestamps.created_at', 'created_at');
         }
 
         $this->query->oldest($column);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 
 trait HasTimestamps
@@ -119,7 +118,7 @@ trait HasTimestamps
             return static::CREATED_AT;
         }
 
-        return Config::get('database.timestamps.created_at', 'created_at');
+        return config('database.timestamps.created_at', 'created_at');
     }
 
     /**
@@ -133,7 +132,7 @@ trait HasTimestamps
             return static::UPDATED_AT;
         }
 
-        return Config::get('database.timestamps.updated_at', 'updated_at');
+        return config('database.timestamps.updated_at', 'updated_at');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -118,7 +118,7 @@ trait HasTimestamps
         if (static::CREATED_AT !== null) {
             return static::CREATED_AT;
         }
-        return Config::get('app.timestamps.created_at', 'created_at');
+        return Config::get('database.timestamps.created_at', 'created_at');
     }
 
     /**
@@ -131,7 +131,7 @@ trait HasTimestamps
         if (static::UPDATED_AT !== null) {
             return static::UPDATED_AT;
         }
-        return Config::get('app.timestamps.updated_at', 'updated_at');
+        return Config::get('database.timestamps.updated_at', 'updated_at');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -118,6 +118,7 @@ trait HasTimestamps
         if (static::CREATED_AT !== null) {
             return static::CREATED_AT;
         }
+
         return Config::get('database.timestamps.created_at', 'created_at');
     }
 
@@ -131,6 +132,7 @@ trait HasTimestamps
         if (static::UPDATED_AT !== null) {
             return static::UPDATED_AT;
         }
+
         return Config::get('database.timestamps.updated_at', 'updated_at');
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 
 trait HasTimestamps
@@ -114,7 +115,10 @@ trait HasTimestamps
      */
     public function getCreatedAtColumn()
     {
-        return static::CREATED_AT;
+        if (static::CREATED_AT !== null) {
+            return static::CREATED_AT;
+        }
+        return Config::get('app.timestamps.created_at', 'created_at');
     }
 
     /**
@@ -124,7 +128,10 @@ trait HasTimestamps
      */
     public function getUpdatedAtColumn()
     {
-        return static::UPDATED_AT;
+        if (static::UPDATED_AT !== null) {
+            return static::UPDATED_AT;
+        }
+        return Config::get('app.timestamps.updated_at', 'updated_at');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -148,14 +148,14 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @var string
      */
-    const CREATED_AT = 'created_at';
+    const CREATED_AT = null;
 
     /**
      * The name of the "updated at" column.
      *
      * @var string
      */
-    const UPDATED_AT = 'updated_at';
+    const UPDATED_AT = null;
 
     /**
      * Create a new Eloquent model instance.

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -186,7 +186,7 @@ trait SoftDeletes
      */
     public function getDeletedAtColumn()
     {
-        return defined('static::DELETED_AT') ? static::DELETED_AT : Config::get('app.timestamps.deleted_at', 'deleted_at');
+        return defined('static::DELETED_AT') ? static::DELETED_AT : Config::get('database.timestamps.deleted_at', 'deleted_at');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Eloquent;
 
-use Illuminate\Support\Facades\Config;
-
 /**
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
@@ -186,7 +184,7 @@ trait SoftDeletes
      */
     public function getDeletedAtColumn()
     {
-        return defined('static::DELETED_AT') ? static::DELETED_AT : Config::get('database.timestamps.deleted_at', 'deleted_at');
+        return defined('static::DELETED_AT') ? static::DELETED_AT : config('database.timestamps.deleted_at', 'deleted_at');
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/SoftDeletes.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent;
 
+use Illuminate\Support\Facades\Config;
+
 /**
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder withTrashed()
  * @method static static|\Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder onlyTrashed()
@@ -184,7 +186,7 @@ trait SoftDeletes
      */
     public function getDeletedAtColumn()
     {
-        return defined('static::DELETED_AT') ? static::DELETED_AT : 'deleted_at';
+        return defined('static::DELETED_AT') ? static::DELETED_AT : Config::get('app.timestamps.deleted_at', 'deleted_at');
     }
 
     /**

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 
@@ -402,7 +401,7 @@ class Blueprint
      */
     public function dropTimestamps()
     {
-        $this->dropColumn(Config::get('database.timestamps.created_at', 'created_at'), Config::get('database.timestamps.updated_at', 'updated_at'));
+        $this->dropColumn(config('database.timestamps.created_at', 'created_at'), config('database.timestamps.updated_at', 'updated_at'));
     }
 
     /**
@@ -424,7 +423,7 @@ class Blueprint
     public function dropSoftDeletes($column = null)
     {
         if ($column === null) {
-            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
+            $column = config('database.timestamps.deleted_at', 'deleted_at');
         }
         $this->dropColumn($column);
     }
@@ -438,7 +437,7 @@ class Blueprint
     public function dropSoftDeletesTz($column = null)
     {
         if ($column === null) {
-            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
+            $column = config('database.timestamps.deleted_at', 'deleted_at');
         }
         $this->dropSoftDeletes($column);
     }
@@ -1069,9 +1068,9 @@ class Blueprint
      */
     public function timestamps($precision = 0)
     {
-        $this->timestamp(Config::get('database.timestamps.created_at', 'created_at'), $precision)->nullable();
+        $this->timestamp(config('database.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestamp(Config::get('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
+        $this->timestamp(config('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1095,9 +1094,9 @@ class Blueprint
      */
     public function timestampsTz($precision = 0)
     {
-        $this->timestampTz(Config::get('database.timestamps.created_at', 'created_at'), $precision)->nullable();
+        $this->timestampTz(config('database.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestampTz(Config::get('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
+        $this->timestampTz(config('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1110,7 +1109,7 @@ class Blueprint
     public function softDeletes($column = null, $precision = 0)
     {
         if ($column === null) {
-            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
+            $column = config('database.timestamps.deleted_at', 'deleted_at');
         }
 
         return $this->timestamp($column, $precision)->nullable();
@@ -1126,7 +1125,7 @@ class Blueprint
     public function softDeletesTz($column = null, $precision = 0)
     {
         if ($column === null) {
-            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
+            $column = config('database.timestamps.deleted_at', 'deleted_at');
         }
 
         return $this->timestampTz($column, $precision)->nullable();

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -1112,6 +1112,7 @@ class Blueprint
         if ($column === null) {
             $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
+
         return $this->timestamp($column, $precision)->nullable();
     }
 
@@ -1127,6 +1128,7 @@ class Blueprint
         if ($column === null) {
             $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
+
         return $this->timestampTz($column, $precision)->nullable();
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
 
@@ -401,7 +402,7 @@ class Blueprint
      */
     public function dropTimestamps()
     {
-        $this->dropColumn('created_at', 'updated_at');
+        $this->dropColumn(Config::get('app.timestamps.created_at', 'created_at'), Config::get('app.timestamps.updated_at', 'updated_at'));
     }
 
     /**
@@ -420,8 +421,11 @@ class Blueprint
      * @param  string  $column
      * @return void
      */
-    public function dropSoftDeletes($column = 'deleted_at')
+    public function dropSoftDeletes($column = null)
     {
+        if ($column === null) {
+            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+        }
         $this->dropColumn($column);
     }
 
@@ -431,8 +435,11 @@ class Blueprint
      * @param  string  $column
      * @return void
      */
-    public function dropSoftDeletesTz($column = 'deleted_at')
+    public function dropSoftDeletesTz($column = null)
     {
+        if ($column === null) {
+            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+        }
         $this->dropSoftDeletes($column);
     }
 
@@ -1062,9 +1069,9 @@ class Blueprint
      */
     public function timestamps($precision = 0)
     {
-        $this->timestamp('created_at', $precision)->nullable();
+        $this->timestamp(Config::get('app.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestamp('updated_at', $precision)->nullable();
+        $this->timestamp(Config::get('app.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1088,9 +1095,9 @@ class Blueprint
      */
     public function timestampsTz($precision = 0)
     {
-        $this->timestampTz('created_at', $precision)->nullable();
+        $this->timestampTz(Config::get('app.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestampTz('updated_at', $precision)->nullable();
+        $this->timestampTz(Config::get('app.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1100,8 +1107,11 @@ class Blueprint
      * @param  int  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletes($column = 'deleted_at', $precision = 0)
+    public function softDeletes($column = null, $precision = 0)
     {
+        if ($column === null) {
+            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+        }
         return $this->timestamp($column, $precision)->nullable();
     }
 
@@ -1112,8 +1122,11 @@ class Blueprint
      * @param  int  $precision
      * @return \Illuminate\Database\Schema\ColumnDefinition
      */
-    public function softDeletesTz($column = 'deleted_at', $precision = 0)
+    public function softDeletesTz($column = null, $precision = 0)
     {
+        if ($column === null) {
+            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+        }
         return $this->timestampTz($column, $precision)->nullable();
     }
 

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -402,7 +402,7 @@ class Blueprint
      */
     public function dropTimestamps()
     {
-        $this->dropColumn(Config::get('app.timestamps.created_at', 'created_at'), Config::get('app.timestamps.updated_at', 'updated_at'));
+        $this->dropColumn(Config::get('database.timestamps.created_at', 'created_at'), Config::get('database.timestamps.updated_at', 'updated_at'));
     }
 
     /**
@@ -424,7 +424,7 @@ class Blueprint
     public function dropSoftDeletes($column = null)
     {
         if ($column === null) {
-            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
         $this->dropColumn($column);
     }
@@ -438,7 +438,7 @@ class Blueprint
     public function dropSoftDeletesTz($column = null)
     {
         if ($column === null) {
-            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
         $this->dropSoftDeletes($column);
     }
@@ -1069,9 +1069,9 @@ class Blueprint
      */
     public function timestamps($precision = 0)
     {
-        $this->timestamp(Config::get('app.timestamps.created_at', 'created_at'), $precision)->nullable();
+        $this->timestamp(Config::get('database.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestamp(Config::get('app.timestamps.updated_at', 'updated_at'), $precision)->nullable();
+        $this->timestamp(Config::get('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1095,9 +1095,9 @@ class Blueprint
      */
     public function timestampsTz($precision = 0)
     {
-        $this->timestampTz(Config::get('app.timestamps.created_at', 'created_at'), $precision)->nullable();
+        $this->timestampTz(Config::get('database.timestamps.created_at', 'created_at'), $precision)->nullable();
 
-        $this->timestampTz(Config::get('app.timestamps.updated_at', 'updated_at'), $precision)->nullable();
+        $this->timestampTz(Config::get('database.timestamps.updated_at', 'updated_at'), $precision)->nullable();
     }
 
     /**
@@ -1110,7 +1110,7 @@ class Blueprint
     public function softDeletes($column = null, $precision = 0)
     {
         if ($column === null) {
-            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
         return $this->timestamp($column, $precision)->nullable();
     }
@@ -1125,7 +1125,7 @@ class Blueprint
     public function softDeletesTz($column = null, $precision = 0)
     {
         if ($column === null) {
-            $column = Config::get('app.timestamps.deleted_at', 'deleted_at');
+            $column = Config::get('database.timestamps.deleted_at', 'deleted_at');
         }
         return $this->timestampTz($column, $precision)->nullable();
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This will allow users to define in a single place the timestamp names for all Models and for the Blueprint itself.
Will help to keep non english database structures consistent without having to define a base model class and do not need to define manually the `$table->timestamps()` in blueprint.