### PR TITLE
[7.x] Add getFirstWhereStartsWith() to ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -117,6 +117,30 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     {
         return $this->whereStartsWith($string);
     }
+    
+    /**
+     * Get the first attribute that starts with the given value from the attribute array.
+     *
+     * @param  string  $string
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getFirstWhereStartsWith($string, $default = null)
+    {
+        return $this->whereStartsWith($string)->getIterator()->current() ?? value($default);
+    }
+    
+    /**
+     * Get the first attribute that starts with the given value from the attribute array.
+     *
+     * @param  string  $string
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getFirstThatStartsWith($string, $default = null)
+    {
+        return $this->getFirstWhereStartsWith($string, $default);
+    }
 
     /**
      * Exclude the given attribute from the attribute array.


### PR DESCRIPTION
Following up on the changes from earlier today, in order to effectively use this with Livewire we need to be able to get the first attribute value that starts with 'wire:model' so we can use that value for the error bag, among other reasons.

This function gives you the ability to do that. Your component would look like this:

Usage
```html
<x-text-input wire:model.lazy="name" />
```

Blade Component
```php
<div>
    <input type="text" {{$attributes->whereStartsWith('wire:model')}} />
    @error($attributes->getFirstWhereStartsWith('wire:model'))
        {{$message}}
    @enderror
</div>
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
