### PR TITLE
[8.x] Add collection exception handling with try/catch

### DIFF
--- a/src/Illuminate/Collections/CatchableCollectionProxy.php
+++ b/src/Illuminate/Collections/CatchableCollectionProxy.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Illuminate\Collections;
+
+/**
+ * @mixin \Illuminate\Collections\Enumerable
+ */
+class CatchableCollectionProxy
+{
+    /**
+     * The collection being operated on.
+     *
+     * @var \Illuminate\Collections\Enumerable
+     */
+    protected $collection;
+
+    /**
+     * The collection methods to handle exceptions for.
+     *
+     * @var array
+     */
+    protected $calledMethods = [];
+
+    /**
+     * Create a new proxy instance.
+     *
+     * @param  \Illuminate\Collections\Enumerable  $collection
+     * @return void
+     */
+    public function __construct(Enumerable $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * Proxy a method call onto the collection items.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return $this
+     */
+    public function __call($method, $parameters)
+    {
+        $this->calledMethods[] = ['name' => $method, 'parameters' => $parameters];
+
+        return $this;
+    }
+
+    /**
+     * @param \Closure[] $handlers
+     *
+     * @return \Illuminate\Collections\Enumerable
+     */
+    public function catch(...$handlers)
+    {
+        $originalCollection = $this->collection;
+
+        try {
+            foreach ($this->calledMethods as $calledMethod) {
+                $this->collection = $this->collection->{$calledMethod['name']}(...$calledMethod['parameters']);
+            }
+        } catch (\Throwable $exception) {
+            foreach ($handlers as $callable) {
+                $type = $this->exceptionType($callable);
+                if ($exception instanceof $type) {
+                    return $callable($exception, $originalCollection) ?? $originalCollection;
+                }
+            }
+
+            throw $exception;
+        }
+
+        return $this->collection;
+    }
+
+    private function exceptionType($callable)
+    {
+        $reflection = new \ReflectionFunction($callable);
+
+        if (empty($reflection->getParameters())) {
+            return \Throwable::class;
+        }
+
+        return optional($reflection->getParameters()[0]->getType())->getName() ?? \Throwable::class;
+    }
+}

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1376,4 +1376,14 @@ class Collection implements ArrayAccess, Enumerable
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Wrap the following collection methods to be catchable.
+     *
+     * @return CatchableCollectionProxy
+     */
+    public function try()
+    {
+        return new CatchableCollectionProxy($this);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4279,6 +4279,148 @@ class SupportCollectionTest extends TestCase
         ], $data->all());
     }
 
+    public function testCatchableCollection()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                return strtoupper($letter);
+            })
+            ->catch(function (Exception $exception) {
+                $this->fail('caught unexpected exception: '.$exception->getMessage());
+            });
+
+        $this->assertEquals(['A', 'B', 'C', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionHandlesException()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                throw new Exception('a catchable collection exception');
+            })
+            ->catch(function (Exception $exception) {
+                $this->assertEquals('a catchable collection exception', $exception->getMessage());
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionHandlesCorrectException()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->each(function () {
+                throw new InvalidArgumentException('an exception thrown by each');
+            })
+            ->catch(function (InvalidArgumentException $exception) {
+                $this->assertEquals('an exception thrown by each', $exception->getMessage());
+            }, function (\UnexpectedValueException $exception) {
+                $this->fail('the incorrect exception was caught');
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionRethrowsUnhandledException()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('rethrow me');
+
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                throw new Exception('rethrow me');
+            })
+            ->catch(function (InvalidArgumentException $exception) {
+                $this->fail('the incorrect exception was caught');
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionDefaultsToCatchAll()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                throw new Exception('catch me with no type-hint');
+            })
+            ->catch(function ($exception) {
+                $this->assertEquals('catch me with no type-hint', $exception->getMessage());
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionDoesNotRequireParameters()
+    {
+        $caught = false;
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                throw new Exception('catch me with no parameters to catch');
+            })
+            ->catch(function () use (&$caught) {
+                $caught = true;
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+        $this->assertTrue($caught);
+    }
+
+    public function testCatchableCollectionAllowsHandlerToReceiveOriginalCollection()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                return strtoupper($letter);
+            })
+            ->each(function ($letter) {
+                throw new Exception('catch me');
+            })
+            ->catch(function (Exception $exception, $collection) {
+                $this->assertEquals('catch me', $exception->getMessage());
+                $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+            });
+
+        $this->assertEquals(['a', 'b', 'c', 1, 2, 3], $collection->toArray());
+    }
+
+    public function testCatchableCollectionAllowsHandlerToReturnCollection()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($letter) {
+                throw new Exception('catch me');
+            })
+            ->catch(function (Exception $exception, $collection) {
+                $this->assertEquals('catch me', $exception->getMessage());
+
+                return collect(['d', 'e', 'f']);
+            });
+
+        $this->assertEquals(['d', 'e', 'f'], $collection->toArray());
+    }
+
+    public function testCatchableCollectionContinuesWithOriginalCollectionAfterException()
+    {
+        $collection = collect(['a', 'b', 'c', 1, 2, 3])
+            ->try()
+            ->map(function ($item) {
+                throw new Exception('carry on');
+            })
+            ->catch(function (Exception $exception) {
+                $this->assertEquals('carry on', $exception->getMessage());
+            })
+            ->filter(function ($item) {
+                return is_int($item);
+            });
+
+        $this->assertEquals([3 => 1, 2, 3], $collection->toArray());
+    }
+
     /**
      * Provides each collection class, respectively.
      *


### PR DESCRIPTION
This adds some syntax symmetry for using `try`/`catch` directly within collection chains.

**Before**
```php
try {
    collect(preg_split('/\R/', $this->input('repositories')))
        ->mapInto(SCS::class);
} catch (\InvalidArgumentException $exception) {
    Log::debug('The repositories format is invalid.');
}
```

**After**
```php
collect(preg_split('/\R/', $this->input('repositories')))
    ->try()
    ->mapInto(SCS::class)
    ->catch(function (\InvalidArgumentException $exception) {
        Log::debug('The repositories format is invalid.');
    });
```

While the methods are named `try`/`catch` for familiarity with PHP, the collection itself behaves more like a database transaction. So when an exception is thrown, the _original_ collection (before the `try`) is returned.

You may gain access to the collection within `catch` by adding a second parameter to your _handler_. You may also manipulate the collection within `catch` by returning a value.

For example:
```php
$collection = collect(['a', 'b', 'c', 1, 2, 3])
    ->try()
    ->map(function ($item) {
        throw new Exception();
    })
    ->catch(function (Exception $exception, $collection) {
        return collect(['d', 'e', 'f']);
    })
    ->map(function ($item) {
        return strtoupper($item);
    });

// ['D', 'E', 'F']
```

---
Co-authored by: @freekmurze