### PR TITLE
[7.x] Http client - Add support for binary body request

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -42,6 +42,13 @@ class PendingRequest
     protected $pendingFiles = [];
 
     /**
+     * The binary for the request.
+     *
+     * @var array
+     */
+    protected $pendingBinary;
+
+    /**
      * The request cookies.
      *
      * @var array
@@ -175,6 +182,34 @@ class PendingRequest
     public function asMultipart()
     {
         return $this->bodyFormat('multipart');
+    }
+
+    /**
+     * Attach a binary to the request.
+     *
+     * @param  string $content
+     * @param  string $contentType
+     * @return $this
+     */
+    public function binary($content, $contentType)
+    {
+        $this->asBinary();
+
+        $this->pendingBinary = $content;
+
+        $this->contentType($contentType);
+
+        return $this;
+    }
+
+    /**
+     * Indicate the request contains form parameters.
+     *
+     * @return $this
+     */
+    public function asBinary()
+    {
+        return $this->bodyFormat('body');
     }
 
     /**
@@ -476,9 +511,15 @@ class PendingRequest
                 $options[$this->bodyFormat] = $this->parseMultipartBodyFormat($options[$this->bodyFormat]);
             }
 
-            $options[$this->bodyFormat] = array_merge(
-                $options[$this->bodyFormat], $this->pendingFiles
-            );
+            if ($this->bodyFormat === 'body') {
+                $options[$this->bodyFormat] = $this->pendingBinary;
+            }
+
+            if (is_array($options[$this->bodyFormat])) {
+                $options[$this->bodyFormat] = array_merge(
+                    $options[$this->bodyFormat], $this->pendingFiles
+                );
+            }
         }
 
         $this->pendingFiles = [];


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a PR for the issue/enhancement reported earlier here: [#33301](https://github.com/laravel/framework/discussions/33301#discussion-7510)

With this pull request it will be possible to send binaries in the body of a request.

Example:

```php
$photo = Storage::put('avatars', $request->file('photo'));

Http::binary(Storage::get($photo), Storage::mimeType($photo))
    ->post('api/settings/profile/photo');
```