### PR TITLE
[8.x] Improve support for Blade component rendering raw HTML

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -4,6 +4,7 @@ namespace Illuminate\View;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -49,20 +50,24 @@ abstract class Component
     /**
      * Get the view / view contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     abstract public function render();
 
     /**
      * Resolve the Blade view or view file that should be used when rendering the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Clousure|string
      */
     public function resolveView()
     {
         $view = $this->render();
 
         if ($view instanceof View) {
+            return $view;
+        }
+
+        if ($view instanceof Htmlable) {
             return $view;
         }
 

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -57,7 +57,7 @@ abstract class Component
     /**
      * Resolve the Blade view or view file that should be used when rendering the component.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Clousure|string
+     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     public function resolveView()
     {

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -3,6 +3,7 @@
 namespace Illuminate\View\Concerns;
 
 use Closure;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\View;
@@ -41,7 +42,7 @@ trait ManagesComponents
     /**
      * Start a component rendering process.
      *
-     * @param  \Illuminate\View\View|\Closure|string  $view
+     * @param  \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
      * @param  array  $data
      * @return void
      */
@@ -89,6 +90,8 @@ trait ManagesComponents
 
         if ($view instanceof View) {
             return $view->with($data)->render();
+        } elseif ($view instanceof Htmlable) {
+            return $view->toHtml();
         } else {
             return $this->make($view, $data)->render();
         }

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -354,7 +354,7 @@ class ViewFactoryTest extends TestCase
     public function testComponentHandlingUsingViewObject()
     {
         $factory = $this->getFactory();
-        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__ . '/fixtures/component.php');
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/component.php');
         $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
         $factory->getDispatcher()->shouldReceive('dispatch');
         $factory->startComponent($factory->make('component'), ['name' => 'Taylor']);

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
@@ -348,6 +349,51 @@ class ViewFactoryTest extends TestCase
         echo 'component';
         $contents = $factory->renderComponent();
         $this->assertSame('title<hr> component Taylor laravel.com', $contents);
+    }
+
+    public function testComponentHandlingUsingViewObject()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__ . '/fixtures/component.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
+        $factory->getDispatcher()->shouldReceive('dispatch');
+        $factory->startComponent($factory->make('component'), ['name' => 'Taylor']);
+        $factory->slot('title');
+        $factory->slot('website', 'laravel.com');
+        echo 'title<hr>';
+        $factory->endSlot();
+        echo 'component';
+        $contents = $factory->renderComponent();
+        $this->assertSame('title<hr> component Taylor laravel.com', $contents);
+    }
+
+    public function testComponentHandlingUsingClosure()
+    {
+        $factory = $this->getFactory();
+        $factory->getFinder()->shouldReceive('find')->andReturn(__DIR__.'/fixtures/component.php');
+        $factory->getEngineResolver()->shouldReceive('resolve')->andReturn(new PhpEngine(new Filesystem));
+        $factory->getDispatcher()->shouldReceive('dispatch');
+        $factory->startComponent(function ($data) use ($factory) {
+            $this->assertArrayHasKey('name', $data);
+            $this->assertSame($data['name'], 'Taylor');
+
+            return $factory->make('component');
+        }, ['name' => 'Taylor']);
+        $factory->slot('title');
+        $factory->slot('website', 'laravel.com');
+        echo 'title<hr>';
+        $factory->endSlot();
+        echo 'component';
+        $contents = $factory->renderComponent();
+        $this->assertSame('title<hr> component Taylor laravel.com', $contents);
+    }
+
+    public function testComponentHandlingUsingHtmlable()
+    {
+        $factory = $this->getFactory();
+        $factory->startComponent(new HtmlString('laravel.com'));
+        $contents = $factory->renderComponent();
+        $this->assertSame('laravel.com', $contents);
     }
 
     public function testTranslation()


### PR DESCRIPTION
Originally, I wrote about this in https://github.com/laravel/ideas/issues/2261 and decided to make a PR.

In some cases we might want to be able to return raw HTML when rendering component, which we generated dynamically based on properties injected through component constructor.

The problem with current implementation is that a string returned from component's `render` method (if not a view name) gets compiled with Blade which means that every time the component renders a new cache file might be created. This is not ideal and the solution would be to skip Blade and just use that raw HTML.

For this reason I propose that components support returning instance of `Illuminate\Contracts\Support\Htmlable` from `render` method to distinguish raw HTML, which should not be compiled.

Thanks in advance for considering this! Cheers! :slightly_smiling_face:

P.S. I know a workaround for this would be to assign the generated HTML to a public property and echo it either using inline Blade template or dedicated view file, but it's not that intuitive.