### PR TITLE
[7.x] Update HTTP client Response json() method documentation to match functionality

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -48,9 +48,9 @@ class Response implements ArrayAccess
     }
 
     /**
-     * Get the JSON decoded body of the response as an array.
+     * Get the JSON decoded body of the response as an array or scalar value.
      *
-     * @return array
+     * @return mixed
      */
     public function json()
     {


### PR DESCRIPTION
When an HTTP client Request is retrieved that contains a non-object JSON response, the return type in the `json()` method may not actually be `array`, for example if the response data is a JSON-encoded string, or null/boolean value, but still parses correctly and returns the expected value. This updates the documentation to match that behavior.

## Example

```php
use Illuminate\Support\Facades\Http;

Http::fake([
    'example.com/string' => Http::response(json_encode('Example'), 200, ['Content-Type' => 'application/json']),
    'example.com/bool' => Http::response(json_encode(true), 200, ['Content-Type' => 'application/json']),
]);

$response = Http::get('http://example.com/string');
$response->json(); // "Example"
$response = Http::get('http://example.com/bool');
$response->json(); // true
```

Fixes #33155.