### PR TITLE
[6.x] Suggest ext-ftp as it's required to use createFtpDriver()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,6 +113,7 @@
         }
     },
     "suggest": {
+        "ext-ftp": "Required to use Illuminate\\Filesystem\\FilesystemManager::createFtpDriver",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",
         "ext-pcntl": "Required to use all features of the queue worker.",

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
         }
     },
     "suggest": {
-        "ext-ftp": "Required to use Illuminate\\Filesystem\\FilesystemManager::createFtpDriver",
+        "ext-ftp": "Required to use the Flysystem FTP driver.",
         "ext-gd": "Required to use Illuminate\\Http\\Testing\\FileFactory::image().",
         "ext-memcached": "Required to use the memcache cache driver.",
         "ext-pcntl": "Required to use all features of the queue worker.",

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -30,6 +30,7 @@
         }
     },
     "suggest": {
+        "ext-ftp": "Required to use the Flysystem FTP driver.",
         "league/flysystem": "Required to use the Flysystem local and FTP drivers (^1.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",


### PR DESCRIPTION
Suggest ext-ftp as it's required to use Illuminate\Filesystem\FilesystemManager::createFtpDriver()
