### PR TITLE
[7.x] Make valid method names for abilities with spaces

### DIFF
--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -719,7 +719,7 @@ class Gate implements GateContract
      */
     protected function formatAbilityToMethod($ability)
     {
-        return strpos($ability, '-') !== false ? Str::camel($ability) : $ability;
+        return (strpos($ability, '-') !== false || strpos($ability, ' ') !== false) ? Str::camel($ability) : $ability;
     }
 
     /**

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -460,6 +460,16 @@ class AuthAccessGateTest extends TestCase
         $this->assertTrue($gate->check('update-dash', new AccessGateTestDummy));
     }
 
+    
+    public function testPolicyConvertsSpaceToCamel()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->policy(AccessGateTestDummy::class, AccessGateTestPolicy::class);
+
+        $this->assertTrue($gate->check('update dash', new AccessGateTestDummy));
+    }
+
     public function testPolicyDefaultToFalseIfMethodDoesNotExistAndGateDoesNotExist()
     {
         $gate = $this->getBasicGate();


### PR DESCRIPTION
If an ability has a space in its name, such as "edit post", the current Gate implementation will check if there's a method named "edit post" in the model's policy. That method obviously doesn't exist because it's invalid PHP. I changed the `formatAbilityToMethod()` method to check for 'editPost' in these situations instead. I think that's intuitive behavior - more intuitive than renaming your ability to "edit-post" as you are now supposed to do.
