### PR TITLE
[6.x] Fix notifications database channel for anonymous notifiables

### DIFF
--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -24,7 +24,7 @@ class AnonymousNotifiable
     public function route($channel, $route)
     {
         if ($channel === 'database') {
-            throw new InvalidArgumentException('Cannot use database channel for on-demand notifications.');
+            throw new InvalidArgumentException('The database channel does not support on-demand notifications.');
         }
 
         $this->routes[$channel] = $route;

--- a/src/Illuminate/Notifications/AnonymousNotifiable.php
+++ b/src/Illuminate/Notifications/AnonymousNotifiable.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Notifications;
 
 use Illuminate\Contracts\Notifications\Dispatcher;
+use InvalidArgumentException;
 
 class AnonymousNotifiable
 {
@@ -22,6 +23,10 @@ class AnonymousNotifiable
      */
     public function route($channel, $route)
     {
+        if ($channel === 'database') {
+            throw new InvalidArgumentException('Cannot use database channel for on-demand notifications.');
+        }
+
         $this->routes[$channel] = $route;
 
         return $this;

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -102,7 +102,9 @@ class NotificationSender
                 $notificationId = Str::uuid()->toString();
 
                 foreach ((array) $viaChannels as $channel) {
-                    $this->sendToNotifiable($notifiable, $notificationId, clone $original, $channel);
+                    if (! ($notifiable instanceof AnonymousNotifiable && $channel === 'database')) {
+                        $this->sendToNotifiable($notifiable, $notificationId, clone $original, $channel);
+                    }
                 }
             });
         }

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -56,7 +56,7 @@ class NotificationRoutesNotificationsTest extends TestCase
     public function testOnDemandNotificationsCannotUseDatabaseChannel()
     {
         $this->expectExceptionObject(
-            new InvalidArgumentException('Cannot use database channel for on-demand notifications.')
+            new InvalidArgumentException('The database channel does not support on-demand notifications.')
         );
 
         Notification::route('database', 'foo');

--- a/tests/Notifications/NotificationRoutesNotificationsTest.php
+++ b/tests/Notifications/NotificationRoutesNotificationsTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Notifications;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Notifications\Dispatcher;
 use Illuminate\Notifications\RoutesNotifications;
+use Illuminate\Support\Facades\Notification;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -49,6 +51,15 @@ class NotificationRoutesNotificationsTest extends TestCase
         $instance = new RoutesNotificationsTestInstance;
         $this->assertSame('bar', $instance->routeNotificationFor('foo'));
         $this->assertSame('taylor@laravel.com', $instance->routeNotificationFor('mail'));
+    }
+
+    public function testOnDemandNotificationsCannotUseDatabaseChannel()
+    {
+        $this->expectExceptionObject(
+            new InvalidArgumentException('Cannot use database channel for on-demand notifications.')
+        );
+
+        Notification::route('database', 'foo');
     }
 }
 

--- a/tests/Notifications/NotificationSenderTest.php
+++ b/tests/Notifications/NotificationSenderTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Bus\Dispatcher as BusDispatcher;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
@@ -34,6 +35,32 @@ class NotificationSenderTest extends TestCase
 
         $sender->send($notifiable, new DummyQueuedNotificationWithStringVia());
     }
+
+    public function testItCanSendNotificationsWithAnEmptyStringVia()
+    {
+        $notifiable = new AnonymousNotifiable;
+        $manager = m::mock(ChannelManager::class);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldNotReceive('dispatch');
+        $events = m::mock(EventDispatcher::class);
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->sendNow($notifiable, new DummyNotificationWithEmptyStringVia());
+    }
+
+    public function testItCannotSendNotificationsViaDatabaseForAnonymousNotifiables()
+    {
+        $notifiable = new AnonymousNotifiable;
+        $manager = m::mock(ChannelManager::class);
+        $bus = m::mock(BusDispatcher::class);
+        $bus->shouldNotReceive('dispatch');
+        $events = m::mock(EventDispatcher::class);
+
+        $sender = new NotificationSender($manager, $bus, $events);
+
+        $sender->sendNow($notifiable, new DummyNotificationWithDatabaseVia());
+    }
 }
 
 class DummyQueuedNotificationWithStringVia extends Notification implements ShouldQueue
@@ -49,5 +76,37 @@ class DummyQueuedNotificationWithStringVia extends Notification implements Shoul
     public function via($notifiable)
     {
         return 'mail';
+    }
+}
+
+class DummyNotificationWithEmptyStringVia extends Notification
+{
+    use Queueable;
+
+    /**
+     * Get the notification channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return '';
+    }
+}
+
+class DummyNotificationWithDatabaseVia extends Notification
+{
+    use Queueable;
+
+    /**
+     * Get the notification channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return 'database';
     }
 }


### PR DESCRIPTION
This PR prevents on-demand notifications from using the database channel by throwing an informative exception when anyone tries it. At the moment you'd receive a fatal error when trying to resolve the routed notification.

It also will skip sending to the database channel of a notification if the notifiable is anonymous.

Fixes https://github.com/laravel/framework/issues/33408