### PR TITLE
[8.x] Allow reporting reportable exceptions with the default logger

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -103,9 +103,9 @@ class Handler implements ExceptionHandlerContract
         }
 
         if (is_callable($reportCallable = [$e, 'report'])) {
-            $this->container->call($reportCallable);
-
-            return;
+            if ($this->container->call($reportCallable) !== false) {
+                return;
+            }
         }
 
         try {

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Validation\Validator;
 use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -28,6 +29,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FoundationExceptionsHandlerTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     protected $config;
 
     protected $container;
@@ -60,8 +63,6 @@ class FoundationExceptionsHandlerTest extends TestCase
 
     protected function tearDown(): void
     {
-        m::close();
-
         Container::setInstance(null);
     }
 
@@ -69,7 +70,7 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $logger = m::mock(LoggerInterface::class);
         $this->container->instance(LoggerInterface::class, $logger);
-        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')]);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
 
         $this->handler->report(new RuntimeException('Exception message'));
     }
@@ -78,7 +79,11 @@ class FoundationExceptionsHandlerTest extends TestCase
     {
         $reporter = m::mock(ReportingService::class);
         $this->container->instance(ReportingService::class, $reporter);
-        $reporter->shouldReceive('send')->withArgs(['Exception message']);
+        $reporter->shouldReceive('send')->withArgs(['Exception message'])->once();
+
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldNotReceive('error');
 
         $this->handler->report(new ReportableException('Exception message'));
     }

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -75,6 +75,15 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->handler->report(new RuntimeException('Exception message'));
     }
 
+    public function testHandlerReportsExceptionWhenUnReportable()
+    {
+        $logger = m::mock(LoggerInterface::class);
+        $this->container->instance(LoggerInterface::class, $logger);
+        $logger->shouldReceive('error')->withArgs(['Exception message', m::hasKey('exception')])->once();
+
+        $this->handler->report(new UnReportableException('Exception message'));
+    }
+
     public function testHandlerCallsReportMethodWithDependencies()
     {
         $reporter = m::mock(ReportingService::class);
@@ -228,6 +237,14 @@ class ReportableException extends Exception
     public function report(ReportingService $reportingService)
     {
         $reportingService->send($this->getMessage());
+    }
+}
+
+class UnReportableException extends Exception
+{
+    public function report()
+    {
+        return false;
     }
 }
 


### PR DESCRIPTION
Currently there is no way to report a reportable exception with the default handler except manually accessing the logger from the report method (and then the default report context is not available).

This pull request allows this by simply returning false from the report method.

Example:
```php
class MyException extends Exception {
//...
    public function report()
    {
        if ($this->shouldReport()) {
            return false; // this will result in using the original log channels
        }

        $this->doSomethingElse();
    }
//...
}
```

Furthermore this PR also fixes the following problems in the test:
- Previously the mockery call count was not defined which defaults to `0 or more`, resulting in no calls were actually checked
- It adds a check that a reportable is not passed to the default handler (except of course intentionally)
- It adds a missing trait so tests are no longer resulting in "This test did not perform any assertions" warnings.