### PR TITLE
[8.x] Delete and release database jobs inside a transaction

### DIFF
--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -340,7 +340,6 @@ class DatabaseQueue extends Queue implements QueueContract
         });
     }
 
-
     /**
      * Get the queue or return the default.
      *

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -322,6 +322,26 @@ class DatabaseQueue extends Queue implements QueueContract
     }
 
     /**
+     * Delete a reserved job from the reserved queue and release it.
+     *
+     * @param  string  $queue
+     * @param  \Illuminate\Queue\Jobs\DatabaseJob  $job
+     * @param  int  $delay
+     * @return void
+     */
+    public function deleteAndRelease($queue, $job, $delay)
+    {
+        $this->database->transaction(function () use ($queue, $job, $delay) {
+            if ($this->database->table($this->table)->lockForUpdate()->find($job->getJobId())) {
+                $this->database->table($this->table)->where('id', $job->getJobId())->delete();
+            }
+
+            $this->release($queue, $job->getJobRecord(), $delay);
+        });
+    }
+
+
+    /**
      * Get the queue or return the default.
      *
      * @param  string|null  $queue

--- a/src/Illuminate/Queue/Jobs/DatabaseJob.php
+++ b/src/Illuminate/Queue/Jobs/DatabaseJob.php
@@ -51,9 +51,7 @@ class DatabaseJob extends Job implements JobContract
     {
         parent::release($delay);
 
-        $this->delete();
-
-        return $this->database->release($this->queue, $this->job, $delay);
+        return $this->database->deleteAndRelease($this->queue, $this, $delay);
     }
 
     /**
@@ -96,5 +94,15 @@ class DatabaseJob extends Job implements JobContract
     public function getRawBody()
     {
         return $this->job->payload;
+    }
+
+    /**
+     * Get the database job record.
+     *
+     * @return \Illuminate\Queue\Jobs\DatabaseJobRecord
+     */
+    public function getJobRecord()
+    {
+        return $this->job;
     }
 }


### PR DESCRIPTION
This PR performs the releasing of database jobs inside a database transaction similar to what happens with the redis queue where we use a Lua script to perform the delete & releasing in a single command.