### PR TITLE
[8.x] `$attributes` default to empty array for firstOrCreate and firstOrNew

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,18 @@
 # Release Notes for 6.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v6.18.20...6.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v6.18.22...6.x)
+
+
+## [v6.18.22 (2020-06-24)](https://github.com/laravel/framework/compare/v6.18.21...v6.18.22)
+
+### Revert
+- Revert "Fixed `Model::originalIsEquivalent()` with floats ([#33259](https://github.com/laravel/framework/pull/33259), [d68d915](https://github.com/laravel/framework/commit/d68d91516db6d1b9cba8a72f99b2c7e8223e988f))" [bf3cb6f](https://github.com/laravel/framework/commit/bf3cb6f6979df2d6965d2e0aa731724d0e2b15e5)
+
+
+## [v6.18.21 (2020-06-23)](https://github.com/laravel/framework/compare/v6.18.20...v6.18.21)
+
+### Fixed
+- Fixed `Model::originalIsEquivalent()` with floats ([#33259](https://github.com/laravel/framework/pull/33259), [d68d915](https://github.com/laravel/framework/commit/d68d91516db6d1b9cba8a72f99b2c7e8223e988f))
 
 
 ## [v6.18.20 (2020-06-16)](https://github.com/laravel/framework/compare/v6.18.19...v6.18.20)

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -430,7 +430,7 @@ class Builder
      * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model|static
      */
-    public function firstOrCreate(array $attributes, array $values = [])
+    public function firstOrCreate(array $attributes = [], array $values = [])
     {
         if (! is_null($instance = $this->where($attributes)->first())) {
             return $instance;

--- a/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
+++ b/src/Illuminate/Database/Eloquent/Relations/HasOneOrMany.php
@@ -213,7 +213,7 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrNew(array $attributes, array $values = [])
+    public function firstOrNew(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->related->newInstance($attributes + $values);
@@ -231,7 +231,7 @@ abstract class HasOneOrMany extends Relation
      * @param  array  $values
      * @return \Illuminate\Database\Eloquent\Model
      */
-    public function firstOrCreate(array $attributes, array $values = [])
+    public function firstOrCreate(array $attributes = [], array $values = [])
     {
         if (is_null($instance = $this->where($attributes)->first())) {
             $instance = $this->create($attributes + $values);

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -547,9 +547,7 @@ class Filesystem
         // If the destination directory does not actually exist, we will go ahead and
         // create it recursively, which just gets the destination prepared to copy
         // the files over. Once we make the directory we'll proceed the copying.
-        if (! $this->isDirectory($destination)) {
-            $this->makeDirectory($destination, 0777, true);
-        }
+        $this->ensureDirectoryExists($destination, 0777);
 
         $items = new FilesystemIterator($directory, $options);
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\HandlerStack;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 
@@ -100,7 +101,7 @@ class PendingRequest
     /**
      * The middleware callables added by users that will handle requests.
      *
-     * @var \Illuminate\Support\Collection|null
+     * @var \Illuminate\Support\Collection
      */
     protected $middleware;
 
@@ -113,6 +114,7 @@ class PendingRequest
     public function __construct(Factory $factory = null)
     {
         $this->factory = $factory;
+        $this->middleware = new Collection;
 
         $this->asJson();
 
@@ -393,16 +395,16 @@ class PendingRequest
     }
 
     /**
-     * Add new middleware the client handlerstack.
+     * Add new middleware the client handler stack.
      *
      * @param  callable  $middleware
      * @return $this
      */
     public function withMiddleware(callable $middleware)
     {
-        return tap($this, function ($request) use ($middleware) {
-            return $this->middleware = collect($this->middleware)->push($middleware);
-        });
+        $this->middleware->push($middleware);
+
+        return $this;
     }
 
     /**
@@ -620,7 +622,7 @@ class PendingRequest
             $stack->push($this->buildRecorderHandler());
             $stack->push($this->buildStubHandler());
 
-            collect($this->middleware)->each(function (callable $middleware) use ($stack) {
+            $this->middleware->each(function ($middleware) use ($stack) {
                 $stack->push($middleware);
             });
         });

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\View\Factory addNamespace(string $namespace, string|array $hints)
- * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array  $data, array  $mergeData)
+ * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array $data, array $mergeData)
  * @method static \Illuminate\Contracts\View\Factory replaceNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])

--- a/src/Illuminate/Support/Facades/View.php
+++ b/src/Illuminate/Support/Facades/View.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support\Facades;
 
 /**
  * @method static \Illuminate\Contracts\View\Factory addNamespace(string $namespace, string|array $hints)
+ * @method static \Illuminate\Contracts\View\Factory first(array $views, \Illuminate\Contracts\Support\Arrayable|array  $data, array  $mergeData)
  * @method static \Illuminate\Contracts\View\Factory replaceNamespace(string $namespace, string|array $hints)
  * @method static \Illuminate\Contracts\View\View file(string $path, array $data = [], array $mergeData = [])
  * @method static \Illuminate\Contracts\View\View make(string $view, array $data = [], array $mergeData = [])


### PR DESCRIPTION
This PR allows using firstOrCreate and firstOrNew without parameters.
Useful for tables with default parameters or where all fields are nullable.

For example:

```php
$user->profile()->firstOrNew();

$settings = Settings::firstOrCreate();
```

For now, we should explicitly pass an empty array and it looks like something is wrong.
