### PR TITLE
[6.x] Fix Model::withoutEvents() not registering listeners inside boot()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Eloquent\Concerns;
 
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
@@ -399,7 +400,9 @@ trait HasEvents
     {
         $dispatcher = static::getEventDispatcher();
 
-        static::unsetEventDispatcher();
+        if ($dispatcher) {
+            static::setEventDispatcher(new NullDispatcher($dispatcher));
+        }
 
         try {
             return $callback();

--- a/src/Illuminate/Events/NullDispatcher.php
+++ b/src/Illuminate/Events/NullDispatcher.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+class NullDispatcher implements DispatcherContract
+{
+    use ForwardsCalls;
+
+    /**
+     * The underlying event dispatcher instance.
+     */
+    protected $dispatcher;
+
+    /**
+     * Create a new event dispatcher instance that does not fire.
+     *
+     * @param  \Illuminate\Contracts\Events\Dispatcher  $dispatcher
+     * @return void
+     */
+    public function __construct(DispatcherContract $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Don't fire an event.
+     *
+     * @param  string|object  $event
+     * @param  mixed  $payload
+     * @param  bool  $halt
+     * @return void
+     */
+    public function dispatch($event, $payload = [], $halt = false)
+    {
+    }
+
+    /**
+     * Don't register an event and payload to be fired later.
+     *
+     * @param  string  $event
+     * @param  array  $payload
+     * @return void
+     */
+    public function push($event, $payload = [])
+    {
+    }
+
+    /**
+     * Don't dispatch an event.
+     *
+     * @param  string|object  $event
+     * @param  mixed  $payload
+     * @return array|null
+     */
+    public function until($event, $payload = [])
+    {
+    }
+
+    /**
+     * Register an event listener with the dispatcher.
+     *
+     * @param  string|array  $events
+     * @param  \Closure|string  $listener
+     * @return void
+     */
+    public function listen($events, $listener)
+    {
+        return $this->dispatcher->listen($events, $listener);
+    }
+
+    /**
+     * Determine if a given event has listeners.
+     *
+     * @param  string  $eventName
+     * @return bool
+     */
+    public function hasListeners($eventName)
+    {
+        return $this->dispatcher->hasListeners($eventName);
+    }
+
+    /**
+     * Register an event subscriber with the dispatcher.
+     *
+     * @param  object|string  $subscriber
+     * @return void
+     */
+    public function subscribe($subscriber)
+    {
+        return $this->dispatcher->subscribe($subscriber);
+    }
+
+    /**
+     * Flush a set of pushed events.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function flush($event)
+    {
+        return $this->dispatcher->flush($event);
+    }
+
+    /**
+     * Remove a set of listeners from the dispatcher.
+     *
+     * @param  string  $event
+     * @return void
+     */
+    public function forget($event)
+    {
+        return $this->dispatcher->forget($event);
+    }
+
+    /**
+     * Forget all of the queued listeners.
+     *
+     * @return void
+     */
+    public function forgetPushed()
+    {
+        return $this->dispatcher->forgetPushed();
+    }
+
+    /**
+     * Dynamically pass method calls to the underlying dispatcher.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        return $this->forwardCallTo($this->dispatcher, $method, $parameters);
+    }
+}

--- a/tests/Integration/Database/EloquentModelWithoutEventsTest.php
+++ b/tests/Integration/Database/EloquentModelWithoutEventsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * @group integration
+ */
+class EloquentModelWithoutEventsTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('auto_filled_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->text('project')->nullable();
+        });
+    }
+
+    public function testWithoutEventsRegistersBootedListenersForLater()
+    {
+        $model = AutoFilledModel::withoutEvents(function () {
+            return AutoFilledModel::create();
+        });
+
+        $this->assertNull($model->project);
+
+        $model->save();
+
+        $this->assertEquals('Laravel', $model->project);
+    }
+}
+
+class AutoFilledModel extends Model
+{
+    public $table = 'auto_filled_models';
+    public $timestamps = false;
+    protected $guarded = ['id'];
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::saving(function ($model) {
+            $model->project = 'Laravel';
+        });
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/32935

Eloquent model `boot()` hooks (and `booting()`/`booted()` in 7.x+) run once per-class in each request. If an Eloquent model class is instantiated for the first time inside `Model::withoutEvents()`, `boot()` callbacks registering custom event listeners expected later will be skipped. e.g.,

```php
class Invoice extends Model
{
    public static function boot()
    {
        parent::boot();

        static::creating(function (Invoice $invoice) {
            if (blank($invoice->number)) {
                $invoice->generateNumber();
            }
        });
    }
}
```

```php
public function test_it_will_auto_generate_unique_invoice_number()
{
    $firstInvoice = User::withoutEvents(function () {
        // Wish to avoid firing listeners from User model events.
        $user = factory(User::class)->create();

        return Invoice::create([
            'user_id' => $user->id,
            'number' => 'I'.Str::random(5),
        ]);
    });

    // This doesn't fire the 'creating' listener to auto-fill database column
    // "invoices"."number". `Invoice` above had no event dispatcher so the
    // 'creating' listener was never registered.
    $secondInvoice = Invoice::create(['user_id' => $firstInvoice->user_id]);
```

Instead of `Model::withoutEvents()` removing the event dispatcher from all models, replace it with a null pattern implementation. Fired event `dispatch()` attempts are noop when inside `withoutEvents()`. However event listeners can still be registered on the concrete dispatcher for post-`withoutEvents()` calls.