### PR TITLE
[6.x] Fix ambiguity SQL error with chunkById and joins

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -77,7 +77,7 @@ trait BuildsQueries
      */
     public function chunkById($count, callable $callback, $column = null, $alias = null)
     {
-        $column = $column ?? $this->getQualifiedKeyName();
+        $column = $column ?? $this->getModel()->getQualifiedKeyName();
 
         $alias = $alias ?? $column;
 

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -77,7 +77,7 @@ trait BuildsQueries
      */
     public function chunkById($count, callable $callback, $column = null, $alias = null)
     {
-        $column = $column ?? $this->defaultKeyName();
+        $column = $column ?? $this->getQualifiedKeyName();
 
         $alias = $alias ?? $column;
 


### PR DESCRIPTION
Using chunkById by default will add to a query (pseudo code):
```and where `$defaultKey` > $chunkMinId```

This creates the potential for `1052 Column '$defaultKey' in where clause is ambiguous` errors if joins are used, most commonly if joins are used where the joined tables may each contain an `id` column.

Using $this->getQualifiedKeyName() instead of $this->defaultKeyName() solves this problem by qualifying the default key.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
