### PR TITLE
[7.x] Added makeVisibleIf and makeHiddenIf

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -2,6 +2,8 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
+use Closure;
+
 trait HidesAttributes
 {
     /**
@@ -94,6 +96,48 @@ trait HidesAttributes
         $this->hidden = array_merge(
             $this->hidden, is_array($attributes) ? $attributes : func_get_args()
         );
+
+        return $this;
+    }
+
+    /**
+     * Make the given, typically hidden, attributes visible,
+     * only if the truth test passes.
+     *
+     * @param  bool|Closure  $truthTest
+     * @param  array|string|null  $attributes
+     * @return $this
+     */
+    public function makeVisibleIf($truthTest, $attributes)
+    {
+        if ($truthTest instanceof Closure) {
+            $truthTest = $truthTest($this);
+        }
+
+        if ($truthTest) {
+            $this->makeVisible($attributes);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Make the given, typically visible, attributes hidden,
+     * only if the truth test passes.
+     *
+     * @param  bool|Closure  $truthTest
+     * @param  array|string|null  $attributes
+     * @return $this
+     */
+    public function makeHiddenIf($truthTest, $attributes)
+    {
+        if ($truthTest instanceof Closure) {
+            $truthTest = $truthTest($this);
+        }
+
+        if ($truthTest) {
+            $this->makeHidden($attributes);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HidesAttributes.php
@@ -114,11 +114,7 @@ trait HidesAttributes
             $truthTest = $truthTest($this);
         }
 
-        if ($truthTest) {
-            $this->makeVisible($attributes);
-        }
-
-        return $this;
+        return $truthTest ? $this->makeVisible($attributes) : $this;
     }
 
     /**
@@ -135,10 +131,6 @@ trait HidesAttributes
             $truthTest = $truthTest($this);
         }
 
-        if ($truthTest) {
-            $this->makeHidden($attributes);
-        }
-
-        return $this;
+        return $truthTest ? $this->makeHidden($attributes) : $this;
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -950,6 +950,65 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertArrayNotHasKey('age', $array);
     }
 
+    public function testMakeVisibleIf()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'id' => 'baz']);
+        $model->setHidden(['age', 'id']);
+        $model->makeVisibleIf(true, 'age');
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayNotHasKey('id', $array);
+
+        $model->setHidden(['age', 'id']);
+        $model->makeVisibleIf(false, 'age');
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('age', $array);
+        $this->assertArrayNotHasKey('id', $array);
+
+        $model->setHidden(['age', 'id']);
+        $model->makeVisibleIf(function ($model) {
+            return ! is_null($model->name);
+        }, 'age');
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayNotHasKey('id', $array);
+    }
+
+    public function testMakeHiddenIf()
+    {
+        $model = new EloquentModelStub(['name' => 'foo', 'age' => 'bar', 'address' => 'foobar', 'id' => 'baz']);
+        $array = $model->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayHasKey('address', $array);
+        $this->assertArrayHasKey('id', $array);
+
+        $array = $model->makeHiddenIf(true, 'address')->toArray();
+        $this->assertArrayNotHasKey('address', $array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayHasKey('id', $array);
+
+        $model->makeVisible('address');
+
+        $array = $model->makeHiddenIf(false, ['name', 'age'])->toArray();
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayHasKey('age', $array);
+        $this->assertArrayHasKey('address', $array);
+        $this->assertArrayHasKey('id', $array);
+
+        $array = $model->makeHiddenIf(function ($model) {
+            return ! is_null($model->id);
+        }, ['name', 'age'])->toArray();
+        $this->assertArrayHasKey('address', $array);
+        $this->assertArrayNotHasKey('name', $array);
+        $this->assertArrayNotHasKey('age', $array);
+        $this->assertArrayHasKey('id', $array);
+    }
+
     public function testFillable()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
What I want to achieve is to show/hide certain attributes based on other model attributes.

For example, hiding `home_lineups` and `away_lineups` for a sport event if they don't have lineups.

```php
$sportEvent->makeHiddenIf(function ($sportEvent) {
    return ! $sportEvent->has_lineups;
}, ['home_lineups, 'away_lineups']);
```

Or, vice-versa, having them hidden by default and showing them:

```php
$sportEvent->makeVisibleIf(function ($sportEvent) {
    return $sportEvent->has_lineups;
}, ['home_lineups, 'away_lineups']);
```