### PR TITLE
[7.x] Collection::sort added expected type int param to match Enumerable::sort

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -192,7 +192,8 @@ class Collection implements ArrayAccess, Enumerable
     public function crossJoin(...$lists)
     {
         return new static(Arr::crossJoin(
-            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
+            $this->items,
+            ...array_map([$this, 'getArrayableItems'], $lists)
         ));
     }
 
@@ -547,7 +548,8 @@ class Collection implements ArrayAccess, Enumerable
     public function intersectByKeys($items)
     {
         return new static(array_intersect_key(
-            $this->items, $this->getArrayableItems($items)
+            $this->items,
+            $this->getArrayableItems($items)
         ));
     }
 
@@ -1073,7 +1075,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null  $callback
+     * @param  callable|null|int  $callback
      * @return static
      */
     public function sort($callback = null)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -192,8 +192,7 @@ class Collection implements ArrayAccess, Enumerable
     public function crossJoin(...$lists)
     {
         return new static(Arr::crossJoin(
-            $this->items,
-            ...array_map([$this, 'getArrayableItems'], $lists)
+            $this->items, ...array_map([$this, 'getArrayableItems'], $lists)
         ));
     }
 
@@ -548,8 +547,7 @@ class Collection implements ArrayAccess, Enumerable
     public function intersectByKeys($items)
     {
         return new static(array_intersect_key(
-            $this->items,
-            $this->getArrayableItems($items)
+            $this->items, $this->getArrayableItems($items)
         ));
     }
 

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1073,7 +1073,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort through each item with a callback.
      *
-     * @param  callable|null|int  $callback
+     * @param  callable|int|null  $callback
      * @return static
      */
     public function sort($callback = null)


### PR DESCRIPTION
Hi,

I would like to add this missing PhpDocBlock param type.

It helps for documentation and when using tools like psalm which returned this error:

Argument 1 of Illuminate\Support\Collection::sort has the more specific type 'callable|null', expecting 'callable|int|null' as defined by Illuminate\Support\Enumerable::sort



<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
