### PR TITLE
[7.x] Resolve ComponentTagCompiler out of the container

### DIFF
--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -317,9 +317,9 @@ class BladeCompiler extends Compiler implements CompilerInterface
             return $value;
         }
 
-        return (new ComponentTagCompiler(
+        return app(ComponentTagCompiler::class, [
             $this->classComponentAliases, $this
-        ))->compile($value);
+        ])->compile($value);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\View\Compilers;
 
+use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -317,7 +318,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
             return $value;
         }
 
-        return app(ComponentTagCompiler::class, [
+        return Container::getInstance()->make(ComponentTagCompiler::class, [
             $this->classComponentAliases, $this,
         ])->compile($value);
     }

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -318,7 +318,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         return app(ComponentTagCompiler::class, [
-            $this->classComponentAliases, $this
+            $this->classComponentAliases, $this,
         ])->compile($value);
     }
 


### PR DESCRIPTION
I'd like to extend ComponentTagCompiler so I can capture the slot and pass other data to it. Basically I want to start a callable here https://github.com/laravel/framework/blob/7.x/src/Illuminate/View/Compilers/ComponentTagCompiler.php#L207 and then close it inside BladeCompiler. 

So inside the component I could pretty much do. `{{ $capture($otherDataThatINeedToPass) }}``, instead of `{{ $slot }}`. This basically allows me to modify the slot and achieve some cool stuff.

A concrete example:

given `old('question')` returns 2 array items

```blade
<x-form.fields for="question">
    <x-form.text-field name="title" label="Question"/>
</x-form.fields>
```


would render
```html
<input name="question[0][title]"/>
<input name="question[1][title]"/>
```

as you can see I don't need to pass $index or anything like that, as my fields component calls {{ `$capture(['index' => 0, 'parent' => 'question'])` (simplified example).

I know I could just extend blade compiler itself, and override the call to  `new ComponentTagCompiler` but it feels hacky. 

I don't know if it's the best idea to call app helper here, so any feedback is welcome. 