### PR TITLE
[7.x] Fix Overriding and extending a view causes loop

### DIFF
--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -126,9 +126,12 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function findInPaths($name, $paths)
     {
+        $name = ltrim($name, static::HINT_PATH_FORCE_VENDOR);
+
         foreach ((array) $paths as $path) {
             foreach ($this->getPossibleViewFiles($name) as $file) {
-                if ($this->files->exists($viewPath = $path.'/'.$file)) {
+                // Check if last resolved view is the same to avoid loop
+                if ($this->files->exists($viewPath = $path.'/'.$file) && end($this->views) != $viewPath) {
                     return $viewPath;
                 }
             }

--- a/src/Illuminate/View/ViewFinderInterface.php
+++ b/src/Illuminate/View/ViewFinderInterface.php
@@ -12,6 +12,13 @@ interface ViewFinderInterface
     const HINT_PATH_DELIMITER = '::';
 
     /**
+     * Hint path force vendor.
+     *
+     * @var string
+     */
+    const HINT_PATH_FORCE_VENDOR = ':';
+
+    /**
      * Get the fully qualified location of the view.
      *
      * @param  string  $view


### PR DESCRIPTION
It's not currently possibile to override and at the same time `@extend` a view because it will cause a loop.
More details about the bug and benefits of fixing it can be found in bug report #33122

I didn't find a way to check which view is calling to avoid loop because resolving is cached, but we can use another syntax like: `@extends('package:::template')` (three colons).

This is the explanation how this PR works:
- Somewhere `package::template` is called and it resolves in the overriding file
- Inside overriding file `package:::template` is called, it checks last resolved template and if it's the same skips it to avoid loop.
- After the local overriding view is skipped the original package view is found and cached with a different key for reuse `package:::template`

I didn't find where the overriding behaviour is tested to add the new test, I would also need some help with documentation.

**Some considerations:**
- `$name` is altered with `ltrim` but as long as we use a prefix that can't be used for naming templates it's not a problem.
- `end()` moves the internal pointer but `$this->views` is always referred with a key so I don't see any problem.
- This PR will not solve the problem if the overriding template is called directly or new syntax is used outside `resources/vendor`, but there is no reason someone should use the new syntax if not to avoid loop.

Fixes #33122

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
