### PR TITLE
[7.x] Conditionally returning appended attributes in API resources

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1485,6 +1485,17 @@ trait HasAttributes
     }
 
     /**
+     * Return whether the accessor attribute has been appended
+     *
+     * @param  string  $attribute
+     * @return bool
+     */
+    public function hasAppended($attribute)
+    {
+        return in_array($attribute, $this->appends);
+    }
+
+    /**
      * Get the mutated attributes for a given instance.
      *
      * @return array

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1485,7 +1485,7 @@ trait HasAttributes
     }
 
     /**
-     * Return whether the accessor attribute has been appended
+     * Return whether the accessor attribute has been appended.
      *
      * @param  string  $attribute
      * @return bool

--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -210,6 +210,23 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve an accessor when it has been appended.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenAppended($attribute, $value = null, $default = null)
+    {
+        if ($this->resource->hasAppended($attribute)) {
+            return func_num_args() >= 2 ? value($value) : $this->resource->$attribute;
+        }
+
+        return func_num_args() === 3 ? value($default) : new MissingValue;
+    }
+
+    /**
      * Transform the given value if it is present.
      *
      * @param  mixed  $value

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1593,6 +1593,10 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('camelCased', $model->camelCased);
         $this->assertSame('StudlyCased', $model->StudlyCased);
 
+        $this->assertTrue($model->hasAppended('is_admin'));
+        $this->assertTrue($model->hasAppended('camelCased'));
+        $this->assertTrue($model->hasAppended('StudlyCased'));
+
         $model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
         $this->assertEquals([], $model->toArray());
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1596,6 +1596,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertTrue($model->hasAppended('is_admin'));
         $this->assertTrue($model->hasAppended('camelCased'));
         $this->assertTrue($model->hasAppended('StudlyCased'));
+        $this->assertFalse($model->hasAppended('not_appended'));
 
         $model->setHidden(['is_admin', 'camelCased', 'StudlyCased']);
         $this->assertEquals([], $model->toArray());

--- a/tests/Integration/Http/Fixtures/Post.php
+++ b/tests/Integration/Http/Fixtures/Post.php
@@ -12,4 +12,14 @@ class Post extends Model
      * @var array
      */
     protected $guarded = [];
+
+    /**
+     * Return whether the post is published
+     *
+     * @return bool
+     */
+    public function getIsPublishedAttribute()
+    {
+        return true;
+    }
 }

--- a/tests/Integration/Http/Fixtures/Post.php
+++ b/tests/Integration/Http/Fixtures/Post.php
@@ -14,7 +14,7 @@ class Post extends Model
     protected $guarded = [];
 
     /**
-     * Return whether the post is published
+     * Return whether the post is published.
      *
      * @return bool
      */

--- a/tests/Integration/Http/Fixtures/PostResourceWithOptionalAppendedAttributes.php
+++ b/tests/Integration/Http/Fixtures/PostResourceWithOptionalAppendedAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PostResourceWithOptionalAppendedAttributes extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'first' => $this->whenAppended('is_published'),
+            'second' => $this->whenAppended('is_published', 'override value'),
+            'third' => $this->whenAppended('is_published', function () {
+                return 'override value';
+            }),
+            'fourth' => $this->whenAppended('is_published', $this->is_published, 'default'),
+            'fifth' => $this->whenAppended('is_published', $this->is_published, function () {
+                return 'default';
+            }),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -17,6 +17,7 @@ use Illuminate\Tests\Integration\Http\Fixtures\Post;
 use Illuminate\Tests\Integration\Http\Fixtures\PostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResource;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithExtraData;
+use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalAppendedAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalData;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalMerging;
 use Illuminate\Tests\Integration\Http\Fixtures\PostResourceWithOptionalPivotRelationship;
@@ -147,6 +148,59 @@ class ResourceTest extends TestCase
                 'id' => 5,
                 'second' => 'value',
                 'third' => 'value',
+                'fourth' => 'default',
+                'fifth' => 'default',
+            ],
+        ]);
+    }
+
+    public function testResourcesMayHaveOptionalAppendedAttributes()
+    {
+        Route::get('/', function () {
+            $post = new Post([
+                'id' => 5,
+            ]);
+
+            $post->append('is_published');
+
+            return new PostResourceWithOptionalAppendedAttributes($post);
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'id' => 5,
+                'first' => true,
+                'second' => 'override value',
+                'third' => 'override value',
+                'fourth' => true,
+                'fifth' => true,
+            ],
+        ]);
+    }
+
+    public function testResourcesWithOptionalAppendedAttributesReturnDefaultValuesAndNotMissingValues()
+    {
+        Route::get('/', function () {
+            return new PostResourceWithOptionalAppendedAttributes(new Post([
+                'id' => 5,
+            ]));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertJson([
+            'data' => [
+                'id' => 5,
                 'fourth' => 'default',
                 'fifth' => 'default',
             ],

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -198,7 +198,7 @@ class ResourceTest extends TestCase
 
         $response->assertStatus(200);
 
-        $response->assertJson([
+        $response->assertExactJson([
             'data' => [
                 'id' => 5,
                 'fourth' => 'default',


### PR DESCRIPTION
I recently needed to return an attribute in an API Resource only when it had been explicitly appended to the model.

I couldn't find a nice public method to determine whether something had been appended to a model, so this PR adds a very simple public `hasAppended()` method to the `HasAttributes` trait so it can be easily checked on any model instance.

Then to improve the ergonomics inside the API Resource, I added a `whenAppended()` method to the `ConditionallyLoadsAttributes` trait that I think has nice symmetry with the other conditional "when" methods like `when()` and `whenLoaded()`.

The usage is then something like this:

```php
public function toArray($request)
{
    return [
        'id' => $this->id,
        'name' => $this->name,
        'email' => $this->email,
        'is_subscribed' => $this->whenAppended('is_subscribed'),
        'created_at' => $this->created_at,
        'updated_at' => $this->updated_at,
    ];
}
```

```php
return new UserResource($user->append('is_subscribed'));
```

This is particularly useful when an accessor contains information that should only sometimes be returned, or where an accessor might make additional database requests that you only want to occur deliberately.

Similar to the `whenLoaded()` method, you can optionally include the value to return if different than the accessor, as well as a default value.

If this is a welcome addition, please let me know and I will add tests. I can also PR the "Conditional Attributes" section of the API Resources docs if warranted.