### PR TITLE
[6.x] Don't return nested data from validator when failing an exclude rule

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -369,7 +369,8 @@ class Validator implements ValidatorContract
      */
     protected function removeAttribute($attribute)
     {
-        unset($this->data[$attribute], $this->rules[$attribute]);
+        Arr::forget($this->data, $attribute);
+        Arr::forget($this->rules, $attribute);
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5153,13 +5153,10 @@ class ValidationValidatorTest extends TestCase
                     'vehicles' => [
                         [
                             'type' => 'car', 'wheels' => [
-                                // The shape field for these blue wheels were correctly excluded (if they weren't, they would
-                                // fail the validation). They still appear in the validated data. This behaviour is unrelated
-                                // to the "exclude" type rules.
                                 ['color' => 'red', 'shape' => 'square'],
-                                ['color' => 'blue', 'shape' => 'hexagon'],
+                                ['color' => 'blue'],
                                 ['color' => 'red', 'shape' => 'round', 'junk' => 'no rule, still present'],
-                                ['color' => 'blue', 'shape' => 'triangle'],
+                                ['color' => 'blue'],
                             ],
                         ],
                         ['type' => 'boat'],


### PR DESCRIPTION
When using the `exclude_if` or `exclude_unless` validation rules, nested fields are excluded from being validated, however they are not being removed from the validated data.

This is a breaking change, however I would consider it a bugfix since the [documentation](https://laravel.com/docs/6.x/validation#rule-exclude-if) is clear that "The field under validation will be excluded from the request data returned by the `validate` and `validated` methods."

The existing test case for this feature did not reflect the intended behaviour, so I just corrected that test rather than including a new one.