### PR TITLE
[7.x] Make Str::endsWith return false if both haystack and needle are empty strings

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -210,7 +210,7 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if (substr($haystack, -strlen($needle)) === (string) $needle) {
+            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -60,6 +60,7 @@ class SupportStrTest extends TestCase
         $this->assertTrue(Str::startsWith('0123', 0));
         $this->assertFalse(Str::startsWith('jason', 'J'));
         $this->assertFalse(Str::startsWith('jason', ''));
+        $this->assertFalse(Str::startsWith('', ''));
         $this->assertFalse(Str::startsWith('7', ' 7'));
         $this->assertTrue(Str::startsWith('7a', '7'));
         $this->assertTrue(Str::startsWith('7a', 7));
@@ -87,6 +88,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('jason', 'no'));
         $this->assertFalse(Str::endsWith('jason', ['no']));
         $this->assertFalse(Str::endsWith('jason', ''));
+        $this->assertFalse(Str::endsWith('', ''));
         $this->assertFalse(Str::endsWith('jason', [null]));
         $this->assertFalse(Str::endsWith('jason', null));
         $this->assertFalse(Str::endsWith('jason', 'N'));
@@ -183,6 +185,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', 'xxx'));
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
+        $this->assertFalse(Str::contains('', ''));
     }
 
     public function testStrContainsAll()


### PR DESCRIPTION
Doing some investigations after looking at this [Stack Overflow question](https://stackoverflow.com/questions/834303/startswith-and-endswith-functions-in-php/834355), this [Laravel PR](https://github.com/laravel/framework/pull/32243) and this [RFC for PHP 8](https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions), I noticed the following with current Laravel code:

```
Str::startsWith('haystack', ''); // false
Str::startsWith('', '');         // false

Str::endsWith('haystack', '');   // false
Str::endsWith('', '');           // true, should be false

Str::contains('haystack', '');   // false
Str::contains('', '');           // false
```

Hence this PR to make `Str::endsWith` more consistent, and to add tests for this case.

Also refs #2628.

On a related note: most other languages (Java, .NET, Python...), and even [future PHP 8](https://wiki.php.net/rfc/add_str_starts_with_and_ends_with_functions#proposal), return true when the needle is an empty string.