### PR TITLE
[7.x] Remove misreading of method parameters

### DIFF
--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -134,8 +134,8 @@ class AliasLoader
     /**
      * Add an alias to the loader.
      *
-     * @param  string  $class
      * @param  string  $alias
+     * @param  string  $class
      * @return void
      */
     public function alias($alias, $class)

--- a/src/Illuminate/Foundation/AliasLoader.php
+++ b/src/Illuminate/Foundation/AliasLoader.php
@@ -138,9 +138,9 @@ class AliasLoader
      * @param  string  $alias
      * @return void
      */
-    public function alias($class, $alias)
+    public function alias($alias, $class)
     {
-        $this->aliases[$class] = $alias;
+        $this->aliases[$alias] = $class;
     }
 
     /**


### PR DESCRIPTION
Swap confusing method parameters names for alias() method. An alias actually comes first, and real class name second. The logical order of arguments remains the same.
