### PR TITLE
[8.x] Allow adding catch callbacks for chains

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "league/flysystem": "^1.0.34",
         "monolog/monolog": "^2.0",
         "nesbot/carbon": "^2.17",
-        "opis/closure": "^3.5",
+        "opis/closure": "^3.5.3",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.0",

--- a/src/Illuminate/Bus/Dispatcher.php
+++ b/src/Illuminate/Bus/Dispatcher.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Bus\QueueingDispatcher;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Jobs\SyncJob;
@@ -151,6 +152,19 @@ class Dispatcher implements QueueingDispatcher
     public function batch($jobs)
     {
         return new PendingBatch($this->container, Collection::wrap($jobs));
+    }
+
+    /**
+     * Create a new chain of queueable jobs.
+     *
+     * @param  \Illuminate\Support\Collection|array  $jobs
+     * @return \Illuminate\Foundation\Bus\PendingChain
+     */
+    public function chain($jobs)
+    {
+        $jobs = Collection::wrap($jobs);
+
+        return new PendingChain($jobs->shift(), $jobs->toArray());
     }
 
     /**

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -24,6 +24,13 @@ trait Queueable
     public $queue;
 
     /**
+     * The callbacks to be executed on chain failure.
+     *
+     * @var array|null
+     */
+    public $chainCatchCallbacks;
+
+    /**
      * The name of the connection the chain should be sent to.
      *
      * @var string|null
@@ -188,9 +195,21 @@ trait Queueable
                 $next->onConnection($next->connection ?: $this->chainConnection);
                 $next->onQueue($next->queue ?: $this->chainQueue);
 
+                $next->chainCatchCallbacks = $this->chainCatchCallbacks;
                 $next->chainConnection = $this->chainConnection;
                 $next->chainQueue = $this->chainQueue;
             }));
         }
+    }
+
+    /**
+     * Dispatch the next job on the chain.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    public function invokeChainCatchCallbacks($e)
+    {
+        collect($this->chainCatchCallbacks)->each->__invoke($e);
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Foundation\Bus;
 
 use Closure;
+use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Queue\SerializableClosure;
 
@@ -87,7 +88,7 @@ class PendingChain
      */
     public function onConnection($connection)
     {
-        $this->job->onConnection($connection);
+        $this->connection = $connection;
 
         return $this;
     }
@@ -100,7 +101,7 @@ class PendingChain
      */
     public function onQueue($queue)
     {
-        $this->job->onQueue($queue);
+        $this->queue = $queue;
 
         return $this;
     }
@@ -121,9 +122,11 @@ class PendingChain
         }
 
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
+
         $firstJob->allOnQueue($this->queue);
         $firstJob->allOnConnection($this->connection);
+        $firstJob->chain($this->chain);
 
-        return (new PendingDispatch($firstJob))->chain($this->chain);
+        return app(Dispatcher::class)->dispatch($firstJob);
     }
 }

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -9,11 +9,11 @@ use Illuminate\Queue\SerializableClosure;
 class PendingChain
 {
     /**
-     * The class name of the job being dispatched.
+     * The name of the connection the chain should be sent to.
      *
-     * @var mixed
+     * @var string|null
      */
-    public $job;
+    public $connection;
 
     /**
      * The jobs to be chained.
@@ -28,6 +28,20 @@ class PendingChain
      * @var array
      */
     public $catchCallbacks = [];
+
+    /**
+     * The name of the queue the chain should be sent to.
+     *
+     * @var string|null
+     */
+    public $queue;
+
+    /**
+     * The class name of the job being dispatched.
+     *
+     * @var mixed
+     */
+    public $job;
 
     /**
      * Create a new PendingChain instance.
@@ -66,6 +80,32 @@ class PendingChain
     }
 
     /**
+     * Set the desired connection for the job.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function onConnection($connection)
+    {
+        $this->job->onConnection($connection);
+
+        return $this;
+    }
+
+    /**
+     * Set the desired queue for the job.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function onQueue($queue)
+    {
+        $this->job->onQueue($queue);
+
+        return $this;
+    }
+
+    /**
      * Dispatch the job with the given arguments.
      *
      * @return \Illuminate\Foundation\Bus\PendingDispatch
@@ -81,6 +121,8 @@ class PendingChain
         }
 
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
+        $firstJob->allOnQueue($this->queue);
+        $firstJob->allOnConnection($this->connection);
 
         return (new PendingDispatch($firstJob))->chain($this->chain);
     }

--- a/src/Illuminate/Queue/CallQueuedHandler.php
+++ b/src/Illuminate/Queue/CallQueuedHandler.php
@@ -193,6 +193,7 @@ class CallQueuedHandler
         $command = unserialize($data['command']);
 
         $this->ensureFailedBatchJobIsRecorded($uuid, $command, $e);
+        $this->ensureChainCatchCallbacksAreInvoked($uuid, $command, $e);
 
         if (method_exists($command, 'failed')) {
             $command->failed($e);
@@ -215,5 +216,20 @@ class CallQueuedHandler
         }
 
         $command->batch()->recordFailedJob($uuid, $e);
+    }
+
+    /**
+     * Ensure the chained job catch callbacks are invoked.
+     *
+     * @param  string  $uuid
+     * @param  mixed  $command
+     * @param  \Throwable  $e
+     * @return void
+     */
+    protected function ensureChainCatchCallbacksAreInvoked(string $uuid, $command, $e)
+    {
+        if (method_exists($command, 'invokeChainCatchCallbacks')) {
+            $command->invokeChainCatchCallbacks($e);
+        }
     }
 }

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -24,7 +24,7 @@
         "illuminate/filesystem": "^8.0",
         "illuminate/pipeline": "^8.0",
         "illuminate/support": "^8.0",
-        "opis/closure": "^3.5",
+        "opis/closure": "^3.5.3",
         "ramsey/uuid": "^4.0",
         "symfony/process": "^5.1"
     },

--- a/src/Illuminate/Support/Facades/Bus.php
+++ b/src/Illuminate/Support/Facades/Bus.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Testing\Fakes\BusFake;
  * @method static void assertDispatchedTimes(string $command, int $times = 1)
  * @method static void assertNotDispatched(string $command, callable|int $callback = null)
  * @method static \Illuminate\Bus\PendingBatch batch(array $jobs)
+ * @method static \Illuminate\Foundation\Bus\PendingChain chain(array $jobs)
  * @method static \Illuminate\Bus\Batch|null findBatch(string $batchId)
  *
  * @see \Illuminate\Contracts\Bus\Dispatcher

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -159,8 +159,8 @@ class JobChainingTest extends TestCase
             new JobChainingTestFirstJob(),
             new JobChainingTestFailingJob(),
             new JobChainingTestSecondJob(),
-        ])->catch(function () use (&$catchRan) {
-            static::$catchCallbackRan = true;
+        ])->catch(function () {
+            self::$catchCallbackRan = true;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -160,7 +160,7 @@ class JobChainingTest extends TestCase
             new JobChainingTestFailingJob(),
             new JobChainingTestSecondJob(),
         ])->catch(static function () {
-            static::$catchCallbackRan = true;
+            self::$catchCallbackRan = true;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -15,6 +15,8 @@ use Orchestra\Testbench\TestCase;
  */
 class JobChainingTest extends TestCase
 {
+    public static $catchCallbackRan = false;
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('app.debug', 'true');
@@ -35,6 +37,7 @@ class JobChainingTest extends TestCase
         JobChainingTestFirstJob::$ran = false;
         JobChainingTestSecondJob::$ran = false;
         JobChainingTestThirdJob::$ran = false;
+        static::$catchCallbackRan = false;
     }
 
     public function testJobsCanBeChainedOnSuccess()
@@ -148,6 +151,21 @@ class JobChainingTest extends TestCase
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);
         $this->assertFalse(JobChainingTestThirdJob::$ran);
+    }
+
+    public function testCatchCallbackIsCalledOnFailure()
+    {
+        Bus::chain([
+            new JobChainingTestFirstJob(),
+            new JobChainingTestFailingJob(),
+            new JobChainingTestSecondJob(),
+        ])->catch(function () use (&$catchRan) {
+            static::$catchCallbackRan = true;
+        })->dispatch();
+
+        $this->assertTrue(JobChainingTestFirstJob::$ran);
+        $this->assertTrue(static::$catchCallbackRan);
+        $this->assertFalse(JobChainingTestSecondJob::$ran);
     }
 
     public function testChainJobsUseSameConfig()

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -160,7 +160,7 @@ class JobChainingTest extends TestCase
             new JobChainingTestFailingJob(),
             new JobChainingTestSecondJob(),
         ])->catch(function () {
-            self::$catchCallbackRan = true;
+            JobChainingTest::$catchCallbackRan = true;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);

--- a/tests/Integration/Queue/JobChainingTest.php
+++ b/tests/Integration/Queue/JobChainingTest.php
@@ -159,8 +159,8 @@ class JobChainingTest extends TestCase
             new JobChainingTestFirstJob(),
             new JobChainingTestFailingJob(),
             new JobChainingTestSecondJob(),
-        ])->catch(function () {
-            JobChainingTest::$catchCallbackRan = true;
+        ])->catch(static function () {
+            static::$catchCallbackRan = true;
         })->dispatch();
 
         $this->assertTrue(JobChainingTestFirstJob::$ran);


### PR DESCRIPTION
This PR add a new `Bus::chain()` method similar to `Bus::batch()` and also allows attaching catch callbacks to chain:

```php
Bus::chain([
    new Job(),
    new Job2(),
    new Job3()
])->catch(function ($e) {
    info($e->getMessage());
})->dispatch();
```

The callbacks will be invoked if any of the jobs fail.