### PR TITLE
[7.x] Add theme to mailable properties

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -133,18 +133,18 @@ class Mailable implements MailableContract, Renderable
     public $callbacks = [];
 
     /**
+     * The name of the theme that should be used when formatting the message.
+     *
+     * @var string|null
+     */
+    public $theme;
+
+    /**
      * The name of the mailer that should send the message.
      *
      * @var string
      */
     public $mailer;
-
-    /**
-     * The name of the theme that should be used in the message (null to use the default theme defined in your config).
-     *
-     * @var string|null
-     */
-    public $theme = null;
 
     /**
      * The callback that should be invoked while building the view data.

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -140,6 +140,13 @@ class Mailable implements MailableContract, Renderable
     public $mailer;
 
     /**
+     * The name of the theme that should be used in the message (null to use the default theme defined in your config).
+     *
+     * @var string|null
+     */
+    public $theme = null;
+
+    /**
      * The callback that should be invoked while building the view data.
      *
      * @var callable


### PR DESCRIPTION
this allows the user to change the theme in the runtime and reflect it in queue because when the object is serialize for queue `$this->theme` would be gone if it's not preserved in the object properties

for example if my `__construct` looks like this

```
public function __construct($user)
{
     $this->theme = 'default-' . $user->user_lang;
}
```

I'm send an email to user and based on the user language I would like to set the theme

so by adding `$theme` to the properties it will be serialized and can be retrieved in the queue correctly