### PR TITLE
[8.x] Add relative URL support to ValidateSignature middleware

### DIFF
--- a/src/Illuminate/Routing/Middleware/ValidateSignature.php
+++ b/src/Illuminate/Routing/Middleware/ValidateSignature.php
@@ -12,13 +12,14 @@ class ValidateSignature
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Closure  $next
+     * @param  string|null  $relative
      * @return \Illuminate\Http\Response
      *
      * @throws \Illuminate\Routing\Exceptions\InvalidSignatureException
      */
-    public function handle($request, Closure $next)
+    public function handle($request, Closure $next, $relative = null)
     {
-        if ($request->hasValidSignature()) {
+        if ($request->hasValidSignature($relative !== 'relative')) {
             return $next($request);
         }
 

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -85,6 +85,19 @@ class UrlSigningTest extends TestCase
         $this->assertIsString($url = URL::signedRoute('foo', $model));
         $this->assertSame('routable', $this->get($url)->original);
     }
+
+    public function testSignedMiddlewareWithRelativePath()
+    {
+        Route::get('/foo/relative', function (Request $request) {
+            return $request->hasValidSignature($absolute = false) ? 'valid' : 'invalid';
+        })->name('foo')->middleware('signed:relative');
+
+        $this->assertIsString($url = 'https://fake.test'.URL::signedRoute('foo', [], null, $absolute = false));
+        $this->assertSame('valid', $this->get($url)->original);
+
+        $response = $this->get('/foo/relative');
+        $response->assertStatus(403);
+    }
 }
 
 class RoutableInterfaceStub implements UrlRoutable


### PR DESCRIPTION
(This is a resubmission of #30336 by @tonysm.)

I needed to verify a relatively signed route and discovered the `signed` middleware that I normally reach for didn't support validating relative urls. This is now possible:

```php
Route::get('foo')->middleware('signed:relative');
```

It helps to avoid writing checks like this in the controller:

```php
public function index(Request $request)
{
    abort_unless($request->hasValidSignature($absolute = false), 403);

    //
```

I prefer to see what routes are signed in my `routes/web.php` file, not buried in the depths below.