### PR TITLE
[8.x] Fix misleading docblocks in `EnumeratesValues` trait

### DIFF
--- a/src/Illuminate/Collections/EnumeratesValues.php
+++ b/src/Illuminate/Collections/EnumeratesValues.php
@@ -518,7 +518,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is not null.
+     * Filter items where the value for the given key is null.
      *
      * @param  string|null  $key
      * @return static
@@ -529,7 +529,7 @@ trait EnumeratesValues
     }
 
     /**
-     * Filter items where the given key is null.
+     * Filter items where the value for the given key is not null.
      *
      * @param  string|null  $key
      * @return static


### PR DESCRIPTION
The docblocks for `whereNull` and `whereNotNull` seem to have been swapped. This PR fixes that.

Redirected to submit to `master` in https://github.com/laravel/framework/pull/33110

Cheers!