### PR TITLE
[8.x] Add setRelation to Eloquent's collection

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -238,6 +238,24 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
+     * Set realtion over each item.
+     *
+     * @return array
+     */
+    public function setRelation($name, $relation)
+    {
+        $relations = is_array($relation) ? $relation : [$name => $relation];
+
+        $this->each(function($model) use ($relations) {
+            foreach($relations as $name => $relation) {
+                $model->setRelation($name, $relation);
+            }
+        });
+
+        return $this;
+    }
+
+    /**
      * Get the array of primary keys.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -240,6 +240,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Set realtion over each item.
      *
+     * @param  mixed  $name
+     * @param  mixed  $relation
      * @return array
      */
     public function setRelation($name, $relation = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -240,8 +240,8 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Set realtion over each item.
      *
-     * @param  mixed  $name
-     * @param  mixed  $relation
+     * @param string|array $name
+     * @param mixed  $relation
      * @return array
      */
     public function setRelation($name, $relation = null)

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -242,9 +242,9 @@ class Collection extends BaseCollection implements QueueableCollection
      *
      * @return array
      */
-    public function setRelation($name, $relation)
+    public function setRelation($name, $relation = null)
     {
-        $relations = is_array($relation) ? $relation : [$name => $relation];
+        $relations = is_array($name) ? $name : [$name => $relation];
 
         $this->each(function($model) use ($relations) {
             foreach($relations as $name => $relation) {

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -479,8 +479,10 @@ class DatabaseEloquentCollectionTest extends TestCase
 
 
         $c = new Collection([$one, $two]);
-        $c->setRelation('testRelation1', $relation1);
-        $c->setRelation('testRelation2', $relation2);
+        $c->setRelation([
+            'testRelation1' => $relation1,
+            'testRelation2' => $relation2,
+        ]);
 
         $this->assertEquals($relation1, $c[0]->testRelation1);
         $this->assertEquals($relation2, $c[0]->testRelation2);

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -455,6 +455,38 @@ class DatabaseEloquentCollectionTest extends TestCase
         $c = new Collection;
         $this->assertEquals($c, $c->fresh());
     }
+
+    public function testSetRelation() {
+        $relation = new TestEloquentCollectionModel();
+
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+
+
+        $c = new Collection([$one, $two]);
+        $c->setRelation('testRelation', $relation);
+
+        $this->assertEquals($relation, $c[0]->testRelation);
+        $this->assertEquals($relation, $c[1]->testRelation);
+    }
+
+    public function testSetManyRelation() {
+        $relation1 = new TestEloquentCollectionModel();
+        $relation2 = new TestEloquentCollectionModel();
+
+        $one = new TestEloquentCollectionModel();
+        $two = new TestEloquentCollectionModel();
+
+
+        $c = new Collection([$one, $two]);
+        $c->setRelation('testRelation1', $relation1);
+        $c->setRelation('testRelation2', $relation2);
+
+        $this->assertEquals($relation1, $c[0]->testRelation1);
+        $this->assertEquals($relation2, $c[0]->testRelation2);
+        $this->assertEquals($relation1, $c[1]->testRelation1);
+        $this->assertEquals($relation2, $c[1]->testRelation2);
+    }
 }
 
 class TestEloquentCollectionModel extends Model


### PR DESCRIPTION
This PR adds a shortcut to set model relation from Eloquent Collection.

```php
# instead of 
$comments = $post->comments;
$comments->each->setRelation('post', $post);

# would be
$comments = $post->comments;
$comments->setRelation('post',$post);
```

also setting many relations would be easy and nice 

```php
# instead of 
$products->setRelation('category', $category);
$products->setRelation('brand', $brand)

# would be
$products->setRelation([ 
  'category' => $category
  'brand' => $brand
]);
```
