### PR TITLE
[8.x] Added EncryptCookies to the priority list, before StartSession

### DIFF
--- a/src/Illuminate/Foundation/Http/Kernel.php
+++ b/src/Illuminate/Foundation/Http/Kernel.php
@@ -71,6 +71,7 @@ class Kernel implements KernelContract
      * @var array
      */
     protected $middlewarePriority = [
+        \Illuminate\Cookie\Middleware\EncryptCookies::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,


### PR DESCRIPTION
Added EncryptCookies to the priority list. It needs to be run before StartSession, which has a priority. This normally works fine, until the user adjusts the middleware list to include at least 2 prioritised middlewares in the 'wrong' order, after which SortMiddleware puts all prioritized middleware at the front of the list. This includes StartSession, which is then executed before EncryptCookies. Basically: because StartSession has a priority and EncryptCookies _always_ needs to run before StartSession, EncryptCookies _should_ also get an explicit priority.

Benefits to end users: users can now mix their middlewares more easily. For example by adding the EncryptCookies and StartSession middlewares to the end of the list of the default 'api' middleware-group, which has a throttle as first middleware. Without this fix, throttle will cause the error to occur, forcing StartSession to the start of the list and causing that middleware to get undecrypted cookies.

Does not break: if EncryptCookies is not run before StartSession, applications do not work. This fix ensures that EncryptCookies is run before StartSession, so will never break any working current application. It might automatically fix applications that are not working due to the problem described above.