### PR TITLE
[7.x] Add monthlyOnLastDay() to Console/Scheduling/ManagesFrequencies

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -340,7 +340,7 @@ trait ManagesFrequencies
     /**
      * Schedule the event to run on the last day of the month.
      *
-     * @param string $time
+     * @param  string  $time
      * @return $this
      */
     public function monthlyOnLastDay($time = '0:0')

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -347,7 +347,7 @@ trait ManagesFrequencies
     {
         $this->dailyAt($time);
 
-        $lastDayOfMonth = now()->endOfMonth()->day;
+        $lastDayOfMonth = Carbon::now()->endOfMonth()->day;
 
         return $this->spliceIntoPosition(3, $lastDayOfMonth);
     }

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -338,6 +338,21 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run on the last day of the month
+     *
+     * @param string $time
+     * @return $this
+     */
+    public function monthlyOnLastDay($time = '0:0')
+    {
+        $this->dailyAt($time);
+
+        $lastDayOfMonth = now()->endOfMonth()->day;
+
+        return $this->spliceIntoPosition(3, $lastDayOfMonth);
+    }
+
+    /**
      * Schedule the event to run twice monthly.
      *
      * @param  int  $first

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -338,7 +338,7 @@ trait ManagesFrequencies
     }
 
     /**
-     * Schedule the event to run on the last day of the month
+     * Schedule the event to run on the last day of the month.
      *
      * @param string $time
      * @return $this


### PR DESCRIPTION
Added function monthlyOnLastDay() to execute a scheduled task on the last day of the current month.

The function takes a string parameter `$time` to specify the time of the day the task should run.