### PR TITLE
[7.x] Pass to view without keys

### DIFF
--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -190,6 +190,41 @@ class View implements ArrayAccess, Htmlable, ViewContract
     }
 
     /**
+     * Pass variables as key values to the view.
+     *
+     * @param mixed ...$vars
+     * @return $this
+     */
+    public function pass(...$vars)
+    {
+        $bt = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT);
+
+        $lines = file($bt[0]['file']);
+        $line = $lines[$bt[0]['line'] - 1];
+
+        preg_match_all("#pass\(([^\)]+)\)#", $line, $matches);
+
+        $keys = explode(',', $matches[1][0]);
+        $keys = array_map(function($key) {
+            if (!Str::contains($key, '$')) {
+                throw new ParseError('Incorrect format: Must be defined variable.');
+            }
+
+            return ltrim(trim($key), '$');
+        }, $keys);
+
+        if (count($keys) !== count($vars)) {
+            throw new ParseError('Incorrect format: Must be defined variables.');
+        }
+
+        foreach (array_combine($keys, $vars) as $key => $variable) {
+            $this->with($key, $variable);
+        }
+
+      	return $this;
+    }
+
+    /**
      * Add a view instance to the view data.
      *
      * @param  string  $key

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -207,7 +207,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
 
         $keys = explode(',', $matches[1][0]);
         $keys = array_map(function ($key) {
-            if (!Str::contains($key, '$')) {
+            if (! Str::contains($key, '$')) {
                 throw new ParseError('Incorrect format: Must be defined variable.');
             }
 

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
 use Throwable;
+use ParseError;
 
 class View implements ArrayAccess, Htmlable, ViewContract
 {

--- a/src/Illuminate/View/View.php
+++ b/src/Illuminate/View/View.php
@@ -14,8 +14,8 @@ use Illuminate\Support\MessageBag;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Support\ViewErrorBag;
-use Throwable;
 use ParseError;
+use Throwable;
 
 class View implements ArrayAccess, Htmlable, ViewContract
 {
@@ -206,7 +206,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
         preg_match_all("#pass\(([^\)]+)\)#", $line, $matches);
 
         $keys = explode(',', $matches[1][0]);
-        $keys = array_map(function($key) {
+        $keys = array_map(function ($key) {
             if (!Str::contains($key, '$')) {
                 throw new ParseError('Incorrect format: Must be defined variable.');
             }
@@ -222,7 +222,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
             $this->with($key, $variable);
         }
 
-      	return $this;
+        return $this;
     }
 
     /**

--- a/tests/View/ViewTest.php
+++ b/tests/View/ViewTest.php
@@ -34,6 +34,18 @@ class ViewTest extends TestCase
         $this->assertEquals(['foo' => 'bar', 'baz' => 'boom'], $view->getData());
     }
 
+    public function testDataCanBeSetOnViewUsingPass()
+    {
+        $view = $this->getView();
+
+        $foo = ['baz' => 'bar'];
+        $bar = 'foo';
+
+        $view->pass($foo, $bar);
+
+        $this->assertEquals(['foo' => $foo, 'bar' => 'foo'], $view->getData());
+    }
+
     public function testRenderProperlyRendersView()
     {
         $view = $this->getView(['foo' => 'bar']);


### PR DESCRIPTION
The proposed method would allow developers to easily pass variables to a view without having to define keys, or use the `compact` method in php.

Imagine we have the following:

`$foobar = ['foo', 'bar', 'baz'];`

Normally we do things like the following:

`view('foo')->with('foobar', $foobar);` or `view('foo')->withFoobar($foobar);` or `view('foo', ['foobar' => $foobar]);` or `view('foo')->with(compact('foobar'));`

This enables developers to do the following:

`view('foo')->pass($foobar);`

and in their view they get the expected `$foobar`.

This PR was made possible by method suggestions from @assertchris 