### PR TITLE
[7.x] Allow rule objects as validator extensions

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -478,6 +478,10 @@ class Validator implements ValidatorContract
     {
         $this->currentRule = $rule;
 
+        if ($this->isRuleExtension($rule)) {
+            $rule = new $this->extensions[$rule];
+        }
+
         [$rule, $parameters] = ValidationRuleParser::parse($rule);
 
         if ($rule == '') {
@@ -604,6 +608,21 @@ class Validator implements ValidatorContract
                $this->passesOptionalCheck($attribute) &&
                $this->isNotNullIfMarkedAsNullable($rule, $attribute) &&
                $this->hasNotFailedPreviousRuleIfPresenceRule($rule, $attribute);
+    }
+
+    /**
+     * Determine if the rule is an extension and implements the Rule contract.
+     *
+     * @param string $rule
+     * @return bool
+     */
+    protected function isRuleExtension(string $rule): bool
+    {
+        if (! array_key_exists($rule, $this->extensions)) {
+            return false;
+        }
+
+        return in_array(RuleContract::class, class_implements($this->extensions[$rule]));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -613,16 +613,19 @@ class Validator implements ValidatorContract
     /**
      * Determine if the rule is an extension and implements the Rule contract.
      *
-     * @param string $rule
+     * @param  array|string  $rule
      * @return bool
      */
-    protected function isRuleExtension(string $rule): bool
+    protected function isRuleExtension($rule): bool
     {
-        if (! array_key_exists($rule, $this->extensions)) {
+        if (! is_string($rule) || ! isset($this->extensions[$rule])) {
             return false;
         }
 
-        return in_array(RuleContract::class, class_implements($this->extensions[$rule]));
+        $rule = $this->extensions[$rule];
+
+        return is_string($rule) && class_exists($rule)
+            && in_array(RuleContract::class, class_implements($rule));
     }
 
     /**

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -478,7 +478,7 @@ class Validator implements ValidatorContract
     {
         $this->currentRule = $rule;
 
-        if ($this->isRuleExtension($rule)) {
+        if ($this->isRuleObjectExtension($rule)) {
             $rule = new $this->extensions[$rule];
         }
 
@@ -611,12 +611,12 @@ class Validator implements ValidatorContract
     }
 
     /**
-     * Determine if the rule is an extension and implements the Rule contract.
+     * Determine if the rule is a Rule object.
      *
      * @param  array|string  $rule
      * @return bool
      */
-    protected function isRuleExtension($rule): bool
+    protected function isRuleObjectExtension($rule): bool
     {
         if (! is_string($rule) || ! isset($this->extensions[$rule])) {
             return false;

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3662,6 +3662,21 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
+    public function testRuleBasedCustomValidators()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['bar' => true], ['bar' => 'foo']);
+        $v->setContainer($container = m::mock(Container::class));
+        $v->addExtension('foo', FooRule::class);
+        $this->assertTrue($v->passes());
+
+        $trans = $this->getIlluminateArrayTranslator();
+        $v = new Validator($trans, ['bar' => false], ['bar' => 'foo']);
+        $v->addExtension('foo', FooRule::class);
+        $this->assertFalse($v->passes());
+        $this->assertSame('foo bar', $v->messages()->first('bar'));
+    }
+
     public function testExceptionThrownOnIncorrectParameterCount()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -5500,4 +5515,17 @@ class ExplicitTableAndConnectionModel extends Model
 
 class NonEloquentModel
 {
+}
+
+class FooRule implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return $value;
+    }
+
+    public function message()
+    {
+        return 'foo :attribute';
+    }
 }

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3666,7 +3666,6 @@ class ValidationValidatorTest extends TestCase
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['bar' => true], ['bar' => 'foo']);
-        $v->setContainer($container = m::mock(Container::class));
         $v->addExtension('foo', FooRule::class);
         $this->assertTrue($v->passes());
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3662,7 +3662,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
     }
 
-    public function testRuleBasedCustomValidators()
+    public function testRuleObjectBasedCustomValidators()
     {
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['bar' => true], ['bar' => 'foo']);


### PR DESCRIPTION
This PR allows the validator to be extended using custom rule objects. 

Currently, the `Validator::extend()` method accepts closures and `'class@method'` syntax, and requires error messages to be passed in as an additional argument, or to be added to the validation language file.

Rule objects are much cleaner and encapsulate everything into a single class. This allows them to be easily testable,  reusable, and extract complex logic + validation error messages in one place.

I feel that allowing the validator to extend rule objects would be best of both worlds:

```php
// AppServiceProvider
Validator::extend('foo', FooRule::class);

// Controller
$request->validate([
    'name' => ['required', 'string', 'foo'],
]);
```

There are no breaking changes, and all tests are green.

---

A little backstory on why I need this: I'm currently building an app that stores form fields + validation rules in the DB. This means that the form config gets serialised and unserialised when needed inside a FormRequest class:

```php
public function rules()
{
    return $this->route('form')->fields;
}
```

This means I can't use the following syntax:

```php
$request->validate([
    'name' => ['required', 'string', new FooRule],
]);
```

This is when I reached for `Validator::extend()`, but as it stands right now, I need to use this syntax to continue using my custom rule object:

```php
Validator::extend('foo', function ($attribute, $value) {
    return (new FooRule)->passes($attribute, $value);
}, (new FooRule)->message());
```

---

Thank you for considering this PR and let me know if there's any questions or feedback!