### PR TITLE
[7.x] Improve SQL Server last insert id retrieval

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -324,6 +324,21 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
+     * Compile an insert and get ID statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  string  $sequence
+     * @return string
+     */
+    public function compileInsertGetId(Builder $query, $values, $sequence)
+    {
+        $sql = $this->compileInsert($query, $values);
+
+        return 'set nocount on;'.$sql.';select scope_identity() as '.$this->wrap($sequence ?: 'id');
+    }
+
+    /**
      * Compile an update statement with joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
+++ b/src/Illuminate/Database/Query/Processors/SqlServerProcessor.php
@@ -2,8 +2,6 @@
 
 namespace Illuminate\Database\Query\Processors;
 
-use Exception;
-use Illuminate\Database\Connection;
 use Illuminate\Database\Query\Builder;
 
 class SqlServerProcessor extends Processor
@@ -21,38 +19,15 @@ class SqlServerProcessor extends Processor
     {
         $connection = $query->getConnection();
 
-        $connection->insert($sql, $values);
+        $connection->recordsHaveBeenModified();
 
-        if ($connection->getConfig('odbc') === true) {
-            $id = $this->processInsertGetIdForOdbc($connection);
-        } else {
-            $id = $connection->getPdo()->lastInsertId();
-        }
+        $result = $connection->selectFromWriteConnection($sql, $values)[0];
+
+        $sequence = $sequence ?: 'id';
+
+        $id = is_object($result) ? $result->{$sequence} : $result[$sequence];
 
         return is_numeric($id) ? (int) $id : $id;
-    }
-
-    /**
-     * Process an "insert get ID" query for ODBC.
-     *
-     * @param  \Illuminate\Database\Connection  $connection
-     * @return int
-     *
-     * @throws \Exception
-     */
-    protected function processInsertGetIdForOdbc(Connection $connection)
-    {
-        $result = $connection->selectFromWriteConnection(
-            'SELECT CAST(COALESCE(SCOPE_IDENTITY(), @@IDENTITY) AS int) AS insertid'
-        );
-
-        if (! $result) {
-            throw new Exception('Unable to retrieve lastInsertID for ODBC.');
-        }
-
-        $row = $result[0];
-
-        return is_object($row) ? $row->insertid : $row['insertid'];
     }
 
     /**

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2130,7 +2130,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->insertGetId([]);
 
         $builder = $this->getSqlServerBuilder();
-        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into [users] default values', [], null);
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'set nocount on;insert into [users] default values;select scope_identity() as [id]', [], null);
         $builder->from('users')->insertGetId([]);
     }
 
@@ -2470,6 +2470,14 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?) returning "id"', ['foo'], 'id')->andReturn(1);
+        $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
+        $this->assertEquals(1, $result);
+    }
+
+    public function testSqlServerInsertGetId()
+    {
+        $builder = $this->getSqlServerBuilder();
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'set nocount on;insert into [users] ([email]) values (?);select scope_identity() as [id]', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
         $this->assertEquals(1, $result);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR addresses issue #32883 

It adds the method `SqlServerGrammar@compileInsertGetId`, and if it gets merged this method will change 
an `INSERT` statement from this:

~~~sql
insert into [users] ([email]) values (?)
~~~

Into this:

~~~sql
set nocount on;
insert into [users] ([email]) values (?);
select scope_identity() as [id]
~~~

*line breaks added for readability*

There are other features in SQL Server that allows retrieving the last inserted ID, but from my research, 
for a `INSERT` statement that inserts a single row, `SCOPE_IDENTITY` seems to be the more reliable.

The alternative methods are:

- **`OUTPUT` clause**: can yield wrong results when target table has an `INSTEAD OF INSERT` trigger.
    
    > For INSTEAD OF triggers, the returned results are generated as if the INSERT, UPDATE, or DELETE 
      **had actually occurred**, even if no modifications take place as the result of the trigger operation.
    
    reference: https://docs.microsoft.com/en-us/sql/t-sql/queries/output-clause-transact-sql

- **`IDENT_CURRENT()` function**: not transaction safe. 
    
    > IDENT_CURRENT returns the last identity value generated for a specific table in **any session** and **any scope**
    
    reference: https://docs.microsoft.com/en-us/sql/t-sql/functions/ident-current-transact-sql

- **`@@IDENTITY` system function**: not trigger safe. 
    
    > If the statement fires one or more triggers that perform inserts that generate identity values, 
      calling @@IDENTITY immediately after the statement returns the last identity value generated by the triggers.
    
    reference: https://docs.microsoft.com/en-us/sql/t-sql/functions/identity-transact-sql

I first tried using the `OUTPUT` clause as from my previous knowledge was a recommended solution 
from Microsoft due to some bugs with `SCOPE_IDENTITY` and `@@IDENTITY`

reference: https://support.microsoft.com/en-us/help/2019779/you-may-receive-incorrect-values-when-using-scope-identity-and-identit

But according to the same reference above the bug was fixed in SQL Server 2005, which is not supported anymore
neither by Microsoft nor by Laravel.

Also using the `OUTPUT` clause incurred in using a temporary `TABLE` variable to address triggers usage. 
And as noted on the list above the `OUTPUT` clause can yield incorrect results if the target table 
has an `INSTEAD OF INSERT` trigger.

So the most reliable way seems to use `SCOPE_IDENTITY()`.

Note that I added `SCOPE_IDENTITY()` in the same SQL generated by `compileInsertGetId`, so it is guaranteed to be 
run in the same session as the `INSERT` statement.

This is necessary as per docs (and my local testing), `SCOPE_IDENTITY()` is safe on the 
same scope (e.g. triggers won't affect it) and session (connection, transaction, etc).

> Returns the last identity value inserted into an identity column in the same scope. A scope is 
  a module: a stored procedure, trigger, function, or batch. Therefore, if two statements are in 
  the same stored procedure, function, or batch, they are in the same scope.

reference: https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql

I also removed the ODBC part from the `SqlServerProcessor` as it run the query on separate database call.
In my local testing, when the target table of a `INSERT` statement has a trigger which inserts a row 
on another table, using `SCOPE_IDENTITY` on separate database call returns an incorrect result 
(the auto generated id from the row inserted by trigger).

## How this PR differs from previous attempts

I found two other previous attempts to solve this:

1. PR #32957

    This PR ended having a very similar code to that PR (difference being the column name used in the `SqlServerGrammar@compileInsertGetId`)
    
    As mentioned above, I first tried using the `OUTPUT` clause, as from my previous knowledge seemed to be 
    a better solution, but after some research on MSDN and other sources I ended up using `SCOPE_IDENTITY()` as
    PR #32957.
    
    Difference is this PR only addressees the last insert id reported on issue #32883, whereas PR #32957 addresses
    other SQL Server related issues.
    
    I would close this PR in favor of PR #32957 if that is preferred, as it is more feature complete.
    
2. Branch `sqlsrv-insert-id` from @staudenmeir fork

    Issue #32883 OP (@kadevland) mentions that fork. The only difference is that this PR does not fallback
    to `@@IDENTITY`, as per `SCOPE_IDENTITY()` docs (linked above):
    
    > The SCOPE_IDENTITY() function returns the null value if the function is invoked before any INSERT statements 
      into an identity column occur in the scope.
    
    Which is not the case as the `SELECT SCOPE_IDENTITY()` is added in the same SQL code as the `INSERT` statement.
    Also as noted above `@@IDENTITY` can return the wrong value if the target table of the `INSERT` statement has
    an associated trigger.
    
    Also @staudenmeir did not make a PR from his fork. I consider him to have more knowledge regarding databases and
    Laravel's Eloquent/Query Builder than me. If he knows any issues that prevented him to make a PR from his fork - 
    maybe he is researching or know a better solution to this problem - I would bet on his attempt and close this PR. 

## Implementation notes

### `SqlServerProcessor`

The changed code in the `SqlServerProcessor` class was copied from the same method in the `PostgresProcessor` class.

Also as already mentioned above, I removed the ODBC special handling to avoid executing `SCOPE_IDENTITY()` 
in a separate query.

### `SET NOCOUNT ON`

`set nocount on` is needed so SQL Server returns the `SELECT` results instead of the affected rows count.

### Testing

I updated an existing test and added a new one to test the code changed by this PR.

## Real usage testing

I setup a local application with SQL Server 2017 running in a docker instance (I run Linux) and did some local 
tests with sample application code. SQL Server version 2017 was used because I already had this docker image installed 
for some other projects I need it.

Everything worked as expected. I tested both inserts in a table with no triggers and in a table with a `INSERT` trigger.

If someone has any suggestions or spot any errors please let me know and I'll make any improvements needed. 
