### PR TITLE
[7.x] Add return to console command stub

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/console.stub
+++ b/src/Illuminate/Foundation/Console/stubs/console.stub
@@ -37,6 +37,6 @@ class {{ class }} extends Command
      */
     public function handle()
     {
-        //
+        return 0;
     }
 }


### PR DESCRIPTION
Since Laravel 7.x Console commands should return an integer, this PR adds a default return to the stub.
