### PR TITLE
[8.x] Count related models, but query the DB only if the count is not available from the already loaded data

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -867,4 +867,34 @@ trait HasRelationships
 
         return $this;
     }
+        
+    /**
+     * Get the relation if it is loaded and its builder otherwise.
+     *
+     * @param  string  $relation
+     * @return mixed
+     */
+    public function getRelationOrQuery(string $relation)
+    {
+        if ($this->relationLoaded($relation))
+            return $this->$relation;
+        
+        return $this->$relation();
+    }
+     
+    /**
+     * Get the count of related models.
+     *
+     * @param  string  $relation
+     * @return integer
+     */
+    public function getCount(string $relation)
+    {
+        $countKey = Str::snake($relation.'_count');
+        
+        if (array_key_exists($countKey, $this->attributes))
+            return $this->$countKey;
+        
+        return $this->getRelationOrQuery($relation)->count();
+    }
 }

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -281,6 +281,53 @@ class DatabaseEloquentRelationTest extends TestCase
         $this->assertInstanceOf(EloquentResolverRelationStub::class, $model->customer());
         $this->assertSame(['key' => 'value'], $model->customer);
     }
+
+    public function testGetRelationOrQueryWhenLoaded()
+    {
+        $parent = new EloquentWithRelationStub;
+        $relation = new Collection();
+        $parent->setRelation('relationStub', $relation);
+
+        $loaded = $parent->getRelationOrQuery('relationStub');
+
+        $this->assertInstanceOf(Collection::class, $loaded);
+        $this->assertTrue($parent->relationLoaded('relationStub'));
+    }
+
+    public function testGetRelationOrQueryWhenNotLoaded()
+    {
+        $parent = new EloquentWithRelationStub;
+
+        $loaded = $parent->getRelationOrQuery('relationStub');
+
+        $this->assertInstanceOf(Relation::class, $loaded);
+        $this->assertFalse($parent->relationLoaded('relationStub'));
+    }
+
+    public function testGetCountWhenLoaded()
+    {
+        $parent = new EloquentWithRelationStub;
+        $relation = new Collection([
+            new EloquentRelationResetModelStub,
+            new EloquentRelationResetModelStub
+        ]);
+        $parent->setRelation('relationStub', $relation);
+
+        $count = $parent->getCount('relationStub');
+
+        $this->assertEquals(2, $count);
+    }
+
+    public function testGetCountWhenCountIsSet()
+    {
+        $parent = new EloquentWithRelationStub;
+        $parent->relation_stub_count = 3;
+
+        $count = $parent->getCount('relationStub');
+
+        $this->assertEquals(3, $count);
+        $this->assertFalse($parent->relationLoaded('relationStub'));
+    }
 }
 
 class EloquentRelationResetModelStub extends Model
@@ -349,5 +396,13 @@ class EloquentResolverRelationStub extends EloquentRelationStub
     public function getResults()
     {
         return ['key' => 'value'];
+    }
+}
+
+class EloquentWithRelationStub extends EloquentRelationResetModelStub
+{
+    public function relationStub()
+    {
+        return $this->hasMany(EloquentRelationResetModelStub::class);
     }
 }


### PR DESCRIPTION
This adds a method that gets the count of related models in a "smarter" way. First it looks if the `[relation_name]_count` is set and returns it. But if it's not set, check if the relation is loaded and count the collection. If that is not available either, execute the `count()` query.

My typical usecase is a computed attribute. It is defined once but used in different places where relation could be preloaded or not. Here's an example:

```
class Project extends Model
{
    public function invoices()
    {
        return $this->hasMany(Invoice::class);
    }

    public function getDeletableAttribute()
    {
        return !$this->getCount('invoices');
    }
}
```

And here are the places where the same attribute could be used without unnecessary queries or case-by-case handling:

```
{{-- projects.blade.php --}}
{{-- $projects = Project::withCount('invoices')->get() --}}

@foreach ($projects as $project)
    {{$project->name}}

    {{-- the count is loaded so we can use the _count attribute --}}
    @if ($project->deletable)
        <delete-button project={{$project->id}} />
    @endif
@endforeach
```

```
{{-- project.blade.php --}}

@include('invoices', ['invoices' => $project->invoices])

{{-- invoices are loaded, we can count them --}}
@if ($project->deletable)
    <delete-button project={{$project->id}} />
@endif
```

```
// ProjectController.php

public function delete(Project $project)
{
    // neither invoices nor the count is loaded, we have to hit the database
    if (!$project->deletable)
        return 400;

    $project->delete();

    return ['status' => 'success'];
}
```