### PR TITLE
[6.x] Improved the reflector

### DIFF
--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Container;
 
 use Closure;
+use ReflectionNamedType;
 
 class Util
 {
@@ -46,8 +47,18 @@ class Util
      */
     public static function getParameterClassName($parameter)
     {
-        $type = $parameter->getType();
+        $type = $parameter->getType()
 
-        return ($type && ! $type->isBuiltin()) ? $type->getName() : null;
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return;
+        }
+
+        $name = $type->getName();
+
+        if ($name === 'self') {
+            return $parameter->getDeclaringClass()->getName();
+        }
+
+        return $name;
     }
 }

--- a/src/Illuminate/Container/Util.php
+++ b/src/Illuminate/Container/Util.php
@@ -47,7 +47,7 @@ class Util
      */
     public static function getParameterClassName($parameter)
     {
-        $type = $parameter->getType()
+        $type = $parameter->getType();
 
         if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
             return;

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -15,7 +15,7 @@ class Reflector
      */
     public static function getParameterClassName($parameter)
     {
-        $type = $parameter->getType()
+        $type = $parameter->getType();
 
         if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
             return;

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support;
 
 use ReflectionClass;
+use ReflectionNamedType;
 
 class Reflector
 {
@@ -14,9 +15,19 @@ class Reflector
      */
     public static function getParameterClassName($parameter)
     {
-        $type = $parameter->getType();
+        $type = $parameter->getType()
 
-        return ($type && ! $type->isBuiltin()) ? $type->getName() : null;
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return;
+        }
+
+        $name = $type->getName();
+
+        if ($name === 'self') {
+            return $parameter->getDeclaringClass()->getName();
+        }
+
+        return $name;
     }
 
     /**


### PR DESCRIPTION
1. Fixed treatment of union types in PHP 8. `Foo|null` and `?Foo` will be treated as `"Foo"`, `Foo|Bar` will be treated as `null`.
2. Fixed treatment of `self` typing. `self` declared in a parameter in a method defined in class `Foo` will be treated as `"Foo"`, even if the reflection parameter was generated from querying a class `Bar` that extends or implements `Foo`. This mimics the behaviour of `getClass` on PHP 7, which was removed in PHP 8 (which is what we are here to simulate).

---

Closes #33177.