### PR TITLE
[8.x] Allows using a custom callback to send a reset link

### DIFF
--- a/src/Illuminate/Auth/Passwords/PasswordBroker.php
+++ b/src/Illuminate/Auth/Passwords/PasswordBroker.php
@@ -42,9 +42,10 @@ class PasswordBroker implements PasswordBrokerContract
      * Send a password reset link to a user.
      *
      * @param  array  $credentials
+     * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials)
+    public function sendResetLink(array $credentials, Closure $callback = null)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of
@@ -59,12 +60,16 @@ class PasswordBroker implements PasswordBrokerContract
             return static::RESET_THROTTLED;
         }
 
-        // Once we have the reset token, we are ready to send the message out to this
-        // user with a link to reset their password. We will then redirect back to
-        // the current URI having nothing set in the session to indicate errors.
-        $user->sendPasswordResetNotification(
-            $this->tokens->create($user)
-        );
+        $token = $this->tokens->create($user);
+
+        if ($callback) {
+            $callback($user, $token);
+        } else {
+            // Once we have the reset token, we are ready to send the message out to this
+            // user with a link to reset their password. We will then redirect back to
+            // the current URI having nothing set in the session to indicate errors.
+            $user->sendPasswordResetNotification($token);
+        }
 
         return static::RESET_LINK_SENT;
     }

--- a/src/Illuminate/Contracts/Auth/PasswordBroker.php
+++ b/src/Illuminate/Contracts/Auth/PasswordBroker.php
@@ -45,9 +45,10 @@ interface PasswordBroker
      * Send a password reset link to a user.
      *
      * @param  array  $credentials
+     * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials);
+    public function sendResetLink(array $credentials, Closure $callback = null);
 
     /**
      * Reset the password for the given token.

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,6 +23,13 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
+     * Models to observe.
+     *
+     * @var array
+     */
+    protected $observers = [];
+
+    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -40,6 +47,10 @@ class EventServiceProvider extends ServiceProvider
 
             foreach ($this->subscribe as $subscriber) {
                 Event::subscribe($subscriber);
+            }
+
+            foreach ($this->observers as $model => $observers) {
+                $model::observe($observers);
             }
         });
     }

--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -23,13 +23,6 @@ class EventServiceProvider extends ServiceProvider
     protected $subscribe = [];
 
     /**
-     * Models to observe.
-     *
-     * @var array
-     */
-    protected $observers = [];
-
-    /**
      * Register the application's event listeners.
      *
      * @return void
@@ -47,10 +40,6 @@ class EventServiceProvider extends ServiceProvider
 
             foreach ($this->subscribe as $subscriber) {
                 Event::subscribe($subscriber);
-            }
-
-            foreach ($this->observers as $model => $observers) {
-                $model::observe($observers);
             }
         });
     }

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -127,7 +127,6 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo'], $closure));
 
         $this->assertTrue($executed);
-
     }
 
     protected function getBroker($mocks)

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -109,6 +109,27 @@ class AuthPasswordBrokerTest extends TestCase
         $this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__password.reset.test']);
     }
 
+    public function testExecutesCallbackInsteadOfSendingNotification()
+    {
+        $executed = false;
+
+        $closure = function () use (&$executed) {
+            $executed = true;
+        };
+
+        $mocks = $this->getMocks();
+        $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['emailResetLink', 'getUri'])->setConstructorArgs(array_values($mocks))->getMock();
+        $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['foo'])->andReturn($user = m::mock(CanResetPassword::class));
+        $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(false);
+        $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
+        $user->shouldReceive('sendPasswordResetNotification')->with('token');
+
+        $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo'], $closure));
+
+        $this->assertTrue($executed);
+
+    }
+
     protected function getBroker($mocks)
     {
         return new PasswordBroker($mocks['tokens'], $mocks['users'], $mocks['mailer'], $mocks['view']);


### PR DESCRIPTION
This enables the password broker to execute a given logic using the User and the token when sending a Password Reset Link.

For example, the developer may want to change what notification to sent at runtime if the user is using another type of password-less authentication.

```php
Password::sendResetLink($credentials, function ($user, $token) {
    if ($user->usesPassword()) {
        $user->sendPasswordResetNotification($token);
    } else {
        $user->sendPasswordlessRecoveryNotification($token);
    }
});
```

The callback will take precedence over the default `sendPasswordResetNotification` execution. If no callback is used, the default call will be executed.

THis is a breaking change, but I consider it minor since only adds a new argument on the `PasswordBroker` interface.