### PR TITLE
[7.x] Add `ScheduledTaskFailed` event

### DIFF
--- a/src/Illuminate/Console/Events/ScheduledTaskFailed.php
+++ b/src/Illuminate/Console/Events/ScheduledTaskFailed.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Console\Events;
+
+use Illuminate\Console\Scheduling\Event;
+use Throwable;
+
+class ScheduledTaskFailed
+{
+    /**
+     * The scheduled event that failed.
+     *
+     * @var \Illuminate\Console\Scheduling\Event
+     */
+    public $task;
+
+    /**
+     * The exception that was thrown.
+     *
+     * @var \Throwable
+     */
+    public $exception;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \Illuminate\Console\Scheduling\Event $task
+     * @param \Throwable $exception
+     */
+    public function __construct(Event $task, Throwable $exception)
+    {
+        $this->task = $task;
+        $this->exception = $exception;
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Console\Scheduling;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Console\Events\ScheduledTaskStarting;
@@ -148,6 +149,8 @@ class ScheduleRunCommand extends Command
 
             $this->eventsRan = true;
         } catch (Throwable $e) {
+            $this->dispatcher->dispatch(new ScheduledTaskFailed($event, $e));
+
             $this->handler->report($e);
         }
     }


### PR DESCRIPTION
This PR adds a new event `ScheduledTaskFailed` that will be fired when a scheduled task failed. 

There were no tests for similar events, so I've not included a test in this PR.