### PR TITLE
added check for file existence before trying to delete it

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -216,12 +216,14 @@ class Filesystem
         $success = true;
 
         foreach ($paths as $path) {
-            try {
-                if (! @unlink($path)) {
+            if (file_exists($path)) {
+                try {
+                    if (!@unlink($path)) {
+                        $success = false;
+                    }
+                } catch (ErrorException $e) {
                     $success = false;
                 }
-            } catch (ErrorException $e) {
-                $success = false;
             }
         }
 


### PR DESCRIPTION
When using the tinker cli or tinkerwell and login a user before tinkering, an error message appears stating we are trying unlink a file that doesn't exist. 
```
$u = User::find(1);
Auth::login($u);
```
message: 
```
PHP Warning:  unlink(....../storage/framework/sessions/x4LgihfRqiKyCk9f3bNjJjzeApJiNTr8tL6w5Nf4): No such file or directory in .../vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php on line 219
```
A quick fix for this is to check if the file exists before defleting it. 