### PR TITLE
[7.x] Use ensureDirectoryExists() inside copyDirectory()

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -547,9 +547,7 @@ class Filesystem
         // If the destination directory does not actually exist, we will go ahead and
         // create it recursively, which just gets the destination prepared to copy
         // the files over. Once we make the directory we'll proceed the copying.
-        if (! $this->isDirectory($destination)) {
-            $this->makeDirectory($destination, 0777, true);
-        }
+        $this->ensureDirectoryExists($destination, 0777);
 
         $items = new FilesystemIterator($directory, $options);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Minor improvement that reuses the `ensureDirectoryExists()` method inside the `copyDirectory()` method of the `Filesystem` class. This just replaces next lines of code:

```php
if (! $this->isDirectory($destination)) {
    $this->makeDirectory($destination, 0777, true);
}
```
by the next call to `ensureDirectoryExists()`:

```php
$this->ensureDirectoryExists($destination, 0777);
```