### PR TITLE
[8.x] Fix json_decode() does not always return an array

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -50,7 +50,7 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an array.
      *
-     * @return array
+     * @return mixed
      */
     public function json()
     {


### PR DESCRIPTION
Update json() function phpdoc in Laravel Http client to reflect more accurate return type upon json decoding a response.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
