### PR TITLE
[7.x] Add hash_equals validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1646,7 +1646,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate that an attribute matches the hash
+     * Validate that an attribute matches the hash.
      *
      * @param  string  $attribute
      * @param  mixed  $value

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1646,6 +1646,23 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute matches the hash
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  array  $parameters
+     * @return bool
+     */
+    public function validateHashEquals($attribute, $value, $parameters)
+    {
+        $hasher = $this->container->make('hash');
+
+        $this->requireParameterCount(1, $parameters, 'hash_equals');
+
+        return $hasher->check($value, $parameters[0]);
+    }
+
+    /**
      * Validate the size of an attribute.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1205,6 +1205,35 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testValidateHashEquals()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        // Fails when hash is incorrect
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->with('baz', 'hashed_bar')->andReturn(false);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $v = new Validator($trans, ['foo' => 'baz'], ['foo' => 'hash_equals:hashed_bar']);
+        $v->setContainer($container);
+
+        $this->assertFalse($v->passes());
+
+        // Succeeds when hash is correct.
+        $hasher = m::mock(Hasher::class);
+        $hasher->shouldReceive('check')->with('bar', 'hashed_bar')->andReturn(true);
+
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with('hash')->andReturn($hasher);
+
+        $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'hash_equals:hashed_bar']);
+        $v->setContainer($container);
+
+        $this->assertTrue($v->passes());
+    }
+
     public function testValidateDifferent()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
I sometimes have the need to compare a value from a form submission against a hashed value. This validation rule allows you to easily do so. It's a new validation rule, doesn't use any new imports, so it doesn't break any existing features.

If the PR passes I will also make a documentation PR.