### PR TITLE
[7.x] Adding limitOnChar Str helper function

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -363,7 +363,7 @@ class Str
 
         $spaceLimit = mb_strrpos($limitedString, $spaceChar);
 
-        if($spaceLimit === false) {
+        if ($spaceLimit === false) {
             $spaceLimit = $limit;
         }
 

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -341,27 +341,27 @@ class Str
     }
 
     /**
-     * Limit the number of characters in a string on the last space before the limit..
+     * Limit the number of characters in a string on the last given char before the limit.
      *
      * @param  string  $value
      * @param  int  $limit
      * @param  string  $end
-     * @param  string  $spaceChar
+     * @param  string  $char
      * @return string
      */
-    public static function limitOnSpace($value, $limit = 100, $end = '...', $spaceChar = ' ')
+    public static function limitOnChar($value, $limit = 100, $end = '...', $char = ' ')
     {
         if (mb_strwidth($value, 'UTF-8') <= $limit) {
             return $value;
         }
 
-        if ($value[$limit] === $spaceChar) {
+        if ($value[$limit] === $char) {
             return self::limit($value, $limit, $end);
         }
 
         $limitedString = mb_strimwidth($value, 0, $limit, '', 'UTF-8');
 
-        $spaceLimit = mb_strrpos($limitedString, $spaceChar);
+        $spaceLimit = mb_strrpos($limitedString, $char);
 
         if ($spaceLimit === false) {
             $spaceLimit = $limit;

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -341,6 +341,36 @@ class Str
     }
 
     /**
+     * Limit the number of characters in a string on the last space before the limit..
+     *
+     * @param  string  $value
+     * @param  int  $limit
+     * @param  string  $end
+     * @param  string  $spaceChar
+     * @return string
+     */
+    public static function limitOnSpace($value, $limit = 100, $end = '...', $spaceChar = ' ')
+    {
+        if (mb_strwidth($value, 'UTF-8') <= $limit) {
+            return $value;
+        }
+
+        if ($value[$limit] === $spaceChar) {
+            return self::limit($value, $limit, $end);
+        }
+
+        $limitedString = mb_strimwidth($value, 0, $limit, '', 'UTF-8');
+
+        $spaceLimit = mb_strrpos($limitedString, $spaceChar);
+
+        if($spaceLimit === false) {
+            $spaceLimit = $limit;
+        }
+
+        return self::limit($value, $spaceLimit, $end);
+    }
+
+    /**
      * Convert the given string to lower-case.
      *
      * @param  string  $value

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -311,6 +311,29 @@ class SupportStrTest extends TestCase
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
+    public function testLimitOnSpace()
+    {
+        $this->assertSame('Laravel is...', Str::limitOnSpace('Laravel is a free, open source PHP web application framework.', 10));
+        $this->assertSame('Laravel is...', Str::limitOnSpace('Laravel is a free, open source PHP web application framework.', 11));
+        $this->assertSame('这是一...', Str::limitOnSpace('这是一段中文', 6));
+
+        $string = 'The PHP framework for web artisans.';
+        $this->assertSame('The PHP...', Str::limitOnSpace($string, 7));
+        $this->assertSame('The PHP...', Str::limitOnSpace($string, 9));
+        $this->assertSame('The PHP ->', Str::limitOnSpace($string, 12, ' ->'));
+        $this->assertSame('The PHP framework for web*', Str::limitOnSpace($string, 34, '*'));
+        $this->assertSame('The PHP framework for web artisans.', Str::limitOnSpace($string, 35));
+        $this->assertSame('The PHP framework for web artisans.', Str::limitOnSpace($string, 100));
+
+        $string = 'ThePHPFrameworkForWebArtisans';
+        $this->assertSame('ThePHP', Str::limitOnSpace($string, 6, ''));
+        $this->assertSame('ThePHP', Str::limitOnSpace($string, 12, '', 'F'));
+
+        $nonAsciiString = '这是一段中文';
+        $this->assertSame('这是一...', Str::limitOnSpace($nonAsciiString, 6));
+        $this->assertSame('这是一', Str::limitOnSpace($nonAsciiString, 6, ''));
+    }
+
     public function testLength()
     {
         $this->assertEquals(11, Str::length('foo bar baz'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -311,27 +311,27 @@ class SupportStrTest extends TestCase
         $this->assertSame('这是一', Str::limit($nonAsciiString, 6, ''));
     }
 
-    public function testLimitOnSpace()
+    public function testLimitOnChar()
     {
-        $this->assertSame('Laravel is...', Str::limitOnSpace('Laravel is a free, open source PHP web application framework.', 10));
-        $this->assertSame('Laravel is...', Str::limitOnSpace('Laravel is a free, open source PHP web application framework.', 11));
-        $this->assertSame('这是一...', Str::limitOnSpace('这是一段中文', 6));
+        $this->assertSame('Laravel is...', Str::limitOnChar('Laravel is a free, open source PHP web application framework.', 10));
+        $this->assertSame('Laravel is...', Str::limitOnChar('Laravel is a free, open source PHP web application framework.', 11));
+        $this->assertSame('这是一...', Str::limitOnChar('这是一段中文', 6));
 
         $string = 'The PHP framework for web artisans.';
-        $this->assertSame('The PHP...', Str::limitOnSpace($string, 7));
-        $this->assertSame('The PHP...', Str::limitOnSpace($string, 9));
-        $this->assertSame('The PHP ->', Str::limitOnSpace($string, 12, ' ->'));
-        $this->assertSame('The PHP framework for web*', Str::limitOnSpace($string, 34, '*'));
-        $this->assertSame('The PHP framework for web artisans.', Str::limitOnSpace($string, 35));
-        $this->assertSame('The PHP framework for web artisans.', Str::limitOnSpace($string, 100));
+        $this->assertSame('The PHP...', Str::limitOnChar($string, 7));
+        $this->assertSame('The PHP...', Str::limitOnChar($string, 9));
+        $this->assertSame('The PHP ->', Str::limitOnChar($string, 12, ' ->'));
+        $this->assertSame('The PHP framework for web*', Str::limitOnChar($string, 34, '*'));
+        $this->assertSame('The PHP framework for web artisans.', Str::limitOnChar($string, 35));
+        $this->assertSame('The PHP framework for web artisans.', Str::limitOnChar($string, 100));
 
         $string = 'ThePHPFrameworkForWebArtisans';
-        $this->assertSame('ThePHP', Str::limitOnSpace($string, 6, ''));
-        $this->assertSame('ThePHP', Str::limitOnSpace($string, 12, '', 'F'));
+        $this->assertSame('ThePHP', Str::limitOnChar($string, 6, ''));
+        $this->assertSame('ThePHP', Str::limitOnChar($string, 12, '', 'F'));
 
         $nonAsciiString = '这是一段中文';
-        $this->assertSame('这是一...', Str::limitOnSpace($nonAsciiString, 6));
-        $this->assertSame('这是一', Str::limitOnSpace($nonAsciiString, 6, ''));
+        $this->assertSame('这是一...', Str::limitOnChar($nonAsciiString, 6));
+        $this->assertSame('这是一', Str::limitOnChar($nonAsciiString, 6, ''));
     }
 
     public function testLength()


### PR DESCRIPTION
Adding a util method in the `\Illuminate\Support\Str` helper class.

`Str::limitOnChar` makes a limit on the last occurrence of space (or another given char).
It can be very useful to make short descriptions, or sending mail, with truncated texts without cutting sentences in a middle of a word.

Example:
```php
use Illuminate\Support\Str;

Str::limitOnChar('The PHP framework for web artisans.', 20); // The PHP framework...
Str::limit('The PHP framework for web artisans.', 20); // The PHP framework fo...
```

If the givent character (default is space) is not found, the behavior is the same as the `Str::limit` method.

```php
use Illuminate\Support\Str;

Str::limitOnChar('ThePHPFrameworkForWebArtisans', 6, ''); //ThePHP
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 


If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
