### PR TITLE
[8.x] Replace file_exists with is_file in hot code

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -475,7 +475,7 @@ class Event
      */
     protected function emailOutput(Mailer $mailer, $addresses, $onlyIfOutputExists = false)
     {
-        $text = file_exists($this->output) ? file_get_contents($this->output) : '';
+        $text = is_file($this->output) ? file_get_contents($this->output) : '';
 
         if ($onlyIfOutputExists && empty($text)) {
             return;
@@ -833,7 +833,7 @@ class Event
     protected function withOutputCallback(Closure $callback, $onlyIfOutputExists = false)
     {
         return function (Container $container) use ($callback, $onlyIfOutputExists) {
-            $output = $this->output && file_exists($this->output) ? file_get_contents($this->output) : '';
+            $output = $this->output && is_file($this->output) ? file_get_contents($this->output) : '';
 
             return $onlyIfOutputExists && empty($output)
                             ? null

--- a/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/MigrateCommand.php
@@ -129,7 +129,7 @@ class MigrateCommand extends BaseCommand
         // continue with the standard migration operation as normal without errors.
         if ($connection instanceof SQLiteConnection ||
             $connection instanceof SqlServerConnection ||
-            ! file_exists($path = $this->schemaPath($connection))) {
+            ! is_file($path = $this->schemaPath($connection))) {
             return;
         }
 

--- a/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
+++ b/src/Illuminate/Database/Console/Seeds/SeederMakeCommand.php
@@ -55,7 +55,7 @@ class SeederMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+        return is_file($customPath = $this->laravel->basePath(trim($stub, '/')))
             ? $customPath
             : __DIR__.$stub;
     }

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -100,7 +100,7 @@ class AliasLoader
      */
     protected function ensureFacadeExists($alias)
     {
-        if (file_exists($path = storage_path('framework/cache/facade-'.sha1($alias).'.php'))) {
+        if (is_file($path = storage_path('framework/cache/facade-'.sha1($alias).'.php'))) {
             return $path;
         }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -957,7 +957,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function configurationIsCached()
     {
-        return file_exists($this->getCachedConfigPath());
+        return is_file($this->getCachedConfigPath());
     }
 
     /**
@@ -1048,7 +1048,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isDownForMaintenance()
     {
-        return file_exists($this->storagePath().'/framework/down');
+        return is_file($this->storagePath().'/framework/down');
     }
 
     /**

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -24,7 +24,7 @@ class LoadConfiguration
         // First we will see if we have a cache configuration file. If we do, we'll load
         // the configuration items from that file so that it is very quick. Otherwise
         // we will need to spin through every configuration file and load them all.
-        if (file_exists($cached = $app->getCachedConfigPath())) {
+        if (is_file($cached = $app->getCachedConfigPath())) {
             $items = require $cached;
 
             $loadedFromCache = true;

--- a/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -68,7 +68,7 @@ class LoadEnvironmentVariables
      */
     protected function setEnvironmentFilePath($app, $file)
     {
-        if (file_exists($app->environmentPath().'/'.$file)) {
+        if (is_file($app->environmentPath().'/'.$file)) {
             $app->loadEnvironmentFrom($file);
 
             return true;

--- a/src/Illuminate/Foundation/ComposerScripts.php
+++ b/src/Illuminate/Foundation/ComposerScripts.php
@@ -54,11 +54,11 @@ class ComposerScripts
     {
         $laravel = new Application(getcwd());
 
-        if (file_exists($servicesPath = $laravel->getCachedServicesPath())) {
+        if (is_file($servicesPath = $laravel->getCachedServicesPath())) {
             @unlink($servicesPath);
         }
 
-        if (file_exists($packagesPath = $laravel->getCachedPackagesPath())) {
+        if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
         }
     }

--- a/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
+++ b/src/Illuminate/Foundation/Console/ClearCompiledCommand.php
@@ -27,11 +27,11 @@ class ClearCompiledCommand extends Command
      */
     public function handle()
     {
-        if (file_exists($servicesPath = $this->laravel->getCachedServicesPath())) {
+        if (is_file($servicesPath = $this->laravel->getCachedServicesPath())) {
             @unlink($servicesPath);
         }
 
-        if (file_exists($packagesPath = $this->laravel->getCachedPackagesPath())) {
+        if (is_file($packagesPath = $this->laravel->getCachedPackagesPath())) {
             @unlink($packagesPath);
         }
 

--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -34,7 +34,7 @@ class DownCommand extends Command
     public function handle()
     {
         try {
-            if (file_exists(storage_path('framework/down'))) {
+            if (is_file(storage_path('framework/down'))) {
                 $this->comment('Application is already down.');
 
                 return 0;

--- a/src/Illuminate/Foundation/Console/UpCommand.php
+++ b/src/Illuminate/Foundation/Console/UpCommand.php
@@ -29,7 +29,7 @@ class UpCommand extends Command
     public function handle()
     {
         try {
-            if (! file_exists(storage_path('framework/down'))) {
+            if (! is_file(storage_path('framework/down'))) {
                 $this->comment('Application is already up.');
 
                 return 0;

--- a/src/Illuminate/Foundation/Mix.php
+++ b/src/Illuminate/Foundation/Mix.php
@@ -29,7 +29,7 @@ class Mix
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(public_path($manifestDirectory.'/hot'))) {
+        if (is_file(public_path($manifestDirectory.'/hot'))) {
             $url = rtrim(file_get_contents(public_path($manifestDirectory.'/hot')));
 
             if (Str::startsWith($url, ['http://', 'https://'])) {
@@ -42,7 +42,7 @@ class Mix
         $manifestPath = public_path($manifestDirectory.'/mix-manifest.json');
 
         if (! isset($manifests[$manifestPath])) {
-            if (! file_exists($manifestPath)) {
+            if (! is_file($manifestPath)) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -102,11 +102,11 @@ class PackageManifest
             return $this->manifest;
         }
 
-        if (! file_exists($this->manifestPath)) {
+        if (! is_file($this->manifestPath)) {
             $this->build();
         }
 
-        return $this->manifest = file_exists($this->manifestPath) ?
+        return $this->manifest = is_file($this->manifestPath) ?
             $this->files->getRequire($this->manifestPath) : [];
     }
 
@@ -154,7 +154,7 @@ class PackageManifest
      */
     protected function packagesToIgnore()
     {
-        if (! file_exists($this->basePath.'/composer.json')) {
+        if (! is_file($this->basePath.'/composer.json')) {
             return [];
         }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -94,7 +94,7 @@ abstract class Component
             $directory = Container::getInstance()['config']->get('view.compiled')
         );
 
-        if (! file_exists($viewFile = $directory.'/'.sha1($contents).'.blade.php')) {
+        if (! is_file($viewFile = $directory.'/'.sha1($contents).'.blade.php')) {
             if (! is_dir($directory)) {
                 mkdir($directory, 0755, true);
             }


### PR DESCRIPTION
Symfony did this a few months ago, and no issues were reported. For Laravel, I've not just blanket changed things, but I've changed cases that will actually make a real difference to apps (for example, I've left all the generator commands alone).