### PR TITLE
 [8.x] Make callback parameter optional in recorded method

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -250,7 +250,7 @@ class Factory
      * @param  callable  $callback
      * @return \Illuminate\Support\Collection
      */
-    public function recorded($callback)
+    public function recorded($callback = null)
     {
         if (empty($this->recorded)) {
             return collect();


### PR DESCRIPTION
When testing Http calls, it can be more 'clean' to not pass `null` as argument in the `recorded` method.

Since the method already check if the argument is truthy, it would default to a `return true` callback anyway:

```php
$callback = $callback ?: function () {
    return true;
};
```

This way we have
```php
Http::recorded()->each/map
```
instead of 
```php
Http::recorded(null)->each/map
```

Best regards