### PR TITLE
[7.x] DocBlock for Lang::has

### DIFF
--- a/src/Illuminate/Support/Facades/Lang.php
+++ b/src/Illuminate/Support/Facades/Lang.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Support\Facades;
 
 /**
+ * @method static bool has(string $key)
  * @method static mixed get(string $key, array $replace = [], string $locale = null, bool $fallback = true)
  * @method static string choice(string $key, \Countable|int|array $number, array $replace = [], string $locale = null)
  * @method static string getLocale()


### PR DESCRIPTION
Add the PHP DocBlock for the `Lang::has` method for IDE completion and static analysis.