### PR TITLE
[7.x] Add method to support clearing registered paths

### DIFF
--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -516,6 +516,14 @@ class Migrator
     }
 
     /**
+     * Clear all registered migration paths.
+     */
+    public function clearPaths()
+    {
+        $this->paths = [];
+    }
+
+    /**
      * Get the default connection name.
      *
      * @return string

--- a/src/Illuminate/Database/Migrations/Migrator.php
+++ b/src/Illuminate/Database/Migrations/Migrator.php
@@ -517,6 +517,8 @@ class Migrator
 
     /**
      * Clear all registered migration paths.
+     *
+     * @return void
      */
     public function clearPaths()
     {


### PR DESCRIPTION
This change should be fairly self-explanitory.

As for the motivation, I'm working on a multi-database SAAS app that needs to run migrations programmatically when a "tenant" (and its associated database) is created.  I'm already able to dynamically add the "tenant migrations" path to the migrator, which works fine,  However, all other registered migrations (including those registered with `loadMigrationsFrom()` in other packages) will still run.

If there's a better approach, I'd love to hear it.

Additionally, I'm happy to write a test for this if you wish, but wasn't sure where to put it.  Guidance would be appreciated.