### PR TITLE
[7.x] Filter a collection searching for a value in an field that is an array

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -572,6 +572,21 @@ trait EnumeratesValues
             return in_array(data_get($item, $key), $values, $strict);
         });
     }
+    
+    /**
+     * Filter items searching for a value in an field that is an array.
+     *
+     * @param  string  $key
+     * @param  mixed  $values
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereIncludes($key, $value, $strict = false)
+    {
+        return $this->filter(function ($item) use ($key, $value, $strict) {
+            return in_array($value, data_get($item, $key), $strict);
+        });
+    }
 
     /**
      * Filter items by the given key value pair using strict comparison.


### PR DESCRIPTION
Add the ability to filter a collection searching for a value in an field that is an array, the inverse of ->whereIn()

This new method is a short way to filter the collection to only the items that has that value in one of the elements in the array, the inverse comparison than whereIn()

For example, if the property in a collection is an array, like ["tag1", "tag2", "tag3"], be able to:

->whereIncludes('tags', 'tag2');

