### PR TITLE
Original is equivalent not correct for floats updated

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1402,7 +1402,12 @@ trait HasAttributes
         $attribute = Arr::get($this->attributes, $key);
         $original = Arr::get($this->original, $key);
 
-        if ($attribute === $original) {
+        if ($this->getCastType($key) === 'float'){
+            return abs(
+                    $this->castAttribute($key, $attribute) -
+                    $this->castAttribute($key, $original)
+                ) < PHP_FLOAT_EPSILON;
+        } elseif ($attribute === $original) {
             return true;
         } elseif (is_null($attribute)) {
             return false;


### PR DESCRIPTION
According to the PHP Docs:
https://www.php.net/manual/en/language.types.float.php

You shouldn't compare two floats directly for equality.
One way to compare them is to use `PHP_FLOAT_EPSILON`. There might be a better way.

I wasn't able to find any specific tests for this. But I'm happy to add some tests.