### PR TITLE
originalIsEquivalent not correct for floats

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1371,7 +1371,7 @@ trait HasAttributes
         $attribute = Arr::get($this->attributes, $key);
         $original = Arr::get($this->original, $key);
 
-        if ($this->getCastType($key) === 'float'){
+        if ($this->hasCast($key, static::$primitiveCastTypes) && $this->getCastType($key) === 'float'){
             return abs(
                     $this->castAttribute($key, $attribute) -
                     $this->castAttribute($key, $original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1372,10 +1372,7 @@ trait HasAttributes
         $original = Arr::get($this->original, $key);
 
         if ($this->getCastType($key) === 'float'){
-            return abs(
-                    $this->castAttribute($key, $attribute) -
-                    $this->castAttribute($key, $original)
-                ) < PHP_FLOAT_EPSILON;
+            return bccomp($this->castAttribute($key, $attribute), $this->castAttribute($key, $original)) === 0;
         } elseif ($attribute === $original) {
             return true;
         } elseif (is_null($attribute)) {

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1371,7 +1371,12 @@ trait HasAttributes
         $attribute = Arr::get($this->attributes, $key);
         $original = Arr::get($this->original, $key);
 
-        if ($attribute === $original) {
+        if ($this->getCastType($key) === 'float'){
+            return abs(
+                    $this->castAttribute($key, $attribute) -
+                    $this->castAttribute($key, $original)
+                ) < PHP_FLOAT_EPSILON;
+        } elseif ($attribute === $original) {
             return true;
         } elseif (is_null($attribute)) {
             return false;


### PR DESCRIPTION
According to the PHP Docs:
https://www.php.net/manual/en/language.types.float.php

You shouldn't compare two floats directly for equality.
I wasn't able to find any specific tests for this. But I'm happy to add some tests.

To test this create a Model with a float field, set it to `0.17`, then update it to `1 - 0.83` (`0.17`) and `->isDirty()` should be false.