### PR TITLE
[8.x] Provide correct index when using eachById

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -83,6 +83,8 @@ trait BuildsQueries
 
         $lastId = null;
 
+        $page = 1;
+
         do {
             $clone = clone $this;
 
@@ -100,13 +102,15 @@ trait BuildsQueries
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            if ($callback($results) === false) {
+            if ($callback($results, $page) === false) {
                 return false;
             }
 
             $lastId = $results->last()->{$alias};
 
             unset($results);
+
+            $page++;
         } while ($countResults == $count);
 
         return true;
@@ -123,9 +127,9 @@ trait BuildsQueries
      */
     public function eachById(callable $callback, $count = 1000, $column = null, $alias = null)
     {
-        return $this->chunkById($count, function ($results) use ($callback) {
+        return $this->chunkById($count, function ($results, $page) use ($callback, $count) {
             foreach ($results as $key => $value) {
-                if ($callback($value, $key) === false) {
+                if ($callback($value, (($page - 1) * $count) + $key) === false) {
                     return false;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php
@@ -861,10 +861,10 @@ class BelongsToMany extends Relation
     {
         $this->query->addSelect($this->shouldSelect());
 
-        return $this->query->chunk($count, function ($results) use ($callback) {
+        return $this->query->chunk($count, function ($results, $page) use ($callback) {
             $this->hydratePivotRelation($results->all());
 
-            return $callback($results);
+            return $callback($results, $page);
         });
     }
 

--- a/tests/Database/DatabaseEloquentIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentIntegrationTest.php
@@ -440,7 +440,7 @@ class DatabaseEloquentIntegrationTest extends TestCase
             function (EloquentTestNonIncrementingSecond $user, $i) use (&$users) {
                 $users[] = [$user->name, $i];
             }, 2, 'name');
-        $this->assertSame([[' First', 0], [' Second', 1], [' Third', 0]], $users);
+        $this->assertSame([[' First', 0], [' Second', 1], [' Third', 2]], $users);
     }
 
     public function testPluck()


### PR DESCRIPTION
Internally, `eachById` currently uses `chunkById` to iterate over large datasets, and passes the chunks index to the callback 
(e.g.`[0,1],[0,1]` for `['a', 'b', 'c', 'd']`)

This PR modifies `eachById` to pass the higher order index to the callback instead of the chunk index 
(e.g. `[0,1,2,3]` for `['a', 'b', 'c', 'd']`)

---

* Changes `chunkById` to pass a `$page` variable to the provided callback
* Changes `eachById` to pass the higher order index to its provided callback instead of the chunks unit index.
* Changes expected page order in [`testEachByIdWithNonIncrementingKey`](`https://github.com/laravel/framework/blob/7f602783a60e7727aa271b6bb51e1f250e0e33ab/tests/Database/DatabaseEloquentIntegrationTest.php#L432-L444`)