### PR TITLE
[7.x] Convert eloquent collection to eloquent query builder

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -629,4 +629,22 @@ class Collection extends BaseCollection implements QueueableCollection
 
         return $connection;
     }
+
+    /**
+     * Get the Eloquent query builder from the collection
+     *
+     * @return Illuminate\Database\Eloquen\Builder
+     *
+     * @throws \LogicException
+     */
+    public function toQuery()
+    {
+        $model = $this->first();
+
+        if (! $model) {
+            throw new LogicException('can not get Eloquent QueryBuilder from an empty Collection.');
+        }
+
+        return $model->newModelQuery()->whereKey($this->modelKeys());
+    }
 }

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -631,7 +631,7 @@ class Collection extends BaseCollection implements QueueableCollection
     }
 
     /**
-     * Get the Eloquent query builder from the collection
+     * Get the Eloquent query builder from the collection.
      *
      * @return Illuminate\Database\Eloquen\Builder
      *

--- a/tests/Database/DatabaseEloquentCollectionTest.php
+++ b/tests/Database/DatabaseEloquentCollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Tests\Database;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection as BaseCollection;
@@ -454,6 +455,30 @@ class DatabaseEloquentCollectionTest extends TestCase
     {
         $c = new Collection;
         $this->assertEquals($c, $c->fresh());
+    }
+
+    public function testCanConvertCollectionOfModelsToEloquentQueryBuilder()
+    {
+        $one = m::mock(Model::class);
+        $one->shouldReceive('getKey')->andReturn(1);
+
+        $two = m::mock(Model::class);
+        $two->shouldReceive('getKey')->andReturn(2);
+
+        $c = new Collection([$one, $two]);
+
+        $mocBuilder = m::mock(Builder::class);
+        $one->shouldReceive('newModelQuery')->once()->andReturn($mocBuilder);
+        $mocBuilder->shouldReceive('whereKey')->once()->with($c->modelKeys())->andReturn($mocBuilder);
+        $this->assertInstanceOf(Builder::class, $c->toQuery());
+    }
+
+    public function testConvertingEmptyCollectionToQueryThrowsException()
+    {
+        $this->expectException(LogicException::class);
+
+        $c = new Collection;
+        $c->toQuery();
     }
 }
 


### PR DESCRIPTION
Some times we have a collection of models that we need to update all of them at once

I found the regular approach is to loop on every single model and make (N) times update query

I can build new query from scratch to update them all something like `Model::whereIn('id', $items->pluck('id'))->update([])`
 but I think writing it this way is ugly what if we can convert this collection of models to a query builder looking for those models under the hood.
so we can write it like that `$items->toQuery()->update([])`

the following image is from a project I am working on it. I am using it as a macro and I thought it could be useful if added to the framework.

<img width="644" alt="Screen Shot 2020-06-27 at 12 14 32 AM" src="https://user-images.githubusercontent.com/29691074/85905396-96a88900-b80b-11ea-83cc-847ed1e031d9.png">
