### PR TITLE
[6.x] Fix `originalIsEquivalent` with floats

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1178,7 +1178,7 @@ trait HasAttributes
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
             return $this->castAttribute($key, $current) ==
                 $this->castAttribute($key, $original);
-        } elseif ($this->hasCast($key, 'float')){
+        } elseif ($this->hasCast($key, 'float')) {
             return bccomp(
                 $this->castAttribute($key, $current),
                 $this->castAttribute($key, $original)

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1178,6 +1178,11 @@ trait HasAttributes
         } elseif ($this->hasCast($key, ['object', 'collection'])) {
             return $this->castAttribute($key, $current) ==
                 $this->castAttribute($key, $original);
+        } elseif ($this->hasCast($key, 'float')){
+            return bccomp(
+                $this->castAttribute($key, $current),
+                $this->castAttribute($key, $original)
+            ) === 0;
         } elseif ($this->hasCast($key)) {
             return $this->castAttribute($key, $current) ===
                    $this->castAttribute($key, $original);

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -151,7 +151,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testCleanWhenFloatUpdateAttribute()
     {
         $original = -16.666347;
-        $new = 20.1-36.766347;
+        $new = 20.1 - 36.766347;
 
         // PHP isn't able to compare two floats using === reliably.
         // See warning here:

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -148,6 +148,23 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse($model->isClean(['foo', 'bar']));
     }
 
+    public function testCleanWhenFloatUpdateAttribute()
+    {
+        $original = -16.666347;
+        $new = 20.1-36.766347;
+
+        // PHP isn't able to compare two floats using === reliably.
+        // See warning here:
+        // https://www.php.net/manual/en/language.types.float.php
+
+        $this->assertTrue($original !== $new);
+        $this->assertTrue(bccomp($original, $new) === 0);
+
+        $model = new EloquentModelStub(['castedFloat' => $original]);
+        $model->syncOriginal();
+        $this->assertTrue($model->originalIsEquivalent('castedFloat', $new));
+    }
+
     public function testCalculatedAttributes()
     {
         $model = new EloquentModelStub;
@@ -1992,6 +2009,7 @@ class EloquentModelStub extends Model
     protected $table = 'stub';
     protected $guarded = [];
     protected $morph_to_stub_type = EloquentModelSaveStub::class;
+    protected $casts = ['castedFloat' => 'float'];
 
     public function getListItemsAttribute($value)
     {


### PR DESCRIPTION
According to the PHP Docs:
https://www.php.net/manual/en/language.types.float.php

You shouldn't compare two floats directly for equality.


This only manifests when you cast to a float, otherwise you'll fall into the:
```
return is_numeric($current) && is_numeric($original)
                && strcmp((string) $current, (string) $original) === 0;
```
Which works for floats fine.