### PR TITLE
[6.x] Improve static analyse

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -242,7 +242,7 @@ class Builder
     /**
      * Add a subselect expression to the query.
      *
-     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  \Closure|$this|string  $query
      * @param  string  $as
      * @return \Illuminate\Database\Query\Builder|static
      *


### PR DESCRIPTION
When we use `$eloquent->newQuery()->selectSub($anotherEloquent->newQuery()->where(...))`, it causes a signature mismatch because Query Builder and Eloquent Builder are not the same class.