### PR TITLE
[7.x] $this->exists is not updated after pivot delete

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -122,7 +122,6 @@ trait AsPivot
 
         return tap($this->getDeleteQuery()->delete(), function () {
             $this->exists = false;
-            
             $this->fireModelEvent('deleted', false);
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -122,6 +122,7 @@ trait AsPivot
 
         return tap($this->getDeleteQuery()->delete(), function () {
             $this->exists = false;
+
             $this->fireModelEvent('deleted', false);
         });
     }

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -121,6 +121,8 @@ trait AsPivot
         $this->touchOwners();
 
         return tap($this->getDeleteQuery()->delete(), function () {
+            $this->exists = false;
+            
             $this->fireModelEvent('deleted', false);
         });
     }


### PR DESCRIPTION
After deleting a pivot model, the flag $this->exists is not updated to false after delete. 

This issue only appears when no primary key for the pivot model is defined.
