### PR TITLE
[8.x] Change __call factory and relation resolution

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -632,15 +632,18 @@ abstract class Factory
             static::throwBadMethodCallException($method);
         }
 
-        $factory = static::factoryForModel(Str::singular(Str::substr($method, 3)));
+        $relationship = Str::camel(Str::substr($method, 3));
+        $related = $this->newModel()->{$relationship}()->getRelated();
+        $factory = static::factoryForModel(get_class($related));
 
         if (Str::startsWith($method, 'for')) {
-            return $this->for($factory->state($parameters[0] ?? []));
+            return $this->for($factory->state($parameters[0] ?? []), $relationship);
         } elseif (Str::startsWith($method, 'has')) {
             return $this->has(
                 $factory
                     ->count(is_numeric($parameters[0] ?? null) ? $parameters[0] : 1)
-                    ->state(is_array($parameters[0] ?? null) ? $parameters[0] : ($parameters[1] ?? []))
+                    ->state(is_array($parameters[0] ?? null) ? $parameters[0] : ($parameters[1] ?? [])),
+                $relationship
             );
         }
     }


### PR DESCRIPTION
This PR aims to resolve 2 problems we could have using magic `forXX` and `hasXX` of `Illuminate\Database\Eloquent\Factories\Factory`

1 : Inconsistency of parameter given to `factoryForModel`
As described in https://github.com/laravel/ideas/issues/2284, if `App\User` uses `Illuminate\Database\Eloquent\Factories\HasFactory`, calling `App\User::factory()` will call `Factory::factoryForModel` with `'App\User'` whereas calling `PostFactory::forUser` will call it with `'user'`. IMHO it should always be called with the fully qualified class name.

2 : Relations are not always called by related model name
It is common to have relation named by something else than the related model name. For example, if a post belongs to a user, the post relation can be named `author`.
This PR allows developer to call `$postFactory()->forAuthor()` to create the post's author.
