### PR TITLE
ConfigurationUrlParser: fix query decoding

### DIFF
--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -37,12 +37,15 @@ class ConfigurationUrlParser
             return $config;
         }
 
-        $parsedUrl = $this->parseUrl($url);
+        $rawComponents = $this->parseUrl($url);
+        $decodedComponents = $this->parseStringsToNativeTypes(
+            array_map('rawurldecode', $rawComponents)
+        );
 
         return array_merge(
             $config,
-            $this->getPrimaryOptions($parsedUrl),
-            $this->getQueryOptions($parsedUrl)
+            $this->getPrimaryOptions($decodedComponents),
+            $this->getQueryOptions($rawComponents)
         );
     }
 
@@ -135,9 +138,7 @@ class ConfigurationUrlParser
             throw new InvalidArgumentException('The database configuration URL is malformed.');
         }
 
-        return $this->parseStringsToNativeTypes(
-            array_map('rawurldecode', $parsedUrl)
-        );
+        return $parsedUrl;
     }
 
     /**

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -174,6 +174,17 @@ class ConfigurationUrlParserTest extends TestCase
                     'driver' => 'mysql',
                 ],
             ],
+            'simple URL with percent encoding in query' => [
+                'mysql://foo:bar%25bar@localhost/baz?timezone=%2B00%3A00',
+                [
+                    'username' => 'foo',
+                    'password' => 'bar%bar',
+                    'host' => 'localhost',
+                    'database' => 'baz',
+                    'driver' => 'mysql',
+                    'timezone' => '+00:00',
+                ],
+            ],
             'URL with mssql alias driver' => [
                 'mssql://null',
                 [


### PR DESCRIPTION
Function `parse_str` is used to parse the query part of URL; it expects a raw string (non-decoded).
But `parseUrl` was already doing decoding URL components.

It affects 5.8 to 7.x.

An URL like this should works: `mysql://foo:bar%25bar@localhost/baz?timezone=%2B00%3A00`
An URL like this should't because the query part is not encoded: `mysql://foo:bar%25bar@localhost/baz?timezone=+00:00`