### PR TITLE
[7.x] Improve performance characteristics of Arr::forget

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -229,7 +229,6 @@ class Arr
 
     /**
      * Removes one item from a given array using "dot" notation"
-     * top level keys containing
      *
      * @param array $array
      * @param string $key

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -242,14 +242,8 @@ class Arr
 
         $nextOffset = strpos($key, ".", $keyOffset);
 
-        // Top level keys can be removed even with .
-        if($keyOffset == 0 && array_key_exists(substr($key, $keyOffset), $array)) {
-            unset($array[substr($key, $keyOffset)]);
-            return;
-        }
-
-        // Otherwise, the key must have no further .
-        if($nextOffset === false && array_key_exists(substr($key, $keyOffset), $array)) {
+        // First check allows top level keys to be removed even if they contain "."
+        if(($keyOffset == 0 || $nextOffset === false) && array_key_exists(substr($key, $keyOffset), $array)) {
             unset($array[substr($key, $keyOffset)]);
             return;
         }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -228,7 +228,7 @@ class Arr
     }
 
     /**
-     * Removes one item from a given array using "dot" notation"
+     * Removes one item from a given array using "dot" notation".
      *
      * @param array $array
      * @param string $key
@@ -237,21 +237,22 @@ class Arr
      */
     private static function forgetKey(&$array, &$key, $keyOffset = 0)
     {
-        if (!is_array($array)) {
+        if (! is_array($array)) {
             return;
         }
 
-        $nextOffset = strpos($key, ".", $keyOffset);
+        $nextOffset = strpos($key, '.', $keyOffset);
 
         // First check allows top-level keys to be removed even if they contain "."
         if (($keyOffset == 0 || $nextOffset === false) && array_key_exists(substr($key, $keyOffset), $array)) {
             unset($array[substr($key, $keyOffset)]);
+
             return;
         }
 
-        $nextIndex  = substr($key, $keyOffset, $nextOffset - $keyOffset);
+        $nextIndex = substr($key, $keyOffset, $nextOffset - $keyOffset);
 
-        if ($nextOffset === false || !array_key_exists($nextIndex, $array)) {
+        if ($nextOffset === false || ! array_key_exists($nextIndex, $array)) {
             return;
         }
 
@@ -270,7 +271,7 @@ class Arr
     {
         $keys = (array) $keys;
 
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             static::forgetKey($array, $key);
         }
     }

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -235,25 +235,26 @@ class Arr
      * @param int $keyOffset
      * @return void
      */
-    private static function forgetKey(&$array, &$key, $keyOffset=0) {
-        if(!is_array($array)) {
+    private static function forgetKey(&$array, &$key, $keyOffset = 0)
+    {
+        if (!is_array($array)) {
             return;
         }
 
         $nextOffset = strpos($key, ".", $keyOffset);
 
-        // First check allows top level keys to be removed even if they contain "."
-        if(($keyOffset == 0 || $nextOffset === false) && array_key_exists(substr($key, $keyOffset), $array)) {
+        // First check allows top-level keys to be removed even if they contain "."
+        if (($keyOffset == 0 || $nextOffset === false) && array_key_exists(substr($key, $keyOffset), $array)) {
             unset($array[substr($key, $keyOffset)]);
             return;
         }
 
-        $nextIndex  = substr($key, $keyOffset, $nextOffset-$keyOffset);
+        $nextIndex  = substr($key, $keyOffset, $nextOffset - $keyOffset);
 
         if ($nextOffset === false || !array_key_exists($nextIndex, $array)) {
             return;
         }
-        
+
         static::forgetKey($array[$nextIndex], $key, $nextOffset + 1);
     }
 

--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -264,7 +264,8 @@ class Arr
     }
 
     /**
-     * Remove one or many array items from a given array using "dot" notation.
+     * Remove one or many array items from a given array using "dot" notation. Removing an array key
+     * containing a "." will only work at the top-level of the array.
      *
      * @param  array  $array
      * @param  array|string  $keys
@@ -280,8 +281,7 @@ class Arr
     }
 
     /**
-     * Get an item from an array using "dot" notation. Removing an array key
-     * containing a "." will only work at the top-level of the array.
+     * Get an item from an array using "dot" notation.
      *
      * @param  \ArrayAccess|array  $array
      * @param  string|int|null  $key


### PR DESCRIPTION
> In addition, please describe the benefit to end users:

`Arr::forget` accounts for 2.5% of execution time in rendering the welcome page in a default Laravel Spark application from my observations. This PR improves those function executions by 40%. Maybe this shaves a millisecond or two off default request time, and possibly much more with other external library usages. I think the main gains came from removing `array_shift` which I  gather does memory allocations.

> the reasons it does not break any existing features

All tests pass and there is no interface change. However, (untested), I think the prior function behavior might have mistakenly unset null keys from an array if 1) a value existed with a null key, and 2) the dot path provided didn't exist. I suppose this is worth checking.

This is my first framework PR so I would appreciate some help taking this over the finish line (or closing if appropriate). One question I have in particular is: are there any existing facilities the project uses for doing performance testing? 

