### PR TITLE
[7.x] Add option to specify a custom guard for the policy

### DIFF
--- a/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/PolicyMakeCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -65,6 +66,28 @@ class PolicyMakeCommand extends GeneratorCommand
             $model,
             $stub
         );
+    }
+
+    /**
+     * Get the model for the guard's user provider.
+     *
+     * @return string|null
+     */
+    protected function userProviderModel()
+    {
+        $config = $this->laravel['config'];
+
+        if ($this->option('any-guard')) {
+            return Authorizable::class;
+        }
+
+        $guard = $this->option('guard')
+                    ? $this->option('guard')
+                    : $config->get('auth.defaults.guard');
+
+        $provider = $config->get('auth.guards.'.$guard.'.provider');
+
+        return $config->get("auth.providers.{$provider}.model");
     }
 
     /**
@@ -160,6 +183,8 @@ class PolicyMakeCommand extends GeneratorCommand
     {
         return [
             ['model', 'm', InputOption::VALUE_OPTIONAL, 'The model that the policy applies to'],
+            ['guard', 'g', InputOption::VALUE_OPTIONAL, 'The guard that the policy relies on'],
+            ['any-guard', null, InputOption::VALUE_NONE, 'Allow use with any authorizable model (overrides --guard)'],
         ];
     }
 }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When using `artisan make:policy`, policies can only be generated with the user model found in the default guard's provider. This PR allows an optional `--guard` option to be specified to override this default behaviour with a non-default guard.

It also adds an `--any-guard` option, which overrides `--guard`, which will instead type hint `Illuminate\Contracts\Auth\Access\Authorizable` in the generated policy, allowing any guard to be used with the policy.

This PR should be fully backwards compatible as omitting both new options results in the existing behaviour (the default guard's provider model is used).

I wanted this because I have two guards, one for `Administrator`s and one for `User`s.