### PR TITLE
[7.x] Fix misleading docblocks in `EnumeratesValues` trait

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -523,7 +523,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is not null.
+     * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
      * @return static
@@ -534,7 +534,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is null.
+     * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
      * @return static


### PR DESCRIPTION
The docblocks for `whereNull` and `whereNotNull` seem to have been swapped. This PR fixes that.

Cheers!