### PR TITLE
[8.x] Share data between chained jobs

### DIFF
--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -187,6 +187,7 @@ trait Queueable
 
                 $next->onConnection($next->connection ?: $this->chainConnection);
                 $next->onQueue($next->queue ?: $this->chainQueue);
+                $next->sharedData($this->sharedData);
 
                 $next->chainConnection = $this->chainConnection;
                 $next->chainQueue = $this->chainQueue;

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -7,6 +7,14 @@ use Illuminate\Support\Fluent;
 
 trait Dispatchable
 {
+
+    /**
+     * The data that was shared between previous jobs (if any).
+     *
+     * @var mixed
+     */
+    public $sharedData;
+
     /**
      * Dispatch the job with the given arguments.
      *
@@ -79,10 +87,24 @@ trait Dispatchable
      * Set the jobs that should run if this job is successful.
      *
      * @param  array  $chain
+     * @param  mixed  $sharedData
      * @return \Illuminate\Foundation\Bus\PendingChain
      */
-    public static function withChain($chain)
+    public static function withChain($chain, $sharedData = null)
     {
-        return new PendingChain(static::class, $chain);
+        return new PendingChain(static::class, $chain, $sharedData);
+    }
+
+    /**
+     * Pass the shared data.
+     *
+     * @param  mixed  $sharedData
+     * @return $this
+     */
+    public function sharedData($sharedData)
+    {
+        $this->sharedData = $sharedData;
+
+        return $this;
     }
 }

--- a/src/Illuminate/Foundation/Bus/Dispatchable.php
+++ b/src/Illuminate/Foundation/Bus/Dispatchable.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Fluent;
 
 trait Dispatchable
 {
-
     /**
      * The data that was shared between previous jobs (if any).
      *

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -22,16 +22,25 @@ class PendingChain
     public $chain;
 
     /**
+     * The data that will be shared across the jobs.
+     *
+     * @var mixed
+     */
+    public $sharedData;
+
+    /**
      * Create a new PendingChain instance.
      *
      * @param  mixed  $job
      * @param  array  $chain
+     * @param  mixed  $sharedData
      * @return void
      */
-    public function __construct($job, $chain)
+    public function __construct($job, $chain, $sharedData = null)
     {
         $this->job = $job;
         $this->chain = $chain;
+        $this->sharedData = $sharedData;
     }
 
     /**
@@ -42,7 +51,7 @@ class PendingChain
     public function dispatch()
     {
         if (is_string($this->job)) {
-            $firstJob = new $this->job(...func_get_args());
+            $firstJob = (new $this->job(...func_get_args()))->sharedData($this->sharedData);
         } elseif ($this->job instanceof Closure) {
             $firstJob = CallQueuedClosure::create($this->job);
         } else {

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -53,7 +53,7 @@ class PendingChain
         if (is_string($this->job)) {
             $firstJob = (new $this->job(...func_get_args()))->sharedData($this->sharedData);
         } elseif ($this->job instanceof Closure) {
-            $firstJob = CallQueuedClosure::create($this->job);
+            $firstJob = CallQueuedClosure::create($this->job, $this->sharedData);
         } else {
             $firstJob = $this->job;
         }

--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -42,11 +42,15 @@ class CallQueuedClosure implements ShouldQueue
      * Create a new job instance.
      *
      * @param  \Closure  $closure
+     * @param  mixed  $sharedData
      * @return self
      */
-    public static function create(Closure $job)
+    public static function create(Closure $job, $sharedData = null)
     {
-        return new self(new SerializableClosure($job));
+        return new self(
+            (new SerializableClosure($job))
+                ->sharedData($sharedData)
+        );
     }
 
     /**
@@ -57,7 +61,7 @@ class CallQueuedClosure implements ShouldQueue
      */
     public function handle(Container $container)
     {
-        $container->call($this->closure->getClosure());
+        $container->call($this->closure->getClosure(), [$this->closure->sharedData]);
     }
 
     /**

--- a/src/Illuminate/Queue/SerializableClosure.php
+++ b/src/Illuminate/Queue/SerializableClosure.php
@@ -9,6 +9,13 @@ class SerializableClosure extends OpisSerializableClosure
     use SerializesAndRestoresModelIdentifiers;
 
     /**
+     * The data that will be shared across the jobs.
+     *
+     * @var mixed
+     */
+    public $sharedData;
+
+    /**
      * Transform the use variables before serialization.
      *
      * @param  array  $data The Closure's use variables
@@ -36,5 +43,18 @@ class SerializableClosure extends OpisSerializableClosure
         }
 
         return $data;
+    }
+
+    /**
+     * Pass the shared data.
+     *
+     * @param  mixed  $sharedData
+     * @return $this
+     */
+    public function sharedData($sharedData)
+    {
+        $this->sharedData = $sharedData;
+
+        return $this;
     }
 }

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -208,7 +208,6 @@ class JobChainingTest extends TestCase
             new JobChainingTestThirdJob,
         ], ['var1' => 1])->dispatch();
 
-
         $this->assertEquals(['var1' => 1], JobChainingTestFirstJob::$usedSharedData);
         $this->assertEquals(['var1' => 1], JobChainingTestSecondJob::$usedSharedData);
         $this->assertEquals(['var1' => 1], JobChainingTestThirdJob::$usedSharedData);
@@ -221,7 +220,6 @@ class JobChainingTest extends TestCase
             new JobChainingTestSecondJob,
         ], ['var1' => 1])->dispatch();
 
-
         $this->assertEquals(['var1' => 1], JobChainingTestThatModifiesSharedData::$usedSharedData);
         $this->assertEquals(['var1' => 1, 'var2' => 2], JobChainingTestFirstJob::$usedSharedData);
         $this->assertEquals(['var1' => 1, 'var2' => 2], JobChainingTestSecondJob::$usedSharedData);
@@ -229,9 +227,9 @@ class JobChainingTest extends TestCase
 
     public function testClosuresCanBeChainedOnSuccessUsingPendingChainAndSharedData()
     {
-        $this->markTestIncomplete(
+        /* $this->markTestIncomplete(
             'Serialized Closures do work properly.'
-        );
+        ); */
 
         $job1SharedData = 'test';
         $job2SharedData = 'test';

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -227,10 +227,6 @@ class JobChainingTest extends TestCase
 
     public function testClosuresCanBeChainedOnSuccessUsingPendingChainAndSharedData()
     {
-        /* $this->markTestIncomplete(
-            'Serialized Closures do work properly.'
-        ); */
-
         $job1SharedData = 'test';
         $job2SharedData = 'test';
         $job3Shareddata = 'test';

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -227,6 +227,34 @@ class JobChainingTest extends TestCase
         $this->assertEquals(['var1' => 1, 'var2' => 2], JobChainingTestSecondJob::$usedSharedData);
     }
 
+    public function testClosuresCanBeChainedOnSuccessUsingPendingChainAndSharedData()
+    {
+        $this->markTestIncomplete(
+            'Serialized Closures do work properly.'
+        );
+
+        $job1SharedData = 'test';
+        $job2SharedData = 'test';
+        $job3Shareddata = 'test';
+
+        JobChainingTestFirstJob::withChain([
+            function ($sharedData) use (&$job1SharedData) {
+                $job1SharedData = $sharedData;
+            },
+            function ($sharedData) use (&$job2SharedData) {
+                $job2SharedData = $sharedData;
+            },
+            function ($sharedData) use (&$job3SharedData) {
+                $job3SharedData = $sharedData;
+            },
+        ], ['var1' => 1])->dispatch();
+
+        $this->assertEquals(['var1' => 1], $job1SharedData);
+        $this->assertEquals(['var1' => 1], $job2SharedData);
+        $this->assertEquals(['var1' => 1], $job3SharedData);
+    }
+}
+
 class JobChainingTestFirstJob implements ShouldQueue
 {
     use Dispatchable, Queueable;


### PR DESCRIPTION
### Use case

Let's start with a use case that would work well with sharing data between jobs that are in the same chain.

Let's say you want to configure three AWS resources, one after another, in separate jobs - an IAM User, an IAM User Key, and an EC2 instance. With the chained jobs, you can do so:

```php
CreateIamUser::withChain([
    new CreateIamKey,
    new CreateEc2Instance,
])->dispatch();
```

The only problem here is that to create an IAM key, you should know the user. Currently, even if you could initialize one, you can't pass a variable to the constructor of `CreateIamKey` job since the `CreateIamUser` should be done.

A workaround would be to trigger the `CreateIamUser` and in the job, to trigger the next one, and the next one, etc. and you will end up bad code to manage and troubleshoot.

### There comes in handy the shared data.

You can just pass it on init at the chain level if you need to and you can either change it during the chain or access it anytime at the job level.

```php
CreateIamUser::withChain([
    new CreateIamKey,
    new CreateEc2Instance,
], ['key' => 'value'])->dispatch();
```

In the `CreateIamUser` job you can change the `sharedData` variable:

```php
public function handle()
{
    $iamUser = $this->createIamUser();

    $this->sharedData['iam_user'] = $iamUser;
}
```

Afterwards, you can access it from `CreateIamKey`:

```php
public function handle()
{
    $this->createIamKeyForUser(
        $this->sharedData['iam_user']
    );
}
```

### Might be fishy

I feel like this `$this->sharedData` thing might not be approachable and it can cause conflicts with user-defined data at the job level. This should be a breaking change.