### PR TITLE
[6.x] Improved Pusher broadcast exception message

### DIFF
--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -119,9 +119,9 @@ class PusherBroadcaster extends Broadcaster
         }
 
         throw new BroadcastException(
-            empty($response['body'])
-                ? 'Failed to connect to Pusher.'
-                : sprintf('Pusher error: %s.', $response['status'])
+            isset($response['body'])
+                ? sprintf('Pusher error: %s.', $response['status'])
+                : 'Failed to connect to Pusher.'
         );
     }
 

--- a/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/PusherBroadcaster.php
@@ -119,7 +119,9 @@ class PusherBroadcaster extends Broadcaster
         }
 
         throw new BroadcastException(
-            is_bool($response) ? 'Failed to connect to Pusher.' : $response['body']
+            empty($response['body'])
+                ? 'Failed to connect to Pusher.'
+                : sprintf('Pusher error: %s.', $response['status'])
         );
     }
 


### PR DESCRIPTION
Response coming from Pusher is always an array, because of debug = true.
Response body is boolean coming from curl_exec, display http status code when possible.