### PR TITLE
[7.x] Support packaging Laravel project in a phar

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
+++ b/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php
@@ -83,12 +83,16 @@ class LoadConfiguration
     {
         $files = [];
 
-        $configPath = realpath($app->configPath());
+        $isPhar = class_exists('Phar') && (bool) \Phar::running();
+
+        $configPath = $isPhar ? $app->configPath() : realpath($app->configPath());
 
         foreach (Finder::create()->files()->name('*.php')->in($configPath) as $file) {
             $directory = $this->getNestedDirectory($file, $configPath);
 
-            $files[$directory.basename($file->getRealPath(), '.php')] = $file->getRealPath();
+            $filePath = $isPhar ? $file->getPathname() : $file->getRealPath();
+
+            $files[$directory.basename($filePath, '.php')] = $filePath;
         }
 
         ksort($files, SORT_NATURAL);


### PR DESCRIPTION
Was going to open this in `laravel/ideas` but thought I'd post it here to show code changes since I have a working example. After being forced to use a web server that only supported SFTP and facing the excessive deploy time of uploading the `vendor` directory files, I thought I'd try packaging the project in a phar. The only part of a vanilla Laravel project that doesn't support this is the configuration loader - see changed files.

### Config
The config has to reflect that phars are read-only. This is solved in a production `.env` with:
```sh
CACHE_DRIVER=array # Anything other than "file"
LOG_CHANNEL=stderr # Anything other than "single/daily/emergency"
SESSION_DRIVER=array # Anything other than "file"
VIEW_COMPILED_PATH=/tmp # Obviously a security concern - would need a way to disable the cache or fix `App::getStoragePath()`'s usage of `realpath()`.
```

### Considerations
`realpath()` should not be used to locate files within the project. This merge request is an example of the necessary check.

### Try it out
Use the below two files in a project with [humbug/box](https://packagist.org/packages/humbug/box) and `php -S localhost:8000 laravel-project.phar` (or try renaming it to `index.php` and put it on a server with the phar PHP module enabled and path rewrites):
`/box.json` (assumes your production `.env` is `.env.production`):
```json
{
  "compression": "GZ",
  "directories": [
    "app",
    "bootstrap",
    "config",
    "database",
    "public",
    "resources",
    "routes",
    "vendor"
  ],
  "exclude-composer-files": false,
  "exclude-dev-files": false,
  "files": [
    ".env.production",
    "artisan",
    "composer.json",
    "composer.lock"
  ],
  "main": "public/index.php",
  "map": [
    { ".env.production": ".env" }
  ],
  "output": "laravel-project.phar",
  "stub": "phar-stub.php"
}
```

`/phar-stub.php` (throws in a crude handler for artisan commands too):
```php
<?php

// Handle artisan commands
if (isset($argv[1]) && $argv[1] == 'artisan') {
  require 'phar://laravel-project.phar/vendor/autoload.php';

  $app = require_once 'phar://laravel-project.phar/bootstrap/app.php';

  $kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);

  $status = $kernel->handle(
      $input = new Symfony\Component\Console\Input\StringInput(isset($argv[2]) ? $argv[2] : ''),
      new Symfony\Component\Console\Output\ConsoleOutput
  );

  $kernel->terminate($input, $status);

  exit($status);
}

// Handle web requests
if (class_exists('Phar')) {
  Phar::mapPhar('laravel-project.phar');

  require 'phar://laravel-project.phar/public/index.php';
} else {
  die('Please enable phar PHP module');
}

__HALT_COMPILER();
```