### PR TITLE
[6.x] Provide correct page when using eachById

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -83,6 +83,8 @@ trait BuildsQueries
 
         $lastId = null;
 
+        $page = 1;
+
         do {
             $clone = clone $this;
 
@@ -100,13 +102,15 @@ trait BuildsQueries
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            if ($callback($results) === false) {
+            if ($callback($results, $page) === false) {
                 return false;
             }
 
             $lastId = $results->last()->{$alias};
 
             unset($results);
+
+            $page++;
         } while ($countResults == $count);
 
         return true;
@@ -123,9 +127,9 @@ trait BuildsQueries
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results) use ($callback) {
+        return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
             foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
+                if ($callback($value, (($page - 1) * $count) + $key) === false) {
                     return false;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -739,10 +739,10 @@ class BelongsToMany extends Relation
     {
         $this->query->addSelect($this->shouldSelect());
 
-        return $this->query->chunk($count, function ($results) use ($callback) {
+        return $this->query->chunk($count, function ($results, $page) use ($callback) {
             $this->hydratePivotRelation($results->all());
 
-            return $callback($results);
+            return $callback($results, $page);
         });
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -420,7 +420,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             function (EloquentTestNonIncrementingSecond $user, $i) use (&$users) {
                 $users[] = [$user->name, $i];
             }, 2, 'name');
-        $this->assertSame([[' First', 0], [' Second', 1], [' Third', 0]], $users);
+        $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
     }
 
     public function testPluck()


### PR DESCRIPTION
Currently, `eachById` uses `chunkById` to iterate over large datasets, and passes the chunks index to the callback (`[1,2],[1,2]` for `[1,2,3,4]`)

This PR modifies `eachById` to use the higher order index instead (`[1,2,3,4]` for `[1,2,3,4]`)

---

* Changes `chunkById` to pass a `$page` variable to the provided callback
* Changes `eachById` to pass the higher order index to its provided callback instead of the chunks unit index.
* Changes expected page order in [`testEachByIdWithNonIncrementingKey`](`https://github.com/laravel/framework/blob/7f602783a60e7727aa271b6bb51e1f250e0e33ab/tests/Database/DatabaseEloquentIntegrationTest.php#L432-L444`)