### PR TITLE
[7.x] Remove `else` when we have early return

### DIFF
--- a/src/Illuminate/Auth/Middleware/Authorize.php
+++ b/src/Illuminate/Auth/Middleware/Authorize.php
@@ -74,10 +74,10 @@ class Authorize
     {
         if ($this->isClassName($model)) {
             return trim($model);
-        } else {
-            return $request->route($model, null) ?:
-                ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
         }
+
+        return $request->route($model, null) ?:
+            ((preg_match("/^['\"](.*)['\"]$/", trim($model), $matches)) ? $matches[1] : null);
     }
 
     /**

--- a/src/Illuminate/Cache/RedisLock.php
+++ b/src/Illuminate/Cache/RedisLock.php
@@ -36,9 +36,9 @@ class RedisLock extends Lock
     {
         if ($this->seconds > 0) {
             return $this->redis->set($this->name, $this->owner, 'EX', $this->seconds, 'NX') == true;
-        } else {
-            return $this->redis->setnx($this->name, $this->owner) === 1;
         }
+
+        return $this->redis->setnx($this->name, $this->owner) === 1;
     }
 
     /**

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -49,9 +49,9 @@ class SqlServerConnector extends Connector implements ConnectorInterface
 
         if (in_array('sqlsrv', $this->getAvailableDrivers())) {
             return $this->getSqlSrvDsn($config);
-        } else {
-            return $this->getDblibDsn($config);
         }
+
+        return $this->getDblibDsn($config);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1584,9 +1584,9 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         if ($relationship instanceof HasManyThrough ||
             $relationship instanceof BelongsToMany) {
             return $relationship->where($relationship->getRelated()->getTable().'.'.$field, $value)->first();
-        } else {
-            return $relationship->where($field, $value)->first();
         }
+
+        return $relationship->where($field, $value)->first();
     }
 
     /**

--- a/src/Illuminate/Foundation/Console/TestMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/TestMakeCommand.php
@@ -76,9 +76,9 @@ class TestMakeCommand extends GeneratorCommand
     {
         if ($this->option('unit')) {
             return $rootNamespace.'\Unit';
-        } else {
-            return $rootNamespace.'\Feature';
         }
+
+        return $rootNamespace.'\Feature';
     }
 
     /**

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -63,12 +63,12 @@ class EventServiceProvider extends ServiceProvider
             $cache = require $this->app->getCachedEventsPath();
 
             return $cache[get_class($this)] ?? [];
-        } else {
-            return array_merge_recursive(
-                $this->discoveredEvents(),
-                $this->listens()
-            );
         }
+
+        return array_merge_recursive(
+            $this->discoveredEvents(),
+            $this->listens()
+        );
     }
 
     /**

--- a/src/Illuminate/Routing/RouteGroup.php
+++ b/src/Illuminate/Routing/RouteGroup.php
@@ -63,9 +63,9 @@ class RouteGroup
 
         if ($prependExistingPrefix) {
             return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
-        } else {
-            return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
         }
+
+        return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -476,9 +476,9 @@ class UrlGenerator implements UrlGeneratorContract
 
         if ($this->rootNamespace && strpos($action, '\\') !== 0) {
             return $this->rootNamespace.'\\'.$action;
-        } else {
-            return trim($action, '\\');
         }
+
+        return trim($action, '\\');
     }
 
     /**

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -58,9 +58,9 @@ class StartSession
         if ($this->manager->shouldBlock() ||
             ($request->route() && $request->route()->locksFor())) {
             return $this->handleRequestWhileBlocking($request, $session, $next);
-        } else {
-            return $this->handleStatefulRequest($request, $session, $next);
         }
+
+        return $this->handleStatefulRequest($request, $session, $next);
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -657,9 +657,9 @@ class Str
     {
         if (! is_null($length)) {
             return substr_count($haystack, $needle, $offset, $length);
-        } else {
-            return substr_count($haystack, $needle, $offset);
         }
+
+        return substr_count($haystack, $needle, $offset);
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -89,9 +89,9 @@ trait ManagesComponents
 
         if ($view instanceof View) {
             return $view->with($data)->render();
-        } else {
-            return $this->make($view, $data)->render();
         }
+
+        return $this->make($view, $data)->render();
     }
 
     /**


### PR DESCRIPTION
This PR moves content of `else` outside the condition and removes `else` when we have early returns. Supposedly, it makes the code look cleaner 🙂 

Cheers!