### PR TITLE
[7.x] Add methods to determine if service provider is loaded

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1292,4 +1292,26 @@ class Application extends Container implements ApplicationContract, CachesConfig
 
         throw new RuntimeException('Unable to detect application namespace.');
     }
+
+    /**
+     * Determine if service provider is loaded.
+     *
+     * @param string $provider
+     * @return bool
+     */
+    public function isProviderLoaded(string $provider): bool
+    {
+        return isset($this->loadedProviders[$provider]);
+    }
+
+    /**
+     * Determine if service provider is not loaded.
+     *
+     * @param string $provider
+     * @return bool
+     */
+    public function isProviderNotLoaded(string $provider): bool
+    {
+        return !$this->isProviderLoaded($provider);
+    }
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1312,6 +1312,6 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isProviderNotLoaded(string $provider): bool
     {
-        return !$this->isProviderLoaded($provider);
+        return ! $this->isProviderLoaded($provider);
     }
 }

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -87,6 +87,30 @@ class FoundationApplicationTest extends TestCase
         $this->assertArrayHasKey($class, $app->getLoadedProviders());
     }
 
+    public function testServiceProvidersCouldBeLoaded()
+    {
+        $provider = m::mock(ServiceProvider::class);
+        $class = get_class($provider);
+        $provider->shouldReceive('register')->once();
+        $app = new Application;
+        $app->register($provider);
+
+        $this->assertTrue($app->isProviderLoaded($class));
+        $this->assertFalse($app->isProviderLoaded(ApplicationBasicServiceProviderStub::class));
+    }
+
+    public function testServiceProvidersCouldBeNotLoaded()
+    {
+        $provider = m::mock(ServiceProvider::class);
+        $class = get_class($provider);
+        $provider->shouldReceive('register')->once();
+        $app = new Application;
+        $app->register($provider);
+
+        $this->assertTrue($app->isProviderNotLoaded(ApplicationBasicServiceProviderStub::class));
+        $this->assertFalse($app->isProviderNotLoaded($class));
+    }
+
     public function testDeferredServicesMarkedAsBound()
     {
         $app = new Application;


### PR DESCRIPTION
This PR adds 2 methods to the Application which determines if service provider loaded or not.

```php
if ($app->isProviderLoaded(OptionalServiceProvider::class)) {
    // Do something
}

if ($app->isProviderNotLoaded(RequiredServiceProvider::class)) {
    // Throw exception
}
```

It might be useful in package development when you want to be 100% sure that provider is loaded. Or when you want to load some extra stuff if some optional providers are loaded.