### PR TITLE
[7.x] Improved Rate Limiting

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -57,10 +57,13 @@ class ThrottleRequests
         $this->limiter->hit($key, $decayMinutes * 60);
 
         $response = $next($request);
-
+        
+        $retryAfter = $maxAttempts === 1 ? $this->getTimeUntilNextRetry($key) : null;
+        
         return $this->addHeaders(
             $response, $maxAttempts,
-            $this->calculateRemainingAttempts($key, $maxAttempts)
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
         );
     }
 

--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -57,9 +57,9 @@ class ThrottleRequests
         $this->limiter->hit($key, $decayMinutes * 60);
 
         $response = $next($request);
-        
+
         $retryAfter = $maxAttempts === 1 ? $this->getTimeUntilNextRetry($key) : null;
-        
+
         return $this->addHeaders(
             $response, $maxAttempts,
             $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),


### PR DESCRIPTION
When sending the check code, the maximum attempt is usually 1 time, and the time is 1 minute. If it can return `Retry-After` and `X-RateLimit-Reset` the front end will be more clear about the remaining time

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
