### PR TITLE
[7.x] Include class name in output of GeneratorCommand

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -146,7 +146,7 @@ abstract class GeneratorCommand extends Command
         if ((! $this->hasOption('force') ||
              ! $this->option('force')) &&
              $this->alreadyExists($this->getNameInput())) {
-            $this->error($this->type.' already exists!');
+            $this->error("{$this->type} {$path} already exists!");
 
             return false;
         }
@@ -158,7 +158,7 @@ abstract class GeneratorCommand extends Command
 
         $this->files->put($path, $this->sortImports($this->buildClass($name)));
 
-        $this->info($this->type.' created successfully.');
+        $this->info("{$this->type} {$path} created successfully.");
     }
 
     /**


### PR DESCRIPTION
It's often useful (especially for Laravel newbies) to know exactly what files were created after running a command. This PR adds the name of the created class for `make:` and other generator commands, making the output more useful.

This shouldn't be a breaking change unless someone is asserting on the output of these commands, which would be a pretty flaky test (you should be checking if the expected files were created).