### PR TITLE
[7.x] Don’t allow multiple params for factory state() function

### DIFF
--- a/src/Illuminate/Database/Eloquent/FactoryBuilder.php
+++ b/src/Illuminate/Database/Eloquent/FactoryBuilder.php
@@ -113,9 +113,15 @@ class FactoryBuilder
      *
      * @param  string  $state
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function state($state)
     {
+        if (func_num_args() > 1) {
+            throw new InvalidArgumentException('Can\'t pass multiple parameters to state(), use states() instead.');
+        }
+
         return $this->states([$state]);
     }
 

--- a/tests/Integration/Database/EloquentFactoryBuilderTest.php
+++ b/tests/Integration/Database/EloquentFactoryBuilderTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
 use Orchestra\Testbench\TestCase;
 
 /**
@@ -214,6 +215,13 @@ class EloquentFactoryBuilderTest extends TestCase
 
         $this->assertSame('active', $server->status);
         $this->assertSame('inline', $inlineServer->status);
+    }
+
+    public function testCreatingModelsWithTooManyStates()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        factory(FactoryBuildableServer::class)->state('inline', 'test')->make();
     }
 
     public function testCreatingModelsWithRelationships()


### PR DESCRIPTION
This PR is to save other developers some time trying to figure out why not all states are being applied to their factory if you accidentally use `state()` instead of `states()`. The difference between the function names is easy to miss but if you pass multiple parameters to the `state()` function only the first one is applied but no error is thrown.

This change does not break any existing features but might surface some incorrect tests for some users.