### PR TITLE
[6.x] Switch to composer 2 on actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,17 +36,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-${{ matrix.stability }}-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          tools: composer:v2
           coverage: none
 
       - name: Setup Memcached
@@ -87,17 +82,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-${{ matrix.stability }}-windows-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp
+          tools: composer:v2
           coverage: none
           ini-values: memory_limit=512M
 


### PR DESCRIPTION
The caching used to take up 5-10 seconds of build time plus Composer 1 would take 25-30 seconds. Composer 2 ran in 8-14 seconds here, without cache. Using the cache would certainly have been slower, due to parallel downloads.

Remember, the cache is just downloaded from some remote server, and so are dependencies by composer. We are saving time by only downloading the ones we are using and not uploading them after! Composer 2 can fetch them all in parallel faster then we can restore and upload them in bulk from/to the cache.