### PR TITLE
[7.x] Fix doc stub console command

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -33,7 +33,7 @@ class {{ class }} extends Command
     /**
      * Execute the console command.
      *
-     * @return mixed
+     * @return int
      */
     public function handle()
     {


### PR DESCRIPTION
[In Document Laravel 7.x](https://laravel.com/docs/7.x/upgrade#symfony-5-related-upgrades) function `handle()` return integer.
> Symfony Console, which is the underlying component that powers Artisan, expects all commands to return an integer. Therefore, you should ensure that any of your commands which return a value are returning integer

```
public function handle()
{
    // Before...
    return true;

    // After...
    return 0;
}
```
