### PR TITLE
[7.x] Get data from QueuedCommand

### DIFF
--- a/src/Illuminate/Foundation/Console/QueuedCommand.php
+++ b/src/Illuminate/Foundation/Console/QueuedCommand.php
@@ -39,4 +39,14 @@ class QueuedCommand implements ShouldQueue
     {
         call_user_func_array([$kernel, 'call'], $this->data);
     }
+
+    /**
+     * Return data.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR allows to get the protected attribute `$data` from the `QueuedCommand` class.

Our use case is the following:

```php
Queue::assertPushed(QueuedCommand::class, function (QueuedCommand $command) {
    return $command->getData()[0] === 'my-command';
});
```

This does not break anything because it only gets the data. I don't know if I should write a test because it's so simple. If you want me to write one, let me know.

