### PR TITLE
Code optimization: Make methods static

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -543,7 +543,7 @@ class Gate implements GateContract
             return $this->abilities[$ability];
         }
 
-        return function () {
+        return static function () {
             //
         };
     }
@@ -726,7 +726,7 @@ class Gate implements GateContract
      */
     public function forUser($user)
     {
-        $callback = function () use ($user) {
+        $callback = static function () use ($user) {
             return $user;
         };
 

--- a/src/Illuminate/Auth/AuthServiceProvider.php
+++ b/src/Illuminate/Auth/AuthServiceProvider.php
@@ -34,7 +34,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAuthenticator()
     {
-        $this->app->singleton('auth', function ($app) {
+        $this->app->singleton('auth', static function ($app) {
             // Once the authentication service has actually been requested by the developer
             // we will set a variable in the application indicating such. This helps us
             // know that we need to set any queued cookies in the after event later.
@@ -43,7 +43,7 @@ class AuthServiceProvider extends ServiceProvider
             return new AuthManager($app);
         });
 
-        $this->app->singleton('auth.driver', function ($app) {
+        $this->app->singleton('auth.driver', static function ($app) {
             return $app['auth']->guard();
         });
     }
@@ -56,7 +56,7 @@ class AuthServiceProvider extends ServiceProvider
     protected function registerUserResolver()
     {
         $this->app->bind(
-            AuthenticatableContract::class, function ($app) {
+            AuthenticatableContract::class, static function ($app) {
                 return call_user_func($app['auth']->userResolver());
             }
         );
@@ -69,8 +69,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerAccessGate()
     {
-        $this->app->singleton(GateContract::class, function ($app) {
-            return new Gate($app, function () use ($app) {
+        $this->app->singleton(GateContract::class, static function ($app) {
+            return new Gate($app, static function () use ($app) {
                 return call_user_func($app['auth']->userResolver());
             });
         });
@@ -84,7 +84,7 @@ class AuthServiceProvider extends ServiceProvider
     protected function registerRequirePassword()
     {
         $this->app->bind(
-            RequirePassword::class, function ($app) {
+            RequirePassword::class, static function ($app) {
                 return new RequirePassword(
                     $app[ResponseFactory::class],
                     $app[UrlGenerator::class],
@@ -101,8 +101,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerRequestRebindHandler()
     {
-        $this->app->rebinding('request', function ($app, $request) {
-            $request->setUserResolver(function ($guard = null) use ($app) {
+        $this->app->rebinding('request', static function ($app, $request) {
+            $request->setUserResolver(static function ($guard = null) use ($app) {
                 return call_user_func($app['auth']->userResolver(), $guard);
             });
         });
@@ -115,7 +115,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected function registerEventRebindHandler()
     {
-        $this->app->rebinding('events', function ($app, $dispatcher) {
+        $this->app->rebinding('events', static function ($app, $dispatcher) {
             if (! $app->resolved('auth')) {
                 return;
             }

--- a/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
+++ b/src/Illuminate/Auth/Passwords/PasswordResetServiceProvider.php
@@ -24,11 +24,11 @@ class PasswordResetServiceProvider extends ServiceProvider implements Deferrable
      */
     protected function registerPasswordBroker()
     {
-        $this->app->singleton('auth.password', function ($app) {
+        $this->app->singleton('auth.password', static function ($app) {
             return new PasswordBrokerManager($app);
         });
 
-        $this->app->bind('auth.password.broker', function ($app) {
+        $this->app->bind('auth.password.broker', static function ($app) {
             return $app->make('auth.password')->broker();
         });
     }

--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -66,7 +66,7 @@ class BroadcastManager implements FactoryContract
 
         $attributes = $attributes ?: ['middleware' => ['web']];
 
-        $this->app['router']->group($attributes, function ($router) {
+        $this->app['router']->group($attributes, static function ($router) {
             $router->match(
                 ['get', 'post'], '/broadcasting/auth',
                 '\\'.BroadcastController::class.'@authenticate'

--- a/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
+++ b/src/Illuminate/Broadcasting/BroadcastServiceProvider.php
@@ -16,11 +16,11 @@ class BroadcastServiceProvider extends ServiceProvider implements DeferrableProv
      */
     public function register()
     {
-        $this->app->singleton(BroadcastManager::class, function ($app) {
+        $this->app->singleton(BroadcastManager::class, static function ($app) {
             return new BroadcastManager($app);
         });
 
-        $this->app->singleton(BroadcasterContract::class, function ($app) {
+        $this->app->singleton(BroadcasterContract::class, static function ($app) {
             return $app->make(BroadcastManager::class)->connection();
         });
 

--- a/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/Broadcaster.php
@@ -94,7 +94,7 @@ abstract class Broadcaster implements BroadcasterContract
     {
         $callbackParameters = $this->extractParameters($callback);
 
-        return collect($this->extractChannelKeys($pattern, $channel))->reject(function ($value, $key) {
+        return collect($this->extractChannelKeys($pattern, $channel))->reject(static function ($value, $key) {
             return is_numeric($key);
         })->map(function ($value, $key) use ($callbackParameters) {
             return $this->resolveBinding($key, $value, $callbackParameters);
@@ -238,7 +238,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function formatChannels(array $channels)
     {
-        return array_map(function ($channel) {
+        return array_map(static function ($channel) {
             return (string) $channel;
         }, $channels);
     }
@@ -266,7 +266,7 @@ abstract class Broadcaster implements BroadcasterContract
      */
     protected function normalizeChannelHandlerToCallable($callback)
     {
-        return is_callable($callback) ? $callback : function (...$args) use ($callback) {
+        return is_callable($callback) ? $callback : static function (...$args) use ($callback) {
             return Container::getInstance()
                 ->make($callback)
                 ->join(...$args);

--- a/src/Illuminate/Bus/BusServiceProvider.php
+++ b/src/Illuminate/Bus/BusServiceProvider.php
@@ -17,8 +17,8 @@ class BusServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton(Dispatcher::class, function ($app) {
-            return new Dispatcher($app, function ($connection = null) use ($app) {
+        $this->app->singleton(Dispatcher::class, static function ($app) {
+            return new Dispatcher($app, static function ($connection = null) use ($app) {
                 return $app[QueueFactoryContract::class]->connection($connection);
             });
         });

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -86,7 +86,7 @@ class Dispatcher implements QueueingDispatcher
     public function dispatchNow($command, $handler = null)
     {
         if ($handler || $handler = $this->getCommandHandler($command)) {
-            $callback = function ($command) use ($handler) {
+            $callback = static function ($command) use ($handler) {
                 return $handler->handle($command);
             };
         } else {

--- a/src/Illuminate/Cache/CacheServiceProvider.php
+++ b/src/Illuminate/Cache/CacheServiceProvider.php
@@ -15,19 +15,19 @@ class CacheServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('cache', function ($app) {
+        $this->app->singleton('cache', static function ($app) {
             return new CacheManager($app);
         });
 
-        $this->app->singleton('cache.store', function ($app) {
+        $this->app->singleton('cache.store', static function ($app) {
             return $app['cache']->driver();
         });
 
-        $this->app->singleton('cache.psr6', function ($app) {
+        $this->app->singleton('cache.psr6', static function ($app) {
             return new Psr16Adapter($app['cache.store']);
         });
 
-        $this->app->singleton('memcached.connector', function () {
+        $this->app->singleton('memcached.connector', static function () {
             return new MemcachedConnector;
         });
     }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -167,7 +167,7 @@ class DatabaseStore implements Store
      */
     public function increment($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current + $value;
         });
     }
@@ -181,7 +181,7 @@ class DatabaseStore implements Store
      */
     public function decrement($key, $value = 1)
     {
-        return $this->incrementOrDecrement($key, $value, function ($current, $value) {
+        return $this->incrementOrDecrement($key, $value, static function ($current, $value) {
             return $current - $value;
         });
     }

--- a/src/Illuminate/Cache/DynamoDbStore.php
+++ b/src/Illuminate/Cache/DynamoDbStore.php
@@ -150,7 +150,7 @@ class DynamoDbStore implements LockProvider, Store
 
         $now = Carbon::now();
 
-        return array_merge(collect(array_flip($keys))->map(function () {
+        return array_merge(collect(array_flip($keys))->map(static function () {
             //
         })->all(), collect($response['Responses'][$this->table])->mapWithKeys(function ($response) use ($now) {
             if ($this->isExpired($response, $now)) {

--- a/src/Illuminate/Cache/Repository.php
+++ b/src/Illuminate/Cache/Repository.php
@@ -120,7 +120,7 @@ class Repository implements ArrayAccess, CacheContract
      */
     public function many(array $keys)
     {
-        $values = $this->store->many(collect($keys)->map(function ($value, $key) {
+        $values = $this->store->many(collect($keys)->map(static function ($value, $key) {
             return is_string($key) ? $key : $value;
         })->values()->all());
 

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -65,7 +65,7 @@ trait CallsCommands
      */
     protected function createInputFromArguments(array $arguments)
     {
-        return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
+        return tap(new ArrayInput(array_merge($this->context(), $arguments)), static function ($input) {
             if ($input->hasParameterOption(['--no-interaction'], true)) {
                 $input->setInteractive(false);
             }
@@ -85,7 +85,7 @@ trait CallsCommands
             'no-interaction',
             'quiet',
             'verbose',
-        ])->filter()->mapWithKeys(function ($value, $key) {
+        ])->filter()->mapWithKeys(static function ($value, $key) {
             return ["--{$key}" => $value];
         })->all();
     }

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -575,7 +575,7 @@ class Event
      */
     protected function pingCallback($url)
     {
-        return function (Container $container, HttpClient $http) use ($url) {
+        return static function (Container $container, HttpClient $http) use ($url) {
             try {
                 $http->request('GET', $url);
             } catch (ClientExceptionInterface | TransferException $e) {
@@ -673,7 +673,7 @@ class Event
      */
     public function when($callback)
     {
-        $this->filters[] = is_callable($callback) ? $callback : function () use ($callback) {
+        $this->filters[] = is_callable($callback) ? $callback : static function () use ($callback) {
             return $callback;
         };
 
@@ -688,7 +688,7 @@ class Event
      */
     public function skip($callback)
     {
-        $this->rejects[] = is_callable($callback) ? $callback : function () use ($callback) {
+        $this->rejects[] = is_callable($callback) ? $callback : static function () use ($callback) {
             return $callback;
         };
 

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -66,7 +66,7 @@ trait ManagesFrequencies
             }
         }
 
-        return function () use ($now, $startTime, $endTime) {
+        return static function () use ($now, $startTime, $endTime) {
             return $now->between($startTime, $endTime);
         };
     }

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -220,16 +220,16 @@ class Schedule
      */
     public function compileArrayInput($key, $value)
     {
-        $value = collect($value)->map(function ($value) {
+        $value = collect($value)->map(static function ($value) {
             return ProcessUtils::escapeArgument($value);
         });
 
         if (Str::startsWith($key, '--')) {
-            $value = $value->map(function ($value) use ($key) {
+            $value = $value->map(static function ($value) use ($key) {
                 return "{$key}={$value}";
             });
         } elseif (Str::startsWith($key, '-')) {
-            $value = $value->map(function ($value) use ($key) {
+            $value = $value->map(static function ($value) use ($key) {
                 return "{$key} {$value}";
             });
         }

--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -28,7 +28,7 @@ class BoundMethod
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }
 
-        return static::callBoundMethod($container, $callback, function () use ($container, $callback, $parameters) {
+        return static::callBoundMethod($container, $callback, static function () use ($container, $callback, $parameters) {
             return call_user_func_array(
                 $callback, static::getMethodDependencies($container, $callback, $parameters)
             );

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -256,7 +256,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     protected function getClosure($abstract, $concrete)
     {
-        return function ($container, $parameters = []) use ($abstract, $concrete) {
+        return static function ($container, $parameters = []) use ($abstract, $concrete) {
             if ($abstract == $concrete) {
                 return $container->build($concrete);
             }
@@ -532,7 +532,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function refresh($abstract, $target, $method)
     {
-        return $this->rebinding($abstract, function ($app, $instance) use ($target, $method) {
+        return $this->rebinding($abstract, static function ($app, $instance) use ($target, $method) {
             $target->{$method}($instance);
         });
     }
@@ -1289,7 +1289,7 @@ class Container implements ArrayAccess, ContainerContract
      */
     public function offsetSet($key, $value)
     {
-        $this->bind($key, $value instanceof Closure ? $value : function () use ($value) {
+        $this->bind($key, $value instanceof Closure ? $value : static function () use ($value) {
             return $value;
         });
     }

--- a/src/Illuminate/Container/ContextualBindingBuilder.php
+++ b/src/Illuminate/Container/ContextualBindingBuilder.php
@@ -75,7 +75,7 @@ class ContextualBindingBuilder implements ContextualBindingBuilderContract
      */
     public function giveTagged($tag)
     {
-        $this->give(function ($container) use ($tag) {
+        $this->give(static function ($container) use ($tag) {
             $taggedServices = $container->tagged($tag);
 
             return is_array($taggedServices) ? $taggedServices : iterator_to_array($taggedServices);

--- a/src/Illuminate/Cookie/CookieServiceProvider.php
+++ b/src/Illuminate/Cookie/CookieServiceProvider.php
@@ -13,7 +13,7 @@ class CookieServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('cookie', function ($app) {
+        $this->app->singleton('cookie', static function ($app) {
             $config = $app->make('config')->get('session');
 
             return (new CookieJar)->setDefaultPathAndDomain(

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -57,7 +57,7 @@ trait BuildsQueries
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;
@@ -123,7 +123,7 @@ trait BuildsQueries
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results) use ($callback) {
+        return $this->chunkById($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -168,7 +168,7 @@ class SqlServerConnector extends Connector implements ConnectorInterface
      */
     protected function buildConnectString($driver, array $arguments)
     {
-        return $driver.':'.implode(';', array_map(function ($key) use ($arguments) {
+        return $driver.':'.implode(';', array_map(static function ($key) use ($arguments) {
             return sprintf('%s=%s', $key, $arguments[$key]);
         }, array_keys($arguments)));
     }

--- a/src/Illuminate/Database/DatabaseServiceProvider.php
+++ b/src/Illuminate/Database/DatabaseServiceProvider.php
@@ -58,18 +58,18 @@ class DatabaseServiceProvider extends ServiceProvider
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->singleton('db.factory', function ($app) {
+        $this->app->singleton('db.factory', static function ($app) {
             return new ConnectionFactory($app);
         });
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->singleton('db', function ($app) {
+        $this->app->singleton('db', static function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
 
-        $this->app->bind('db.connection', function ($app) {
+        $this->app->bind('db.connection', static function ($app) {
             return $app['db']->connection();
         });
     }
@@ -81,7 +81,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerEloquentFactory()
     {
-        $this->app->singleton(FakerGenerator::class, function ($app, $parameters) {
+        $this->app->singleton(FakerGenerator::class, static function ($app, $parameters) {
             $locale = $parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US');
 
             if (! isset(static::$fakers[$locale])) {
@@ -107,7 +107,7 @@ class DatabaseServiceProvider extends ServiceProvider
      */
     protected function registerQueueableEntityResolver()
     {
-        $this->app->singleton(EntityResolver::class, function () {
+        $this->app->singleton(EntityResolver::class, static function () {
             return new QueueEntityResolver;
         });
     }

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -310,7 +310,7 @@ class Builder
     {
         $instance = $this->newModelInstance();
 
-        return $instance->newCollection(array_map(function ($item) use ($instance) {
+        return $instance->newCollection(array_map(static function ($item) use ($instance) {
             return $instance->newFromBuilder($item);
         }, $items));
     }
@@ -436,7 +436,7 @@ class Builder
             return $instance;
         }
 
-        return tap($this->newModelInstance($attributes + $values), function ($instance) {
+        return tap($this->newModelInstance($attributes + $values), static function ($instance) {
             $instance->save();
         });
     }
@@ -450,7 +450,7 @@ class Builder
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
+        return tap($this->firstOrNew($attributes), static function ($instance) use ($values) {
             $instance->fill($values)->save();
         });
     }
@@ -763,7 +763,7 @@ class Builder
      */
     public function create(array $attributes = [])
     {
-        return tap($this->newModelInstance($attributes), function ($instance) {
+        return tap($this->newModelInstance($attributes), static function ($instance) {
             $instance->save();
         });
     }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -37,7 +37,7 @@ class Collection extends BaseCollection implements QueueableCollection
             return $this->whereIn($this->first()->getKeyName(), $key);
         }
 
-        return Arr::first($this->items, function ($model) use ($key) {
+        return Arr::first($this->items, static function ($model) use ($key) {
             return $model->getKey() == $key;
         }, $default);
     }
@@ -153,7 +153,7 @@ class Collection extends BaseCollection implements QueueableCollection
             $relation = reset($relation);
         }
 
-        $models->filter(function ($model) use ($name) {
+        $models->filter(static function ($model) use ($name) {
             return ! is_null($model) && ! $model->relationLoaded($name);
         })->load($relation);
 
@@ -181,10 +181,10 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(function ($model) {
+            ->groupBy(static function ($model) {
                 return get_class($model);
             })
-            ->each(function ($models, $className) use ($relations) {
+            ->each(static function ($models, $className) use ($relations) {
                 static::make($models)->load($relations[$className] ?? []);
             });
 
@@ -202,10 +202,10 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $this->pluck($relation)
             ->filter()
-            ->groupBy(function ($model) {
+            ->groupBy(static function ($model) {
                 return get_class($model);
             })
-            ->each(function ($models, $className) use ($relations) {
+            ->each(static function ($models, $className) use ($relations) {
                 static::make($models)->loadCount($relations[$className] ?? []);
             });
 
@@ -227,12 +227,12 @@ class Collection extends BaseCollection implements QueueableCollection
         }
 
         if ($key instanceof Model) {
-            return parent::contains(function ($model) use ($key) {
+            return parent::contains(static function ($model) use ($key) {
                 return $model->is($key);
             });
         }
 
-        return parent::contains(function ($model) use ($key) {
+        return parent::contains(static function ($model) use ($key) {
             return $model->getKey() == $key;
         });
     }
@@ -244,7 +244,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     public function modelKeys()
     {
-        return array_map(function ($model) {
+        return array_map(static function ($model) {
             return $model->getKey();
         }, $this->items);
     }
@@ -276,7 +276,7 @@ class Collection extends BaseCollection implements QueueableCollection
     {
         $result = parent::map($callback);
 
-        return $result->contains(function ($item) {
+        return $result->contains(static function ($item) {
             return ! $item instanceof Model;
         }) ? $result->toBase() : $result;
     }
@@ -301,7 +301,7 @@ class Collection extends BaseCollection implements QueueableCollection
             ->get()
             ->getDictionary();
 
-        return $this->map(function ($model) use ($freshModels) {
+        return $this->map(static function ($model) use ($freshModels) {
             return $model->exists && isset($freshModels[$model->getKey()])
                     ? $freshModels[$model->getKey()] : null;
         });
@@ -539,7 +539,7 @@ class Collection extends BaseCollection implements QueueableCollection
      */
     protected function duplicateComparator($strict)
     {
-        return function ($a, $b) {
+        return static function ($a, $b) {
             return $a->is($b);
         };
     }
@@ -559,7 +559,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $class = get_class($this->first());
 
-        $this->each(function ($model) use ($class) {
+        $this->each(static function ($model) use ($class) {
             if (get_class($model) !== $class) {
                 throw new LogicException('Queueing collections with multiple model types is not supported.');
             }
@@ -621,7 +621,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $connection = $this->first()->getConnectionName();
 
-        $this->each(function ($model) use ($connection) {
+        $this->each(static function ($model) use ($connection) {
             if ($model->getConnectionName() !== $connection) {
                 throw new LogicException('Queueing collections with multiple model connections is not supported.');
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -733,8 +733,7 @@ trait HasAttributes
         $caster = $this->resolveCasterClass($key);
 
         if (is_null($value)) {
-            $this->attributes = array_merge($this->attributes, array_map(
-                function () {
+            $this->attributes = array_merge($this->attributes, array_map(static function () {
                 },
                 $this->normalizeCastClassResponse($key, $caster->set(
                     $this, $key, $this->{$key}, $this->attributes
@@ -766,7 +765,7 @@ trait HasAttributes
      */
     protected function getArrayAttributeWithValue($path, $key, $value)
     {
-        return tap($this->getArrayAttributeByKey($key), function (&$array) use ($path, $value) {
+        return tap($this->getArrayAttributeByKey($key), static function (&$array) use ($path, $value) {
             Arr::set($array, str_replace('->', '.', $path), $value);
         });
     }
@@ -1492,7 +1491,7 @@ trait HasAttributes
      */
     public static function cacheMutatedAttributes($class)
     {
-        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))->map(function ($match) {
+        static::$mutatorCache[$class] = collect(static::getMutatorMethods($class))->map(static function ($match) {
             return lcfirst(static::$snakeAttributes ? Str::snake($match) : $match);
         })->all();
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -218,7 +218,7 @@ trait HasEvents
     protected function filterModelEventResults($result)
     {
         if (is_array($result)) {
-            $result = array_filter($result, function ($response) {
+            $result = array_filter($result, static function ($response) {
                 return ! is_null($response);
             });
         }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -628,7 +628,7 @@ trait HasRelationships
      */
     protected function guessBelongsToManyRelation()
     {
-        $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($trace) {
+        $caller = Arr::first(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), static function ($trace) {
             return ! in_array(
                 $trace['function'],
                 array_merge(static::$manyMethods, ['guessBelongsToManyRelation'])

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -85,7 +85,7 @@ trait QueriesRelationships
             $count = 1;
         }
 
-        $closure = function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
+        $closure = static function ($q) use (&$closure, &$relations, $operator, $count, $callback) {
             // In order to nest "has", we need to add count relation constraints on the
             // callback Closure. We'll do this by simply passing the Closure its own
             // reference to itself so it calls itself recursively on each segment.
@@ -217,7 +217,7 @@ trait QueriesRelationships
                     $belongsTo = $this->getBelongsToRelation($relation, $type);
 
                     if ($callback) {
-                        $callback = function ($query) use ($callback, $type) {
+                        $callback = static function ($query) use ($callback, $type) {
                             return $callback($query, $type);
                         };
                     }

--- a/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
+++ b/src/Illuminate/Database/Eloquent/HigherOrderBuilderProxy.php
@@ -43,7 +43,7 @@ class HigherOrderBuilderProxy
      */
     public function __call($method, $parameters)
     {
-        return $this->builder->{$this->method}(function ($value) use ($method, $parameters) {
+        return $this->builder->{$this->method}(static function ($value) use ($method, $parameters) {
             return $value->{$method}(...$parameters);
         });
     }

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1236,7 +1236,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             static::newQueryWithoutScopes()->findOrFail($this->getKey())->attributes
         );
 
-        $this->load(collect($this->relations)->reject(function ($relation) {
+        $this->load(collect($this->relations)->reject(static function ($relation) {
             return $relation instanceof Pivot
                 || (is_object($relation) && in_array(AsPivot::class, class_uses_recursive($relation), true));
         })->keys()->all());

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -903,7 +903,7 @@ class BelongsToMany extends Relation
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -293,7 +293,7 @@ trait AsPivot
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
                 return $query->where($segments[0], $segments[1])
                     ->where($segments[2], $segments[3]);
             });

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -131,7 +131,7 @@ trait InteractsWithPivotTable
      */
     protected function formatRecordsList(array $records)
     {
-        return collect($records)->mapWithKeys(function ($attributes, $id) {
+        return collect($records)->mapWithKeys(static function ($attributes, $id) {
             if (! is_array($attributes)) {
                 [$id, $attributes] = [$attributes, []];
             }

--- a/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasManyThrough.php
@@ -499,7 +499,7 @@ class HasManyThrough extends Relation
      */
     public function each(callable $callback, $count = 1000)
     {
-        return $this->chunk($count, function ($results) use ($callback) {
+        return $this->chunk($count, static function ($results) use ($callback) {
             foreach ($results as $key => $value) {
                 if ($callback($value, $key) === false) {
                     return false;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -183,7 +183,7 @@ abstract class HasOneOrMany extends Relation
     {
         $foreign = $this->getForeignKeyName();
 
-        return $results->mapToDictionary(function ($result) use ($foreign) {
+        return $results->mapToDictionary(static function ($result) use ($foreign) {
             return [$result->{$foreign} => $result];
         })->all();
     }
@@ -249,7 +249,7 @@ abstract class HasOneOrMany extends Relation
      */
     public function updateOrCreate(array $attributes, array $values = [])
     {
-        return tap($this->firstOrNew($attributes), function ($instance) use ($values) {
+        return tap($this->firstOrNew($attributes), static function ($instance) use ($values) {
             $instance->fill($values);
 
             $instance->save();

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -148,7 +148,7 @@ class MorphPivot extends Pivot
         foreach ($ids as $id) {
             $segments = explode(':', $id);
 
-            $query->orWhere(function ($query) use ($segments) {
+            $query->orWhere(static function ($query) use ($segments) {
                 return $query->where($segments[0], $segments[1])
                              ->where($segments[2], $segments[3])
                              ->where($segments[4], $segments[5]);

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -222,7 +222,7 @@ abstract class Relation
      */
     protected function getKeys(array $models, $key = null)
     {
-        return collect($models)->map(function ($value) use ($key) {
+        return collect($models)->map(static function ($value) use ($key) {
             return $key ? $value->getAttribute($key) : $value->getKey();
         })->values()->unique(null, true)->sort()->all();
     }
@@ -353,7 +353,7 @@ abstract class Relation
             return $models;
         }
 
-        return array_combine(array_map(function ($model) {
+        return array_combine(array_map(static function ($model) {
             return (new $model)->getTable();
         }, $models), $models);
     }

--- a/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
+++ b/src/Illuminate/Database/Eloquent/SoftDeletingScope.php
@@ -67,7 +67,7 @@ class SoftDeletingScope implements Scope
      */
     protected function addRestore(Builder $builder)
     {
-        $builder->macro('restore', function (Builder $builder) {
+        $builder->macro('restore', static function (Builder $builder) {
             $builder->withTrashed();
 
             return $builder->update([$builder->getModel()->getDeletedAtColumn() => null]);

--- a/src/Illuminate/Database/MigrationServiceProvider.php
+++ b/src/Illuminate/Database/MigrationServiceProvider.php
@@ -57,7 +57,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerRepository()
     {
-        $this->app->singleton('migration.repository', function ($app) {
+        $this->app->singleton('migration.repository', static function ($app) {
             $table = $app['config']['database.migrations'];
 
             return new DatabaseMigrationRepository($app['db'], $table);
@@ -74,7 +74,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
         // The migrator is responsible for actually running and rollback the migration
         // files in the application. We'll pass in our database connection resolver
         // so the migrator can resolve any of these connections when it needs to.
-        $this->app->singleton('migrator', function ($app) {
+        $this->app->singleton('migrator', static function ($app) {
             $repository = $app['migration.repository'];
 
             return new Migrator($repository, $app['db'], $app['files'], $app['events']);
@@ -88,7 +88,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerCreator()
     {
-        $this->app->singleton('migration.creator', function ($app) {
+        $this->app->singleton('migration.creator', static function ($app) {
             return new MigrationCreator($app['files'], $app->basePath('stubs'));
         });
     }
@@ -115,7 +115,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateCommand()
     {
-        $this->app->singleton('command.migrate', function ($app) {
+        $this->app->singleton('command.migrate', static function ($app) {
             return new MigrateCommand($app['migrator']);
         });
     }
@@ -127,7 +127,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateFreshCommand()
     {
-        $this->app->singleton('command.migrate.fresh', function () {
+        $this->app->singleton('command.migrate.fresh', static function () {
             return new FreshCommand;
         });
     }
@@ -139,7 +139,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateInstallCommand()
     {
-        $this->app->singleton('command.migrate.install', function ($app) {
+        $this->app->singleton('command.migrate.install', static function ($app) {
             return new InstallCommand($app['migration.repository']);
         });
     }
@@ -151,7 +151,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateMakeCommand()
     {
-        $this->app->singleton('command.migrate.make', function ($app) {
+        $this->app->singleton('command.migrate.make', static function ($app) {
             // Once we have the migration creator registered, we will create the command
             // and inject the creator. The creator is responsible for the actual file
             // creation of the migrations, and may be extended by these developers.
@@ -170,7 +170,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRefreshCommand()
     {
-        $this->app->singleton('command.migrate.refresh', function () {
+        $this->app->singleton('command.migrate.refresh', static function () {
             return new RefreshCommand;
         });
     }
@@ -182,7 +182,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateResetCommand()
     {
-        $this->app->singleton('command.migrate.reset', function ($app) {
+        $this->app->singleton('command.migrate.reset', static function ($app) {
             return new ResetCommand($app['migrator']);
         });
     }
@@ -194,7 +194,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateRollbackCommand()
     {
-        $this->app->singleton('command.migrate.rollback', function ($app) {
+        $this->app->singleton('command.migrate.rollback', static function ($app) {
             return new RollbackCommand($app['migrator']);
         });
     }
@@ -206,7 +206,7 @@ class MigrationServiceProvider extends ServiceProvider implements DeferrableProv
      */
     protected function registerMigrateStatusCommand()
     {
-        $this->app->singleton('command.migrate.status', function ($app) {
+        $this->app->singleton('command.migrate.status', static function ($app) {
             return new StatusCommand($app['migrator']);
         });
     }

--- a/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
+++ b/src/Illuminate/Database/Migrations/DatabaseMigrationRepository.php
@@ -147,7 +147,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     {
         $schema = $this->getConnection()->getSchemaBuilder();
 
-        $schema->create($this->table, function ($table) {
+        $schema->create($this->table, static function ($table) {
             // The migrations table is responsible for keeping track of which of the
             // migrations have actually run for the application. We'll create the
             // table to hold the migration file's path as well as the batch ID.

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -326,7 +326,7 @@ class Migrator
         // Since the getRan method that retrieves the migration name just gives us the
         // migration name, we will format the names into objects with the name as a
         // property on the objects so that we can pass it to the rollback method.
-        $migrations = collect($migrations)->map(function ($m) {
+        $migrations = collect($migrations)->map(static function ($m) {
             return (object) ['migration' => $m];
         })->all();
 
@@ -433,7 +433,7 @@ class Migrator
             $migration->getConnection()
         );
 
-        return $db->pretend(function () use ($migration, $method) {
+        return $db->pretend(static function () use ($migration, $method) {
             if (method_exists($migration, $method)) {
                 $migration->{$method}();
             }
@@ -465,7 +465,7 @@ class Migrator
             return Str::endsWith($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
         })->filter()->values()->keyBy(function ($file) {
             return $this->getMigrationName($file);
-        })->sortBy(function ($file, $key) {
+        })->sortBy(static function ($file, $key) {
             return $key;
         })->all();
     }

--- a/src/Illuminate/Database/Migrations/stubs/migration.create.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.create.stub
@@ -13,7 +13,7 @@ class {{ class }} extends Migration
      */
     public function up()
     {
-        Schema::create('{{ table }}', function (Blueprint $table) {
+        Schema::create('{{ table }}', static function (Blueprint $table) {
             $table->id();
             $table->timestamps();
         });

--- a/src/Illuminate/Database/Migrations/stubs/migration.update.stub
+++ b/src/Illuminate/Database/Migrations/stubs/migration.update.stub
@@ -13,7 +13,7 @@ class {{ class }} extends Migration
      */
     public function up()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }
@@ -25,7 +25,7 @@ class {{ class }} extends Migration
      */
     public function down()
     {
-        Schema::table('{{ table }}', function (Blueprint $table) {
+        Schema::table('{{ table }}', static function (Blueprint $table) {
             //
         });
     }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -724,7 +724,7 @@ class Builder
      */
     protected function addArrayOfWheres($column, $boolean, $method = 'where')
     {
-        return $this->whereNested(function ($query) use ($column, $method, $boolean) {
+        return $this->whereNested(static function ($query) use ($column, $method, $boolean) {
             foreach ($column as $key => $value) {
                 if (is_numeric($key) && is_array($value)) {
                     $query->{$method}(...array_values($value));
@@ -2069,7 +2069,7 @@ class Builder
     protected function removeExistingOrdersFor($column)
     {
         return Collection::make($this->orders)
-                    ->reject(function ($order) use ($column) {
+                    ->reject(static function ($order) use ($column) {
                         return isset($order['column'])
                                ? $order['column'] === $column : false;
                     })->values()->all();
@@ -2320,7 +2320,7 @@ class Builder
      */
     protected function withoutSelectAliases(array $columns)
     {
-        return array_map(function ($column) {
+        return array_map(static function ($column) {
             return is_string($column) && ($aliasPosition = stripos($column, ' as ')) !== false
                     ? substr($column, 0, $aliasPosition) : $column;
         }, $columns);
@@ -3019,7 +3019,7 @@ class Builder
      */
     protected function cleanBindings(array $bindings)
     {
-        return array_values(array_filter($bindings, function ($binding) {
+        return array_values(array_filter($bindings, static function ($binding) {
             return ! $binding instanceof Expression;
         }));
     }
@@ -3097,7 +3097,7 @@ class Builder
      */
     public function cloneWithout(array $properties)
     {
-        return tap(clone $this, function ($clone) use ($properties) {
+        return tap(clone $this, static function ($clone) use ($properties) {
             foreach ($properties as $property) {
                 $clone->{$property} = null;
             }
@@ -3112,7 +3112,7 @@ class Builder
      */
     public function cloneWithoutBindings(array $except)
     {
-        return tap(clone $this, function ($clone) use ($except) {
+        return tap(clone $this, static function ($clone) use ($except) {
             foreach ($except as $type) {
                 $clone->bindings[$type] = [];
             }

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1223,7 +1223,7 @@ class Grammar extends BaseGrammar
      */
     protected function concatenate($segments)
     {
-        return implode(' ', array_filter($segments, function ($value) {
+        return implode(' ', array_filter($segments, static function ($value) {
             return (string) $value !== '';
         }));
     }

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -212,7 +212,7 @@ class MySqlGrammar extends Grammar
     {
         $values = collect($values)->reject(function ($value, $column) {
             return $this->isJsonSelector($column) && is_bool($value);
-        })->map(function ($value) {
+        })->map(static function ($value) {
             return is_array($value) ? json_encode($value) : $value;
         })->all();
 

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -379,7 +379,7 @@ class PostgresGrammar extends Grammar
      */
     protected function wrapJsonPathAttributes($path)
     {
-        return array_map(function ($attribute) {
+        return array_map(static function ($attribute) {
             return filter_var($attribute, FILTER_VALIDATE_INT) !== false
                         ? $attribute
                         : "'$attribute'";

--- a/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php
@@ -246,7 +246,7 @@ class SQLiteGrammar extends Grammar
 
         $values = collect($values)->reject(function ($value, $key) {
             return $this->isJsonSelector($key);
-        })->merge($groups)->map(function ($value) {
+        })->merge($groups)->map(static function ($value) {
             return is_array($value) ? json_encode($value) : $value;
         })->all();
 

--- a/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/MySqlProcessor.php
@@ -12,7 +12,7 @@ class MySqlProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->column_name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/PostgresProcessor.php
@@ -38,7 +38,7 @@ class PostgresProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->column_name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SQLiteProcessor.php
@@ -12,7 +12,7 @@ class SQLiteProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->name;
         }, $results);
     }

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -63,7 +63,7 @@ class SqlServerProcessor extends Processor
      */
     public function processColumnListing($results)
     {
-        return array_map(function ($result) {
+        return array_map(static function ($result) {
             return ((object) $result)->name;
         }, $results);
     }

--- a/src/Illuminate/Database/README.md
+++ b/src/Illuminate/Database/README.md
@@ -51,7 +51,7 @@ $results = Capsule::select('select * from users where id = ?', [1]);
 **Using The Schema Builder**
 
 ```PHP
-Capsule::schema()->create('users', function ($table) {
+Capsule::schema()->create('users', static function ($table) {
     $table->increments('id');
     $table->string('email')->unique();
     $table->timestamps();

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -167,7 +167,7 @@ class Blueprint
      */
     protected function commandsNamed(array $names)
     {
-        return collect($this->commands)->filter(function ($command) use ($names) {
+        return collect($this->commands)->filter(static function ($command) use ($names) {
             return in_array($command->name, $names);
         });
     }
@@ -257,7 +257,7 @@ class Blueprint
      */
     protected function creating()
     {
-        return collect($this->commands)->contains(function ($command) {
+        return collect($this->commands)->contains(static function ($command) {
             return $command->name === 'create';
         });
     }
@@ -1442,7 +1442,7 @@ class Blueprint
      */
     public function removeColumn($name)
     {
-        $this->columns = array_values(array_filter($this->columns, function ($c) use ($name) {
+        $this->columns = array_values(array_filter($this->columns, static function ($c) use ($name) {
             return $c['name'] != $name;
         }));
 
@@ -1512,7 +1512,7 @@ class Blueprint
      */
     public function getAddedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return ! $column->change;
         });
     }
@@ -1524,7 +1524,7 @@ class Blueprint
      */
     public function getChangedColumns()
     {
-        return array_filter($this->columns, function ($column) {
+        return array_filter($this->columns, static function ($column) {
             return (bool) $column->change;
         });
     }

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -160,7 +160,7 @@ class Builder
      */
     public function create($table, Closure $callback)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) use ($callback) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) use ($callback) {
             $blueprint->create();
 
             $callback($blueprint);
@@ -175,7 +175,7 @@ class Builder
      */
     public function drop($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
             $blueprint->drop();
         }));
     }
@@ -188,7 +188,7 @@ class Builder
      */
     public function dropIfExists($table)
     {
-        $this->build(tap($this->createBlueprint($table), function ($blueprint) {
+        $this->build(tap($this->createBlueprint($table), static function ($blueprint) {
             $blueprint->dropIfExists();
         }));
     }
@@ -250,7 +250,7 @@ class Builder
      */
     public function rename($from, $to)
     {
-        $this->build(tap($this->createBlueprint($from), function ($blueprint) use ($to) {
+        $this->build(tap($this->createBlueprint($from), static function ($blueprint) use ($to) {
             $blueprint->rename($to);
         }));
     }

--- a/src/Illuminate/Database/Schema/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/Grammar.php
@@ -185,7 +185,7 @@ abstract class Grammar extends BaseGrammar
      */
     protected function getCommandsByName(Blueprint $blueprint, $name)
     {
-        return array_filter($blueprint->getCommands(), function ($value) use ($name) {
+        return array_filter($blueprint->getCommands(), static function ($value) use ($name) {
             return $value->name == $name;
         });
     }
@@ -199,7 +199,7 @@ abstract class Grammar extends BaseGrammar
      */
     public function prefixArray($prefix, array $values)
     {
-        return array_map(function ($value) use ($prefix) {
+        return array_map(static function ($value) use ($prefix) {
             return $prefix.' '.$value;
         }, $values);
     }
@@ -259,7 +259,7 @@ abstract class Grammar extends BaseGrammar
     {
         $table = $this->getTablePrefix().$blueprint->getTable();
 
-        return tap(new TableDiff($table), function ($tableDiff) use ($schema, $table) {
+        return tap(new TableDiff($table), static function ($tableDiff) use ($schema, $table) {
             $tableDiff->fromTable = $schema->listTableDetails($table);
         });
     }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -75,7 +75,7 @@ class EncryptionServiceProvider extends ServiceProvider
      */
     protected function key(array $config)
     {
-        return tap($config['key'], function ($key) {
+        return tap($config['key'], static function ($key) {
             if (empty($key)) {
                 throw new RuntimeException(
                     'No application encryption key has been specified.'

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -160,7 +160,7 @@ class CallQueuedListener implements ShouldQueue
      */
     public function __clone()
     {
-        $this->data = array_map(function ($data) {
+        $this->data = array_map(static function ($data) {
             return is_object($data) ? clone $data : $data;
         }, $this->data);
     }

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -361,7 +361,7 @@ class Dispatcher implements DispatcherContract
             return $this->createClassListener($listener, $wildcard);
         }
 
-        return function ($event, $payload) use ($listener, $wildcard) {
+        return static function ($event, $payload) use ($listener, $wildcard) {
             if ($wildcard) {
                 return $listener($event, $payload);
             }
@@ -445,7 +445,7 @@ class Dispatcher implements DispatcherContract
     protected function createQueuedHandlerCallable($class, $method)
     {
         return function () use ($class, $method) {
-            $arguments = array_map(function ($a) {
+            $arguments = array_map(static function ($a) {
                 return is_object($a) ? clone $a : $a;
             }, func_get_args());
 
@@ -522,7 +522,7 @@ class Dispatcher implements DispatcherContract
      */
     protected function propagateListenerOptions($listener, $job)
     {
-        return tap($job, function ($job) use ($listener) {
+        return tap($job, static function ($job) use ($listener) {
             $job->tries = $listener->tries ?? null;
             $job->retryAfter = method_exists($listener, 'retryAfter')
                                 ? $listener->retryAfter() : ($listener->retryAfter ?? null);

--- a/src/Illuminate/Events/EventServiceProvider.php
+++ b/src/Illuminate/Events/EventServiceProvider.php
@@ -14,8 +14,8 @@ class EventServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('events', function ($app) {
-            return (new Dispatcher($app))->setQueueResolver(function () use ($app) {
+        $this->app->singleton('events', static function ($app) {
+            return (new Dispatcher($app))->setQueueResolver(static function () use ($app) {
                 return $app->make(QueueFactoryContract::class);
             });
         });

--- a/src/Illuminate/Filesystem/FilesystemServiceProvider.php
+++ b/src/Illuminate/Filesystem/FilesystemServiceProvider.php
@@ -25,7 +25,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerNativeFilesystem()
     {
-        $this->app->singleton('files', function () {
+        $this->app->singleton('files', static function () {
             return new Filesystem;
         });
     }
@@ -55,7 +55,7 @@ class FilesystemServiceProvider extends ServiceProvider
      */
     protected function registerManager()
     {
-        $this->app->singleton('filesystem', function ($app) {
+        $this->app->singleton('filesystem', static function ($app) {
             return new FilesystemManager($app);
         });
     }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -594,7 +594,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     public function registerConfiguredProviders()
     {
         $providers = Collection::make($this->config['app.providers'])
-                        ->partition(function ($provider) {
+                        ->partition(static function ($provider) {
                             return strpos($provider, 'Illuminate\\') === 0;
                         });
 
@@ -674,7 +674,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
     {
         $name = is_string($provider) ? $provider : get_class($provider);
 
-        return Arr::where($this->serviceProviders, function ($value) use ($name) {
+        return Arr::where($this->serviceProviders, static function ($value) use ($name) {
             return $value instanceof $name;
         });
     }

--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -42,7 +42,7 @@ class LoadConfiguration
         // Finally, we will set the application's environment based on the configuration
         // values that were loaded. We will pass a callback which will be used to get
         // the environment in a web context where an "--env" switch is not present.
-        $app->detectEnvironment(function () use ($config) {
+        $app->detectEnvironment(static function () use ($config) {
             return $config->get('app.env', 'production');
         });
 

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -102,7 +102,7 @@ class ComponentMakeCommand extends GeneratorCommand
         $name = str_replace('\\', '/', $this->argument('name'));
 
         return collect(explode('/', $name))
-            ->map(function ($part) {
+            ->map(static function ($part) {
                 return Str::kebab($part);
             })
             ->implode('.');

--- a/src/Illuminate/Foundation/Console/EventListCommand.php
+++ b/src/Illuminate/Foundation/Console/EventListCommand.php
@@ -57,7 +57,7 @@ class EventListCommand extends Command
             $events = $this->filterEvents($events);
         }
 
-        return collect($events)->map(function ($listeners, $event) {
+        return collect($events)->map(static function ($listeners, $event) {
             return ['Event' => $event, 'Listeners' => implode(PHP_EOL, $listeners)];
         })->sortBy('Event')->values()->toArray();
     }
@@ -74,7 +74,7 @@ class EventListCommand extends Command
             return $events;
         }
 
-        return collect($events)->filter(function ($listeners, $event) use ($eventName) {
+        return collect($events)->filter(static function ($listeners, $event) use ($eventName) {
             return Str::contains($event, $eventName);
         })->toArray();
     }

--- a/src/Illuminate/Foundation/Console/Kernel.php
+++ b/src/Illuminate/Foundation/Console/Kernel.php
@@ -192,7 +192,7 @@ class Kernel implements KernelContract
     {
         $command = new ClosureCommand($signature, $callback);
 
-        Artisan::starting(function ($artisan) use ($command) {
+        Artisan::starting(static function ($artisan) use ($command) {
             $artisan->add($command);
         });
 
@@ -209,7 +209,7 @@ class Kernel implements KernelContract
     {
         $paths = array_unique(Arr::wrap($paths));
 
-        $paths = array_filter($paths, function ($path) {
+        $paths = array_filter($paths, static function ($path) {
             return is_dir($path);
         });
 
@@ -228,7 +228,7 @@ class Kernel implements KernelContract
 
             if (is_subclass_of($command, Command::class) &&
                 ! (new ReflectionClass($command))->isAbstract()) {
-                Artisan::starting(function ($artisan) use ($command) {
+                Artisan::starting(static function ($artisan) use ($command) {
                     $artisan->resolve($command);
                 });
             }

--- a/src/Illuminate/Foundation/Console/RouteCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteCacheCommand.php
@@ -76,7 +76,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplicationRoutes()
     {
-        return tap($this->getFreshApplication()['router']->getRoutes(), function ($routes) {
+        return tap($this->getFreshApplication()['router']->getRoutes(), static function ($routes) {
             $routes->refreshNameLookups();
             $routes->refreshActionLookups();
         });
@@ -89,7 +89,7 @@ class RouteCacheCommand extends Command
      */
     protected function getFreshApplication()
     {
-        return tap(require $this->laravel->bootstrapPath().'/app.php', function ($app) {
+        return tap(require $this->laravel->bootstrapPath().'/app.php', static function ($app) {
             $app->make(ConsoleKernelContract::class)->bootstrap();
         });
     }

--- a/src/Illuminate/Foundation/Console/RouteListCommand.php
+++ b/src/Illuminate/Foundation/Console/RouteListCommand.php
@@ -127,7 +127,7 @@ class RouteListCommand extends Command
      */
     protected function sortRoutes($sort, array $routes)
     {
-        return Arr::sort($routes, function ($route) use ($sort) {
+        return Arr::sort($routes, static function ($route) use ($sort) {
             return $route[$sort];
         });
     }
@@ -170,7 +170,7 @@ class RouteListCommand extends Command
      */
     protected function getMiddleware($route)
     {
-        return collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
+        return collect($this->router->gatherRouteMiddleware($route))->map(static function ($middleware) {
             return $middleware instanceof Closure ? 'Closure' : $middleware;
         })->implode("\n");
     }

--- a/src/Illuminate/Foundation/Console/ViewCacheCommand.php
+++ b/src/Illuminate/Foundation/Console/ViewCacheCommand.php
@@ -49,7 +49,7 @@ class ViewCacheCommand extends Command
     {
         $compiler = $this->laravel['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
-        $views->map(function (SplFileInfo $file) use ($compiler) {
+        $views->map(static function (SplFileInfo $file) use ($compiler) {
             $compiler->compile($file->getRealPath());
         });
     }

--- a/src/Illuminate/Foundation/Events/DiscoverEvents.php
+++ b/src/Illuminate/Foundation/Events/DiscoverEvents.php
@@ -23,7 +23,7 @@ class DiscoverEvents
     {
         return collect(static::getListenerEvents(
             (new Finder)->files()->in($listenerPath), $basePath
-        ))->mapToDictionary(function ($event, $listener) {
+        ))->mapToDictionary(static function ($event, $listener) {
             return [$event => $listener];
         })->all();
     }

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -145,7 +145,7 @@ class Handler implements ExceptionHandlerContract
     {
         $dontReport = array_merge($this->dontReport, $this->internalDontReport);
 
-        return ! is_null(Arr::first($dontReport, function ($type) use ($e) {
+        return ! is_null(Arr::first($dontReport, static function ($type) use ($e) {
             return $e instanceof $type;
         }));
     }
@@ -420,7 +420,7 @@ class Handler implements ExceptionHandlerContract
     {
         $paths = collect(config('view.paths'));
 
-        View::replaceNamespace('errors', $paths->map(function ($path) {
+        View::replaceNamespace('errors', $paths->map(static function ($path) {
             return "{$path}/errors";
         })->push(__DIR__.'/views')->all());
     }
@@ -488,7 +488,7 @@ class Handler implements ExceptionHandlerContract
             'exception' => get_class($e),
             'file' => $e->getFile(),
             'line' => $e->getLine(),
-            'trace' => collect($e->getTrace())->map(function ($trace) {
+            'trace' => collect($e->getTrace())->map(static function ($trace) {
                 return Arr::except($trace, ['args']);
             })->all(),
         ] : [

--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -86,7 +86,7 @@ class PackageManifest
      */
     public function config($key)
     {
-        return collect($this->getManifest())->flatMap(function ($configuration) use ($key) {
+        return collect($this->getManifest())->flatMap(static function ($configuration) use ($key) {
             return (array) ($configuration[$key] ?? []);
         })->filter()->all();
     }
@@ -129,9 +129,9 @@ class PackageManifest
 
         $this->write(collect($packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
-        })->each(function ($configuration) use (&$ignore) {
+        })->each(static function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
-        })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
+        })->reject(static function ($configuration, $package) use ($ignore, $ignoreAll) {
             return $ignoreAll || in_array($package, $ignore);
         })->filter()->all());
     }

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -185,7 +185,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheClearCommand()
     {
-        $this->app->singleton('command.cache.clear', function ($app) {
+        $this->app->singleton('command.cache.clear', static function ($app) {
             return new CacheClearCommand($app['cache'], $app['files']);
         });
     }
@@ -197,7 +197,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheForgetCommand()
     {
-        $this->app->singleton('command.cache.forget', function ($app) {
+        $this->app->singleton('command.cache.forget', static function ($app) {
             return new CacheForgetCommand($app['cache']);
         });
     }
@@ -209,7 +209,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCacheTableCommand()
     {
-        $this->app->singleton('command.cache.table', function ($app) {
+        $this->app->singleton('command.cache.table', static function ($app) {
             return new CacheTableCommand($app['files'], $app['composer']);
         });
     }
@@ -221,7 +221,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerCastMakeCommand()
     {
-        $this->app->singleton('command.cast.make', function ($app) {
+        $this->app->singleton('command.cast.make', static function ($app) {
             return new CastMakeCommand($app['files']);
         });
     }
@@ -233,7 +233,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerChannelMakeCommand()
     {
-        $this->app->singleton('command.channel.make', function ($app) {
+        $this->app->singleton('command.channel.make', static function ($app) {
             return new ChannelMakeCommand($app['files']);
         });
     }
@@ -245,7 +245,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearCompiledCommand()
     {
-        $this->app->singleton('command.clear-compiled', function () {
+        $this->app->singleton('command.clear-compiled', static function () {
             return new ClearCompiledCommand;
         });
     }
@@ -257,7 +257,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerClearResetsCommand()
     {
-        $this->app->singleton('command.auth.resets.clear', function () {
+        $this->app->singleton('command.auth.resets.clear', static function () {
             return new ClearResetsCommand;
         });
     }
@@ -269,7 +269,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerComponentMakeCommand()
     {
-        $this->app->singleton('command.component.make', function ($app) {
+        $this->app->singleton('command.component.make', static function ($app) {
             return new ComponentMakeCommand($app['files']);
         });
     }
@@ -281,7 +281,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigCacheCommand()
     {
-        $this->app->singleton('command.config.cache', function ($app) {
+        $this->app->singleton('command.config.cache', static function ($app) {
             return new ConfigCacheCommand($app['files']);
         });
     }
@@ -293,7 +293,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConfigClearCommand()
     {
-        $this->app->singleton('command.config.clear', function ($app) {
+        $this->app->singleton('command.config.clear', static function ($app) {
             return new ConfigClearCommand($app['files']);
         });
     }
@@ -305,7 +305,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerConsoleMakeCommand()
     {
-        $this->app->singleton('command.console.make', function ($app) {
+        $this->app->singleton('command.console.make', static function ($app) {
             return new ConsoleMakeCommand($app['files']);
         });
     }
@@ -317,7 +317,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerControllerMakeCommand()
     {
-        $this->app->singleton('command.controller.make', function ($app) {
+        $this->app->singleton('command.controller.make', static function ($app) {
             return new ControllerMakeCommand($app['files']);
         });
     }
@@ -329,7 +329,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDbWipeCommand()
     {
-        $this->app->singleton('command.db.wipe', function () {
+        $this->app->singleton('command.db.wipe', static function () {
             return new WipeCommand;
         });
     }
@@ -341,7 +341,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventGenerateCommand()
     {
-        $this->app->singleton('command.event.generate', function () {
+        $this->app->singleton('command.event.generate', static function () {
             return new EventGenerateCommand;
         });
     }
@@ -353,7 +353,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventMakeCommand()
     {
-        $this->app->singleton('command.event.make', function ($app) {
+        $this->app->singleton('command.event.make', static function ($app) {
             return new EventMakeCommand($app['files']);
         });
     }
@@ -365,7 +365,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerExceptionMakeCommand()
     {
-        $this->app->singleton('command.exception.make', function ($app) {
+        $this->app->singleton('command.exception.make', static function ($app) {
             return new ExceptionMakeCommand($app['files']);
         });
     }
@@ -377,7 +377,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerFactoryMakeCommand()
     {
-        $this->app->singleton('command.factory.make', function ($app) {
+        $this->app->singleton('command.factory.make', static function ($app) {
             return new FactoryMakeCommand($app['files']);
         });
     }
@@ -389,7 +389,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerDownCommand()
     {
-        $this->app->singleton('command.down', function () {
+        $this->app->singleton('command.down', static function () {
             return new DownCommand;
         });
     }
@@ -401,7 +401,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEnvironmentCommand()
     {
-        $this->app->singleton('command.environment', function () {
+        $this->app->singleton('command.environment', static function () {
             return new EnvironmentCommand;
         });
     }
@@ -413,7 +413,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventCacheCommand()
     {
-        $this->app->singleton('command.event.cache', function () {
+        $this->app->singleton('command.event.cache', static function () {
             return new EventCacheCommand;
         });
     }
@@ -425,7 +425,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventClearCommand()
     {
-        $this->app->singleton('command.event.clear', function ($app) {
+        $this->app->singleton('command.event.clear', static function ($app) {
             return new EventClearCommand($app['files']);
         });
     }
@@ -437,7 +437,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerEventListCommand()
     {
-        $this->app->singleton('command.event.list', function () {
+        $this->app->singleton('command.event.list', static function () {
             return new EventListCommand();
         });
     }
@@ -449,7 +449,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerJobMakeCommand()
     {
-        $this->app->singleton('command.job.make', function ($app) {
+        $this->app->singleton('command.job.make', static function ($app) {
             return new JobMakeCommand($app['files']);
         });
     }
@@ -461,7 +461,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerKeyGenerateCommand()
     {
-        $this->app->singleton('command.key.generate', function () {
+        $this->app->singleton('command.key.generate', static function () {
             return new KeyGenerateCommand;
         });
     }
@@ -473,7 +473,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerListenerMakeCommand()
     {
-        $this->app->singleton('command.listener.make', function ($app) {
+        $this->app->singleton('command.listener.make', static function ($app) {
             return new ListenerMakeCommand($app['files']);
         });
     }
@@ -485,7 +485,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMailMakeCommand()
     {
-        $this->app->singleton('command.mail.make', function ($app) {
+        $this->app->singleton('command.mail.make', static function ($app) {
             return new MailMakeCommand($app['files']);
         });
     }
@@ -497,7 +497,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerMiddlewareMakeCommand()
     {
-        $this->app->singleton('command.middleware.make', function ($app) {
+        $this->app->singleton('command.middleware.make', static function ($app) {
             return new MiddlewareMakeCommand($app['files']);
         });
     }
@@ -509,7 +509,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerModelMakeCommand()
     {
-        $this->app->singleton('command.model.make', function ($app) {
+        $this->app->singleton('command.model.make', static function ($app) {
             return new ModelMakeCommand($app['files']);
         });
     }
@@ -521,7 +521,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationMakeCommand()
     {
-        $this->app->singleton('command.notification.make', function ($app) {
+        $this->app->singleton('command.notification.make', static function ($app) {
             return new NotificationMakeCommand($app['files']);
         });
     }
@@ -533,7 +533,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerNotificationTableCommand()
     {
-        $this->app->singleton('command.notification.table', function ($app) {
+        $this->app->singleton('command.notification.table', static function ($app) {
             return new NotificationTableCommand($app['files'], $app['composer']);
         });
     }
@@ -545,7 +545,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeCommand()
     {
-        $this->app->singleton('command.optimize', function () {
+        $this->app->singleton('command.optimize', static function () {
             return new OptimizeCommand;
         });
     }
@@ -557,7 +557,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerObserverMakeCommand()
     {
-        $this->app->singleton('command.observer.make', function ($app) {
+        $this->app->singleton('command.observer.make', static function ($app) {
             return new ObserverMakeCommand($app['files']);
         });
     }
@@ -569,7 +569,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerOptimizeClearCommand()
     {
-        $this->app->singleton('command.optimize.clear', function () {
+        $this->app->singleton('command.optimize.clear', static function () {
             return new OptimizeClearCommand;
         });
     }
@@ -581,7 +581,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPackageDiscoverCommand()
     {
-        $this->app->singleton('command.package.discover', function () {
+        $this->app->singleton('command.package.discover', static function () {
             return new PackageDiscoverCommand;
         });
     }
@@ -593,7 +593,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerPolicyMakeCommand()
     {
-        $this->app->singleton('command.policy.make', function ($app) {
+        $this->app->singleton('command.policy.make', static function ($app) {
             return new PolicyMakeCommand($app['files']);
         });
     }
@@ -605,7 +605,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerProviderMakeCommand()
     {
-        $this->app->singleton('command.provider.make', function ($app) {
+        $this->app->singleton('command.provider.make', static function ($app) {
             return new ProviderMakeCommand($app['files']);
         });
     }
@@ -617,7 +617,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedCommand()
     {
-        $this->app->singleton('command.queue.failed', function () {
+        $this->app->singleton('command.queue.failed', static function () {
             return new ListFailedQueueCommand;
         });
     }
@@ -629,7 +629,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueForgetCommand()
     {
-        $this->app->singleton('command.queue.forget', function () {
+        $this->app->singleton('command.queue.forget', static function () {
             return new ForgetFailedQueueCommand;
         });
     }
@@ -641,7 +641,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFlushCommand()
     {
-        $this->app->singleton('command.queue.flush', function () {
+        $this->app->singleton('command.queue.flush', static function () {
             return new FlushFailedQueueCommand;
         });
     }
@@ -653,7 +653,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueListenCommand()
     {
-        $this->app->singleton('command.queue.listen', function ($app) {
+        $this->app->singleton('command.queue.listen', static function ($app) {
             return new QueueListenCommand($app['queue.listener']);
         });
     }
@@ -665,7 +665,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRestartCommand()
     {
-        $this->app->singleton('command.queue.restart', function ($app) {
+        $this->app->singleton('command.queue.restart', static function ($app) {
             return new QueueRestartCommand($app['cache.store']);
         });
     }
@@ -677,7 +677,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueRetryCommand()
     {
-        $this->app->singleton('command.queue.retry', function () {
+        $this->app->singleton('command.queue.retry', static function () {
             return new QueueRetryCommand;
         });
     }
@@ -689,7 +689,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueWorkCommand()
     {
-        $this->app->singleton('command.queue.work', function ($app) {
+        $this->app->singleton('command.queue.work', static function ($app) {
             return new QueueWorkCommand($app['queue.worker'], $app['cache.store']);
         });
     }
@@ -701,7 +701,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueFailedTableCommand()
     {
-        $this->app->singleton('command.queue.failed-table', function ($app) {
+        $this->app->singleton('command.queue.failed-table', static function ($app) {
             return new FailedTableCommand($app['files'], $app['composer']);
         });
     }
@@ -713,7 +713,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerQueueTableCommand()
     {
-        $this->app->singleton('command.queue.table', function ($app) {
+        $this->app->singleton('command.queue.table', static function ($app) {
             return new TableCommand($app['files'], $app['composer']);
         });
     }
@@ -725,7 +725,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRequestMakeCommand()
     {
-        $this->app->singleton('command.request.make', function ($app) {
+        $this->app->singleton('command.request.make', static function ($app) {
             return new RequestMakeCommand($app['files']);
         });
     }
@@ -737,7 +737,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerResourceMakeCommand()
     {
-        $this->app->singleton('command.resource.make', function ($app) {
+        $this->app->singleton('command.resource.make', static function ($app) {
             return new ResourceMakeCommand($app['files']);
         });
     }
@@ -749,7 +749,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRuleMakeCommand()
     {
-        $this->app->singleton('command.rule.make', function ($app) {
+        $this->app->singleton('command.rule.make', static function ($app) {
             return new RuleMakeCommand($app['files']);
         });
     }
@@ -761,7 +761,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeederMakeCommand()
     {
-        $this->app->singleton('command.seeder.make', function ($app) {
+        $this->app->singleton('command.seeder.make', static function ($app) {
             return new SeederMakeCommand($app['files'], $app['composer']);
         });
     }
@@ -773,7 +773,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSessionTableCommand()
     {
-        $this->app->singleton('command.session.table', function ($app) {
+        $this->app->singleton('command.session.table', static function ($app) {
             return new SessionTableCommand($app['files'], $app['composer']);
         });
     }
@@ -785,7 +785,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerStorageLinkCommand()
     {
-        $this->app->singleton('command.storage.link', function () {
+        $this->app->singleton('command.storage.link', static function () {
             return new StorageLinkCommand;
         });
     }
@@ -797,7 +797,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteCacheCommand()
     {
-        $this->app->singleton('command.route.cache', function ($app) {
+        $this->app->singleton('command.route.cache', static function ($app) {
             return new RouteCacheCommand($app['files']);
         });
     }
@@ -809,7 +809,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteClearCommand()
     {
-        $this->app->singleton('command.route.clear', function ($app) {
+        $this->app->singleton('command.route.clear', static function ($app) {
             return new RouteClearCommand($app['files']);
         });
     }
@@ -821,7 +821,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerRouteListCommand()
     {
-        $this->app->singleton('command.route.list', function ($app) {
+        $this->app->singleton('command.route.list', static function ($app) {
             return new RouteListCommand($app['router']);
         });
     }
@@ -833,7 +833,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerSeedCommand()
     {
-        $this->app->singleton('command.seed', function ($app) {
+        $this->app->singleton('command.seed', static function ($app) {
             return new SeedCommand($app['db']);
         });
     }
@@ -865,7 +865,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerServeCommand()
     {
-        $this->app->singleton('command.serve', function () {
+        $this->app->singleton('command.serve', static function () {
             return new ServeCommand;
         });
     }
@@ -877,7 +877,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerStubPublishCommand()
     {
-        $this->app->singleton('command.stub.publish', function () {
+        $this->app->singleton('command.stub.publish', static function () {
             return new StubPublishCommand;
         });
     }
@@ -889,7 +889,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerTestMakeCommand()
     {
-        $this->app->singleton('command.test.make', function ($app) {
+        $this->app->singleton('command.test.make', static function ($app) {
             return new TestMakeCommand($app['files']);
         });
     }
@@ -901,7 +901,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerUpCommand()
     {
-        $this->app->singleton('command.up', function () {
+        $this->app->singleton('command.up', static function () {
             return new UpCommand;
         });
     }
@@ -913,7 +913,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerVendorPublishCommand()
     {
-        $this->app->singleton('command.vendor.publish', function ($app) {
+        $this->app->singleton('command.vendor.publish', static function ($app) {
             return new VendorPublishCommand($app['files']);
         });
     }
@@ -925,7 +925,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewCacheCommand()
     {
-        $this->app->singleton('command.view.cache', function () {
+        $this->app->singleton('command.view.cache', static function () {
             return new ViewCacheCommand;
         });
     }
@@ -937,7 +937,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      */
     protected function registerViewClearCommand()
     {
-        $this->app->singleton('command.view.clear', function ($app) {
+        $this->app->singleton('command.view.clear', static function ($app) {
             return new ViewClearCommand($app['files']);
         });
     }

--- a/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ComposerServiceProvider.php
@@ -15,7 +15,7 @@ class ComposerServiceProvider extends ServiceProvider implements DeferrableProvi
      */
     public function register()
     {
-        $this->app->singleton('composer', function ($app) {
+        $this->app->singleton('composer', static function ($app) {
             return new Composer($app['files'], $app->basePath());
         });
     }

--- a/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/FormRequestServiceProvider.php
@@ -26,11 +26,11 @@ class FormRequestServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app->afterResolving(ValidatesWhenResolved::class, function ($resolved) {
+        $this->app->afterResolving(ValidatesWhenResolved::class, static function ($resolved) {
             $resolved->validateResolved();
         });
 
-        $this->app->resolving(FormRequest::class, function ($request, $app) {
+        $this->app->resolving(FormRequest::class, static function ($request, $app) {
             $request = FormRequest::createFrom($app['request'], $request);
 
             $request->setContainer($app)->setRedirector($app->make(Redirector::class));

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -101,10 +101,10 @@ class EventServiceProvider extends ServiceProvider
     public function discoverEvents()
     {
         return collect($this->discoverEventsWithin())
-                    ->reject(function ($directory) {
+                    ->reject(static function ($directory) {
                         return ! is_dir($directory);
                     })
-                    ->reduce(function ($discovered, $directory) {
+                    ->reduce(static function ($discovered, $directory) {
                         return array_merge_recursive(
                             $discovered,
                             DiscoverEvents::within($directory, base_path())

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -88,7 +88,7 @@ trait InteractsWithContainer
             $this->originalMix = app(Mix::class);
         }
 
-        $this->swap(Mix::class, function () {
+        $this->swap(Mix::class, static function () {
             return '';
         });
 

--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -572,7 +572,7 @@ trait MakesHttpRequests
             return array_merge($this->defaultCookies, $this->unencryptedCookies);
         }
 
-        return collect($this->defaultCookies)->map(function ($value) {
+        return collect($this->defaultCookies)->map(static function ($value) {
             return encrypt($value, false);
         })->merge($this->unencryptedCookies)->all();
     }

--- a/src/Illuminate/Hashing/HashServiceProvider.php
+++ b/src/Illuminate/Hashing/HashServiceProvider.php
@@ -14,11 +14,11 @@ class HashServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('hash', function ($app) {
+        $this->app->singleton('hash', static function ($app) {
             return new HashManager($app);
         });
 
-        $this->app->singleton('hash.driver', function ($app) {
+        $this->app->singleton('hash.driver', static function ($app) {
             return $app['hash']->driver();
         });
     }

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -94,7 +94,7 @@ class Factory
         $this->record();
 
         if (is_null($callback)) {
-            $callback = function () {
+            $callback = static function () {
                 return static::response();
             };
         }
@@ -110,7 +110,7 @@ class Factory
         $this->stubCallbacks = $this->stubCallbacks->merge(collect([
             $callback instanceof Closure
                     ? $callback
-                    : function () use ($callback) {
+                    : static function () use ($callback) {
                         return $callback;
                     },
         ]));
@@ -140,7 +140,7 @@ class Factory
      */
     public function stubUrl($url, $callback)
     {
-        return $this->fake(function ($request, $options) use ($url, $callback) {
+        return $this->fake(static function ($request, $options) use ($url, $callback) {
             if (! Str::is(Str::start($url, '*'), $request->url())) {
                 return;
             }
@@ -256,11 +256,11 @@ class Factory
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->recorded)->filter(function ($pair) use ($callback) {
+        return collect($this->recorded)->filter(static function ($pair) use ($callback) {
             return $callback($pair[0], $pair[1]);
         });
     }

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -514,7 +514,7 @@ class PendingRequest
      */
     protected function parseMultipartBodyFormat(array $data)
     {
-        return collect($data)->map(function ($value, $key) {
+        return collect($data)->map(static function ($value, $key) {
             return is_array($value) ? $value : ['name' => $key, 'contents' => $value];
         })->values()->all();
     }

--- a/src/Illuminate/Http/Client/Request.php
+++ b/src/Illuminate/Http/Client/Request.php
@@ -117,7 +117,7 @@ class Request implements ArrayAccess
      */
     public function headers()
     {
-        return collect($this->request->getHeaders())->mapWithKeys(function ($values, $header) {
+        return collect($this->request->getHeaders())->mapWithKeys(static function ($values, $header) {
             return [$header => $values];
         })->all();
     }
@@ -146,7 +146,7 @@ class Request implements ArrayAccess
             return false;
         }
 
-        return collect($this->data)->reject(function ($file) use ($name, $value, $filename) {
+        return collect($this->data)->reject(static function ($file) use ($name, $value, $filename) {
             return $file['name'] != $name ||
                 ($value && $file['contents'] != $value) ||
                 ($filename && $file['filename'] != $filename);

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -89,7 +89,7 @@ class Response implements ArrayAccess
      */
     public function headers()
     {
-        return collect($this->response->getHeaders())->mapWithKeys(function ($v, $k) {
+        return collect($this->response->getHeaders())->mapWithKeys(static function ($v, $k) {
             return [$k => $v];
         })->all();
     }

--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -55,7 +55,7 @@ class SetCacheHeaders
      */
     protected function parseOptions($options)
     {
-        return collect(explode(';', $options))->mapWithKeys(function ($option) {
+        return collect(explode(';', $options))->mapWithKeys(static function ($option) {
             $data = explode('=', $option, 2);
 
             return [$data[0] => $data[1] ?? true];

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -176,7 +176,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     {
         $segments = explode('/', $this->decodedPath());
 
-        return array_values(array_filter($segments, function ($value) {
+        return array_values(array_filter($segments, static function ($value) {
             return $value !== '';
         }));
     }
@@ -575,7 +575,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getUserResolver()
     {
-        return $this->userResolver ?: function () {
+        return $this->userResolver ?: static function () {
             //
         };
     }
@@ -600,7 +600,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      */
     public function getRouteResolver()
     {
-        return $this->routeResolver ?: function () {
+        return $this->routeResolver ?: static function () {
             //
         };
     }

--- a/src/Illuminate/Http/Resources/Json/JsonResource.php
+++ b/src/Illuminate/Http/Resources/Json/JsonResource.php
@@ -76,7 +76,7 @@ class JsonResource implements ArrayAccess, JsonSerializable, Responsable, UrlRou
      */
     public static function collection($resource)
     {
-        return tap(new AnonymousResourceCollection($resource, static::class), function ($collection) {
+        return tap(new AnonymousResourceCollection($resource, static::class), static function ($collection) {
             if (property_exists(static::class, 'preserveKeys')) {
                 $collection->preserveKeys = (new static([]))->preserveKeys === true;
             }

--- a/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
+++ b/src/Illuminate/Http/Resources/Json/PaginatedResourceResponse.php
@@ -25,7 +25,7 @@ class PaginatedResourceResponse extends ResourceResponse
             ),
             $this->calculateStatus()
         ), function ($response) use ($request) {
-            $response->original = $this->resource->resource->map(function ($item) {
+            $response->original = $this->resource->resource->map(static function ($item) {
                 return is_array($item) ? Arr::get($item, 'resource') : $item->resource;
             });
 

--- a/src/Illuminate/Http/Testing/FileFactory.php
+++ b/src/Illuminate/Http/Testing/FileFactory.php
@@ -20,7 +20,7 @@ class FileFactory
             return $this->createWithContent($name, $kilobytes);
         }
 
-        return tap(new File($name, tmpfile()), function ($file) use ($kilobytes, $mimeType) {
+        return tap(new File($name, tmpfile()), static function ($file) use ($kilobytes, $mimeType) {
             $file->sizeToReport = $kilobytes * 1024;
             $file->mimeTypeToReport = $mimeType;
         });
@@ -39,7 +39,7 @@ class FileFactory
 
         fwrite($tmpfile, $content);
 
-        return tap(new File($name, $tmpfile), function ($file) use ($tmpfile) {
+        return tap(new File($name, $tmpfile), static function ($file) use ($tmpfile) {
             $file->sizeToReport = fstat($tmpfile)['size'];
         });
     }
@@ -69,7 +69,7 @@ class FileFactory
      */
     protected function generateImage($width, $height, $type)
     {
-        return tap(tmpfile(), function ($temp) use ($width, $height, $type) {
+        return tap(tmpfile(), static function ($temp) use ($width, $height, $type) {
             ob_start();
 
             $image = imagecreatetruecolor($width, $height);

--- a/src/Illuminate/Log/LogManager.php
+++ b/src/Illuminate/Log/LogManager.php
@@ -119,7 +119,7 @@ class LogManager implements LoggerInterface
                 return $this->channels[$name] = $this->tap($name, new Logger($logger, $this->app['events']));
             });
         } catch (Throwable $e) {
-            return tap($this->createEmergencyLogger(), function ($logger) use ($e) {
+            return tap($this->createEmergencyLogger(), static function ($logger) use ($e) {
                 $logger->emergency('Unable to create configured logger. Using emergency logger.', [
                     'exception' => $e,
                 ]);
@@ -413,7 +413,7 @@ class LogManager implements LoggerInterface
      */
     protected function formatter()
     {
-        return tap(new LineFormatter(null, $this->dateFormat, true, true), function ($formatter) {
+        return tap(new LineFormatter(null, $this->dateFormat, true, true), static function ($formatter) {
             $formatter->includeStacktraces();
         });
     }

--- a/src/Illuminate/Log/LogServiceProvider.php
+++ b/src/Illuminate/Log/LogServiceProvider.php
@@ -13,7 +13,7 @@ class LogServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton('log', function ($app) {
+        $this->app->singleton('log', static function ($app) {
             return new LogManager($app);
         });
     }

--- a/src/Illuminate/Mail/MailManager.php
+++ b/src/Illuminate/Mail/MailManager.php
@@ -329,7 +329,7 @@ class MailManager implements FactoryContract
     {
         return tap(new PostmarkTransport(
             $config['token'] ?? $this->app['config']->get('services.postmark.token')
-        ), function ($transport) {
+        ), static function ($transport) {
             $transport->registerPlugin(new ThrowExceptionOnFailurePlugin());
         });
     }

--- a/src/Illuminate/Mail/MailServiceProvider.php
+++ b/src/Illuminate/Mail/MailServiceProvider.php
@@ -25,11 +25,11 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerIlluminateMailer()
     {
-        $this->app->singleton('mail.manager', function ($app) {
+        $this->app->singleton('mail.manager', static function ($app) {
             return new MailManager($app);
         });
 
-        $this->app->bind('mailer', function ($app) {
+        $this->app->bind('mailer', static function ($app) {
             return $app->make('mail.manager')->mailer();
         });
     }
@@ -47,7 +47,7 @@ class MailServiceProvider extends ServiceProvider implements DeferrableProvider
             ], 'laravel-mail');
         }
 
-        $this->app->singleton(Markdown::class, function ($app) {
+        $this->app->singleton(Markdown::class, static function ($app) {
             $config = $app->make('config');
 
             return new Markdown($app->make('view'), [

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -458,7 +458,7 @@ class Mailable implements MailableContract, Renderable
      */
     public function priority($level = 3)
     {
-        $this->callbacks[] = function ($message) use ($level) {
+        $this->callbacks[] = static function ($message) use ($level) {
             $message->setPriority($level);
         };
 
@@ -661,7 +661,7 @@ class Mailable implements MailableContract, Renderable
             'address' => $expected->email,
         ];
 
-        return collect($this->{$property})->contains(function ($actual) use ($expected) {
+        return collect($this->{$property})->contains(static function ($actual) use ($expected) {
             if (! isset($expected['name'])) {
                 return $actual['address'] == $expected['address'];
             }
@@ -805,7 +805,7 @@ class Mailable implements MailableContract, Renderable
             'path' => $path,
             'name' => $name ?? basename($path),
             'options' => $options,
-        ])->unique(function ($file) {
+        ])->unique(static function ($file) {
             return $file['name'].$file['disk'].$file['path'];
         })->all();
 
@@ -824,7 +824,7 @@ class Mailable implements MailableContract, Renderable
     {
         $this->rawAttachments = collect($this->rawAttachments)
                 ->push(compact('data', 'name', 'options'))
-                ->unique(function ($file) {
+                ->unique(static function ($file) {
                     return $file['name'].$file['data'];
                 })->all();
 

--- a/src/Illuminate/Mail/Markdown.php
+++ b/src/Illuminate/Mail/Markdown.php
@@ -118,7 +118,7 @@ class Markdown
      */
     public function htmlComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/html';
         }, $this->componentPaths());
     }
@@ -130,7 +130,7 @@ class Markdown
      */
     public function textComponentPaths()
     {
-        return array_map(function ($path) {
+        return array_map(static function ($path) {
             return $path.'/text';
         }, $this->componentPaths());
     }

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -119,7 +119,7 @@ class MailgunTransport extends Transport
      */
     protected function getTo(Swift_Mime_SimpleMessage $message)
     {
-        return collect($this->allContacts($message))->map(function ($display, $address) {
+        return collect($this->allContacts($message))->map(static function ($display, $address) {
             return $display ? $display." <{$address}>" : $address;
         })->values()->implode(',');
     }

--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -208,7 +208,7 @@ class MailChannel
             $recipients = [$recipients];
         }
 
-        return collect($recipients)->mapWithKeys(function ($recipient, $email) {
+        return collect($recipients)->mapWithKeys(static function ($recipient, $email) {
             return is_numeric($email)
                     ? [$email => (is_string($recipient) ? $recipient : $recipient->email)]
                     : [$email => $recipient];

--- a/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
+++ b/src/Illuminate/Notifications/Events/BroadcastNotificationCreated.php
@@ -64,7 +64,7 @@ class BroadcastNotificationCreated implements ShouldBroadcast
             return [new PrivateChannel($channels)];
         }
 
-        return collect($channels)->map(function ($channel) {
+        return collect($channels)->map(static function ($channel) {
             return new PrivateChannel($channel);
         })->all();
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -284,7 +284,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     protected function parseAddresses($value)
     {
-        return collect($value)->map(function ($address, $name) {
+        return collect($value)->map(static function ($address, $name) {
             return [$address, is_numeric($name) ? null : $name];
         })->values()->all();
     }

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -117,7 +117,7 @@ class NotificationSender
      */
     protected function preferredLocale($notifiable, $notification)
     {
-        return $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+        return $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
             if ($notifiable instanceof HasLocalePreference) {
                 return $notifiable->preferredLocale();
             }

--- a/src/Illuminate/Notifications/NotificationServiceProvider.php
+++ b/src/Illuminate/Notifications/NotificationServiceProvider.php
@@ -31,7 +31,7 @@ class NotificationServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(ChannelManager::class, function ($app) {
+        $this->app->singleton(ChannelManager::class, static function ($app) {
             return new ChannelManager($app);
         });
 

--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -110,7 +110,7 @@ class Pipeline implements PipelineContract
      */
     public function thenReturn()
     {
-        return $this->then(function ($passable) {
+        return $this->then(static function ($passable) {
             return $passable;
         });
     }

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -266,7 +266,7 @@ class DatabaseQueue extends Queue implements QueueContract
     {
         $expiration = Carbon::now()->subSeconds($this->retryAfter)->getTimestamp();
 
-        $query->orWhere(function ($query) use ($expiration) {
+        $query->orWhere(static function ($query) use ($expiration) {
             $query->where('reserved_at', '<=', $expiration);
         });
     }

--- a/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DynamoDbFailedJobProvider.php
@@ -96,7 +96,7 @@ class DynamoDbFailedJobProvider implements FailedJobProviderInterface
             'ScanIndexForward' => false,
         ]);
 
-        return collect($results['Items'])->map(function ($result) {
+        return collect($results['Items'])->map(static function ($result) {
             return (object) [
                 'id' => $result['uuid']['S'],
                 'connection' => $result['connection']['S'],

--- a/src/Illuminate/Queue/Listener.php
+++ b/src/Illuminate/Queue/Listener.php
@@ -156,7 +156,7 @@ class Listener
             "--memory={$options->memory}",
             "--sleep={$options->sleep}",
             "--tries={$options->maxTries}",
-        ], function ($value) {
+        ], static function ($value) {
             return ! is_null($value);
         });
     }

--- a/src/Illuminate/Queue/QueueServiceProvider.php
+++ b/src/Illuminate/Queue/QueueServiceProvider.php
@@ -60,7 +60,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerConnection()
     {
-        $this->app->singleton('queue.connection', function ($app) {
+        $this->app->singleton('queue.connection', static function ($app) {
             return $app['queue']->connection();
         });
     }
@@ -86,7 +86,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerNullConnector($manager)
     {
-        $manager->addConnector('null', function () {
+        $manager->addConnector('null', static function () {
             return new NullConnector;
         });
     }
@@ -99,7 +99,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSyncConnector($manager)
     {
-        $manager->addConnector('sync', function () {
+        $manager->addConnector('sync', static function () {
             return new SyncConnector;
         });
     }
@@ -138,7 +138,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerBeanstalkdConnector($manager)
     {
-        $manager->addConnector('beanstalkd', function () {
+        $manager->addConnector('beanstalkd', static function () {
             return new BeanstalkdConnector;
         });
     }
@@ -151,7 +151,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerSqsConnector($manager)
     {
-        $manager->addConnector('sqs', function () {
+        $manager->addConnector('sqs', static function () {
             return new SqsConnector;
         });
     }
@@ -184,7 +184,7 @@ class QueueServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     protected function registerListener()
     {
-        $this->app->singleton('queue.listener', function ($app) {
+        $this->app->singleton('queue.listener', static function ($app) {
             return new Listener($app->basePath());
         });
     }

--- a/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
+++ b/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php
@@ -83,7 +83,7 @@ trait SerializesAndRestoresModelIdentifiers
         $collectionClass = get_class($collection);
 
         return new $collectionClass(
-            collect($value->id)->map(function ($id) use ($collection) {
+            collect($value->id)->map(static function ($id) use ($collection) {
                 return $collection[$id] ?? null;
             })->filter()
         );

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -24,7 +24,7 @@ trait SerializesModels
             ));
         }
 
-        return array_values(array_filter(array_map(function ($p) {
+        return array_values(array_filter(array_map(static function ($p) {
             return $p->isStatic() ? null : $p->getName();
         }, $properties)));
     }

--- a/src/Illuminate/Redis/Connections/PhpRedisConnection.php
+++ b/src/Illuminate/Redis/Connections/PhpRedisConnection.php
@@ -65,7 +65,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function mget(array $keys)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             return $value !== false ? $value : null;
         }, $this->command('mget', [$keys]));
     }
@@ -442,7 +442,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function subscribe($channels, Closure $callback)
     {
-        $this->client->subscribe((array) $channels, function ($redis, $channel, $message) use ($callback) {
+        $this->client->subscribe((array) $channels, static function ($redis, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }
@@ -456,7 +456,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      */
     public function psubscribe($channels, Closure $callback)
     {
-        $this->client->psubscribe((array) $channels, function ($redis, $pattern, $channel, $message) use ($callback) {
+        $this->client->psubscribe((array) $channels, static function ($redis, $pattern, $channel, $message) use ($callback) {
             $callback($message, $channel);
         });
     }

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -151,7 +151,7 @@ class PhpRedisConnector implements Connector
             $parameters[] = $options['password'] ?? null;
         }
 
-        return tap(new RedisCluster(...$parameters), function ($client) use ($options) {
+        return tap(new RedisCluster(...$parameters), static function ($client) use ($options) {
             if (! empty($options['prefix'])) {
                 $client->setOption(RedisCluster::OPT_PREFIX, $options['prefix']);
             }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -185,7 +185,7 @@ class RedisManager implements Factory
     {
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
 
-        return array_filter($parsed, function ($key) {
+        return array_filter($parsed, static function ($key) {
             return ! in_array($key, ['driver', 'username'], true);
         }, ARRAY_FILTER_USE_KEY);
     }

--- a/src/Illuminate/Redis/RedisServiceProvider.php
+++ b/src/Illuminate/Redis/RedisServiceProvider.php
@@ -15,13 +15,13 @@ class RedisServiceProvider extends ServiceProvider implements DeferrableProvider
      */
     public function register()
     {
-        $this->app->singleton('redis', function ($app) {
+        $this->app->singleton('redis', static function ($app) {
             $config = $app->make('config')->get('database.redis', []);
 
             return new RedisManager($app, Arr::pull($config, 'client', 'phpredis'), $config);
         });
 
-        $this->app->bind('redis.connection', function ($app) {
+        $this->app->bind('redis.connection', static function ($app) {
             return $app['redis']->connection();
         });
     }

--- a/src/Illuminate/Routing/AbstractRouteCollection.php
+++ b/src/Illuminate/Routing/AbstractRouteCollection.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection StaticClosureCanBeUsedInspection */
 
 namespace Illuminate\Routing;
 
@@ -74,11 +74,11 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
      */
     protected function matchAgainstRoutes(array $routes, $request, $includingMethod = true)
     {
-        [$fallbacks, $routes] = collect($routes)->partition(function ($route) {
+        [$fallbacks, $routes] = collect($routes)->partition(static function ($route) {
             return $route->isFallback;
         });
 
-        return $routes->merge($fallbacks)->first(function (Route $route) use ($request, $includingMethod) {
+        return $routes->merge($fallbacks)->first(static function (Route $route) use ($request, $includingMethod) {
             return $route->matches($request, $includingMethod);
         });
     }
@@ -95,7 +95,7 @@ abstract class AbstractRouteCollection implements Countable, IteratorAggregate, 
     protected function getRouteForMethods($request, array $methods)
     {
         if ($request->method() === 'OPTIONS') {
-            return (new Route('OPTIONS', $request->path(), function () use ($methods) {
+            return (new Route('OPTIONS', $request->path(), static function () use ($methods) {
                 return new Response('', 200, ['Allow' => implode(',', $methods)]);
             }))->bind($request);
         }

--- a/src/Illuminate/Routing/CompiledRouteCollection.php
+++ b/src/Illuminate/Routing/CompiledRouteCollection.php
@@ -208,7 +208,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
      */
     public function getByAction($action)
     {
-        $attributes = collect($this->attributes)->first(function (array $attributes) use ($action) {
+        $attributes = collect($this->attributes)->first(static function (array $attributes) use ($action) {
             if (isset($attributes['action']['controller'])) {
                 return trim($attributes['action']['controller'], '\\') === $action;
             }
@@ -247,11 +247,11 @@ class CompiledRouteCollection extends AbstractRouteCollection
     public function getRoutesByMethod()
     {
         return collect($this->getRoutes())
-            ->groupBy(function (Route $route) {
+            ->groupBy(static function (Route $route) {
                 return $route->methods();
             })
-            ->map(function (Collection $routes) {
-                return $routes->mapWithKeys(function (Route $route) {
+            ->map(static function (Collection $routes) {
+                return $routes->mapWithKeys(static function (Route $route) {
                     return [$route->uri => $route];
                 })->all();
             })
@@ -266,7 +266,7 @@ class CompiledRouteCollection extends AbstractRouteCollection
     public function getRoutesByName()
     {
         return collect($this->getRoutes())
-            ->keyBy(function (Route $route) {
+            ->keyBy(static function (Route $route) {
                 return $route->getName();
             })
             ->all();

--- a/src/Illuminate/Routing/ControllerDispatcher.php
+++ b/src/Illuminate/Routing/ControllerDispatcher.php
@@ -61,7 +61,7 @@ class ControllerDispatcher implements ControllerDispatcherContract
             return [];
         }
 
-        return collect($controller->getMiddleware())->reject(function ($data) use ($method) {
+        return collect($controller->getMiddleware())->reject(static function ($data) use ($method) {
             return static::methodExcludedByOptions($method, $data['options']);
         })->pluck('middleware')->all();
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -118,7 +118,7 @@ class ResourceRegistrar
         // We need to extract the base resource from the resource name. Nested resources
         // are supported in the framework, but we need to know what name to use for a
         // place-holder on the route parameters, which should be the base resources.
-        $callback = function ($me) use ($name, $controller, $options) {
+        $callback = static function ($me) use ($name, $controller, $options) {
             $me->resource($name, $controller, $options);
         };
 

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -447,7 +447,7 @@ class Route
      */
     public function parametersWithoutNulls()
     {
-        return array_filter($this->parameters(), function ($p) {
+        return array_filter($this->parameters(), static function ($p) {
             return ! is_null($p);
         });
     }
@@ -475,7 +475,7 @@ class Route
     {
         preg_match_all('/\{(.*?)\}/', $this->getDomain().$this->uri, $matches);
 
-        return array_map(function ($m) {
+        return array_map(static function ($m) {
             return trim($m, '?');
         }, $matches[1]);
     }

--- a/src/Illuminate/Routing/RouteAction.php
+++ b/src/Illuminate/Routing/RouteAction.php
@@ -59,7 +59,7 @@ class RouteAction
      */
     protected static function missingAction($uri)
     {
-        return ['uses' => function () use ($uri) {
+        return ['uses' => static function () use ($uri) {
             throw new LogicException("Route for [{$uri}] has no action.");
         }];
     }
@@ -72,7 +72,7 @@ class RouteAction
      */
     protected static function findCallable(array $action)
     {
-        return Arr::first($action, function ($value, $key) {
+        return Arr::first($action, static function ($value, $key) {
             return is_callable($value) && is_numeric($key);
         });
     }

--- a/src/Illuminate/Routing/RouteBinding.php
+++ b/src/Illuminate/Routing/RouteBinding.php
@@ -33,7 +33,7 @@ class RouteBinding
      */
     protected static function createClassBinding($container, $binding)
     {
-        return function ($value, $route) use ($container, $binding) {
+        return static function ($value, $route) use ($container, $binding) {
             // If the binding has an @ sign, we will assume it's being used to delimit
             // the class name from the bind method name. This allows for bindings
             // to run multiple bind methods in a single class for convenience.
@@ -57,7 +57,7 @@ class RouteBinding
      */
     public static function forModel($container, $class, $callback = null)
     {
-        return function ($value) use ($container, $class, $callback) {
+        return static function ($value) use ($container, $class, $callback) {
             if (is_null($value)) {
                 return;
             }

--- a/src/Illuminate/Routing/RouteDependencyResolverTrait.php
+++ b/src/Illuminate/Routing/RouteDependencyResolverTrait.php
@@ -91,7 +91,7 @@ trait RouteDependencyResolverTrait
      */
     protected function alreadyInParameters($class, array $parameters)
     {
-        return ! is_null(Arr::first($parameters, function ($value) use ($class) {
+        return ! is_null(Arr::first($parameters, static function ($value) use ($class) {
             return $value instanceof $class;
         }));
     }

--- a/src/Illuminate/Routing/RouteParameterBinder.php
+++ b/src/Illuminate/Routing/RouteParameterBinder.php
@@ -89,7 +89,7 @@ class RouteParameterBinder
 
         $parameters = array_intersect_key($matches, array_flip($parameterNames));
 
-        return array_filter($parameters, function ($value) {
+        return array_filter($parameters, static function ($value) {
             return is_string($value) && strlen($value) > 0;
         });
     }

--- a/src/Illuminate/Routing/RouteSignatureParameters.php
+++ b/src/Illuminate/Routing/RouteSignatureParameters.php
@@ -22,7 +22,7 @@ class RouteSignatureParameters
                         ? static::fromClassMethodString($action['uses'])
                         : (new ReflectionFunction($action['uses']))->getParameters();
 
-        return is_null($subClass) ? $parameters : array_filter($parameters, function ($p) use ($subClass) {
+        return is_null($subClass) ? $parameters : array_filter($parameters, static function ($p) use ($subClass) {
             return Reflector::isParameterSubclassOf($p, $subClass);
         });
     }

--- a/src/Illuminate/Routing/RouteUrlGenerator.php
+++ b/src/Illuminate/Routing/RouteUrlGenerator.php
@@ -196,7 +196,7 @@ class RouteUrlGenerator
     {
         $path = $this->replaceNamedParameters($path, $parameters);
 
-        $path = preg_replace_callback('/\{.*?\}/', function ($match) use (&$parameters) {
+        $path = preg_replace_callback('/\{.*?\}/', static function ($match) use (&$parameters) {
             // Reset only the numeric keys...
             $parameters = array_merge($parameters);
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -652,7 +652,7 @@ class Router implements BindingRegistrar, RegistrarContract
      */
     protected function runRoute(Request $request, Route $route)
     {
-        $request->setRouteResolver(function () use ($route) {
+        $request->setRouteResolver(static function () use ($route) {
             return $route;
         });
 
@@ -701,7 +701,7 @@ class Router implements BindingRegistrar, RegistrarContract
 
         $middleware = collect($route->gatherMiddleware())->map(function ($name) {
             return (array) MiddlewareNameResolver::resolve($name, $this->middleware, $this->middlewareGroups);
-        })->flatten()->reject(function ($name) use ($route, $excluded) {
+        })->flatten()->reject(static function ($name) use ($route, $excluded) {
             return in_array($name, $excluded, true);
         })->values();
 

--- a/src/Illuminate/Routing/RoutingServiceProvider.php
+++ b/src/Illuminate/Routing/RoutingServiceProvider.php
@@ -39,7 +39,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRouter()
     {
-        $this->app->singleton('router', function ($app) {
+        $this->app->singleton('router', static function ($app) {
             return new Router($app['events'], $app);
         });
     }
@@ -81,7 +81,7 @@ class RoutingServiceProvider extends ServiceProvider
             // If the route collection is "rebound", for example, when the routes stay
             // cached for the application, we will need to rebind the routes on the
             // URL generator instance so it has the latest version of the routes.
-            $app->rebinding('routes', function ($app, $routes) {
+            $app->rebinding('routes', static function ($app, $routes) {
                 $app['url']->setRoutes($routes);
             });
 
@@ -96,7 +96,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function requestRebinder()
     {
-        return function ($app, $request) {
+        return static function ($app, $request) {
             $app['url']->setRequest($request);
         };
     }
@@ -108,7 +108,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerRedirector()
     {
-        $this->app->singleton('redirect', function ($app) {
+        $this->app->singleton('redirect', static function ($app) {
             $redirector = new Redirector($app['url']);
 
             // If the session is set on the application instance, we'll inject it into
@@ -129,7 +129,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrRequest()
     {
-        $this->app->bind(ServerRequestInterface::class, function ($app) {
+        $this->app->bind(ServerRequestInterface::class, static function ($app) {
             if (class_exists(Psr17Factory::class) && class_exists(PsrHttpFactory::class)) {
                 $psr17Factory = new Psr17Factory;
 
@@ -148,7 +148,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerPsrResponse()
     {
-        $this->app->bind(ResponseInterface::class, function () {
+        $this->app->bind(ResponseInterface::class, static function () {
             if (class_exists(PsrResponse::class)) {
                 return new PsrResponse;
             }
@@ -164,7 +164,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerResponseFactory()
     {
-        $this->app->singleton(ResponseFactoryContract::class, function ($app) {
+        $this->app->singleton(ResponseFactoryContract::class, static function ($app) {
             return new ResponseFactory($app[ViewFactoryContract::class], $app['redirect']);
         });
     }
@@ -176,7 +176,7 @@ class RoutingServiceProvider extends ServiceProvider
      */
     protected function registerControllerDispatcher()
     {
-        $this->app->singleton(ControllerDispatcherContract::class, function ($app) {
+        $this->app->singleton(ControllerDispatcherContract::class, static function ($app) {
             return new ControllerDispatcher($app);
         });
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -432,7 +432,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function toRoute($route, $parameters, $absolute)
     {
-        $parameters = collect(Arr::wrap($parameters))->map(function ($value, $key) use ($route) {
+        $parameters = collect(Arr::wrap($parameters))->map(static function ($value, $key) use ($route) {
             return $value instanceof UrlRoutable && $route->bindingFieldFor($key)
                     ? $value->{$route->bindingFieldFor($key)}
                     : $value;
@@ -672,7 +672,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function pathFormatter()
     {
-        return $this->formatPathUsing ?: function ($path) {
+        return $this->formatPathUsing ?: static function ($path) {
             return $path;
         };
     }

--- a/src/Illuminate/Session/Middleware/StartSession.php
+++ b/src/Illuminate/Session/Middleware/StartSession.php
@@ -136,7 +136,7 @@ class StartSession
      */
     protected function startSession(Request $request, $session)
     {
-        return tap($session, function ($session) use ($request) {
+        return tap($session, static function ($session) use ($request) {
             $session->setRequestOnHandler($request);
 
             $session->start();
@@ -151,7 +151,7 @@ class StartSession
      */
     public function getSession(Request $request)
     {
-        return tap($this->manager->driver(), function ($session) use ($request) {
+        return tap($this->manager->driver(), static function ($session) use ($request) {
             $session->setId($request->cookies->get($session->getName()));
         });
     }

--- a/src/Illuminate/Session/SessionServiceProvider.php
+++ b/src/Illuminate/Session/SessionServiceProvider.php
@@ -33,7 +33,7 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionManager()
     {
-        $this->app->singleton('session', function ($app) {
+        $this->app->singleton('session', static function ($app) {
             return new SessionManager($app);
         });
     }
@@ -45,7 +45,7 @@ class SessionServiceProvider extends ServiceProvider
      */
     protected function registerSessionDriver()
     {
-        $this->app->singleton('session.store', function ($app) {
+        $this->app->singleton('session.store', static function ($app) {
             // First, we will create the session manager which is responsible for the
             // creation of the various session drivers when they are needed by the
             // application instance, and will resolve them on a lazy load basis.

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -80,9 +80,9 @@ class Collection implements ArrayAccess, Enumerable
     {
         $callback = $this->valueRetriever($callback);
 
-        $items = $this->map(function ($value) use ($callback) {
+        $items = $this->map(static function ($value) use ($callback) {
             return $callback($value);
-        })->filter(function ($value) {
+        })->filter(static function ($value) {
             return ! is_null($value);
         });
 
@@ -100,7 +100,7 @@ class Collection implements ArrayAccess, Enumerable
     public function median($key = null)
     {
         $values = (isset($key) ? $this->pluck($key) : $this)
-            ->filter(function ($item) {
+            ->filter(static function ($item) {
                 return ! is_null($item);
             })->sort()->values();
 
@@ -137,7 +137,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $counts = new self;
 
-        $collection->each(function ($value) use ($counts) {
+        $collection->each(static function ($value) use ($counts) {
             $counts[$value] = isset($counts[$value]) ? $counts[$value] + 1 : 1;
         });
 
@@ -145,7 +145,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $highestValue = $sorted->last();
 
-        return $sorted->filter(function ($value) use ($highestValue) {
+        return $sorted->filter(static function ($value) use ($highestValue) {
             return $value == $highestValue;
         })->sort()->keys()->all();
     }
@@ -313,12 +313,12 @@ class Collection implements ArrayAccess, Enumerable
     protected function duplicateComparator($strict)
     {
         if ($strict) {
-            return function ($a, $b) {
+            return static function ($a, $b) {
                 return $a === $b;
             };
         }
 
-        return function ($a, $b) {
+        return static function ($a, $b) {
             return $a == $b;
         };
     }
@@ -1267,7 +1267,8 @@ class Collection implements ArrayAccess, Enumerable
             return $this->getArrayableItems($items);
         }, func_get_args());
 
-        $params = array_merge([function () {
+        $params = array_merge([
+            static function () {
             return new static(func_get_args());
         }, $this->items], $arrayableItems);
 

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -61,7 +61,7 @@ class ConfigurationUrlParser
             'port' => $url['port'] ?? null,
             'username' => $url['user'] ?? null,
             'password' => $url['pass'] ?? null,
-        ], function ($value) {
+        ], static function ($value) {
             return ! is_null($value);
         });
     }

--- a/src/Illuminate/Support/Env.php
+++ b/src/Illuminate/Support/Env.php
@@ -79,7 +79,7 @@ class Env
     public static function get($key, $default = null)
     {
         return Option::fromValue(static::getRepository()->get($key))
-            ->map(function ($value) {
+            ->map(static function ($value) {
                 switch (strtolower($value)) {
                     case 'true':
                     case '(true)':
@@ -101,7 +101,7 @@ class Env
 
                 return $value;
             })
-            ->getOrCall(function () use ($default) {
+            ->getOrCall(static function () use ($default) {
                 return value($default);
             });
     }

--- a/src/Illuminate/Support/Facades/Event.php
+++ b/src/Illuminate/Support/Facades/Event.php
@@ -56,7 +56,7 @@ class Event extends Facade
 
         static::fake($eventsToFake);
 
-        return tap($callable(), function () use ($originalDispatcher) {
+        return tap($callable(), static function () use ($originalDispatcher) {
             static::swap($originalDispatcher);
 
             Model::setEventDispatcher($originalDispatcher);

--- a/src/Illuminate/Support/Facades/Facade.php
+++ b/src/Illuminate/Support/Facades/Facade.php
@@ -37,7 +37,7 @@ abstract class Facade
             $callback(static::getFacadeRoot());
         }
 
-        static::$app->afterResolving($accessor, function ($service) use ($callback) {
+        static::$app->afterResolving($accessor, static function ($service) use ($callback) {
             $callback($service);
         });
     }
@@ -52,7 +52,7 @@ abstract class Facade
         if (! static::isMock()) {
             $class = static::getMockableClass();
 
-            return tap($class ? Mockery::spy($class) : Mockery::spy(), function ($spy) {
+            return tap($class ? Mockery::spy($class) : Mockery::spy(), static function ($spy) {
                 static::swap($spy);
             });
         }
@@ -97,7 +97,7 @@ abstract class Facade
      */
     protected static function createFreshMockInstance()
     {
-        return tap(static::createMock(), function ($mock) {
+        return tap(static::createMock(), static function ($mock) {
             static::swap($mock);
 
             $mock->shouldAllowMockingProtectedMethods();

--- a/src/Illuminate/Support/HigherOrderCollectionProxy.php
+++ b/src/Illuminate/Support/HigherOrderCollectionProxy.php
@@ -42,7 +42,7 @@ class HigherOrderCollectionProxy
      */
     public function __get($key)
     {
-        return $this->collection->{$this->method}(function ($value) use ($key) {
+        return $this->collection->{$this->method}(static function ($value) use ($key) {
             return is_array($value) ? $value[$key] : $value->{$key};
         });
     }
@@ -56,7 +56,7 @@ class HigherOrderCollectionProxy
      */
     public function __call($method, $parameters)
     {
-        return $this->collection->{$this->method}(function ($value) use ($method, $parameters) {
+        return $this->collection->{$this->method}(static function ($value) use ($method, $parameters) {
             return $value->{$method}(...$parameters);
         });
     }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -60,7 +60,7 @@ class LazyCollection implements Enumerable
             return new static;
         }
 
-        $instance = new static(function () use ($number) {
+        $instance = new static(static function () use ($number) {
             for ($current = 1; $current <= $number; $current++) {
                 yield $current;
             }
@@ -78,7 +78,7 @@ class LazyCollection implements Enumerable
      */
     public static function range($from, $to)
     {
-        return new static(function () use ($from, $to) {
+        return new static(static function () use ($from, $to) {
             for (; $from <= $to; $from++) {
                 yield $from;
             }
@@ -122,7 +122,7 @@ class LazyCollection implements Enumerable
 
         $cache = [];
 
-        return new static(function () use ($iterator, &$iteratorIndex, &$cache) {
+        return new static(static function () use ($iterator, &$iteratorIndex, &$cache) {
             for ($index = 0; true; $index++) {
                 if (array_key_exists($index, $cache)) {
                     yield $cache[$index][0] => $cache[$index][1];
@@ -352,7 +352,7 @@ class LazyCollection implements Enumerable
     public function filter(callable $callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return (bool) $value;
             };
         }
@@ -900,7 +900,7 @@ class LazyCollection implements Enumerable
     {
         $predicate = $this->useAsCallable($value)
             ? $value
-            : function ($item) use ($value, $strict) {
+            : static function ($item) use ($value, $strict) {
                 return $strict ? $item === $value : $item == $value;
             };
 

--- a/src/Illuminate/Support/MessageBag.php
+++ b/src/Illuminate/Support/MessageBag.php
@@ -211,7 +211,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     protected function getMessagesForWildcardKey($key, $format)
     {
         return collect($this->messages)
-                ->filter(function ($messages, $messageKey) use ($key) {
+                ->filter(static function ($messages, $messageKey) use ($key) {
                     return Str::is($key, $messageKey);
                 })
                 ->map(function ($messages, $messageKey) use ($format) {
@@ -262,7 +262,7 @@ class MessageBag implements Arrayable, Countable, Jsonable, JsonSerializable, Me
     protected function transform($messages, $format, $messageKey)
     {
         return collect((array) $messages)
-            ->map(function ($message) use ($format, $messageKey) {
+            ->map(static function ($message) use ($format, $messageKey) {
                 // We will simply spin through the given messages and transform each one
                 // replacing the :message place holder with the real message allowing
                 // the messages to be easily formatted to each developer's desires.

--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -114,7 +114,7 @@ abstract class ServiceProvider
      */
     protected function loadViewComponentsAs($prefix, array $components)
     {
-        $this->callAfterResolving(BladeCompiler::class, function ($blade) use ($prefix, $components) {
+        $this->callAfterResolving(BladeCompiler::class, static function ($blade) use ($prefix, $components) {
             foreach ($components as $alias => $component) {
                 $blade->component($component, is_string($alias) ? $alias : null, $prefix);
             }
@@ -130,7 +130,7 @@ abstract class ServiceProvider
      */
     protected function loadTranslationsFrom($path, $namespace)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path, $namespace) {
+        $this->callAfterResolving('translator', static function ($translator) use ($path, $namespace) {
             $translator->addNamespace($namespace, $path);
         });
     }
@@ -143,7 +143,7 @@ abstract class ServiceProvider
      */
     protected function loadJsonTranslationsFrom($path)
     {
-        $this->callAfterResolving('translator', function ($translator) use ($path) {
+        $this->callAfterResolving('translator', static function ($translator) use ($path) {
             $translator->addJsonPath($path);
         });
     }
@@ -156,7 +156,7 @@ abstract class ServiceProvider
      */
     protected function loadMigrationsFrom($paths)
     {
-        $this->callAfterResolving('migrator', function ($migrator) use ($paths) {
+        $this->callAfterResolving('migrator', static function ($migrator) use ($paths) {
             foreach ((array) $paths as $path) {
                 $migrator->path($path);
             }
@@ -171,7 +171,7 @@ abstract class ServiceProvider
      */
     protected function loadFactoriesFrom($paths)
     {
-        $this->callAfterResolving(ModelFactory::class, function ($factory) use ($paths) {
+        $this->callAfterResolving(ModelFactory::class, static function ($factory) use ($paths) {
             foreach ((array) $paths as $path) {
                 $factory->load($path);
             }
@@ -256,7 +256,7 @@ abstract class ServiceProvider
             return $paths;
         }
 
-        return collect(static::$publishes)->reduce(function ($paths, $p) {
+        return collect(static::$publishes)->reduce(static function ($paths, $p) {
             return array_merge($paths, $p);
         }, []);
     }
@@ -327,7 +327,7 @@ abstract class ServiceProvider
     {
         $commands = is_array($commands) ? $commands : func_get_args();
 
-        Artisan::starting(function ($artisan) use ($commands) {
+        Artisan::starting(static function ($artisan) use ($commands) {
             $artisan->resolveCommands($commands);
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/BusFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/BusFake.php
@@ -188,11 +188,11 @@ class BusFake implements QueueingDispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->commands[$command])->filter(function ($command) use ($callback) {
+        return collect($this->commands[$command])->filter(static function ($command) use ($callback) {
             return $callback($command);
         });
     }
@@ -210,11 +210,11 @@ class BusFake implements QueueingDispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->commandsAfterResponse[$command])->filter(function ($command) use ($callback) {
+        return collect($this->commandsAfterResponse[$command])->filter(static function ($command) use ($callback) {
             return $callback($command);
         });
     }
@@ -315,7 +315,7 @@ class BusFake implements QueueingDispatcher
         }
 
         return collect($this->jobsToFake)
-            ->filter(function ($job) use ($command) {
+            ->filter(static function ($job) use ($command) {
                 return $job instanceof Closure
                             ? $job($command)
                             : $job === get_class($command);

--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -119,11 +119,11 @@ class EventFake implements Dispatcher
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->events[$event])->filter(function ($arguments) use ($callback) {
+        return collect($this->events[$event])->filter(static function ($arguments) use ($callback) {
             return $callback(...$arguments);
         });
     }
@@ -229,7 +229,7 @@ class EventFake implements Dispatcher
         }
 
         return collect($this->eventsToFake)
-            ->filter(function ($event) use ($eventName, $payload) {
+            ->filter(static function ($event) use ($eventName, $payload) {
                 return $event instanceof Closure
                             ? $event($eventName, $payload)
                             : $event === $eventName;

--- a/src/Illuminate/Support/Testing/Fakes/MailFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/MailFake.php
@@ -104,7 +104,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertNothingSent()
     {
-        $mailableNames = collect($this->mailables)->map(function ($mailable) {
+        $mailableNames = collect($this->mailables)->map(static function ($mailable) {
             return get_class($mailable);
         })->join(', ');
 
@@ -173,7 +173,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     public function assertNothingQueued()
     {
-        $mailableNames = collect($this->queuedMailables)->map(function ($mailable) {
+        $mailableNames = collect($this->queuedMailables)->map(static function ($mailable) {
             return get_class($mailable);
         })->join(', ');
 
@@ -193,11 +193,11 @@ class MailFake implements Factory, Mailer, MailQueue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return $this->mailablesOf($mailable)->filter(function ($mailable) use ($callback) {
+        return $this->mailablesOf($mailable)->filter(static function ($mailable) use ($callback) {
             return $callback($mailable);
         });
     }
@@ -226,11 +226,11 @@ class MailFake implements Factory, Mailer, MailQueue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return $this->queuedMailablesOf($mailable)->filter(function ($mailable) use ($callback) {
+        return $this->queuedMailablesOf($mailable)->filter(static function ($mailable) use ($callback) {
             return $callback($mailable);
         });
     }
@@ -254,7 +254,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     protected function mailablesOf($type)
     {
-        return collect($this->mailables)->filter(function ($mailable) use ($type) {
+        return collect($this->mailables)->filter(static function ($mailable) use ($type) {
             return $mailable instanceof $type;
         });
     }
@@ -267,7 +267,7 @@ class MailFake implements Factory, Mailer, MailQueue
      */
     protected function queuedMailablesOf($type)
     {
-        return collect($this->queuedMailables)->filter(function ($mailable) use ($type) {
+        return collect($this->queuedMailables)->filter(static function ($mailable) use ($type) {
             return $mailable instanceof $type;
         });
     }

--- a/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/NotificationFake.php
@@ -142,7 +142,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
     {
         $actualCount = collect($this->notifications)
             ->flatten(1)
-            ->reduce(function ($count, $sent) use ($notification) {
+            ->reduce(static function ($count, $sent) use ($notification) {
                 return $count + count($sent[$notification] ?? []);
             }, 0);
 
@@ -166,13 +166,13 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
         $notifications = collect($this->notificationsFor($notifiable, $notification));
 
-        return $notifications->filter(function ($arguments) use ($callback) {
+        return $notifications->filter(static function ($arguments) use ($callback) {
             return $callback(...array_values($arguments));
         })->pluck('notification');
     }
@@ -236,7 +236,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
                 'notification' => $notification,
                 'channels' => $channels ?: $notification->via($notifiable),
                 'notifiable' => $notifiable,
-                'locale' => $notification->locale ?? $this->locale ?? value(function () use ($notifiable) {
+                'locale' => $notification->locale ?? $this->locale ?? value(static function () use ($notifiable) {
                     if ($notifiable instanceof HasLocalePreference) {
                         return $notifiable->preferredLocale();
                     }

--- a/src/Illuminate/Support/Testing/Fakes/QueueFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/QueueFake.php
@@ -74,7 +74,7 @@ class QueueFake extends QueueManager implements Queue
             [$job, $callback] = [$this->firstClosureParameterType($job), $job];
         }
 
-        return $this->assertPushed($job, function ($job, $pushedQueue) use ($callback, $queue) {
+        return $this->assertPushed($job, static function ($job, $pushedQueue) use ($callback, $queue) {
             if ($pushedQueue !== $queue) {
                 return false;
             }
@@ -135,12 +135,12 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function assertPushedWithChainOfObjects($job, $expectedChain, $callback)
     {
-        $chain = collect($expectedChain)->map(function ($job) {
+        $chain = collect($expectedChain)->map(static function ($job) {
             return serialize($job);
         })->all();
 
         PHPUnit::assertTrue(
-            $this->pushed($job, $callback)->filter(function ($job) use ($chain) {
+            $this->pushed($job, $callback)->filter(static function ($job) use ($chain) {
                 return $job->chained == $chain;
             })->isNotEmpty(),
             'The expected chain was not pushed.'
@@ -157,11 +157,11 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function assertPushedWithChainOfClasses($job, $expectedChain, $callback)
     {
-        $matching = $this->pushed($job, $callback)->map->chained->map(function ($chain) {
-            return collect($chain)->map(function ($job) {
+        $matching = $this->pushed($job, $callback)->map->chained->map(static function ($chain) {
+            return collect($chain)->map(static function ($job) {
                 return get_class(unserialize($job));
             });
-        })->filter(function ($chain) use ($expectedChain) {
+        })->filter(static function ($chain) use ($expectedChain) {
             return $chain->all() === $expectedChain;
         });
 
@@ -178,7 +178,7 @@ class QueueFake extends QueueManager implements Queue
      */
     protected function isChainOfObjects($chain)
     {
-        return ! collect($chain)->contains(function ($job) {
+        return ! collect($chain)->contains(static function ($job) {
             return ! is_object($job);
         });
     }
@@ -225,11 +225,11 @@ class QueueFake extends QueueManager implements Queue
             return collect();
         }
 
-        $callback = $callback ?: function () {
+        $callback = $callback ?: static function () {
             return true;
         };
 
-        return collect($this->jobs[$job])->filter(function ($data) use ($callback) {
+        return collect($this->jobs[$job])->filter(static function ($data) use ($callback) {
             return $callback($data['job'], $data['queue']);
         })->pluck('job');
     }
@@ -264,7 +264,7 @@ class QueueFake extends QueueManager implements Queue
      */
     public function size($queue = null)
     {
-        return collect($this->jobs)->flatten(1)->filter(function ($job) use ($queue) {
+        return collect($this->jobs)->flatten(1)->filter(static function ($job) use ($queue) {
             return $job['queue'] === $queue;
         })->count();
     }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -143,7 +143,7 @@ trait EnumeratesValues
     public function containsStrict($key, $value = null)
     {
         if (func_num_args() === 2) {
-            return $this->contains(function ($item) use ($key, $value) {
+            return $this->contains(static function ($item) use ($key, $value) {
                 return data_get($item, $key) === $value;
             });
         }
@@ -183,7 +183,7 @@ trait EnumeratesValues
     {
         (new static(func_get_args()))
             ->push($this)
-            ->each(function ($item) {
+            ->each(static function ($item) {
                 VarDumper::dump($item);
             });
 
@@ -215,7 +215,7 @@ trait EnumeratesValues
      */
     public function eachSpread(callable $callback)
     {
-        return $this->each(function ($chunk, $key) use ($callback) {
+        return $this->each(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -278,7 +278,7 @@ trait EnumeratesValues
      */
     public function mapSpread(callable $callback)
     {
-        return $this->map(function ($chunk, $key) use ($callback) {
+        return $this->map(static function ($chunk, $key) use ($callback) {
             $chunk[] = $key;
 
             return $callback(...$chunk);
@@ -319,7 +319,7 @@ trait EnumeratesValues
      */
     public function mapInto($class)
     {
-        return $this->map(function ($value, $key) use ($class) {
+        return $this->map(static function ($value, $key) use ($class) {
             return new $class($value, $key);
         });
     }
@@ -334,11 +334,11 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->map(function ($value) use ($callback) {
+        return $this->map(static function ($value) use ($callback) {
             return $callback($value);
-        })->filter(function ($value) {
+        })->filter(static function ($value) {
             return ! is_null($value);
-        })->reduce(function ($result, $value) {
+        })->reduce(static function ($result, $value) {
             return is_null($result) || $value < $result ? $value : $result;
         });
     }
@@ -353,9 +353,9 @@ trait EnumeratesValues
     {
         $callback = $this->valueRetriever($callback);
 
-        return $this->filter(function ($value) {
+        return $this->filter(static function ($value) {
             return ! is_null($value);
-        })->reduce(function ($result, $item) use ($callback) {
+        })->reduce(static function ($result, $item) use ($callback) {
             $value = $callback($item);
 
             return is_null($result) || $value > $result ? $value : $result;
@@ -413,14 +413,14 @@ trait EnumeratesValues
     public function sum($callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return $value;
             };
         } else {
             $callback = $this->valueRetriever($callback);
         }
 
-        return $this->reduce(function ($result, $item) use ($callback) {
+        return $this->reduce(static function ($result, $item) use ($callback) {
             return $result + $callback($item);
         }, 0);
     }
@@ -568,7 +568,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->filter(function ($item) use ($key, $values, $strict) {
+        return $this->filter(static function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
     }
@@ -606,7 +606,7 @@ trait EnumeratesValues
      */
     public function whereNotBetween($key, $values)
     {
-        return $this->filter(function ($item) use ($key, $values) {
+        return $this->filter(static function ($item) use ($key, $values) {
             return data_get($item, $key) < reset($values) || data_get($item, $key) > end($values);
         });
     }
@@ -623,7 +623,7 @@ trait EnumeratesValues
     {
         $values = $this->getArrayableItems($values);
 
-        return $this->reject(function ($item) use ($key, $values, $strict) {
+        return $this->reject(static function ($item) use ($key, $values, $strict) {
             return in_array(data_get($item, $key), $values, $strict);
         });
     }
@@ -648,7 +648,7 @@ trait EnumeratesValues
      */
     public function whereInstanceOf($type)
     {
-        return $this->filter(function ($value) use ($type) {
+        return $this->filter(static function ($value) use ($type) {
             return $value instanceof $type;
         });
     }
@@ -687,7 +687,7 @@ trait EnumeratesValues
     {
         $useAsCallable = $this->useAsCallable($callback);
 
-        return $this->filter(function ($value, $key) use ($callback, $useAsCallable) {
+        return $this->filter(static function ($value, $key) use ($callback, $useAsCallable) {
             return $useAsCallable
                 ? ! $callback($value, $key)
                 : $value != $callback;
@@ -707,7 +707,7 @@ trait EnumeratesValues
 
         $exists = [];
 
-        return $this->reject(function ($item, $key) use ($callback, $strict, &$exists) {
+        return $this->reject(static function ($item, $key) use ($callback, $strict, &$exists) {
             if (in_array($id = $callback($item, $key), $exists, $strict)) {
                 return true;
             }
@@ -759,7 +759,7 @@ trait EnumeratesValues
      */
     public function toArray()
     {
-        return $this->map(function ($value) {
+        return $this->map(static function ($value) {
             return $value instanceof Arrayable ? $value->toArray() : $value;
         })->all();
     }
@@ -771,7 +771,7 @@ trait EnumeratesValues
      */
     public function jsonSerialize()
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             if ($value instanceof JsonSerializable) {
                 return $value->jsonSerialize();
             } elseif ($value instanceof Jsonable) {
@@ -815,12 +815,12 @@ trait EnumeratesValues
     public function countBy($callback = null)
     {
         if (is_null($callback)) {
-            $callback = function ($value) {
+            $callback = static function ($value) {
                 return $value;
             };
         }
 
-        return new static($this->groupBy($callback)->map(function ($value) {
+        return new static($this->groupBy($callback)->map(static function ($value) {
             return $value->count();
         }));
     }
@@ -910,10 +910,10 @@ trait EnumeratesValues
             $operator = '=';
         }
 
-        return function ($item) use ($key, $operator, $value) {
+        return static function ($item) use ($key, $operator, $value) {
             $retrieved = data_get($item, $key);
 
-            $strings = array_filter([$retrieved, $value], function ($value) {
+            $strings = array_filter([$retrieved, $value], static function ($value) {
                 return is_string($value) || (is_object($value) && method_exists($value, '__toString'));
             });
 
@@ -960,7 +960,7 @@ trait EnumeratesValues
             return $value;
         }
 
-        return function ($item) use ($value) {
+        return static function ($item) use ($value) {
             return data_get($item, $value);
         };
     }
@@ -973,7 +973,7 @@ trait EnumeratesValues
      */
     protected function equality($value)
     {
-        return function ($item) use ($value) {
+        return static function ($item) use ($value) {
             return $item === $value;
         };
     }
@@ -986,7 +986,7 @@ trait EnumeratesValues
      */
     protected function negate(Closure $callback)
     {
-        return function (...$params) use ($callback) {
+        return static function (...$params) use ($callback) {
             return ! $callback(...$params);
         };
     }

--- a/src/Illuminate/Support/Traits/ReflectsClosures.php
+++ b/src/Illuminate/Support/Traits/ReflectsClosures.php
@@ -21,7 +21,7 @@ trait ReflectsClosures
     {
         $reflection = new ReflectionFunction($closure);
 
-        return collect($reflection->getParameters())->mapWithKeys(function ($parameter) {
+        return collect($reflection->getParameters())->mapWithKeys(static function ($parameter) {
             if ($parameter->isVariadic()) {
                 return [$parameter->getName() => null];
             }

--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -372,7 +372,7 @@ if (! function_exists('preg_replace_array')) {
      */
     function preg_replace_array($pattern, array $replacements, $subject)
     {
-        return preg_replace_callback($pattern, function () use (&$replacements) {
+        return preg_replace_callback($pattern, static function () use (&$replacements) {
             foreach ($replacements as $key => $value) {
                 return array_shift($replacements);
             }

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -246,7 +246,7 @@ class PendingCommand
                 });
         }
 
-        $this->app->bind(OutputStyle::class, function () use ($mock) {
+        $this->app->bind(OutputStyle::class, static function () use ($mock) {
             return $mock;
         });
 

--- a/src/Illuminate/Translation/MessageSelector.php
+++ b/src/Illuminate/Translation/MessageSelector.php
@@ -91,7 +91,7 @@ class MessageSelector
      */
     private function stripConditions($segments)
     {
-        return collect($segments)->map(function ($part) {
+        return collect($segments)->map(static function ($part) {
             return preg_replace('/^[\{\[]([^\[\]\{\}]*)[\}\]]/', '', $part);
         })->all();
     }

--- a/src/Illuminate/Translation/TranslationServiceProvider.php
+++ b/src/Illuminate/Translation/TranslationServiceProvider.php
@@ -16,7 +16,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
     {
         $this->registerLoader();
 
-        $this->app->singleton('translator', function ($app) {
+        $this->app->singleton('translator', static function ($app) {
             $loader = $app['translation.loader'];
 
             // When registering the translator component, we'll need to set the default
@@ -39,7 +39,7 @@ class TranslationServiceProvider extends ServiceProvider implements DeferrablePr
      */
     protected function registerLoader()
     {
-        $this->app->singleton('translation.loader', function ($app) {
+        $this->app->singleton('translation.loader', static function ($app) {
             return new FileLoader($app['files'], $app['path.lang']);
         });
     }

--- a/src/Illuminate/Translation/Translator.php
+++ b/src/Illuminate/Translation/Translator.php
@@ -237,7 +237,7 @@ class Translator extends NamespacedItemResolver implements TranslatorContract
      */
     protected function sortReplacements(array $replace)
     {
-        return (new Collection($replace))->sortBy(function ($value, $key) {
+        return (new Collection($replace))->sortBy(static function ($value, $key) {
             return mb_strlen($key) * -1;
         })->all();
     }

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -622,7 +622,7 @@ trait ValidatesAttributes
 
         $pattern = str_replace('\*', '[^.]+', preg_quote($attribute, '#'));
 
-        return Arr::where(Arr::dot($attributeData), function ($value, $key) use ($pattern) {
+        return Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($pattern) {
             return (bool) preg_match('#^'.$pattern.'\z#u', $key);
         });
     }
@@ -643,7 +643,7 @@ trait ValidatesAttributes
 
         $validations = collect($parameters)
             ->unique()
-            ->map(function ($validation) {
+            ->map(static function ($validation) {
                 if ($validation === 'rfc') {
                     return new RFCValidation();
                 } elseif ($validation === 'strict') {
@@ -1087,7 +1087,7 @@ trait ValidatesAttributes
 
         $attributeData = ValidationData::extractDataFromPath($explicitPath, $this->data);
 
-        $otherValues = Arr::where(Arr::dot($attributeData), function ($value, $key) use ($parameters) {
+        $otherValues = Arr::where(Arr::dot($attributeData), static function ($value, $key) use ($parameters) {
             return Str::is($parameters[0], $key);
         });
 
@@ -1492,7 +1492,7 @@ trait ValidatesAttributes
      */
     protected function convertValuesToBoolean($values)
     {
-        return array_map(function ($value) {
+        return array_map(static function ($value) {
             if ($value === 'true') {
                 return true;
             } elseif ($value === 'false') {
@@ -1850,7 +1850,7 @@ trait ValidatesAttributes
      */
     protected function parseNamedParameters($parameters)
     {
-        return array_reduce($parameters, function ($result, $item) {
+        return array_reduce($parameters, static function ($result, $item) {
             [$key, $value] = array_pad(explode('=', $item, 2), 2, null);
 
             $result[$key] = $value;

--- a/src/Illuminate/Validation/DatabasePresenceVerifier.php
+++ b/src/Illuminate/Validation/DatabasePresenceVerifier.php
@@ -82,7 +82,7 @@ class DatabasePresenceVerifier implements DatabasePresenceVerifierInterface
     {
         foreach ($conditions as $key => $value) {
             if ($value instanceof Closure) {
-                $query->where(function ($query) use ($value) {
+                $query->where(static function ($query) use ($value) {
                     $value($query);
                 });
             } else {

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -142,7 +142,7 @@ trait DatabaseRule
      */
     public function whereIn($column, array $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
             $query->whereIn($column, $values);
         });
     }
@@ -156,7 +156,7 @@ trait DatabaseRule
      */
     public function whereNotIn($column, array $values)
     {
-        return $this->where(function ($query) use ($column, $values) {
+        return $this->where(static function ($query) use ($column, $values) {
             $query->whereNotIn($column, $values);
         });
     }
@@ -191,7 +191,7 @@ trait DatabaseRule
      */
     protected function formatWheres()
     {
-        return collect($this->wheres)->map(function ($where) {
+        return collect($this->wheres)->map(static function ($where) {
             return $where['column'].','.'"'.str_replace('"', '""', $where['value']).'"';
         })->implode(',');
     }

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -36,7 +36,7 @@ class In
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -34,7 +34,7 @@ class NotIn
      */
     public function __toString()
     {
-        $values = array_map(function ($value) {
+        $values = array_map(static function ($value) {
             return '"'.str_replace('"', '""', $value).'"';
         }, $this->values);
 

--- a/src/Illuminate/Validation/ValidationException.php
+++ b/src/Illuminate/Validation/ValidationException.php
@@ -68,7 +68,7 @@ class ValidationException extends Exception
      */
     public static function withMessages(array $messages)
     {
-        return new static(tap(ValidatorFacade::make([], []), function ($validator) use ($messages) {
+        return new static(tap(ValidatorFacade::make([], []), static function ($validator) use ($messages) {
             foreach ($messages as $key => $value) {
                 foreach (Arr::wrap($value) as $message) {
                     $validator->errors()->add($key, $message);

--- a/src/Illuminate/Validation/ValidationServiceProvider.php
+++ b/src/Illuminate/Validation/ValidationServiceProvider.php
@@ -26,7 +26,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerValidationFactory()
     {
-        $this->app->singleton('validator', function ($app) {
+        $this->app->singleton('validator', static function ($app) {
             $validator = new Factory($app['translator'], $app);
 
             // The validation presence verifier is responsible for determining the existence of
@@ -47,7 +47,7 @@ class ValidationServiceProvider extends ServiceProvider implements DeferrablePro
      */
     protected function registerPresenceVerifier()
     {
-        $this->app->singleton('validation.presence', function ($app) {
+        $this->app->singleton('validation.presence', static function ($app) {
             return new DatabasePresenceVerifier($app['db']);
         });
     }

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -581,7 +581,7 @@ class Validator implements ValidatorContract
      */
     protected function replaceAsterisksInParameters(array $parameters, array $keys)
     {
-        return array_map(function ($field) use ($keys) {
+        return array_map(static function ($field) use ($keys) {
             return vsprintf(str_replace('*', '%s', $field), $keys);
         }, $parameters);
     }
@@ -823,7 +823,7 @@ class Validator implements ValidatorContract
      */
     protected function attributesThatHaveMessages()
     {
-        return collect($this->messages()->toArray())->map(function ($message, $key) {
+        return collect($this->messages()->toArray())->map(static function ($message, $key) {
             return explode('.', $key)[0];
         })->unique()->flip()->all();
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -179,7 +179,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         return collect(token_get_all($contents))
             ->pluck(0)
-            ->filter(function ($token) {
+            ->filter(static function ($token) {
                 return in_array($token, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG]);
             });
     }
@@ -493,25 +493,25 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $this->conditions[$name] = $callback;
 
-        $this->directive($name, function ($expression) use ($name) {
+        $this->directive($name, static function ($expression) use ($name) {
             return $expression !== ''
                     ? "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                     : "<?php if (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('unless'.$name, function ($expression) use ($name) {
+        $this->directive('unless'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php if (! \Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('else'.$name, function ($expression) use ($name) {
+        $this->directive('else'.$name, static function ($expression) use ($name) {
             return $expression !== ''
                 ? "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}', {$expression})): ?>"
                 : "<?php elseif (\Illuminate\Support\Facades\Blade::check('{$name}')): ?>";
         });
 
-        $this->directive('end'.$name, function () {
+        $this->directive('end'.$name, static function () {
             return '<?php endif; ?>';
         });
     }
@@ -544,7 +544,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
 
         if (is_null($alias)) {
             $alias = Str::contains($class, '\\View\\Components\\')
-                            ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(function ($segment) {
+                            ? collect(explode('\\', Str::after($class, '\\View\\Components\\')))->map(static function ($segment) {
                                 return Str::kebab($segment);
                             })->implode(':')
                             : Str::kebab(class_basename($class));
@@ -596,13 +596,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     {
         $alias = $alias ?: Arr::last(explode('.', $path));
 
-        $this->directive($alias, function ($expression) use ($path) {
+        $this->directive($alias, static function ($expression) use ($path) {
             return $expression
                         ? "<?php \$__env->startComponent('{$path}', {$expression}); ?>"
                         : "<?php \$__env->startComponent('{$path}'); ?>";
         });
 
-        $this->directive('end'.$alias, function ($expression) {
+        $this->directive('end'.$alias, static function ($expression) {
             return '<?php echo $__env->renderComponent(); ?>';
         });
     }

--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -185,7 +185,7 @@ class ComponentTagCompiler
 
         [$data, $attributes] = $this->partitionDataAndAttributes($class, $attributes);
 
-        $data = $data->mapWithKeys(function ($value, $key) {
+        $data = $data->mapWithKeys(static function ($value, $key) {
             return [Str::camel($key) => $value];
         });
 
@@ -258,7 +258,7 @@ class ComponentTagCompiler
                     ->make(Application::class)
                     ->getNamespace();
 
-        $componentPieces = array_map(function ($componentPiece) {
+        $componentPieces = array_map(static function ($componentPiece) {
             return ucfirst(Str::camel($componentPiece));
         }, explode('.', $component));
 
@@ -287,7 +287,7 @@ class ComponentTagCompiler
                     ? collect($constructor->getParameters())->map->getName()->all()
                     : [];
 
-        return collect($attributes)->partition(function ($value, $key) use ($parameterNames) {
+        return collect($attributes)->partition(static function ($value, $key) use ($parameterNames) {
             return in_array(Str::camel($key), $parameterNames);
         });
     }
@@ -418,7 +418,7 @@ class ComponentTagCompiler
      */
     protected function escapeSingleQuotesOutsideOfPhpBlocks(string $value)
     {
-        return collect(token_get_all($value))->map(function ($token) {
+        return collect(token_get_all($value))->map(static function ($token) {
             if (! is_array($token)) {
                 return $token;
             }

--- a/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesEchos.php
@@ -43,7 +43,7 @@ trait CompilesEchos
     {
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->rawTags[0], $this->rawTags[1]);
 
-        $callback = function ($matches) {
+        $callback = static function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
             return $matches[1] ? substr($matches[0], 1) : "<?php echo {$matches[2]}; ?>{$whitespace}";
@@ -83,7 +83,7 @@ trait CompilesEchos
     {
         $pattern = sprintf('/(@)?%s\s*(.+?)\s*%s(\r?\n)?/s', $this->escapedTags[0], $this->escapedTags[1]);
 
-        $callback = function ($matches) {
+        $callback = static function ($matches) {
             $whitespace = empty($matches[3]) ? '' : $matches[3].$matches[3];
 
             return $matches[1] ? $matches[0] : "<?php echo e({$matches[2]}); ?>{$whitespace}";

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -74,7 +74,7 @@ abstract class Component
                         : $this->createBladeViewFromString($factory, $view);
         };
 
-        return $view instanceof Closure ? function (array $data = []) use ($view, $resolver) {
+        return $view instanceof Closure ? static function (array $data = []) use ($view, $resolver) {
             return $resolver($view($data));
         }
         : $resolver($view);
@@ -136,7 +136,7 @@ abstract class Component
                 ->reject(function (ReflectionProperty $property) {
                     return $this->shouldIgnore($property->getName());
                 })
-                ->map(function (ReflectionProperty $property) {
+                ->map(static function (ReflectionProperty $property) {
                     return $property->getName();
                 })->all();
         }
@@ -166,7 +166,7 @@ abstract class Component
                 ->reject(function (ReflectionMethod $method) {
                     return $this->shouldIgnore($method->getName());
                 })
-                ->map(function (ReflectionMethod $method) {
+                ->map(static function (ReflectionMethod $method) {
                     return $method->getName();
                 });
         }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -110,7 +110,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         $attributes = [];
 
-        $attributeDefaults = array_map(function ($value) {
+        $attributeDefaults = array_map(static function ($value) {
             if (is_null($value) || is_bool($value)) {
                 return $value;
             }

--- a/src/Illuminate/View/Concerns/ManagesEvents.php
+++ b/src/Illuminate/View/Concerns/ManagesEvents.php
@@ -160,7 +160,7 @@ trait ManagesEvents
     protected function addEventListener($name, $callback)
     {
         if (Str::contains($name, '*')) {
-            $callback = function ($name, array $data) use ($callback) {
+            $callback = static function ($name, array $data) use ($callback) {
                 return $callback($data[0]);
             };
         }

--- a/src/Illuminate/View/Factory.php
+++ b/src/Illuminate/View/Factory.php
@@ -299,7 +299,7 @@ class Factory implements FactoryContract
     {
         $extensions = array_keys($this->extensions);
 
-        return Arr::first($extensions, function ($value) use ($path) {
+        return Arr::first($extensions, static function ($value) use ($path) {
             return Str::endsWith($path, '.'.$value);
         });
     }

--- a/src/Illuminate/View/FileViewFinder.php
+++ b/src/Illuminate/View/FileViewFinder.php
@@ -145,7 +145,7 @@ class FileViewFinder implements ViewFinderInterface
      */
     protected function getPossibleViewFiles($name)
     {
-        return array_map(function ($extension) use ($name) {
+        return array_map(static function ($extension) use ($name) {
             return str_replace('.', '/', $name).'.'.$extension;
         }, $this->extensions);
     }

--- a/src/Illuminate/View/ViewServiceProvider.php
+++ b/src/Illuminate/View/ViewServiceProvider.php
@@ -75,7 +75,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerViewFinder()
     {
-        $this->app->bind('view.finder', function ($app) {
+        $this->app->bind('view.finder', static function ($app) {
             return new FileViewFinder($app['files'], $app['config']['view.paths']);
         });
     }
@@ -87,7 +87,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerBladeCompiler()
     {
-        $this->app->singleton('blade.compiler', function ($app) {
+        $this->app->singleton('blade.compiler', static function ($app) {
             return new BladeCompiler($app['files'], $app['config']['view.compiled']);
         });
     }
@@ -121,7 +121,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerFileEngine($resolver)
     {
-        $resolver->register('file', function () {
+        $resolver->register('file', static function () {
             return new FileEngine;
         });
     }
@@ -134,7 +134,7 @@ class ViewServiceProvider extends ServiceProvider
      */
     public function registerPhpEngine($resolver)
     {
-        $resolver->register('php', function () {
+        $resolver->register('php', static function () {
             return new PhpEngine;
         });
     }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -17,10 +17,10 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
+        $gate->define('foo', static function ($user) {
             return true;
         });
-        $gate->define('bar', function ($user) {
+        $gate->define('bar', static function ($user) {
             return false;
         });
 
@@ -30,7 +30,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testBeforeCanTakeAnArrayCallbackAsObject()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
@@ -41,7 +41,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testBeforeCanTakeAnArrayCallbackAsObjectStatic()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
@@ -52,7 +52,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testBeforeCanTakeAnArrayCallbackWithStaticMethod()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
@@ -63,11 +63,11 @@ class AuthAccessGateTest extends TestCase
 
     public function testBeforeCanAllowGuests()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
-        $gate->before(function (?stdClass $user) {
+        $gate->before(static function (?stdClass $user) {
             return true;
         });
 
@@ -76,11 +76,11 @@ class AuthAccessGateTest extends TestCase
 
     public function testAfterCanAllowGuests()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
-        $gate->after(function (?stdClass $user) {
+        $gate->after(static function (?stdClass $user) {
             return true;
         });
 
@@ -89,15 +89,15 @@ class AuthAccessGateTest extends TestCase
 
     public function testClosuresCanAllowGuestUsers()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
-        $gate->define('foo', function (?stdClass $user) {
+        $gate->define('foo', static function (?stdClass $user) {
             return true;
         });
 
-        $gate->define('bar', function (stdClass $user) {
+        $gate->define('bar', static function (stdClass $user) {
             return false;
         });
 
@@ -109,7 +109,7 @@ class AuthAccessGateTest extends TestCase
     {
         unset($_SERVER['__laravel.testBefore']);
 
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
@@ -133,7 +133,7 @@ class AuthAccessGateTest extends TestCase
     {
         $_SERVER['__laravel.testBefore'] = false;
 
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
@@ -153,27 +153,27 @@ class AuthAccessGateTest extends TestCase
         $_SERVER['__laravel.gateAfter'] = false;
         $_SERVER['__laravel.gateAfter2'] = false;
 
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 
-        $gate->before(function (?stdClass $user) {
+        $gate->before(static function (?stdClass $user) {
             $_SERVER['__laravel.gateBefore'] = true;
         });
 
-        $gate->after(function (?stdClass $user) {
+        $gate->after(static function (?stdClass $user) {
             $_SERVER['__laravel.gateAfter'] = true;
         });
 
-        $gate->before(function (stdClass $user) {
+        $gate->before(static function (stdClass $user) {
             $_SERVER['__laravel.gateBefore2'] = true;
         });
 
-        $gate->after(function (stdClass $user) {
+        $gate->after(static function (stdClass $user) {
             $_SERVER['__laravel.gateAfter2'] = true;
         });
 
-        $gate->define('foo', function ($user = null) {
+        $gate->define('foo', static function ($user = null) {
             return true;
         });
 
@@ -223,7 +223,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
+        $gate->define('foo', static function ($user) {
             return true;
         });
         $gate->before(function ($user, $ability) {
@@ -239,10 +239,10 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
+        $gate->define('foo', static function ($user) {
             return true;
         });
-        $gate->before(function () {
+        $gate->before(static function () {
             //
         });
 
@@ -253,11 +253,11 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function ($user) {
+        $gate->define('foo', static function ($user) {
             return true;
         });
 
-        $gate->define('bar', function ($user) {
+        $gate->define('bar', static function ($user) {
             return false;
         });
 
@@ -280,7 +280,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->after(function ($user, $ability, $result) {
+        $gate->after(static function ($user, $ability, $result) {
             return true;
         });
 
@@ -291,15 +291,15 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('deny', function ($user) {
+        $gate->define('deny', static function ($user) {
             return false;
         });
 
-        $gate->define('allow', function ($user) {
+        $gate->define('allow', static function ($user) {
             return true;
         });
 
-        $gate->after(function ($user, $ability, $result) {
+        $gate->after(static function ($user, $ability, $result) {
             return ! $result;
         });
 
@@ -311,11 +311,11 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->after(function ($user, $ability, $result) {
+        $gate->after(static function ($user, $ability, $result) {
             return $ability == 'allow';
         });
 
-        $gate->after(function ($user, $ability, $result) {
+        $gate->after(static function ($user, $ability, $result) {
             return ! $result;
         });
 
@@ -504,7 +504,7 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('nonexistent_method', function ($user) {
+        $gate->define('nonexistent_method', static function ($user) {
             return true;
         });
 
@@ -531,12 +531,12 @@ class AuthAccessGateTest extends TestCase
     {
         $gate = $this->getBasicGate();
 
-        $gate->define('foo', function () {
+        $gate->define('foo', static function () {
             return true;
         });
 
         $counter = 0;
-        $guesserCallback = function () use (&$counter) {
+        $guesserCallback = static function () use (&$counter) {
             $counter++;
         };
         $gate->guessPolicyNamesUsing($guesserCallback);
@@ -689,7 +689,7 @@ class AuthAccessGateTest extends TestCase
 
     protected function getBasicGate($isAdmin = false)
     {
-        return new Gate(new Container, function () use ($isAdmin) {
+        return new Gate(new Container, static function () use ($isAdmin) {
             return (object) ['id' => 1, 'isAdmin' => $isAdmin];
         });
     }
@@ -796,7 +796,7 @@ class AuthAccessGateTest extends TestCase
 
     public function testClassesCanBeDefinedAsCallbacksUsingAtNotationForGuests()
     {
-        $gate = new Gate(new Container, function () {
+        $gate = new Gate(new Container, static function () {
             //
         });
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -76,7 +76,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
 
-        $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->reset(['creds'], function () {
+        $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->reset(['creds'], static function () {
             //
         }));
     }
@@ -88,7 +88,7 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
-        $this->assertEquals(PasswordBrokerContract::INVALID_TOKEN, $broker->reset($creds, function () {
+        $this->assertEquals(PasswordBrokerContract::INVALID_TOKEN, $broker->reset($creds, static function () {
             //
         }));
     }
@@ -99,7 +99,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['validateReset', 'getPassword', 'getToken'])->setConstructorArgs(array_values($mocks = $this->getMocks()))->getMock();
         $broker->expects($this->once())->method('validateReset')->willReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('delete')->once()->with($user);
-        $callback = function ($user, $password) {
+        $callback = static function ($user, $password) {
             $_SERVER['__password.reset.test'] = compact('user', 'password');
 
             return 'foo';

--- a/tests/Auth/AuthenticateMiddlewareTest.php
+++ b/tests/Auth/AuthenticateMiddlewareTest.php
@@ -152,7 +152,7 @@ class AuthenticateMiddlewareTest extends TestCase
     {
         $driver = $this->createAuthDriver($authenticated);
 
-        $this->auth->extend($name, function () use ($driver) {
+        $this->auth->extend($name, static function () use ($driver) {
             return $driver;
         });
 
@@ -167,7 +167,7 @@ class AuthenticateMiddlewareTest extends TestCase
      */
     protected function createAuthDriver($authenticated)
     {
-        return new RequestGuard(function () use ($authenticated) {
+        return new RequestGuard(static function () use ($authenticated) {
             return $authenticated ? new stdClass : null;
         }, m::mock(Request::class), m::mock(EloquentUserProvider::class));
     }
@@ -186,7 +186,7 @@ class AuthenticateMiddlewareTest extends TestCase
 
         $nextParam = null;
 
-        $next = function ($param) use (&$nextParam) {
+        $next = static function ($param) use (&$nextParam) {
             $nextParam = $param;
         };
 

--- a/tests/Auth/AuthorizeMiddlewareTest.php
+++ b/tests/Auth/AuthorizeMiddlewareTest.php
@@ -64,7 +64,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('dashboard', [
             'middleware' => Authorize::class.':view-dashboard',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -74,13 +74,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testSimpleAbilityAuthorized()
     {
-        $this->gate()->define('view-dashboard', function ($user) {
+        $this->gate()->define('view-dashboard', static function ($user) {
             return true;
         });
 
         $this->router->get('dashboard', [
             'middleware' => Authorize::class.':view-dashboard',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -92,13 +92,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testSimpleAbilityWithStringParameter()
     {
-        $this->gate()->define('view-dashboard', function ($user, $param) {
+        $this->gate()->define('view-dashboard', static function ($user, $param) {
             return $param === 'some string';
         });
 
         $this->router->get('dashboard', [
             'middleware' => Authorize::class.':view-dashboard,"some string"',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -118,7 +118,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('dashboard', [
             'middleware' => Authorize::class.':view-dashboard,null',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -130,11 +130,11 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         $post = new stdClass;
 
-        $this->router->bind('post', function () use ($post) {
+        $this->router->bind('post', static function () use ($post) {
             return $post;
         });
 
-        $this->gate()->define('view-comments', function ($user, $model = null) {
+        $this->gate()->define('view-comments', static function ($user, $model = null) {
             return true;
         });
 
@@ -142,13 +142,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('comments', [
             'middleware' => $middleware,
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
         $this->router->get('posts/{post}/comments', [
             'middleware' => $middleware,
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -162,13 +162,13 @@ class AuthorizeMiddlewareTest extends TestCase
 
     public function testSimpleAbilityWithStringParameterFromRouteParameter()
     {
-        $this->gate()->define('view-dashboard', function ($user, $param) {
+        $this->gate()->define('view-dashboard', static function ($user, $param) {
             return $param === 'true';
         });
 
         $this->router->get('dashboard/{route_parameter}', [
             'middleware' => Authorize::class.':view-dashboard,route_parameter',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -191,7 +191,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('users/create', [
             'middleware' => [SubstituteBindings::class, Authorize::class.':create,App\User'],
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -209,7 +209,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('users/create', [
             'middleware' => Authorize::class.':create,App\User',
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -226,7 +226,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $post = new stdClass;
 
-        $this->router->bind('post', function () use ($post) {
+        $this->router->bind('post', static function () use ($post) {
             return $post;
         });
 
@@ -238,7 +238,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('posts/{post}/edit', [
             'middleware' => [SubstituteBindings::class, Authorize::class.':edit,post'],
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -250,7 +250,7 @@ class AuthorizeMiddlewareTest extends TestCase
     {
         $post = new stdClass;
 
-        $this->router->bind('post', function () use ($post) {
+        $this->router->bind('post', static function () use ($post) {
             return $post;
         });
 
@@ -262,7 +262,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $this->router->get('posts/{post}/edit', [
             'middleware' => [SubstituteBindings::class, Authorize::class.':edit,post'],
-            'uses' => function () {
+            'uses' => static function () {
                 return 'success';
             },
         ]);
@@ -286,7 +286,7 @@ class AuthorizeMiddlewareTest extends TestCase
 
         $nextParam = null;
 
-        $next = function ($param) use (&$nextParam) {
+        $next = static function ($param) use (&$nextParam) {
             $nextParam = $param;
         };
 

--- a/tests/Broadcasting/BroadcasterTest.php
+++ b/tests/Broadcasting/BroadcasterTest.php
@@ -35,25 +35,25 @@ class BroadcasterTest extends TestCase
 
     public function testExtractingParametersWhileCheckingForUserAccess()
     {
-        $callback = function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {
+        $callback = static function ($user, BroadcasterTestEloquentModelStub $model, $nonModel) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{nonModel}', 'asd.1.something', $callback);
         $this->assertEquals(['model.1.instance', 'something'], $parameters);
 
-        $callback = function ($user, BroadcasterTestEloquentModelStub $model, BroadcasterTestEloquentModelStub $model2, $something) {
+        $callback = static function ($user, BroadcasterTestEloquentModelStub $model, BroadcasterTestEloquentModelStub $model2, $something) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd.{model}.{model2}.{nonModel}', 'asd.1.uid.something', $callback);
         $this->assertEquals(['model.1.instance', 'model.uid.instance', 'something'], $parameters);
 
-        $callback = function ($user) {
+        $callback = static function ($user) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
         $this->assertEquals([], $parameters);
 
-        $callback = function ($user, $something) {
+        $callback = static function ($user, $something) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('asd', 'asd', $callback);
@@ -65,11 +65,11 @@ class BroadcasterTest extends TestCase
         $container = new Container;
         Container::setInstance($container);
         $binder = m::mock(BindingRegistrar::class);
-        $binder->shouldReceive('getBindingCallback')->times(2)->with('model')->andReturn(function () {
+        $binder->shouldReceive('getBindingCallback')->times(2)->with('model')->andReturn(static function () {
             return 'bound';
         });
         $container->instance(BindingRegistrar::class, $binder);
-        $callback = function ($user, $model) {
+        $callback = static function ($user, $model) {
             //
         };
         $parameters = $this->broadcaster->extractAuthParameters('something.{model}', 'something.1', $callback);
@@ -92,7 +92,7 @@ class BroadcasterTest extends TestCase
 
     public function testCanRegisterChannelsAsClasses()
     {
-        $this->broadcaster->channel('something', function () {
+        $this->broadcaster->channel('something', static function () {
             //
         });
 
@@ -103,7 +103,7 @@ class BroadcasterTest extends TestCase
     {
         $this->expectException(HttpException::class);
 
-        $callback = function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
+        $callback = static function ($user, BroadcasterTestEloquentModelNotFoundStub $model) {
             //
         };
         $this->broadcaster->extractAuthParameters('asd.{model}', 'asd.1', $callback);
@@ -111,7 +111,7 @@ class BroadcasterTest extends TestCase
 
     public function testCanRegisterChannelsWithoutOptions()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         });
     }
@@ -119,7 +119,7 @@ class BroadcasterTest extends TestCase
     public function testCanRegisterChannelsWithOptions()
     {
         $options = ['a' => ['b', 'c']];
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, $options);
     }
@@ -127,7 +127,7 @@ class BroadcasterTest extends TestCase
     public function testCanRetrieveChannelsOptions()
     {
         $options = ['a' => ['b', 'c']];
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, $options);
 
@@ -140,7 +140,7 @@ class BroadcasterTest extends TestCase
     public function testCanRetrieveChannelsOptionsUsingAChannelNameContainingArgs()
     {
         $options = ['a' => ['b', 'c']];
-        $this->broadcaster->channel('somechannel.{id}.test.{text}', function () {
+        $this->broadcaster->channel('somechannel.{id}.test.{text}', static function () {
             //
         }, $options);
 
@@ -153,10 +153,10 @@ class BroadcasterTest extends TestCase
     public function testCanRetrieveChannelsOptionsWhenMultipleChannelsAreRegistered()
     {
         $options = ['a' => ['b', 'c']];
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         });
-        $this->broadcaster->channel('someotherchannel', function () {
+        $this->broadcaster->channel('someotherchannel', static function () {
             //
         }, $options);
 
@@ -169,7 +169,7 @@ class BroadcasterTest extends TestCase
     public function testDontRetrieveChannelsOptionsWhenChannelDoesntExists()
     {
         $options = ['a' => ['b', 'c']];
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, $options);
 
@@ -181,7 +181,7 @@ class BroadcasterTest extends TestCase
 
     public function testRetrieveUserWithoutGuard()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         });
 
@@ -199,7 +199,7 @@ class BroadcasterTest extends TestCase
 
     public function testRetrieveUserWithOneGuardUsingAStringForSpecifyingGuard()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, ['guards' => 'myguard']);
 
@@ -217,10 +217,10 @@ class BroadcasterTest extends TestCase
 
     public function testRetrieveUserWithMultipleGuardsAndRespectGuardsOrder()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, ['guards' => ['myguard1', 'myguard2']]);
-        $this->broadcaster->channel('someotherchannel', function () {
+        $this->broadcaster->channel('someotherchannel', static function () {
             //
         }, ['guards' => ['myguard2', 'myguard1']]);
 
@@ -248,7 +248,7 @@ class BroadcasterTest extends TestCase
 
     public function testRetrieveUserDontUseDefaultGuardWhenOneGuardSpecified()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, ['guards' => 'myguard']);
 
@@ -265,7 +265,7 @@ class BroadcasterTest extends TestCase
 
     public function testRetrieveUserDontUseDefaultGuardWhenMultipleGuardsSpecified()
     {
-        $this->broadcaster->channel('somechannel', function () {
+        $this->broadcaster->channel('somechannel', static function () {
             //
         }, ['guards' => ['myguard1', 'myguard2']]);
 

--- a/tests/Broadcasting/PusherBroadcasterTest.php
+++ b/tests/Broadcasting/PusherBroadcasterTest.php
@@ -27,7 +27,7 @@ class PusherBroadcasterTest extends TestCase
 
     public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
     {
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return true;
         });
 
@@ -43,7 +43,7 @@ class PusherBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return false;
         });
 
@@ -56,7 +56,7 @@ class PusherBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return true;
         });
 
@@ -68,7 +68,7 @@ class PusherBroadcasterTest extends TestCase
     public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
     {
         $returnData = [1, 2, 3, 4];
-        $this->broadcaster->channel('test', function () use ($returnData) {
+        $this->broadcaster->channel('test', static function () use ($returnData) {
             return $returnData;
         });
 
@@ -84,7 +84,7 @@ class PusherBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             //
         });
 
@@ -97,7 +97,7 @@ class PusherBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return [1, 2, 3, 4];
         });
 

--- a/tests/Broadcasting/RedisBroadcasterTest.php
+++ b/tests/Broadcasting/RedisBroadcasterTest.php
@@ -36,7 +36,7 @@ class RedisBroadcasterTest extends TestCase
 
     public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
     {
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return true;
         });
 
@@ -52,7 +52,7 @@ class RedisBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return false;
         });
 
@@ -65,7 +65,7 @@ class RedisBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return true;
         });
 
@@ -77,7 +77,7 @@ class RedisBroadcasterTest extends TestCase
     public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
     {
         $returnData = [1, 2, 3, 4];
-        $this->broadcaster->channel('test', function () use ($returnData) {
+        $this->broadcaster->channel('test', static function () use ($returnData) {
             return $returnData;
         });
 
@@ -93,7 +93,7 @@ class RedisBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             //
         });
 
@@ -106,7 +106,7 @@ class RedisBroadcasterTest extends TestCase
     {
         $this->expectException(AccessDeniedHttpException::class);
 
-        $this->broadcaster->channel('test', function () {
+        $this->broadcaster->channel('test', static function () {
             return [1, 2, 3, 4];
         });
 

--- a/tests/Bus/BusDispatcherTest.php
+++ b/tests/Bus/BusDispatcherTest.php
@@ -23,7 +23,7 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueued()
     {
         $container = new Container;
-        $dispatcher = new Dispatcher($container, function () {
+        $dispatcher = new Dispatcher($container, static function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 
@@ -36,7 +36,7 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueuedUsingCustomHandler()
     {
         $container = new Container;
-        $dispatcher = new Dispatcher($container, function () {
+        $dispatcher = new Dispatcher($container, static function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 
@@ -49,7 +49,7 @@ class BusDispatcherTest extends TestCase
     public function testCommandsThatShouldQueueIsQueuedUsingCustomQueueAndDelay()
     {
         $container = new Container;
-        $dispatcher = new Dispatcher($container, function () {
+        $dispatcher = new Dispatcher($container, static function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('laterOn')->once()->with('foo', 10, m::type(BusDispatcherTestSpecificQueueAndDelayCommand::class));
 
@@ -64,7 +64,7 @@ class BusDispatcherTest extends TestCase
         $container = new Container;
         $mock = m::mock(Queue::class);
         $mock->shouldReceive('push')->never();
-        $dispatcher = new Dispatcher($container, function () use ($mock) {
+        $dispatcher = new Dispatcher($container, static function () use ($mock) {
             return $mock;
         });
 
@@ -75,7 +75,7 @@ class BusDispatcherTest extends TestCase
     {
         $container = new Container;
         $mock = m::mock(Queue::class);
-        $dispatcher = new Dispatcher($container, function () use ($mock) {
+        $dispatcher = new Dispatcher($container, static function () use ($mock) {
             return $mock;
         });
 
@@ -89,7 +89,7 @@ class BusDispatcherTest extends TestCase
     public function testOnConnectionOnJobWhenDispatching()
     {
         $container = new Container;
-        $container->singleton('config', function () {
+        $container->singleton('config', static function () {
             return new Config([
                 'queue' => [
                     'default' => 'null',
@@ -100,7 +100,7 @@ class BusDispatcherTest extends TestCase
             ]);
         });
 
-        $dispatcher = new Dispatcher($container, function () {
+        $dispatcher = new Dispatcher($container, static function () {
             $mock = m::mock(Queue::class);
             $mock->shouldReceive('push')->once();
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -81,7 +81,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->with('table')->andReturn($table);
         $store->expects($this->once())->method('getTime')->willReturn(1);
-        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(function () {
+        $table->shouldReceive('insert')->once()->with(['key' => 'prefixfoo', 'value' => serialize('bar'), 'expiration' => 61])->andReturnUsing(static function () {
             throw new Exception;
         });
         $table->shouldReceive('where')->once()->with('key', 'prefixfoo')->andReturn($table);
@@ -139,7 +139,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $cache = m::mock(stdClass::class);
 
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -149,7 +149,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->increment('foo'));
 
         $cache->value = serialize('bar');
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -159,7 +159,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->increment('foo'));
 
         $cache->value = serialize(2);
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -178,7 +178,7 @@ class CacheDatabaseStoreTest extends TestCase
         $table = m::mock(stdClass::class);
         $cache = m::mock(stdClass::class);
 
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -188,7 +188,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->decrement('foo'));
 
         $cache->value = serialize('bar');
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
@@ -198,7 +198,7 @@ class CacheDatabaseStoreTest extends TestCase
         $this->assertFalse($store->decrement('foo'));
 
         $cache->value = serialize(3);
-        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(function ($closure) {
+        $store->getConnection()->shouldReceive('transaction')->once()->with(m::type(Closure::class))->andReturnUsing(static function ($closure) {
             return $closure();
         });
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);

--- a/tests/Cache/CacheEventsTest.php
+++ b/tests/Cache/CacheEventsTest.php
@@ -121,13 +121,13 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99]));
-        $this->assertSame('bar', $repository->remember('foo', 99, function () {
+        $this->assertSame('bar', $repository->remember('foo', 99, static function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => 99, 'tags' => ['taylor']]));
-        $this->assertSame('bar', $repository->tags('taylor')->remember('foo', 99, function () {
+        $this->assertSame('bar', $repository->tags('taylor')->remember('foo', 99, static function () {
             return 'bar';
         }));
     }
@@ -139,13 +139,13 @@ class CacheEventsTest extends TestCase
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo']));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null]));
-        $this->assertSame('bar', $repository->rememberForever('foo', function () {
+        $this->assertSame('bar', $repository->rememberForever('foo', static function () {
             return 'bar';
         }));
 
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(CacheMissed::class, ['key' => 'foo', 'tags' => ['taylor']]));
         $dispatcher->shouldReceive('dispatch')->once()->with($this->assertEventMatches(KeyWritten::class, ['key' => 'foo', 'value' => 'bar', 'seconds' => null, 'tags' => ['taylor']]));
-        $this->assertSame('bar', $repository->tags('taylor')->rememberForever('foo', function () {
+        $this->assertSame('bar', $repository->tags('taylor')->rememberForever('foo', static function () {
             return 'bar';
         }));
     }
@@ -176,7 +176,7 @@ class CacheEventsTest extends TestCase
 
     protected function assertEventMatches($eventClass, $properties = [])
     {
-        return m::on(function ($event) use ($eventClass, $properties) {
+        return m::on(static function ($event) use ($eventClass, $properties) {
             if (! $event instanceof $eventClass) {
                 return false;
             }

--- a/tests/Cache/CacheFileStoreTest.php
+++ b/tests/Cache/CacheFileStoreTest.php
@@ -87,7 +87,7 @@ class CacheFileStoreTest extends TestCase
         $store = $this->getMockBuilder(FileStore::class)->setMethods(['expiration'])->setConstructorArgs([$files, __DIR__, 0644])->getMock();
         $hash = sha1('foo');
         $cache_dir = substr($hash, 0, 2).'/'.substr($hash, 2, 2);
-        $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(function ($name, $value) {
+        $files->shouldReceive('put')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash, m::any(), m::any()])->andReturnUsing(static function ($name, $value) {
             return strlen($value);
         });
         $files->shouldReceive('chmod')->withArgs([__DIR__.'/'.$cache_dir.'/'.$hash])->andReturnValues(['0600', '0644'])->times(3);

--- a/tests/Cache/CacheRepositoryTest.php
+++ b/tests/Cache/CacheRepositoryTest.php
@@ -50,7 +50,7 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
         $this->assertSame('bar', $repo->get('foo', 'bar'));
-        $this->assertSame('baz', $repo->get('boom', function () {
+        $this->assertSame('baz', $repo->get('boom', static function () {
             return 'baz';
         }));
     }
@@ -89,7 +89,7 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 10);
-        $result = $repo->remember('foo', 10, function () {
+        $result = $repo->remember('foo', 10, static function () {
             return 'bar';
         });
         $this->assertSame('bar', $result);
@@ -103,11 +103,11 @@ class CacheRepositoryTest extends TestCase
         $repo->getStore()->shouldReceive('get')->times(2)->andReturn(null);
         $repo->getStore()->shouldReceive('put')->once()->with('foo', 'bar', 602);
         $repo->getStore()->shouldReceive('put')->once()->with('baz', 'qux', 598);
-        $result = $repo->remember('foo', Carbon::now()->addMinutes(10)->addSeconds(2), function () {
+        $result = $repo->remember('foo', Carbon::now()->addMinutes(10)->addSeconds(2), static function () {
             return 'bar';
         });
         $this->assertSame('bar', $result);
-        $result = $repo->remember('baz', Carbon::now()->addMinutes(10)->subSeconds(2), function () {
+        $result = $repo->remember('baz', Carbon::now()->addMinutes(10)->subSeconds(2), static function () {
             return 'qux';
         });
         $this->assertSame('qux', $result);
@@ -118,7 +118,7 @@ class CacheRepositoryTest extends TestCase
         $repo = $this->getRepository();
         $repo->getStore()->shouldReceive('get')->once()->andReturn(null);
         $repo->getStore()->shouldReceive('forever')->once()->with('foo', 'bar');
-        $result = $repo->rememberForever('foo', function () {
+        $result = $repo->rememberForever('foo', static function () {
             return 'bar';
         });
         $this->assertSame('bar', $result);

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -32,7 +32,7 @@ class CommandTest extends TestCase
         $output = new NullOutput();
         $application->shouldReceive('make')->with(OutputStyle::class, ['input' => $input, 'output' => $output])->andReturn(m::mock(OutputStyle::class));
 
-        $application->shouldReceive('call')->with([$command, 'handle'])->andReturnUsing(function () use ($command, $application) {
+        $application->shouldReceive('call')->with([$command, 'handle'])->andReturnUsing(static function () use ($command, $application) {
             $commandCalled = m::mock(Command::class);
 
             $application->shouldReceive('make')->once()->with(Command::class)->andReturn($commandCalled);
@@ -104,7 +104,7 @@ class CommandTest extends TestCase
     public function testTheOutputSetterOverwrite()
     {
         $output = m::mock(OutputStyle::class);
-        $output->shouldReceive('writeln')->once()->withArgs(function (...$args) {
+        $output->shouldReceive('writeln')->once()->withArgs(static function (...$args) {
             return $args[0] === '<info>foo</info>';
         });
 
@@ -117,7 +117,7 @@ class CommandTest extends TestCase
     public function testChoiceIsSingleSelectByDefault()
     {
         $output = m::mock(OutputStyle::class);
-        $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
+        $output->shouldReceive('askQuestion')->once()->withArgs(static function (ChoiceQuestion $question) {
             return $question->isMultiselect() === false;
         });
 
@@ -130,7 +130,7 @@ class CommandTest extends TestCase
     public function testChoiceWithMultiselect()
     {
         $output = m::mock(OutputStyle::class);
-        $output->shouldReceive('askQuestion')->once()->withArgs(function (ChoiceQuestion $question) {
+        $output->shouldReceive('askQuestion')->once()->withArgs(static function (ChoiceQuestion $question) {
             return $question->isMultiselect() === true;
         });
 

--- a/tests/Console/ConsoleScheduledEventTest.php
+++ b/tests/Console/ConsoleScheduledEventTest.php
@@ -40,10 +40,10 @@ class ConsoleScheduledEventTest extends TestCase
         $event = new Event(m::mock(EventMutex::class), 'php foo');
         $this->assertSame('* * * * *', $event->getExpression());
         $this->assertTrue($event->isDue($app));
-        $this->assertTrue($event->skip(function () {
+        $this->assertTrue($event->skip(static function () {
             return true;
         })->isDue($app));
-        $this->assertFalse($event->skip(function () {
+        $this->assertFalse($event->skip(static function () {
             return true;
         })->filtersPass($app));
 
@@ -53,7 +53,7 @@ class ConsoleScheduledEventTest extends TestCase
 
         $event = new Event(m::mock(EventMutex::class), 'php foo');
         $this->assertSame('* * * * *', $event->getExpression());
-        $this->assertFalse($event->when(function () {
+        $this->assertFalse($event->when(static function () {
             return false;
         })->filtersPass($app));
 

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -68,14 +68,14 @@ class ContainerCallTest extends TestCase
     public function testCallWithBoundMethod()
     {
         $container = new Container;
-        $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', function ($stub) {
+        $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', static function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call(ContainerTestCallStub::class.'@unresolvable');
         $this->assertEquals(['foo', 'bar'], $result);
 
         $container = new Container;
-        $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', function ($stub) {
+        $container->bindMethod(ContainerTestCallStub::class.'@unresolvable', static function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
@@ -95,14 +95,14 @@ class ContainerCallTest extends TestCase
     public function testBindMethodAcceptsAnArray()
     {
         $container = new Container;
-        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
+        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], static function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call(ContainerTestCallStub::class.'@unresolvable');
         $this->assertEquals(['foo', 'bar'], $result);
 
         $container = new Container;
-        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], function ($stub) {
+        $container->bindMethod([ContainerTestCallStub::class, 'unresolvable'], static function ($stub) {
             return $stub->unresolvable('foo', 'bar');
         });
         $result = $container->call([new ContainerTestCallStub, 'unresolvable']);
@@ -112,11 +112,11 @@ class ContainerCallTest extends TestCase
     public function testClosureCallWithInjectedDependency()
     {
         $container = new Container;
-        $container->call(function (ContainerCallConcreteStub $stub) {
+        $container->call(static function (ContainerCallConcreteStub $stub) {
             //
         }, ['foo' => 'bar']);
 
-        $container->call(function (ContainerCallConcreteStub $stub) {
+        $container->call(static function (ContainerCallConcreteStub $stub) {
             //
         }, ['foo' => 'bar', 'stub' => new ContainerCallConcreteStub]);
     }
@@ -124,14 +124,14 @@ class ContainerCallTest extends TestCase
     public function testCallWithDependencies()
     {
         $container = new Container;
-        $result = $container->call(function (stdClass $foo, $bar = []) {
+        $result = $container->call(static function (stdClass $foo, $bar = []) {
             return func_get_args();
         });
 
         $this->assertInstanceOf(stdClass::class, $result[0]);
         $this->assertEquals([], $result[1]);
 
-        $result = $container->call(function (stdClass $foo, $bar = []) {
+        $result = $container->call(static function (stdClass $foo, $bar = []) {
             return func_get_args();
         }, ['bar' => 'taylor']);
 
@@ -139,7 +139,7 @@ class ContainerCallTest extends TestCase
         $this->assertSame('taylor', $result[1]);
 
         $stub = new ContainerCallConcreteStub;
-        $result = $container->call(function (stdClass $foo, ContainerCallConcreteStub $bar) {
+        $result = $container->call(static function (stdClass $foo, ContainerCallConcreteStub $bar) {
             return func_get_args();
         }, [ContainerCallConcreteStub::class => $stub]);
 
@@ -149,7 +149,7 @@ class ContainerCallTest extends TestCase
         /*
          * Wrap a function...
          */
-        $result = $container->wrap(function (stdClass $foo, $bar = []) {
+        $result = $container->wrap(static function (stdClass $foo, $bar = []) {
             return func_get_args();
         }, ['bar' => 'taylor']);
 
@@ -184,7 +184,7 @@ class ContainerCallTest extends TestCase
         $this->expectExceptionMessage('Unable to resolve dependency [Parameter #0 [ <required> $foo ]] in class Illuminate\Tests\Container\ContainerCallTest');
 
         $container = new Container;
-        $foo = $container->call(function ($foo, $bar = 'default') {
+        $foo = $container->call(static function ($foo, $bar = 'default') {
             return $foo;
         });
     }

--- a/tests/Container/ContainerExtendTest.php
+++ b/tests/Container/ContainerExtendTest.php
@@ -12,7 +12,7 @@ class ContainerExtendTest extends TestCase
     {
         $container = new Container;
         $container['foo'] = 'foo';
-        $container->extend('foo', function ($old, $container) {
+        $container->extend('foo', static function ($old, $container) {
             return $old.'bar';
         });
 
@@ -20,10 +20,10 @@ class ContainerExtendTest extends TestCase
 
         $container = new Container;
 
-        $container->singleton('foo', function () {
+        $container->singleton('foo', static function () {
             return (object) ['name' => 'taylor'];
         });
-        $container->extend('foo', function ($old, $container) {
+        $container->extend('foo', static function ($old, $container) {
             $old->age = 26;
 
             return $old;
@@ -39,7 +39,7 @@ class ContainerExtendTest extends TestCase
     public function testExtendInstancesArePreserved()
     {
         $container = new Container;
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             $obj = new stdClass;
             $obj->foo = 'bar';
 
@@ -49,12 +49,12 @@ class ContainerExtendTest extends TestCase
         $obj = new stdClass;
         $obj->foo = 'foo';
         $container->instance('foo', $obj);
-        $container->extend('foo', function ($obj, $container) {
+        $container->extend('foo', static function ($obj, $container) {
             $obj->bar = 'baz';
 
             return $obj;
         });
-        $container->extend('foo', function ($obj, $container) {
+        $container->extend('foo', static function ($obj, $container) {
             $obj->baz = 'foo';
 
             return $obj;
@@ -71,7 +71,7 @@ class ContainerExtendTest extends TestCase
 
         $container = new Container;
         $container->bind(ContainerLazyExtendStub::class);
-        $container->extend(ContainerLazyExtendStub::class, function ($obj, $container) {
+        $container->extend(ContainerLazyExtendStub::class, static function ($obj, $container) {
             $obj->init();
 
             return $obj;
@@ -84,7 +84,7 @@ class ContainerExtendTest extends TestCase
     public function testExtendCanBeCalledBeforeBind()
     {
         $container = new Container;
-        $container->extend('foo', function ($old, $container) {
+        $container->extend('foo', static function ($old, $container) {
             return $old.'bar';
         });
         $container['foo'] = 'foo';
@@ -97,14 +97,14 @@ class ContainerExtendTest extends TestCase
         $_SERVER['_test_rebind'] = false;
 
         $container = new Container;
-        $container->rebinding('foo', function () {
+        $container->rebinding('foo', static function () {
             $_SERVER['_test_rebind'] = true;
         });
 
         $obj = new stdClass;
         $container->instance('foo', $obj);
 
-        $container->extend('foo', function ($obj, $container) {
+        $container->extend('foo', static function ($obj, $container) {
             return $obj;
         });
 
@@ -116,10 +116,10 @@ class ContainerExtendTest extends TestCase
         $_SERVER['_test_rebind'] = false;
 
         $container = new Container;
-        $container->rebinding('foo', function () {
+        $container->rebinding('foo', static function () {
             $_SERVER['_test_rebind'] = true;
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return new stdClass;
         });
 
@@ -127,7 +127,7 @@ class ContainerExtendTest extends TestCase
 
         $container->make('foo');
 
-        $container->extend('foo', function ($obj, $container) {
+        $container->extend('foo', static function ($obj, $container) {
             return $obj;
         });
 
@@ -137,11 +137,11 @@ class ContainerExtendTest extends TestCase
     public function testExtensionWorksOnAliasedBindings()
     {
         $container = new Container;
-        $container->singleton('something', function () {
+        $container->singleton('something', static function () {
             return 'some value';
         });
         $container->alias('something', 'something-alias');
-        $container->extend('something-alias', function ($value) {
+        $container->extend('something-alias', static function ($value) {
             return $value.' extended';
         });
 
@@ -152,10 +152,10 @@ class ContainerExtendTest extends TestCase
     {
         $container = new Container;
         $container['foo'] = 'foo';
-        $container->extend('foo', function ($old, $container) {
+        $container->extend('foo', static function ($old, $container) {
             return $old.'bar';
         });
-        $container->extend('foo', function ($old, $container) {
+        $container->extend('foo', static function ($old, $container) {
             return $old.'baz';
         });
 
@@ -165,14 +165,14 @@ class ContainerExtendTest extends TestCase
     public function testUnsetExtend()
     {
         $container = new Container;
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             $obj = new stdClass;
             $obj->foo = 'bar';
 
             return $obj;
         });
 
-        $container->extend('foo', function ($obj, $container) {
+        $container->extend('foo', static function ($obj, $container) {
             $obj->bar = 'baz';
 
             return $obj;
@@ -181,7 +181,7 @@ class ContainerExtendTest extends TestCase
         unset($container['foo']);
         $container->forgetExtenders('foo');
 
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return 'foo';
         });
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -33,7 +33,7 @@ class ContainerTest extends TestCase
     public function testClosureResolution()
     {
         $container = new Container;
-        $container->bind('name', function () {
+        $container->bind('name', static function () {
             return 'Taylor';
         });
         $this->assertSame('Taylor', $container->make('name'));
@@ -42,10 +42,10 @@ class ContainerTest extends TestCase
     public function testBindIfDoesntRegisterIfServiceAlreadyRegistered()
     {
         $container = new Container;
-        $container->bind('name', function () {
+        $container->bind('name', static function () {
             return 'Taylor';
         });
-        $container->bindIf('name', function () {
+        $container->bindIf('name', static function () {
             return 'Dayle';
         });
 
@@ -55,10 +55,10 @@ class ContainerTest extends TestCase
     public function testBindIfDoesRegisterIfServiceNotRegisteredYet()
     {
         $container = new Container;
-        $container->bind('surname', function () {
+        $container->bind('surname', static function () {
             return 'Taylor';
         });
-        $container->bindIf('name', function () {
+        $container->bindIf('name', static function () {
             return 'Dayle';
         });
 
@@ -68,11 +68,11 @@ class ContainerTest extends TestCase
     public function testSingletonIfDoesntRegisterIfBindingAlreadyRegistered()
     {
         $container = new Container;
-        $container->singleton('class', function () {
+        $container->singleton('class', static function () {
             return new stdClass;
         });
         $firstInstantiation = $container->make('class');
-        $container->singletonIf('class', function () {
+        $container->singletonIf('class', static function () {
             return new ContainerConcreteStub;
         });
         $secondInstantiation = $container->make('class');
@@ -82,10 +82,10 @@ class ContainerTest extends TestCase
     public function testSingletonIfDoesRegisterIfBindingNotRegisteredYet()
     {
         $container = new Container;
-        $container->singleton('class', function () {
+        $container->singleton('class', static function () {
             return new stdClass;
         });
-        $container->singletonIf('otherClass', function () {
+        $container->singletonIf('otherClass', static function () {
             return new ContainerConcreteStub;
         });
         $firstInstantiation = $container->make('otherClass');
@@ -96,7 +96,7 @@ class ContainerTest extends TestCase
     public function testSharedClosureResolution()
     {
         $container = new Container;
-        $container->singleton('class', function () {
+        $container->singleton('class', static function () {
             return new stdClass;
         });
         $firstInstantiation = $container->make('class');
@@ -140,7 +140,7 @@ class ContainerTest extends TestCase
     public function testContainerIsPassedToResolvers()
     {
         $container = new Container;
-        $container->bind('something', function ($c) {
+        $container->bind('something', static function ($c) {
             return $c;
         });
         $c = $container->make('something');
@@ -150,7 +150,7 @@ class ContainerTest extends TestCase
     public function testArrayAccess()
     {
         $container = new Container;
-        $container['something'] = function () {
+        $container['something'] = static function () {
             return 'foo';
         };
         $this->assertTrue(isset($container['something']));
@@ -173,7 +173,7 @@ class ContainerTest extends TestCase
     public function testAliasesWithArrayOfParameters()
     {
         $container = new Container;
-        $container->bind('foo', function ($app, $config) {
+        $container->bind('foo', static function ($app, $config) {
             return $config;
         });
         $container->alias('foo', 'baz');
@@ -239,13 +239,13 @@ class ContainerTest extends TestCase
         unset($_SERVER['__test.rebind']);
 
         $container = new Container;
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             //
         });
-        $container->rebinding('foo', function () {
+        $container->rebinding('foo', static function () {
             $_SERVER['__test.rebind'] = true;
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             //
         });
 
@@ -257,13 +257,13 @@ class ContainerTest extends TestCase
         unset($_SERVER['__test.rebind']);
 
         $container = new Container;
-        $container->instance('foo', function () {
+        $container->instance('foo', static function () {
             //
         });
-        $container->rebinding('foo', function () {
+        $container->rebinding('foo', static function () {
             $_SERVER['__test.rebind'] = true;
         });
-        $container->instance('foo', function () {
+        $container->instance('foo', static function () {
             //
         });
 
@@ -275,10 +275,10 @@ class ContainerTest extends TestCase
         $_SERVER['__test.rebind'] = false;
 
         $container = new Container;
-        $container->rebinding('foo', function () {
+        $container->rebinding('foo', static function () {
             $_SERVER['__test.rebind'] = true;
         });
-        $container->instance('foo', function () {
+        $container->instance('foo', static function () {
             //
         });
 
@@ -352,7 +352,7 @@ class ContainerTest extends TestCase
     public function testContainerFlushFlushesAllBindingsAliasesAndResolvedInstances()
     {
         $container = new Container;
-        $container->bind('ConcreteStub', function () {
+        $container->bind('ConcreteStub', static function () {
             return new ContainerConcreteStub;
         }, true);
         $container->alias('ConcreteStub', 'ContainerConcreteStub');
@@ -371,7 +371,7 @@ class ContainerTest extends TestCase
     public function testResolvedResolvesAliasToBindingNameBeforeChecking()
     {
         $container = new Container;
-        $container->bind('ConcreteStub', function () {
+        $container->bind('ConcreteStub', static function () {
             return new ContainerConcreteStub;
         }, true);
         $container->alias('ConcreteStub', 'foo');
@@ -404,7 +404,7 @@ class ContainerTest extends TestCase
     public function testContainerGetFactory()
     {
         $container = new Container;
-        $container->bind('name', function () {
+        $container->bind('name', static function () {
             return 'Taylor';
         });
 
@@ -437,7 +437,7 @@ class ContainerTest extends TestCase
         $instance = $container->make(ContainerDefaultValueStub::class);
         $this->assertSame('taylor', $instance->default);
 
-        $container->bind('foo', function ($app, $config) {
+        $container->bind('foo', static function ($app, $config) {
             return $config;
         });
 
@@ -455,10 +455,10 @@ class ContainerTest extends TestCase
     public function testNestedParameterOverride()
     {
         $container = new Container;
-        $container->bind('foo', function ($app, $config) {
+        $container->bind('foo', static function ($app, $config) {
             return $app->make('bar', ['name' => 'Taylor']);
         });
-        $container->bind('bar', function ($app, $config) {
+        $container->bind('bar', static function ($app, $config) {
             return $config;
         });
 
@@ -469,11 +469,11 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->bind('foo', function ($app, $config) {
+        $container->bind('foo', static function ($app, $config) {
             return $app->make('bar');
         });
 
-        $container->bind('bar', function ($app, $config) {
+        $container->bind('bar', static function ($app, $config) {
             return $config;
         });
 
@@ -484,7 +484,7 @@ class ContainerTest extends TestCase
     {
         $container = new Container;
 
-        $container->singleton('foo', function ($app, $config) {
+        $container->singleton('foo', static function ($app, $config) {
             return $config;
         });
 

--- a/tests/Container/ContextualBindingTest.php
+++ b/tests/Container/ContextualBindingTest.php
@@ -30,7 +30,7 @@ class ContextualBindingTest extends TestCase
         $container->bind(IContainerContextContractStub::class, ContainerContextImplementationStub::class);
 
         $container->when(ContainerTestContextInjectOne::class)->needs(IContainerContextContractStub::class)->give(ContainerContextImplementationStub::class);
-        $container->when(ContainerTestContextInjectTwo::class)->needs(IContainerContextContractStub::class)->give(function ($container) {
+        $container->when(ContainerTestContextInjectTwo::class)->needs(IContainerContextContractStub::class)->give(static function ($container) {
             return $container->make(ContainerContextImplementationStubTwo::class);
         });
 
@@ -184,7 +184,7 @@ class ContextualBindingTest extends TestCase
         $this->assertEquals(100, $instance->something);
 
         $container = new Container;
-        $container->when(ContainerInjectVariableStub::class)->needs('$something')->give(function ($container) {
+        $container->when(ContainerInjectVariableStub::class)->needs('$something')->give(static function ($container) {
             return $container->make(ContainerConcreteStub::class);
         });
         $instance = $container->make(ContainerInjectVariableStub::class);
@@ -214,7 +214,7 @@ class ContextualBindingTest extends TestCase
     {
         $container = new Container;
 
-        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(function () {
+        $container->when(ContainerTestContextInjectTwoInstances::class)->needs(ContainerTestContextInjectTwo::class)->give(static function () {
             return new ContainerTestContextInjectTwo(new ContainerContextImplementationStubTwo);
         });
 
@@ -236,7 +236,7 @@ class ContextualBindingTest extends TestCase
     {
         $container = new Container;
 
-        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->give(function ($c) {
+        $container->when(ContainerTestContextInjectVariadic::class)->needs(IContainerContextContractStub::class)->give(static function ($c) {
             return [
                 $c->make(ContainerContextImplementationStub::class),
                 $c->make(ContainerContextImplementationStubTwo::class),
@@ -263,7 +263,7 @@ class ContextualBindingTest extends TestCase
     {
         $container = new Container;
 
-        $container->when(ContainerTestContextInjectVariadicAfterNonVariadic::class)->needs(IContainerContextContractStub::class)->give(function ($c) {
+        $container->when(ContainerTestContextInjectVariadicAfterNonVariadic::class)->needs(IContainerContextContractStub::class)->give(static function ($c) {
             return [
                 $c->make(ContainerContextImplementationStub::class),
                 $c->make(ContainerContextImplementationStubTwo::class),

--- a/tests/Container/ResolvingCallbackTest.php
+++ b/tests/Container/ResolvingCallbackTest.php
@@ -11,10 +11,10 @@ class ResolvingCallbackTest extends TestCase
     public function testResolvingCallbacksAreCalledForSpecificAbstracts()
     {
         $container = new Container;
-        $container->resolving('foo', function ($object) {
+        $container->resolving('foo', static function ($object) {
             return $object->name = 'taylor';
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return new stdClass;
         });
         $instance = $container->make('foo');
@@ -25,10 +25,10 @@ class ResolvingCallbackTest extends TestCase
     public function testResolvingCallbacksAreCalled()
     {
         $container = new Container;
-        $container->resolving(function ($object) {
+        $container->resolving(static function ($object) {
             return $object->name = 'taylor';
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return new stdClass;
         });
         $instance = $container->make('foo');
@@ -39,10 +39,10 @@ class ResolvingCallbackTest extends TestCase
     public function testResolvingCallbacksAreCalledForType()
     {
         $container = new Container;
-        $container->resolving(stdClass::class, function ($object) {
+        $container->resolving(stdClass::class, static function ($object) {
             return $object->name = 'taylor';
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return new stdClass;
         });
         $instance = $container->make('foo');
@@ -54,10 +54,10 @@ class ResolvingCallbackTest extends TestCase
     {
         $container = new Container;
         $container->alias(stdClass::class, 'std');
-        $container->resolving('std', function ($object) {
+        $container->resolving('std', static function ($object) {
             return $object->name = 'taylor';
         });
-        $container->bind('foo', function () {
+        $container->bind('foo', static function () {
             return new stdClass;
         });
         $instance = $container->make('foo');
@@ -70,7 +70,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -88,7 +88,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(function () use (&$callCounter) {
+        $container->resolving(static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -106,7 +106,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -132,7 +132,7 @@ class ResolvingCallbackTest extends TestCase
         $container->make(ResolvingImplementationStub::class);
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -147,7 +147,7 @@ class ResolvingCallbackTest extends TestCase
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
 
         $callCounter = 0;
-        $container->resolving(ResolvingImplementationStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -164,7 +164,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving('foo', function () use (&$callCounter) {
+        $container->resolving('foo', static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -182,7 +182,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingImplementationStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -208,11 +208,11 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
-        $container->bind(ResolvingContractStub::class, function () {
+        $container->bind(ResolvingContractStub::class, static function () {
             return new ResolvingImplementationStub;
         });
 
@@ -234,12 +234,12 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
         $container->bind(ResolvingContractStub::class, ResolvingImplementationStub::class);
-        $container->bind(ResolvingContractStub::class, function () {
+        $container->bind(ResolvingContractStub::class, static function () {
             return new ResolvingImplementationStub;
         });
 
@@ -287,7 +287,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -302,7 +302,7 @@ class ResolvingCallbackTest extends TestCase
         $container->make(ResolvingImplementationStubTwo::class);
         $this->assertEquals(3, $callCounter);
 
-        $container->bind(ResolvingContractStub::class, function () {
+        $container->bind(ResolvingContractStub::class, static function () {
             return new ResolvingImplementationStubTwo();
         });
         $this->assertEquals(4, $callCounter);
@@ -317,11 +317,11 @@ class ResolvingCallbackTest extends TestCase
 
         $callCounter = 0;
 
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
-        $container->resolving(ResolvingImplementationStubTwo::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStubTwo::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -346,7 +346,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -362,7 +362,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingImplementationStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -380,7 +380,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingImplementationStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -398,7 +398,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingImplementationStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingImplementationStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -413,7 +413,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->resolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->resolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 
@@ -429,7 +429,7 @@ class ResolvingCallbackTest extends TestCase
         $container = new Container;
 
         $callCounter = 0;
-        $container->afterResolving(ResolvingContractStub::class, function () use (&$callCounter) {
+        $container->afterResolving(ResolvingContractStub::class, static function () use (&$callCounter) {
             $callCounter++;
         });
 

--- a/tests/Container/RewindableGeneratorTest.php
+++ b/tests/Container/RewindableGeneratorTest.php
@@ -9,7 +9,7 @@ class RewindableGeneratorTest extends TestCase
 {
     public function testCountUsesProvidedValue()
     {
-        $generator = new RewindableGenerator(function () {
+        $generator = new RewindableGenerator(static function () {
             yield 'foo';
         }, 999);
 
@@ -20,9 +20,9 @@ class RewindableGeneratorTest extends TestCase
     {
         $called = 0;
 
-        $generator = new RewindableGenerator(function () {
+        $generator = new RewindableGenerator(static function () {
             yield 'foo';
-        }, function () use (&$called) {
+        }, static function () use (&$called) {
             $called++;
 
             return 500;

--- a/tests/Container/UtilTest.php
+++ b/tests/Container/UtilTest.php
@@ -11,7 +11,7 @@ class UtilTest extends TestCase
     public function testUnwrapIfClosure()
     {
         $this->assertSame('foo', Util::unwrapIfClosure('foo'));
-        $this->assertSame('foo', Util::unwrapIfClosure(function () {
+        $this->assertSame('foo', Util::unwrapIfClosure(static function () {
             return 'foo';
         }));
     }

--- a/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
+++ b/tests/Cookie/Middleware/AddQueuedCookiesToResponseTest.php
@@ -19,7 +19,7 @@ class AddQueuedCookiesToResponseTest extends TestCase
         $cookieJar->queue($cookieOne);
         $cookieJar->queue($cookieTwo);
         $addQueueCookiesToResponseMiddleware = new AddQueuedCookiesToResponse($cookieJar);
-        $next = function (Request $request) {
+        $next = static function (Request $request) {
             return new Response();
         };
         $this->assertEquals(

--- a/tests/Cookie/Middleware/EncryptCookiesTest.php
+++ b/tests/Cookie/Middleware/EncryptCookiesTest.php
@@ -31,7 +31,7 @@ class EncryptCookiesTest extends TestCase
         parent::setUp();
 
         $container = new Container;
-        $container->singleton(EncrypterContract::class, function () {
+        $container->singleton(EncrypterContract::class, static function () {
             return new Encrypter(str_repeat('a', 16));
         });
 

--- a/tests/Database/DatabaseConnectionTest.php
+++ b/tests/Database/DatabaseConnectionTest.php
@@ -248,7 +248,7 @@ class DatabaseConnectionTest extends TestCase
         $mock = $this->getMockConnection([], $pdo);
         $pdo->expects($this->once())->method('beginTransaction');
         $pdo->expects($this->once())->method('commit');
-        $result = $mock->transaction(function ($db) {
+        $result = $mock->transaction(static function ($db) {
             return $db;
         });
         $this->assertEquals($mock, $result);
@@ -264,7 +264,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->exactly(3))->method('commit')->will($this->throwException(new DatabaseConnectionTestMockPDOException('Serialization failure', '40001')));
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->expects($this->never())->method('rollBack');
-        $mock->transaction(function () {
+        $mock->transaction(static function () {
         }, 3);
     }
 
@@ -278,7 +278,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->exactly(3))->method('beginTransaction');
         $pdo->expects($this->exactly(3))->method('rollBack');
         $pdo->expects($this->never())->method('commit');
-        $mock->transaction(function () {
+        $mock->transaction(static function () {
             throw new QueryException('', [], new Exception('Deadlock found when trying to get lock'));
         }, 3);
     }
@@ -291,7 +291,7 @@ class DatabaseConnectionTest extends TestCase
         $pdo->expects($this->once())->method('rollBack');
         $pdo->expects($this->never())->method('commit');
         try {
-            $mock->transaction(function () {
+            $mock->transaction(static function () {
                 throw new Exception('foo');
             });
         } catch (Exception $e) {
@@ -329,7 +329,7 @@ class DatabaseConnectionTest extends TestCase
 
         $called = false;
 
-        $connection->setReconnector(function ($connection) use (&$called) {
+        $connection->setReconnector(static function ($connection) use (&$called) {
             $called = true;
         });
 
@@ -347,7 +347,7 @@ class DatabaseConnectionTest extends TestCase
         $mock = $this->getMockConnection(['tryAgainIfCausedByLostConnection'], $pdo);
         $mock->expects($this->once())->method('tryAgainIfCausedByLostConnection');
 
-        $method->invokeArgs($mock, ['', [], function () {
+        $method->invokeArgs($mock, ['', [], static function () {
             throw new QueryException('', [], new Exception);
         }]);
     }
@@ -366,7 +366,7 @@ class DatabaseConnectionTest extends TestCase
         $mock->expects($this->never())->method('tryAgainIfCausedByLostConnection');
         $mock->beginTransaction();
 
-        $method->invokeArgs($mock, ['', [], function () {
+        $method->invokeArgs($mock, ['', [], static function () {
             throw new QueryException('', [], new Exception);
         }]);
     }
@@ -406,7 +406,7 @@ class DatabaseConnectionTest extends TestCase
     public function testPretendOnlyLogsQueries()
     {
         $connection = $this->getMockConnection();
-        $queries = $connection->pretend(function ($connection) {
+        $queries = $connection->pretend(static function ($connection) {
             $connection->select('foo bar', ['baz']);
         });
         $this->assertSame('foo bar', $queries[0]['query']);

--- a/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManyChunkByIdTest.php
@@ -31,17 +31,17 @@ class DatabaseEloquentBelongsToManyChunkByIdTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
         });
 
-        $this->schema()->create('articles', function ($table) {
+        $this->schema()->create('articles', static function ($table) {
             $table->increments('aid');
             $table->string('title');
         });
 
-        $this->schema()->create('article_user', function ($table) {
+        $this->schema()->create('article_user', static function ($table) {
             $table->integer('article_id')->unsigned();
             $table->foreign('article_id')->references('aid')->on('articles');
             $table->integer('user_id')->unsigned();

--- a/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToManySyncReturnValueTypeTest.php
@@ -30,19 +30,19 @@ class DatabaseEloquentBelongsToManySyncReturnValueTypeTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
         });
 
-        $this->schema()->create('articles', function ($table) {
+        $this->schema()->create('articles', static function ($table) {
             $table->string('id');
             $table->string('title');
 
             $table->primary('id');
         });
 
-        $this->schema()->create('article_user', function ($table) {
+        $this->schema()->create('article_user', static function ($table) {
             $table->string('article_id');
             $table->foreign('article_id')->references('id')->on('articles');
             $table->integer('user_id')->unsigned();

--- a/tests/Database/DatabaseEloquentBelongsToTest.php
+++ b/tests/Database/DatabaseEloquentBelongsToTest.php
@@ -36,7 +36,7 @@ class DatabaseEloquentBelongsToTest extends TestCase
 
     public function testBelongsToWithDynamicDefault()
     {
-        $relation = $this->getRelation()->withDefault(function ($newModel) {
+        $relation = $this->getRelation()->withDefault(static function ($newModel) {
             $newModel->username = 'taylor';
         });
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -252,7 +252,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
 
-        $builder->chunk(2, function ($results) use ($callbackAssertor) {
+        $builder->chunk(2, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         });
     }
@@ -272,7 +272,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
-        $builder->chunk(2, function ($results) use ($callbackAssertor) {
+        $builder->chunk(2, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         });
     }
@@ -292,7 +292,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk2);
 
-        $builder->chunk(2, function ($results) use ($callbackAssertor) {
+        $builder->chunk(2, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
 
             return false;
@@ -311,7 +311,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor = m::mock(stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
-        $builder->chunk(0, function ($results) use ($callbackAssertor) {
+        $builder->chunk(0, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         });
     }
@@ -334,7 +334,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
         $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
 
-        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+        $builder->chunkById(2, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         }, 'someIdField');
     }
@@ -354,7 +354,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
         $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
 
-        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+        $builder->chunkById(2, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         }, 'someIdField');
     }
@@ -371,7 +371,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $callbackAssertor = m::mock(stdClass::class);
         $callbackAssertor->shouldReceive('doSomething')->never();
 
-        $builder->chunkById(0, function ($results) use ($callbackAssertor) {
+        $builder->chunkById(0, static function ($results) use ($callbackAssertor) {
             $callbackAssertor->doSomething($results);
         }, 'someIdField');
     }
@@ -435,7 +435,7 @@ class DatabaseEloquentBuilderTest extends TestCase
             m::mock(Grammar::class),
             m::mock(Processor::class)
         ));
-        $builder->macro('fooBar', function ($builder) {
+        $builder->macro('fooBar', static function ($builder) {
             $_SERVER['__test.builder'] = $builder;
 
             return $builder;
@@ -489,10 +489,10 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testEagerLoadRelationsLoadTopLevelRelationships()
     {
         $builder = m::mock(Builder::class.'[eagerLoadRelation]', [$this->getMockQueryBuilder()]);
-        $nop1 = function () {
+        $nop1 = static function () {
             //
         };
-        $nop2 = function () {
+        $nop2 = static function () {
             //
         };
         $builder->setEagerLoads(['foo' => $nop1, 'foo.bar' => $nop2]);
@@ -505,7 +505,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testRelationshipEagerLoadProcess()
     {
         $builder = m::mock(Builder::class.'[getRelation]', [$this->getMockQueryBuilder()]);
-        $builder->setEagerLoads(['orders' => function ($query) {
+        $builder->setEagerLoads(['orders' => static function ($query) {
             $_SERVER['__eloquent.constrain'] = $query;
         }]);
         $relation = m::mock(stdClass::class);
@@ -591,7 +591,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertInstanceOf(Closure::class, $eagers['orders.lines']);
 
         $builder = $this->getBuilder();
-        $builder->with(['orders' => function () {
+        $builder->with(['orders' => static function () {
             return 'foo';
         }]);
         $eagers = $builder->getEagerLoads();
@@ -599,7 +599,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('foo', $eagers['orders']());
 
         $builder = $this->getBuilder();
-        $builder->with(['orders.lines' => function () {
+        $builder->with(['orders.lines' => static function () {
             return 'foo';
         }]);
         $eagers = $builder->getEagerLoads();
@@ -671,7 +671,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('addNestedWhereQuery')->once()->with($nestedRawQuery, 'and');
         $nestedQuery->shouldReceive('foo')->once();
 
-        $result = $builder->where(function ($query) {
+        $result = $builder->where(static function ($query) {
             $query->foo();
         });
         $this->assertEquals($builder, $result);
@@ -681,7 +681,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
-        $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) {
+        $query = $model->newQuery()->where('foo', '=', 'bar')->where(static function ($query) {
             $query->where('baz', '>', 9000);
         });
         $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
@@ -692,7 +692,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
-        $query = $model->newQuery()->where('foo', '=', 'bar')->where(function ($query) {
+        $query = $model->newQuery()->where('foo', '=', 'bar')->where(static function ($query) {
             $query->where('baz', '>', 9000)->onlyTrashed();
         })->withTrashed();
         $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ? and "table"."deleted_at" is not null)', $query->toSql());
@@ -703,7 +703,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestNestedStub;
         $this->mockConnectionForModel($model, 'SQLite');
-        $query = $model->newQuery()->empty()->where('foo', '=', 'bar')->empty()->where(function ($query) {
+        $query = $model->newQuery()->empty()->where('foo', '=', 'bar')->empty()->where(static function ($query) {
             $query->empty()->where('baz', '>', 9000);
         });
         $this->assertSame('select * from "table" where "foo" = ? and ("baz" > ?) and "table"."deleted_at" is null', $query->toSql());
@@ -745,7 +745,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testDeleteOverride()
     {
         $builder = $this->getBuilder();
-        $builder->onDelete(function ($builder) {
+        $builder->onDelete(static function ($builder) {
             return ['foo' => $builder];
         });
         $this->assertEquals(['foo' => $builder], $builder->delete());
@@ -773,7 +773,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->select('id')->withCount(['activeFoo' => function ($q) {
+        $builder = $model->select('id')->withCount(['activeFoo' => static function ($q) {
             $q->where('bam', '>', 'qux');
         }]);
 
@@ -784,14 +784,14 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testWithCountAndGlobalScope()
     {
         $model = new EloquentBuilderTestModelParentStub;
-        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCount', function ($query) {
+        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCount', static function ($query) {
             return $query->addSelect('id');
         });
 
         $builder = $model->select('id')->withCount(['foo']);
 
         // Remove the global scope so it doesn't interfere with any other tests
-        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCount', function ($query) {
+        EloquentBuilderTestModelCloseRelatedStub::addGlobalScope('withCount', static function ($query) {
             //
         });
 
@@ -803,7 +803,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->where('bar', 'baz');
-        $builder->withCount(['foo' => function ($q) {
+        $builder->withCount(['foo' => static function ($q) {
             $q->where('bam', '>', 'qux');
         }])->having('foo_count', '>=', 1);
 
@@ -834,7 +834,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->where('bar', 'baz');
-        $builder->whereHas('foo', function ($q) {
+        $builder->whereHas('foo', static function ($q) {
             $q->having('bam', '>', 'qux');
         })->where('quux', 'quuux');
 
@@ -847,7 +847,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->where('name', 'larry');
-        $builder->whereHas('address', function ($q) {
+        $builder->whereHas('address', static function ($q) {
             $q->where('zipcode', '90210');
             $q->orWhere('zipcode', '90220');
             $q->having('street', '=', 'fooside dr');
@@ -861,8 +861,8 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
         $builder = $model->where('bar', 'baz');
-        $builder->whereHas('foo', function ($q) {
-            $q->join('quuuux', function ($j) {
+        $builder->whereHas('foo', static function ($q) {
+            $q->join('quuuux', static function ($j) {
                 $j->where('quuuuux', '=', 'quuuuuux');
             });
             $q->having('bam', '>', 'qux');
@@ -877,7 +877,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->where('bar', 'baz');
-        $builder->whereHas('foo', function ($q) {
+        $builder->whereHas('foo', static function ($q) {
             $q->having('bam', '>', 'qux');
         }, '>=', 2)->where('quux', 'quuux');
 
@@ -890,7 +890,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $model = new EloquentBuilderTestModelParentStub;
 
         $builder = $model->newQuery();
-        $builder->withCount(['foo' => function ($q) use ($model) {
+        $builder->withCount(['foo' => static function ($q) use ($model) {
             $q->selectSub($model->newQuery()->where('bam', '=', 3)->selectRaw('count(0)'), 'bam_3_count');
         }]);
 
@@ -902,13 +902,13 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->whereHas('foo', function ($q) {
-            $q->whereHas('bar', function ($q) {
+        $builder = $model->whereHas('foo', static function ($q) {
+            $q->whereHas('bar', static function ($q) {
                 $q->where('baz', 'bam');
             });
         })->toSql();
 
-        $result = $model->whereHas('foo.bar', function ($q) {
+        $result = $model->whereHas('foo.bar', static function ($q) {
             $q->where('baz', 'bam');
         })->toSql();
 
@@ -919,7 +919,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->whereHas('foo', function ($q) {
+        $builder = $model->whereHas('foo', static function ($q) {
             $q->has('bar');
         });
 
@@ -932,9 +932,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->whereHas('foo', function ($q) {
+        $builder = $model->whereHas('foo', static function ($q) {
             $q->has('bar');
-        })->orWhereHas('foo', function ($q) {
+        })->orWhereHas('foo', static function ($q) {
             $q->has('baz');
         });
 
@@ -947,7 +947,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelSelfRelatedStub;
 
-        $nestedSql = $model->whereHas('parentFoo', function ($q) {
+        $nestedSql = $model->whereHas('parentFoo', static function ($q) {
             $q->has('childFoo');
         })->toSql();
 
@@ -1010,7 +1010,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->whereDoesntHave('foo', function ($query) {
+        $builder = $model->whereDoesntHave('foo', static function ($query) {
             $query->where('bar', 'baz');
         });
 
@@ -1022,7 +1022,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     {
         $model = new EloquentBuilderTestModelParentStub;
 
-        $builder = $model->where('bar', 'baz')->orWhereDoesntHave('foo', function ($query) {
+        $builder = $model->where('bar', 'baz')->orWhereDoesntHave('foo', static function ($query) {
             $query->where('qux', 'quux');
         });
 
@@ -1262,7 +1262,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $grammar = new $grammarClass;
         $processor = new $processorClass;
         $connection = m::mock(ConnectionInterface::class, ['getQueryGrammar' => $grammar, 'getPostProcessor' => $processor]);
-        $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
+        $connection->shouldReceive('query')->andReturnUsing(static function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -114,10 +114,10 @@ class DatabaseEloquentCollectionTest extends TestCase
         $mockModel2->shouldReceive('getKey')->andReturn(2);
         $c = new Collection([$mockModel1, $mockModel2]);
 
-        $this->assertTrue($c->contains(function ($model) {
+        $this->assertTrue($c->contains(static function ($model) {
             return $model->getKey() < 2;
         }));
-        $this->assertFalse($c->contains(function ($model) {
+        $this->assertFalse($c->contains(static function ($model) {
             return $model->getKey() > 2;
         }));
     }
@@ -209,7 +209,7 @@ class DatabaseEloquentCollectionTest extends TestCase
 
         $c = new Collection([$one, $two]);
 
-        $cAfterMap = $c->map(function ($item) {
+        $cAfterMap = $c->map(static function ($item) {
             return $item;
         });
 
@@ -222,7 +222,7 @@ class DatabaseEloquentCollectionTest extends TestCase
         $one = m::mock(Model::class);
         $two = m::mock(Model::class);
 
-        $c = (new Collection([$one, $two]))->map(function ($item) {
+        $c = (new Collection([$one, $two]))->map(static function ($item) {
             return 'not-a-model';
         });
 

--- a/tests/Database/DatabaseEloquentGlobalScopesTest.php
+++ b/tests/Database/DatabaseEloquentGlobalScopesTest.php
@@ -131,11 +131,11 @@ class EloquentClosureGlobalScopesTestModel extends Model
 
     public static function boot()
     {
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope(static function ($query) {
             $query->orderBy('name');
         });
 
-        static::addGlobalScope('active_scope', function ($query) {
+        static::addGlobalScope('active_scope', static function ($query) {
             $query->where('active', 1);
         });
 
@@ -167,11 +167,11 @@ class EloquentClosureGlobalScopesWithOrTestModel extends EloquentClosureGlobalSc
 {
     public static function boot()
     {
-        static::addGlobalScope('or_scope', function ($query) {
+        static::addGlobalScope('or_scope', static function ($query) {
             $query->where('email', 'taylor@gmail.com')->orWhere('email', 'someone@else.com');
         });
 
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope(static function ($query) {
             $query->select('email', 'password');
         });
 

--- a/tests/Database/DatabaseEloquentHasManyTest.php
+++ b/tests/Database/DatabaseEloquentHasManyTest.php
@@ -188,7 +188,7 @@ class DatabaseEloquentHasManyTest extends TestCase
     {
         $relation = $this->getRelation();
         $model = m::mock(Model::class);
-        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array = []) {
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(static function ($array = []) {
             return new Collection($array);
         });
         $model->shouldReceive('setRelation')->once()->with('foo', m::type(Collection::class));
@@ -241,7 +241,7 @@ class DatabaseEloquentHasManyTest extends TestCase
         $model3 = new EloquentHasManyModelStub;
         $model3->id = 3;
 
-        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(function ($array) {
+        $relation->getRelated()->shouldReceive('newCollection')->andReturnUsing(static function ($array) {
             return new Collection($array);
         });
         $models = $relation->match([$model1, $model2, $model3], new Collection([$result1, $result2, $result3]), 'foo');

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -34,7 +34,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->unsignedInteger('country_id');
@@ -43,7 +43,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('posts', function ($table) {
+        $this->schema()->create('posts', static function ($table) {
             $table->increments('id');
             $table->integer('user_id');
             $table->string('title');
@@ -52,7 +52,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('countries', function ($table) {
+        $this->schema()->create('countries', static function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->string('shortname');
@@ -114,7 +114,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
     public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
     {
         $this->seedData();
-        $country = HasManyThroughIntermediateTestCountry::whereHas('posts', function ($query) {
+        $country = HasManyThroughIntermediateTestCountry::whereHas('posts', static function ($query) {
             $query->where('title', 'A title');
         })->get();
 
@@ -268,7 +268,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
         $i = 0;
         $count = 0;
 
-        $country->posts()->chunkById(2, function ($collection) use (&$i, &$count) {
+        $country->posts()->chunkById(2, static function ($collection) use (&$i, &$count) {
             $i++;
             $count += $collection->count();
         });
@@ -403,14 +403,14 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     protected function migrateDefault()
     {
-        $this->schema()->create('users_default', function ($table) {
+        $this->schema()->create('users_default', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->unsignedInteger('has_many_through_default_test_country_id');
             $table->timestamps();
         });
 
-        $this->schema()->create('posts_default', function ($table) {
+        $this->schema()->create('posts_default', static function ($table) {
             $table->increments('id');
             $table->integer('has_many_through_default_test_user_id');
             $table->string('title');
@@ -418,7 +418,7 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('countries_default', function ($table) {
+        $this->schema()->create('countries_default', static function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();

--- a/tests/Database/DatabaseEloquentHasOneTest.php
+++ b/tests/Database/DatabaseEloquentHasOneTest.php
@@ -41,7 +41,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     public function testHasOneWithDynamicDefault()
     {
-        $relation = $this->getRelation()->withDefault(function ($newModel) {
+        $relation = $this->getRelation()->withDefault(static function ($newModel) {
             $newModel->username = 'taylor';
         });
 
@@ -60,7 +60,7 @@ class DatabaseEloquentHasOneTest extends TestCase
 
     public function testHasOneWithDynamicDefaultUseParentModel()
     {
-        $relation = $this->getRelation()->withDefault(function ($newModel, $parentModel) {
+        $relation = $this->getRelation()->withDefault(static function ($newModel, $parentModel) {
             $newModel->username = $parentModel->username;
         });
 

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -32,7 +32,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->unsignedInteger('position_id')->unique()->nullable();
@@ -41,7 +41,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('contracts', function ($table) {
+        $this->schema()->create('contracts', static function ($table) {
             $table->increments('id');
             $table->integer('user_id')->unique();
             $table->string('title');
@@ -50,7 +50,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('positions', function ($table) {
+        $this->schema()->create('positions', static function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->string('shortname');
@@ -109,7 +109,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
     public function testWhereHasOnARelationWithCustomIntermediateAndLocalKey()
     {
         $this->seedData();
-        $position = HasOneThroughIntermediateTestPosition::whereHas('contract', function ($query) {
+        $position = HasOneThroughIntermediateTestPosition::whereHas('contract', static function ($query) {
             $query->where('title', 'A title');
         })->get();
 
@@ -297,14 +297,14 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     protected function migrateDefault()
     {
-        $this->schema()->create('users_default', function ($table) {
+        $this->schema()->create('users_default', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->unsignedInteger('has_one_through_default_test_position_id')->unique()->nullable();
             $table->timestamps();
         });
 
-        $this->schema()->create('contracts_default', function ($table) {
+        $this->schema()->create('contracts_default', static function ($table) {
             $table->increments('id');
             $table->integer('has_one_through_default_test_user_id')->unique();
             $table->string('title');
@@ -312,7 +312,7 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('positions_default', function ($table) {
+        $this->schema()->create('positions_default', static function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -53,24 +53,24 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     protected function createSchema()
     {
-        $this->schema('default')->create('test_orders', function ($table) {
+        $this->schema('default')->create('test_orders', static function ($table) {
             $table->increments('id');
             $table->string('item_type');
             $table->integer('item_id');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('with_json', function ($table) {
+        $this->schema('default')->create('with_json', static function ($table) {
             $table->increments('id');
             $table->text('json')->default(json_encode([]));
         });
 
-        $this->schema('second_connection')->create('test_items', function ($table) {
+        $this->schema('second_connection')->create('test_items', static function ($table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('users_with_space_in_colum_name', function ($table) {
+        $this->schema('default')->create('users_with_space_in_colum_name', static function ($table) {
             $table->increments('id');
             $table->string('name')->nullable();
             $table->string('email address');
@@ -78,7 +78,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         });
 
         foreach (['default', 'second_connection'] as $connection) {
-            $this->schema($connection)->create('users', function ($table) {
+            $this->schema($connection)->create('users', static function ($table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
                 $table->string('email');
@@ -86,13 +86,13 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->timestamps();
             });
 
-            $this->schema($connection)->create('friends', function ($table) {
+            $this->schema($connection)->create('friends', static function ($table) {
                 $table->integer('user_id');
                 $table->integer('friend_id');
                 $table->integer('friend_level_id')->nullable();
             });
 
-            $this->schema($connection)->create('posts', function ($table) {
+            $this->schema($connection)->create('posts', static function ($table) {
                 $table->increments('id');
                 $table->integer('user_id');
                 $table->integer('parent_id')->nullable();
@@ -100,27 +100,27 @@ class DatabaseEloquentIntegrationTest extends TestCase
                 $table->timestamps();
             });
 
-            $this->schema($connection)->create('comments', function ($table) {
+            $this->schema($connection)->create('comments', static function ($table) {
                 $table->increments('id');
                 $table->integer('post_id');
                 $table->string('content');
                 $table->timestamps();
             });
 
-            $this->schema($connection)->create('friend_levels', function ($table) {
+            $this->schema($connection)->create('friend_levels', static function ($table) {
                 $table->increments('id');
                 $table->string('level');
                 $table->timestamps();
             });
 
-            $this->schema($connection)->create('photos', function ($table) {
+            $this->schema($connection)->create('photos', static function ($table) {
                 $table->increments('id');
                 $table->morphs('imageable');
                 $table->string('name');
                 $table->timestamps();
             });
 
-            $this->schema($connection)->create('soft_deleted_users', function ($table) {
+            $this->schema($connection)->create('soft_deleted_users', static function ($table) {
                 $table->increments('id');
                 $table->string('name')->nullable();
                 $table->string('email');
@@ -129,7 +129,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             });
         }
 
-        $this->schema($connection)->create('non_incrementing_users', function ($table) {
+        $this->schema($connection)->create('non_incrementing_users', static function ($table) {
             $table->string('name')->nullable();
         });
     }
@@ -228,7 +228,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestUser::create(['id' => 2, 'email' => 'abigailotwell@gmail.com']);
         EloquentTestUser::create(['id' => 3, 'email' => 'foo@gmail.com']);
 
-        Paginator::currentPageResolver(function () {
+        Paginator::currentPageResolver(static function () {
             return 1;
         });
         $models = EloquentTestUser::oldest('id')->paginate(2);
@@ -240,7 +240,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertSame('taylorotwell@gmail.com', $models[0]->email);
         $this->assertSame('abigailotwell@gmail.com', $models[1]->email);
 
-        Paginator::currentPageResolver(function () {
+        Paginator::currentPageResolver(static function () {
             return 2;
         });
         $models = EloquentTestUser::oldest('id')->paginate(2);
@@ -253,7 +253,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
     public function testPaginatedModelCollectionRetrievalWhenNoElements()
     {
-        Paginator::currentPageResolver(function () {
+        Paginator::currentPageResolver(static function () {
             return 1;
         });
         $models = EloquentTestUser::oldest('id')->paginate(2);
@@ -261,7 +261,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $this->assertCount(0, $models);
         $this->assertInstanceOf(LengthAwarePaginator::class, $models);
 
-        Paginator::currentPageResolver(function () {
+        Paginator::currentPageResolver(static function () {
             return 2;
         });
         $models = EloquentTestUser::oldest('id')->paginate(2);
@@ -436,8 +436,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         EloquentTestNonIncrementingSecond::create(['name' => ' Third']);
 
         $users = [];
-        EloquentTestNonIncrementingSecond::query()->eachById(
-            function (EloquentTestNonIncrementingSecond $user, $i) use (&$users) {
+        EloquentTestNonIncrementingSecond::query()->eachById(static function (EloquentTestNonIncrementingSecond $user, $i) use (&$users) {
                 $users[] = [$user->name, $i];
             }, 2, 'name');
         $this->assertSame([[' First', 0], [' Second', 1], [' Third', 0]], $users);
@@ -602,7 +601,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = EloquentTestUser::create(['email' => 'taylorotwell@gmail.com']);
         $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
 
-        $results = EloquentTestUser::whereHas('friends', function ($query) {
+        $results = EloquentTestUser::whereHas('friends', static function ($query) {
             $query->where('email', 'abigailotwell@gmail.com');
         })->get();
 
@@ -628,7 +627,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $friend = $user->friends()->create(['email' => 'abigailotwell@gmail.com']);
         $friend->friends()->create(['email' => 'foo@gmail.com']);
 
-        $results = EloquentTestUser::whereHas('friends.friends', function ($query) {
+        $results = EloquentTestUser::whereHas('friends.friends', static function ($query) {
             $query->where('email', 'foo@gmail.com');
         })->get();
 
@@ -684,7 +683,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
 
-        $results = EloquentTestPost::whereHas('parentPost', function ($query) {
+        $results = EloquentTestPost::whereHas('parentPost', static function ($query) {
             $query->where('name', 'Parent Post');
         })->get();
 
@@ -710,7 +709,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
         EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 3]);
 
-        $results = EloquentTestPost::whereHas('parentPost.parentPost', function ($query) {
+        $results = EloquentTestPost::whereHas('parentPost.parentPost', static function ($query) {
             $query->where('name', 'Grandparent Post');
         })->get();
 
@@ -734,7 +733,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'user_id' => 1]);
         EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 2]);
 
-        $results = EloquentTestPost::whereHas('childPosts', function ($query) {
+        $results = EloquentTestPost::whereHas('childPosts', static function ($query) {
             $query->where('name', 'Child Post');
         })->get();
 
@@ -760,7 +759,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $parentPost = EloquentTestPost::create(['name' => 'Parent Post', 'parent_id' => $grandParentPost->id, 'user_id' => 2]);
         EloquentTestPost::create(['name' => 'Child Post', 'parent_id' => $parentPost->id, 'user_id' => 3]);
 
-        $results = EloquentTestPost::whereHas('childPosts.childPosts', function ($query) {
+        $results = EloquentTestPost::whereHas('childPosts.childPosts', static function ($query) {
             $query->where('name', 'Child Post');
         })->get();
 
@@ -1045,7 +1044,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
         $user = EloquentTestUser::create(['email' => 'taylor@laravel.com']);
         $this->connection()->transaction(function () use ($user) {
             try {
-                $this->connection()->transaction(function () use ($user) {
+                $this->connection()->transaction(static function () use ($user) {
                     $user->email = 'otwell@laravel.com';
                     $user->save();
                     throw new Exception;
@@ -1504,7 +1503,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingUser::withoutTouching(function () use ($post) {
+        EloquentTouchingUser::withoutTouching(static function () use ($post) {
             $post->touch();
         });
 
@@ -1533,7 +1532,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingUser::withoutTouching(function () use ($post) {
+        EloquentTouchingUser::withoutTouching(static function () use ($post) {
             $post->update(['name' => 'Updated']);
         });
 
@@ -1555,7 +1554,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        Model::withoutTouching(function () use ($post) {
+        Model::withoutTouching(static function () use ($post) {
             $post->update(['name' => 'Updated']);
         });
 
@@ -1577,7 +1576,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingUser::withoutTouching(function () use ($post) {
+        EloquentTouchingUser::withoutTouching(static function () use ($post) {
             $post->delete();
         });
 
@@ -1598,7 +1597,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingUser::withoutTouching(function () {
+        EloquentTouchingUser::withoutTouching(static function () {
             EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);
         });
 
@@ -1620,7 +1619,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingPost::withoutTouching(function () {
+        EloquentTouchingPost::withoutTouching(static function () {
             EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);
         });
 
@@ -1642,8 +1641,8 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        EloquentTouchingUser::withoutTouching(function () {
-            EloquentTouchingPost::withoutTouching(function () {
+        EloquentTouchingUser::withoutTouching(static function () {
+            EloquentTouchingPost::withoutTouching(static function () {
                 EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);
             });
         });
@@ -1666,7 +1665,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
 
         Carbon::setTestNow($future = $before->copy()->addDays(3));
 
-        Model::withoutTouchingOn([EloquentTouchingUser::class, EloquentTouchingPost::class], function () {
+        Model::withoutTouchingOn([EloquentTouchingUser::class, EloquentTouchingPost::class], static function () {
             EloquentTouchingComment::create(['content' => 'Comment content', 'post_id' => 1]);
         });
 
@@ -1773,7 +1772,7 @@ class EloquentTestUser extends Eloquent
 
     public function postWithPhotos()
     {
-        return $this->post()->join('photo', function ($join) {
+        return $this->post()->join('photo', static function ($join) {
             $join->on('photo.imageable_id', 'post.id');
             $join->where('photo.imageable_type', 'EloquentTestPost');
         });
@@ -1813,7 +1812,7 @@ class EloquentTestUserWithGlobalScope extends EloquentTestUser
     {
         parent::boot();
 
-        static::addGlobalScope(function ($builder) {
+        static::addGlobalScope(static function ($builder) {
             $builder->with('posts');
         });
     }
@@ -1825,7 +1824,7 @@ class EloquentTestUserWithOmittingGlobalScope extends EloquentTestUser
     {
         parent::boot();
 
-        static::addGlobalScope(function ($builder) {
+        static::addGlobalScope(static function ($builder) {
             $builder->where('email', '!=', 'taylorotwell@gmail.com');
         });
     }
@@ -1841,7 +1840,7 @@ class EloquentTestUserWithGlobalScopeRemovingOtherScope extends Eloquent
 
     public static function boot()
     {
-        static::addGlobalScope(function ($builder) {
+        static::addGlobalScope(static function ($builder) {
             $builder->withoutGlobalScope(SoftDeletingScope::class);
         });
 

--- a/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationWithTablePrefixTest.php
@@ -34,18 +34,18 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
 
     protected function createSchema()
     {
-        $this->schema('default')->create('users', function ($table) {
+        $this->schema('default')->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('friends', function ($table) {
+        $this->schema('default')->create('friends', static function ($table) {
             $table->integer('user_id');
             $table->integer('friend_id');
         });
 
-        $this->schema('default')->create('posts', function ($table) {
+        $this->schema('default')->create('posts', static function ($table) {
             $table->increments('id');
             $table->integer('user_id');
             $table->integer('parent_id')->nullable();
@@ -53,7 +53,7 @@ class DatabaseEloquentIntegrationWithTablePrefixTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema('default')->create('photos', function ($table) {
+        $this->schema('default')->create('photos', static function ($table) {
             $table->increments('id');
             $table->morphs('imageable');
             $table->string('name');

--- a/tests/Database/DatabaseEloquentIrregularPluralTest.php
+++ b/tests/Database/DatabaseEloquentIrregularPluralTest.php
@@ -25,28 +25,28 @@ class DatabaseEloquentIrregularPluralTest extends TestCase
 
     public function createSchema()
     {
-        $this->schema()->create('irregular_plural_humans', function ($table) {
+        $this->schema()->create('irregular_plural_humans', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->timestamps();
         });
 
-        $this->schema()->create('irregular_plural_tokens', function ($table) {
+        $this->schema()->create('irregular_plural_tokens', static function ($table) {
             $table->increments('id');
             $table->string('title');
         });
 
-        $this->schema()->create('irregular_plural_human_irregular_plural_token', function ($table) {
+        $this->schema()->create('irregular_plural_human_irregular_plural_token', static function ($table) {
             $table->integer('irregular_plural_human_id')->unsigned();
             $table->integer('irregular_plural_token_id')->unsigned();
         });
 
-        $this->schema()->create('irregular_plural_mottoes', function ($table) {
+        $this->schema()->create('irregular_plural_mottoes', static function ($table) {
             $table->increments('id');
             $table->string('name');
         });
 
-        $this->schema()->create('cool_mottoes', function ($table) {
+        $this->schema()->create('cool_mottoes', static function ($table) {
             $table->integer('irregular_plural_motto_id');
             $table->integer('cool_motto_id');
             $table->string('cool_motto_type');

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -745,7 +745,7 @@ class DatabaseEloquentModelTest extends TestCase
         $grammar = m::mock(Grammar::class);
         $processor = m::mock(Processor::class);
         EloquentModelStub::setConnectionResolver($resolver = m::mock(ConnectionResolverInterface::class));
-        $conn->shouldReceive('query')->andReturnUsing(function () use ($conn, $grammar, $processor) {
+        $conn->shouldReceive('query')->andReturnUsing(static function () use ($conn, $grammar, $processor) {
             return new BaseBuilder($conn, $grammar, $processor);
         });
         $resolver->shouldReceive('connection')->andReturn($conn);
@@ -1042,7 +1042,7 @@ class DatabaseEloquentModelTest extends TestCase
 
     public function testUnguardedRunsCallbackWhileBeingUnguarded()
     {
-        $model = Model::unguarded(function () {
+        $model = Model::unguarded(static function () {
             return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
         });
         $this->assertSame('Taylor', $model->name);
@@ -1052,7 +1052,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testUnguardedCallDoesNotChangeUnguardedState()
     {
         Model::unguard();
-        $model = Model::unguarded(function () {
+        $model = Model::unguarded(static function () {
             return (new EloquentModelStub)->guard(['*'])->fill(['name' => 'Taylor']);
         });
         $this->assertSame('Taylor', $model->name);
@@ -1063,7 +1063,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testUnguardedCallDoesNotChangeUnguardedStateOnException()
     {
         try {
-            Model::unguarded(function () {
+            Model::unguarded(static function () {
                 throw new Exception;
             });
         } catch (Exception $e) {
@@ -1414,14 +1414,14 @@ class DatabaseEloquentModelTest extends TestCase
         $events->shouldReceive('forget');
         EloquentModelSaveStub::observe(EloquentTestObserverStub::class);
 
-        $model = EloquentModelSaveStub::withoutEvents(function () {
+        $model = EloquentModelSaveStub::withoutEvents(static function () {
             $model = new EloquentModelSaveStub;
             $model->save();
 
             return $model;
         });
 
-        $model->withoutEvents(function () use ($model) {
+        $model->withoutEvents(static function () use ($model) {
             $model->first_name = 'Taylor';
             $model->save();
         });
@@ -1558,7 +1558,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
 
         $model->setEventDispatcher($events = m::mock(Dispatcher::class));
-        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(function ($m) use ($model) {
+        $events->shouldReceive('dispatch')->once()->with('eloquent.replicating: '.get_class($model), m::on(static function ($m) use ($model) {
             return $model->is($m);
         }));
 
@@ -1939,7 +1939,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $called = false;
 
-        EloquentModelStub::withoutTouching(function () use (&$called) {
+        EloquentModelStub::withoutTouching(static function () use (&$called) {
             $called = true;
         });
 
@@ -1952,7 +1952,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         $called = false;
 
-        Model::withoutTouchingOn([EloquentModelStub::class], function () use (&$called) {
+        Model::withoutTouchingOn([EloquentModelStub::class], static function () use (&$called) {
             $called = true;
         });
 
@@ -1965,7 +1965,7 @@ class DatabaseEloquentModelTest extends TestCase
         $resolver->shouldReceive('connection')->andReturn($connection = m::mock(Connection::class));
         $connection->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
         $connection->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
-        $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
+        $connection->shouldReceive('query')->andReturnUsing(static function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
     }
@@ -2248,7 +2248,7 @@ class EloquentModelSaveStub extends Model
         $mock->shouldReceive('getQueryGrammar')->andReturn($grammar = m::mock(Grammar::class));
         $mock->shouldReceive('getPostProcessor')->andReturn($processor = m::mock(Processor::class));
         $mock->shouldReceive('getName')->andReturn('name');
-        $mock->shouldReceive('query')->andReturnUsing(function () use ($mock, $grammar, $processor) {
+        $mock->shouldReceive('query')->andReturnUsing(static function () use ($mock, $grammar, $processor) {
             return new BaseBuilder($mock, $grammar, $processor);
         });
 

--- a/tests/Database/DatabaseEloquentMorphToTest.php
+++ b/tests/Database/DatabaseEloquentMorphToTest.php
@@ -58,7 +58,7 @@ class DatabaseEloquentMorphToTest extends TestCase
 
     public function testMorphToWithDynamicDefault()
     {
-        $relation = $this->getRelation()->withDefault(function ($newModel) {
+        $relation = $this->getRelation()->withDefault(static function ($newModel) {
             $newModel->username = 'taylor';
         });
 

--- a/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicIntegrationTest.php
@@ -30,13 +30,13 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->timestamps();
         });
 
-        $this->schema()->create('posts', function ($table) {
+        $this->schema()->create('posts', static function ($table) {
             $table->increments('id');
             $table->integer('user_id');
             $table->string('title');
@@ -44,7 +44,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('comments', function ($table) {
+        $this->schema()->create('comments', static function ($table) {
             $table->increments('id');
             $table->integer('commentable_id');
             $table->string('commentable_type');
@@ -53,7 +53,7 @@ class DatabaseEloquentPolymorphicIntegrationTest extends TestCase
             $table->timestamps();
         });
 
-        $this->schema()->create('likes', function ($table) {
+        $this->schema()->create('likes', static function ($table) {
             $table->increments('id');
             $table->integer('likeable_id');
             $table->string('likeable_type');

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -31,22 +31,22 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
 
     protected function createSchema()
     {
-        $this->schema('default')->create('posts', function ($table) {
+        $this->schema('default')->create('posts', static function ($table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('images', function ($table) {
+        $this->schema('default')->create('images', static function ($table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('tags', function ($table) {
+        $this->schema('default')->create('tags', static function ($table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        $this->schema('default')->create('taggables', function ($table) {
+        $this->schema('default')->create('taggables', static function ($table) {
             $table->integer('eloquent_many_to_many_polymorphic_test_tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -274,7 +274,7 @@ class DatabaseEloquentRelationTest extends TestCase
         $builder = m::mock(Builder::class);
         $builder->shouldReceive('getModel')->andReturn($model);
 
-        EloquentRelationResetModelStub::resolveRelationUsing('customer', function ($model) use ($builder) {
+        EloquentRelationResetModelStub::resolveRelationUsing('customer', static function ($model) use ($builder) {
             return new EloquentResolverRelationStub($builder, $model);
         });
 

--- a/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentSoftDeletesIntegrationTest.php
@@ -38,7 +38,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->integer('group_id')->nullable();
             $table->string('email')->unique();
@@ -46,7 +46,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('posts', function ($table) {
+        $this->schema()->create('posts', static function ($table) {
             $table->increments('id');
             $table->integer('user_id');
             $table->string('title');
@@ -54,7 +54,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('comments', function ($table) {
+        $this->schema()->create('comments', static function ($table) {
             $table->increments('id');
             $table->integer('owner_id')->nullable();
             $table->string('owner_type')->nullable();
@@ -64,7 +64,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('addresses', function ($table) {
+        $this->schema()->create('addresses', static function ($table) {
             $table->increments('id');
             $table->integer('user_id');
             $table->string('address');
@@ -72,7 +72,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             $table->softDeletes();
         });
 
-        $this->schema()->create('groups', function ($table) {
+        $this->schema()->create('groups', static function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
@@ -124,7 +124,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $count = 0;
         $query = SoftDeletesTestUser::query();
-        $query->chunk(2, function ($user) use (&$count) {
+        $query->chunk(2, static function ($user) use (&$count) {
             $count += count($user);
         });
         $this->assertEquals(1, $count);
@@ -132,7 +132,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $query = SoftDeletesTestUser::query();
         $this->assertCount(1, $query->pluck('email')->all());
 
-        Paginator::currentPageResolver(function () {
+        Paginator::currentPageResolver(static function () {
             return 1;
         });
 
@@ -478,17 +478,17 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::where('email', 'doesnt@exist.com')->orHas('posts')->get();
         $this->assertCount(1, $users);
 
-        $users = SoftDeletesTestUser::whereHas('posts', function ($query) {
+        $users = SoftDeletesTestUser::whereHas('posts', static function ($query) {
             $query->where('title', 'First Title');
         })->get();
         $this->assertCount(1, $users);
 
-        $users = SoftDeletesTestUser::whereHas('posts', function ($query) {
+        $users = SoftDeletesTestUser::whereHas('posts', static function ($query) {
             $query->where('title', 'Another Title');
         })->get();
         $this->assertCount(0, $users);
 
-        $users = SoftDeletesTestUser::where('email', 'doesnt@exist.com')->orWhereHas('posts', function ($query) {
+        $users = SoftDeletesTestUser::where('email', 'doesnt@exist.com')->orWhereHas('posts', static function ($query) {
             $query->where('title', 'First Title');
         })->get();
         $this->assertCount(1, $users);
@@ -511,12 +511,12 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $users = SoftDeletesTestUser::has('posts')->get();
         $this->assertCount(0, $users);
 
-        $users = SoftDeletesTestUser::whereHas('posts', function ($q) {
+        $users = SoftDeletesTestUser::whereHas('posts', static function ($q) {
             $q->onlyTrashed();
         })->get();
         $this->assertCount(1, $users);
 
-        $users = SoftDeletesTestUser::whereHas('posts', function ($q) {
+        $users = SoftDeletesTestUser::whereHas('posts', static function ($q) {
             $q->withTrashed();
         })->get();
         $this->assertCount(1, $users);
@@ -571,22 +571,22 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
         $user = SoftDeletesTestUser::withCount('posts')->orderBy('postsCount', 'desc')->first();
         $this->assertEquals(2, $user->posts_count);
 
-        $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
+        $user = SoftDeletesTestUser::withCount(['posts' => static function ($q) {
             $q->onlyTrashed();
         }])->orderBy('postsCount', 'desc')->first();
         $this->assertEquals(1, $user->posts_count);
 
-        $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
+        $user = SoftDeletesTestUser::withCount(['posts' => static function ($q) {
             $q->withTrashed();
         }])->orderBy('postsCount', 'desc')->first();
         $this->assertEquals(3, $user->posts_count);
 
-        $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
+        $user = SoftDeletesTestUser::withCount(['posts' => static function ($q) {
             $q->withTrashed()->where('title', 'First Title');
         }])->orderBy('postsCount', 'desc')->first();
         $this->assertEquals(1, $user->posts_count);
 
-        $user = SoftDeletesTestUser::withCount(['posts' => function ($q) {
+        $user = SoftDeletesTestUser::withCount(['posts' => static function ($q) {
             $q->where('title', 'First Title');
         }])->orderBy('postsCount', 'desc')->first();
         $this->assertEquals(0, $user->posts_count);
@@ -614,19 +614,19 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
 
         $abigail->delete();
 
-        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
+        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => static function ($q) {
             $q->withoutGlobalScope(SoftDeletingScope::class);
         }])->first();
 
         $this->assertEquals($abigail->email, $comment->owner->email);
 
-        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
+        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => static function ($q) {
             $q->withTrashed();
         }])->first();
 
         $this->assertEquals($abigail->email, $comment->owner->email);
 
-        $comment = TestCommentWithoutSoftDelete::with(['owner' => function ($q) {
+        $comment = TestCommentWithoutSoftDelete::with(['owner' => static function ($q) {
             $q->withTrashed();
         }])->first();
 
@@ -648,7 +648,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             'owner_id' => $abigail->id,
         ]);
 
-        TestCommentWithoutSoftDelete::with(['owner' => function ($q) {
+        TestCommentWithoutSoftDelete::with(['owner' => static function ($q) {
             $q->thisMethodDoesNotExist();
         }])->first();
     }
@@ -665,7 +665,7 @@ class DatabaseEloquentSoftDeletesIntegrationTest extends TestCase
             'owner_id' => $abigail->id,
         ]);
 
-        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => function ($q) {
+        $comment = SoftDeletesTestCommentWithTrashed::with(['owner' => static function ($q) {
             $q->where('email', 'taylorotwell@gmail.com');
         }])->first();
 

--- a/tests/Database/DatabaseEloquentTimestampsTest.php
+++ b/tests/Database/DatabaseEloquentTimestampsTest.php
@@ -32,19 +32,19 @@ class DatabaseEloquentTimestampsTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('users', function ($table) {
+        $this->schema()->create('users', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->timestamps();
         });
 
-        $this->schema()->create('users_created_at', function ($table) {
+        $this->schema()->create('users_created_at', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->string('created_at');
         });
 
-        $this->schema()->create('users_updated_at', function ($table) {
+        $this->schema()->create('users_updated_at', static function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
             $table->string('updated_at');

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -35,7 +35,7 @@ class DatabaseMigrationCreatorTest extends TestCase
 
         $creator = $this->getCreator();
         unset($_SERVER['__migration.creator']);
-        $creator->afterCreate(function ($table) {
+        $creator->afterCreate(static function ($table) {
             $_SERVER['__migration.creator'] = $table;
         });
 

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -24,7 +24,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -43,7 +43,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -61,7 +61,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -78,7 +78,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -95,7 +95,7 @@ class DatabaseMigrationMigrateCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -25,7 +25,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->with(null, m::type(Closure::class))->andReturnUsing(function ($connection, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->with(null, m::type(Closure::class))->andReturnUsing(static function ($connection, $callback) {
             $callback();
         });
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
@@ -42,7 +42,7 @@ class DatabaseMigrationResetCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->with('foo', m::type(Closure::class))->andReturnUsing(function ($connection, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->with('foo', m::type(Closure::class))->andReturnUsing(static function ($connection, $callback) {
             $callback();
         });
         $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -24,7 +24,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -40,7 +40,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -56,7 +56,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
@@ -72,7 +72,7 @@ class DatabaseMigrationRollbackCommandTest extends TestCase
         $app->useDatabasePath(__DIR__);
         $command->setLaravel($app);
         $migrator->shouldReceive('paths')->once()->andReturn([]);
-        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(function ($name, $callback) {
+        $migrator->shouldReceive('usingConnection')->once()->andReturnUsing(static function ($name, $callback) {
             return $callback();
         });
         $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -1070,7 +1070,7 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.
-        $this->getGrammar()::macro('compileReplace', function () {
+        $this->getGrammar()::macro('compileReplace', static function () {
             return true;
         });
 

--- a/tests/Database/DatabasePostgresSchemaGrammarTest.php
+++ b/tests/Database/DatabasePostgresSchemaGrammarTest.php
@@ -976,7 +976,7 @@ class DatabasePostgresSchemaGrammarTest extends TestCase
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.
-        $this->getGrammar()::macro('compileReplace', function () {
+        $this->getGrammar()::macro('compileReplace', static function () {
             return true;
         });
 

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -112,7 +112,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $schema = $db->getConnection()->getSchemaBuilder();
 
-        $schema->create('users', function (Blueprint $table) {
+        $schema->create('users', static function (Blueprint $table) {
             $table->string('email');
             $table->string('name');
         });
@@ -120,7 +120,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertTrue($schema->hasTable('users'));
         $this->assertTrue($schema->hasColumn('users', 'name'));
 
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', static function (Blueprint $table) {
             $table->dropColumn('name');
         });
 
@@ -163,12 +163,12 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
 
         $schema = $db->getConnection()->getSchemaBuilder();
 
-        $schema->create('users', function (Blueprint $table) {
+        $schema->create('users', static function (Blueprint $table) {
             $table->string('name');
             $table->string('email');
         });
 
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', static function (Blueprint $table) {
             $table->index(['name', 'email'], 'index1');
         });
 
@@ -177,7 +177,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $this->assertTrue($details->hasIndex('index1'));
         $this->assertFalse($details->hasIndex('index2'));
 
-        $schema->table('users', function (Blueprint $table) {
+        $schema->table('users', static function (Blueprint $table) {
             $table->renameIndex('index1', 'index2');
         });
 
@@ -813,7 +813,7 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.
-        $this->getGrammar()::macro('compileReplace', function () {
+        $this->getGrammar()::macro('compileReplace', static function () {
             return true;
         });
 

--- a/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintIntegrationTest.php
@@ -45,12 +45,12 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     public function testRenamingAndChangingColumnsWork()
     {
-        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('users', static function ($table) {
             $table->string('name');
             $table->string('age');
         });
 
-        $blueprint = new Blueprint('users', function ($table) {
+        $blueprint = new Blueprint('users', static function ($table) {
             $table->renameColumn('name', 'first_name');
             $table->integer('age')->change();
         });
@@ -75,15 +75,15 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     public function testChangingColumnWithCollationWorks()
     {
-        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('users', static function ($table) {
             $table->string('age');
         });
 
-        $blueprint = new Blueprint('users', function ($table) {
+        $blueprint = new Blueprint('users', static function ($table) {
             $table->integer('age')->collation('RTRIM')->change();
         });
 
-        $blueprint2 = new Blueprint('users', function ($table) {
+        $blueprint2 = new Blueprint('users', static function ($table) {
             $table->integer('age')->collation('NOCASE')->change();
         });
 
@@ -112,16 +112,16 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     public function testRenameIndexWorks()
     {
-        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('users', static function ($table) {
             $table->string('name');
             $table->string('age');
         });
 
-        $this->db->connection()->getSchemaBuilder()->table('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->table('users', static function ($table) {
             $table->index(['name'], 'index1');
         });
 
-        $blueprint = new Blueprint('users', function ($table) {
+        $blueprint = new Blueprint('users', static function ($table) {
             $table->renameIndex('index1', 'index2');
         });
 
@@ -161,11 +161,11 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     public function testAddUniqueIndexWithoutNameWorks()
     {
-        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('users', static function ($table) {
             $table->string('name')->nullable();
         });
 
-        $blueprintMySql = new Blueprint('users', function ($table) {
+        $blueprintMySql = new Blueprint('users', static function ($table) {
             $table->string('name')->nullable()->unique()->change();
         });
 
@@ -182,7 +182,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintPostgres = new Blueprint('users', function ($table) {
+        $blueprintPostgres = new Blueprint('users', static function ($table) {
             $table->string('name')->nullable()->unique()->change();
         });
 
@@ -199,7 +199,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintSQLite = new Blueprint('users', function ($table) {
+        $blueprintSQLite = new Blueprint('users', static function ($table) {
             $table->string('name')->nullable()->unique()->change();
         });
 
@@ -216,7 +216,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintSqlServer = new Blueprint('users', function ($table) {
+        $blueprintSqlServer = new Blueprint('users', static function ($table) {
             $table->string('name')->nullable()->unique()->change();
         });
 
@@ -236,11 +236,11 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
     public function testAddUniqueIndexWithNameWorks()
     {
-        $this->db->connection()->getSchemaBuilder()->create('users', function ($table) {
+        $this->db->connection()->getSchemaBuilder()->create('users', static function ($table) {
             $table->string('name')->nullable();
         });
 
-        $blueprintMySql = new Blueprint('users', function ($table) {
+        $blueprintMySql = new Blueprint('users', static function ($table) {
             $table->string('name')->nullable()->unique('index1')->change();
         });
 
@@ -257,7 +257,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintPostgres = new Blueprint('users', function ($table) {
+        $blueprintPostgres = new Blueprint('users', static function ($table) {
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
@@ -274,7 +274,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintSQLite = new Blueprint('users', function ($table) {
+        $blueprintSQLite = new Blueprint('users', static function ($table) {
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
@@ -291,7 +291,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
 
         $this->assertEquals($expected, $queries);
 
-        $blueprintSqlServer = new Blueprint('users', function ($table) {
+        $blueprintSqlServer = new Blueprint('users', static function ($table) {
             $table->unsignedInteger('name')->nullable()->unique('index1')->change();
         });
 
@@ -313,7 +313,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
     {
         $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
 
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->table('users', static function (Blueprint $table) {
             $table->dropColumn('name');
             $table->dropColumn('email');
         });
@@ -323,7 +323,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
     {
         $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
 
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->table('users', static function (Blueprint $table) {
             $table->renameColumn('name', 'first_name');
             $table->renameColumn('name2', 'last_name');
         });
@@ -333,7 +333,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
     {
         $this->expectExceptionMessage("SQLite doesn't support multiple calls to dropColumn / renameColumn in a single modification.");
 
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->table('users', static function (Blueprint $table) {
             $table->dropColumn('name');
             $table->renameColumn('name2', 'last_name');
         });
@@ -343,7 +343,7 @@ class DatabaseSchemaBlueprintIntegrationTest extends TestCase
     {
         $this->expectExceptionMessage("SQLite doesn't support dropping foreign keys (you would need to re-create the table).");
 
-        $this->db->connection()->getSchemaBuilder()->table('users', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->table('users', static function (Blueprint $table) {
             $table->dropForeign('something');
         });
     }

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -104,7 +104,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testDefaultCurrentDateTime()
     {
-        $base = new Blueprint('users', function ($table) {
+        $base = new Blueprint('users', static function ($table) {
             $table->dateTime('created')->useCurrent();
         });
 
@@ -125,7 +125,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testDefaultCurrentTimestamp()
     {
-        $base = new Blueprint('users', function ($table) {
+        $base = new Blueprint('users', static function ($table) {
             $table->timestamp('created')->useCurrent();
         });
 
@@ -146,7 +146,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testUnsignedDecimalTable()
     {
-        $base = new Blueprint('users', function ($table) {
+        $base = new Blueprint('users', static function ($table) {
             $table->unsignedDecimal('money', 10, 2)->useCurrent();
         });
 
@@ -158,7 +158,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
 
     public function testRemoveColumn()
     {
-        $base = new Blueprint('users', function ($table) {
+        $base = new Blueprint('users', static function ($table) {
             $table->string('foo');
             $table->string('remove_this');
             $table->removeColumn('remove_this');
@@ -181,7 +181,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
             return 'bar';
         });
 
-        $blueprint = new Blueprint('users', function ($table) {
+        $blueprint = new Blueprint('users', static function ($table) {
             $table->foo();
         });
 

--- a/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
+++ b/tests/Database/DatabaseSchemaBuilderIntegrationTest.php
@@ -41,12 +41,12 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
 
     public function testDropAllTablesWorksWithForeignKeys()
     {
-        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
         });
 
-        $this->db->connection()->getSchemaBuilder()->create('table2', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->create('table2', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('user_id');
             $table->foreign('user_id')->references('id')->on('table1');
@@ -65,7 +65,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
     {
         $this->db->connection()->setTablePrefix('test_');
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
         });
@@ -82,7 +82,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'prefix_indexes' => false,
         ]);
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('name')->index();
         });
@@ -99,7 +99,7 @@ class DatabaseSchemaBuilderIntegrationTest extends TestCase
             'prefix_indexes' => true,
         ]);
 
-        $this->db->connection()->getSchemaBuilder()->create('table1', function (Blueprint $table) {
+        $this->db->connection()->getSchemaBuilder()->create('table1', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('name')->index();
         });

--- a/tests/Database/DatabaseSoftDeletingTest.php
+++ b/tests/Database/DatabaseSoftDeletingTest.php
@@ -21,7 +21,7 @@ class DatabaseSoftDeletingTest extends TestCase
         $model = new class extends SoftDeletingModel {
             protected $dates = ['deleted_at'];
         };
-        $entries = array_filter($model->getDates(), function ($attribute) {
+        $entries = array_filter($model->getDates(), static function ($attribute) {
             return $attribute === 'deleted_at';
         });
 

--- a/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerSchemaGrammarTest.php
@@ -843,7 +843,7 @@ class DatabaseSqlServerSchemaGrammarTest extends TestCase
     public function testGrammarsAreMacroable()
     {
         // compileReplace macro.
-        $this->getGrammar()::macro('compileReplace', function () {
+        $this->getGrammar()::macro('compileReplace', static function () {
             return true;
         });
 

--- a/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
+++ b/tests/Database/migrations/one/2016_01_01_000000_create_users_table.php
@@ -13,7 +13,7 @@ class CreateUsersTable extends Migration
      */
     public function up()
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();

--- a/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
+++ b/tests/Database/migrations/one/2016_01_01_100000_create_password_resets_table.php
@@ -13,7 +13,7 @@ class CreatePasswordResetsTable extends Migration
      */
     public function up()
     {
-        Schema::create('password_resets', function (Blueprint $table) {
+        Schema::create('password_resets', static function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token')->index();
             $table->timestamp('created_at');

--- a/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
+++ b/tests/Database/migrations/two/2016_01_01_200000_create_flights_table.php
@@ -13,7 +13,7 @@ class CreateFlightsTable extends Migration
      */
     public function up()
     {
-        Schema::create('flights', function (Blueprint $table) {
+        Schema::create('flights', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });

--- a/tests/Events/BroadcastedEventsTest.php
+++ b/tests/Events/BroadcastedEventsTest.php
@@ -39,7 +39,7 @@ class BroadcastedEventsTest extends TestCase
         $broadcast->shouldReceive('queue')->once();
         $container->shouldReceive('make')->once()->with(BroadcastFactory::class)->andReturn($broadcast);
 
-        $d->listen(AlwaysBroadcastEvent::class, function ($payload) {
+        $d->listen(AlwaysBroadcastEvent::class, static function ($payload) {
             $_SERVER['__event.test'] = $payload;
         });
 

--- a/tests/Events/EventsDispatcherTest.php
+++ b/tests/Events/EventsDispatcherTest.php
@@ -20,7 +20,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo', function ($foo) {
+        $d->listen('foo', static function ($foo) {
             $_SERVER['__event.test'] = $foo;
         });
         $response = $d->dispatch('foo', ['bar']);
@@ -38,7 +38,7 @@ class EventsDispatcherTest extends TestCase
 
             return 'here';
         });
-        $d->listen('foo', function ($foo) {
+        $d->listen('foo', static function ($foo) {
             throw new Exception('should not be called');
         });
 
@@ -64,17 +64,17 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo', function ($foo) {
+        $d->listen('foo', static function ($foo) {
             return $foo;
         });
 
-        $d->listen('foo', function ($foo) {
+        $d->listen('foo', static function ($foo) {
             $_SERVER['__event.test'] = $foo;
 
             return false;
         });
 
-        $d->listen('foo', function ($foo) {
+        $d->listen('foo', static function ($foo) {
             throw new Exception('should not be called');
         });
 
@@ -88,16 +88,16 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
             return 0;
         });
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
             return [];
         });
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
             return '';
         });
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
         });
 
         $response = $d->dispatch('foo', ['bar']);
@@ -129,17 +129,17 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('update', function ($name) {
+        $d->listen('update', static function ($name) {
             $_SERVER['__event.test'] = $name;
         });
         $d->push('update', ['name' => 'taylor']);
-        $d->listen('update', function ($name) {
+        $d->listen('update', static function ($name) {
             $_SERVER['__event.test'] .= '_'.$name;
         });
 
         $this->assertFalse(isset($_SERVER['__event.test']));
         $d->flush('update');
-        $d->listen('update', function ($name) {
+        $d->listen('update', static function ($name) {
             $_SERVER['__event.test'] .= $name;
         });
         $this->assertSame('taylor_taylor', $_SERVER['__event.test']);
@@ -150,7 +150,7 @@ class EventsDispatcherTest extends TestCase
         $_SERVER['__event.test'] = 'unset';
         $d = new Dispatcher;
         $d->push('update', ['name' => 'taylor']);
-        $d->listen('update', function ($name) {
+        $d->listen('update', static function ($name) {
             $_SERVER['__event.test'] = $name;
         });
 
@@ -165,7 +165,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $d->push('update', ['name' => 'taylor ']);
         $d->push('update', ['name' => 'otwell']);
-        $d->listen('update', function ($name) {
+        $d->listen('update', static function ($name) {
             $_SERVER['__event.test'] .= $name;
         });
 
@@ -177,13 +177,13 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo.bar', function () {
+        $d->listen('foo.bar', static function () {
             $_SERVER['__event.test'] = 'regular';
         });
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             $_SERVER['__event.test'] = 'wildcard';
         });
-        $d->listen('bar.*', function () {
+        $d->listen('bar.*', static function () {
             $_SERVER['__event.test'] = 'nope';
         });
 
@@ -197,13 +197,13 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo.bar', function () {
+        $d->listen('foo.bar', static function () {
             return 'regular';
         });
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             return 'wildcard';
         });
-        $d->listen('bar.*', function () {
+        $d->listen('bar.*', static function () {
             return 'nope';
         });
 
@@ -216,13 +216,13 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             $_SERVER['__event.test'] = 'cached_wildcard';
         });
         $d->dispatch('foo.bar');
         $this->assertSame('cached_wildcard', $_SERVER['__event.test']);
 
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             $_SERVER['__event.test'] = 'new_wildcard';
         });
         $d->dispatch('foo.bar');
@@ -233,7 +233,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
             $_SERVER['__event.test'] = 'foo';
         });
         $d->forget('foo');
@@ -246,7 +246,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             $_SERVER['__event.test'] = 'foo';
         });
         $d->forget('foo.*');
@@ -260,7 +260,7 @@ class EventsDispatcherTest extends TestCase
         unset($_SERVER['__event.test']);
 
         $d = new Dispatcher;
-        $d->listen('foo*', function () {
+        $d->listen('foo*', static function () {
             $_SERVER['__event.test'] = 'foo';
         });
         $d->dispatch('foo');
@@ -280,7 +280,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $this->assertFalse($d->hasListeners('foo'));
 
-        $d->listen('foo', function () {
+        $d->listen('foo', static function () {
             //
         });
         $this->assertTrue($d->hasListeners('foo'));
@@ -291,7 +291,7 @@ class EventsDispatcherTest extends TestCase
         $d = new Dispatcher;
         $this->assertFalse($d->hasListeners('foo.*'));
 
-        $d->listen('foo.*', function () {
+        $d->listen('foo.*', static function () {
             //
         });
         $this->assertTrue($d->hasListeners('foo.*'));
@@ -319,7 +319,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen(ExampleEvent::class, function () {
+        $d->listen(ExampleEvent::class, static function () {
             $_SERVER['__event.test'] = 'baz';
         });
         $d->dispatch(new ExampleEvent);
@@ -331,7 +331,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen(ExampleEvent::class, function ($payload) {
+        $d->listen(ExampleEvent::class, static function ($payload) {
             $_SERVER['__event.test'] = $payload;
         });
         $d->dispatch($e = new ExampleEvent, ['foo']);
@@ -343,7 +343,7 @@ class EventsDispatcherTest extends TestCase
     {
         unset($_SERVER['__event.test']);
         $d = new Dispatcher;
-        $d->listen(SomeEventInterface::class, function () {
+        $d->listen(SomeEventInterface::class, static function () {
             $_SERVER['__event.test'] = 'bar';
         });
         $d->dispatch(new AnotherEvent);
@@ -356,11 +356,11 @@ class EventsDispatcherTest extends TestCase
         unset($_SERVER['__event.test']);
         $_SERVER['__event.test'] = [];
         $d = new Dispatcher;
-        $d->listen(AnotherEvent::class, function ($p) {
+        $d->listen(AnotherEvent::class, static function ($p) {
             $_SERVER['__event.test'][] = $p;
             $_SERVER['__event.test1'] = 'fooo';
         });
-        $d->listen(SomeEventInterface::class, function ($p) {
+        $d->listen(SomeEventInterface::class, static function ($p) {
             $_SERVER['__event.test'][] = $p;
             $_SERVER['__event.test2'] = 'baar';
         });

--- a/tests/Events/QueuedEventsTest.php
+++ b/tests/Events/QueuedEventsTest.php
@@ -27,7 +27,7 @@ class QueuedEventsTest extends TestCase
 
         $queue->shouldReceive('pushOn')->once()->with(null, m::type(CallQueuedListener::class));
 
-        $d->setQueueResolver(function () use ($queue) {
+        $d->setQueueResolver(static function () use ($queue) {
             return $queue;
         });
 
@@ -41,7 +41,7 @@ class QueuedEventsTest extends TestCase
 
         $fakeQueue = new QueueFake(new Container());
 
-        $d->setQueueResolver(function () use ($fakeQueue) {
+        $d->setQueueResolver(static function () use ($fakeQueue) {
             return $fakeQueue;
         });
 

--- a/tests/Filesystem/FilesystemManagerTest.php
+++ b/tests/Filesystem/FilesystemManagerTest.php
@@ -14,7 +14,7 @@ class FilesystemManagerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Disk [local] does not have a configured driver.');
 
-        $filesystem = new FilesystemManager(tap(new Application, function ($app) {
+        $filesystem = new FilesystemManager(tap(new Application, static function ($app) {
             $app['config'] = ['filesystems.disks.local' => null];
         }));
 

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -111,7 +111,7 @@ class FoundationApplicationTest extends TestCase
     {
         $app = new Application;
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
-        $app->extend('foo', function ($instance, $container) {
+        $app->extend('foo', static function ($instance, $container) {
             return $instance.'bar';
         });
         $this->assertSame('foobar', $app->make('foo'));
@@ -143,7 +143,7 @@ class FoundationApplicationTest extends TestCase
         $app->setDeferredServices(['foo' => ApplicationDeferredServiceProviderStub::class]);
         $this->assertTrue($app->bound('foo'));
         $this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
-        $app->extend('foo', function ($instance, $container) {
+        $app->extend('foo', static function ($instance, $container) {
             return $instance.'bar';
         });
         $this->assertFalse(ApplicationDeferredServiceProviderStub::$initialized);
@@ -228,7 +228,7 @@ class FoundationApplicationTest extends TestCase
     public function testMethodAfterLoadingEnvironmentAddsClosure()
     {
         $app = new Application;
-        $closure = function () {
+        $closure = static function () {
             //
         };
         $app->afterLoadingEnvironment($closure);
@@ -238,7 +238,7 @@ class FoundationApplicationTest extends TestCase
     public function testBeforeBootstrappingAddsClosure()
     {
         $app = new Application;
-        $closure = function () {
+        $closure = static function () {
             //
         };
         $app->beforeBootstrapping(RegisterFacades::class, $closure);
@@ -250,15 +250,15 @@ class FoundationApplicationTest extends TestCase
         $app = new Application;
 
         $result = [];
-        $callback1 = function () use (&$result) {
+        $callback1 = static function () use (&$result) {
             $result[] = 1;
         };
 
-        $callback2 = function () use (&$result) {
+        $callback2 = static function () use (&$result) {
             $result[] = 2;
         };
 
-        $callback3 = function () use (&$result) {
+        $callback3 = static function () use (&$result) {
             $result[] = 3;
         };
 
@@ -274,7 +274,7 @@ class FoundationApplicationTest extends TestCase
     public function testAfterBootstrappingAddsClosure()
     {
         $app = new Application;
-        $closure = function () {
+        $closure = static function () {
             //
         };
         $app->afterBootstrapping(RegisterFacades::class, $closure);
@@ -485,7 +485,7 @@ class ApplicationDeferredSharedServiceProviderStub extends ServiceProvider imple
 {
     public function register()
     {
-        $this->app->singleton('foo', function () {
+        $this->app->singleton('foo', static function () {
             return new stdClass;
         });
     }
@@ -545,7 +545,7 @@ class SampleImplementationDeferredServiceProvider extends ServiceProvider implem
 {
     public function register()
     {
-        $this->app->when(SampleImplementation::class)->needs('$primitive')->give(function () {
+        $this->app->when(SampleImplementation::class)->needs('$primitive')->give(static function () {
             return 'foo';
         });
     }
@@ -555,7 +555,7 @@ class ApplicationFactoryProviderStub extends ServiceProvider implements Deferrab
 {
     public function register()
     {
-        $this->app->bind('foo', function () {
+        $this->app->bind('foo', static function () {
             static $count = 0;
 
             return ++$count;
@@ -567,10 +567,10 @@ class ApplicationMultiProviderStub extends ServiceProvider implements Deferrable
 {
     public function register()
     {
-        $this->app->singleton('foo', function () {
+        $this->app->singleton('foo', static function () {
             return 'foo';
         });
-        $this->app->singleton('bar', function ($app) {
+        $this->app->singleton('bar', static function ($app) {
             return $app['foo'].'bar';
         });
     }

--- a/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
+++ b/tests/Foundation/FoundationAuthorizesRequestsTraitTest.php
@@ -23,7 +23,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
 
         $gate = $this->getBasicGate();
 
-        $gate->define('baz', function () {
+        $gate->define('baz', static function () {
             $_SERVER['_test.authorizes.trait'] = true;
 
             return true;
@@ -42,7 +42,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
 
         $gate = $this->getBasicGate();
 
-        $gate->define('baz', function () {
+        $gate->define('baz', static function () {
             return false;
         });
 
@@ -108,7 +108,7 @@ class FoundationAuthorizesRequestsTraitTest extends TestCase
     {
         $container = Container::setInstance(new Container);
 
-        $gate = new Gate($container, function () {
+        $gate = new Gate($container, static function () {
             return (object) ['id' => 1];
         });
 

--- a/tests/Foundation/FoundationEnvironmentDetectorTest.php
+++ b/tests/Foundation/FoundationEnvironmentDetectorTest.php
@@ -17,7 +17,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
     {
         $env = new EnvironmentDetector;
 
-        $result = $env->detect(function () {
+        $result = $env->detect(static function () {
             return 'foobar';
         });
         $this->assertSame('foobar', $result);
@@ -27,7 +27,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
     {
         $env = new EnvironmentDetector;
 
-        $result = $env->detect(function () {
+        $result = $env->detect(static function () {
             return 'foobar';
         }, ['--env=local']);
         $this->assertSame('local', $result);
@@ -37,7 +37,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
     {
         $env = new EnvironmentDetector;
 
-        $result = $env->detect(function () {
+        $result = $env->detect(static function () {
             return 'foobar';
         }, ['--env', 'local']);
         $this->assertSame('local', $result);
@@ -47,7 +47,7 @@ class FoundationEnvironmentDetectorTest extends TestCase
     {
         $env = new EnvironmentDetector;
 
-        $result = $env->detect(function () {
+        $result = $env->detect(static function () {
             return 'foobar';
         }, ['--env']);
         $this->assertSame('foobar', $result);

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -48,7 +48,7 @@ class FoundationExceptionsHandlerTest extends TestCase
             return $this->config;
         });
 
-        $this->container->singleton(ResponseFactoryContract::class, function () {
+        $this->container->singleton(ResponseFactoryContract::class, static function () {
             return new ResponseFactory(
                 m::mock(Factory::class),
                 m::mock(Redirector::class)
@@ -154,14 +154,13 @@ class FoundationExceptionsHandlerTest extends TestCase
         $argumentExpected = ['input' => 'My input value'];
         $argumentActual = null;
 
-        $this->container->singleton('redirect', function () use (&$argumentActual) {
+        $this->container->singleton('redirect', static function () use (&$argumentActual) {
             $redirector = m::mock(Redirector::class);
 
             $redirector->shouldReceive('to')->once()
                 ->andReturn($responser = m::mock(RedirectResponse::class));
 
-            $responser->shouldReceive('withInput')->once()->with(m::on(
-                function ($argument) use (&$argumentActual) {
+            $responser->shouldReceive('withInput')->once()->with(m::on(static function ($argument) use (&$argumentActual) {
                     $argumentActual = $argument;
 
                     return true;

--- a/tests/Foundation/FoundationFormRequestTest.php
+++ b/tests/Foundation/FoundationFormRequestTest.php
@@ -281,7 +281,7 @@ class FoundationTestFormRequestTwiceStub extends FormRequest
 
     public function withValidator(Validator $validator)
     {
-        $validator->after(function ($validator) {
+        $validator->after(static function ($validator) {
             self::$count++;
         });
     }

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -47,7 +47,7 @@ class FoundationHelpersTest extends TestCase
     {
         $file = 'unversioned.css';
 
-        app()->singleton('path.public', function () {
+        app()->singleton('path.public', static function () {
             return __DIR__;
         });
 
@@ -215,7 +215,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeHotModuleReloadFile($url, $directory = '')
     {
-        app()->singleton('path.public', function () {
+        app()->singleton('path.public', static function () {
             return __DIR__;
         });
 
@@ -230,7 +230,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeManifest($directory = '')
     {
-        app()->singleton('path.public', function () {
+        app()->singleton('path.public', static function () {
             return __DIR__;
         });
 
@@ -249,7 +249,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixIsSwappableForTests()
     {
-        (new Application)->instance(Mix::class, function () {
+        (new Application)->instance(Mix::class, static function () {
             return 'expected';
         });
 

--- a/tests/Foundation/FoundationProviderRepositoryTest.php
+++ b/tests/Foundation/FoundationProviderRepositoryTest.php
@@ -52,7 +52,7 @@ class FoundationProviderRepositoryTest extends TestCase
         // bar mock is added to eagers since it's not reserved
         $repo->shouldReceive('createProvider')->once()->with('bar')->andReturn($barMock = m::mock(ServiceProvider::class));
         $barMock->shouldReceive('isDeferred')->once()->andReturn(false);
-        $repo->shouldReceive('writeManifest')->once()->andReturnUsing(function ($manifest) {
+        $repo->shouldReceive('writeManifest')->once()->andReturnUsing(static function ($manifest) {
             return $manifest;
         });
 

--- a/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
+++ b/tests/Foundation/Http/Middleware/CheckForMaintenanceModeTest.php
@@ -53,7 +53,7 @@ class CheckForMaintenanceModeTest extends TestCase
 
         $middleware = new CheckForMaintenanceMode($app);
 
-        $result = $middleware->handle(Request::create('/'), function ($request) {
+        $result = $middleware->handle(Request::create('/'), static function ($request) {
             return 'Running normally.';
         });
 
@@ -70,7 +70,7 @@ class CheckForMaintenanceModeTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('ip')->once()->andReturn('127.0.0.1');
 
-        $result = $middleware->handle($request, function ($request) {
+        $result = $middleware->handle($request, static function ($request) {
             return 'Allowing [127.0.0.1]';
         });
 
@@ -82,7 +82,7 @@ class CheckForMaintenanceModeTest extends TestCase
         $request = m::mock(Request::class);
         $request->shouldReceive('ip')->once()->andReturn('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
 
-        $result = $middleware->handle($request, function ($request) {
+        $result = $middleware->handle($request, static function ($request) {
             return 'Allowing [2001:0db8:85a3:0000:0000:8a2e:0370:7334]';
         });
 
@@ -96,7 +96,7 @@ class CheckForMaintenanceModeTest extends TestCase
 
         $middleware = new CheckForMaintenanceMode($this->createMaintenanceApplication());
 
-        $middleware->handle(Request::create('/'), function ($request) {
+        $middleware->handle(Request::create('/'), static function ($request) {
             //
         });
     }
@@ -114,7 +114,7 @@ class CheckForMaintenanceModeTest extends TestCase
             }
         };
 
-        $result = $middleware->handle(Request::create('/foo/bar'), function ($request) {
+        $result = $middleware->handle(Request::create('/foo/bar'), static function ($request) {
             return 'Excepting /foo/bar';
         });
 
@@ -128,7 +128,7 @@ class CheckForMaintenanceModeTest extends TestCase
 
         $middleware = new CheckForMaintenanceMode($this->createMaintenanceApplication());
 
-        $middleware->handle(Request::create('/foo/bar'), function ($request) {
+        $middleware->handle(Request::create('/foo/bar'), static function ($request) {
             //
         });
     }

--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -37,7 +37,7 @@ class MakesHttpRequestsTest extends TestCase
 
     public function testWithoutAndWithMiddlewareWithParameter()
     {
-        $next = function ($request) {
+        $next = static function ($request) {
             return $request;
         };
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -64,7 +64,7 @@ class HttpClientTest extends TestCase
         $this->assertSame('bar', $barResponse['page']);
         $this->assertSame('fallback', $fallbackResponse['page']);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/test' &&
                    $request->hasHeader('Content-Type', 'application/json');
         });
@@ -81,7 +81,7 @@ class HttpClientTest extends TestCase
             'name' => 'Taylor',
         ]);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
                    $request->hasHeader('Content-Type', 'application/json') &&
                    $request->hasHeader('X-Test-Header', 'foo') &&
@@ -99,7 +99,7 @@ class HttpClientTest extends TestCase
             'title' => 'Laravel Developer',
         ]);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/form' &&
                    $request->hasHeader('Content-Type', 'application/x-www-form-urlencoded') &&
                    $request['name'] === 'Taylor';
@@ -114,7 +114,7 @@ class HttpClientTest extends TestCase
             'name' => 'Taylor',
         ]);
 
-        $this->factory->assertNotSent(function (Request $request) {
+        $this->factory->assertNotSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/form' &&
                 $request['name'] === 'Peter';
         });
@@ -157,7 +157,7 @@ class HttpClientTest extends TestCase
             ],
         ]);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/multipart' &&
                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                    $request[0]['name'] === 'foo';
@@ -171,7 +171,7 @@ class HttpClientTest extends TestCase
         $this->factory->attach('foo', 'data', 'file.txt', ['X-Test-Header' => 'foo'])
                 ->post('http://foo.com/file');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/file' &&
                    Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                    $request[0]['name'] === 'foo' &&
@@ -187,7 +187,7 @@ class HttpClientTest extends TestCase
             'foo' => 'bar',
         ]);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/multipart' &&
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'foo' &&
@@ -208,7 +208,7 @@ class HttpClientTest extends TestCase
             ],
         ]);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/multipart' &&
                 Str::startsWith($request->header('Content-Type')[0], 'multipart') &&
                 $request[0]['name'] === 'foo' &&
@@ -225,7 +225,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->withToken('token')->post('http://foo.com/json');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
                 $request->hasHeader('Authorization', 'Bearer token');
         });
@@ -326,7 +326,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', ['foo' => 'bar']);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo=bar'
                 && $request['foo'] === 'bar';
         });
@@ -338,7 +338,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', 'foo=bar');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo=bar'
                 && $request['foo'] === 'bar';
         });
@@ -350,7 +350,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo=bar&page=1');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo=bar&page=1'
                 && $request['foo'] === 'bar'
                 && $request['page'] === '1';
@@ -363,7 +363,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo;bar;1;5;10&page=1');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo;bar;1;5;10&page=1'
                 && ! isset($request['foo'])
                 && ! isset($request['bar'])
@@ -377,7 +377,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get?foo=bar&page=1', ['hello' => 'world']);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?hello=world'
                 && $request['hello'] === 'world';
         });
@@ -389,7 +389,7 @@ class HttpClientTest extends TestCase
 
         $this->factory->get('http://foo.com/get', ['foo;bar; space test' => 'laravel']);
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/get?foo%3Bbar%3B%20space%20test=laravel'
                 && $request['foo;bar; space test'] === 'laravel';
         });
@@ -404,7 +404,7 @@ class HttpClientTest extends TestCase
             'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->post('http://foo.com/json');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
                    $request->hasHeaders([
                        'X-Test-Header' => 'foo',
@@ -422,7 +422,7 @@ class HttpClientTest extends TestCase
             'X-Test-ArrayHeader' => ['bar', 'baz'],
         ])->post('http://foo.com/json');
 
-        $this->factory->assertSent(function (Request $request) {
+        $this->factory->assertSent(static function (Request $request) {
             return $request->url() === 'http://foo.com/json' &&
                    $request->hasHeaders('X-Test-Header');
         });

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -182,7 +182,7 @@ class HttpRequestTest extends TestCase
 
         $this->assertFalse($request->routeIs('foo.bar'));
 
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/foo/bar', ['as' => 'foo.bar']);
             $route->bind($request);
 
@@ -198,7 +198,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/foo/bar', 'GET');
 
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/foo/{required}/{optional?}', []);
             $route->bind($request);
 
@@ -419,7 +419,7 @@ class HttpRequestTest extends TestCase
     {
         $request = Request::create('/', 'GET', ['name' => null, 'foo' => ['bar' => null, 'baz' => '']]);
 
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/foo/bar/{id}/{name}', []);
             $route->bind($request);
             $route->setParameter('id', 'foo');
@@ -892,7 +892,7 @@ class HttpRequestTest extends TestCase
     public function testUserResolverMakesUserAvailableAsMagicProperty()
     {
         $request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
-        $request->setUserResolver(function () {
+        $request->setUserResolver(static function () {
             return 'user';
         });
         $this->assertSame('user', $request->user());
@@ -901,7 +901,7 @@ class HttpRequestTest extends TestCase
     public function testFingerprintMethod()
     {
         $request = Request::create('/', 'GET', [], [], [], []);
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/foo/bar/{id}', []);
             $route->bind($request);
 
@@ -965,7 +965,7 @@ class HttpRequestTest extends TestCase
 
         // Simulates Route parameters.
         $request = Request::create('/example/bar', 'GET', ['xyz' => 'overwritten']);
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/example/{foo}/{xyz?}/{undefined?}', []);
             $route->bind($request);
 
@@ -991,7 +991,7 @@ class HttpRequestTest extends TestCase
 
         // Simulates empty QueryString and Routes.
         $request = Request::create('/', 'GET');
-        $request->setRouteResolver(function () use ($request) {
+        $request->setRouteResolver(static function () use ($request) {
             $route = new Route('GET', '/', []);
             $route->bind($request);
 

--- a/tests/Http/Middleware/CacheTest.php
+++ b/tests/Http/Middleware/CacheTest.php
@@ -16,7 +16,7 @@ class CacheTest extends TestCase
         $request = new Request;
         $request->setMethod('PUT');
 
-        $response = (new Cache)->handle($request, function () {
+        $response = (new Cache)->handle($request, static function () {
             return new Response('Hello Laravel');
         }, 'max_age=120;s_maxage=60');
 
@@ -25,7 +25,7 @@ class CacheTest extends TestCase
 
     public function testDoNotSetHeaderWhenNoContent()
     {
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response;
         }, 'max_age=120;s_maxage=60');
 
@@ -35,7 +35,7 @@ class CacheTest extends TestCase
 
     public function testAddHeaders()
     {
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, 'max_age=100;s_maxage=200;etag=ABC');
 
@@ -45,7 +45,7 @@ class CacheTest extends TestCase
 
     public function testAddHeadersUsingArray()
     {
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, ['max_age' => 100, 's_maxage' => 200, 'etag' => 'ABC']);
 
@@ -55,7 +55,7 @@ class CacheTest extends TestCase
 
     public function testGenerateEtag()
     {
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, 'etag;max_age=100;s_maxage=200');
 
@@ -68,7 +68,7 @@ class CacheTest extends TestCase
         $request = new Request;
         $request->headers->set('If-None-Match', '"9893532233caff98cd083a116b013c0b"');
 
-        $response = (new Cache)->handle($request, function () {
+        $response = (new Cache)->handle($request, static function () {
             return new Response('some content');
         }, 'etag;max_age=100;s_maxage=200');
 
@@ -79,7 +79,7 @@ class CacheTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Cache)->handle(new Request, function () {
+        (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, 'invalid');
     }
@@ -88,7 +88,7 @@ class CacheTest extends TestCase
     {
         $time = time();
 
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, "last_modified=$time");
 
@@ -98,7 +98,7 @@ class CacheTest extends TestCase
     public function testLastModifiedStringDate()
     {
         $birthdate = '1973-04-09 10:10:10';
-        $response = (new Cache)->handle(new Request, function () {
+        $response = (new Cache)->handle(new Request, static function () {
             return new Response('some content');
         }, "last_modified=$birthdate");
 

--- a/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
+++ b/tests/Integration/Auth/ApiAuthenticationWithEloquentTest.php
@@ -33,7 +33,7 @@ class ApiAuthenticationWithEloquentTest extends TestCase
 
     public function testAuthenticationViaApiWithEloquentUsingWrongDatabaseCredentialsShouldNotCauseInfiniteLoop()
     {
-        Route::get('/auth', function () {
+        Route::get('/auth', static function () {
             return 'success';
         })->middleware('auth:api');
 

--- a/tests/Integration/Auth/AuthenticationTest.php
+++ b/tests/Integration/Auth/AuthenticationTest.php
@@ -45,7 +45,7 @@ class AuthenticationTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->string('username');
@@ -297,7 +297,7 @@ class AuthenticationTest extends TestCase
             'provider' => 'user',
         ];
 
-        Auth::extend('myCustomDriver', function () {
+        Auth::extend('myCustomDriver', static function () {
             return new MyCustomGuardStub();
         });
 
@@ -317,7 +317,7 @@ class AuthenticationTest extends TestCase
             'provider' => 'user',
         ];
 
-        Auth::extend('myCustomDriver', function () {
+        Auth::extend('myCustomDriver', static function () {
             return new MyDispatcherLessCustomGuardStub();
         });
 

--- a/tests/Integration/Auth/GatePolicyResolutionTest.php
+++ b/tests/Integration/Auth/GatePolicyResolutionTest.php
@@ -22,7 +22,7 @@ class GatePolicyResolutionTest extends TestCase
 
     public function testPolicyCanBeGuessedUsingCallback()
     {
-        Gate::guessPolicyNamesUsing(function () {
+        Gate::guessPolicyNamesUsing(static function () {
             return AuthenticationTestUserPolicy::class;
         });
 
@@ -34,7 +34,7 @@ class GatePolicyResolutionTest extends TestCase
 
     public function testPolicyCanBeGuessedMultipleTimes()
     {
-        Gate::guessPolicyNamesUsing(function () {
+        Gate::guessPolicyNamesUsing(static function () {
             return [
                 'App\\Policies\\TestUserPolicy',
                 AuthenticationTestUserPolicy::class,

--- a/tests/Integration/Auth/Middleware/RequirePasswordTest.php
+++ b/tests/Integration/Auth/Middleware/RequirePasswordTest.php
@@ -19,7 +19,7 @@ class RequirePasswordTest extends TestCase
         /** @var \Illuminate\Contracts\Routing\Registrar $router */
         $router = $this->app->make(Registrar::class);
 
-        $router->get('test-route', function (): Response {
+        $router->get('test-route', static function (): Response {
             return new Response('foobar');
         })->middleware([StartSession::class, RequirePassword::class]);
 
@@ -36,11 +36,11 @@ class RequirePasswordTest extends TestCase
         /** @var \Illuminate\Contracts\Routing\Registrar $router */
         $router = $this->app->make(Registrar::class);
 
-        $router->get('password-confirm', function (): Response {
+        $router->get('password-confirm', static function (): Response {
             return new Response('foo');
         })->name('password.confirm');
 
-        $router->get('test-route', function (): Response {
+        $router->get('test-route', static function (): Response {
             return new Response('foobar');
         })->middleware([StartSession::class, RequirePassword::class]);
 
@@ -57,11 +57,11 @@ class RequirePasswordTest extends TestCase
         /** @var \Illuminate\Contracts\Routing\Registrar $router */
         $router = $this->app->make(Registrar::class);
 
-        $router->get('confirm', function (): Response {
+        $router->get('confirm', static function (): Response {
             return new Response('foo');
         })->name('my-password.confirm');
 
-        $router->get('test-route', function (): Response {
+        $router->get('test-route', static function (): Response {
             return new Response('foobar');
         })->middleware([StartSession::class, RequirePassword::class.':my-password.confirm']);
 
@@ -78,11 +78,11 @@ class RequirePasswordTest extends TestCase
         /** @var \Illuminate\Contracts\Routing\Registrar $router */
         $router = $this->app->make(Registrar::class);
 
-        $router->get('password-confirm', function (): Response {
+        $router->get('password-confirm', static function (): Response {
             return new Response('foo');
         })->name('password.confirm');
 
-        $router->get('test-route', function (): Response {
+        $router->get('test-route', static function (): Response {
             return new Response('foobar');
         })->middleware([StartSession::class, RequirePassword::class]);
 

--- a/tests/Integration/Cache/MemcachedCacheLockTest.php
+++ b/tests/Integration/Cache/MemcachedCacheLockTest.php
@@ -27,7 +27,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
         Carbon::setTestNow();
 
         Cache::store('memcached')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, static function () {
             return 'taylor';
         }));
 
@@ -38,7 +38,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
     public function testLocksCanRunCallbacks()
     {
         Cache::store('memcached')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->get(function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->get(static function () {
             return 'taylor';
         }));
     }
@@ -51,7 +51,7 @@ class MemcachedCacheLockTest extends MemcachedIntegrationTest
 
         Cache::store('memcached')->lock('foo')->release();
         Cache::store('memcached')->lock('foo', 5)->get();
-        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('memcached')->lock('foo', 10)->block(1, static function () {
             return 'taylor';
         }));
     }

--- a/tests/Integration/Cache/RedisCacheLockTest.php
+++ b/tests/Integration/Cache/RedisCacheLockTest.php
@@ -49,7 +49,7 @@ class RedisCacheLockTest extends TestCase
         Carbon::setTestNow();
 
         Cache::store('redis')->lock('foo')->forceRelease();
-        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, function () {
+        $this->assertSame('taylor', Cache::store('redis')->lock('foo', 10)->block(1, static function () {
             return 'taylor';
         }));
 
@@ -80,7 +80,7 @@ class RedisCacheLockTest extends TestCase
         $firstLock = Cache::store('redis')->lock('foo', 10);
 
         try {
-            $firstLock->block(1, function () {
+            $firstLock->block(1, static function () {
                 throw new Exception('failed');
             });
         } catch (Exception $e) {

--- a/tests/Integration/Console/JobSchedulingTest.php
+++ b/tests/Integration/Console/JobSchedulingTest.php
@@ -34,7 +34,7 @@ class JobSchedulingTest extends TestCase
         Queue::assertPushedOn('test-queue', JobWithDefaultQueue::class);
         Queue::assertPushedOn('another-queue', JobWithDefaultQueueTwo::class);
         Queue::assertPushedOn(null, JobWithoutDefaultQueue::class);
-        $this->assertTrue(Queue::pushed(JobWithDefaultQueueTwo::class, function ($job, $pushedQueue) {
+        $this->assertTrue(Queue::pushed(JobWithDefaultQueueTwo::class, static function ($job, $pushedQueue) {
             return $pushedQueue === 'test-queue-two';
         })->isEmpty());
     }
@@ -60,23 +60,23 @@ class JobSchedulingTest extends TestCase
             $event->run($this->app);
         }
 
-        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, static function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'test-connection';
         })->count());
 
-        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertSame(1, Queue::pushed(JobWithDefaultConnection::class, static function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'foo';
         })->count());
 
-        $this->assertSame(0, Queue::pushed(JobWithDefaultConnection::class, function (JobWithDefaultConnection $job, $pushedQueue) {
+        $this->assertSame(0, Queue::pushed(JobWithDefaultConnection::class, static function (JobWithDefaultConnection $job, $pushedQueue) {
             return $job->connection === null;
         })->count());
 
-        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
+        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, static function (JobWithoutDefaultConnection $job, $pushedQueue) {
             return $job->connection === null;
         })->count());
 
-        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, function (JobWithoutDefaultConnection $job, $pushedQueue) {
+        $this->assertSame(1, Queue::pushed(JobWithoutDefaultConnection::class, static function (JobWithoutDefaultConnection $job, $pushedQueue) {
             return $job->connection === 'bar';
         })->count());
     }

--- a/tests/Integration/Console/Scheduling/EventPingTest.php
+++ b/tests/Integration/Console/Scheduling/EventPingTest.php
@@ -46,7 +46,7 @@ class EventPingTest extends TestCase
         $thenCalled = false;
 
         $event->pingBefore('https://httpstat.us/500')
-            ->then(function () use (&$thenCalled) {
+            ->then(static function () use (&$thenCalled) {
                 $thenCalled = true;
             });
 

--- a/tests/Integration/Cookie/CookieTest.php
+++ b/tests/Integration/Cookie/CookieTest.php
@@ -21,7 +21,7 @@ class CookieTest extends TestCase
     {
         $this->app['config']->set('session.expire_on_close', true);
 
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return 'hello world';
         })->middleware('web');
 
@@ -35,7 +35,7 @@ class CookieTest extends TestCase
         $this->app['config']->set('session.expire_on_close', false);
         $this->app['config']->set('session.lifetime', 1);
 
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return 'hello world';
         })->middleware('web');
 
@@ -57,7 +57,7 @@ class CookieTest extends TestCase
         $app['config']->set('app.key', Str::random(32));
         $app['config']->set('session.driver', 'fake-null');
 
-        Session::extend('fake-null', function () {
+        Session::extend('fake-null', static function () {
             return new NullSessionHandler;
         });
     }

--- a/tests/Integration/Database/DatabaseLockTest.php
+++ b/tests/Integration/Database/DatabaseLockTest.php
@@ -16,7 +16,7 @@ class DatabaseLockTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('cache_locks', function (Blueprint $table) {
+        Schema::create('cache_locks', static function (Blueprint $table) {
             $table->string('key')->primary();
             $table->string('owner');
             $table->integer('expiration');

--- a/tests/Integration/Database/DatabaseMySqlConnectionTest.php
+++ b/tests/Integration/Database/DatabaseMySqlConnectionTest.php
@@ -22,7 +22,7 @@ class DatabaseMySqlConnectionTest extends DatabaseMySqlTestCase
         }
 
         if (! Schema::hasTable(self::TABLE)) {
-            Schema::create(self::TABLE, function (Blueprint $table) {
+            Schema::create(self::TABLE, static function (Blueprint $table) {
                 $table->json(self::JSON_COL)->nullable();
                 $table->float(self::FLOAT_COL)->nullable();
             });

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -9,7 +9,7 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
 {
     public function testRenameColumnOnTableWithEnum()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', static function (Blueprint $table) {
             $table->renameColumn('name', 'username');
         });
 
@@ -18,7 +18,7 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
 
     public function testChangeColumnOnTableWithEnum()
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', static function (Blueprint $table) {
             $table->unsignedInteger('age')->charset('')->change();
         });
 
@@ -29,7 +29,7 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->integer('id');
             $table->string('name');
             $table->string('age');

--- a/tests/Integration/Database/EloquentBelongsToManyTest.php
+++ b/tests/Integration/Database/EloquentBelongsToManyTest.php
@@ -22,34 +22,34 @@ class EloquentBelongsToManyTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('uuid');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('uuid');
             $table->string('title');
             $table->timestamps();
         });
 
-        Schema::create('tags', function (Blueprint $table) {
+        Schema::create('tags', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('users_posts', function (Blueprint $table) {
+        Schema::create('users_posts', static function (Blueprint $table) {
             $table->string('user_uuid');
             $table->string('post_uuid');
             $table->tinyInteger('is_draft')->default(1);
             $table->timestamps();
         });
 
-        Schema::create('posts_tags', function (Blueprint $table) {
+        Schema::create('posts_tags', static function (Blueprint $table) {
             $table->integer('post_id');
             $table->integer('tag_id');
             $table->string('flag')->default('')->nullable();
@@ -916,7 +916,7 @@ class User extends Model
     protected static function boot()
     {
         parent::boot();
-        static::creating(function ($model) {
+        static::creating(static function ($model) {
             $model->setAttribute('uuid', Str::random());
         });
     }
@@ -940,7 +940,7 @@ class Post extends Model
     protected static function boot()
     {
         parent::boot();
-        static::creating(function ($model) {
+        static::creating(static function ($model) {
             $model->setAttribute('uuid', Str::random());
         });
     }
@@ -1062,7 +1062,7 @@ class TagWithGlobalScope extends Model
     {
         parent::boot();
 
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope(static function ($query) {
             $query->select('tags.id');
         });
     }

--- a/tests/Integration/Database/EloquentBelongsToTest.php
+++ b/tests/Integration/Database/EloquentBelongsToTest.php
@@ -17,7 +17,7 @@ class EloquentBelongsToTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('slug')->nullable();
             $table->unsignedInteger('parent_id')->nullable();

--- a/tests/Integration/Database/EloquentCollectionFreshTest.php
+++ b/tests/Integration/Database/EloquentCollectionFreshTest.php
@@ -15,7 +15,7 @@ class EloquentCollectionFreshTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });

--- a/tests/Integration/Database/EloquentCollectionLoadCountTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadCountTest.php
@@ -19,18 +19,18 @@ class EloquentCollectionLoadCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('some_default_value');
             $table->softDeletes();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('post_id');
         });
 
-        Schema::create('likes', function (Blueprint $table) {
+        Schema::create('likes', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('post_id');
         });

--- a/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentCollectionLoadMissingTest.php
@@ -17,22 +17,22 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('parent_id')->nullable();
             $table->unsignedInteger('post_id');
         });
 
-        Schema::create('revisions', function (Blueprint $table) {
+        Schema::create('revisions', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('comment_id');
         });
@@ -68,7 +68,7 @@ class EloquentCollectionLoadMissingTest extends DatabaseTestCase
 
         DB::enableQueryLog();
 
-        $posts->loadMissing(['comments.parent' => function ($query) {
+        $posts->loadMissing(['comments.parent' => static function ($query) {
             $query->select('id');
         }]);
 

--- a/tests/Integration/Database/EloquentCustomPivotCastTest.php
+++ b/tests/Integration/Database/EloquentCustomPivotCastTest.php
@@ -16,17 +16,17 @@ class EloquentCustomPivotCastTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });
 
-        Schema::create('projects', function (Blueprint $table) {
+        Schema::create('projects', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });
 
-        Schema::create('project_users', function (Blueprint $table) {
+        Schema::create('project_users', static function (Blueprint $table) {
             $table->integer('user_id');
             $table->integer('project_id');
             $table->text('permissions');

--- a/tests/Integration/Database/EloquentDeleteTest.php
+++ b/tests/Integration/Database/EloquentDeleteTest.php
@@ -31,20 +31,20 @@ class EloquentDeleteTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();
             $table->timestamps();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('body')->nullable();
             $table->integer('post_id');
             $table->timestamps();
         });
 
-        Schema::create('roles', function (Blueprint $table) {
+        Schema::create('roles', static function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
             $table->softDeletes();

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -33,27 +33,27 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory = new Factory($app->make(Generator::class));
 
-        $factory->define(FactoryBuildableUser::class, function (Generator $faker) {
+        $factory->define(FactoryBuildableUser::class, static function (Generator $faker) {
             return [
                 'name' => $faker->name,
                 'email' => $faker->unique()->safeEmail,
             ];
         });
 
-        $factory->define(FactoryBuildableProfile::class, function (Generator $faker) {
+        $factory->define(FactoryBuildableProfile::class, static function (Generator $faker) {
             return [
-                'user_id' => function () {
+                'user_id' => static function () {
                     return factory(FactoryBuildableUser::class)->create()->id;
                 },
             ];
         });
 
-        $factory->afterMaking(FactoryBuildableUser::class, function (FactoryBuildableUser $user, Generator $faker) {
+        $factory->afterMaking(FactoryBuildableUser::class, static function (FactoryBuildableUser $user, Generator $faker) {
             $profile = factory(FactoryBuildableProfile::class)->make(['user_id' => $user->id]);
             $user->setRelation('profile', $profile);
         });
 
-        $factory->afterMakingState(FactoryBuildableUser::class, 'with_callable_server', function (FactoryBuildableUser $user, Generator $faker) {
+        $factory->afterMakingState(FactoryBuildableUser::class, 'with_callable_server', static function (FactoryBuildableUser $user, Generator $faker) {
             $server = factory(FactoryBuildableServer::class)
                 ->state('callable')
                 ->make(['user_id' => $user->id]);
@@ -61,37 +61,37 @@ class EloquentFactoryBuilderTest extends TestCase
             $user->servers->push($server);
         });
 
-        $factory->define(FactoryBuildableTeam::class, function (Generator $faker) {
+        $factory->define(FactoryBuildableTeam::class, static function (Generator $faker) {
             return [
                 'name' => $faker->name,
-                'owner_id' => function () {
+                'owner_id' => static function () {
                     return factory(FactoryBuildableUser::class)->create()->id;
                 },
             ];
         });
 
-        $factory->afterCreating(FactoryBuildableTeam::class, function (FactoryBuildableTeam $team, Generator $faker) {
+        $factory->afterCreating(FactoryBuildableTeam::class, static function (FactoryBuildableTeam $team, Generator $faker) {
             $team->users()->attach($team->owner);
         });
 
-        $factory->define(FactoryBuildableServer::class, function (Generator $faker) {
+        $factory->define(FactoryBuildableServer::class, static function (Generator $faker) {
             return [
                 'name' => $faker->name,
                 'status' => 'active',
                 'tags' => ['Storage', 'Data'],
-                'user_id' => function () {
+                'user_id' => static function () {
                     return factory(FactoryBuildableUser::class)->create()->id;
                 },
             ];
         });
 
-        $factory->state(FactoryBuildableServer::class, 'callable', function (Generator $faker) {
+        $factory->state(FactoryBuildableServer::class, 'callable', static function (Generator $faker) {
             return [
                 'status' => 'callable',
             ];
         });
 
-        $factory->afterCreatingState(FactoryBuildableUser::class, 'with_callable_server', function (FactoryBuildableUser $user, Generator $faker) {
+        $factory->afterCreatingState(FactoryBuildableUser::class, 'with_callable_server', static function (FactoryBuildableUser $user, Generator $faker) {
             factory(FactoryBuildableServer::class)
                 ->state('callable')
                 ->create(['user_id' => $user->id]);
@@ -99,7 +99,7 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $factory->state(FactoryBuildableServer::class, 'inline', ['status' => 'inline']);
 
-        $app->singleton(Factory::class, function ($app) use ($factory) {
+        $app->singleton(Factory::class, static function ($app) use ($factory) {
             return $factory;
         });
     }
@@ -108,36 +108,36 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email');
         });
 
-        Schema::create('profiles', function (Blueprint $table) {
+        Schema::create('profiles', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('teams', function (Blueprint $table) {
+        Schema::create('teams', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('owner_id');
         });
 
-        Schema::create('team_users', function (Blueprint $table) {
+        Schema::create('team_users', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('team_id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::connection('alternative-connection')->create('users', function (Blueprint $table) {
+        Schema::connection('alternative-connection')->create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email');
         });
 
-        Schema::create('servers', function (Blueprint $table) {
+        Schema::create('servers', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('tags');
@@ -220,7 +220,7 @@ class EloquentFactoryBuilderTest extends TestCase
     {
         factory(FactoryBuildableUser::class, 2)
             ->create()
-            ->each(function ($user) {
+            ->each(static function ($user) {
                 $user->servers()->saveMany(factory(FactoryBuildableServer::class, 2)->make());
             })
             ->each(function ($user) {

--- a/tests/Integration/Database/EloquentHasManyThroughTest.php
+++ b/tests/Integration/Database/EloquentHasManyThroughTest.php
@@ -18,26 +18,26 @@ class EloquentHasManyThroughTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('slug')->nullable();
             $table->integer('team_id')->nullable();
             $table->string('name');
         });
 
-        Schema::create('teams', function (Blueprint $table) {
+        Schema::create('teams', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('owner_id')->nullable();
             $table->string('owner_slug')->nullable();
         });
 
-        Schema::create('categories', function (Blueprint $table) {
+        Schema::create('categories', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('parent_id')->nullable();
             $table->softDeletes();
         });
 
-        Schema::create('products', function (Blueprint $table) {
+        Schema::create('products', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('category_id');
         });
@@ -158,7 +158,7 @@ class UserWithGlobalScope extends Model
     {
         parent::boot();
 
-        static::addGlobalScope(function ($query) {
+        static::addGlobalScope(static function ($query) {
             $query->select('users.id');
         });
     }

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -17,16 +17,16 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('one', function (Blueprint $table) {
+        Schema::create('one', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('two', function (Blueprint $table) {
+        Schema::create('two', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
         });
 
-        Schema::create('three', function (Blueprint $table) {
+        Schema::create('three', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
         });

--- a/tests/Integration/Database/EloquentModelConnectionsTest.php
+++ b/tests/Integration/Database/EloquentModelConnectionsTest.php
@@ -36,23 +36,23 @@ class EloquentModelConnectionsTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('parent', function (Blueprint $table) {
+        Schema::create('parent', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });
 
-        Schema::create('child', function (Blueprint $table) {
+        Schema::create('child', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->integer('parent_id');
         });
 
-        Schema::connection('conn2')->create('parent', function (Blueprint $table) {
+        Schema::connection('conn2')->create('parent', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });
 
-        Schema::connection('conn2')->create('child', function (Blueprint $table) {
+        Schema::connection('conn2')->create('child', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->integer('parent_id');

--- a/tests/Integration/Database/EloquentModelCustomEventsTest.php
+++ b/tests/Integration/Database/EloquentModelCustomEventsTest.php
@@ -17,11 +17,11 @@ class EloquentModelCustomEventsTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('test_model1', function (Blueprint $table) {
+        Schema::create('test_model1', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Event::listen(CustomEvent::class, function () {
+        Event::listen(CustomEvent::class, static function () {
             $_SERVER['fired_event'] = true;
         });
     }

--- a/tests/Integration/Database/EloquentModelDateCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDateCastingTest.php
@@ -17,7 +17,7 @@ class EloquentModelDateCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('test_model1', function (Blueprint $table) {
+        Schema::create('test_model1', static function (Blueprint $table) {
             $table->increments('id');
             $table->date('date_field')->nullable();
             $table->datetime('datetime_field')->nullable();

--- a/tests/Integration/Database/EloquentModelDecimalCastingTest.php
+++ b/tests/Integration/Database/EloquentModelDecimalCastingTest.php
@@ -16,7 +16,7 @@ class EloquentModelDecimalCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('test_model1', function (Blueprint $table) {
+        Schema::create('test_model1', static function (Blueprint $table) {
             $table->increments('id');
             $table->decimal('decimal_field_2', 8, 2)->nullable();
             $table->decimal('decimal_field_4', 8, 4)->nullable();

--- a/tests/Integration/Database/EloquentModelJsonCastingTest.php
+++ b/tests/Integration/Database/EloquentModelJsonCastingTest.php
@@ -18,7 +18,7 @@ class EloquentModelJsonCastingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('json_casts', function (Blueprint $table) {
+        Schema::create('json_casts', static function (Blueprint $table) {
             $table->increments('id');
             $table->json('basic_string_as_json_field')->nullable();
             $table->json('json_string_as_json_field')->nullable();

--- a/tests/Integration/Database/EloquentModelLoadCountTest.php
+++ b/tests/Integration/Database/EloquentModelLoadCountTest.php
@@ -17,21 +17,21 @@ class EloquentModelLoadCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('base_models', function (Blueprint $table) {
+        Schema::create('base_models', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('related1s', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedInteger('base_model_id');
-        });
-
-        Schema::create('related2s', function (Blueprint $table) {
+        Schema::create('related1s', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('base_model_id');
         });
 
-        Schema::create('deleted_related', function (Blueprint $table) {
+        Schema::create('related2s', static function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('base_model_id');
+        });
+
+        Schema::create('deleted_related', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('base_model_id');
             $table->softDeletes();

--- a/tests/Integration/Database/EloquentModelLoadMissingTest.php
+++ b/tests/Integration/Database/EloquentModelLoadMissingTest.php
@@ -17,11 +17,11 @@ class EloquentModelLoadMissingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('parent_id')->nullable();
             $table->unsignedInteger('post_id');

--- a/tests/Integration/Database/EloquentModelRefreshTest.php
+++ b/tests/Integration/Database/EloquentModelRefreshTest.php
@@ -18,7 +18,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->timestamps();
@@ -61,7 +61,7 @@ class EloquentModelRefreshTest extends DatabaseTestCase
 
     public function testAsPivot()
     {
-        Schema::create('post_posts', function (Blueprint $table) {
+        Schema::create('post_posts', static function (Blueprint $table) {
             $table->bigInteger('foreign_id');
             $table->bigInteger('related_id');
         });
@@ -89,7 +89,7 @@ class Post extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('age', function ($query) {
+        static::addGlobalScope('age', static function ($query) {
             $query->where('title', '!=', 'mohamed');
         });
     }

--- a/tests/Integration/Database/EloquentModelStringCastingTest.php
+++ b/tests/Integration/Database/EloquentModelStringCastingTest.php
@@ -35,7 +35,7 @@ class EloquentModelStringCastingTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create('casting_table', function (Blueprint $table) {
+        $this->schema()->create('casting_table', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('array_attributes');
             $table->string('json_attributes');

--- a/tests/Integration/Database/EloquentModelTest.php
+++ b/tests/Integration/Database/EloquentModelTest.php
@@ -17,12 +17,12 @@ class EloquentModelTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('test_model1', function (Blueprint $table) {
+        Schema::create('test_model1', static function (Blueprint $table) {
             $table->increments('id');
             $table->timestamp('nullable_date')->nullable();
         });
 
-        Schema::create('test_model2', function (Blueprint $table) {
+        Schema::create('test_model2', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('title');

--- a/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountEagerLoadingTest.php
@@ -17,25 +17,25 @@ class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('likes', function (Blueprint $table) {
+        Schema::create('likes', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('post_id');
         });
 
-        Schema::create('views', function (Blueprint $table) {
+        Schema::create('views', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('video_id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('videos', function (Blueprint $table) {
+        Schema::create('videos', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
@@ -56,7 +56,7 @@ class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphCountLoading()
     {
         $comments = Comment::query()
-            ->with(['commentable' => function (MorphTo $morphTo) {
+            ->with(['commentable' => static function (MorphTo $morphTo) {
                 $morphTo->morphWithCount([Post::class => ['likes']]);
             }])
             ->get();
@@ -70,7 +70,7 @@ class EloquentMorphCountEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphCountLoadingWithSingleRelation()
     {
         $comments = Comment::query()
-            ->with(['commentable' => function (MorphTo $morphTo) {
+            ->with(['commentable' => static function (MorphTo $morphTo) {
                 $morphTo->morphWithCount([Post::class => 'likes']);
             }])
             ->get();

--- a/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphCountLazyEagerLoadingTest.php
@@ -16,16 +16,16 @@ class EloquentMorphCountLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('likes', function (Blueprint $table) {
+        Schema::create('likes', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('post_id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');

--- a/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphEagerLoadingTest.php
@@ -17,20 +17,20 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('post_id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('videos', function (Blueprint $table) {
+        Schema::create('videos', static function (Blueprint $table) {
             $table->increments('video_id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
@@ -49,7 +49,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphLoading()
     {
         $comments = Comment::query()
-            ->with(['commentable' => function (MorphTo $morphTo) {
+            ->with(['commentable' => static function (MorphTo $morphTo) {
                 $morphTo->morphWith([Post::class => ['user']]);
             }])
             ->get();
@@ -62,7 +62,7 @@ class EloquentMorphEagerLoadingTest extends DatabaseTestCase
     public function testWithMorphLoadingWithSingleRelation()
     {
         $comments = Comment::query()
-            ->with(['commentable' => function (MorphTo $morphTo) {
+            ->with(['commentable' => static function (MorphTo $morphTo) {
                 $morphTo->morphWith([Post::class => 'user']);
             }])
             ->get();

--- a/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphLazyEagerLoadingTest.php
@@ -16,16 +16,16 @@ class EloquentMorphLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('post_id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');

--- a/tests/Integration/Database/EloquentMorphManyTest.php
+++ b/tests/Integration/Database/EloquentMorphManyTest.php
@@ -18,13 +18,13 @@ class EloquentMorphManyTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->timestamps();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->integer('commentable_id');

--- a/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
+++ b/tests/Integration/Database/EloquentMorphToGlobalScopesTest.php
@@ -18,12 +18,12 @@ class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->softDeletes();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
@@ -46,7 +46,7 @@ class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 
     public function testWithoutGlobalScope()
     {
-        $comments = Comment::with(['commentable' => function ($query) {
+        $comments = Comment::with(['commentable' => static function ($query) {
             $query->withoutGlobalScopes([SoftDeletingScope::class]);
         }])->get();
 
@@ -56,7 +56,7 @@ class EloquentMorphToGlobalScopesTest extends DatabaseTestCase
 
     public function testWithoutGlobalScopes()
     {
-        $comments = Comment::with(['commentable' => function ($query) {
+        $comments = Comment::with(['commentable' => static function ($query) {
             $query->withoutGlobalScopes();
         }])->get();
 

--- a/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentMorphToLazyEagerLoadingTest.php
@@ -17,20 +17,20 @@ class EloquentMorphToLazyEagerLoadingTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('post_id');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('videos', function (Blueprint $table) {
+        Schema::create('videos', static function (Blueprint $table) {
             $table->increments('video_id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');

--- a/tests/Integration/Database/EloquentMorphToSelectTest.php
+++ b/tests/Integration/Database/EloquentMorphToSelectTest.php
@@ -16,12 +16,12 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
@@ -40,7 +40,7 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
 
     public function testSelectRaw()
     {
-        $comments = Comment::with(['commentable' => function ($query) {
+        $comments = Comment::with(['commentable' => static function ($query) {
             $query->selectRaw('id');
         }])->get();
 
@@ -49,8 +49,8 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
 
     public function testSelectSub()
     {
-        $comments = Comment::with(['commentable' => function ($query) {
-            $query->selectSub(function ($query) {
+        $comments = Comment::with(['commentable' => static function ($query) {
+            $query->selectSub(static function ($query) {
                 $query->select('id');
             }, 'id');
         }])->get();
@@ -60,7 +60,7 @@ class EloquentMorphToSelectTest extends DatabaseTestCase
 
     public function testAddSelect()
     {
-        $comments = Comment::with(['commentable' => function ($query) {
+        $comments = Comment::with(['commentable' => static function ($query) {
             $query->addSelect('id');
         }])->get();
 

--- a/tests/Integration/Database/EloquentMorphToTouchesTest.php
+++ b/tests/Integration/Database/EloquentMorphToTouchesTest.php
@@ -17,12 +17,12 @@ class EloquentMorphToTouchesTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->timestamps();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->nullableMorphs('commentable');
         });

--- a/tests/Integration/Database/EloquentPaginateTest.php
+++ b/tests/Integration/Database/EloquentPaginateTest.php
@@ -16,14 +16,14 @@ class EloquentPaginateTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title')->nullable();
             $table->unsignedInteger('user_id')->nullable();
             $table->timestamps();
         });
 
-        Schema::create('users', function ($table) {
+        Schema::create('users', static function ($table) {
             $table->increments('id');
             $table->timestamps();
         });

--- a/tests/Integration/Database/EloquentPivotEventsTest.php
+++ b/tests/Integration/Database/EloquentPivotEventsTest.php
@@ -16,19 +16,19 @@ class EloquentPivotEventsTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->timestamps();
         });
 
-        Schema::create('projects', function (Blueprint $table) {
+        Schema::create('projects', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('project_users', function (Blueprint $table) {
+        Schema::create('project_users', static function (Blueprint $table) {
             $table->integer('user_id');
             $table->integer('project_id');
             $table->text('permissions')->nullable();
@@ -160,37 +160,37 @@ class PivotEventsTestCollaborator extends Pivot
     {
         parent::boot();
 
-        static::creating(function ($model) {
+        static::creating(static function ($model) {
             static::$eventsCalled[] = 'creating';
         });
 
-        static::created(function ($model) {
+        static::created(static function ($model) {
             static::$eventsCalled[] = 'created';
         });
 
-        static::updating(function ($model) {
+        static::updating(static function ($model) {
             static::$eventsCalled[] = 'updating';
         });
 
-        static::updated(function ($model) {
+        static::updated(static function ($model) {
             $_SERVER['pivot_attributes'] = $model->getAttributes();
             $_SERVER['pivot_dirty_attributes'] = $model->getDirty();
             static::$eventsCalled[] = 'updated';
         });
 
-        static::saving(function ($model) {
+        static::saving(static function ($model) {
             static::$eventsCalled[] = 'saving';
         });
 
-        static::saved(function ($model) {
+        static::saved(static function ($model) {
             static::$eventsCalled[] = 'saved';
         });
 
-        static::deleting(function ($model) {
+        static::deleting(static function ($model) {
             static::$eventsCalled[] = 'deleting';
         });
 
-        static::deleted(function ($model) {
+        static::deleted(static function ($model) {
             static::$eventsCalled[] = 'deleted';
         });
     }

--- a/tests/Integration/Database/EloquentPivotSerializationTest.php
+++ b/tests/Integration/Database/EloquentPivotSerializationTest.php
@@ -19,30 +19,30 @@ class EloquentPivotSerializationTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->timestamps();
         });
 
-        Schema::create('projects', function (Blueprint $table) {
+        Schema::create('projects', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('project_users', function (Blueprint $table) {
+        Schema::create('project_users', static function (Blueprint $table) {
             $table->integer('user_id');
             $table->integer('project_id');
         });
 
-        Schema::create('tags', function (Blueprint $table) {
+        Schema::create('tags', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
         });
 
-        Schema::create('taggables', function (Blueprint $table) {
+        Schema::create('taggables', static function (Blueprint $table) {
             $table->integer('tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');

--- a/tests/Integration/Database/EloquentPushTest.php
+++ b/tests/Integration/Database/EloquentPushTest.php
@@ -15,18 +15,18 @@ class EloquentPushTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->unsignedInteger('user_id');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('comment');
             $table->unsignedInteger('post_id');

--- a/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
+++ b/tests/Integration/Database/EloquentTouchParentWithGlobalScopeTest.php
@@ -18,13 +18,13 @@ class EloquentTouchParentWithGlobalScopeTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->timestamps();
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('post_id');
             $table->string('title');
@@ -61,7 +61,7 @@ class Post extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('age', function ($builder) {
+        static::addGlobalScope('age', static function ($builder) {
             $builder->join('comments', 'comments.post_id', '=', 'posts.id');
         });
     }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -31,13 +31,13 @@ class EloquentUpdateTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('test_model1', function (Blueprint $table) {
+        Schema::create('test_model1', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->nullable();
             $table->string('title')->nullable();
         });
 
-        Schema::create('test_model2', function (Blueprint $table) {
+        Schema::create('test_model2', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('job')->nullable();
@@ -45,7 +45,7 @@ class EloquentUpdateTest extends TestCase
             $table->timestamps();
         });
 
-        Schema::create('test_model3', function (Blueprint $table) {
+        Schema::create('test_model3', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('counter');
             $table->softDeletes();
@@ -88,7 +88,7 @@ class EloquentUpdateTest extends TestCase
             'name' => Str::random(),
         ]);
 
-        TestUpdateModel2::join('test_model1', function ($join) {
+        TestUpdateModel2::join('test_model1', static function ($join) {
             $join->on('test_model1.id', '=', 'test_model2.id')
                 ->where('test_model1.title', '=', 'Mr.');
         })->update(['test_model2.name' => 'Abdul', 'job'=>'Engineer']);
@@ -109,7 +109,7 @@ class EloquentUpdateTest extends TestCase
             'name' => Str::random(),
         ]);
 
-        TestUpdateModel2::join('test_model1', function ($join) {
+        TestUpdateModel2::join('test_model1', static function ($join) {
             $join->on('test_model1.id', '=', 'test_model2.id')
                 ->where('test_model1.title', '=', 'Mr.');
         })->delete();

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -19,18 +19,18 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->softDeletes();
         });
 
-        Schema::create('videos', function (Blueprint $table) {
+        Schema::create('videos', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->morphs('commentable');
             $table->softDeletes();
@@ -54,7 +54,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testWhereHasMorph()
     {
-        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], static function (Builder $query) {
             $query->where('title', 'foo');
         })->get();
 
@@ -68,7 +68,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
 
         try {
-            $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+            $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], static function (Builder $query) {
                 $query->where('title', 'foo');
             })->get();
 
@@ -84,7 +84,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         Comment::where('commentable_type', Video::class)->delete();
 
         $comments = Comment::withTrashed()
-            ->whereHasMorph('commentable', '*', function (Builder $query) {
+            ->whereHasMorph('commentable', '*', static function (Builder $query) {
                 $query->where('title', 'foo');
             })->get();
 
@@ -98,7 +98,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
 
         try {
-            $comments = Comment::whereHasMorph('commentable', '*', function (Builder $query) {
+            $comments = Comment::whereHasMorph('commentable', '*', static function (Builder $query) {
                 $query->where('title', 'foo');
             })->get();
 
@@ -110,7 +110,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testWhereHasMorphWithRelationConstraint()
     {
-        $comments = Comment::whereHasMorph('commentableWithConstraint', Video::class, function (Builder $query) {
+        $comments = Comment::whereHasMorph('commentableWithConstraint', Video::class, static function (Builder $query) {
             $query->where('title', 'like', 'ba%');
         })->get();
 
@@ -119,7 +119,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testWhereHasMorphWitDifferentConstraints()
     {
-        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query, $type) {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], static function (Builder $query, $type) {
             if ($type === Post::class) {
                 $query->where('title', 'foo');
             }
@@ -134,11 +134,11 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testWhereHasMorphWithOwnerKey()
     {
-        Schema::table('posts', function (Blueprint $table) {
+        Schema::table('posts', static function (Blueprint $table) {
             $table->string('slug')->nullable();
         });
 
-        Schema::table('comments', function (Blueprint $table) {
+        Schema::table('comments', static function (Blueprint $table) {
             $table->string('commentable_id')->change();
         });
 
@@ -146,7 +146,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
         Comment::where('id', 1)->update(['commentable_id' => 'foo']);
 
-        $comments = Comment::whereHasMorph('commentableWithOwnerKey', Post::class, function (Builder $query) {
+        $comments = Comment::whereHasMorph('commentableWithOwnerKey', Post::class, static function (Builder $query) {
             $query->where('title', 'foo');
         })->get();
 
@@ -184,7 +184,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
     public function testOrWhereHasMorph()
     {
         $comments = Comment::where('id', 1)
-            ->orWhereHasMorph('commentable', Video::class, function (Builder $query) {
+            ->orWhereHasMorph('commentable', Video::class, static function (Builder $query) {
                 $query->where('title', 'foo');
             })->get();
 
@@ -193,7 +193,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testWhereDoesntHaveMorph()
     {
-        $comments = Comment::whereDoesntHaveMorph('commentable', Post::class, function (Builder $query) {
+        $comments = Comment::whereDoesntHaveMorph('commentable', Post::class, static function (Builder $query) {
             $query->where('title', 'foo');
         })->get();
 
@@ -203,7 +203,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
     public function testOrWhereDoesntHaveMorph()
     {
         $comments = Comment::where('id', 1)
-            ->orWhereDoesntHaveMorph('commentable', Post::class, function (Builder $query) {
+            ->orWhereDoesntHaveMorph('commentable', Post::class, static function (Builder $query) {
                 $query->where('title', 'foo');
             })->get();
 
@@ -212,7 +212,7 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
 
     public function testModelScopesAreAccessible()
     {
-        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+        $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], static function (Builder $query) {
             $query->someSharedModelScope();
         })->get();
 

--- a/tests/Integration/Database/EloquentWhereHasTest.php
+++ b/tests/Integration/Database/EloquentWhereHasTest.php
@@ -16,17 +16,17 @@ class EloquentWhereHasTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
             $table->boolean('public');
         });
 
-        Schema::create('comments', function (Blueprint $table) {
+        Schema::create('comments', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('commentable_type');
             $table->integer('commentable_id');
@@ -43,7 +43,7 @@ class EloquentWhereHasTest extends DatabaseTestCase
 
     public function testWithCount()
     {
-        $users = User::whereHas('posts', function ($query) {
+        $users = User::whereHas('posts', static function ($query) {
             $query->where('public', true);
         })->get();
 

--- a/tests/Integration/Database/EloquentWhereTest.php
+++ b/tests/Integration/Database/EloquentWhereTest.php
@@ -15,7 +15,7 @@ class EloquentWhereTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email');

--- a/tests/Integration/Database/EloquentWithCountTest.php
+++ b/tests/Integration/Database/EloquentWithCountTest.php
@@ -16,21 +16,21 @@ class EloquentWithCountTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('one', function (Blueprint $table) {
+        Schema::create('one', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('two', function (Blueprint $table) {
+        Schema::create('two', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
         });
 
-        Schema::create('three', function (Blueprint $table) {
+        Schema::create('three', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('two_id');
         });
 
-        Schema::create('four', function (Blueprint $table) {
+        Schema::create('four', static function (Blueprint $table) {
             $table->increments('id');
             $table->integer('one_id');
         });
@@ -43,7 +43,7 @@ class EloquentWithCountTest extends DatabaseTestCase
         $two->threes()->Create();
 
         $results = Model1::withCount([
-            'twos' => function ($query) {
+            'twos' => static function ($query) {
                 $query->where('id', '>=', 1);
             },
         ]);
@@ -109,7 +109,7 @@ class Model2 extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('app', function ($builder) {
+        static::addGlobalScope('app', static function ($builder) {
             $builder->latest();
         });
     }
@@ -130,7 +130,7 @@ class Model3 extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('app', function ($builder) {
+        static::addGlobalScope('app', static function ($builder) {
             $builder->where('idz', '>', 0);
         });
     }
@@ -146,7 +146,7 @@ class Model4 extends Model
     {
         parent::boot();
 
-        static::addGlobalScope('app', function ($builder) {
+        static::addGlobalScope('app', static function ($builder) {
             $builder->where('id', '>', 1);
         });
     }

--- a/tests/Integration/Database/MigratorEventsTest.php
+++ b/tests/Integration/Database/MigratorEventsTest.php
@@ -40,16 +40,16 @@ class MigratorEventsTest extends DatabaseTestCase
         $this->artisan('migrate', $this->migrateOptions());
         $this->artisan('migrate:rollback', $this->migrateOptions());
 
-        Event::assertDispatched(MigrationStarted::class, function ($event) {
+        Event::assertDispatched(MigrationStarted::class, static function ($event) {
             return $event->method == 'up' && $event->migration instanceof Migration;
         });
-        Event::assertDispatched(MigrationStarted::class, function ($event) {
+        Event::assertDispatched(MigrationStarted::class, static function ($event) {
             return $event->method == 'down' && $event->migration instanceof Migration;
         });
-        Event::assertDispatched(MigrationEnded::class, function ($event) {
+        Event::assertDispatched(MigrationEnded::class, static function ($event) {
             return $event->method == 'up' && $event->migration instanceof Migration;
         });
-        Event::assertDispatched(MigrationEnded::class, function ($event) {
+        Event::assertDispatched(MigrationEnded::class, static function ($event) {
             return $event->method == 'down' && $event->migration instanceof Migration;
         });
     }
@@ -61,10 +61,10 @@ class MigratorEventsTest extends DatabaseTestCase
         $this->artisan('migrate');
         $this->artisan('migrate:rollback');
 
-        Event::assertDispatched(NoPendingMigrations::class, function ($event) {
+        Event::assertDispatched(NoPendingMigrations::class, static function ($event) {
             return $event->method == 'up';
         });
-        Event::assertDispatched(NoPendingMigrations::class, function ($event) {
+        Event::assertDispatched(NoPendingMigrations::class, static function ($event) {
             return $event->method == 'down';
         });
     }

--- a/tests/Integration/Database/QueryBuilderTest.php
+++ b/tests/Integration/Database/QueryBuilderTest.php
@@ -17,7 +17,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->text('content');
@@ -50,7 +50,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $this->assertSame(
             ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
-            (array) DB::table('posts')->select(['id', 'title', 'foo' => function ($query) {
+            (array) DB::table('posts')->select(['id', 'title', 'foo' => static function ($query) {
                 $query->select('bar');
             }])->first()
         );
@@ -69,7 +69,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $this->assertSame(
             ['id' => '1', 'title' => 'Foo Post', 'foo' => 'bar'],
-            (array) DB::table('posts')->addSelect(['id', 'title', 'foo' => function ($query) {
+            (array) DB::table('posts')->addSelect(['id', 'title', 'foo' => static function ($query) {
                 $query->select('bar');
             }])->first()
         );
@@ -84,7 +84,7 @@ class QueryBuilderTest extends DatabaseTestCase
     {
         $this->assertSame(
             'Fake Post',
-            DB::table(function ($query) {
+            DB::table(static function ($query) {
                 $query->selectRaw("'Fake Post' as title");
             }, 'posts')->first()->title
         );
@@ -92,7 +92,7 @@ class QueryBuilderTest extends DatabaseTestCase
 
     public function testWhereValueSubQuery()
     {
-        $subQuery = function ($query) {
+        $subQuery = static function ($query) {
             $query->selectRaw("'Sub query value'");
         };
 

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -17,13 +17,13 @@ class SchemaBuilderTest extends DatabaseTestCase
 {
     public function testDropAllTables()
     {
-        Schema::create('table', function (Blueprint $table) {
+        Schema::create('table', static function (Blueprint $table) {
             $table->increments('id');
         });
 
         Schema::dropAllTables();
 
-        Schema::create('table', function (Blueprint $table) {
+        Schema::create('table', static function (Blueprint $table) {
             $table->increments('id');
         });
 
@@ -45,11 +45,11 @@ class SchemaBuilderTest extends DatabaseTestCase
     {
         Schema::registerCustomDoctrineType(TinyInteger::class, TinyInteger::NAME, 'TINYINT');
 
-        Schema::create('test', function (Blueprint $table) {
+        Schema::create('test', static function (Blueprint $table) {
             $table->string('test_column');
         });
 
-        $blueprint = new Blueprint('test', function (Blueprint $table) {
+        $blueprint = new Blueprint('test', static function (Blueprint $table) {
             $table->tinyInteger('test_column')->change();
         });
 

--- a/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
+++ b/tests/Integration/Database/stubs/2014_10_12_000000_create_members_table.php
@@ -13,7 +13,7 @@ class CreateMembersTable extends Migration
      */
     public function up()
     {
-        Schema::create('members', function (Blueprint $table) {
+        Schema::create('members', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();

--- a/tests/Integration/Events/EventFakeTest.php
+++ b/tests/Integration/Events/EventFakeTest.php
@@ -39,7 +39,7 @@ class EventFakeTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('title');
             $table->string('slug')->unique();
@@ -76,13 +76,13 @@ class EventFakeTest extends TestCase
     public function testNonFakedEventGetsProperlyDispatchedAndReturnsResponses()
     {
         Event::fake(NonImportantEvent::class);
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             // one
         });
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             return 'two';
         });
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             //
         });
 
@@ -94,10 +94,10 @@ class EventFakeTest extends TestCase
     public function testNonFakedEventGetsProperlyDispatchedAndCancelsFutureListeners()
     {
         Event::fake(NonImportantEvent::class);
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             // one
         });
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             return false;
         });
         Event::listen('test', function () {
@@ -112,10 +112,10 @@ class EventFakeTest extends TestCase
     public function testNonFakedHaltedEventGetsProperlyDispatchedAndReturnsResponse()
     {
         Event::fake(NonImportantEvent::class);
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             // one
         });
-        Event::listen('test', function () {
+        Event::listen('test', static function () {
             return 'two';
         });
         Event::listen('test', function () {

--- a/tests/Integration/Foundation/FoundationHelpersTest.php
+++ b/tests/Integration/Foundation/FoundationHelpersTest.php
@@ -15,17 +15,17 @@ class FoundationHelpersTest extends TestCase
 {
     public function testRescue()
     {
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals(rescue(static function () {
             throw new Exception;
         }, 'rescued!'), 'rescued!');
 
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals(rescue(static function () {
             throw new Exception;
-        }, function () {
+        }, static function () {
             return 'rescued!';
         }), 'rescued!');
 
-        $this->assertEquals(rescue(function () {
+        $this->assertEquals(rescue(static function () {
             return 'no need to rescue';
         }, 'rescued!'), 'no need to rescue');
 
@@ -36,7 +36,7 @@ class FoundationHelpersTest extends TestCase
             }
         };
 
-        $this->assertEquals(rescue(function () use ($testClass) {
+        $this->assertEquals(rescue(static function () use ($testClass) {
             $testClass->test([]);
         }, 'rescued!'), 'rescued!');
     }
@@ -90,7 +90,7 @@ class FoundationHelpersTest extends TestCase
         $this->app->instance(ExceptionHandler::class, $handler);
         $this->app['config']->set('app.debug', true);
         $manifest = $this->makeManifest();
-        Route::get('test-route', function () {
+        Route::get('test-route', static function () {
             mix('missing.js');
         });
 
@@ -103,7 +103,7 @@ class FoundationHelpersTest extends TestCase
 
     protected function makeManifest($directory = '')
     {
-        $this->app->singleton('path.public', function () {
+        $this->app->singleton('path.public', static function () {
             return __DIR__;
         });
 

--- a/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
+++ b/tests/Integration/Foundation/Testing/Concerns/InteractsWithAuthenticationTest.php
@@ -28,7 +28,7 @@ class InteractsWithAuthenticationTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->string('username');
@@ -47,7 +47,7 @@ class InteractsWithAuthenticationTest extends TestCase
 
     public function testActingAsIsProperlyHandledForSessionAuth()
     {
-        Route::get('me', function (Request $request) {
+        Route::get('me', static function (Request $request) {
             return 'Hello '.$request->user()->username;
         })->middleware(['auth']);
 
@@ -61,11 +61,11 @@ class InteractsWithAuthenticationTest extends TestCase
 
     public function testActingAsIsProperlyHandledForAuthViaRequest()
     {
-        Route::get('me', function (Request $request) {
+        Route::get('me', static function (Request $request) {
             return 'Hello '.$request->user()->username;
         })->middleware(['auth:api']);
 
-        Auth::viaRequest('api', function ($request) {
+        Auth::viaRequest('api', static function ($request) {
             return $request->user();
         });
 

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalRelationship.php
@@ -10,7 +10,7 @@ class AuthorResourceWithOptionalRelationship extends PostResource
             'name' => $this->name,
             'posts_count' => $this->whenLoaded('posts', function () {
                 return $this->posts->count().' posts';
-            }, function () {
+            }, static function () {
                 return 'not loaded';
             }),
             'latest_post_title' => $this->whenLoaded('posts', function () {

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalData.php
@@ -12,11 +12,11 @@ class PostResourceWithOptionalData extends JsonResource
             'id' => $this->id,
             'first' => $this->when(false, 'value'),
             'second' => $this->when(true, 'value'),
-            'third' => $this->when(true, function () {
+            'third' => $this->when(true, static function () {
                 return 'value';
             }),
             'fourth' => $this->when(false, 'value', 'default'),
-            'fifth' => $this->when(false, 'value', function () {
+            'fifth' => $this->when(false, 'value', static function () {
                 return 'default';
             }),
         ];

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalPivotRelationship.php
@@ -8,12 +8,12 @@ class PostResourceWithOptionalPivotRelationship extends PostResource
     {
         return [
             'id' => $this->id,
-            'subscription' => $this->whenPivotLoaded(Subscription::class, function () {
+            'subscription' => $this->whenPivotLoaded(Subscription::class, static function () {
                 return [
                     'foo' => 'bar',
                 ];
             }),
-            'custom_subscription' => $this->whenPivotLoadedAs('accessor', Subscription::class, function () {
+            'custom_subscription' => $this->whenPivotLoadedAs('accessor', Subscription::class, static function () {
                 return [
                     'foo' => 'bar',
                 ];

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -35,7 +35,7 @@ class ResourceTest extends TestCase
 {
     public function testResourcesMayBeConvertedToJson()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -70,7 +70,7 @@ class ResourceTest extends TestCase
 
     public function testAnObjectsMayBeConvertedToJson()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return ObjectResource::make(
                 (object) ['first_name' => 'Bob', 'age' => 40]
             );
@@ -89,7 +89,7 @@ class ResourceTest extends TestCase
 
     public function testArraysWithObjectsMayBeConvertedToJson()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $objects = [
                 (object) ['first_name' => 'Bob', 'age' => 40],
                 (object) ['first_name' => 'Jack', 'age' => 25],
@@ -111,7 +111,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveNoWrap()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResourceWithoutWrap(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -130,7 +130,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalValues()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResourceWithOptionalData(new Post([
                 'id' => 5,
             ]));
@@ -155,7 +155,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalMerges()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResourceWithOptionalMerging(new Post([
                 'id' => 5,
             ]));
@@ -177,7 +177,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalRelationships()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResourceWithOptionalRelationship(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -199,7 +199,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayLoadOptionalRelationships()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $post = new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -227,7 +227,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayShowsNullForLoadedRelationshipWithValueNull()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $post = new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -255,7 +255,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalRelationshipsWithDefaultValues()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new AuthorResourceWithOptionalRelationship(new Author([
                 'name' => 'jrrmartin',
             ]));
@@ -278,7 +278,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalPivotRelationships()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $post = new Post(['id' => 5]);
             $post->setRelation('pivot', new Subscription);
 
@@ -303,7 +303,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayHaveOptionalPivotRelationshipsWithCustomAccessor()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $post = new Post(['id' => 5]);
             $post->setRelation('accessor', new Subscription);
 
@@ -343,7 +343,7 @@ class ResourceTest extends TestCase
             'title' => 'Test Title',
         ]));
 
-        Route::get('/post/{id}', function () use ($post) {
+        Route::get('/post/{id}', static function () use ($post) {
             return route('post.show', $post);
         })->name('post.show');
 
@@ -354,7 +354,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayBeSerializable()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new SerializablePostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -376,7 +376,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayCustomizeResponses()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -393,7 +393,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayCustomizeExtraData()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostResourceWithExtraData(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -415,7 +415,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayCustomizeExtraDataWhenBuildingResponse()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return (new PostResourceWithExtraData(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -438,7 +438,7 @@ class ResourceTest extends TestCase
 
     public function testCustomHeadersMayBeSetOnResponses()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return (new PostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -455,7 +455,7 @@ class ResourceTest extends TestCase
 
     public function testResourcesMayReceiveProperStatusCodeForFreshModels()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $post = new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -475,7 +475,7 @@ class ResourceTest extends TestCase
 
     public function testCollectionsAreNotDoubledWrapped()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new PostCollectionResource(collect([new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -500,7 +500,7 @@ class ResourceTest extends TestCase
 
     public function testPaginatorsReceiveLinks()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $paginator = new LengthAwarePaginator(
                 collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
                 10, 15, 1
@@ -542,7 +542,7 @@ class ResourceTest extends TestCase
 
     public function testPaginatorResourceCanPreserveQueryParameters()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $collection = collect([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
             $paginator = new LengthAwarePaginator(
                 $collection, 3, 1, 2
@@ -584,7 +584,7 @@ class ResourceTest extends TestCase
 
     public function testPaginatorResourceCanReceiveQueryParameters()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             $collection = collect([new Post(['id' => 2, 'title' => 'Laravel Nova'])]);
             $paginator = new LengthAwarePaginator(
                 $collection, 3, 1, 2
@@ -626,7 +626,7 @@ class ResourceTest extends TestCase
 
     public function testToJsonMayBeLeftOffOfCollection()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new EmptyPostCollectionResource(new LengthAwarePaginator(
                 collect([new Post(['id' => 5, 'title' => 'Test Title'])]),
                 10, 15, 1
@@ -667,7 +667,7 @@ class ResourceTest extends TestCase
 
     public function testToJsonMayBeLeftOffOfSingleResource()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return new ReallyEmptyPostResource(new Post([
                 'id' => 5,
                 'title' => 'Test Title',
@@ -691,7 +691,7 @@ class ResourceTest extends TestCase
     public function testOriginalOnResponseIsModelWhenSingleResource()
     {
         $createdPost = new Post(['id' => 5, 'title' => 'Test Title']);
-        Route::get('/', function () use ($createdPost) {
+        Route::get('/', static function () use ($createdPost) {
             return new ReallyEmptyPostResource($createdPost);
         });
         $response = $this->withoutExceptionHandling()->get(
@@ -706,7 +706,7 @@ class ResourceTest extends TestCase
             new Post(['id' => 5, 'title' => 'Test Title']),
             new Post(['id' => 6, 'title' => 'Test Title 2']),
         ]);
-        Route::get('/', function () use ($createdPosts) {
+        Route::get('/', static function () use ($createdPosts) {
             return new EmptyPostCollectionResource(new LengthAwarePaginator($createdPosts, 10, 15, 1));
         });
         $response = $this->withoutExceptionHandling()->get(
@@ -755,7 +755,7 @@ class ResourceTest extends TestCase
             ],
         ];
 
-        Route::get('/', function () use ($data) {
+        Route::get('/', static function () use ($data) {
             return new ResourceWithPreservedKeys($data);
         });
 
@@ -788,7 +788,7 @@ class ResourceTest extends TestCase
             ],
         ])->keyBy->id;
 
-        Route::get('/', function () use ($data) {
+        Route::get('/', static function () use ($data) {
             return ResourceWithPreservedKeys::collection($data);
         });
 
@@ -1107,7 +1107,7 @@ class ResourceTest extends TestCase
 
     private function assertJsonResourceResponse($data, $expectedJson)
     {
-        Route::get('/', function () use ($data) {
+        Route::get('/', static function () use ($data) {
             return new JsonResource($data);
         });
 

--- a/tests/Integration/Http/ThrottleRequestsTest.php
+++ b/tests/Integration/Http/ThrottleRequestsTest.php
@@ -29,7 +29,7 @@ class ThrottleRequestsTest extends TestCase
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 0, 0, 0));
 
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return 'yes';
         })->middleware(ThrottleRequests::class.':2,1');
 

--- a/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
+++ b/tests/Integration/Http/ThrottleRequestsWithRedisTest.php
@@ -34,7 +34,7 @@ class ThrottleRequestsWithRedisTest extends TestCase
 
             Carbon::setTestNow($now);
 
-            Route::get('/', function () {
+            Route::get('/', static function () {
                 return 'yes';
             })->middleware(ThrottleRequestsWithRedis::class.':2,1');
 

--- a/tests/Integration/Mail/SendingMailWithLocaleTest.php
+++ b/tests/Integration/Mail/SendingMailWithLocaleTest.php
@@ -81,7 +81,7 @@ class SendingMailWithLocaleTest extends TestCase
     {
         Carbon::setTestNow('2018-04-01');
 
-        Event::listen(LocaleUpdated::class, function ($event) {
+        Event::listen(LocaleUpdated::class, static function ($event) {
             Carbon::setLocale($event->locale);
         });
 

--- a/tests/Integration/Migration/fixtures/2014_10_12_000000_create_people_table.php
+++ b/tests/Integration/Migration/fixtures/2014_10_12_000000_create_people_table.php
@@ -13,7 +13,7 @@ class CreatePeopleTable extends Migration
      */
     public function up()
     {
-        Schema::create('people', function (Blueprint $table) {
+        Schema::create('people', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('name');
             $table->string('email')->unique();

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -67,7 +67,7 @@ class SendingMailNotificationsTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->string('name')->nullable();
@@ -93,7 +93,7 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            m::on(function ($closure) {
+            m::on(static function ($closure) {
                 $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
@@ -139,7 +139,7 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            m::on(function ($closure) {
+            m::on(static function ($closure) {
                 $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com' => 'Taylor Otwell', 'foo_taylor@laravel.com']);
@@ -184,7 +184,7 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            m::on(function ($closure) {
+            m::on(static function ($closure) {
                 $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
@@ -219,7 +219,7 @@ class SendingMailNotificationsTest extends TestCase
                 '__laravel_notification' => get_class($notification),
                 '__laravel_notification_queued' => false,
             ]),
-            m::on(function ($closure) {
+            m::on(static function ($closure) {
                 $message = m::mock(Message::class);
 
                 $message->shouldReceive('to')->once()->with(['foo_taylor@laravel.com', 'bar_taylor@laravel.com']);

--- a/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsViaAnonymousNotifiableTest.php
@@ -52,7 +52,7 @@ class SendingNotificationsViaAnonymousNotifiableTest extends TestCase
         );
 
         NotificationFacade::assertSentTo(new AnonymousNotifiable, TestMailNotificationForAnonymousNotifiable::class,
-            function ($notification, $channels, $notifiable, $locale) {
+            static function ($notification, $channels, $notifiable, $locale) {
                 return $notifiable->routes['testchannel'] === 'enzo' &&
                     $notifiable->routes['anothertestchannel'] === 'enzo@deepblue.com' &&
                     $locale === 'it';

--- a/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
+++ b/tests/Integration/Notifications/SendingNotificationsWithLocaleTest.php
@@ -59,7 +59,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
             $table->string('name')->nullable();
@@ -136,7 +136,7 @@ class SendingNotificationsWithLocaleTest extends TestCase
     {
         Carbon::setTestNow('2018-07-25');
 
-        Event::listen(LocaleUpdated::class, function ($event) {
+        Event::listen(LocaleUpdated::class, static function ($event) {
             Carbon::setLocale($event->locale);
         });
 

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -39,35 +39,35 @@ class ModelSerializationTest extends TestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });
 
-        Schema::connection('custom')->create('users', function (Blueprint $table) {
+        Schema::connection('custom')->create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('email');
         });
 
-        Schema::create('orders', function (Blueprint $table) {
+        Schema::create('orders', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('lines', function (Blueprint $table) {
+        Schema::create('lines', static function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('order_id');
             $table->unsignedInteger('product_id');
         });
 
-        Schema::create('products', function (Blueprint $table) {
+        Schema::create('products', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('roles', function (Blueprint $table) {
+        Schema::create('roles', static function (Blueprint $table) {
             $table->increments('id');
         });
 
-        Schema::create('role_user', function (Blueprint $table) {
+        Schema::create('role_user', static function (Blueprint $table) {
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('role_id');
         });
@@ -149,7 +149,7 @@ class ModelSerializationTest extends TestCase
 
     public function testItReloadsRelationships()
     {
-        $order = tap(Order::create(), function (Order $order) {
+        $order = tap(Order::create(), static function (Order $order) {
             $order->wasRecentlyCreated = false;
         });
 
@@ -169,7 +169,7 @@ class ModelSerializationTest extends TestCase
 
     public function testItReloadsNestedRelationships()
     {
-        $order = tap(Order::create(), function (Order $order) {
+        $order = tap(Order::create(), static function (Order $order) {
             $order->wasRecentlyCreated = false;
         });
 
@@ -194,7 +194,7 @@ class ModelSerializationTest extends TestCase
     {
         $user = tap(User::create([
             'email' => 'taylor@laravel.com',
-        ]), function (User $user) {
+        ]), static function (User $user) {
             $user->wasRecentlyCreated = false;
         });
 
@@ -204,7 +204,7 @@ class ModelSerializationTest extends TestCase
         RoleUser::create(['user_id' => $user->id, 'role_id' => $role1->id]);
         RoleUser::create(['user_id' => $user->id, 'role_id' => $role2->id]);
 
-        $user->roles->each(function ($role) {
+        $user->roles->each(static function ($role) {
             $role->pivot->load('user', 'role');
         });
 

--- a/tests/Integration/Queue/QueuedListenersTest.php
+++ b/tests/Integration/Queue/QueuedListenersTest.php
@@ -24,11 +24,11 @@ class QueuedListenersTest extends TestCase
             new QueuedListenersTestEvent
         );
 
-        Queue::assertPushed(CallQueuedListener::class, function ($job) {
+        Queue::assertPushed(CallQueuedListener::class, static function ($job) {
             return $job->class == QueuedListenersTestListenerShouldQueue::class;
         });
 
-        Queue::assertNotPushed(CallQueuedListener::class, function ($job) {
+        Queue::assertNotPushed(CallQueuedListener::class, static function ($job) {
             return $job->class == QueuedListenersTestListenerShouldNotQueue::class;
         });
     }

--- a/tests/Integration/Routing/FallbackRouteTest.php
+++ b/tests/Integration/Routing/FallbackRouteTest.php
@@ -12,11 +12,11 @@ class FallbackRouteTest extends TestCase
 {
     public function testBasicFallback()
     {
-        Route::fallback(function () {
+        Route::fallback(static function () {
             return response('fallback', 404);
         });
 
-        Route::get('one', function () {
+        Route::get('one', static function () {
             return 'one';
         });
 
@@ -27,12 +27,12 @@ class FallbackRouteTest extends TestCase
 
     public function testFallbackWithPrefix()
     {
-        Route::group(['prefix' => 'prefix'], function () {
-            Route::fallback(function () {
+        Route::group(['prefix' => 'prefix'], static function () {
+            Route::fallback(static function () {
                 return response('fallback', 404);
             });
 
-            Route::get('one', function () {
+            Route::get('one', static function () {
                 return 'one';
             });
         });
@@ -45,15 +45,15 @@ class FallbackRouteTest extends TestCase
 
     public function testFallbackWithWildcards()
     {
-        Route::fallback(function () {
+        Route::fallback(static function () {
             return response('fallback', 404);
         });
 
-        Route::get('one', function () {
+        Route::get('one', static function () {
             return 'one';
         });
 
-        Route::get('{any}', function () {
+        Route::get('{any}', static function () {
             return 'wildcard';
         })->where('any', '.*');
 
@@ -64,7 +64,7 @@ class FallbackRouteTest extends TestCase
 
     public function testNoRoutes()
     {
-        Route::fallback(function () {
+        Route::fallback(static function () {
             return response('fallback', 404);
         });
 
@@ -74,11 +74,11 @@ class FallbackRouteTest extends TestCase
 
     public function testRespondWithNamedFallbackRoute()
     {
-        Route::fallback(function () {
+        Route::fallback(static function () {
             return response('fallback', 404);
         })->name('testFallbackRoute');
 
-        Route::get('one', function () {
+        Route::get('one', static function () {
             return Route::respondWithRoute('testFallbackRoute');
         });
 
@@ -88,7 +88,7 @@ class FallbackRouteTest extends TestCase
 
     public function testNoFallbacks()
     {
-        Route::get('one', function () {
+        Route::get('one', static function () {
             return 'one';
         });
 

--- a/tests/Integration/Routing/FluentRoutingTest.php
+++ b/tests/Integration/Routing/FluentRoutingTest.php
@@ -13,20 +13,20 @@ class FluentRoutingTest extends TestCase
     public function testMiddlewareRunWhenRegisteredAsArrayOrParams()
     {
         Route::middleware(Middleware::class, Middleware2::class)
-            ->get('one', function () {
+            ->get('one', static function () {
                 return 'Hello World';
             });
 
-        Route::get('two', function () {
+        Route::get('two', static function () {
             return 'Hello World';
         })->middleware(Middleware::class, Middleware2::class);
 
         Route::middleware([Middleware::class, Middleware2::class])
-            ->get('three', function () {
+            ->get('three', static function () {
                 return 'Hello World';
             });
 
-        Route::get('four', function () {
+        Route::get('four', static function () {
             return 'Hello World';
         })->middleware([Middleware::class, Middleware2::class]);
 

--- a/tests/Integration/Routing/PreviousUrlTest.php
+++ b/tests/Integration/Routing/PreviousUrlTest.php
@@ -11,7 +11,7 @@ class PreviousUrlTest extends TestCase
 {
     public function testPreviousUrlWithoutSession()
     {
-        Route::post('/previous-url', function (DummyFormRequest $request) {
+        Route::post('/previous-url', static function (DummyFormRequest $request) {
             return 'OK';
         });
 
@@ -24,7 +24,7 @@ class PreviousUrlTest extends TestCase
     {
         $providers = parent::getApplicationProviders($app);
 
-        return array_filter($providers, function ($provider) {
+        return array_filter($providers, static function ($provider) {
             return $provider !== SessionServiceProvider::class;
         });
     }

--- a/tests/Integration/Routing/ResponsableTest.php
+++ b/tests/Integration/Routing/ResponsableTest.php
@@ -13,7 +13,7 @@ class ResponsableTest extends TestCase
 {
     public function testResponsableObjectsAreRendered()
     {
-        Route::get('/responsable', function () {
+        Route::get('/responsable', static function () {
             return new TestResponsableResponse;
         });
 

--- a/tests/Integration/Routing/SimpleRouteTest.php
+++ b/tests/Integration/Routing/SimpleRouteTest.php
@@ -12,7 +12,7 @@ class SimpleRouteTest extends TestCase
 {
     public function testSimpleRouteThroughTheFramework()
     {
-        Route::get('/', function () {
+        Route::get('/', static function () {
             return 'Hello World';
         });
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -17,7 +17,7 @@ class UrlSigningTest extends TestCase
 {
     public function testSigningUrl()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
+        Route::get('/foo/{id}', static function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
@@ -27,7 +27,7 @@ class UrlSigningTest extends TestCase
 
     public function testTemporarySignedUrls()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
+        Route::get('/foo/{id}', static function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
@@ -41,7 +41,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedUrlWithUrlWithoutSignatureParameter()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
+        Route::get('/foo/{id}', static function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo');
 
@@ -50,7 +50,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddleware()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
+        Route::get('/foo/{id}', static function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo')->middleware(ValidateSignature::class);
 
@@ -61,7 +61,7 @@ class UrlSigningTest extends TestCase
 
     public function testSignedMiddlewareWithInvalidUrl()
     {
-        Route::get('/foo/{id}', function (Request $request, $id) {
+        Route::get('/foo/{id}', static function (Request $request, $id) {
             return $request->hasValidSignature() ? 'valid' : 'invalid';
         })->name('foo')->middleware(ValidateSignature::class);
 
@@ -78,7 +78,7 @@ class UrlSigningTest extends TestCase
         $model = new RoutableInterfaceStub;
         $model->routable = 'routable';
 
-        Route::get('/foo/{bar}', function (Request $request, $routable) {
+        Route::get('/foo/{bar}', static function (Request $request, $routable) {
             return $request->hasValidSignature() ? $routable : 'invalid';
         })->name('foo');
 

--- a/tests/Integration/Session/SessionPersistenceTest.php
+++ b/tests/Integration/Session/SessionPersistenceTest.php
@@ -22,11 +22,11 @@ class SessionPersistenceTest extends TestCase
         $handler = new FakeNullSessionHandler;
         $this->assertFalse($handler->written);
 
-        Session::extend('fake-null', function () use ($handler) {
+        Session::extend('fake-null', static function () use ($handler) {
             return $handler;
         });
 
-        Route::get('/', function () {
+        Route::get('/', static function () {
             throw new TokenMismatchException;
         })->middleware('web');
 

--- a/tests/Integration/Support/FacadesTest.php
+++ b/tests/Integration/Support/FacadesTest.php
@@ -16,7 +16,7 @@ class FacadesTest extends TestCase
 
     public function testFacadeResolvedCanResolveCallback()
     {
-        Auth::resolved(function () {
+        Auth::resolved(static function () {
             $_SERVER['__laravel.authResolved'] = true;
         });
 
@@ -33,7 +33,7 @@ class FacadesTest extends TestCase
 
         $this->assertFalse(isset($_SERVER['__laravel.authResolved']));
 
-        Auth::resolved(function () {
+        Auth::resolved(static function () {
             $_SERVER['__laravel.authResolved'] = true;
         });
 

--- a/tests/Integration/Validation/ValidatorTest.php
+++ b/tests/Integration/Validation/ValidatorTest.php
@@ -17,7 +17,7 @@ class ValidatorTest extends DatabaseTestCase
     {
         parent::setUp();
 
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', static function (Blueprint $table) {
             $table->increments('id');
             $table->string('first_name');
         });
@@ -38,7 +38,7 @@ class ValidatorTest extends DatabaseTestCase
         $translator->addLines(['validation.string' => ':attribute must be a string!'], 'en');
         $validator = new Validator($translator, [['name' => 1]], ['*.name' => 'string']);
 
-        $validator->setImplicitAttributesFormatter(function ($attribute) {
+        $validator->setImplicitAttributesFormatter(static function ($attribute) {
             [$line, $attribute] = explode('.', $attribute);
 
             return sprintf('%s at line %d', $attribute, $line + 1);

--- a/tests/Log/LogLoggerTest.php
+++ b/tests/Log/LogLoggerTest.php
@@ -31,7 +31,7 @@ class LogLoggerTest extends TestCase
         $writer = new Logger($monolog = m::mock(Monolog::class), $events = new Dispatcher);
         $monolog->shouldReceive('error')->once()->with('foo', []);
 
-        $events->listen(MessageLogged::class, function ($event) {
+        $events->listen(MessageLogged::class, static function ($event) {
             $_SERVER['__log.level'] = $event->level;
             $_SERVER['__log.message'] = $event->message;
             $_SERVER['__log.context'] = $event->context;
@@ -55,7 +55,7 @@ class LogLoggerTest extends TestCase
         $this->expectExceptionMessage('Events dispatcher has not been set.');
 
         $writer = new Logger(m::mock(Monolog::class));
-        $writer->listen(function () {
+        $writer->listen(static function () {
             //
         });
     }
@@ -64,7 +64,7 @@ class LogLoggerTest extends TestCase
     {
         $writer = new Logger(m::mock(Monolog::class), $events = m::mock(DispatcherContract::class));
 
-        $callback = function () {
+        $callback = static function () {
             return 'success';
         };
         $events->shouldReceive('listen')->with(MessageLogged::class, $callback)->once();

--- a/tests/Mail/MailMailableDataTest.php
+++ b/tests/Mail/MailMailableDataTest.php
@@ -12,13 +12,13 @@ class MailMailableDataTest extends TestCase
         $testData = ['first_name' => 'James'];
 
         $mailable = new MailableStub;
-        $mailable->build(function ($m) use ($testData) {
+        $mailable->build(static function ($m) use ($testData) {
             $m->view('view', $testData);
         });
         $this->assertSame($testData, $mailable->buildViewData());
 
         $mailable = new MailableStub;
-        $mailable->build(function ($m) use ($testData) {
+        $mailable->build(static function ($m) use ($testData) {
             $m->view('view', $testData)
               ->text('text-view');
         });

--- a/tests/Mail/MailMailerTest.php
+++ b/tests/Mail/MailMailerTest.php
@@ -37,7 +37,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
-        $mailer->send('foo', ['data'], function ($m) {
+        $mailer->send('foo', ['data'], static function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
         unset($_SERVER['__mailer.test']);
@@ -58,7 +58,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
-        $mailer->send(['html' => new HtmlString('rendered.view'), 'text' => new HtmlString('rendered.text')], ['data'], function ($m) {
+        $mailer->send(['html' => new HtmlString('rendered.view'), 'text' => new HtmlString('rendered.text')], ['data'], static function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
         unset($_SERVER['__mailer.test']);
@@ -78,7 +78,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
-        $mailer->html('rendered.view', function ($m) {
+        $mailer->html('rendered.view', static function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
         unset($_SERVER['__mailer.test']);
@@ -100,7 +100,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
-        $mailer->send(['foo', 'bar'], ['data'], function ($m) {
+        $mailer->send(['foo', 'bar'], ['data'], static function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
         unset($_SERVER['__mailer.test']);
@@ -122,7 +122,7 @@ class MailMailerTest extends TestCase
         $this->setSwiftMailer($mailer);
         $message->shouldReceive('getSwiftMessage')->once()->andReturn($message);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with($message, []);
-        $mailer->send(['html' => 'foo', 'text' => 'bar'], ['data'], function ($m) {
+        $mailer->send(['html' => 'foo', 'text' => 'bar'], ['data'], static function ($m) {
             $_SERVER['__mailer.test'] = $m;
         });
         unset($_SERVER['__mailer.test']);
@@ -140,7 +140,7 @@ class MailMailerTest extends TestCase
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
             $this->assertEquals(['taylorotwell@gmail.com' => 'Taylor Otwell'], $message->getFrom());
         });
-        $mailer->send('foo', ['data'], function ($m) {
+        $mailer->send('foo', ['data'], static function ($m) {
             //
         });
     }
@@ -157,7 +157,7 @@ class MailMailerTest extends TestCase
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), [])->andReturnUsing(function ($message) {
             $this->assertSame('taylorotwell@gmail.com', $message->getReturnPath());
         });
-        $mailer->send('foo', ['data'], function ($m) {
+        $mailer->send('foo', ['data'], static function ($m) {
             //
         });
     }
@@ -174,7 +174,7 @@ class MailMailerTest extends TestCase
         $swift = new FailingSwiftMailerStub;
         $mailer->setSwiftMailer($swift);
 
-        $mailer->send('foo', ['data'], function ($m) {
+        $mailer->send('foo', ['data'], static function ($m) {
             //
         });
 
@@ -193,7 +193,7 @@ class MailMailerTest extends TestCase
         $view->shouldReceive('render')->once()->andReturn('rendered.view');
         $this->setSwiftMailer($mailer);
         $mailer->getSwiftMailer()->shouldReceive('send')->once()->with(m::type(Swift_Message::class), []);
-        $mailer->send('foo', ['data'], function ($m) {
+        $mailer->send('foo', ['data'], static function ($m) {
             //
         });
     }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -18,7 +18,7 @@ class MailSesTransportTest extends TestCase
     {
         $container = new Container();
 
-        $container->singleton('config', function () {
+        $container->singleton('config', static function () {
             return new Repository([
                 'services.ses' => [
                     'key' => 'foo',

--- a/tests/Mail/MailableQueuedTest.php
+++ b/tests/Mail/MailableQueuedTest.php
@@ -66,7 +66,7 @@ class MailableQueuedTest extends TestCase
         $filesystemFactory = $this->getMockBuilder(FilesystemManager::class)
             ->setConstructorArgs([$app])
             ->getMock();
-        $container->singleton('filesystem', function () use ($filesystemFactory) {
+        $container->singleton('filesystem', static function () use ($filesystemFactory) {
             return $filesystemFactory;
         });
         $queueFake = new QueueFake($app);

--- a/tests/Notifications/NotificationBroadcastChannelTest.php
+++ b/tests/Notifications/NotificationBroadcastChannelTest.php
@@ -82,7 +82,7 @@ class NotificationBroadcastChannelTest extends TestCase
         $notifiable = m::mock();
 
         $events = m::mock(Dispatcher::class);
-        $events->shouldReceive('dispatch')->once()->with(m::on(function ($event) {
+        $events->shouldReceive('dispatch')->once()->with(m::on(static function ($event) {
             return $event->connection == 'sync';
         }));
         $channel = new BroadcastChannel($events);

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -77,7 +77,7 @@ class NotificationMailMessageTest extends TestCase
 
     public function testCallbackIsSetCorrectly()
     {
-        $callback = function () {
+        $callback = static function () {
             //
         };
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -22,7 +22,7 @@ class NotificationSendQueuedNotificationTest extends TestCase
     {
         $job = new SendQueuedNotifications('notifiables', 'notification');
         $manager = m::mock(ChannelManager::class);
-        $manager->shouldReceive('sendNow')->once()->withArgs(function ($notifiables, $notification, $channels) {
+        $manager->shouldReceive('sendNow')->once()->withArgs(static function ($notifiables, $notification, $channels) {
             return $notifiables instanceof Collection && $notifiables->toArray() === ['notifiables']
                 && $notification === 'notification'
                 && $channels === null;

--- a/tests/Pipeline/PipelineTest.php
+++ b/tests/Pipeline/PipelineTest.php
@@ -11,7 +11,7 @@ class PipelineTest extends TestCase
 {
     public function testPipelineBasicUsage()
     {
-        $pipeTwo = function ($piped, $next) {
+        $pipeTwo = static function ($piped, $next) {
             $_SERVER['__test.pipe.two'] = $piped;
 
             return $next($piped);
@@ -20,7 +20,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
                     ->send('foo')
                     ->through([PipelineTestPipeOne::class, $pipeTwo])
-                    ->then(function ($piped) {
+                    ->then(static function ($piped) {
                         return $piped;
                     });
 
@@ -37,7 +37,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([new PipelineTestPipeOne])
-            ->then(function ($piped) {
+            ->then(static function ($piped) {
                 return $piped;
             });
 
@@ -52,8 +52,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([new PipelineTestPipeTwo])
-            ->then(
-                function ($piped) {
+            ->then(static function ($piped) {
                     return $piped;
                 }
             );
@@ -66,7 +65,7 @@ class PipelineTest extends TestCase
 
     public function testPipelineUsageWithCallable()
     {
-        $function = function ($piped, $next) {
+        $function = static function ($piped, $next) {
             $_SERVER['__test.pipe.one'] = 'foo';
 
             return $next($piped);
@@ -75,8 +74,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([$function])
-            ->then(
-                function ($piped) {
+            ->then(static function ($piped) {
                     return $piped;
                 }
             );
@@ -102,8 +100,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through([PipelineTestPipeTwo::class])
-            ->then(
-                function ($piped) {
+            ->then(static function ($piped) {
                     return $piped;
                 }
             );
@@ -121,7 +118,7 @@ class PipelineTest extends TestCase
         $result = (new Pipeline(new Container))
             ->send('foo')
             ->through(PipelineTestParameterPipe::class.':'.implode(',', $parameters))
-            ->then(function ($piped) {
+            ->then(static function ($piped) {
                 return $piped;
             });
 
@@ -137,7 +134,7 @@ class PipelineTest extends TestCase
         $result = $pipelineInstance->send('data')
             ->through(PipelineTestPipeOne::class)
             ->via('differentMethod')
-            ->then(function ($piped) {
+            ->then(static function ($piped) {
                 return $piped;
             });
         $this->assertSame('data', $result);
@@ -150,7 +147,7 @@ class PipelineTest extends TestCase
 
         (new Pipeline)->send('data')
             ->through(PipelineTestPipeOne::class)
-            ->then(function ($piped) {
+            ->then(static function ($piped) {
                 return $piped;
             });
     }

--- a/tests/Queue/DynamoDbFailedJobProviderTest.php
+++ b/tests/Queue/DynamoDbFailedJobProviderTest.php
@@ -23,7 +23,7 @@ class DynamoDbFailedJobProviderTest extends TestCase
     {
         $uuid = Str::orderedUuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 

--- a/tests/Queue/QueueBeanstalkdQueueTest.php
+++ b/tests/Queue/QueueBeanstalkdQueueTest.php
@@ -22,7 +22,7 @@ class QueueBeanstalkdQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -42,7 +42,7 @@ class QueueBeanstalkdQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -58,7 +58,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
      */
     public function createSchema()
     {
-        $this->schema()->create($this->table, function (Blueprint $table) {
+        $this->schema()->create($this->table, static function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('queue');
             $table->longText('payload');

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -22,7 +22,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -46,7 +46,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -107,7 +107,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 

--- a/tests/Queue/QueueManagerTest.php
+++ b/tests/Queue/QueueManagerTest.php
@@ -30,7 +30,7 @@ class QueueManagerTest extends TestCase
         $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('sync')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'sync'])->andReturn($queue);
-        $manager->addConnector('sync', function () use ($connector) {
+        $manager->addConnector('sync', static function () use ($connector) {
             return $connector;
         });
 
@@ -53,7 +53,7 @@ class QueueManagerTest extends TestCase
         $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('foo')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'bar'])->andReturn($queue);
-        $manager->addConnector('bar', function () use ($connector) {
+        $manager->addConnector('bar', static function () use ($connector) {
             return $connector;
         });
         $queue->shouldReceive('setContainer')->once()->with($app);
@@ -75,7 +75,7 @@ class QueueManagerTest extends TestCase
         $queue = m::mock(stdClass::class);
         $queue->shouldReceive('setConnectionName')->once()->with('null')->andReturnSelf();
         $connector->shouldReceive('connect')->once()->with(['driver' => 'null'])->andReturn($queue);
-        $manager->addConnector('null', function () use ($connector) {
+        $manager->addConnector('null', static function () use ($connector) {
             return $connector;
         });
         $queue->shouldReceive('setContainer')->once()->with($app);

--- a/tests/Queue/QueueRedisQueueTest.php
+++ b/tests/Queue/QueueRedisQueueTest.php
@@ -22,7 +22,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -41,7 +41,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -50,7 +50,7 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'delay' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'id' => 'foo', 'attempts' => 0]));
 
-        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+        Queue::createPayloadUsing(static function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
         });
 
@@ -66,7 +66,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -75,11 +75,11 @@ class QueueRedisQueueTest extends TestCase
         $redis->shouldReceive('connection')->once()->andReturn($redis);
         $redis->shouldReceive('eval')->once()->with(LuaScripts::push(), 2, 'queues:default', 'queues:default:notify', json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'delay' => null, 'timeout' => null, 'data' => ['data'], 'custom' => 'taylor', 'bar' => 'foo', 'id' => 'foo', 'attempts' => 0]));
 
-        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+        Queue::createPayloadUsing(static function ($connection, $queue, $payload) {
             return ['custom' => 'taylor'];
         });
 
-        Queue::createPayloadUsing(function ($connection, $queue, $payload) {
+        Queue::createPayloadUsing(static function ($connection, $queue, $payload) {
             return ['bar' => 'foo'];
         });
 
@@ -95,7 +95,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 
@@ -120,7 +120,7 @@ class QueueRedisQueueTest extends TestCase
     {
         $uuid = Str::uuid();
 
-        Str::createUuidsUsing(function () use ($uuid) {
+        Str::createUuidsUsing(static function () use ($uuid) {
             return $uuid;
         });
 

--- a/tests/Queue/QueueWorkerTest.php
+++ b/tests/Queue/QueueWorkerTest.php
@@ -101,7 +101,7 @@ class QueueWorkerTest extends TestCase
             new WorkerFakeManager('default', new BrokenQueueConnection($e = new RuntimeException)),
             $this->events,
             $this->exceptionHandler,
-            function () {
+            static function () {
                 return false;
             }
         );
@@ -122,7 +122,7 @@ class QueueWorkerTest extends TestCase
     {
         $e = new RuntimeException;
 
-        $job = new WorkerFakeJob(function () use ($e) {
+        $job = new WorkerFakeJob(static function () use ($e) {
             throw $e;
         });
 
@@ -140,7 +140,7 @@ class QueueWorkerTest extends TestCase
     {
         $e = new RuntimeException;
 
-        $job = new WorkerFakeJob(function ($job) use ($e) {
+        $job = new WorkerFakeJob(static function ($job) use ($e) {
             // In normal use this would be incremented by being popped off the queue
             $job->attempts++;
 
@@ -163,7 +163,7 @@ class QueueWorkerTest extends TestCase
     {
         $e = new RuntimeException;
 
-        $job = new WorkerFakeJob(function ($job) use ($e) {
+        $job = new WorkerFakeJob(static function ($job) use ($e) {
             // In normal use this would be incremented by being popped off the queue
             $job->attempts++;
 
@@ -191,7 +191,7 @@ class QueueWorkerTest extends TestCase
 
     public function testJobIsFailedIfItHasAlreadyExceededMaxAttempts()
     {
-        $job = new WorkerFakeJob(function ($job) {
+        $job = new WorkerFakeJob(static function ($job) {
             $job->attempts++;
         });
 
@@ -210,7 +210,7 @@ class QueueWorkerTest extends TestCase
 
     public function testJobIsFailedIfItHasAlreadyExpired()
     {
-        $job = new WorkerFakeJob(function ($job) {
+        $job = new WorkerFakeJob(static function ($job) {
             $job->attempts++;
         });
 
@@ -235,7 +235,7 @@ class QueueWorkerTest extends TestCase
 
     public function testJobBasedMaxRetries()
     {
-        $job = new WorkerFakeJob(function ($job) {
+        $job = new WorkerFakeJob(static function ($job) {
             $job->attempts++;
         });
         $job->attempts = 2;
@@ -251,7 +251,7 @@ class QueueWorkerTest extends TestCase
 
     public function testJobBasedFailedDelay()
     {
-        $job = new WorkerFakeJob(function ($job) {
+        $job = new WorkerFakeJob(static function ($job) {
             throw new Exception('Something went wrong.');
         });
 
@@ -266,11 +266,11 @@ class QueueWorkerTest extends TestCase
 
     public function testJobRunsIfAppIsNotInMaintenanceMode()
     {
-        $firstJob = new WorkerFakeJob(function ($job) {
+        $firstJob = new WorkerFakeJob(static function ($job) {
             $job->attempts++;
         });
 
-        $secondJob = new WorkerFakeJob(function ($job) {
+        $secondJob = new WorkerFakeJob(static function ($job) {
             $job->attempts++;
         });
 
@@ -299,7 +299,7 @@ class QueueWorkerTest extends TestCase
 
     public function testJobDoesNotFireIfDeleted()
     {
-        $job = new WorkerFakeJob(function () {
+        $job = new WorkerFakeJob(static function () {
             return true;
         });
 
@@ -329,7 +329,7 @@ class QueueWorkerTest extends TestCase
             new WorkerFakeManager($connectionName, new WorkerFakeConnection($jobs)),
             $this->events,
             $this->exceptionHandler,
-            $isInMaintenanceMode ?? function () {
+            $isInMaintenanceMode ?? static function () {
                 return false;
             },
         ];
@@ -445,7 +445,7 @@ class WorkerFakeJob implements QueueJobContract
 
     public function __construct($callback = null)
     {
-        $this->callback = $callback ?: function () {
+        $this->callback = $callback ?: static function () {
             //
         };
     }

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -233,7 +233,7 @@ class RedisQueueIntegrationTest extends TestCase
      */
     public function testBlockingPopProperlyPopsExpiredJobs($driver)
     {
-        Str::createUuidsUsing(function () {
+        Str::createUuidsUsing(static function () {
             return 'uuid';
         });
 

--- a/tests/Redis/ConcurrentLimiterTest.php
+++ b/tests/Redis/ConcurrentLimiterTest.php
@@ -34,20 +34,20 @@ class ConcurrentLimiterTest extends TestCase
         $store = [];
 
         foreach (range(1, 2) as $i) {
-            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(2, function () use (&$store, $i) {
+            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(2, static function () use (&$store, $i) {
                 $store[] = $i;
             });
         }
 
         try {
-            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(0, function () use (&$store) {
+            (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 2, 5))->block(0, static function () use (&$store) {
                 $store[] = 3;
             });
         } catch (Throwable $e) {
             $this->assertInstanceOf(LimiterTimeoutException::class, $e);
         }
 
-        (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'other_key', 2, 5))->block(2, function () use (&$store) {
+        (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'other_key', 2, 5))->block(2, static function () use (&$store) {
             $store[] = 4;
         });
 
@@ -59,7 +59,7 @@ class ConcurrentLimiterTest extends TestCase
         $store = [];
 
         foreach (range(1, 4) as $i) {
-            (new ConcurrencyLimiter($this->redis(), 'key', 2, 5))->block(2, function () use (&$store, $i) {
+            (new ConcurrencyLimiter($this->redis(), 'key', 2, 5))->block(2, static function () use (&$store, $i) {
                 $store[] = $i;
             });
         }
@@ -73,12 +73,12 @@ class ConcurrentLimiterTest extends TestCase
 
         $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 1));
 
-        $lock->block(2, function () use (&$store) {
+        $lock->block(2, static function () use (&$store) {
             $store[] = 1;
         });
 
         try {
-            $lock->block(0, function () use (&$store) {
+            $lock->block(0, static function () use (&$store) {
                 $store[] = 2;
             });
         } catch (Throwable $e) {
@@ -87,7 +87,7 @@ class ConcurrentLimiterTest extends TestCase
 
         usleep(1.2 * 1000000);
 
-        $lock->block(0, function () use (&$store) {
+        $lock->block(0, static function () use (&$store) {
             $store[] = 3;
         });
 
@@ -100,19 +100,19 @@ class ConcurrentLimiterTest extends TestCase
 
         $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 2));
 
-        $lock->block(2, function () use (&$store) {
+        $lock->block(2, static function () use (&$store) {
             $store[] = 1;
         });
 
         try {
-            $lock->block(0, function () use (&$store) {
+            $lock->block(0, static function () use (&$store) {
                 $store[] = 2;
             });
         } catch (Throwable $e) {
             $this->assertInstanceOf(LimiterTimeoutException::class, $e);
         }
 
-        $lock->block(3, function () use (&$store) {
+        $lock->block(3, static function () use (&$store) {
             $store[] = 3;
         });
 
@@ -125,12 +125,12 @@ class ConcurrentLimiterTest extends TestCase
 
         $lock = (new ConcurrencyLimiterMockThatDoesntRelease($this->redis(), 'key', 1, 10));
 
-        $lock->block(2, function () use (&$store) {
+        $lock->block(2, static function () use (&$store) {
             $store[] = 1;
         });
 
         try {
-            $lock->block(2, function () use (&$store) {
+            $lock->block(2, static function () use (&$store) {
                 $store[] = 2;
             });
         } catch (Throwable $e) {

--- a/tests/Redis/DurationLimiterTest.php
+++ b/tests/Redis/DurationLimiterTest.php
@@ -33,16 +33,16 @@ class DurationLimiterTest extends TestCase
     {
         $store = [];
 
-        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, function () use (&$store) {
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, static function () use (&$store) {
             $store[] = 1;
         });
 
-        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, function () use (&$store) {
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, static function () use (&$store) {
             $store[] = 2;
         });
 
         try {
-            (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, function () use (&$store) {
+            (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, static function () use (&$store) {
                 $store[] = 3;
             });
         } catch (Throwable $e) {
@@ -53,7 +53,7 @@ class DurationLimiterTest extends TestCase
 
         sleep(2);
 
-        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, function () use (&$store) {
+        (new DurationLimiter($this->redis(), 'key', 2, 2))->block(0, static function () use (&$store) {
             $store[] = 3;
         });
 
@@ -64,19 +64,19 @@ class DurationLimiterTest extends TestCase
     {
         $store = [];
 
-        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, function () use (&$store) {
+        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, static function () use (&$store) {
             $store[] = 1;
         });
 
         try {
-            (new DurationLimiter($this->redis(), 'key', 1, 1))->block(0, function () use (&$store) {
+            (new DurationLimiter($this->redis(), 'key', 1, 1))->block(0, static function () use (&$store) {
                 $store[] = 2;
             });
         } catch (Throwable $e) {
             $this->assertInstanceOf(LimiterTimeoutException::class, $e);
         }
 
-        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, function () use (&$store) {
+        (new DurationLimiter($this->redis(), 'key', 1, 1))->block(2, static function () use (&$store) {
             $store[] = 3;
         });
 
@@ -87,7 +87,7 @@ class DurationLimiterTest extends TestCase
     {
         $limiter = new DurationLimiter($this->redis(), 'key', 1, 1);
 
-        $result = $limiter->block(1, function () {
+        $result = $limiter->block(1, static function () {
             return 'foo';
         });
 

--- a/tests/Redis/RedisConnectionTest.php
+++ b/tests/Redis/RedisConnectionTest.php
@@ -479,7 +479,7 @@ class RedisConnectionTest extends TestCase
     public function testItRunsPipes()
     {
         foreach ($this->connections() as $redis) {
-            $result = $redis->pipeline(function ($pipe) {
+            $result = $redis->pipeline(static function ($pipe) {
                 $pipe->set('test:pipeline:1', 1);
                 $pipe->get('test:pipeline:1');
                 $pipe->set('test:pipeline:2', 2);
@@ -497,7 +497,7 @@ class RedisConnectionTest extends TestCase
     public function testItRunsTransactions()
     {
         foreach ($this->connections() as $redis) {
-            $result = $redis->transaction(function ($pipe) {
+            $result = $redis->transaction(static function ($pipe) {
                 $pipe->set('test:transaction:1', 1);
                 $pipe->get('test:transaction:1');
                 $pipe->set('test:transaction:2', 2);

--- a/tests/Redis/RedisManagerExtensionTest.php
+++ b/tests/Redis/RedisManagerExtensionTest.php
@@ -81,7 +81,7 @@ class RedisManagerExtensionTest extends TestCase
             return m::mock(Connector::class)
                 ->shouldReceive('connectToCluster')
                 ->once()
-                ->withArgs(function ($configArg) use ($config) {
+                ->withArgs(static function ($configArg) use ($config) {
                     return $config === $configArg;
                 })
                 ->getMock();

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -31,28 +31,28 @@ class RouteRegistrarTest extends TestCase
 
     public function testMiddlewareFluentRegistration()
     {
-        $this->router->middleware(['one', 'two'])->get('users', function () {
+        $this->router->middleware(['one', 'two'])->get('users', static function () {
             return 'all-users';
         });
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['one', 'two'], $this->getRoute()->middleware());
 
-        $this->router->middleware('three', 'four')->get('users', function () {
+        $this->router->middleware('three', 'four')->get('users', static function () {
             return 'all-users';
         });
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['three', 'four'], $this->getRoute()->middleware());
 
-        $this->router->get('users', function () {
+        $this->router->get('users', static function () {
             return 'all-users';
         })->middleware('five', 'six');
 
         $this->seeResponse('all-users', Request::create('users', 'GET'));
         $this->assertEquals(['five', 'six'], $this->getRoute()->middleware());
 
-        $this->router->middleware('seven')->get('users', function () {
+        $this->router->middleware('seven')->get('users', static function () {
             return 'all-users';
         });
 
@@ -62,7 +62,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testWithoutMiddlewareRegistration()
     {
-        $this->router->middleware(['one', 'two'])->get('users', function () {
+        $this->router->middleware(['one', 'two'])->get('users', static function () {
             return 'all-users';
         })->withoutMiddleware('one');
 
@@ -73,7 +73,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGetRouteWithClosureAction()
     {
-        $this->router->middleware('get-middleware')->get('users', function () {
+        $this->router->middleware('get-middleware')->get('users', static function () {
             return 'all-users';
         });
 
@@ -83,7 +83,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterPostRouteWithClosureAction()
     {
-        $this->router->middleware('post-middleware')->post('users', function () {
+        $this->router->middleware('post-middleware')->post('users', static function () {
             return 'saved';
         });
 
@@ -93,7 +93,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterAnyRouteWithClosureAction()
     {
-        $this->router->middleware('test-middleware')->any('users', function () {
+        $this->router->middleware('test-middleware')->any('users', static function () {
             return 'anything';
         });
 
@@ -103,7 +103,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterMatchRouteWithClosureAction()
     {
-        $this->router->middleware('match-middleware')->match(['DELETE'], 'users', function () {
+        $this->router->middleware('match-middleware')->match(['DELETE'], 'users', static function () {
             return 'deleted';
         });
 
@@ -113,7 +113,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterRouteWithArrayAndClosureAction()
     {
-        $this->router->middleware('patch-middleware')->patch('users', [function () {
+        $this->router->middleware('patch-middleware')->patch('users', [
+            static function () {
             return 'updated';
         }]);
 
@@ -123,7 +124,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterRouteWithArrayAndClosureUsesAction()
     {
-        $this->router->middleware('put-middleware')->put('users', ['uses' => function () {
+        $this->router->middleware('put-middleware')->put('users', ['uses' => static function () {
             return 'replaced';
         }]);
 
@@ -152,8 +153,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithMiddleware()
     {
-        $this->router->middleware('group-middleware')->group(function ($router) {
-            $router->get('users', function () {
+        $this->router->middleware('group-middleware')->group(static function ($router) {
+            $router->get('users', static function () {
                 return 'all-users';
             });
         });
@@ -164,7 +165,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithNamespace()
     {
-        $this->router->namespace('App\Http\Controllers')->group(function ($router) {
+        $this->router->namespace('App\Http\Controllers')->group(static function ($router) {
             $router->get('users', 'UsersController@index');
         });
 
@@ -176,7 +177,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithPrefix()
     {
-        $this->router->prefix('api')->group(function ($router) {
+        $this->router->prefix('api')->group(static function ($router) {
             $router->get('users', 'UsersController@index');
         });
 
@@ -185,8 +186,8 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithPrefixAndWhere()
     {
-        $this->router->prefix('foo/{bar}')->where(['bar' => '[0-9]+'])->group(function ($router) {
-            $router->get('here', function () {
+        $this->router->prefix('foo/{bar}')->where(['bar' => '[0-9]+'])->group(static function ($router) {
+            $router->get('here', static function () {
                 return 'good';
             });
         });
@@ -196,7 +197,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithNamePrefix()
     {
-        $this->router->name('api.')->group(function ($router) {
+        $this->router->name('api.')->group(static function ($router) {
             $router->get('users', 'UsersController@index')->name('users');
         });
 
@@ -205,7 +206,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithDomain()
     {
-        $this->router->domain('{account}.myapp.com')->group(function ($router) {
+        $this->router->domain('{account}.myapp.com')->group(static function ($router) {
             $router->get('users', 'UsersController@index');
         });
 
@@ -214,7 +215,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanRegisterGroupWithDomainAndNamePrefix()
     {
-        $this->router->domain('{account}.myapp.com')->name('api.')->group(function ($router) {
+        $this->router->domain('{account}.myapp.com')->name('api.')->group(static function ($router) {
             $router->get('users', 'UsersController@index')->name('users');
         });
 
@@ -227,7 +228,7 @@ class RouteRegistrarTest extends TestCase
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage('Method Illuminate\Routing\RouteRegistrar::missing does not exist.');
 
-        $this->router->domain('foo')->missing('bar')->group(function ($router) {
+        $this->router->domain('foo')->missing('bar')->group(static function ($router) {
             //
         });
     }
@@ -527,7 +528,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanSetRouteName()
     {
-        $this->router->as('users.index')->get('users', function () {
+        $this->router->as('users.index')->get('users', static function () {
             return 'all-users';
         });
 
@@ -537,7 +538,7 @@ class RouteRegistrarTest extends TestCase
 
     public function testCanSetRouteNameUsingNameAlias()
     {
-        $this->router->name('users.index')->get('users', function () {
+        $this->router->name('users.index')->get('users', static function () {
             return 'all-users';
         });
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -39,76 +39,76 @@ class RoutingRouteTest extends TestCase
     public function testBasicDispatchingOfRoutes()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             throw new HttpResponseException(new Response('hello'));
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', ['domain' => 'api.{name}.bar', function ($name) {
+        $router->get('foo/bar', ['domain' => 'api.{name}.bar', static function ($name) {
             return $name;
         }]);
-        $router->get('foo/bar', ['domain' => 'api.{name}.baz', function ($name) {
+        $router->get('foo/bar', ['domain' => 'api.{name}.baz', static function ($name) {
             return $name;
         }]);
         $this->assertSame('taylor', $router->dispatch(Request::create('http://api.taylor.bar/foo/bar', 'GET'))->getContent());
         $this->assertSame('dayle', $router->dispatch(Request::create('http://api.dayle.baz/foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/{age}', ['domain' => 'api.{name}.bar', function ($name, $age) {
+        $router->get('foo/{age}', ['domain' => 'api.{name}.bar', static function ($name, $age) {
             return $name.$age;
         }]);
         $this->assertSame('taylor25', $router->dispatch(Request::create('http://api.taylor.bar/foo/25', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
-        $router->post('foo/bar', function () {
+        $router->post('foo/bar', static function () {
             return 'post hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
         $this->assertSame('post hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/{bar}', function ($name) {
+        $router->get('foo/{bar}', static function ($name) {
             return $name;
         });
         $this->assertSame('taylor', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/{bar}/{baz?}', function ($name, $age = 25) {
+        $router->get('foo/{bar}/{baz?}', static function ($name, $age = 25) {
             return $name.$age;
         });
         $this->assertSame('taylor25', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/{name}/boom/{age?}/{location?}', function ($name, $age = 25, $location = 'AR') {
+        $router->get('foo/{name}/boom/{age?}/{location?}', static function ($name, $age = 25, $location = 'AR') {
             return $name.$age.$location;
         });
         $this->assertSame('taylor30AR', $router->dispatch(Request::create('foo/taylor/boom/30', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('{bar}/{baz?}', function ($name, $age = 25) {
+        $router->get('{bar}/{baz?}', static function ($name, $age = 25) {
             return $name.$age;
         });
         $this->assertSame('taylor25', $router->dispatch(Request::create('taylor', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('{baz?}', function ($age = 25) {
+        $router->get('{baz?}', static function ($age = 25) {
             return $age;
         });
         $this->assertSame('25', $router->dispatch(Request::create('/', 'GET'))->getContent());
         $this->assertSame('30', $router->dispatch(Request::create('30', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('{foo?}/{baz?}', ['as' => 'foo', function ($name = 'taylor', $age = 25) {
+        $router->get('{foo?}/{baz?}', ['as' => 'foo', static function ($name = 'taylor', $age = 25) {
             return $name.$age;
         }]);
         $this->assertSame('taylor25', $router->dispatch(Request::create('/', 'GET'))->getContent());
@@ -121,47 +121,47 @@ class RoutingRouteTest extends TestCase
         $this->assertFalse($router->is('bar'));
 
         $router = $this->getRouter();
-        $router->get('foo/{file}', function ($file) {
+        $router->get('foo/{file}', static function ($file) {
             return $file;
         });
         $this->assertSame('oxygen%20', $router->dispatch(Request::create('http://test.com/foo/oxygen%2520', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->patch('foo/bar', ['as' => 'foo', function () {
+        $router->patch('foo/bar', ['as' => 'foo', static function () {
             return 'bar';
         }]);
         $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'PATCH'))->getContent());
         $this->assertSame('foo', $router->currentRouteName());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
         $this->assertEmpty($router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
 
         $router = $this->getRouter();
-        $router->any('foo/bar', function () {
+        $router->any('foo/bar', static function () {
             return 'hello';
         });
         $this->assertEmpty($router->dispatch(Request::create('foo/bar', 'HEAD'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'first';
         });
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'second';
         });
         $this->assertSame('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar/åαф', function () {
+        $router->get('foo/bar/åαф', static function () {
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->get('foo/bar', ['boom' => 'auth', function () {
+        $router->get('foo/bar', ['boom' => 'auth', static function () {
             return 'closure';
         }]);
         $this->assertSame('closure', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -170,7 +170,7 @@ class RoutingRouteTest extends TestCase
     public function testNotModifiedResponseIsProperlyReturned()
     {
         $router = $this->getRouter();
-        $router->get('test', function () {
+        $router->get('test', static function () {
             return (new SymfonyResponse('test', 304, ['foo' => 'bar']))->setLastModified(new DateTime);
         });
 
@@ -184,10 +184,10 @@ class RoutingRouteTest extends TestCase
     public function testClosureMiddleware()
     {
         $router = $this->getRouter();
-        $middleware = function ($request, $next) {
+        $middleware = static function ($request, $next) {
             return 'caught';
         };
-        $router->get('foo/bar', ['middleware' => $middleware, function () {
+        $router->get('foo/bar', ['middleware' => $middleware, static function () {
             return 'hello';
         }]);
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -198,7 +198,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $router->aliasMiddleware('web', RoutingTestMiddlewareGroupTwo::class);
 
-        $router->get('foo/bar', ['middleware' => 'web', function () {
+        $router->get('foo/bar', ['middleware' => 'web', static function () {
             return 'hello';
         }])->withoutMiddleware(RoutingTestMiddlewareGroupTwo::class);
 
@@ -221,10 +221,10 @@ class RoutingRouteTest extends TestCase
     {
         // Before calling controller
         $router = $this->getRouter();
-        $middleware = function ($request, $next) {
+        $middleware = static function ($request, $next) {
             return 'caught';
         };
-        $router->get('foo/bar', ['middleware' => $middleware, function () {
+        $router->get('foo/bar', ['middleware' => $middleware, static function () {
             throw new HttpResponseException(new Response('hello'));
         }]);
         $response = $router->dispatch(Request::create('foo/bar', 'GET'))->getContent();
@@ -240,7 +240,7 @@ class RoutingRouteTest extends TestCase
 
             return new Response($response->getContent().' caught');
         };
-        $router->get('foo/bar', ['middleware' => $middleware, function () use ($response) {
+        $router->get('foo/bar', ['middleware' => $middleware, static function () use ($response) {
             throw new HttpResponseException($response);
         }]);
 
@@ -255,13 +255,13 @@ class RoutingRouteTest extends TestCase
             'uses' => RouteTestClosureMiddlewareController::class.'@index',
             'middleware' => ['foo', 'bar', 'baz'],
         ]);
-        $router->aliasMiddleware('foo', function ($request, $next) {
+        $router->aliasMiddleware('foo', static function ($request, $next) {
             return $next($request);
         });
-        $router->aliasMiddleware('bar', function ($request, $next) {
+        $router->aliasMiddleware('bar', static function ($request, $next) {
             return new ResponsableResponse;
         });
-        $router->aliasMiddleware('baz', function ($request, $next) {
+        $router->aliasMiddleware('baz', static function ($request, $next) {
             return $next($request);
         });
         $this->assertSame(
@@ -273,10 +273,10 @@ class RoutingRouteTest extends TestCase
     public function testDefinedClosureMiddleware()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', ['middleware' => 'foo', function () {
+        $router->get('foo/bar', ['middleware' => 'foo', static function () {
             return 'hello';
         }]);
-        $router->aliasMiddleware('foo', function ($request, $next) {
+        $router->aliasMiddleware('foo', static function ($request, $next) {
             return 'caught';
         });
         $this->assertSame('caught', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -289,7 +289,7 @@ class RoutingRouteTest extends TestCase
             'uses' => RouteTestClosureMiddlewareController::class.'@index',
             'middleware' => 'foo',
         ]);
-        $router->aliasMiddleware('foo', function ($request, $next) {
+        $router->aliasMiddleware('foo', static function ($request, $next) {
             $request['foo-middleware'] = 'foo-middleware';
 
             return $next($request);
@@ -307,15 +307,15 @@ class RoutingRouteTest extends TestCase
         $this->expectExceptionMessage('Route for [foo/bar] has no action.');
 
         $router = $this->getRouter();
-        $router->get('foo/bar')->uses(function () {
+        $router->get('foo/bar')->uses(static function () {
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
-        $router->post('foo/bar')->uses(function () {
+        $router->post('foo/bar')->uses(static function () {
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'POST'))->getContent());
-        $router->get('foo/bar')->uses(function () {
+        $router->get('foo/bar')->uses(static function () {
             return 'middleware';
         })->middleware(RouteTestControllerMiddleware::class);
         $this->assertSame('middleware', $router->dispatch(Request::create('foo/bar'))->getContent());
@@ -331,7 +331,7 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('Hello World', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
         $router = $this->getRouter();
-        $router->group(['namespace' => 'App'], function ($router) {
+        $router->group(['namespace' => 'App'], static function ($router) {
             $router->get('foo/bar')->uses(RouteTestControllerStub::class.'@index');
         });
         $action = $router->getRoutes()->getRoutes()[0]->getAction();
@@ -342,7 +342,7 @@ class RoutingRouteTest extends TestCase
     {
         unset($_SERVER['__middleware.group']);
         $router = $this->getRouter();
-        $router->get('foo/bar', ['middleware' => 'web', function () {
+        $router->get('foo/bar', ['middleware' => 'web', static function () {
             return 'hello';
         }]);
 
@@ -359,7 +359,7 @@ class RoutingRouteTest extends TestCase
     {
         unset($_SERVER['__middleware.group']);
         $router = $this->getRouter();
-        $router->get('foo/bar', ['middleware' => 'web', function () {
+        $router->get('foo/bar', ['middleware' => 'web', static function () {
             return 'hello';
         }]);
 
@@ -376,8 +376,8 @@ class RoutingRouteTest extends TestCase
     public function testFluentRouteNamingWithinAGroup()
     {
         $router = $this->getRouter();
-        $router->group(['as' => 'foo.'], function () use ($router) {
-            $router->get('bar', function () {
+        $router->group(['as' => 'foo.'], static function () use ($router) {
+            $router->get('bar', static function () {
                 return 'bar';
             })->name('bar');
         });
@@ -389,7 +389,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $route = $router->get('foo', function () {
+        $route = $router->get('foo', static function () {
             return 'foo';
         })->name('foo');
 
@@ -403,13 +403,13 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $route = $router->get('foo/{bar:slug}', function () {
+        $route = $router->get('foo/{bar:slug}', static function () {
             return 'foo';
         })->name('foo');
 
         $this->assertSame('slug', $route->bindingFieldFor('bar'));
 
-        $route = $router->get('foo/{bar:slug}/{baz}', function () {
+        $route = $router->get('foo/{bar:slug}/{baz}', static function () {
             return 'foo';
         })->name('foo');
 
@@ -420,7 +420,7 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
         $router->macro('webhook', function () use ($router) {
-            $router->match(['GET', 'POST'], 'webhook', function () {
+            $router->match(['GET', 'POST'], 'webhook', static function () {
                 return 'OK';
             });
         });
@@ -439,7 +439,7 @@ class RoutingRouteTest extends TestCase
             return $this;
         });
 
-        $router->get('foo', function () {
+        $router->get('foo', static function () {
             return 'bar';
         })->breadcrumb('fooBreadcrumb')->name('foo');
 
@@ -452,7 +452,7 @@ class RoutingRouteTest extends TestCase
     {
         unset($_SERVER['__test.route_inject']);
         $router = $this->getRouter();
-        $router->get('foo/{var}', function (stdClass $foo, $var) {
+        $router->get('foo/{var}', static function (stdClass $foo, $var) {
             $_SERVER['__test.route_inject'] = func_get_args();
 
             return 'hello';
@@ -469,11 +469,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
 
-        $container->bind(RoutingTestUserModel::class, function () {
+        $container->bind(RoutingTestUserModel::class, static function () {
         });
 
         $router->get('foo/{team}/{post}', [
@@ -491,10 +491,10 @@ class RoutingRouteTest extends TestCase
     public function testOptionsResponsesAreGeneratedByDefault()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
-        $router->post('foo/bar', function () {
+        $router->post('foo/bar', static function () {
             return 'hello';
         });
         $response = $router->dispatch(Request::create('foo/bar', 'OPTIONS'));
@@ -506,7 +506,7 @@ class RoutingRouteTest extends TestCase
     public function testHeadDispatcher()
     {
         $router = $this->getRouter();
-        $router->match(['GET', 'POST'], 'foo', function () {
+        $router->match(['GET', 'POST'], 'foo', static function () {
             return 'bar';
         });
 
@@ -519,7 +519,7 @@ class RoutingRouteTest extends TestCase
         $this->assertEmpty($response->getContent());
 
         $router = $this->getRouter();
-        $router->match(['GET'], 'foo', function () {
+        $router->match(['GET'], 'foo', static function () {
             return 'bar';
         });
 
@@ -528,7 +528,7 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('GET,HEAD', $response->headers->get('Allow'));
 
         $router = $this->getRouter();
-        $router->match(['POST'], 'foo', function () {
+        $router->match(['POST'], 'foo', static function () {
             return 'bar';
         });
 
@@ -539,7 +539,7 @@ class RoutingRouteTest extends TestCase
 
     public function testNonGreedyMatches()
     {
-        $route = new Route('GET', 'images/{id}.{ext}', function () {
+        $route = new Route('GET', 'images/{id}.{ext}', static function () {
             //
         });
 
@@ -558,7 +558,7 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('png', $route->parameter('ext'));
 
         // Test parameter() default value
-        $route = new Route('GET', 'foo/{foo?}', function () {
+        $route = new Route('GET', 'foo/{foo?}', static function () {
             //
         });
 
@@ -577,7 +577,7 @@ class RoutingRouteTest extends TestCase
         $router->get('foo/{bar?}', ['uses' => RouteTestControllerWithParameterStub::class.'@returnParameter'])->defaults('bar', 'foo');
         $this->assertSame('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
-        $router->get('foo/{bar?}', function ($bar = '') {
+        $router->get('foo/{bar?}', static function ($bar = '') {
             return $bar;
         })->defaults('bar', 'foo');
         $this->assertSame('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
@@ -638,7 +638,7 @@ class RoutingRouteTest extends TestCase
         $router = $this->getRouter();
         $outer_one = 'abc1234'; // a string that is not one we're testing
         $router->get('{one?}', [
-            'uses' => function ($one = null) use (&$outer_one) {
+            'uses' => static function ($one = null) use (&$outer_one) {
                 $outer_one = $one;
 
                 return $one;
@@ -660,7 +660,7 @@ class RoutingRouteTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         $router = $this->getRouter();
-        $router->get('{baz?}', function ($age = 25) {
+        $router->get('{baz?}', static function ($age = 25) {
             return $age;
         });
         $this->assertSame('25', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
@@ -671,7 +671,7 @@ class RoutingRouteTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         $router = $this->getRouter();
-        $router->get('foo/bar', ['domain' => 'api.foo.bar', function () {
+        $router->get('foo/bar', ['domain' => 'api.foo.bar', static function () {
             return 'hello';
         }]);
         $this->assertSame('hello', $router->dispatch(Request::create('http://api.baz.boom/foo/bar', 'GET'))->getContent());
@@ -680,7 +680,7 @@ class RoutingRouteTest extends TestCase
     public function testRouteDomainRegistration()
     {
         $router = $this->getRouter();
-        $router->get('/foo/bar')->domain('api.foo.bar')->uses(function () {
+        $router->get('/foo/bar')->domain('api.foo.bar')->uses(static function () {
             return 'hello';
         });
         $this->assertSame('hello', $router->dispatch(Request::create('http://api.foo.bar/foo/bar', 'GET'))->getContent());
@@ -692,13 +692,13 @@ class RoutingRouteTest extends TestCase
          * Basic
          */
         $request = Request::create('foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', function () {
+        $route = new Route('GET', 'foo/{bar}', static function () {
             //
         });
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/bar', 'GET');
-        $route = new Route('GET', 'foo', function () {
+        $route = new Route('GET', 'foo', static function () {
             //
         });
         $this->assertFalse($route->matches($request));
@@ -707,13 +707,13 @@ class RoutingRouteTest extends TestCase
          * Method checks
          */
         $request = Request::create('foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', function () {
+        $route = new Route('GET', 'foo/{bar}', static function () {
             //
         });
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/bar', 'POST');
-        $route = new Route('GET', 'foo', function () {
+        $route = new Route('GET', 'foo', static function () {
             //
         });
         $this->assertFalse($route->matches($request));
@@ -722,13 +722,13 @@ class RoutingRouteTest extends TestCase
          * Domain checks
          */
         $request = Request::create('http://something.foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['domain' => '{foo}.foo.com', function () {
+        $route = new Route('GET', 'foo/{bar}', ['domain' => '{foo}.foo.com', static function () {
             //
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('http://something.bar.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['domain' => '{foo}.foo.com', function () {
+        $route = new Route('GET', 'foo/{bar}', ['domain' => '{foo}.foo.com', static function () {
             //
         }]);
         $this->assertFalse($route->matches($request));
@@ -737,19 +737,19 @@ class RoutingRouteTest extends TestCase
          * HTTPS checks
          */
         $request = Request::create('https://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['https', function () {
+        $route = new Route('GET', 'foo/{bar}', ['https', static function () {
             //
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('https://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['https', 'baz' => true, function () {
+        $route = new Route('GET', 'foo/{bar}', ['https', 'baz' => true, static function () {
             //
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['https', function () {
+        $route = new Route('GET', 'foo/{bar}', ['https', static function () {
             //
         }]);
         $this->assertFalse($route->matches($request));
@@ -758,19 +758,19 @@ class RoutingRouteTest extends TestCase
          * HTTP checks
          */
         $request = Request::create('https://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['http', function () {
+        $route = new Route('GET', 'foo/{bar}', ['http', static function () {
             //
         }]);
         $this->assertFalse($route->matches($request));
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['http', function () {
+        $route = new Route('GET', 'foo/{bar}', ['http', static function () {
             //
         }]);
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['baz' => true, function () {
+        $route = new Route('GET', 'foo/{bar}', ['baz' => true, static function () {
             //
         }]);
         $this->assertTrue($route->matches($request));
@@ -779,21 +779,21 @@ class RoutingRouteTest extends TestCase
     public function testWherePatternsProperlyFilter()
     {
         $request = Request::create('foo/123', 'GET');
-        $route = new Route('GET', 'foo/{bar}', function () {
+        $route = new Route('GET', 'foo/{bar}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/123abc', 'GET');
-        $route = new Route('GET', 'foo/{bar}', function () {
+        $route = new Route('GET', 'foo/{bar}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
         $this->assertFalse($route->matches($request));
 
         $request = Request::create('foo/123abc', 'GET');
-        $route = new Route('GET', 'foo/{bar}', ['where' => ['bar' => '[0-9]+'], function () {
+        $route = new Route('GET', 'foo/{bar}', ['where' => ['bar' => '[0-9]+'], static function () {
             //
         }]);
         $route->where('bar', '[0-9]+');
@@ -803,35 +803,35 @@ class RoutingRouteTest extends TestCase
          * Optional
          */
         $request = Request::create('foo/123', 'GET');
-        $route = new Route('GET', 'foo/{bar?}', function () {
+        $route = new Route('GET', 'foo/{bar?}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/123', 'GET');
-        $route = new Route('GET', 'foo/{bar?}', ['where' => ['bar' => '[0-9]+'], function () {
+        $route = new Route('GET', 'foo/{bar?}', ['where' => ['bar' => '[0-9]+'], static function () {
             //
         }]);
         $route->where('bar', '[0-9]+');
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/123', 'GET');
-        $route = new Route('GET', 'foo/{bar?}/{baz?}', function () {
+        $route = new Route('GET', 'foo/{bar?}/{baz?}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/123/foo', 'GET');
-        $route = new Route('GET', 'foo/{bar?}/{baz?}', function () {
+        $route = new Route('GET', 'foo/{bar?}/{baz?}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
         $this->assertTrue($route->matches($request));
 
         $request = Request::create('foo/123abc', 'GET');
-        $route = new Route('GET', 'foo/{bar?}', function () {
+        $route = new Route('GET', 'foo/{bar?}', static function () {
             //
         });
         $route->where('bar', '[0-9]+');
@@ -840,7 +840,7 @@ class RoutingRouteTest extends TestCase
 
     public function testRoutePrefixParameterParsing()
     {
-        $route = new Route('GET', '/foo', ['prefix' => 'profiles/{user:username}/portfolios', 'uses' => function () {
+        $route = new Route('GET', '/foo', ['prefix' => 'profiles/{user:username}/portfolios', 'uses' => static function () {
             //
         }]);
 
@@ -849,7 +849,7 @@ class RoutingRouteTest extends TestCase
 
     public function testDotDoesNotMatchEverything()
     {
-        $route = new Route('GET', 'images/{id}.{ext}', function () {
+        $route = new Route('GET', 'images/{id}.{ext}', static function () {
             //
         });
 
@@ -869,10 +869,10 @@ class RoutingRouteTest extends TestCase
     public function testRouteBinding()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
-        $router->bind('bar', function ($value) {
+        $router->bind('bar', static function ($value) {
             return strtoupper($value);
         });
         $this->assertSame('TAYLOR', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
@@ -881,7 +881,7 @@ class RoutingRouteTest extends TestCase
     public function testRouteClassBinding()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class);
@@ -891,7 +891,7 @@ class RoutingRouteTest extends TestCase
     public function testRouteClassMethodBinding()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
         $router->bind('bar', RouteBindingStub::class.'@find');
@@ -913,7 +913,7 @@ class RoutingRouteTest extends TestCase
 
         $router->middlewarePriority = [ExampleMiddlewareContract::class, Authenticate::class, SubstituteBindings::class, Authorize::class];
 
-        $route = $router->get('foo', ['middleware' => $middleware, 'uses' => function ($name) {
+        $route = $router->get('foo', ['middleware' => $middleware, 'uses' => static function ($name) {
             return $name;
         }]);
 
@@ -930,7 +930,7 @@ class RoutingRouteTest extends TestCase
     public function testModelBinding()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
         $router->model('bar', RouteModelBindingStub::class);
@@ -943,7 +943,7 @@ class RoutingRouteTest extends TestCase
         $this->expectExceptionMessage('No query results for model [Illuminate\Tests\Routing\RouteModelBindingNullStub].');
 
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
         $router->model('bar', RouteModelBindingNullStub::class);
@@ -953,10 +953,10 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithCustomNullReturn()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
-        $router->model('bar', RouteModelBindingNullStub::class, function () {
+        $router->model('bar', RouteModelBindingNullStub::class, static function () {
             return 'missing';
         });
         $this->assertSame('missing', $router->dispatch(Request::create('foo/taylor', 'GET'))->getContent());
@@ -965,10 +965,10 @@ class RoutingRouteTest extends TestCase
     public function testModelBindingWithBindingClosure()
     {
         $router = $this->getRouter();
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
-        $router->model('bar', RouteModelBindingNullStub::class, function ($value) {
+        $router->model('bar', RouteModelBindingNullStub::class, static function ($value) {
             return (new RouteModelBindingClosureStub)->findAlternate($value);
         });
         $this->assertSame('tayloralt', $router->dispatch(Request::create('foo/TAYLOR', 'GET'))->getContent());
@@ -993,11 +993,11 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $container->bind(RouteModelInterface::class, RouteModelBindingStub::class);
-        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => function ($name) {
+        $router->get('foo/{bar}', ['middleware' => SubstituteBindings::class, 'uses' => static function ($name) {
             return $name;
         }]);
         $router->model('bar', RouteModelInterface::class);
@@ -1032,8 +1032,8 @@ class RoutingRouteTest extends TestCase
          * getPrefix() method
          */
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo'], function () use ($router) {
-            $router->get('bar', function () {
+        $router->group(['prefix' => 'foo'], static function () use ($router) {
+            $router->get('bar', static function () {
                 return 'hello';
             });
         });
@@ -1046,8 +1046,8 @@ class RoutingRouteTest extends TestCase
     {
         $router = $this->getRouter();
 
-        $router->group(['namespace' => 'App\Http\Controllers'], function ($router) {
-            $router->group(['namespace' => '\Foo\Bar'], function ($router) {
+        $router->group(['namespace' => 'App\Http\Controllers'], static function ($router) {
+            $router->group(['namespace' => '\Foo\Bar'], static function ($router) {
                 $router->get('users', 'UsersController@index');
             });
         });
@@ -1095,8 +1095,8 @@ class RoutingRouteTest extends TestCase
     public function testRouteGroupingWithAs()
     {
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
-            $router->get('bar', ['as' => 'bar', function () {
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], static function () use ($router) {
+            $router->get('bar', ['as' => 'bar', static function () {
                 return 'hello';
             }]);
         });
@@ -1111,9 +1111,9 @@ class RoutingRouteTest extends TestCase
          * nested with all layers present
          */
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
-            $router->group(['prefix' => 'bar', 'as' => 'Bar::'], function () use ($router) {
-                $router->get('baz', ['as' => 'baz', function () {
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], static function () use ($router) {
+            $router->group(['prefix' => 'bar', 'as' => 'Bar::'], static function () use ($router) {
+                $router->get('baz', ['as' => 'baz', static function () {
                     return 'hello';
                 }]);
             });
@@ -1126,9 +1126,9 @@ class RoutingRouteTest extends TestCase
          * nested with layer skipped
          */
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
-            $router->group(['prefix' => 'bar'], function () use ($router) {
-                $router->prefix('foz')->get('baz', ['as' => 'baz', function () {
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], static function () use ($router) {
+            $router->group(['prefix' => 'bar'], static function () use ($router) {
+                $router->prefix('foz')->get('baz', ['as' => 'baz', static function () {
                     return 'hello';
                 }]);
             });
@@ -1144,8 +1144,8 @@ class RoutingRouteTest extends TestCase
          * nested with layer skipped
          */
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], function () use ($router) {
-            $router->prefix('bar')->get('baz', ['as' => 'baz', function () {
+        $router->group(['prefix' => 'foo', 'as' => 'Foo::'], static function () use ($router) {
+            $router->prefix('bar')->get('baz', ['as' => 'baz', static function () {
                 return 'hello';
             }]);
         });
@@ -1157,8 +1157,8 @@ class RoutingRouteTest extends TestCase
     public function testRouteMiddlewareMergeWithMiddlewareAttributesAsStrings()
     {
         $router = $this->getRouter();
-        $router->group(['prefix' => 'foo', 'middleware' => 'boo:foo'], function () use ($router) {
-            $router->get('bar', function () {
+        $router->group(['prefix' => 'foo', 'middleware' => 'boo:foo'], static function () use ($router) {
+            $router->get('bar', static function () {
                 return 'hello';
             })->middleware('baz:gaz');
         });
@@ -1176,7 +1176,7 @@ class RoutingRouteTest extends TestCase
          * Prefix route
          */
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
         $routes = $router->getRoutes();
@@ -1188,7 +1188,7 @@ class RoutingRouteTest extends TestCase
          * Use empty prefix
          */
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
         $routes = $router->getRoutes();
@@ -1200,7 +1200,7 @@ class RoutingRouteTest extends TestCase
          * Prefix homepage
          */
         $router = $this->getRouter();
-        $router->get('/', function () {
+        $router->get('/', static function () {
             return 'hello';
         });
         $routes = $router->getRoutes();
@@ -1212,7 +1212,7 @@ class RoutingRouteTest extends TestCase
          * Prefix homepage with empty prefix
          */
         $router = $this->getRouter();
-        $router->get('/', function () {
+        $router->get('/', static function () {
             return 'hello';
         });
         $routes = $router->getRoutes();
@@ -1224,7 +1224,7 @@ class RoutingRouteTest extends TestCase
     public function testRoutePreservingOriginalParametersState()
     {
         $router = $this->getRouter();
-        $router->bind('bar', function ($value) {
+        $router->bind('bar', static function ($value) {
             return strlen($value);
         });
         $router->get('foo/{bar}', [
@@ -1246,7 +1246,7 @@ class RoutingRouteTest extends TestCase
     public function testMergingControllerUses()
     {
         $router = $this->getRouter();
-        $router->group(['namespace' => 'Namespace'], function () use ($router) {
+        $router->group(['namespace' => 'Namespace'], static function () use ($router) {
             $router->get('foo/bar', 'Controller@action');
         });
         $routes = $router->getRoutes()->getRoutes();
@@ -1255,8 +1255,8 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('Namespace\\Controller@action', $action['controller']);
 
         $router = $this->getRouter();
-        $router->group(['namespace' => 'Namespace'], function () use ($router) {
-            $router->group(['namespace' => 'Nested'], function () use ($router) {
+        $router->group(['namespace' => 'Namespace'], static function () use ($router) {
+            $router->group(['namespace' => 'Nested'], static function () use ($router) {
                 $router->get('foo/bar', 'Controller@action');
             });
         });
@@ -1266,8 +1266,8 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('Namespace\\Nested\\Controller@action', $action['controller']);
 
         $router = $this->getRouter();
-        $router->group(['prefix' => 'baz'], function () use ($router) {
-            $router->group(['namespace' => 'Namespace'], function () use ($router) {
+        $router->group(['prefix' => 'baz'], static function () use ($router) {
+            $router->group(['namespace' => 'Namespace'], static function () use ($router) {
                 $router->get('foo/bar', 'Controller@action');
             });
         });
@@ -1491,22 +1491,22 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return '';
         });
 
         $request = Request::create('http://foo.com/foo/bar', 'GET');
-        $route = new Route('GET', 'foo/bar', ['http', function () {
+        $route = new Route('GET', 'foo/bar', ['http', static function () {
             //
         }]);
 
         $_SERVER['__router.request'] = null;
         $_SERVER['__router.route'] = null;
 
-        $router->matched(function ($event) {
+        $router->matched(static function ($event) {
             $_SERVER['__router.request'] = $event->request;
             $_SERVER['__router.route'] = $event->route;
         });
@@ -1701,7 +1701,7 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
 
@@ -1732,7 +1732,7 @@ class RoutingRouteTest extends TestCase
     public function testResponseIsReturned()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return 'hello';
         });
 
@@ -1744,7 +1744,7 @@ class RoutingRouteTest extends TestCase
     public function testJsonResponseIsReturned()
     {
         $router = $this->getRouter();
-        $router->get('foo/bar', function () {
+        $router->get('foo/bar', static function () {
             return ['foo', 'bar'];
         });
 
@@ -1757,18 +1757,18 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('contact_us', function () {
+        $router->get('contact_us', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->redirect('contact_us', 'contact');
@@ -1782,18 +1782,18 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('contact_us', function () {
+        $router->get('contact_us', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->redirect('contact_us', '/contact');
@@ -1807,18 +1807,18 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('contact_us', function () {
+        $router->get('contact_us', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->redirect('contact_us', 'contact');
@@ -1835,18 +1835,18 @@ class RoutingRouteTest extends TestCase
 
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('users', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('users', function () {
+        $router->get('users', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->redirect('users', 'users/{user}');
@@ -1858,18 +1858,18 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('contact_us', function () {
+        $router->get('contact_us', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->redirect('contact_us', 'contact', 301);
@@ -1883,18 +1883,18 @@ class RoutingRouteTest extends TestCase
     {
         $container = new Container;
         $router = new Router(new Dispatcher, $container);
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
         $request = Request::create('contact_us', 'GET');
-        $container->singleton(Request::class, function () use ($request) {
+        $container->singleton(Request::class, static function () use ($request) {
             return $request;
         });
         $urlGenerator = new UrlGenerator(new RouteCollection, $request);
-        $container->singleton(UrlGenerator::class, function () use ($urlGenerator) {
+        $container->singleton(UrlGenerator::class, static function () use ($urlGenerator) {
             return $urlGenerator;
         });
-        $router->get('contact_us', function () {
+        $router->get('contact_us', static function () {
             throw new Exception('Route should not be reachable.');
         });
         $router->permanentRedirect('contact_us', 'contact');
@@ -1910,7 +1910,7 @@ class RoutingRouteTest extends TestCase
 
         $router = new Router(new Dispatcher, $container);
 
-        $container->singleton(Registrar::class, function () use ($router) {
+        $container->singleton(Registrar::class, static function () use ($router) {
             return $router;
         });
 
@@ -2008,7 +2008,7 @@ class RouteTestClosureMiddlewareController extends Controller
 {
     public function __construct()
     {
-        $this->middleware(function ($request, $next) {
+        $this->middleware(static function ($request, $next) {
             $response = $next($request);
 
             return $response->setContent(

--- a/tests/Routing/RoutingSortedMiddlewareTest.php
+++ b/tests/Routing/RoutingSortedMiddlewareTest.php
@@ -48,11 +48,11 @@ class RoutingSortedMiddlewareTest extends TestCase
 
     public function testItDoesNotMoveNonStringValues()
     {
-        $closure = function () {
+        $closure = static function () {
             return 'foo';
         };
 
-        $closure2 = function () {
+        $closure2 = static function () {
             return 'bar';
         };
 

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -59,7 +59,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
         $routes->add($route);
 
-        $url->formatHostUsing(function ($host) {
+        $url->formatHostUsing(static function ($host) {
             return str_replace('foo.com', 'foo.org', $host);
         });
 
@@ -136,7 +136,7 @@ class RoutingUrlGeneratorTest extends TestCase
         $route = new Route(['GET'], '/named-route', ['as' => 'plain']);
         $routes->add($route);
 
-        $url->formatPathUsing(function ($path) {
+        $url->formatPathUsing(static function ($path) {
             return '/something'.$path;
         });
 
@@ -154,11 +154,11 @@ class RoutingUrlGeneratorTest extends TestCase
         $namedRoute = new Route(['GET'], '/bar', ['as' => 'plain', 'root' => 'bar.com', 'path' => 'foo']);
         $routes->add($namedRoute);
 
-        $url->formatHostUsing(function ($root, $route) {
+        $url->formatHostUsing(static function ($root, $route) {
             return $route ? 'http://'.$route->getAction('root') : $root;
         });
 
-        $url->formatPathUsing(function ($path, $route) {
+        $url->formatPathUsing(static function ($path, $route) {
             return $route ? '/'.$route->getAction('path') : $path;
         });
 
@@ -237,7 +237,7 @@ class RoutingUrlGeneratorTest extends TestCase
          * With Default Parameter
          */
         $url->defaults(['locale' => 'en']);
-        $route = new Route(['GET'], 'foo', ['as' => 'defaults', 'domain' => '{locale}.example.com', function () {
+        $route = new Route(['GET'], 'foo', ['as' => 'defaults', 'domain' => '{locale}.example.com', static function () {
             //
         }]);
         $routes->add($route);
@@ -542,7 +542,7 @@ class RoutingUrlGeneratorTest extends TestCase
             Request::create('http://www.foo.com:8080/')
         );
 
-        $route = new Route(['GET'], 'foo/{one}/{two?}/{three?}', ['as' => 'foo', function () {
+        $route = new Route(['GET'], 'foo/{one}/{two?}/{three?}', ['as' => 'foo', static function () {
             //
         }]);
         $routes->add($route);
@@ -617,11 +617,11 @@ class RoutingUrlGeneratorTest extends TestCase
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com/')
         );
-        $url->setKeyResolver(function () {
+        $url->setKeyResolver(static function () {
             return 'secret';
         });
 
-        $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', static function () {
             //
         }]);
         $routes->add($route);
@@ -641,11 +641,11 @@ class RoutingUrlGeneratorTest extends TestCase
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com/')
         );
-        $url->setKeyResolver(function () {
+        $url->setKeyResolver(static function () {
             return 'secret';
         });
 
-        $route = new Route(['GET'], 'foo', ['as' => 'foo', function () {
+        $route = new Route(['GET'], 'foo', ['as' => 'foo', static function () {
             //
         }]);
         $routes->add($route);
@@ -667,11 +667,11 @@ class RoutingUrlGeneratorTest extends TestCase
             $routes = new RouteCollection,
             $request = Request::create('http://www.foo.com/')
         );
-        $url->setKeyResolver(function () {
+        $url->setKeyResolver(static function () {
             return 'secret';
         });
 
-        $route = new Route(['GET'], 'foo/{signature}', ['as' => 'foo', function () {
+        $route = new Route(['GET'], 'foo/{signature}', ['as' => 'foo', static function () {
             //
         }]);
         $routes->add($route);

--- a/tests/Routing/fixtures/routes.php
+++ b/tests/Routing/fixtures/routes.php
@@ -1,5 +1,5 @@
 <?php
 
-$router->get('users', function () {
+$router->get('users', static function () {
     return 'all-users';
 });

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -456,7 +456,7 @@ class SessionStoreTest extends TestCase
     {
         $session = $this->getSession();
         $session->getHandler()->shouldReceive('get')->andReturn(null);
-        $result = $session->remember('foo', function () {
+        $result = $session->remember('foo', static function () {
             return 'bar';
         });
         $this->assertSame('bar', $session->get('foo'));

--- a/tests/Support/DateFacadeTest.php
+++ b/tests/Support/DateFacadeTest.php
@@ -36,7 +36,7 @@ class DateFacadeTest extends TestCase
         $start = Carbon::now()->getTimestamp();
         $this->assertSame(Carbon::class, get_class(Date::now()));
         $this->assertBetweenStartAndNow($start, Date::now()->getTimestamp());
-        DateFactory::use(function (Carbon $date) {
+        DateFactory::use(static function (Carbon $date) {
             return new DateTime($date->format('Y-m-d H:i:s.u'), $date->getTimezone());
         });
         $start = Carbon::now()->getTimestamp();
@@ -61,11 +61,11 @@ class DateFacadeTest extends TestCase
         $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
         DateFactory::use(Carbon::class);
         $this->assertSame(Carbon::class, get_class(Date::now()));
-        DateFactory::use(function (Carbon $date) {
+        DateFactory::use(static function (Carbon $date) {
             return $date->toImmutable();
         });
         $this->assertSame(CarbonImmutable::class, get_class(Date::now()));
-        DateFactory::use(function ($date) {
+        DateFactory::use(static function ($date) {
             return $date;
         });
         $this->assertSame(Carbon::class, get_class(Date::now()));
@@ -91,7 +91,7 @@ class DateFacadeTest extends TestCase
 
     public function testMacro()
     {
-        Date::macro('returnNonDate', function () {
+        Date::macro('returnNonDate', static function () {
             return 'string';
         });
 

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -146,7 +146,7 @@ class SupportArrTest extends TestCase
         // Callback is null and array is empty
         $this->assertNull(Arr::first([], null));
         $this->assertSame('foo', Arr::first([], null, 'foo'));
-        $this->assertSame('bar', Arr::first([], null, function () {
+        $this->assertSame('bar', Arr::first([], null, static function () {
             return 'bar';
         }));
 
@@ -154,21 +154,21 @@ class SupportArrTest extends TestCase
         $this->assertEquals(100, Arr::first($array));
 
         // Callback is not null and array is not empty
-        $value = Arr::first($array, function ($value) {
+        $value = Arr::first($array, static function ($value) {
             return $value >= 150;
         });
         $this->assertEquals(200, $value);
 
         // Callback is not null, array is not empty but no satisfied item
-        $value2 = Arr::first($array, function ($value) {
+        $value2 = Arr::first($array, static function ($value) {
             return $value > 300;
         });
-        $value3 = Arr::first($array, function ($value) {
+        $value3 = Arr::first($array, static function ($value) {
             return $value > 300;
         }, 'bar');
-        $value4 = Arr::first($array, function ($value) {
+        $value4 = Arr::first($array, static function ($value) {
             return $value > 300;
-        }, function () {
+        }, static function () {
             return 'baz';
         });
         $this->assertNull($value2);
@@ -180,12 +180,12 @@ class SupportArrTest extends TestCase
     {
         $array = [100, 200, 300];
 
-        $last = Arr::last($array, function ($value) {
+        $last = Arr::last($array, static function ($value) {
             return $value < 250;
         });
         $this->assertEquals(200, $last);
 
-        $last = Arr::last($array, function ($value, $key) {
+        $last = Arr::last($array, static function ($value, $key) {
             return $key < 2;
         });
         $this->assertEquals(200, $last);
@@ -325,7 +325,7 @@ class SupportArrTest extends TestCase
         // Test return default value for non-existing key.
         $array = ['names' => ['developer' => 'taylor']];
         $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', 'dayle'));
-        $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', function () {
+        $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', static function () {
             return 'dayle';
         }));
     }
@@ -731,7 +731,7 @@ class SupportArrTest extends TestCase
         $this->assertEquals($expected, $sorted);
 
         // sort with closure
-        $sortedWithClosure = array_values(Arr::sort($unsorted, function ($value) {
+        $sortedWithClosure = array_values(Arr::sort($unsorted, static function ($value) {
             return $value['name'];
         }));
         $this->assertEquals($expected, $sortedWithClosure);
@@ -803,7 +803,7 @@ class SupportArrTest extends TestCase
     {
         $array = [100, '200', 300, '400', 500];
 
-        $array = Arr::where($array, function ($value, $key) {
+        $array = Arr::where($array, static function ($value, $key) {
             return is_string($value);
         });
 
@@ -814,7 +814,7 @@ class SupportArrTest extends TestCase
     {
         $array = ['10' => 1, 'foo' => 3, 20 => 2];
 
-        $array = Arr::where($array, function ($value, $key) {
+        $array = Arr::where($array, static function ($value, $key) {
             return is_numeric($key);
         });
 

--- a/tests/Support/SupportCarbonTest.php
+++ b/tests/Support/SupportCarbonTest.php
@@ -50,7 +50,7 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonIsMacroableWhenCalledStatically()
     {
-        Carbon::macro('twoDaysAgoAtNoon', function () {
+        Carbon::macro('twoDaysAgoAtNoon', static function () {
             return Carbon::now()->subDays(2)->setTime(12, 0, 0);
         });
 
@@ -75,7 +75,7 @@ class SupportCarbonTest extends TestCase
 
     public function testCarbonAllowsCustomSerializer()
     {
-        Carbon::serializeUsing(function (Carbon $carbon) {
+        Carbon::serializeUsing(static function (Carbon $carbon) {
             return $carbon->getTimestamp();
         });
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -36,7 +36,7 @@ class SupportCollectionTest extends TestCase
     public function testFirstWithCallback($collection)
     {
         $data = new $collection(['foo', 'bar', 'baz']);
-        $result = $data->first(function ($value) {
+        $result = $data->first(static function ($value) {
             return $value === 'bar';
         });
         $this->assertSame('bar', $result);
@@ -48,7 +48,7 @@ class SupportCollectionTest extends TestCase
     public function testFirstWithCallbackAndDefault($collection)
     {
         $data = new $collection(['foo', 'bar']);
-        $result = $data->first(function ($value) {
+        $result = $data->first(static function ($value) {
             return $value === 'baz';
         }, 'default');
         $this->assertSame('default', $result);
@@ -95,11 +95,11 @@ class SupportCollectionTest extends TestCase
     public function testLastWithCallback($collection)
     {
         $data = new $collection([100, 200, 300]);
-        $result = $data->last(function ($value) {
+        $result = $data->last(static function ($value) {
             return $value < 250;
         });
         $this->assertEquals(200, $result);
-        $result = $data->last(function ($value, $key) {
+        $result = $data->last(static function ($value, $key) {
             return $key < 2;
         });
         $this->assertEquals(200, $result);
@@ -111,7 +111,7 @@ class SupportCollectionTest extends TestCase
     public function testLastWithCallbackAndDefault($collection)
     {
         $data = new $collection(['foo', 'bar']);
-        $result = $data->last(function ($value) {
+        $result = $data->last(static function ($value) {
             return $value === 'baz';
         }, 'default');
         $this->assertSame('default', $result);
@@ -223,7 +223,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame([3, 3, 4, 4], $data->all());
 
-        $data = $data->skipUntil(function ($value, $key) {
+        $data = $data->skipUntil(static function ($value, $key) {
             return $value > 3;
         })->values();
 
@@ -241,7 +241,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame([2, 2, 3, 3, 4, 4], $data->all());
 
-        $data = $data->skipWhile(function ($value, $key) {
+        $data = $data->skipWhile(static function ($value, $key) {
             return $value < 3;
         })->values();
 
@@ -454,12 +454,12 @@ class SupportCollectionTest extends TestCase
     public function testCountableByWithPredicate($collection)
     {
         $c = new $collection(['alice', 'aaron', 'bob', 'carla']);
-        $this->assertEquals(['a' => 2, 'b' => 1, 'c' => 1], $c->countBy(function ($name) {
+        $this->assertEquals(['a' => 2, 'b' => 1, 'c' => 1], $c->countBy(static function ($name) {
             return substr($name, 0, 1);
         })->all());
 
         $c = new $collection([1, 2, 3, 4, 5]);
-        $this->assertEquals([true => 2, false => 3], $c->countBy(function ($i) {
+        $this->assertEquals([true => 2, false => 3], $c->countBy(static function ($i) {
             return $i % 2 === 0;
         })->all());
     }
@@ -486,7 +486,7 @@ class SupportCollectionTest extends TestCase
     public function testFilter($collection)
     {
         $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
-        $this->assertEquals([1 => ['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
+        $this->assertEquals([1 => ['id' => 2, 'name' => 'World']], $c->filter(static function ($item) {
             return $item['id'] == 2;
         })->all());
 
@@ -494,7 +494,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['Hello', 'World'], $c->filter()->values()->toArray());
 
         $c = new $collection(['id' => 1, 'first' => 'Hello', 'second' => 'World']);
-        $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(function ($item, $key) {
+        $this->assertEquals(['first' => 'Hello', 'second' => 'World'], $c->filter(static function ($item, $key) {
             return $key != 'id';
         })->all());
     }
@@ -735,7 +735,7 @@ class SupportCollectionTest extends TestCase
     public function testValues($collection)
     {
         $c = new $collection([['id' => 1, 'name' => 'Hello'], ['id' => 2, 'name' => 'World']]);
-        $this->assertEquals([['id' => 2, 'name' => 'World']], $c->filter(function ($item) {
+        $this->assertEquals([['id' => 2, 'name' => 'World']], $c->filter(static function ($item) {
             return $item['id'] == 2;
         })->values()->all());
     }
@@ -1101,7 +1101,7 @@ class SupportCollectionTest extends TestCase
     public function testDuplicatesWithCallback($collection)
     {
         $items = [['framework' => 'vue'], ['framework' => 'laravel'], ['framework' => 'laravel']];
-        $duplicates = $collection::make($items)->duplicates(function ($item) {
+        $duplicates = $collection::make($items)->duplicates(static function ($item) {
             return $item['framework'];
         })->all();
         $this->assertSame([2 => 'laravel'], $duplicates);
@@ -1137,13 +1137,13 @@ class SupportCollectionTest extends TestCase
         $c = new $collection($original = [1, 2, 'foo' => 'bar', 'bam' => 'baz']);
 
         $result = [];
-        $c->each(function ($item, $key) use (&$result) {
+        $c->each(static function ($item, $key) use (&$result) {
             $result[$key] = $item;
         });
         $this->assertEquals($original, $result);
 
         $result = [];
-        $c->each(function ($item, $key) use (&$result) {
+        $c->each(static function ($item, $key) use (&$result) {
             $result[$key] = $item;
             if (is_string($key)) {
                 return false;
@@ -1160,13 +1160,13 @@ class SupportCollectionTest extends TestCase
         $c = new $collection([[1, 'a'], [2, 'b']]);
 
         $result = [];
-        $c->eachSpread(function ($number, $character) use (&$result) {
+        $c->eachSpread(static function ($number, $character) use (&$result) {
             $result[] = [$number, $character];
         });
         $this->assertEquals($c->all(), $result);
 
         $result = [];
-        $c->eachSpread(function ($number, $character) use (&$result) {
+        $c->eachSpread(static function ($number, $character) use (&$result) {
             $result[] = [$number, $character];
 
             return false;
@@ -1174,14 +1174,14 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals([[1, 'a']], $result);
 
         $result = [];
-        $c->eachSpread(function ($number, $character, $key) use (&$result) {
+        $c->eachSpread(static function ($number, $character, $key) use (&$result) {
             $result[] = [$number, $character, $key];
         });
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
 
         $c = new $collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
         $result = [];
-        $c->eachSpread(function ($number, $character, $key) use (&$result) {
+        $c->eachSpread(static function ($number, $character, $key) use (&$result) {
             $result[] = [$number, $character, $key];
         });
         $this->assertEquals([[1, 'a', 0], [2, 'b', 1]], $result);
@@ -1258,14 +1258,14 @@ class SupportCollectionTest extends TestCase
             1 => ['id' => 1, 'first' => 'Taylor', 'last' => 'Otwell'],
             3 => ['id' => 3, 'first' => 'Abigail', 'last' => 'Otwell'],
             5 => ['id' => 5, 'first' => 'Taylor', 'last' => 'Swift'],
-        ], $c->unique(function ($item) {
+        ], $c->unique(static function ($item) {
             return $item['first'].$item['last'];
         })->all());
 
         $this->assertEquals([
             1 => ['id' => 1, 'first' => 'Taylor', 'last' => 'Otwell'],
             2 => ['id' => 2, 'first' => 'Taylor', 'last' => 'Otwell'],
-        ], $c->unique(function ($item, $key) {
+        ], $c->unique(static function ($item, $key) {
             return $key % 2;
         })->all());
     }
@@ -1415,7 +1415,7 @@ class SupportCollectionTest extends TestCase
      */
     public function testSortWithCallback($collection)
     {
-        $data = (new $collection([5, 3, 1, 2, 4]))->sort(function ($a, $b) {
+        $data = (new $collection([5, 3, 1, 2, 4]))->sort(static function ($a, $b) {
             if ($a === $b) {
                 return 0;
             }
@@ -1432,14 +1432,14 @@ class SupportCollectionTest extends TestCase
     public function testSortBy($collection)
     {
         $data = new $collection(['taylor', 'dayle']);
-        $data = $data->sortBy(function ($x) {
+        $data = $data->sortBy(static function ($x) {
             return $x;
         });
 
         $this->assertEquals(['dayle', 'taylor'], array_values($data->all()));
 
         $data = new $collection(['dayle', 'taylor']);
-        $data = $data->sortByDesc(function ($x) {
+        $data = $data->sortByDesc(static function ($x) {
             return $x;
         });
 
@@ -1468,14 +1468,14 @@ class SupportCollectionTest extends TestCase
     public function testSortByAlwaysReturnsAssoc($collection)
     {
         $data = new $collection(['a' => 'taylor', 'b' => 'dayle']);
-        $data = $data->sortBy(function ($x) {
+        $data = $data->sortBy(static function ($x) {
             return $x;
         });
 
         $this->assertEquals(['b' => 'dayle', 'a' => 'taylor'], $data->all());
 
         $data = new $collection(['taylor', 'dayle']);
-        $data = $data->sortBy(function ($x) {
+        $data = $data->sortBy(static function ($x) {
             return $x;
         });
 
@@ -1575,22 +1575,22 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([]);
         $this->assertTrue($c->every('key', 'value'));
-        $this->assertTrue($c->every(function () {
+        $this->assertTrue($c->every(static function () {
             return false;
         }));
 
         $c = new $collection([['age' => 18], ['age' => 20], ['age' => 20]]);
         $this->assertFalse($c->every('age', 18));
         $this->assertTrue($c->every('age', '>=', 18));
-        $this->assertTrue($c->every(function ($item) {
+        $this->assertTrue($c->every(static function ($item) {
             return $item['age'] >= 18;
         }));
-        $this->assertFalse($c->every(function ($item) {
+        $this->assertFalse($c->every(static function ($item) {
             return $item['age'] >= 20;
         }));
 
         $c = new $collection([null, null]);
-        $this->assertTrue($c->every(function ($item) {
+        $this->assertTrue($c->every(static function ($item) {
             return $item === null;
         }));
 
@@ -1779,7 +1779,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3, 4]);
 
-        $data = $data->takeUntil(function ($item) {
+        $data = $data->takeUntil(static function ($item) {
             return $item >= 3;
         });
 
@@ -1797,7 +1797,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame($data->toArray(), $actual->toArray());
 
-        $actual = $data->takeUntil(function ($item) {
+        $actual = $data->takeUntil(static function ($item) {
             return $item >= 99;
         });
 
@@ -1841,7 +1841,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3, 4]);
 
-        $data = $data->takeWhile(function ($item) {
+        $data = $data->takeWhile(static function ($item) {
             return $item < 3;
         });
 
@@ -1859,7 +1859,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertSame([], $actual->toArray());
 
-        $actual = $data->takeWhile(function ($item) {
+        $actual = $data->takeWhile(static function ($item) {
             return $item == 99;
         });
 
@@ -1892,7 +1892,7 @@ class SupportCollectionTest extends TestCase
     {
         // Foo() macro : unique values starting with A
         $collection::macro('foo', function () {
-            return $this->filter(function ($item) {
+            return $this->filter(static function ($item) {
                 return strpos($item, 'a') === 0;
             })
                 ->unique()
@@ -1910,7 +1910,7 @@ class SupportCollectionTest extends TestCase
     public function testCanAddMethodsToProxy($collection)
     {
         $collection::macro('adults', function ($callback) {
-            return $this->filter(function ($item) use ($callback) {
+            return $this->filter(static function ($item) use ($callback) {
                 return $callback($item) >= 18;
             });
         });
@@ -2056,15 +2056,15 @@ class SupportCollectionTest extends TestCase
      */
     public function testTimesMethod($collection)
     {
-        $two = $collection::times(2, function ($number) {
+        $two = $collection::times(2, static function ($number) {
             return 'slug-'.$number;
         });
 
-        $zero = $collection::times(0, function ($number) {
+        $zero = $collection::times(0, static function ($number) {
             return 'slug-'.$number;
         });
 
-        $negative = $collection::times(-4, function ($number) {
+        $negative = $collection::times(-4, static function ($number) {
             return 'slug-'.$number;
         });
 
@@ -2176,7 +2176,7 @@ class SupportCollectionTest extends TestCase
     public function testMap($collection)
     {
         $data = new $collection(['first' => 'taylor', 'last' => 'otwell']);
-        $data = $data->map(function ($item, $key) {
+        $data = $data->map(static function ($item, $key) {
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
@@ -2189,18 +2189,18 @@ class SupportCollectionTest extends TestCase
     {
         $c = new $collection([[1, 'a'], [2, 'b']]);
 
-        $result = $c->mapSpread(function ($number, $character) {
+        $result = $c->mapSpread(static function ($number, $character) {
             return "{$number}-{$character}";
         });
         $this->assertEquals(['1-a', '2-b'], $result->all());
 
-        $result = $c->mapSpread(function ($number, $character, $key) {
+        $result = $c->mapSpread(static function ($number, $character, $key) {
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
 
         $c = new $collection([new Collection([1, 'a']), new Collection([2, 'b'])]);
-        $result = $c->mapSpread(function ($number, $character, $key) {
+        $result = $c->mapSpread(static function ($number, $character, $key) {
             return "{$number}-{$character}-{$key}";
         });
         $this->assertEquals(['1-a-0', '2-b-1'], $result->all());
@@ -2215,7 +2215,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'taylor', 'hobbies' => ['programming', 'basketball']],
             ['name' => 'adam', 'hobbies' => ['music', 'powerlifting']],
         ]);
-        $data = $data->flatMap(function ($person) {
+        $data = $data->flatMap(static function ($person) {
             return $person['hobbies'];
         });
         $this->assertEquals(['programming', 'basketball', 'music', 'powerlifting'], $data->all());
@@ -2233,7 +2233,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 4, 'name' => 'B'],
         ]);
 
-        $groups = $data->mapToDictionary(function ($item, $key) {
+        $groups = $data->mapToDictionary(static function ($item, $key) {
             return [$item['name'] => $item['id']];
         });
 
@@ -2249,7 +2249,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3, 2, 1]);
 
-        $groups = $data->mapToDictionary(function ($item, $key) {
+        $groups = $data->mapToDictionary(static function ($item, $key) {
             return [$item => $key];
         });
 
@@ -2268,7 +2268,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 4, 'name' => 'B'],
         ]);
 
-        $groups = $data->mapToGroups(function ($item, $key) {
+        $groups = $data->mapToGroups(static function ($item, $key) {
             return [$item['name'] => $item['id']];
         });
 
@@ -2284,7 +2284,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3, 2, 1]);
 
-        $groups = $data->mapToGroups(function ($item, $key) {
+        $groups = $data->mapToGroups(static function ($item, $key) {
             return [$item => $key];
         });
 
@@ -2301,7 +2301,7 @@ class SupportCollectionTest extends TestCase
             ['name' => 'Charmander', 'type' => 'Fire', 'idx' => 4],
             ['name' => 'Dragonair', 'type' => 'Dragon', 'idx' => 148],
         ]);
-        $data = $data->mapWithKeys(function ($pokemon) {
+        $data = $data->mapWithKeys(static function ($pokemon) {
             return [$pokemon['name'] => $pokemon['type']];
         });
         $this->assertEquals(
@@ -2320,7 +2320,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 3, 'name' => 'B'],
             ['id' => 2, 'name' => 'C'],
         ]);
-        $data = $data->mapWithKeys(function ($item) {
+        $data = $data->mapWithKeys(static function ($item) {
             return [$item['id'] => $item];
         });
         $this->assertSame(
@@ -2339,7 +2339,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 2, 'name' => 'B'],
             ['id' => 3, 'name' => 'C'],
         ]);
-        $data = $data->mapWithKeys(function ($item) {
+        $data = $data->mapWithKeys(static function ($item) {
             return [$item['id'] => $item['name'], $item['name'] => $item['id']];
         });
         $this->assertSame(
@@ -2365,7 +2365,7 @@ class SupportCollectionTest extends TestCase
             5 => ['id' => 3, 'name' => 'B'],
             4 => ['id' => 2, 'name' => 'C'],
         ]);
-        $data = $data->mapWithKeys(function ($item, $key) {
+        $data = $data->mapWithKeys(static function ($item, $key) {
             return [$key => $item['id']];
         });
         $this->assertSame(
@@ -2419,7 +2419,7 @@ class SupportCollectionTest extends TestCase
             ['id' => 2, 'name' => 'B'],
             ['id' => 1, 'name' => 'C'],
         ]);
-        $data = $data->mapWithKeys(function ($item) {
+        $data = $data->mapWithKeys(static function ($item) {
             return [$item['id'] => $item['name']];
         });
         $this->assertSame(
@@ -2434,7 +2434,7 @@ class SupportCollectionTest extends TestCase
     public function testTransform()
     {
         $data = new Collection(['first' => 'taylor', 'last' => 'otwell']);
-        $data->transform(function ($item, $key) {
+        $data->transform(static function ($item, $key) {
             return $key.'-'.strrev($item);
         });
         $this->assertEquals(['first' => 'first-rolyat', 'last' => 'last-llewto'], $data->all());
@@ -2502,7 +2502,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([['rating' => 1, 'url' => '1'], ['rating' => 1, 'url' => '1'], ['rating' => 2, 'url' => '2']]);
 
-        $result = $data->groupBy(function ($item) {
+        $result = $data->groupBy(static function ($item) {
             return $item['rating'];
         });
 
@@ -2516,7 +2516,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([10 => ['rating' => 1, 'url' => '1'], 20 => ['rating' => 1, 'url' => '1'], 30 => ['rating' => 2, 'url' => '2']]);
 
-        $result = $data->groupBy(function ($item) {
+        $result = $data->groupBy(static function ($item) {
             return $item['rating'];
         }, true);
 
@@ -2539,7 +2539,7 @@ class SupportCollectionTest extends TestCase
             ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy(function ($item) {
+        $result = $data->groupBy(static function ($item) {
             return $item['roles'];
         });
 
@@ -2571,7 +2571,7 @@ class SupportCollectionTest extends TestCase
             30 => ['user' => 3, 'roles' => ['Role_1']],
         ]);
 
-        $result = $data->groupBy(function ($item) {
+        $result = $data->groupBy(static function ($item) {
             return $item['roles'];
         }, true);
 
@@ -2606,7 +2606,7 @@ class SupportCollectionTest extends TestCase
 
         $result = $data->groupBy([
             'skilllevel',
-            function ($item) {
+            static function ($item) {
                 return $item['roles'];
             },
         ], true);
@@ -2647,7 +2647,7 @@ class SupportCollectionTest extends TestCase
         $result = $data->keyBy('rating');
         $this->assertEquals([1 => ['rating' => 1, 'name' => '1'], 2 => ['rating' => 2, 'name' => '2'], 3 => ['rating' => 3, 'name' => '3']], $result->all());
 
-        $result = $data->keyBy(function ($item) {
+        $result = $data->keyBy(static function ($item) {
             return $item['rating'] * 2;
         });
         $this->assertEquals([2 => ['rating' => 1, 'name' => '1'], 4 => ['rating' => 2, 'name' => '2'], 6 => ['rating' => 3, 'name' => '3']], $result->all());
@@ -2662,7 +2662,7 @@ class SupportCollectionTest extends TestCase
             ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
         ]);
-        $result = $data->keyBy(function ($item, $key) {
+        $result = $data->keyBy(static function ($item, $key) {
             return strtolower($key.'-'.$item['firstname'].$item['lastname']);
         });
         $this->assertEquals([
@@ -2680,7 +2680,7 @@ class SupportCollectionTest extends TestCase
             ['firstname' => 'Taylor', 'lastname' => 'Otwell', 'locale' => 'US'],
             ['firstname' => 'Lucas', 'lastname' => 'Michot', 'locale' => 'FR'],
         ]);
-        $result = $data->keyBy(function ($item, $key) use ($collection) {
+        $result = $data->keyBy(static function ($item, $key) use ($collection) {
             return new $collection([$key, $item['firstname'], $item['lastname']]);
         });
         $this->assertEquals([
@@ -2718,10 +2718,10 @@ class SupportCollectionTest extends TestCase
         $this->assertTrue($c->contains(false));
         $this->assertTrue($c->contains(null));
 
-        $this->assertTrue($c->contains(function ($value) {
+        $this->assertTrue($c->contains(static function ($value) {
             return $value < 5;
         }));
-        $this->assertFalse($c->contains(function ($value) {
+        $this->assertFalse($c->contains(static function ($value) {
             return $value > 5;
         }));
 
@@ -2745,7 +2745,7 @@ class SupportCollectionTest extends TestCase
             null, 1, 2,
         ]);
 
-        $this->assertTrue($c->contains(function ($value) {
+        $this->assertTrue($c->contains(static function ($value) {
             return is_null($value);
         }));
     }
@@ -2759,10 +2759,10 @@ class SupportCollectionTest extends TestCase
 
         $this->assertTrue($c->some(1));
         $this->assertFalse($c->some(2));
-        $this->assertTrue($c->some(function ($value) {
+        $this->assertTrue($c->some(static function ($value) {
             return $value < 5;
         }));
-        $this->assertFalse($c->some(function ($value) {
+        $this->assertFalse($c->some(static function ($value) {
             return $value > 5;
         }));
 
@@ -2786,7 +2786,7 @@ class SupportCollectionTest extends TestCase
             null, 1, 2,
         ]);
 
-        $this->assertTrue($c->some(function ($value) {
+        $this->assertTrue($c->some(static function ($value) {
             return is_null($value);
         }));
     }
@@ -2803,10 +2803,10 @@ class SupportCollectionTest extends TestCase
         $this->assertFalse($c->containsStrict(2));
         $this->assertTrue($c->containsStrict('02'));
         $this->assertFalse($c->containsStrict(true));
-        $this->assertTrue($c->containsStrict(function ($value) {
+        $this->assertTrue($c->containsStrict(static function ($value) {
             return $value < 5;
         }));
-        $this->assertFalse($c->containsStrict(function ($value) {
+        $this->assertFalse($c->containsStrict(static function ($value) {
             return $value > 5;
         }));
 
@@ -2861,7 +2861,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(100, $c->sum('foo'));
 
         $c = new $collection([(object) ['foo' => 50], (object) ['foo' => 50]]);
-        $this->assertEquals(100, $c->sum(function ($i) {
+        $this->assertEquals(100, $c->sum(static function ($i) {
             return $i->foo;
         }));
     }
@@ -2927,7 +2927,7 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo'], $c->reject('bar')->values()->all());
 
         $c = new $collection(['foo', 'bar']);
-        $this->assertEquals(['foo'], $c->reject(function ($v) {
+        $this->assertEquals(['foo'], $c->reject(static function ($v) {
             return $v == 'bar';
         })->values()->all());
 
@@ -2938,12 +2938,12 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $c->reject('baz')->values()->all());
 
         $c = new $collection(['foo', 'bar']);
-        $this->assertEquals(['foo', 'bar'], $c->reject(function ($v) {
+        $this->assertEquals(['foo', 'bar'], $c->reject(static function ($v) {
             return $v == 'baz';
         })->values()->all());
 
         $c = new $collection(['id' => 1, 'primary' => 'foo', 'secondary' => 'bar']);
-        $this->assertEquals(['primary' => 'foo', 'secondary' => 'bar'], $c->reject(function ($item, $key) {
+        $this->assertEquals(['primary' => 'foo', 'secondary' => 'bar'], $c->reject(static function ($item, $key) {
             return $key == 'id';
         })->all());
     }
@@ -2981,10 +2981,10 @@ class SupportCollectionTest extends TestCase
         $this->assertEquals(1, $c->search(2));
         $this->assertEquals(1, $c->search('2'));
         $this->assertSame('foo', $c->search('bar'));
-        $this->assertEquals(4, $c->search(function ($value) {
+        $this->assertEquals(4, $c->search(static function ($value) {
             return $value > 4;
         }));
-        $this->assertSame('foo', $c->search(function ($value) {
+        $this->assertSame('foo', $c->search(static function ($value) {
             return ! is_numeric($value);
         }));
     }
@@ -3013,10 +3013,10 @@ class SupportCollectionTest extends TestCase
 
         $this->assertFalse($c->search(6));
         $this->assertFalse($c->search('foo'));
-        $this->assertFalse($c->search(function ($value) {
+        $this->assertFalse($c->search(static function ($value) {
             return $value < 1 && is_numeric($value);
         }));
-        $this->assertFalse($c->search(function ($value) {
+        $this->assertFalse($c->search(static function ($value) {
             return $value == 'nope';
         }));
     }
@@ -3155,7 +3155,7 @@ class SupportCollectionTest extends TestCase
     public function testGettingMaxItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(20, $c->max(function ($item) {
+        $this->assertEquals(20, $c->max(static function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(20, $c->max('foo'));
@@ -3178,7 +3178,7 @@ class SupportCollectionTest extends TestCase
     public function testGettingMinItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(10, $c->min(function ($item) {
+        $this->assertEquals(10, $c->min(static function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(10, $c->min('foo'));
@@ -3228,14 +3228,14 @@ class SupportCollectionTest extends TestCase
     public function testGettingAvgItemsFromCollection($collection)
     {
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20]]);
-        $this->assertEquals(15, $c->avg(function ($item) {
+        $this->assertEquals(15, $c->avg(static function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(15, $c->avg('foo'));
         $this->assertEquals(15, $c->avg->foo);
 
         $c = new $collection([(object) ['foo' => 10], (object) ['foo' => 20], (object) ['foo' => null]]);
-        $this->assertEquals(15, $c->avg(function ($item) {
+        $this->assertEquals(15, $c->avg(static function ($item) {
             return $item->foo;
         }));
         $this->assertEquals(15, $c->avg('foo'));
@@ -3371,7 +3371,7 @@ class SupportCollectionTest extends TestCase
     public function testReduce($collection)
     {
         $data = new $collection([1, 2, 3]);
-        $this->assertEquals(6, $data->reduce(function ($carry, $element) {
+        $this->assertEquals(6, $data->reduce(static function ($carry, $element) {
             return $carry += $element;
         }));
     }
@@ -3394,7 +3394,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection([1, 2, 3]);
 
-        $this->assertEquals(6, $data->pipe(function ($data) {
+        $this->assertEquals(6, $data->pipe(static function ($data) {
             return $data->sum();
         }));
     }
@@ -3593,7 +3593,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd']],
-            $data->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
@@ -3602,7 +3602,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
-            $data->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
@@ -3617,7 +3617,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a', 'b'], ['c']],
-            $data->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
@@ -3632,7 +3632,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a']],
-            $data->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
@@ -3647,7 +3647,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a', 'b'], ['c'], ['d']],
-            $data->split(3)->map(function (Collection $chunk) {
+            $data->split(3)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
@@ -3662,7 +3662,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd'], ['e']],
-            $data->split(3)->map(function (Collection $chunk) {
+            $data->split(3)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
@@ -3677,7 +3677,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i'], ['j']],
-            $data->split(6)->map(function (Collection $chunk) {
+            $data->split(6)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
             );
@@ -3692,7 +3692,7 @@ class SupportCollectionTest extends TestCase
 
         $this->assertEquals(
             [],
-            $data->split(2)->map(function (Collection $chunk) {
+            $data->split(2)->map(static function (Collection $chunk) {
                 return $chunk->values()->toArray();
             })->toArray()
         );
@@ -3762,7 +3762,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(range(1, 10));
 
-        [$firstPartition, $secondPartition] = $data->partition(function ($i) {
+        [$firstPartition, $secondPartition] = $data->partition(static function ($i) {
             return $i <= 5;
         })->all();
 
@@ -3777,7 +3777,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['zero', 'one', 'two', 'three']);
 
-        [$even, $odd] = $data->partition(function ($item, $index) {
+        [$even, $odd] = $data->partition(static function ($item, $index) {
             return $index % 2 === 0;
         })->all();
 
@@ -3859,7 +3859,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection;
 
-        $this->assertCount(2, $data->partition(function () {
+        $this->assertCount(2, $data->partition(static function () {
             return true;
         }));
     }
@@ -3888,7 +3888,7 @@ class SupportCollectionTest extends TestCase
         $data = new $collection([1, 2, 3]);
 
         $fromTap = [];
-        $data = $data->tap(function ($data) use (&$fromTap) {
+        $data = $data->tap(static function ($data) use (&$fromTap) {
             $fromTap = $data->slice(0, 1)->toArray();
         });
 
@@ -3903,7 +3903,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when('adam', function ($data, $newName) {
+        $data = $data->when('adam', static function ($data, $newName) {
             return $data->concat([$newName]);
         });
 
@@ -3911,7 +3911,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(false, function ($data) {
+        $data = $data->when(false, static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -3925,9 +3925,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->when(false, function ($data) {
+        $data = $data->when(false, static function ($data) {
             return $data->concat(['adam']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 
@@ -3941,7 +3941,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($collection) {
+        $data = $data->whenEmpty(static function ($collection) {
             return $data->concat(['adam']);
         });
 
@@ -3949,7 +3949,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection;
 
-        $data = $data->whenEmpty(function ($data) {
+        $data = $data->whenEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -3963,9 +3963,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenEmpty(function ($data) {
+        $data = $data->whenEmpty(static function ($data) {
             return $data->concat(['adam']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 
@@ -3979,7 +3979,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenNotEmpty(function ($data) {
+        $data = $data->whenNotEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -3987,7 +3987,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection;
 
-        $data = $data->whenNotEmpty(function ($data) {
+        $data = $data->whenNotEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4001,9 +4001,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->whenNotEmpty(function ($data) {
+        $data = $data->whenNotEmpty(static function ($data) {
             return $data->concat(['adam']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 
@@ -4017,7 +4017,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unless(false, function ($data) {
+        $data = $data->unless(false, static function ($data) {
             return $data->concat(['caleb']);
         });
 
@@ -4025,7 +4025,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unless(true, function ($data) {
+        $data = $data->unless(true, static function ($data) {
             return $data->concat(['caleb']);
         });
 
@@ -4039,9 +4039,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unless(true, function ($data) {
+        $data = $data->unless(true, static function ($data) {
             return $data->concat(['caleb']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 
@@ -4055,7 +4055,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unlessEmpty(function ($data) {
+        $data = $data->unlessEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4063,7 +4063,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection;
 
-        $data = $data->unlessEmpty(function ($data) {
+        $data = $data->unlessEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4077,9 +4077,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unlessEmpty(function ($data) {
+        $data = $data->unlessEmpty(static function ($data) {
             return $data->concat(['adam']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 
@@ -4093,7 +4093,7 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unlessNotEmpty(function ($data) {
+        $data = $data->unlessNotEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4101,7 +4101,7 @@ class SupportCollectionTest extends TestCase
 
         $data = new $collection;
 
-        $data = $data->unlessNotEmpty(function ($data) {
+        $data = $data->unlessNotEmpty(static function ($data) {
             return $data->concat(['adam']);
         });
 
@@ -4115,9 +4115,9 @@ class SupportCollectionTest extends TestCase
     {
         $data = new $collection(['michael', 'tom']);
 
-        $data = $data->unlessNotEmpty(function ($data) {
+        $data = $data->unlessNotEmpty(static function ($data) {
             return $data->concat(['adam']);
-        }, function ($data) {
+        }, static function ($data) {
             return $data->concat(['taylor']);
         });
 

--- a/tests/Support/SupportFacadesEventTest.php
+++ b/tests/Support/SupportFacadesEventTest.php
@@ -44,7 +44,7 @@ class SupportFacadesEventTest extends TestCase
 
     public function testFakeFor()
     {
-        Event::fakeFor(function () {
+        Event::fakeFor(static function () {
             (new FakeForStub)->dispatch();
 
             Event::assertDispatched(EventStub::class);

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -36,7 +36,7 @@ class SupportHelpersTest extends TestCase
     public function testValue()
     {
         $this->assertSame('foo', value('foo'));
-        $this->assertSame('foo', value(function () {
+        $this->assertSame('foo', value(static function () {
             return 'foo';
         }));
     }
@@ -61,7 +61,7 @@ class SupportHelpersTest extends TestCase
         $this->assertSame('Taylor', data_get($array, '0.users.0.name'));
         $this->assertNull(data_get($array, '0.users.3'));
         $this->assertSame('Not found', data_get($array, '0.users.3', 'Not found'));
-        $this->assertSame('Not found', data_get($array, '0.users.3', function () {
+        $this->assertSame('Not found', data_get($array, '0.users.3', static function () {
             return 'Not found';
         }));
         $this->assertSame('Taylor', data_get($dottedArray, ['users', 'first.name']));
@@ -352,7 +352,7 @@ class SupportHelpersTest extends TestCase
     public function testTap()
     {
         $object = (object) ['id' => 1];
-        $this->assertEquals(2, tap($object, function ($object) {
+        $this->assertEquals(2, tap($object, static function ($object) {
             $object->id = 2;
         })->id);
 
@@ -395,13 +395,13 @@ class SupportHelpersTest extends TestCase
 
     public function testOptionalWithCallback()
     {
-        $this->assertNull(optional(null, function () {
+        $this->assertNull(optional(null, static function () {
             throw new RuntimeException(
                 'The optional callback should not be called for null'
             );
         }));
 
-        $this->assertEquals(10, optional(5, function ($number) {
+        $this->assertEquals(10, optional(5, static function ($number) {
             return $number * 2;
         }));
     }
@@ -480,7 +480,7 @@ class SupportHelpersTest extends TestCase
     {
         $startTime = microtime(true);
 
-        $attempts = retry(2, function ($attempts) {
+        $attempts = retry(2, static function ($attempts) {
             if ($attempts > 1) {
                 return $attempts;
             }
@@ -499,13 +499,13 @@ class SupportHelpersTest extends TestCase
     {
         $startTime = microtime(true);
 
-        $attempts = retry(2, function ($attempts) {
+        $attempts = retry(2, static function ($attempts) {
             if ($attempts > 1) {
                 return $attempts;
             }
 
             throw new RuntimeException;
-        }, 100, function ($ex) {
+        }, 100, static function ($ex) {
             return true;
         });
 
@@ -520,37 +520,37 @@ class SupportHelpersTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        retry(2, function ($attempts) {
+        retry(2, static function ($attempts) {
             if ($attempts > 1) {
                 return $attempts;
             }
 
             throw new RuntimeException;
-        }, 100, function ($ex) {
+        }, 100, static function ($ex) {
             return false;
         });
     }
 
     public function testTransform()
     {
-        $this->assertEquals(10, transform(5, function ($value) {
+        $this->assertEquals(10, transform(5, static function ($value) {
             return $value * 2;
         }));
 
-        $this->assertNull(transform(null, function () {
+        $this->assertNull(transform(null, static function () {
             return 10;
         }));
     }
 
     public function testTransformDefaultWhenBlank()
     {
-        $this->assertSame('baz', transform(null, function () {
+        $this->assertSame('baz', transform(null, static function () {
             return 'bar';
         }, 'baz'));
 
-        $this->assertSame('baz', transform('', function () {
+        $this->assertSame('baz', transform('', static function () {
             return 'bar';
-        }, function () {
+        }, static function () {
             return 'baz';
         }));
     }
@@ -559,7 +559,7 @@ class SupportHelpersTest extends TestCase
     {
         $this->assertEquals(10, with(10));
 
-        $this->assertEquals(10, with(5, function ($five) {
+        $this->assertEquals(10, with(5, static function ($five) {
             return $five + 5;
         }));
     }

--- a/tests/Support/SupportLazyCollectionIsLazyTest.php
+++ b/tests/Support/SupportLazyCollectionIsLazyTest.php
@@ -10,7 +10,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 {
     public function testEagerEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection = $collection->eager();
 
             $collection->count();
@@ -20,11 +20,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testChunkIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->chunk(3);
         });
 
-        $this->assertEnumerates(15, function ($collection) {
+        $this->assertEnumerates(15, static function ($collection) {
             $collection->chunk(5)->take(3)->all();
         });
     }
@@ -37,11 +37,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
             [7, 8, 9],
         ]);
 
-        $this->assertDoesNotEnumerateCollection($collection, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($collection, static function ($collection) {
             $collection->collapse();
         });
 
-        $this->assertEnumeratesCollection($collection, 1, function ($collection) {
+        $this->assertEnumeratesCollection($collection, 1, static function ($collection) {
             $collection->collapse()->take(3)->all();
         });
     }
@@ -92,34 +92,34 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testContainsIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection->contains(5);
         });
     }
 
     public function testContainsStrictIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection->containsStrict(5);
         });
     }
 
     public function testCountEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->count();
         });
     }
 
     public function testCountByIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->countBy();
         });
 
         $this->assertEnumeratesCollectionOnce(
             $this->make([1, 2, 2, 3]),
-            function ($collection) {
+            static function ($collection) {
                 $collection->countBy()->all();
             }
         );
@@ -127,120 +127,120 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testCrossJoinIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->crossJoin([1]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->crossJoin([1], [2])->all();
         });
     }
 
     public function testDiffIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diff([1, 2]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diff([1, 2])->all();
         });
     }
 
     public function testDiffAssocIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diffAssoc([1, 2]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diffAssoc([1, 2])->all();
         });
     }
 
     public function testDiffAssocUsingIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diffAssocUsing([1, 2], 'strcasecmp');
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diffAssocUsing([1, 2], 'strcasecmp')->all();
         });
     }
 
     public function testDiffKeysIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diffKeys([1, 2]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diffKeys([1, 2])->all();
         });
     }
 
     public function testDiffKeysUsingIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diffKeysUsing([1, 2], 'strcasecmp');
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diffKeysUsing([1, 2], 'strcasecmp')->all();
         });
     }
 
     public function testDiffUsingIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->diffUsing([1, 2], 'strcasecmp');
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->diffUsing([1, 2], 'strcasecmp')->all();
         });
     }
 
     public function testDuplicatesIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->duplicates();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->duplicates()->all();
         });
     }
 
     public function testDuplicatesStrictIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->duplicatesStrict();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->duplicatesStrict()->all();
         });
     }
 
     public function testEachIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
-            $collection->each(function ($value, $key) {
+        $this->assertEnumerates(5, static function ($collection) {
+            $collection->each(static function ($value, $key) {
                 if ($value == 5) {
                     return false;
                 }
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->each(function ($value, $key) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->each(static function ($value, $key) {
                 // Silence is golden!
             });
         });
 
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             foreach ($collection as $key => $value) {
                 if ($value == 5) {
                     return false;
@@ -248,7 +248,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
             }
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             foreach ($collection as $key => $value) {
                 // Silence is golden!
             }
@@ -259,16 +259,16 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([[1, 2], [3, 4], [5, 6], [7, 8]]);
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
-            $collection->eachSpread(function ($first, $second, $key) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
+            $collection->eachSpread(static function ($first, $second, $key) {
                 if ($first == 3) {
                     return false;
                 }
             });
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
-            $collection->eachSpread(function ($first, $second, $key) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
+            $collection->eachSpread(static function ($first, $second, $key) {
                 // Silence is golden!
             });
         });
@@ -276,40 +276,40 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testEveryIsLazy()
     {
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->every(function ($value) {
+        $this->assertEnumerates(2, static function ($collection) {
+            $collection->every(static function ($value) {
                 return $value == 1;
             });
         });
 
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3]]);
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->every('a', 1);
         });
     }
 
     public function testExceptIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->except([1, 2]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->except([1, 2])->all();
         });
     }
 
     public function testFilterIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->filter(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->filter(static function ($value) {
                 return $value > 5;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->filter(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->filter(static function ($value) {
                 return $value > 5;
             })->all();
         });
@@ -317,12 +317,12 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testFirstIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
             $collection->first();
         });
 
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->first(function ($value) {
+        $this->assertEnumerates(2, static function ($collection) {
+            $collection->first(static function ($value) {
                 return $value == 2;
             });
         });
@@ -332,7 +332,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3]]);
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->firstWhere('a', 2);
         });
     }
@@ -341,14 +341,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([1, 2, 3, 4, 5]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
-            $collection->flatMap(function ($values) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
+            $collection->flatMap(static function ($values) {
                 return array_sum($values);
             });
         });
 
-        $this->assertEnumeratesCollection($data, 3, function ($collection) {
-            $collection->flatMap(function ($value) {
+        $this->assertEnumeratesCollection($data, 3, static function ($collection) {
+            $collection->flatMap(static function ($value) {
                 return range(1, $value);
             })->take(5)->all();
         });
@@ -358,54 +358,54 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([1, [2, 3], [4, 5], [6, 7]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->flatten();
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->flatten()->take(3)->all();
         });
     }
 
     public function testFlipIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->flip();
         });
 
-        $this->assertEnumerates(2, function ($collection) {
+        $this->assertEnumerates(2, static function ($collection) {
             $collection->flip()->take(2)->all();
         });
     }
 
     public function testForPageIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->forPage(2, 10);
         });
 
-        $this->assertEnumerates(20, function ($collection) {
+        $this->assertEnumerates(20, static function ($collection) {
             $collection->forPage(2, 10)->all();
         });
     }
 
     public function testGetIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection->get(4);
         });
     }
 
     public function testGroupByIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->groupBy(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->groupBy(static function ($value) {
                 return $value % 5;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->groupBy(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->groupBy(static function ($value) {
                 return $value % 5;
             })->all();
         });
@@ -413,78 +413,78 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testHasIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection->has(4);
         });
     }
 
     public function testImplodeEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->implode(', ');
         });
     }
 
     public function testIntersectIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->intersect([1, 2, 3]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->intersect([1, 2, 3])->all();
         });
     }
 
     public function testIntersectByKeysIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->intersectByKeys([1, 2, 3]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->intersectByKeys([1, 2, 3])->all();
         });
     }
 
     public function testIsEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
             $collection->isEmpty();
         });
     }
 
     public function testIsNotEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
             $collection->isNotEmpty();
         });
     }
 
     public function testJoinIsLazy()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->join(', ', ' and ');
         });
     }
 
     public function testJsonSerializeEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->jsonSerialize();
         });
     }
 
     public function testKeyByIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->keyBy(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->keyBy(static function ($value) {
                 return "key-of-{$value}";
             });
         });
 
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->keyBy(function ($value) {
+        $this->assertEnumerates(2, static function ($collection) {
+            $collection->keyBy(static function ($value) {
                 return "key-of-{$value}";
             })->take(2)->all();
         });
@@ -492,32 +492,32 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testKeysIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->keys();
         });
 
-        $this->assertEnumerates(2, function ($collection) {
+        $this->assertEnumerates(2, static function ($collection) {
             $collection->keys()->take(2)->all();
         });
     }
 
     public function testLastEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->last();
         });
     }
 
     public function testMapIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->map(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->map(static function ($value) {
                 return $value + 1;
             });
         });
 
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->map(function ($value) {
+        $this->assertEnumerates(2, static function ($collection) {
+            $collection->map(static function ($value) {
                 return $value + 1;
             })->take(2)->all();
         });
@@ -525,11 +525,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testMapIntoIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->mapInto(stdClass::class);
         });
 
-        $this->assertEnumerates(2, function ($collection) {
+        $this->assertEnumerates(2, static function ($collection) {
             $collection->mapInto(stdClass::class)->take(2)->all();
         });
     }
@@ -538,14 +538,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([[1, 2], [3, 4], [5, 6], [7, 8]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
-            $collection->mapSpread(function ($first, $second, $key) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
+            $collection->mapSpread(static function ($first, $second, $key) {
                 return $first + $second + $key;
             });
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
-            $collection->mapSpread(function ($first, $second, $key) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
+            $collection->mapSpread(static function ($first, $second, $key) {
                 return $first + $second + $key;
             })->take(2)->all();
         });
@@ -553,14 +553,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testMapToDictionaryIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->mapToDictionary(function ($value, $key) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->mapToDictionary(static function ($value, $key) {
                 return [$value => $key];
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->mapToDictionary(function ($value, $key) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->mapToDictionary(static function ($value, $key) {
                 return [$value => $key];
             })->all();
         });
@@ -568,14 +568,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testMapToGroupsIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->mapToGroups(function ($value, $key) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->mapToGroups(static function ($value, $key) {
                 return [$value => $key];
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->mapToGroups(function ($value, $key) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->mapToGroups(static function ($value, $key) {
                 return [$value => $key];
             })->all();
         });
@@ -583,14 +583,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testMapWithKeysIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->mapWithKeys(function ($value, $key) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->mapWithKeys(static function ($value, $key) {
                 return [$value => $key];
             });
         });
 
-        $this->assertEnumerates(2, function ($collection) {
-            $collection->mapWithKeys(function ($value, $key) {
+        $this->assertEnumerates(2, static function ($collection) {
+            $collection->mapWithKeys(static function ($value, $key) {
                 return [$value => $key];
             })->take(2)->all();
         });
@@ -598,96 +598,96 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testMaxEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->max();
         });
     }
 
     public function testMedianEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->median();
         });
     }
 
     public function testMergeIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->merge([1, 2, 3]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->merge([1, 2, 3])->all();
         });
     }
 
     public function testMergeRecursiveIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->mergeRecursive([1, 2, 3]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->mergeRecursive([1, 2, 3])->all();
         });
     }
 
     public function testMinEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->min();
         });
     }
 
     public function testModeEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->mode();
         });
     }
 
     public function testNthIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->nth(5);
         });
 
-        $this->assertEnumerates(11, function ($collection) {
+        $this->assertEnumerates(11, static function ($collection) {
             $collection->nth(5)->take(3)->all();
         });
     }
 
     public function testOnlyIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->only(5, 6, 7);
         });
 
-        $this->assertEnumerates(8, function ($collection) {
+        $this->assertEnumerates(8, static function ($collection) {
             $collection->only(5, 6, 7)->all();
         });
     }
 
     public function testPadIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->pad(200, null);
             $collection->pad(-200, null);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->pad(20, null)->all();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->pad(-20, null)->all();
         });
     }
 
     public function testPartitionEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->partition(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->partition(static function ($value) {
                 return $value > 10;
             });
         });
@@ -695,8 +695,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testPipeDoesNotEnumerate()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->pipe(function () {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->pipe(static function () {
                 // Silence is golden!
             });
         });
@@ -706,22 +706,22 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->pluck('a');
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
             $collection->pluck('a')->all();
         });
     }
 
     public function testRandomEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->random();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->random(5);
         });
     }
@@ -730,19 +730,19 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = LazyCollection::range(10, 1000);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->take(50);
         });
 
-        $this->assertEnumeratesCollection($data, 5, function ($collection) {
+        $this->assertEnumeratesCollection($data, 5, static function ($collection) {
             $collection->take(5)->all();
         });
     }
 
     public function testReduceEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->reduce(function ($total, $value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->reduce(static function ($total, $value) {
                 return $total + $value;
             }, 0);
         });
@@ -750,14 +750,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testRejectIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->reject(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->reject(static function ($value) {
                 return $value % 2;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->reject(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->reject(static function ($value) {
                 return $value % 2;
             })->all();
         });
@@ -765,18 +765,18 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testRememberIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->remember();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection = $collection->remember();
 
             $collection->all();
             $collection->all();
         });
 
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection = $collection->remember();
 
             $collection->take(5)->all();
@@ -786,82 +786,82 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testReplaceIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->replace([5 => 'a', 10 => 'b']);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->replace([5 => 'a', 10 => 'b'])->all();
         });
     }
 
     public function testReplaceRecursiveIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->replaceRecursive([5 => 'a', 10 => 'b']);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->replaceRecursive([5 => 'a', 10 => 'b'])->all();
         });
     }
 
     public function testReverseIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->reverse();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->reverse()->all();
         });
     }
 
     public function testSearchIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
+        $this->assertEnumerates(5, static function ($collection) {
             $collection->search(5);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->search('missing');
         });
     }
 
     public function testShuffleIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->shuffle();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->shuffle()->all();
         });
     }
 
     public function testSkipIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->skip(10);
         });
 
-        $this->assertEnumerates(12, function ($collection) {
+        $this->assertEnumerates(12, static function ($collection) {
             $collection->skip(10)->take(2)->all();
         });
     }
 
     public function testSkipUntilIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->skipUntil(INF);
         });
 
-        $this->assertEnumerates(10, function ($collection) {
+        $this->assertEnumerates(10, static function ($collection) {
             $collection->skipUntil(10)->first();
         });
 
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->skipUntil(function ($item) {
+        $this->assertEnumerates(10, static function ($collection) {
+            $collection->skipUntil(static function ($item) {
                 return $item === 10;
             })->first();
         });
@@ -869,16 +869,16 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testSkipWhileIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->skipWhile(1);
         });
 
-        $this->assertEnumerates(2, function ($collection) {
+        $this->assertEnumerates(2, static function ($collection) {
             $collection->skipWhile(1)->first();
         });
 
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->skipWhile(function ($item) {
+        $this->assertEnumerates(10, static function ($collection) {
+            $collection->skipWhile(static function ($item) {
                 return $item < 10;
             })->first();
         });
@@ -886,35 +886,35 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testSliceIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->slice(2);
             $collection->slice(2, 2);
             $collection->slice(-2, 2);
         });
 
-        $this->assertEnumerates(4, function ($collection) {
+        $this->assertEnumerates(4, static function ($collection) {
             $collection->slice(2)->take(2)->all();
         });
 
-        $this->assertEnumerates(4, function ($collection) {
+        $this->assertEnumerates(4, static function ($collection) {
             $collection->slice(2, 2)->all();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->slice(-2, 2)->all();
         });
     }
 
     public function testSomeIsLazy()
     {
-        $this->assertEnumerates(5, function ($collection) {
-            $collection->some(function ($value) {
+        $this->assertEnumerates(5, static function ($collection) {
+            $collection->some(static function ($value) {
                 return $value == 5;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->some(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->some(static function ($value) {
                 return false;
             });
         });
@@ -922,36 +922,36 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testSortIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->sort();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->sort()->all();
         });
     }
 
     public function testSortDescIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->sortDesc();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->sortDesc()->all();
         });
     }
 
     public function testSortByIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->sortBy(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->sortBy(static function ($value) {
                 return $value;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->sortBy(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->sortBy(static function ($value) {
                 return $value;
             })->all();
         });
@@ -959,14 +959,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testSortByDescIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->sortByDesc(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->sortByDesc(static function ($value) {
                 return $value;
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->sortByDesc(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->sortByDesc(static function ($value) {
                 return $value;
             })->all();
         });
@@ -974,67 +974,67 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testSortKeysIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->sortKeys();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->sortKeys()->all();
         });
     }
 
     public function testSortKeysDescIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->sortKeysDesc();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->sortKeysDesc()->all();
         });
     }
 
     public function testSplitIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->split(4);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->split(4)->all();
         });
     }
 
     public function testSumEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->sum();
         });
     }
 
     public function testTakeIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->take(10);
         });
 
-        $this->assertEnumerates(10, function ($collection) {
+        $this->assertEnumerates(10, static function ($collection) {
             $collection->take(10)->all();
         });
     }
 
     public function testTakeUntilIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->takeUntil(INF);
         });
 
-        $this->assertEnumerates(10, function ($collection) {
+        $this->assertEnumerates(10, static function ($collection) {
             $collection->takeUntil(10)->all();
         });
 
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->takeUntil(function ($item) {
+        $this->assertEnumerates(10, static function ($collection) {
+            $collection->takeUntil(static function ($item) {
                 return $item === 10;
             })->all();
         });
@@ -1042,16 +1042,16 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testTakeWhileIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->takeWhile(0);
         });
 
-        $this->assertEnumerates(1, function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
             $collection->takeWhile(0)->all();
         });
 
-        $this->assertEnumerates(10, function ($collection) {
-            $collection->takeWhile(function ($item) {
+        $this->assertEnumerates(10, static function ($collection) {
+            $collection->takeWhile(static function ($item) {
                 return $item < 10;
             })->all();
         });
@@ -1059,8 +1059,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testTapDoesNotEnumerate()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->tap(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->tap(static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1068,14 +1068,14 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testTapEachIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->tapEach(function ($value) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->tapEach(static function ($value) {
                 // Silence is golden!
             });
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
-            $collection->tapEach(function ($value) {
+        $this->assertEnumeratesOnce(static function ($collection) {
+            $collection->tapEach(static function ($value) {
                 // Silence is golden!
             })->all();
         });
@@ -1085,66 +1085,66 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = LazyCollection::times(INF);
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->take(2)->all();
         });
     }
 
     public function testToArrayEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->toArray();
         });
     }
 
     public function testToJsonEnumeratesOnce()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->toJson();
         });
     }
 
     public function testUnionIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->union([4, 5, 6]);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->union([4, 5, 6])->all();
         });
     }
 
     public function testUniqueIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->unique();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->unique()->all();
         });
     }
 
     public function testUniqueStrictIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->uniqueStrict();
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             $collection->uniqueStrict()->all();
         });
     }
 
     public function testUnlessDoesNotEnumerate()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->unless(true, function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->unless(true, static function ($collection) {
                 // Silence is golden!
             });
 
-            $collection->unless(false, function ($collection) {
+            $collection->unless(false, static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1152,8 +1152,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testUnlessEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
-            $collection->unlessEmpty(function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
+            $collection->unlessEmpty(static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1161,8 +1161,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testUnlessNotEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
-            $collection->unlessNotEmpty(function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
+            $collection->unlessNotEmpty(static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1170,30 +1170,30 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testUnwrapEnumeratesOne()
     {
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             LazyCollection::unwrap($collection);
         });
     }
 
     public function testValuesIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             $collection->values();
         });
 
-        $this->assertEnumerates(2, function ($collection) {
+        $this->assertEnumerates(2, static function ($collection) {
             $collection->values()->take(2)->all();
         });
     }
 
     public function testWhenDoesNotEnumerate()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
-            $collection->when(true, function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
+            $collection->when(true, static function ($collection) {
                 // Silence is golden!
             });
 
-            $collection->when(false, function ($collection) {
+            $collection->when(false, static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1201,8 +1201,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testWhenEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
-            $collection->whenEmpty(function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
+            $collection->whenEmpty(static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1210,8 +1210,8 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     public function testWhenNotEmptyIsLazy()
     {
-        $this->assertEnumerates(1, function ($collection) {
-            $collection->whenNotEmpty(function ($collection) {
+        $this->assertEnumerates(1, static function ($collection) {
+            $collection->whenNotEmpty(static function ($collection) {
                 // Silence is golden!
             });
         });
@@ -1221,11 +1221,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->where('a', '<', 3);
         });
 
-        $this->assertEnumeratesCollection($data, 1, function ($collection) {
+        $this->assertEnumeratesCollection($data, 1, static function ($collection) {
             $collection->where('a', '<', 3)->take(1)->all();
         });
     }
@@ -1234,11 +1234,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereBetween('a', [2, 4]);
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->whereBetween('a', [2, 4])->take(1)->all();
         });
     }
@@ -1247,11 +1247,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereIn('a', [2, 3]);
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->whereIn('a', [2, 3])->take(1)->all();
         });
     }
@@ -1263,11 +1263,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
                  ->mapInto(stdClass::class)
          );
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereInstanceOf(stdClass::class);
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->whereInstanceOf(stdClass::class)->take(1)->all();
         });
     }
@@ -1276,11 +1276,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereInStrict('a', ['2', 3]);
         });
 
-        $this->assertEnumeratesCollection($data, 3, function ($collection) {
+        $this->assertEnumeratesCollection($data, 3, static function ($collection) {
             $collection->whereInStrict('a', ['2', 3])->take(1)->all();
         });
     }
@@ -1289,11 +1289,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNotBetween('a', [1, 2]);
         });
 
-        $this->assertEnumeratesCollection($data, 3, function ($collection) {
+        $this->assertEnumeratesCollection($data, 3, static function ($collection) {
             $collection->whereNotBetween('a', [1, 2])->take(1)->all();
         });
     }
@@ -1302,11 +1302,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNotIn('a', [1, 2]);
         });
 
-        $this->assertEnumeratesCollection($data, 3, function ($collection) {
+        $this->assertEnumeratesCollection($data, 3, static function ($collection) {
             $collection->whereNotIn('a', [1, 2])->take(1)->all();
         });
     }
@@ -1315,11 +1315,11 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNotInStrict('a', ['1', 2]);
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->whereNotInStrict('a', [1, '2'])->take(1)->all();
         });
     }
@@ -1328,21 +1328,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => null], ['a' => 2], ['a' => 3]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNotNull('a');
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
             $collection->whereNotNull('a')->all();
         });
 
         $data = $this->make([1, null, 2, null, 3]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNotNull();
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
             $collection->whereNotNull()->all();
         });
     }
@@ -1351,21 +1351,21 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => null], ['a' => 2], ['a' => 3]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNull('a');
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
             $collection->whereNull('a')->all();
         });
 
         $data = $this->make([1, null, 2, null, 3]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereNull();
         });
 
-        $this->assertEnumeratesCollectionOnce($data, function ($collection) {
+        $this->assertEnumeratesCollectionOnce($data, static function ($collection) {
             $collection->whereNull()->all();
         });
     }
@@ -1374,22 +1374,22 @@ class SupportLazyCollectionIsLazyTest extends TestCase
     {
         $data = $this->make([['a' => 1], ['a' => 2], ['a' => 3], ['a' => 4]]);
 
-        $this->assertDoesNotEnumerateCollection($data, function ($collection) {
+        $this->assertDoesNotEnumerateCollection($data, static function ($collection) {
             $collection->whereStrict('a', 2);
         });
 
-        $this->assertEnumeratesCollection($data, 2, function ($collection) {
+        $this->assertEnumeratesCollection($data, 2, static function ($collection) {
             $collection->whereStrict('a', 2)->take(1)->all();
         });
     }
 
     public function testWrapIsLazy()
     {
-        $this->assertDoesNotEnumerate(function ($collection) {
+        $this->assertDoesNotEnumerate(static function ($collection) {
             LazyCollection::wrap($collection);
         });
 
-        $this->assertEnumeratesOnce(function ($collection) {
+        $this->assertEnumeratesOnce(static function ($collection) {
             LazyCollection::wrap($collection)->all();
         });
     }
@@ -1485,7 +1485,7 @@ class SupportLazyCollectionIsLazyTest extends TestCase
 
     protected function countEnumerations(LazyCollection $collection, &$count)
     {
-        return $collection->tapEach(function () use (&$count) {
+        return $collection->tapEach(static function () use (&$count) {
             $count++;
         });
     }

--- a/tests/Support/SupportLazyCollectionTest.php
+++ b/tests/Support/SupportLazyCollectionTest.php
@@ -46,7 +46,7 @@ class SupportLazyCollectionTest extends TestCase
 
     public function testCanCreateCollectionFromClosure()
     {
-        $data = LazyCollection::make(function () {
+        $data = LazyCollection::make(static function () {
             yield 1;
             yield 2;
             yield 3;
@@ -54,7 +54,7 @@ class SupportLazyCollectionTest extends TestCase
 
         $this->assertSame([1, 2, 3], $data->all());
 
-        $data = LazyCollection::make(function () {
+        $data = LazyCollection::make(static function () {
             yield 'a' => 1;
             yield 'b' => 2;
             yield 'c' => 3;
@@ -71,7 +71,7 @@ class SupportLazyCollectionTest extends TestCase
     {
         $source = [1, 2, 3, 4, 5];
 
-        $data = LazyCollection::make(function () use (&$source) {
+        $data = LazyCollection::make(static function () use (&$source) {
             yield from $source;
         })->eager();
 
@@ -84,7 +84,7 @@ class SupportLazyCollectionTest extends TestCase
     {
         $source = [1, 2, 3, 4];
 
-        $collection = LazyCollection::make(function () use (&$source) {
+        $collection = LazyCollection::make(static function () use (&$source) {
             yield from $source;
         })->remember();
 
@@ -99,7 +99,7 @@ class SupportLazyCollectionTest extends TestCase
     {
         $source = [1, 2, 3, 4];
 
-        $collection = LazyCollection::make(function () use (&$source) {
+        $collection = LazyCollection::make(static function () use (&$source) {
             yield from $source;
         })->remember();
 
@@ -142,12 +142,12 @@ class SupportLazyCollectionTest extends TestCase
 
     public function testRememberWithDuplicateKeys()
     {
-        $collection = LazyCollection::make(function () {
+        $collection = LazyCollection::make(static function () {
             yield 'key' => 1;
             yield 'key' => 2;
         })->remember();
 
-        $results = $collection->map(function ($value, $key) {
+        $results = $collection->map(static function ($value, $key) {
             return [$key, $value];
         })->values()->all();
 
@@ -160,7 +160,7 @@ class SupportLazyCollectionTest extends TestCase
 
         $tapped = [];
 
-        $data = $data->tapEach(function ($value, $key) use (&$tapped) {
+        $data = $data->tapEach(static function ($value, $key) use (&$tapped) {
             $tapped[$key] = $value;
         });
 

--- a/tests/Support/SupportMacroableTest.php
+++ b/tests/Support/SupportMacroableTest.php
@@ -22,7 +22,7 @@ class SupportMacroableTest extends TestCase
     public function testRegisterMacro()
     {
         $macroable = $this->macroable;
-        $macroable::macro(__CLASS__, function () {
+        $macroable::macro(__CLASS__, static function () {
             return 'Taylor';
         });
         $this->assertSame('Taylor', $macroable::{__CLASS__}());
@@ -42,7 +42,7 @@ class SupportMacroableTest extends TestCase
         TestMacroable::macro('tryInstance', function () {
             return $this->protectedVariable;
         });
-        TestMacroable::macro('tryStatic', function () {
+        TestMacroable::macro('tryStatic', static function () {
             return static::getProtectedStatic();
         });
         $instance = new TestMacroable;

--- a/tests/Support/SupportReflectsClosuresTest.php
+++ b/tests/Support/SupportReflectsClosuresTest.php
@@ -10,36 +10,36 @@ class SupportReflectsClosuresTest extends TestCase
 {
     public function testReflectsClosures()
     {
-        $this->assertParameterTypes([ExampleParameter::class], function (ExampleParameter $one) {
+        $this->assertParameterTypes([ExampleParameter::class], static function (ExampleParameter $one) {
             // assert the Closure isn't actually executed
             throw new RuntimeException();
         });
 
-        $this->assertParameterTypes([], function () {
+        $this->assertParameterTypes([], static function () {
             //
         });
 
-        $this->assertParameterTypes([null], function ($one) {
+        $this->assertParameterTypes([null], static function ($one) {
             //
         });
 
-        $this->assertParameterTypes([null, ExampleParameter::class], function ($one, ExampleParameter $two = null) {
+        $this->assertParameterTypes([null, ExampleParameter::class], static function ($one, ExampleParameter $two = null) {
             //
         });
 
-        $this->assertParameterTypes([null, ExampleParameter::class], function (string $one, ?ExampleParameter $two) {
+        $this->assertParameterTypes([null, ExampleParameter::class], static function (string $one, ?ExampleParameter $two) {
             //
         });
 
         // Because the parameter is variadic, the closure will always receive an array.
-        $this->assertParameterTypes([null], function (ExampleParameter ...$vars) {
+        $this->assertParameterTypes([null], static function (ExampleParameter ...$vars) {
             //
         });
     }
 
     public function testItReturnsTheFirstParameterType()
     {
-        $type = ReflectsClosuresClass::reflectFirst(function (ExampleParameter $a) {
+        $type = ReflectsClosuresClass::reflectFirst(static function (ExampleParameter $a) {
             //
         });
 
@@ -50,7 +50,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        ReflectsClosuresClass::reflectFirst(function () {
+        ReflectsClosuresClass::reflectFirst(static function () {
             //
         });
     }
@@ -59,7 +59,7 @@ class SupportReflectsClosuresTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        ReflectsClosuresClass::reflectFirst(function ($a, ExampleParameter $b) {
+        ReflectsClosuresClass::reflectFirst(static function ($a, ExampleParameter $b) {
             //
         });
     }

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -78,16 +78,16 @@ class SupportStringableTest extends TestCase
     public function testWhenEmpty()
     {
         tap($this->stringable(), function ($stringable) {
-            $this->assertSame($stringable, $stringable->whenEmpty(function () {
+            $this->assertSame($stringable, $stringable->whenEmpty(static function () {
                 //
             }));
         });
 
-        $this->assertSame('empty', (string) $this->stringable()->whenEmpty(function () {
+        $this->assertSame('empty', (string) $this->stringable()->whenEmpty(static function () {
             return 'empty';
         }));
 
-        $this->assertSame('not-empty', (string) $this->stringable('not-empty')->whenEmpty(function () {
+        $this->assertSame('not-empty', (string) $this->stringable('not-empty')->whenEmpty(static function () {
             return 'empty';
         }));
     }

--- a/tests/Support/SupportTappableTest.php
+++ b/tests/Support/SupportTappableTest.php
@@ -9,7 +9,7 @@ class SupportTappableTest extends TestCase
 {
     public function testTappableClassWithCallback()
     {
-        $name = TappableClass::make()->tap(function ($tappable) {
+        $name = TappableClass::make()->tap(static function ($tappable) {
             $tappable->setName('MyName');
         })->getName();
 

--- a/tests/Support/SupportTestingBusFakeTest.php
+++ b/tests/Support/SupportTestingBusFakeTest.php
@@ -44,7 +44,7 @@ class SupportTestingBusFakeTest extends TestCase
     {
         $this->fake->dispatch(new BusJobStub);
 
-        $this->fake->assertDispatched(function (BusJobStub $job) {
+        $this->fake->assertDispatched(static function (BusJobStub $job) {
             return true;
         });
     }
@@ -66,7 +66,7 @@ class SupportTestingBusFakeTest extends TestCase
     public function testAssertDispatchedAfterResponseClosure()
     {
         try {
-            $this->fake->assertDispatchedAfterResponse(function (BusJobStub $job) {
+            $this->fake->assertDispatchedAfterResponse(static function (BusJobStub $job) {
                 return true;
             });
             $this->fail();
@@ -118,7 +118,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->dispatchNow(new OtherBusJobStub(1));
 
         try {
-            $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+            $this->fake->assertDispatched(OtherBusJobStub::class, static function ($job) {
                 return $job->id === 0;
             });
             $this->fail();
@@ -126,11 +126,11 @@ class SupportTestingBusFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\OtherBusJobStub] job was not dispatched.'));
         }
 
-        $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+        $this->fake->assertDispatched(OtherBusJobStub::class, static function ($job) {
             return $job->id === null;
         });
 
-        $this->fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+        $this->fake->assertDispatched(OtherBusJobStub::class, static function ($job) {
             return $job->id === 1;
         });
     }
@@ -141,7 +141,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->dispatchAfterResponse(new OtherBusJobStub(1));
 
         try {
-            $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+            $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, static function ($job) {
                 return $job->id === 0;
             });
             $this->fail();
@@ -149,11 +149,11 @@ class SupportTestingBusFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\OtherBusJobStub] job was not dispatched for after sending the response.'));
         }
 
-        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, static function ($job) {
             return $job->id === null;
         });
 
-        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, function ($job) {
+        $this->fake->assertDispatchedAfterResponse(OtherBusJobStub::class, static function ($job) {
             return $job->id === 1;
         });
     }
@@ -209,7 +209,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->dispatchNow(new BusJobStub);
 
         try {
-            $this->fake->assertNotDispatched(function (BusJobStub $job) {
+            $this->fake->assertNotDispatched(static function (BusJobStub $job) {
                 return true;
             });
             $this->fail();
@@ -237,7 +237,7 @@ class SupportTestingBusFakeTest extends TestCase
         $this->fake->dispatchAfterResponse(new BusJobStub);
 
         try {
-            $this->fake->assertNotDispatchedAfterResponse(function (BusJobStub $job) {
+            $this->fake->assertNotDispatchedAfterResponse(static function (BusJobStub $job) {
                 return true;
             });
             $this->fail();
@@ -287,7 +287,7 @@ class SupportTestingBusFakeTest extends TestCase
         $dispatcher->shouldReceive('dispatchNow')->never()->with($anotherJob, null);
 
         $fake = new BusFake($dispatcher, [
-            function ($command) {
+            static function ($command) {
                 return $command instanceof OtherBusJobStub && $command->id === 1;
             },
         ]);
@@ -303,10 +303,10 @@ class SupportTestingBusFakeTest extends TestCase
 
         $fake->assertNotDispatched(BusJobStub::class);
         $fake->assertDispatchedTimes(OtherBusJobStub::class, 2);
-        $fake->assertNotDispatched(OtherBusJobStub::class, function ($job) {
+        $fake->assertNotDispatched(OtherBusJobStub::class, static function ($job) {
             return $job->id === null;
         });
-        $fake->assertDispatched(OtherBusJobStub::class, function ($job) {
+        $fake->assertDispatched(OtherBusJobStub::class, static function ($job) {
             return $job->id === 1;
         });
     }

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -35,7 +35,7 @@ class SupportTestingEventFakeTest extends TestCase
     {
         $this->fake->dispatch(new EventStub);
 
-        $this->fake->assertDispatched(function (EventStub $event) {
+        $this->fake->assertDispatched(static function (EventStub $event) {
             return true;
         });
     }
@@ -89,7 +89,7 @@ class SupportTestingEventFakeTest extends TestCase
         $this->fake->dispatch(new EventStub);
 
         try {
-            $this->fake->assertNotDispatched(function (EventStub $event) {
+            $this->fake->assertNotDispatched(static function (EventStub $event) {
                 return true;
             });
             $this->fail();
@@ -105,7 +105,7 @@ class SupportTestingEventFakeTest extends TestCase
 
         $fake = new EventFake($dispatcher, [
             'Foo',
-            function ($event, $payload) {
+            static function ($event, $payload) {
                 return $event === 'Bar' && $payload['id'] === 1;
             },
         ]);

--- a/tests/Support/SupportTestingMailFakeTest.php
+++ b/tests/Support/SupportTestingMailFakeTest.php
@@ -50,7 +50,7 @@ class SupportTestingMailFakeTest extends TestCase
 
         $this->fake->to($user)->send($this->mailable);
 
-        $this->fake->assertSent(MailableStub::class, function ($mail) use ($user) {
+        $this->fake->assertSent(MailableStub::class, static function ($mail) use ($user) {
             return $mail->hasTo($user) && $mail->locale === 'au';
         });
     }
@@ -159,7 +159,7 @@ class SupportTestingMailFakeTest extends TestCase
     {
         $this->fake->to($user = new LocalizedRecipientStub)->queue($this->mailable);
 
-        $this->fake->assertQueued(function (MailableStub $mail) use ($user) {
+        $this->fake->assertQueued(static function (MailableStub $mail) use ($user) {
             return $mail->hasTo($user);
         });
     }
@@ -168,7 +168,7 @@ class SupportTestingMailFakeTest extends TestCase
     {
         $this->fake->to($user = new LocalizedRecipientStub)->send($this->mailable);
 
-        $this->fake->assertSent(function (MailableStub $mail) use ($user) {
+        $this->fake->assertSent(static function (MailableStub $mail) use ($user) {
             return $mail->hasTo($user);
         });
     }

--- a/tests/Support/SupportTestingNotificationFakeTest.php
+++ b/tests/Support/SupportTestingNotificationFakeTest.php
@@ -55,7 +55,7 @@ class SupportTestingNotificationFakeTest extends TestCase
     {
         $this->fake->send($this->user, new NotificationStub);
 
-        $this->fake->assertSentTo($this->user, function (NotificationStub $notification) {
+        $this->fake->assertSentTo($this->user, static function (NotificationStub $notification) {
             return true;
         });
     }
@@ -79,7 +79,7 @@ class SupportTestingNotificationFakeTest extends TestCase
         $this->fake->send($this->user, new NotificationStub);
 
         try {
-            $this->fake->assertNotSentTo($this->user, function (NotificationStub $notification) {
+            $this->fake->assertNotSentTo($this->user, static function (NotificationStub $notification) {
                 return true;
             });
             $this->fail();
@@ -139,7 +139,7 @@ class SupportTestingNotificationFakeTest extends TestCase
 
         $this->fake->send($user, new NotificationStub);
 
-        $this->fake->assertSentTo($user, NotificationStub::class, function ($notification, $channels, $notifiable, $locale) use ($user) {
+        $this->fake->assertSentTo($user, NotificationStub::class, static function ($notification, $channels, $notifiable, $locale) use ($user) {
             return $notifiable === $user && $locale === 'au';
         });
     }

--- a/tests/Support/SupportTestingQueueFakeTest.php
+++ b/tests/Support/SupportTestingQueueFakeTest.php
@@ -47,7 +47,7 @@ class SupportTestingQueueFakeTest extends TestCase
     {
         $this->fake->push($this->job);
 
-        $this->fake->assertPushed(function (JobStub $job) {
+        $this->fake->assertPushed(static function (JobStub $job) {
             return true;
         });
     }
@@ -80,7 +80,7 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->push($this->job);
 
         try {
-            $this->fake->assertNotPushed(function (JobStub $job) {
+            $this->fake->assertNotPushed(static function (JobStub $job) {
                 return true;
             });
             $this->fail();
@@ -108,7 +108,7 @@ class SupportTestingQueueFakeTest extends TestCase
         $this->fake->push($this->job, '', 'foo');
 
         try {
-            $this->fake->assertPushedOn('bar', function (JobStub $job) {
+            $this->fake->assertPushedOn('bar', static function (JobStub $job) {
                 return true;
             });
             $this->fail();
@@ -116,7 +116,7 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->assertThat($e, new ExceptionMessage('The expected [Illuminate\Tests\Support\JobStub] job was not pushed.'));
         }
 
-        $this->fake->assertPushedOn('foo', function (JobStub $job) {
+        $this->fake->assertPushedOn('foo', static function (JobStub $job) {
             return true;
         });
     }
@@ -219,7 +219,7 @@ class SupportTestingQueueFakeTest extends TestCase
 
         $this->fake->assertPushedWithChain(JobWithChainAndParameterStub::class, [
             JobStub::class,
-        ], function ($job) {
+        ], static function ($job) {
             return $job->parameter == 'second';
         });
 
@@ -227,7 +227,7 @@ class SupportTestingQueueFakeTest extends TestCase
             $this->fake->assertPushedWithChain(JobWithChainAndParameterStub::class, [
                 JobStub::class,
                 JobStub::class,
-            ], function ($job) {
+            ], static function ($job) {
                 return $job->parameter == 'second';
             });
             $this->fail();

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -63,7 +63,7 @@ class TestResponseTest extends TestCase
             'gatherData' => ['foo' => 'bar'],
         ]);
 
-        $response->assertViewHas('foo', function ($value) {
+        $response->assertViewHas('foo', static function ($value) {
             return $value === 'bar';
         });
     }
@@ -193,7 +193,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage('Response status code ['.$statusCode.'] does not match expected 200 status code.');
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -209,7 +209,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage('Response status code ['.$statusCode.'] does not match expected 201 status code.');
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -224,7 +224,7 @@ class TestResponseTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a not found status code.');
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -240,7 +240,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not a forbidden status code.');
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -256,7 +256,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage('Response status code ['.$statusCode.'] is not an unauthorized status code.');
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -272,7 +272,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage("Expected status code 204 but received {$statusCode}");
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -289,7 +289,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage("Expected status code {$expectedStatusCode} but received {$statusCode}");
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -303,7 +303,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage('Response content is not empty');
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->setStatusCode(204);
             $response->setContent('non-empty-response-content');
         });
@@ -321,7 +321,7 @@ class TestResponseTest extends TestCase
 
         $this->expectExceptionMessage("Expected status code {$expectedStatusCode} but received {$statusCode}");
 
-        $baseResponse = tap(new Response, function ($response) use ($statusCode) {
+        $baseResponse = tap(new Response, static function ($response) use ($statusCode) {
             $response->setStatusCode($statusCode);
         });
 
@@ -333,7 +333,7 @@ class TestResponseTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->header('Location', '/foo');
         });
 
@@ -347,7 +347,7 @@ class TestResponseTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
         $this->expectExceptionMessage('Unexpected header [Location] is present on response.');
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->header('Location', '/foo');
         });
 
@@ -749,7 +749,7 @@ class TestResponseTest extends TestCase
 
     public function testAssertJsonMissingValidationErrors()
     {
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->setContent(json_encode(['errors' => [
                 'foo' => [],
                 'bar' => ['one', 'two'],
@@ -760,7 +760,7 @@ class TestResponseTest extends TestCase
 
         $response->assertJsonMissingValidationErrors('baz');
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->setContent(json_encode(['foo' => 'bar']));
         });
 
@@ -772,7 +772,7 @@ class TestResponseTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->setContent(json_encode(['errors' => [
                 'foo' => [],
                 'bar' => ['one', 'two'],
@@ -788,7 +788,7 @@ class TestResponseTest extends TestCase
     {
         $this->expectException(AssertionFailedError::class);
 
-        $baseResponse = tap(new Response, function ($response) {
+        $baseResponse = tap(new Response, static function ($response) {
             $response->setContent(json_encode(['errors' => [
                 'foo' => [],
                 'bar' => ['one', 'two'],
@@ -912,7 +912,7 @@ class TestResponseTest extends TestCase
 
     private function makeMockResponse($content)
     {
-        $baseResponse = tap(new Response, function ($response) use ($content) {
+        $baseResponse = tap(new Response, static function ($response) use ($content) {
             $response->setContent(m::mock(View::class, $content));
         });
 

--- a/tests/Validation/ValidationDatabasePresenceVerifierTest.php
+++ b/tests/Validation/ValidationDatabasePresenceVerifierTest.php
@@ -43,7 +43,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $conn->shouldReceive('table')->once()->with('table')->andReturn($builder = m::mock(stdClass::class));
         $builder->shouldReceive('useWritePdo')->once()->andReturn($builder);
         $builder->shouldReceive('where')->with('column', '=', 'value')->andReturn($builder);
-        $closure = function ($query) {
+        $closure = static function ($query) {
             $query->where('closure', 1);
         };
         $extra = ['foo' => 'NULL', 'bar' => 'NOT_NULL', 'baz' => 'taylor', 'faz' => true, 'not' => '!admin', 0 => $closure];
@@ -52,7 +52,7 @@ class ValidationDatabasePresenceVerifierTest extends TestCase
         $builder->shouldReceive('where')->with('baz', 'taylor');
         $builder->shouldReceive('where')->with('faz', true);
         $builder->shouldReceive('where')->with('not', '!=', 'admin');
-        $builder->shouldReceive('where')->with(m::type(Closure::class))->andReturnUsing(function () use ($builder, $closure) {
+        $builder->shouldReceive('where')->with(m::type(Closure::class))->andReturnUsing(static function () use ($builder, $closure) {
             $closure($builder);
         });
         $builder->shouldReceive('where')->with('closure', 1);

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -134,7 +134,7 @@ class ValidationExistsRuleTest extends TestCase
 
     protected function createSchema()
     {
-        $this->schema('default')->create('users', function ($table) {
+        $this->schema('default')->create('users', static function ($table) {
             $table->unsignedInteger('id');
             $table->string('type');
         });

--- a/tests/Validation/ValidationFactoryTest.php
+++ b/tests/Validation/ValidationFactoryTest.php
@@ -26,13 +26,13 @@ class ValidationFactoryTest extends TestCase
         $this->assertEquals(['baz' => ['boom']], $validator->getRules());
 
         $presence = m::mock(PresenceVerifierInterface::class);
-        $noop1 = function () {
+        $noop1 = static function () {
             //
         };
-        $noop2 = function () {
+        $noop2 = static function () {
             //
         };
-        $noop3 = function () {
+        $noop3 = static function () {
             //
         };
         $factory->extend('foo', $noop1);
@@ -81,7 +81,7 @@ class ValidationFactoryTest extends TestCase
         unset($_SERVER['__validator.factory']);
         $translator = m::mock(TranslatorInterface::class);
         $factory = new Factory($translator);
-        $factory->resolver(function ($translator, $data, $rules) {
+        $factory->resolver(static function ($translator, $data, $rules) {
             $_SERVER['__validator.factory'] = true;
 
             return new Validator($translator, $data, $rules);
@@ -99,7 +99,7 @@ class ValidationFactoryTest extends TestCase
     {
         $translator = m::mock(TranslatorInterface::class);
         $factory = new Factory($translator);
-        $factory->extend('foo', function ($attribute, $value, $parameters, $validator) {
+        $factory->extend('foo', static function ($attribute, $value, $parameters, $validator) {
             return $validator->validateArray($attribute, $value);
         });
 

--- a/tests/Validation/ValidationRequiredIfTest.php
+++ b/tests/Validation/ValidationRequiredIfTest.php
@@ -9,13 +9,13 @@ class ValidationRequiredIfTest extends TestCase
 {
     public function testItClousureReturnsFormatsAStringVersionOfTheRule()
     {
-        $rule = new RequiredIf(function () {
+        $rule = new RequiredIf(static function () {
             return true;
         });
 
         $this->assertSame('required', (string) $rule);
 
-        $rule = new RequiredIf(function () {
+        $rule = new RequiredIf(static function () {
             return false;
         });
 

--- a/tests/Validation/ValidationRuleTest.php
+++ b/tests/Validation/ValidationRuleTest.php
@@ -10,7 +10,7 @@ class ValidationRuleTest extends TestCase
     public function testMacroable()
     {
         // phone macro : validate a phone number
-        Rule::macro('phone', function () {
+        Rule::macro('phone', static function () {
             return 'regex:/^([0-9\s\-\+\(\)]*)$/';
         });
         $c = Rule::phone();

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -54,7 +54,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar', 'baz' => 'boom'], ['foo' => 'Same:baz']);
         $v->setContainer(new Container);
-        $v->after(function ($validator) {
+        $v->after(static function ($validator) {
             $_SERVER['__validator.after.test'] = true;
 
             // For asserting we can actually work with the instance
@@ -242,7 +242,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.required' => 'foo bar'], 'en');
         $v = new Validator($trans, ['name' => ''], ['name' => 'Required']);
-        $v->addReplacer('required', function ($message, $attribute, $rule, $parameters) {
+        $v->addReplacer('required', static function ($message, $attribute, $rule, $parameters) {
             return str_replace('bar', 'taylor', $message);
         });
         $this->assertFalse($v->passes());
@@ -417,7 +417,7 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.framework_php' => ':input is not a valid PHP Framework'], 'en');
 
         $v = new Validator($trans, ['framework' => 3], ['framework' => 'framework_php']);
-        $v->addExtension('framework_php', function ($attribute, $value, $parameters, $validator) {
+        $v->addExtension('framework_php', static function ($attribute, $value, $parameters, $validator) {
             return in_array($value, [1, 2]);
         });
         $v->addCustomValues(['framework' => $frameworks]);
@@ -520,12 +520,12 @@ class ValidationValidatorTest extends TestCase
         $trans->addLines(['validation.attributes.firstname' => 'Firstname'], 'en');
         $trans->addLines(['validation.attributes.lastname' => 'Lastname'], 'en');
         $v = new Validator($trans, ['firstname' => 'Bob', 'lastname' => 'Smith'], ['lastname' => 'alliteration:firstname']);
-        $v->addExtension('alliteration', function ($attribute, $value, $parameters, $validator) {
+        $v->addExtension('alliteration', static function ($attribute, $value, $parameters, $validator) {
             $other = Arr::get($validator->getData(), $parameters[0]);
 
             return $value[0] == $other[0];
         });
-        $v->addReplacer('alliteration', function ($message, $attribute, $rule, $parameters, $validator) {
+        $v->addReplacer('alliteration', static function ($message, $attribute, $rule, $parameters, $validator) {
             return str_replace(':other', $validator->getDisplayableAttribute($parameters[0]), $message);
         });
         $this->assertFalse($v->passes());
@@ -537,12 +537,12 @@ class ValidationValidatorTest extends TestCase
         $customAttributes = ['firstname' => 'Firstname', 'lastname' => 'Lastname'];
         $v = new Validator($trans, ['firstname' => 'Bob', 'lastname' => 'Smith'], ['lastname' => 'alliteration:firstname']);
         $v->addCustomAttributes($customAttributes);
-        $v->addExtension('alliteration', function ($attribute, $value, $parameters, $validator) {
+        $v->addExtension('alliteration', static function ($attribute, $value, $parameters, $validator) {
             $other = Arr::get($validator->getData(), $parameters[0]);
 
             return $value[0] == $other[0];
         });
-        $v->addReplacer('alliteration', function ($message, $attribute, $rule, $parameters, $validator) {
+        $v->addReplacer('alliteration', static function ($message, $attribute, $rule, $parameters, $validator) {
             return str_replace(':other', $validator->getDisplayableAttribute($parameters[0]), $message);
         });
         $this->assertFalse($v->passes());
@@ -2185,7 +2185,7 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['email' => 'foo'], ['email' => 'Unique:users,email_addr,NULL,id_col,foo,bar']);
         $mock = m::mock(DatabasePresenceVerifierInterface::class);
         $mock->shouldReceive('setConnection')->once()->with(null);
-        $mock->shouldReceive('getCount')->once()->withArgs(function () {
+        $mock->shouldReceive('getCount')->once()->withArgs(static function () {
             return func_get_args() === ['users', 'email_addr', 'foo', null, 'id_col', ['foo' => 'bar']];
         })->andReturn(2);
         $v->setPresenceVerifier($mock);
@@ -2206,7 +2206,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $trans = $this->getIlluminateArrayTranslator();
-        $closure = function () {
+        $closure = static function () {
             //
         };
         $v = new Validator($trans, [['email' => 'foo', 'type' => 'bar']], [
@@ -3523,42 +3523,42 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
-        $v->sometimes('x', 'Confirmed', function ($i) {
+        $v->sometimes('x', 'Confirmed', static function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Confirmed']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => ''], ['y' => 'Required']);
-        $v->sometimes('x', 'Required', function ($i) {
+        $v->sometimes('x', 'Required', static function ($i) {
             return true;
         });
         $this->assertEquals(['x' => ['Required'], 'y' => ['Required']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
-        $v->sometimes('x', 'Confirmed', function ($i) {
+        $v->sometimes('x', 'Confirmed', static function ($i) {
             return $i->x == 'bar';
         });
         $this->assertEquals(['x' => ['Required']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
-        $v->sometimes('x', 'Foo|Bar', function ($i) {
+        $v->sometimes('x', 'Foo|Bar', static function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['x' => 'foo'], ['x' => 'Required']);
-        $v->sometimes('x', ['Foo', 'Bar:Baz'], function ($i) {
+        $v->sometimes('x', ['Foo', 'Bar:Baz'], static function ($i) {
             return $i->x == 'foo';
         });
         $this->assertEquals(['x' => ['Required', 'Foo', 'Bar:Baz']], $v->getRules());
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => [['name' => 'first', 'title' => null]]], []);
-        $v->sometimes('foo.*.name', 'Required|String', function ($i) {
+        $v->sometimes('foo.*.name', 'Required|String', static function ($i) {
             return is_null($i['foo'][0]['title']);
         });
         $this->assertEquals(['foo.0.name' => ['Required', 'String']], $v->getRules());
@@ -3569,7 +3569,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo']);
-        $v->addExtension('foo', function () {
+        $v->addExtension('foo', static function () {
             return false;
         });
         $this->assertFalse($v->passes());
@@ -3579,7 +3579,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $trans->addLines(['validation.foo_bar' => 'foo!'], 'en');
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
-        $v->addExtension('FooBar', function () {
+        $v->addExtension('FooBar', static function () {
             return false;
         });
         $this->assertFalse($v->passes());
@@ -3588,7 +3588,7 @@ class ValidationValidatorTest extends TestCase
 
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
-        $v->addExtension('FooBar', function () {
+        $v->addExtension('FooBar', static function () {
             return false;
         });
         $v->setFallbackMessages(['foo_bar' => 'foo!']);
@@ -3599,7 +3599,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['name' => 'taylor'], ['name' => 'foo_bar']);
         $v->addExtensions([
-            'FooBar' => function () {
+            'FooBar' => static function () {
                 return false;
             },
         ]);
@@ -3641,7 +3641,7 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, [], ['implicit_rule' => 'foo']);
-        $v->addImplicitExtension('implicit_rule', function () {
+        $v->addImplicitExtension('implicit_rule', static function () {
             return true;
         });
         $this->assertTrue($v->passes());
@@ -3656,7 +3656,7 @@ class ValidationValidatorTest extends TestCase
             ],
             ['*.name' => 'dependent_rule:*.age']
         );
-        $v->addDependentExtension('dependent_rule', function ($name) use ($v) {
+        $v->addDependentExtension('dependent_rule', static function ($name) use ($v) {
             return Arr::get($v->getData(), $name) == 'Jamie';
         });
         $this->assertTrue($v->passes());
@@ -4753,7 +4753,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'taylor'],
             [
-                'name.*' => function ($attribute, $value, $fail) {
+                'name.*' => static function ($attribute, $value, $fail) {
                     if ($value !== 'taylor') {
                         $fail(':attribute was '.$value.' instead of taylor');
                     }
@@ -4768,7 +4768,7 @@ class ValidationValidatorTest extends TestCase
             $this->getIlluminateArrayTranslator(),
             ['name' => 'adam'],
             [
-                'name' => function ($attribute, $value, $fail) {
+                'name' => static function ($attribute, $value, $fail) {
                     if ($value !== 'taylor') {
                         $fail(':attribute was '.$value.' instead of taylor');
                     }
@@ -4795,7 +4795,7 @@ class ValidationValidatorTest extends TestCase
                         return ':attribute must be AR or TX';
                     }
                 },
-                'name' => function ($attribute, $value, $fail) {
+                'name' => static function ($attribute, $value, $fail) {
                     if ($value !== 'taylor') {
                         $fail(':attribute must be taylor');
                     }
@@ -4803,7 +4803,7 @@ class ValidationValidatorTest extends TestCase
                 'number' => [
                     'required',
                     'integer',
-                    function ($attribute, $value, $fail) {
+                    static function ($attribute, $value, $fail) {
                         if ($value % 4 !== 0) {
                             $fail(':attribute must be divisible by 4');
                         }
@@ -4901,7 +4901,7 @@ class ValidationValidatorTest extends TestCase
         $post = ['first' => 'john', 'preferred' => 'john', 'last' => 'doe', 'type' => 'admin'];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'preferred' => 'required']);
-        $v->sometimes('type', 'required', function () {
+        $v->sometimes('type', 'required', static function () {
             return false;
         });
         $data = $v->validate();
@@ -4916,7 +4916,7 @@ class ValidationValidatorTest extends TestCase
         $rules = ['nested.foo' => 'required', 'array.*' => 'integer'];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, $rules);
-        $v->sometimes('type', 'required', function () {
+        $v->sometimes('type', 'required', static function () {
             return false;
         });
         $data = $v->validate();
@@ -4929,7 +4929,7 @@ class ValidationValidatorTest extends TestCase
         $post = ['nested' => ['foo' => 'bar', 'with' => 'extras', 'type' => 'admin']];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['nested.foo' => 'required']);
-        $v->sometimes('nested.type', 'required', function () {
+        $v->sometimes('nested.type', 'required', static function () {
             return false;
         });
         $data = $v->validate();
@@ -4942,7 +4942,7 @@ class ValidationValidatorTest extends TestCase
         $post = ['nested' => [['bar' => 'baz', 'with' => 'extras', 'type' => 'admin'], ['bar' => 'baz2', 'with' => 'extras', 'type' => 'admin']]];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['nested.*.bar' => 'required']);
-        $v->sometimes('nested.*.type', 'required', function () {
+        $v->sometimes('nested.*.type', 'required', static function () {
             return false;
         });
         $data = $v->validate();
@@ -4955,7 +4955,7 @@ class ValidationValidatorTest extends TestCase
         $post = ['first' => 'john', 'preferred' => 'john', 'last' => 'doe', 'type' => 'admin'];
 
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'preferred' => 'required']);
-        $v->sometimes('type', 'required', function () {
+        $v->sometimes('type', 'required', static function () {
             return false;
         });
         $data = $v->validate();
@@ -4971,7 +4971,7 @@ class ValidationValidatorTest extends TestCase
 
         $validateCount = 0;
         $v = new Validator($this->getIlluminateArrayTranslator(), $post, ['first' => 'required', 'preferred' => 'required']);
-        $v->after(function () use (&$validateCount) {
+        $v->after(static function () use (&$validateCount) {
             $validateCount++;
         });
         $data = $v->validate();

--- a/tests/View/Blade/BladeCustomTest.php
+++ b/tests/View/Blade/BladeCustomTest.php
@@ -18,7 +18,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomExtensionsAreCompiled()
     {
-        $this->compiler->extend(function ($value) {
+        $this->compiler->extend(static function ($value) {
             return str_replace('foo', 'bar', $value);
         });
         $this->assertSame('bar', $this->compiler->compileString('foo'));
@@ -27,7 +27,7 @@ class BladeCustomTest extends AbstractBladeTestCase
     public function testCustomStatements()
     {
         $this->assertCount(0, $this->compiler->getCustomDirectives());
-        $this->compiler->directive('customControl', function ($expression) {
+        $this->compiler->directive('customControl', static function ($expression) {
             return "<?php echo custom_control({$expression}); ?>";
         });
         $this->assertCount(1, $this->compiler->getCustomDirectives());
@@ -43,7 +43,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomShortStatements()
     {
-        $this->compiler->directive('customControl', function ($expression) {
+        $this->compiler->directive('customControl', static function ($expression) {
             return '<?php echo custom_control(); ?>';
         });
 
@@ -54,16 +54,16 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testValidCustomNames()
     {
-        $this->assertNull($this->compiler->directive('custom', function () {
+        $this->assertNull($this->compiler->directive('custom', static function () {
             //
         }));
-        $this->assertNull($this->compiler->directive('custom_custom', function () {
+        $this->assertNull($this->compiler->directive('custom_custom', static function () {
             //
         }));
-        $this->assertNull($this->compiler->directive('customCustom', function () {
+        $this->assertNull($this->compiler->directive('customCustom', static function () {
             //
         }));
-        $this->assertNull($this->compiler->directive('custom::custom', function () {
+        $this->assertNull($this->compiler->directive('custom::custom', static function () {
             //
         }));
     }
@@ -72,7 +72,7 @@ class BladeCustomTest extends AbstractBladeTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The directive name [custom-custom] is not valid.');
-        $this->compiler->directive('custom-custom', function () {
+        $this->compiler->directive('custom-custom', static function () {
             //
         });
     }
@@ -81,14 +81,14 @@ class BladeCustomTest extends AbstractBladeTestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The directive name [custom:custom] is not valid.');
-        $this->compiler->directive('custom:custom', function () {
+        $this->compiler->directive('custom:custom', static function () {
             //
         });
     }
 
     public function testCustomExtensionOverwritesCore()
     {
-        $this->compiler->directive('foreach', function ($expression) {
+        $this->compiler->directive('foreach', static function ($expression) {
             return '<?php custom(); ?>';
         });
 
@@ -99,7 +99,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomConditions()
     {
-        $this->compiler->if('custom', function ($user) {
+        $this->compiler->if('custom', static function ($user) {
             return true;
         });
 
@@ -112,7 +112,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomIfElseConditions()
     {
-        $this->compiler->if('custom', function ($anything) {
+        $this->compiler->if('custom', static function ($anything) {
             return true;
         });
 
@@ -129,7 +129,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomUnlessConditions()
     {
-        $this->compiler->if('custom', function ($anything) {
+        $this->compiler->if('custom', static function ($anything) {
             return true;
         });
 
@@ -142,7 +142,7 @@ class BladeCustomTest extends AbstractBladeTestCase
 
     public function testCustomConditionsAccepts0AsArgument()
     {
-        $this->compiler->if('custom', function ($number) {
+        $this->compiler->if('custom', static function ($number) {
             return true;
         });
 

--- a/tests/View/ViewEngineResolverTest.php
+++ b/tests/View/ViewEngineResolverTest.php
@@ -12,7 +12,7 @@ class ViewEngineResolverTest extends TestCase
     public function testResolversMayBeResolved()
     {
         $resolver = new EngineResolver;
-        $resolver->register('foo', function () {
+        $resolver->register('foo', static function () {
             return new stdClass;
         });
         $result = $resolver->resolve('foo');

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -37,7 +37,7 @@ class ViewFactoryTest extends TestCase
         $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock(Engine::class));
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('php');
         $factory->setDispatcher(new Dispatcher);
-        $factory->creator('view', function ($view) {
+        $factory->creator('view', static function ($view) {
             $_SERVER['__test.view'] = $view;
         });
         $factory->addExtension('php', 'php');
@@ -69,7 +69,7 @@ class ViewFactoryTest extends TestCase
         $factory->getEngineResolver()->shouldReceive('resolve')->once()->with('php')->andReturn($engine = m::mock(Engine::class));
         $factory->getFinder()->shouldReceive('addExtension')->once()->with('php');
         $factory->setDispatcher(new Dispatcher);
-        $factory->creator('view', function ($view) {
+        $factory->creator('view', static function ($view) {
             $_SERVER['__test.view'] = $view;
         });
         $factory->addExtension('php', 'php');
@@ -125,7 +125,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
 
-        $resolver = function () {
+        $resolver = static function () {
             //
         };
 
@@ -171,7 +171,7 @@ class ViewFactoryTest extends TestCase
     {
         $factory = $this->getFactory();
         $factory->getDispatcher()->shouldReceive('listen')->once()->with('composing: foo', m::type(Closure::class));
-        $callback = $factory->composer('foo', function () {
+        $callback = $factory->composer('foo', static function () {
             return 'bar';
         });
         $callback = $callback[0];
@@ -489,7 +489,7 @@ class ViewFactoryTest extends TestCase
         $this->expectExceptionMessage('section exception message');
 
         $engine = new CompilerEngine(m::mock(CompilerInterface::class));
-        $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(function ($path) {
+        $engine->getCompiler()->shouldReceive('getCompiledPath')->andReturnUsing(static function ($path) {
             return $path;
         });
         $engine->getCompiler()->shouldReceive('isExpired')->twice()->andReturn(false);

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -62,15 +62,15 @@ class ViewTest extends TestCase
         $view->getFactory()->shouldReceive('decrementRender');
         $view->getFactory()->shouldReceive('flushStateIfDoneRendering');
 
-        $this->assertSame('new contents', $view->render(function () {
+        $this->assertSame('new contents', $view->render(static function () {
             return 'new contents';
         }));
 
-        $this->assertEmpty($view->render(function () {
+        $this->assertEmpty($view->render(static function () {
             return '';
         }));
 
-        $this->assertSame('contents', $view->render(function () {
+        $this->assertSame('contents', $view->render(static function () {
             //
         }));
     }


### PR DESCRIPTION
[PHP Inpections](https://plugins.jetbrains.com/plugin/7622-php-inspections-ea-extended-) suggested to make closures static that don't depend on `$this`. The only place where this is not possible is in Macros. Those are excluded from the optimization.

The optimization is based on this PR: https://github.com/Ocramius/GeneratedHydrator/pull/83

I ran a couple of framework unit tests on my local Ubuntu with PHP 7.4 and this is the result:

```
before:
Time: 00:41.122, Memory: 236.50 MB
Time: 00:40.884, Memory: 236.50 MB
Time: 00:41.165, Memory: 236.50 MB

after (with static):
Time: 00:42.184, Memory: 234.50 MB
Time: 00:41.700, Memory: 234.50 MB
Time: 00:41.686, Memory: 234.50 MB
```

Concerning the time there is no difference but we save 2 MB by this micro optimization!