### PR TITLE
[7.x] Speed up seeders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -1119,11 +1118,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * Create a new Eloquent Collection instance.
      *
      * @param  array  $models
-     * @return \Illuminate\Support\LazyCollection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function newCollection(array $models = [])
     {
-        return new LazyCollection($models);
+        return new Collection($models);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
 use JsonSerializable;
@@ -1118,11 +1119,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * Create a new Eloquent Collection instance.
      *
      * @param  array  $models
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Support\LazyCollection
      */
     public function newCollection(array $models = [])
     {
-        return new Collection($models);
+        return new LazyCollection($models);
     }
 
     /**


### PR DESCRIPTION
So I been working around seeding huge data and found out seeding thousands of models taking a little too long. 

This PR aims to minimize time used on seeding data.
All I had to do was to create an extra method `::quickCreate()` so this will not be a breaking change.

Below are the tests I ran using the current seeder vs the new (quick seeder).

> Currently
![Screenshot from 2020-06-25 18-34-42](https://user-images.githubusercontent.com/12772919/85767938-cf1b6a80-b718-11ea-9ce4-a4736ec6e335.png)

> This PR
![Screenshot from 2020-06-25 18-52-50](https://user-images.githubusercontent.com/12772919/85767992-db072c80-b718-11ea-84a2-0936c434cf6e.png)


However I haven't found a way yet to return the created models to use for creating other models. The result is just constructed model object without the model id so you can`t use it with extra seeding.

This `quickCreate` takes default params as the normal `create`

> On a side note, I tried seeding 100k records and on my machine it took 76seconds
