### PR TITLE
Filter a collection searching for a value in an field that is an array

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -574,6 +574,21 @@ trait EnumeratesValues
     }
 
     /**
+     * Filter items searching for a value in an property that is an array.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @param  bool  $strict
+     * @return static
+     */
+    public function whereIncludes($key, $value, $strict = false)
+    {
+        return $this->filter(function ($item) use ($key, $value, $strict) {
+            return in_array($value, data_get($item, $key), $strict);
+        });
+    }
+
+    /**
      * Filter items by the given key value pair using strict comparison.
      *
      * @param  string  $key

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -705,6 +705,15 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testWhereIncludes($collection)
+    {
+        $c = new $collection([['id' => 1, 'tags' => ['a', 'b']], ['id' => 2, 'tags' => ['b', 'c']], ['id' => 3, 'tags' => ['c', 'd']], ['id' => '3', 'tags' => ['d', 'e']], ['id' => 4, 'tags' => ['e', 'f']]]);
+        $this->assertEquals([['id' => 2, 'tags' => ['b', 'c']], ['id' => 3, 'tags' => ['c', 'd']]], $c->whereIncludes('tags', 'c')->values()->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testWhereInStrict($collection)
     {
         $c = new $collection([['v' => 1], ['v' => 2], ['v' => 3], ['v' => '3'], ['v' => 4]]);


### PR DESCRIPTION
Add the ability to filter a collection searching for a value in an field that is an array, the inverse of `->whereIn()`

This new method is a short way to filter the collection to only the items that has that value in one of the elements in the array, the inverse comparison than whereIn()
For example, if the property in a collection is an array, like ["tag1", "tag2", "tag3"], be able to:

`$collection->whereIncludes('tags', 'tag2');`