### PR TITLE
[7.x] add `everyXMinutes()` and `everyXHours()`

### DIFF
--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Support\Carbon;
+use InvalidArgumentException;
 
 trait ManagesFrequencies
 {
@@ -76,11 +77,13 @@ trait ManagesFrequencies
      *
      * @param  int  $minutes
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function everyXMinutes($minutes = 1)
     {
         if (60 % $minutes !== 0) {
-            throw new \InvalidArgumentException('$minutes must be a factor of 60.');
+            throw new InvalidArgumentException('$minutes must be a factor of 60.');
         }
 
         return $this->spliceIntoPosition(1, '*/'.$minutes);
@@ -171,11 +174,13 @@ trait ManagesFrequencies
      *
      * @param  int  $hours
      * @return $this
+     *
+     * @throws \InvalidArgumentException
      */
     public function everyXHours($hours = 1)
     {
         if (24 % $hours !== 0) {
-            throw new \InvalidArgumentException('$hours must be a factor of 24.');
+            throw new InvalidArgumentException('$hours must be a factor of 24.');
         }
 
         return $this->spliceIntoPosition(1, 0)

--- a/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
+++ b/src/Illuminate/Console/Scheduling/ManagesFrequencies.php
@@ -72,6 +72,21 @@ trait ManagesFrequencies
     }
 
     /**
+     * Schedule the event to run every minute that is divisible by the interval.
+     *
+     * @param  int  $minutes
+     * @return $this
+     */
+    public function everyXMinutes($minutes = 1)
+    {
+        if (60 % $minutes !== 0) {
+            throw new \InvalidArgumentException('$minutes must be a factor of 60.');
+        }
+
+        return $this->spliceIntoPosition(1, '*/'.$minutes);
+    }
+
+    /**
      * Schedule the event to run every minute.
      *
      * @return $this
@@ -149,6 +164,22 @@ trait ManagesFrequencies
     public function everyThirtyMinutes()
     {
         return $this->spliceIntoPosition(1, '0,30');
+    }
+
+    /**
+     * Schedule the event to run every hour that is divisible by the interval.
+     *
+     * @param  int  $hours
+     * @return $this
+     */
+    public function everyXHours($hours = 1)
+    {
+        if (24 % $hours !== 0) {
+            throw new \InvalidArgumentException('$hours must be a factor of 24.');
+        }
+
+        return $this->spliceIntoPosition(1, 0)
+                    ->spliceIntoPosition(2, '*/'.$hours);
     }
 
     /**

--- a/tests/Console/Scheduling/FrequencyTest.php
+++ b/tests/Console/Scheduling/FrequencyTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\EventMutex;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -30,10 +31,19 @@ class FrequencyTest extends TestCase
 
     public function testEveryXMinutes()
     {
-        $this->assertSame('*/2 * * * *', $this->event->everyTwoMinutes()->getExpression());
-        $this->assertSame('*/3 * * * *', $this->event->everyThreeMinutes()->getExpression());
-        $this->assertSame('*/4 * * * *', $this->event->everyFourMinutes()->getExpression());
-        $this->assertSame('*/5 * * * *', $this->event->everyFiveMinutes()->getExpression());
+        $this->assertSame('*/2 * * * *', $this->event->everyXMinutes(2)->getExpression());
+        $this->assertSame('*/3 * * * *', $this->event->everyXMinutes(3)->getExpression());
+        $this->assertSame('*/4 * * * *', $this->event->everyXMinutes(4)->getExpression());
+        $this->assertSame('*/5 * * * *', $this->event->everyXMinutes(5)->getExpression());
+        $this->assertSame('*/6 * * * *', $this->event->everyXMinutes(6)->getExpression());
+        $this->assertSame('*/10 * * * *', $this->event->everyXMinutes(10)->getExpression());
+        $this->assertSame('*/12 * * * *', $this->event->everyXMinutes(12)->getExpression());
+        $this->assertSame('*/15 * * * *', $this->event->everyXMinutes(15)->getExpression());
+        $this->assertSame('*/20 * * * *', $this->event->everyXMinutes(20)->getExpression());
+        $this->assertSame('*/30 * * * *', $this->event->everyXMinutes(30)->getExpression());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->event->everyXMinutes(7);
     }
 
     public function testDaily()
@@ -53,12 +63,17 @@ class FrequencyTest extends TestCase
         $this->assertSame('15,30,45 * * * *', $this->event->hourlyAt([15, 30, 45])->getExpression());
     }
 
-    public function testHourly()
+    public function testEveryXHours()
     {
-        $this->assertSame('0 */2 * * *', $this->event->everyTwoHours()->getExpression());
-        $this->assertSame('0 */3 * * *', $this->event->everyThreeHours()->getExpression());
-        $this->assertSame('0 */4 * * *', $this->event->everyFourHours()->getExpression());
-        $this->assertSame('0 */6 * * *', $this->event->everySixHours()->getExpression());
+        $this->assertSame('0 */2 * * *', $this->event->everyXHours(2)->getExpression());
+        $this->assertSame('0 */3 * * *', $this->event->everyXHours(3)->getExpression());
+        $this->assertSame('0 */4 * * *', $this->event->everyXHours(4)->getExpression());
+        $this->assertSame('0 */6 * * *', $this->event->everyXHours(6)->getExpression());
+        $this->assertSame('0 */8 * * *', $this->event->everyXHours(8)->getExpression());
+        $this->assertSame('0 */12 * * *', $this->event->everyXHours(12)->getExpression());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->event->everyXHours(5);
     }
 
     public function testMonthlyOn()


### PR DESCRIPTION
Recently a large number of methods have been added for specific minute and hour scheduling intervals:

```php
->everyTwoMinutes();
->everyThreeMinutes();
->everyTwoHours();
->everyThreeHours();
etc...
```

This PR creates more generic methods that allow passing a parameter:

```php
->everyXMinutes(2);
->everyXMinutes(3);
->everyXHours(2);
->everyXHours(3);
```

This keeps the LOCs down and maintenance a little easier. 

It also makes available the intervals that are currently missing from the new methods:

```php
->everyXMinutes(6);
->everyXMinutes(12);
->everyXMinutes(20);
->everyXHours(8);
->everyXHours(12);
```

I previously submitted this [PR](33380).  Taylor's concern there was that numbers that were not factors of 60 would cause unexpected results.  This PR solves that by requiring the parameter to be a factor of either 60 (for minutes) or 24 (for hours), and throws an `InvalidArgumentException()` otherwise.
