### PR TITLE
Check original value was not null while updating model.

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1170,7 +1170,7 @@ trait HasAttributes
 
         if ($current === $original) {
             return true;
-        } elseif (is_null($current)) {
+        } elseif (is_null($current) || is_null($original)) {
             return false;
         } elseif ($this->isDateAttribute($key)) {
             return $this->fromDateTime($current) ===


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

When creating a new model which casts to float but nullable value, when trying to save the property as 0 it can not save.

Here's an example of the issue, assuming discount_price casts as float.
```
$coupon = Coupon::create(['discount_price' => null]);

var_dump($coupon->fresh()->discount_price); // NULL
$coupon->discount_price = 0;
$coupon->save();
var_dump($coupon->discount_price); // 0
var_dump($coupon->fresh()->discount_price); // NULL
```