### PR TITLE
[7.x] Check if UiServiceProvider loaded using providerIsLoaded method

### DIFF
--- a/src/Illuminate/Support/Facades/Auth.php
+++ b/src/Illuminate/Support/Facades/Auth.php
@@ -52,7 +52,7 @@ class Auth extends Facade
      */
     public static function routes(array $options = [])
     {
-        if (! array_key_exists(UiServiceProvider::class, static::$app->getLoadedProviders())) {
+        if (! static::$app->providerIsLoaded(UiServiceProvider::class)) {
             throw new RuntimeException('In order to use the Auth::routes() method, please install the laravel/ui package.');
         }
 


### PR DESCRIPTION
Follow up #33286

Start using special method `providerIsLoaded` introduced in #33286 to check if laravel/ui package's UiServiceProvider has been loaded.