### PR TITLE
[7.x] Adds a round robin method for collections

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1377,4 +1377,22 @@ class Collection implements ArrayAccess, Enumerable
     {
         unset($this->items[$key]);
     }
+
+    /**
+     * Returns the collection shifted by one based on a given value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function roundRobin($value)
+    {
+        $found = false;
+        $partitions = $this->partition(function ($currentItem, $key) use ($value, &$found) {
+            $found = $found || $value === $key;
+
+            return $found;
+        });
+
+        return $partitions->first()->merge($partitions->last())->values();
+    }
 }

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1343,4 +1343,15 @@ class LazyCollection implements Enumerable
             yield from $this->collect()->$method(...$params);
         });
     }
+
+    /**
+     * Returns the collection shifted by one based on a given value.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    public function roundRobin($value)
+    {
+        return $this->collect()->roundRobin($value);
+    }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4241,6 +4241,24 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testRoundRobin($collection)
+    {
+        $data = new $collection([1, 2, 3, 4]);
+
+        $this->assertEquals([2, 3, 4, 1], $data->roundRobin(1)->all());
+        $this->assertEquals([3, 4, 1, 2], $data->roundRobin(2)->all());
+        $this->assertEquals([4, 1, 2, 3], $data->roundRobin(3)->all());
+        $this->assertEquals([1, 2, 3, 4], $data->roundRobin(4)->all());
+
+        // return the original collection on edge cases
+        foreach ([5, 0, -1, null, false] as $i) {
+            $this->assertEquals([1, 2, 3, 4], $data->roundRobin($i)->all());
+        }
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testCollect($collection)
     {
         $data = $collection::make([


### PR DESCRIPTION
Provides a useful collection method to ensure even distribution. Here is an example how I use it to distribute appointments between different calendars:

```
public function nextAvailableCalendar(int $lastId, Carbon $from, Carbon $to): ?Calendar
{
    return Calendar::all()
        ->keyBy('id')
        ->roundRobin($lastId)
        ->skipUntil(function (Calendar $calendar) use ($from, $to) {
            return $calendar->isAvailableAt($from, $to);
        })
        ->first();
}
```