### PR TITLE
[7.x] Adding useful functions to the session contract

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -12,6 +12,14 @@ interface Session
     public function getName();
 
     /**
+     * Set the name of the session.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setName($name);
+
+    /**
      * Get the current session ID.
      *
      * @return string
@@ -89,6 +97,13 @@ interface Session
     public function token();
 
     /**
+     * Regenerate the CSRF token value.
+     *
+     * @return void
+     */
+    public function regenerateToken();
+
+    /**
      * Remove an item from the session, returning its value.
      *
      * @param  string  $key
@@ -110,6 +125,21 @@ interface Session
      * @return void
      */
     public function flush();
+
+    /**
+     * Flush the session data and regenerate the ID.
+     *
+     * @return bool
+     */
+    public function invalidate();
+
+    /**
+     * Generate a new session identifier.
+     *
+     * @param  bool  $destroy
+     * @return bool
+     */
+    public function regenerate($destroy = false);
 
     /**
      * Generate a new session ID for the session.


### PR DESCRIPTION
This pull request is a small addition to session contract.

In my default flow I like to use the contracts over the facades.
At this current moment I am working on some functions where I need the `regenerate` function in the contract.

I was also so free to take a look at other functions. 
Beside the contract I am thinking about the `invalidate`, `regenerateToken` and `seName` function to be useful too.

Those functions feels to me like an expectation.
For example the `getName` is available in the contract, therefor I would have expected the `setName`  to be available too.
The `token` function is available in the contract, therefor I would expect the `regenerateToken` too.
Both the `flush` and the `migrate` are available, both used in the `invalidate` function, therefor I would expect this function too.

And last because, `migrate` is all ready in the contract, and because of the logic above the `regenerateToken` will be added to contract, and there for I think regenerate should also be in the contract.