### PR TITLE
[7.x] Add a more generic minute schedule method

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -82,6 +82,17 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every minute on the hour that is divisible by the interval.
+     *
+     * @param  int  $minutes
+     * @return $this
+     */
+    public function everyMinuteInterval($minutes = 1)
+    {
+        return $this->spliceIntoPosition(1, '*/'.$minutes);
+    }
+
+    /**
      * Schedule the event to run every five minutes.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -28,6 +28,13 @@ class FrequencyTest extends TestCase
         $this->assertSame('* * * * *', $this->event->everyMinute()->getExpression());
     }
 
+    public function testEveryMinuteInterval()
+    {
+        $this->assertSame('*/7 * * * *', $this->event->everyMinuteInterval(7)->getExpression());
+        $this->assertSame('*/31 * * * *', $this->event->everyMinuteInterval(31)->getExpression());
+        $this->assertSame('*/43 * * * *', $this->event->everyMinuteInterval(43)->getExpression());
+    }
+
     public function testEveryFiveMinutes()
     {
         $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());


### PR DESCRIPTION
this PR was inspired by #33379 

Rather than adding a method for every iteration of minute intervals, the thought is to have one method that accepts a parameter.

If there are any suggestions for a better method name, definitely open to them.

The only concern here is that we make it clear in the documentation how this actually works, specifically with values that are not factors of 60.  For example, a value of `*/17` will run at the 0, 17, 34, and 51 minutes, and then start over again at zero on the next hour, so the expressions is not truly running every 17th minute.

If we can come up with a readable name, we could possibly deprecate and remove the existing function like `->everyFiveMinutes()`, `->everyFifteenMinutes()`, etc.