### PR TITLE
[8.x] Guzzle-like request body summary added to HttpClient RequestException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "aws/aws-sdk-php": "^3.0",
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.4",
-        "guzzlehttp/guzzle": "^6.3.1|^7.0",
+        "guzzlehttp/guzzle": "^6.4.0|^7.0",
         "guzzlehttp/psr7": "^1.5.2",
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.3.1",

--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         "doctrine/dbal": "^2.6",
         "filp/whoops": "^2.4",
         "guzzlehttp/guzzle": "^6.3.1|^7.0",
+        "guzzlehttp/psr7": "^1.5.2",
         "league/flysystem-cached-adapter": "^1.0",
         "mockery/mockery": "^1.3.1",
         "moontoast/math": "^1.1",

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -35,7 +35,7 @@ class RequestException extends Exception
     /**
      * Get a short summary from the body of response.
      *
-     * @param \Illuminate\Http\Client\Response $response
+     * @param  \Illuminate\Http\Client\Response  $response
      * @return string|null
      */
     private static function getResponseBodySummary(Response $response)

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -32,33 +32,14 @@ class RequestException extends Exception
         $this->response = $response;
     }
 
-    private static function getResponseBodySummary(Response $response, $truncateAt = 120)
+    /**
+     * Get a short summary from the body of response.
+     *
+     * @param \Illuminate\Http\Client\Response $response
+     * @return string|null
+     */
+    private static function getResponseBodySummary(Response $response)
     {
-        $body = $response->toPsrResponse()->getBody();
-
-        if (! $body->isSeekable() || ! $body->isReadable()) {
-            return;
-        }
-
-        $size = $body->getSize();
-
-        if ($size === 0) {
-            return;
-        }
-
-        $summary = $body->read($truncateAt);
-        $body->rewind();
-
-        if ($size > $truncateAt) {
-            $summary .= ' (truncated...)';
-        }
-
-        // Matches any printable character, including unicode characters:
-        // letters, marks, numbers, punctuation, spacing, and separators.
-        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
-            return;
-        }
-
-        return $summary;
+        return \GuzzleHttp\Psr7\get_message_body_summary($response->toPsrResponse());
     }
 }

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -21,8 +21,44 @@ class RequestException extends Exception
      */
     public function __construct(Response $response)
     {
-        parent::__construct("HTTP request returned status code {$response->status()}.", $response->status());
+        $message = "HTTP request returned status code {$response->status()}";
+        $summary = self::getResponseBodySummary($response);
 
+        if ($summary !== null) {
+            $message .= ":\n{$summary}\n";
+        }
+
+        parent::__construct($message, $response->status());
         $this->response = $response;
+    }
+
+    private static function getResponseBodySummary(Response $response, $truncateAt = 120)
+    {
+        $body = $response->toPsrResponse()->getBody();
+
+        if (! $body->isSeekable() || ! $body->isReadable()) {
+            return;
+        }
+
+        $size = $body->getSize();
+
+        if ($size === 0) {
+            return;
+        }
+
+        $summary = $body->read($truncateAt);
+        $body->rewind();
+
+        if ($size > $truncateAt) {
+            $summary .= ' (truncated...)';
+        }
+
+        // Matches any printable character, including unicode characters:
+        // letters, marks, numbers, punctuation, spacing, and separators.
+        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
+            return;
+        }
+
+        return $summary;
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -2,8 +2,11 @@
 
 namespace Illuminate\Tests\Http;
 
+use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Str;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
@@ -426,5 +429,47 @@ class HttpClientTest extends TestCase
             return $request->url() === 'http://foo.com/json' &&
                    $request->hasHeaders('X-Test-Header');
         });
+    }
+
+    public function testRequestExceptionSummary()
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed"}}');
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        throw new RequestException(new Response($response));
+    }
+
+    public function testRequestExceptionTruncatedSummary()
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessage('{"error":{"code":403,"message":"The Request can not be completed because quota limit was exceeded. Please, check our sup (truncated...)');
+
+        $error = [
+            'error' => [
+                'code' => 403,
+                'message' => 'The Request can not be completed because quota limit was exceeded. Please, check our support team to increase your limit',
+            ],
+        ];
+        $response = new Psr7Response(403, [], json_encode($error));
+
+        throw new RequestException(new Response($response));
+    }
+
+    public function testRequestExceptionEmptyBody()
+    {
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessageMatches('/HTTP request returned status code 403$/');
+
+        $response = new Psr7Response(403);
+
+        throw new RequestException(new Response($response));
     }
 }


### PR DESCRIPTION
As it was said in https://github.com/laravel/framework/pull/33353, I'm reopening this PR but to the master branch instead.