### PR TITLE
[7.x] default unknown environments to production

### DIFF
--- a/src/Illuminate/Console/ConfirmableTrait.php
+++ b/src/Illuminate/Console/ConfirmableTrait.php
@@ -46,7 +46,7 @@ trait ConfirmableTrait
     protected function getDefaultConfirmCallback()
     {
         return function () {
-            return $this->getLaravel()->environment() === 'production';
+            return $this->getLaravel()->isProduction();
         };
     }
 }

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -546,7 +546,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isProduction()
     {
-        return ! in_array($this['env'], ['local', 'staging', 'testing']);
+        return ! in_array($this['env'], ['development', 'local', 'staging', 'testing']);
     }
 
     /**

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -546,7 +546,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      */
     public function isProduction()
     {
-        return $this['env'] === 'production';
+        return ! in_array($this['env'], ['local', 'staging', 'testing']);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -75,7 +75,7 @@ trait CompilesConditionals
      */
     protected function compileProduction()
     {
-        return "<?php if(app()->environment('production')): ?>";
+        return "<?php if(app()->isProduction()): ?>";
     }
 
     /**

--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -75,7 +75,7 @@ trait CompilesConditionals
      */
     protected function compileProduction()
     {
-        return "<?php if(app()->isProduction()): ?>";
+        return '<?php if(app()->isProduction()): ?>';
     }
 
     /**

--- a/tests/Database/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Database/DatabaseMigrationMigrateCommandTest.php
@@ -120,8 +120,8 @@ class ApplicationDatabaseMigrationStub extends Application
         }
     }
 
-    public function environment(...$environments)
+    public function isProduction()
     {
-        return 'development';
+        return false;
     }
 }

--- a/tests/Database/DatabaseMigrationRefreshCommandTest.php
+++ b/tests/Database/DatabaseMigrationRefreshCommandTest.php
@@ -98,8 +98,8 @@ class ApplicationDatabaseRefreshStub extends Application
         }
     }
 
-    public function environment(...$environments)
+    public function isProduction()
     {
-        return 'development';
+        return false;
     }
 }

--- a/tests/Database/DatabaseMigrationResetCommandTest.php
+++ b/tests/Database/DatabaseMigrationResetCommandTest.php
@@ -67,8 +67,8 @@ class ApplicationDatabaseResetStub extends Application
         }
     }
 
-    public function environment(...$environments)
+    public function isProduction()
     {
-        return 'development';
+        return false;
     }
 }

--- a/tests/Database/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Database/DatabaseMigrationRollbackCommandTest.php
@@ -96,8 +96,8 @@ class ApplicationDatabaseRollbackStub extends Application
         }
     }
 
-    public function environment(...$environments)
+    public function isProduction()
     {
-        return 'development';
+        return false;
     }
 }

--- a/tests/Database/SeedCommandTest.php
+++ b/tests/Database/SeedCommandTest.php
@@ -30,7 +30,7 @@ class SeedCommandTest extends TestCase
 
         $container = m::mock(Container::class);
         $container->shouldReceive('call');
-        $container->shouldReceive('environment')->once()->andReturn('testing');
+        $container->shouldReceive('isProduction')->once()->andReturn(false);
         $container->shouldReceive('make')->with('DatabaseSeeder')->andReturn($seeder);
         $container->shouldReceive('make')->with(OutputStyle::class, m::any())->andReturn(
             new OutputStyle($input, $output)

--- a/tests/Foundation/FoundationApplicationTest.php
+++ b/tests/Foundation/FoundationApplicationTest.php
@@ -235,6 +235,13 @@ class FoundationApplicationTest extends TestCase
         $this->assertTrue($testing->runningUnitTests());
         $this->assertFalse($testing->isLocal());
         $this->assertFalse($testing->isProduction());
+
+        $empty = new Application;
+        $empty['env'] = '';
+
+        $this->assertTrue($empty->isProduction());
+        $this->assertFalse($empty->runningUnitTests());
+        $this->assertFalse($empty->isLocal());
     }
 
     public function testMethodAfterLoadingEnvironmentAddsClosure()

--- a/tests/View/Blade/BladeEnvironmentStatementsTest.php
+++ b/tests/View/Blade/BladeEnvironmentStatementsTest.php
@@ -26,7 +26,7 @@ breeze
 @else
 boom
 @endproduction';
-        $expected = "<?php if(app()->environment('production')): ?>
+        $expected = "<?php if(app()->isProduction()): ?>
 breeze
 <?php else: ?>
 boom

--- a/tests/View/Blade/BladeEnvironmentStatementsTest.php
+++ b/tests/View/Blade/BladeEnvironmentStatementsTest.php
@@ -26,11 +26,11 @@ breeze
 @else
 boom
 @endproduction';
-        $expected = "<?php if(app()->isProduction()): ?>
+        $expected = '<?php if(app()->isProduction()): ?>
 breeze
 <?php else: ?>
 boom
-<?php endif; ?>";
+<?php endif; ?>';
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 }


### PR DESCRIPTION
As one outcome of the ongoing discussion at https://github.com/laravel/laravel/pull/5331, I propose defaulting any unknown environments to production.

Currently, only if `APP_ENV` is set to _'production'_, the app is assumed to be in production mode. If `APP_ENV` is left empty or a developer produces a typo like _'prodution'_, the app will basically run unrestricted, with migrations running without confirmation as well as any other tool checking for `app()->isProduction()` or `app()->environment() === 'production'`.

This pull request also refactors the use of direct environment name comparisons to `->isProduction()` in the ConfirmableTrait and the Blade `@production` conditional.

This change is assumed to be a breaking change, so maybe it should be scheduled for 8.x instead. It could also be discussed to have all allowed environments listed in the app config rather than hardcoding them in the Application class. This way developers using custom environment names could list them there to make sure they are not perceived as production environments.
