### PR TITLE
[7.x] Accept callable as value for when method

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -438,7 +438,7 @@ trait EnumeratesValues
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
         }
-        
+
         if (is_callable($value)) {
             $value = $value($this);
         }

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -428,7 +428,7 @@ trait EnumeratesValues
     /**
      * Apply the callback if the value is truthy.
      *
-     * @param  bool|mixed  $value
+     * @param  bool|callable|mixed  $value
      * @param  callable|null  $callback
      * @param  callable|null  $default
      * @return static|mixed
@@ -437,6 +437,10 @@ trait EnumeratesValues
     {
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
+        }
+        
+        if (is_callable($value)) {
+            $value = $value($this);
         }
 
         if ($value) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Accept callable as value for `when` method in `EnumerateValues` trait to allow making this value dependent of collection values.

## Example
```php
Str::of('UNSUBSCRIBE_ACTION')
  ->explode('_')
  ->when(
  fn($collection) => $collection->first() === 'UNSUBSCRIBE', 
  function($collection) {
    //...
    echo 'unsubscribed';
  }
);
```