### PR TITLE
[7.x] Fix "Undefined variable: current" exception

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1399,7 +1399,7 @@ trait HasAttributes
                 $this->castAttribute($key, $original);
         } elseif ($this->hasCast($key, ['real', 'float', 'double'])) {
             return bccomp(
-                $this->castAttribute($key, $current),
+                $this->castAttribute($key, $attribute),
                 $this->castAttribute($key, $original)
             ) === 0;
         } elseif ($this->hasCast($key, static::$primitiveCastTypes)) {


### PR DESCRIPTION
It seems like after merging some different PRs the `$current` got into the v7 branch which has changed to `$attribute` instead of `$current`.
This results in an exception thrown:
> ErrorException: Undefined variable: current
> vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php#1402

This PR fixes the usage of `$current` for v7 branch.