### PR TITLE
[7.x] Add SeedDatabase trait

### DIFF
--- a/src/Illuminate/Foundation/Testing/SeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabase.php
@@ -13,6 +13,9 @@ trait SeedDatabase
      */
     public function seed(string $seederClass = 'DatabaseSeeder', string $connection = '')
     {
+        if ($seederClass == '') {
+            $seederClass = 'DatabaseSeeder';
+        }
         if ($connection == '') {
             $connection = config('database.default');
         }

--- a/src/Illuminate/Foundation/Testing/SeedDatabase.php
+++ b/src/Illuminate/Foundation/Testing/SeedDatabase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Foundation\Testing;
+
+trait SeedDatabase
+{
+    /**
+     * Seed the database.
+     *
+     * @param string $seederClass
+     * @param string $connection
+     * @return void
+     */
+    public function seed(string $seederClass = 'DatabaseSeeder', string $connection = '')
+    {
+        if ($connection == '') {
+            $connection = config('database.default');
+        }
+
+        $this->artisan(sprintf('db:seed --class=%s --database=%s', $seederClass, $connection));
+    }
+}

--- a/src/Illuminate/Foundation/Testing/TestCase.php
+++ b/src/Illuminate/Foundation/Testing/TestCase.php
@@ -123,6 +123,10 @@ abstract class TestCase extends BaseTestCase
             $this->beginDatabaseTransaction();
         }
 
+        if (isset($uses[SeedDatabase::class])) {
+            $this->seed();
+        }
+
         if (isset($uses[WithoutMiddleware::class])) {
             $this->disableMiddlewareForAllTests();
         }


### PR DESCRIPTION
Hi, 

I would like to add a trait "SeedDatabase", I think this would be very helpful when writing tests.

Usually to seed the database for a test I would write the following:

```php
<?php

namespace Tests\Feature;

use DatabaseSeeder;
use Illuminate\Foundation\Testing\DatabaseMigrations;
use Tests\TestCase;

class AuthControllerTest extends TestCase
{
    use DatabaseMigrations;

    protected function setUp(): void
    {
        parent::setUp();
        $this->seed(DatabaseSeeder::class);
    }
}
```

Instead I could just specify two traits:

```php
<?php

namespace Tests\Feature;

use Illuminate\Foundation\Testing\DatabaseMigrations;
use Illuminate\Foundation\Testing\SeedDatabase;
use Tests\TestCase;

class AuthControllerTest extends TestCase
{
    use DatabaseMigrations, SeedDatabase;
}
```
