### PR TITLE
[7.x] Improve event subscribers

### DIFF
--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -161,7 +161,15 @@ class Dispatcher implements DispatcherContract
     {
         $subscriber = $this->resolveSubscriber($subscriber);
 
-        $subscriber->subscribe($this);
+        $events = $subscriber->subscribe($this);
+
+        if (is_array($events)) {
+            foreach ($events as $event => $listeners) {
+                foreach (array_unique($listeners) as $listener) {
+                    $this->listen($event, $listener);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This allows the event subscribers to return an array like the `$listen` property on the `EventsServiceProvider`
In fact, it introduces some syntactic sugar, by removing `$events->listen(`

also improves the doc-block of the public interface.

The example in laravel documentation:
```php
    public function subscribe($events)
    {
        $events->listen(
            'App\Events\UserLoggedIn',
            'App\Listeners\UserEventListener@onUserLogin'
        );

        $events->listen(
            'App\Events\UserLoggedOut',
            'App\Listeners\UserEventListener@onUserLogout'
        );
    }
```

Can be refactored to:
```php

    public function subscribe()
    {
         return [
            'App\Events\UserLoggedIn' => ['App\Listeners\UserEventListener@onUserLogin'],
            'App\Events\UserLoggedOut' =>  ['App\Listeners\UserEventListener@onUserLogout']
         ];
    }
```

This is mostly backward compatible except in case someone returns a sequential array from the subscriber for no reason.
(It is possible to make is fully backward compatible by checking the array is assoc but it has performance hit, in the boot phase.)

- If accepted I add the needed tests and documentation
- This introduces a little bit of code duplication from `EventServiceProvider.php` which can be refactored if accepted.
(the two nested foreach loops are copy/pasted)
https://github.com/laravel/framework/blob/192356b8d519dc307bd453786551fc5c765c7cab/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php#L34
