### PR TITLE
[7.x] Fix line endings error for response test

### DIFF
--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -250,7 +250,7 @@ class HttpClientTest extends TestCase
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');
-        $this->assertSame("This is a story about something that happened long ago when your grandfather was a child.\n", $response->body());
+        $this->assertSame(file_get_contents(__DIR__.'/fixtures/test.txt'), $response->body());
         $this->assertSame(200, $response->status());
 
         $response = $this->factory->get('https://example.com');


### PR DESCRIPTION
This test fails on windows because of line-ending of the original file.
I think if the specification of the mock does not say that it replaces the line-endings of the mock file.
It should be tested like this.

![image](https://user-images.githubusercontent.com/6961695/84571769-bd49d700-adaa-11ea-826c-4fce6cad0a59.png)
