### PR TITLE
[7.x] Add "every 2 / 3 / 4 / 6 hours" methods to scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -175,6 +175,50 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every two hours.
+     *
+     * @return $this
+     */
+    public function everyTwoHours()
+    {
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/2');
+    }
+
+    /**
+     * Schedule the event to run every three hours.
+     *
+     * @return $this
+     */
+    public function everyThreeHours()
+    {
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/3');
+    }
+
+    /**
+     * Schedule the event to run every four hours.
+     *
+     * @return $this
+     */
+    public function everyFourHours()
+    {
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/4');
+    }
+
+    /**
+     * Schedule the event to run every six hours.
+     *
+     * @return $this
+     */
+    public function everySixHours()
+    {
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/6');
+    }
+
+    /**
      * Schedule the event to run daily.
      *
      * @return $this

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -53,6 +53,14 @@ class FrequencyTest extends TestCase
         $this->assertSame('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
+    public function testHourly()
+    {
+        $this->assertSame('0 */2 * * *', $this->event->everyTwoHours()->getExpression());
+        $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());
+        $this->assertSame('0 */4 * * *', $this->event->everyFourHours()->getExpression());
+        $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
+    }
+
     public function testMonthlyOn()
     {
         $this->assertSame('0 15 4 * *', $this->event->monthlyOn(4, '15:00')->getExpression());


### PR DESCRIPTION
This PR, just like https://github.com/laravel/framework/pull/33379, adds more useful methods to the scheduler:
- `everyTwoHours()`
- `everyThreeHours()`
- `everyFourHours()`
- `everySixHours()`

These new methods go alongside the currently available `hourly` and `twiceDaily` methods (`twiceDaily` is essentially `everyTwelveHours`).

I believe scheduling cron jobs at these intervals is common enough that they deserve dedicated methods. You can currently only achieve the same behavior by writing a custom cron expression:

```php
$schedule->job(SyncSomething::class)->cron('0 */2 * * *'); // once every 2 hours

// or, with this PR

$schedule->job(SyncSomething::class)->everyTwoHours();
```

It is easy to make mistakes when writing your own cron expressions. For example, if you by mistake write `* */2 * * *`, your job will be running 60 times every 2 hours.






