### PR TITLE
[7.x] Support for default values model inserting

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2734,7 +2734,6 @@ class Builder
      * Evaluate the values of default attributes passed if closures exist.
      *
      * @param  array  $attributes
-     *
      * @return array
      */
     private function resolveInsertDefalts(array $attributes)

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2710,7 +2710,6 @@ class Builder
             $values = [$values];
         }
 
-
         // Here, we will sort the insert keys for every record so that each insert is
         // in the same order for the record. We need to make sure this is the case
         // so there are not any errors or problems when inserting these records.
@@ -2738,7 +2737,8 @@ class Builder
      *
      * @return array
      */
-    private function resolveInsertDefalts(array $attributes){
+    private function resolveInsertDefalts(array $attributes)
+    {
         return collect($attributes)
             ->map(function ($value, $key) {
                 if ($value instanceof Closure) {


### PR DESCRIPTION
This PR aims to add default and dynamic attributes to a `Model::insert($values)` op.
Originally we have to map the correct values before we insert which is cool but then there are moments when you wanna save even dynamic values on the fly too. 

My use case is when I am using TheModel with a `uuid` as the `primary key`. Since the id is not auto-incremented we need a way of creating on saving bulky entries.

Accoriding to the tip by Povilas Korop [https://www.youtube.com/watch?v=sAjLREMr-9k](https://www.youtube.com/watch?v=sAjLREMr-9k) the `Model::insert($values)` is quite a performant op so thats where I got the reason to extend the core a little.

Here is my use example:
```php
TheModel::insert($originalArrayedData, [
	'created_at' => now()->toDatetimeString(),		//append static attributes
	'user_id' => $user->id,
	'id' => function() {
		return Str::uuid()->toString()				//append dynamic attributes
	}
]);
```
I can add tests If you think you need this.