### PR TITLE
[7.x] Add "every 2 / 3 / 4 minutes" methods to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -82,6 +82,36 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every two minutes.
+     *
+     * @return $this
+     */
+    public function everyTwoMinutes()
+    {
+        return $this->spliceIntoPosition(1, '*/2');
+    }
+
+    /**
+     * Schedule the event to run every three minutes.
+     *
+     * @return $this
+     */
+    public function everyThreeMinutes()
+    {
+        return $this->spliceIntoPosition(1, '*/3');
+    }
+
+    /**
+     * Schedule the event to run every four minutes.
+     *
+     * @return $this
+     */
+    public function everyFourMinutes()
+    {
+        return $this->spliceIntoPosition(1, '*/4');
+    }
+
+    /**
      * Schedule the event to run every five minutes.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -28,8 +28,11 @@ class FrequencyTest extends TestCase
         $this->assertSame('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
-    public function testEveryFiveMinutes()
+    public function testEveryXMinutes()
     {
+        $this->assertSame('*/2 * * * *', $this->event->everyTwoMinutes()->getExpression());
+        $this->assertSame('*/3 * * * *', $this->event->everyThreeMinutes()->getExpression());
+        $this->assertSame('*/4 * * * *', $this->event->everyFourMinutes()->getExpression());
         $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
     }
 


### PR DESCRIPTION
This PR adds the following methods to the scheduler:
- `everyTwoMinutes()`
- `everyThreeMinutes()`
- `everyFourMinutes()`

These new methods go alongside the currently available `everyMinute` and `everyFiveMinutes` methods.

I need these methods for an application that syncs data from a legacy system. We have to sync the data "in real time" (as in, so that it feels like "real time"). Using `everyMinute` seems like overkill, and might overload their server. On the other hand, `everyFiveMinutes` doesn't feel "real time" enough. Being able to schedule the sync every 2 or 3 minutes would be perfect.

Scheduling jobs that should run very often is a common use-case. These new methods give developers more choice in exactly how often.


