### PR TITLE
[7.x] Make ComponentAttributeBag Macroable

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -8,10 +8,13 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 
 class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
 {
+    use Macroable;
+    
     /**
      * The raw array of attributes.
      *


### PR DESCRIPTION
I think the ComponentAttributeBag should be macroable in general, but specifically because I'd like to submit a PR to Livewire to create a method on the ComponentAttributeBag that easily allows the user to do the following: `<x-text-input wire:model="name" />`. Once this class is macroable, I can submit the PR to Livewire to make it easier to integrate blade components with Livewire.

You can reference this gist to see how the implementation with Livewire would work, but this would be cleaner to pull out the code in the @php blade directive and put it into a macro.

https://gist.github.com/iAmKevinMcKee/c116282dbbbe34dcd5b3bda4242a3d7a

I've spoken with Caleb and he would accept the PR to Livewire to add this macro once the class is macroable.