### PR TITLE
[7.x] Unify handling of exceptions for failed jobs

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -416,8 +416,6 @@ class Worker
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  int  $maxTries
      * @return void
-     *
-     * @throws \Throwable
      */
     protected function markJobAsFailedIfAlreadyExceedsMaxAttempts($connectionName, $job, $maxTries)
     {
@@ -434,8 +432,6 @@ class Worker
         }
 
         $this->failJob($job, $e = $this->maxAttemptsExceededException($job));
-
-        throw $e;
     }
 
     /**
@@ -493,10 +489,14 @@ class Worker
      * @param  \Illuminate\Contracts\Queue\Job  $job
      * @param  \Throwable  $e
      * @return void
+     *
+     * @throws \Throwable
      */
     protected function failJob($job, Throwable $e)
     {
-        return $job->fail($e);
+        $job->fail($e);
+
+        throw $e;
     }
 
     /**


### PR DESCRIPTION
We recently noticed that we weren't getting the MaxAttempt exceptions in our error logging anymore. As it turns out there is a discrepancy between `markJobAsFailedIfWillExceedMaxAttempts` and `markJobAsFailedIfAlreadyExceedsMaxAttempts` on the `Worker` class. The former doesn't `throw $e` whereas the latter does.

Since timeouts are now handled "differently" due to PR #29024, using the first method, there no longer is that automatic error reporting.

We figured this might be an oversight, or at least an inconsistency in how failing jobs are handled. To unify the handling of these errors we have moved `throw $e` from `markJobAsFailedIfAlreadyExceedsMaxAttempts` to `failJob` instead.