### PR TITLE
[7.x] Fixed paginator JSON serialization not serializing the items correctly

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -184,7 +184,20 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return [
+            'current_page' => $this->currentPage(),
+            'data' => $this->items->jsonSerialize(),
+            'first_page_url' => $this->url(1),
+            'from' => $this->firstItem(),
+            'last_page' => $this->lastPage(),
+            'last_page_url' => $this->url($this->lastPage()),
+            'next_page_url' => $this->nextPageUrl(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'prev_page_url' => $this->previousPageUrl(),
+            'to' => $this->lastItem(),
+            'total' => $this->total(),
+        ];
     }
 
     /**

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -160,7 +160,17 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
      */
     public function jsonSerialize()
     {
-        return $this->toArray();
+        return [
+            'current_page' => $this->currentPage(),
+            'data' => $this->items->jsonSerialize(),
+            'first_page_url' => $this->url(1),
+            'from' => $this->firstItem(),
+            'next_page_url' => $this->nextPageUrl(),
+            'path' => $this->path(),
+            'per_page' => $this->perPage(),
+            'prev_page_url' => $this->previousPageUrl(),
+            'to' => $this->lastItem(),
+        ];
     }
 
     /**

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -2,7 +2,10 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
 class LengthAwarePaginatorTest extends TestCase
@@ -110,5 +113,24 @@ class LengthAwarePaginatorTest extends TestCase
     public function testItRetrievesThePaginatorOptions()
     {
         $this->assertSame($this->options, $this->p->getOptions());
+    }
+
+    public function testLengthAwarePaginatorCorrectlyJsonSerializesItsItems()
+    {
+        $this->p->setCollection(Collection::make([
+            new class implements Arrayable, JsonSerializable {
+                public function toArray()
+                {
+                    return 'array';
+                }
+
+                public function jsonSerialize()
+                {
+                    return 'JSON';
+                }
+            }
+        ]));
+
+        $this->assertSame(['JSON'], $this->p->jsonSerialize()['data']);
     }
 }

--- a/tests/Pagination/PaginatorTest.php
+++ b/tests/Pagination/PaginatorTest.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Tests\Pagination;
 
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Pagination\Paginator;
+use JsonSerializable;
 use PHPUnit\Framework\TestCase;
 
 class PaginatorTest extends TestCase
@@ -61,5 +63,24 @@ class PaginatorTest extends TestCase
                                     ['path' => 'http://website.com/test']);
 
         $this->assertSame($p->path(), 'http://website.com/test');
+    }
+
+    public function testPaginatorCorrectlyJsonSerializesItsItems()
+    {
+        $p = new Paginator($array = [
+            new class implements Arrayable, JsonSerializable {
+                public function toArray()
+                {
+                    return 'array';
+                }
+
+                public function jsonSerialize()
+                {
+                    return 'JSON';
+                }
+            }
+        ], 2, 2);
+
+        $this->assertSame(['JSON'], $p->jsonSerialize()['data']);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`Paginator::jsonSerialize()`/`LengthAwarePaginator::jsonSerialize()` currently calls `$this->items->toArray()` when serializing the items. This means that any custom `jsonSerialize()` or `toJson()` methods on individual items don't get called, which probably isn't what an end user is expecting.

This PR changes this so that `$this->items->jsonSerialize()` is called instead, which in turn will call any of these custom serialization methods.