### PR TITLE
[6.x] Full PHP 8.0 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
@@ -47,8 +47,15 @@ jobs:
       - name: Setup Memcached
         uses: niden/actions-memcached@v7
 
+      - name: Setup problem matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose
@@ -62,14 +69,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4]
-        include:
-          - php: 7.2
-            stability: prefer-lowest
-          - php: 7.3
-            stability: prefer-stable
-          - php: 7.4
-            stability: prefer-stable
+        php: [7.2, 7.3, 7.4, 8.0]
+        stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - Windows
 
@@ -89,10 +90,16 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, gd, pdo_mysql, fileinfo, ftp
           tools: composer:v2
           coverage: none
-          ini-values: memory_limit=512M
+
+      - name: Setup problem matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.0).",
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
         "filp/whoops": "Required for friendly error pages in development (^2.8).",
-        "fzaninotto/faker": "Required to use the eloquent factory builder (^1.9.1).",
+        "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "guzzlehttp/guzzle": "Required to use the Mailgun mail driver and the ping methods on schedules (^6.3.1|^7.0.1).",
         "laravel/tinker": "Required to use the tinker console command (^2.0).",
         "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (^1.0).",

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "~1.3.3|^1.4.2",
         "moontoast/math": "^1.1",
-        "orchestra/testbench-core": "^4.0",
+        "orchestra/testbench-core": "^4.8",
         "pda/pheanstalk": "^4.0",
         "phpunit/phpunit": "^7.5.15|^8.4|^9.3.3",
         "predis/predis": "^1.1.1",

--- a/src/Illuminate/Auth/composer.json
+++ b/src/Illuminate/Auth/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/http": "^6.0",
         "illuminate/queue": "^6.0",

--- a/src/Illuminate/Broadcasting/composer.json
+++ b/src/Illuminate/Broadcasting/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "psr/log": "^1.0",
         "illuminate/bus": "^6.0",

--- a/src/Illuminate/Bus/composer.json
+++ b/src/Illuminate/Bus/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/pipeline": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Cache/composer.json
+++ b/src/Illuminate/Cache/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Config/composer.json
+++ b/src/Illuminate/Config/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Console/composer.json
+++ b/src/Illuminate/Console/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/console": "^4.3.4",

--- a/src/Illuminate/Container/composer.json
+++ b/src/Illuminate/Container/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "psr/container": "^1.0"
     },

--- a/src/Illuminate/Contracts/composer.json
+++ b/src/Illuminate/Contracts/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "psr/container": "^1.0",
         "psr/simple-cache": "^1.0"
     },

--- a/src/Illuminate/Cookie/composer.json
+++ b/src/Illuminate/Cookie/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/http-foundation": "^4.3.4",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -33,7 +33,7 @@
     },
     "suggest": {
         "doctrine/dbal": "Required to rename columns and drop SQLite columns (^2.6).",
-        "fzaninotto/faker": "Required to use the eloquent factory builder (^1.9.1).",
+        "fakerphp/faker": "Required to use the eloquent factory builder (^1.9.1).",
         "illuminate/console": "Required to use the database commands (^6.0).",
         "illuminate/events": "Required to use the observers with Eloquent (^6.0).",
         "illuminate/filesystem": "Required to use the migrations (^6.0).",

--- a/src/Illuminate/Database/composer.json
+++ b/src/Illuminate/Database/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Encryption/composer.json
+++ b/src/Illuminate/Encryption/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/finder": "^4.3.4"

--- a/src/Illuminate/Hashing/composer.json
+++ b/src/Illuminate/Hashing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Http/composer.json
+++ b/src/Illuminate/Http/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/session": "^6.0",
         "illuminate/support": "^6.0",

--- a/src/Illuminate/Log/composer.json
+++ b/src/Illuminate/Log/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "monolog/monolog": "^1.12|^2.0"

--- a/src/Illuminate/Mail/composer.json
+++ b/src/Illuminate/Mail/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Notifications/composer.json
+++ b/src/Illuminate/Notifications/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/broadcasting": "^6.0",
         "illuminate/bus": "^6.0",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/Pagination/composer.json
+++ b/src/Illuminate/Pagination/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"

--- a/src/Illuminate/Pipeline/composer.json
+++ b/src/Illuminate/Pipeline/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0",
         "symfony/debug": "^4.3.4"

--- a/src/Illuminate/Queue/composer.json
+++ b/src/Illuminate/Queue/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/console": "^6.0",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "illuminate/contracts": "^6.0",
         "illuminate/support": "^6.0"
     },

--- a/src/Illuminate/Routing/composer.json
+++ b/src/Illuminate/Routing/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",

--- a/src/Illuminate/Session/composer.json
+++ b/src/Illuminate/Session/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/filesystem": "^6.0",

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "doctrine/inflector": "^1.4|^2.0",

--- a/src/Illuminate/Translation/composer.json
+++ b/src/Illuminate/Translation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/contracts": "^6.0",
         "illuminate/filesystem": "^6.0",

--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "egulias/email-validator": "^2.1.10",
         "illuminate/container": "^6.0",

--- a/src/Illuminate/View/composer.json
+++ b/src/Illuminate/View/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-json": "*",
         "illuminate/container": "^6.0",
         "illuminate/contracts": "^6.0",


### PR DESCRIPTION
Draft until most libraries have started to release PHP 8 compatible versions or at least dev builds.

Todo/Requirements:

- [x] `tijsverkoyen/css-to-inline-styles`: https://github.com/tijsverkoyen/CssToInlineStyles/pull/198
- [x] `opis/closure`: https://github.com/opis/closure/pull/67, https://github.com/opis/closure/pull/81
- [x] `guzzlehttp/guzzle`: https://github.com/guzzle/guzzle/issues/2702, https://github.com/guzzle/guzzle/pull/2808
- [x] AWS SDK: https://github.com/aws/aws-sdk-php/pull/2079
- [x] `mockery/mockery` (https://github.com/mockery/mockery/pull/1072, https://github.com/mockery/mockery/pull/1088)
- [x] PHPUnit 9.3 release (will be released on [2020-08-07](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-9.3.md#930---2020-08-07))
- [x] `doctrine/dbal` ^3.0 or ^2.12 release (https://github.com/doctrine/dbal/pull/4347)
- [x] `phpdocumentor/reflection-docblock` ^5.2 release
- [x] Flysystem 1.1 release (https://github.com/thephpleague/mime-type-detection/pull/1, https://github.com/thephpleague/flysystem/pull/1183)
- [x] Re-enable fast-finish
- [x] Prophecy PHP 8 support
- [x] Whoops PHP 8 support (https://github.com/filp/whoops/pull/672)
- [x] Cron expression PHP 8 support (https://github.com/dragonmantank/cron-expression/issues/94)
- [x] Revert extra build steps
- [x] Faker PHP 8 support (https://github.com/FakerPHP/Faker/pull/1)
- [x] Testbench PHP 8 support
- [x] Resolve sort issues