### PR TITLE
[7.x] Add delimiter option for route prefix

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -720,27 +720,32 @@ class Route
     /**
      * Add a prefix to the route URI.
      *
-     * @param  string  $prefix
+     * @param string $prefix
+     * @param string $delimiter
      * @return $this
      */
-    public function prefix($prefix)
+    public function prefix($prefix, $delimiter = '/')
     {
-        $this->updatePrefixOnAction($prefix);
+        $trimmer = $delimiter === '/' ? $delimiter : '/'.$delimiter;
 
-        $uri = rtrim($prefix, '/').'/'.ltrim($this->uri, '/');
+        $this->updatePrefixOnAction($prefix, $delimiter, $trimmer);
 
-        return $this->setUri($uri !== '/' ? trim($uri, '/') : $uri);
+        $uri = rtrim($prefix, $trimmer).$delimiter.ltrim($this->uri, $trimmer);
+
+        return $this->setUri($uri !== $trimmer ? trim($uri, $trimmer) : $uri);
     }
 
     /**
      * Update the "prefix" attribute on the action array.
      *
-     * @param  string  $prefix
+     * @param string $prefix
+     * @param string $delimiter
+     * @param string $trimmer
      * @return void
      */
-    protected function updatePrefixOnAction($prefix)
+    protected function updatePrefixOnAction($prefix, $delimiter = '/', $trimmer = '/')
     {
-        if (! empty($newPrefix = trim(rtrim($prefix, '/').'/'.ltrim($this->action['prefix'] ?? '', '/'), '/'))) {
+        if (! empty($newPrefix = trim(rtrim($prefix, $trimmer).$delimiter.ltrim($this->action['prefix'] ?? '', $trimmer), $trimmer))) {
             $this->action['prefix'] = $newPrefix;
         }
     }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -1185,6 +1185,18 @@ class RoutingRouteTest extends TestCase
         $this->assertSame('prefix/foo/bar', $routes[0]->uri());
 
         /*
+         * Prefix route with '.' delimiter
+         */
+        $router = $this->getRouter();
+        $router->get('foo/baz', function () {
+            return 'hello';
+        });
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+        $routes[0]->prefix('prefix', '.');
+        $this->assertSame('prefix.foo/baz', $routes[0]->uri());
+
+        /*
          * Use empty prefix
          */
         $router = $this->getRouter();
@@ -1206,6 +1218,18 @@ class RoutingRouteTest extends TestCase
         $routes = $router->getRoutes();
         $routes = $routes->getRoutes();
         $routes[0]->prefix('prefix');
+        $this->assertSame('prefix', $routes[0]->uri());
+
+        /*
+         * Prefix homepage with '.' delimiter
+         */
+        $router = $this->getRouter();
+        $router->get('/', function () {
+            return 'hello';
+        });
+        $routes = $router->getRoutes();
+        $routes = $routes->getRoutes();
+        $routes[0]->prefix('prefix', '.');
         $this->assertSame('prefix', $routes[0]->uri());
 
         /*


### PR DESCRIPTION
Currently there is no option to customize the route prefix delimiter which is `/` 99% of the time and it totally made sense that Laravel had it hardcoded.

However this made it hard for users who are in needs to customize the delimiter in different cases.

This PR aims to provide a delimiter option to the `prefix` method with `/` as the default delimiter.

Usage would be:
```php
Route::prefix('chat', '.')
  ->group(function () {
     Route::post('send', 'ChatController@send');
  });
```
And the route would be registered as `POST /chat.send`