### PR TITLE
Add sort options to Arr::sortRecursive

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -605,20 +605,24 @@ class Arr
      * Recursively sort an array by keys and values.
      *
      * @param  array  $array
+     * @param  int  $options
+     * @param  bool  $descending
      * @return array
      */
-    public static function sortRecursive($array)
+    public static function sortRecursive($array, $options = SORT_REGULAR, $descending = false)
     {
         foreach ($array as &$value) {
             if (is_array($value)) {
-                $value = static::sortRecursive($value);
+                $value = static::sortRecursive($value, $options, $descending);
             }
         }
 
         if (static::isAssoc($array)) {
-            ksort($array);
+            $descending ? krsort($array, $options)
+                : ksort($array, $options);
         } else {
-            sort($array);
+            $descending ? rsort($array, $options)
+                : sort($array, $options);
         }
 
         return $array;


### PR DESCRIPTION
This PR adds parameters for flag delivery to the sort function in Arr::sortRecursive method.
And this change will have little impact.

I had to pass the "SORT_NATURAL" option, but I found my code was similar to Arr:sortRecursive.
But it couldn't get the desired value because it couldn't deliver the flag.
And I found a similar function in Collection::sortBy method that carries this flag option.

This change may be minor, but I think it may prevent other users, including myself, from having duplicate codes.