### PR TITLE
[7.x] Added debug helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -361,6 +361,23 @@ if (! function_exists('database_path')) {
     }
 }
 
+if (! function_exists('debug')) {
+    /**
+     * Return default value only in debug mode.
+     *
+     * @param  mixed  $value
+     * @return mixed
+     */
+    function debug($value)
+    {
+        if (! config('app.debug')) {
+            return;
+        }
+
+        return value($value);
+    }
+}
+
 if (! function_exists('decrypt')) {
     /**
      * Decrypt the given value.

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -17,7 +17,7 @@ class FoundationHelpersTest extends TestCase
     {
         m::close();
     }
-    
+
     public function testDebug()
     {
         $app = new Application;

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -17,6 +17,21 @@ class FoundationHelpersTest extends TestCase
     {
         m::close();
     }
+    
+    public function testDebug()
+    {
+        $app = new Application;
+        $app['config'] = $config = m::mock('config');
+
+        $config->shouldReceive('get')->withArgs(['app.debug', null])->andReturn(true)->twice();
+        $this->assertSame('foo', debug('foo'));
+        $this->assertSame('foo', debug(function () {
+            return 'foo';
+        }));
+
+        $config->shouldReceive('get')->withArgs(['app.debug', null])->andReturn(false)->once();
+        $this->assertNull(debug('foo'));
+    }
 
     public function testCache()
     {


### PR DESCRIPTION
Edit: Moved helper to foundation.

I have added a helper that I've been using a lot lately. The helper simplifies a syntax to execute code or output error messages in debug mode. 

Here is how I use the helper mostly:
```php
abort(404, config('app.debug') ? "My debug error message" : null);
// Is the same as:
abort(404, debug("My debug error message"));
```

The example adds an error message to the not found exception in debug mode. Error messages in production, for example for an api, should not give too exact insights into the system. However, details about the error during debugging can be a blessing.

A closure may be passed to the debug helper as well:
```php
debug(function() {
    // Do something in debug mode.
});
```