### PR TITLE
[8.x] Add worker --max-time and --max-jobs

### DIFF
--- a/src/Illuminate/Queue/Console/WorkCommand.php
+++ b/src/Illuminate/Queue/Console/WorkCommand.php
@@ -28,6 +28,8 @@ class WorkCommand extends Command
                             {--stop-when-empty : Stop when the queue is empty}
                             {--delay=0 : The number of seconds to delay failed jobs (Deprecated)}
                             {--backoff=0 : The number of seconds to wait before retrying a job that encountered an uncaught exception}
+                            {--max-jobs=0 : The number of jobs to process before stopping}
+                            {--max-time=0 : The number of seconds before stopping}
                             {--force : Force the worker to run even in maintenance mode}
                             {--memory=128 : The memory limit in megabytes}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
@@ -134,7 +136,9 @@ class WorkCommand extends Command
             $this->option('sleep'),
             $this->option('tries'),
             $this->option('force'),
-            $this->option('stop-when-empty')
+            $this->option('stop-when-empty'),
+            $this->option('max-jobs'),
+            $this->option('max-time')
         );
     }
 

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -122,7 +122,7 @@ class Worker
 
         $lastRestart = $this->getTimestampOfLastQueueRestart();
 
-        $timer = microtime(true);
+        $timer = hrtime(true) / 1e9;
         $counter = 0;
 
         while (true) {
@@ -274,7 +274,7 @@ class Worker
             return static::EXIT_SUCCESS;
         } elseif ($options->stopWhenEmpty && is_null($job)) {
             return static::EXIT_SUCCESS;
-        } elseif ($options->maxTime && microtime(true) - $timer >= $options->maxTime) {
+        } elseif ($options->maxTime && hrtime(true) / 1e9 - $timer >= $options->maxTime) {
             return static::EXIT_SUCCESS;
         } elseif ($options->maxJobs && $counter >= $options->maxJobs) {
             return static::EXIT_SUCCESS;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -130,7 +130,7 @@ class Worker
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.
             if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
-                $status = $this->pauseWorker($options, $lastRestart);
+                $status = $this->pauseWorker($options, $lastRestart, $timer, $counter);
 
                 if (! is_null($status)) {
                     return $this->stop($status);
@@ -264,7 +264,7 @@ class Worker
      * @param  mixed  $job
      * @return int|null
      */
-    protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $timer, $counter, $job = null)
+    protected function stopIfNecessary(WorkerOptions $options, $lastRestart, $timer = 0, $counter = 0, $job = null)
     {
         if ($this->shouldQuit) {
             return static::EXIT_SUCCESS;

--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -130,7 +130,7 @@ class Worker
             // if it is we will just pause this worker for a given amount of time and
             // make sure we do not need to kill this worker process off completely.
             if (! $this->daemonShouldRun($options, $connectionName, $queue)) {
-                $status = $this->pauseWorker($options, $lastRestart, $timer, $counter);
+                $status = $this->pauseWorker($options, $lastRestart);
 
                 if (! is_null($status)) {
                     return $this->stop($status);

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -61,6 +61,20 @@ class WorkerOptions
     public $stopWhenEmpty;
 
     /**
+     * The maximum number of jobs to run.
+     *
+     * @var int
+     */
+    public $maxJobs;
+
+    /**
+     * The maximum number of seconds a worker may live.
+     *
+     * @var int
+     */
+    public $maxTime;
+
+    /**
      * Create a new worker options instance.
      *
      * @param  string  $name
@@ -73,7 +87,8 @@ class WorkerOptions
      * @param  bool  $stopWhenEmpty
      * @return void
      */
-    public function __construct($name = 'default', $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1, $force = false, $stopWhenEmpty = false)
+    public function __construct($name = 'default', $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1,
+                                $force = false, $stopWhenEmpty = false, $maxJobs = 0, $maxTime = 0)
     {
         $this->name = $name;
         $this->backoff = $backoff;
@@ -83,5 +98,7 @@ class WorkerOptions
         $this->timeout = $timeout;
         $this->maxTries = $maxTries;
         $this->stopWhenEmpty = $stopWhenEmpty;
+        $this->maxJobs = $maxJobs;
+        $this->maxTime = $maxTime;
     }
 }

--- a/src/Illuminate/Queue/WorkerOptions.php
+++ b/src/Illuminate/Queue/WorkerOptions.php
@@ -85,6 +85,8 @@ class WorkerOptions
      * @param  int  $maxTries
      * @param  bool  $force
      * @param  bool  $stopWhenEmpty
+     * @param  int  $maxJobs
+     * @param  int  $maxTime
      * @return void
      */
     public function __construct($name = 'default', $backoff = 0, $memory = 128, $timeout = 60, $sleep = 3, $maxTries = 1,

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -45,6 +45,7 @@ class WorkCommandTest extends TestCase
 
         FirstJob::$ran = false;
         SecondJob::$ran = false;
+        ThirdJob::$ran = false;
     }
 
     public function testRunningOneJob()
@@ -97,6 +98,44 @@ class WorkCommandTest extends TestCase
         $this->assertTrue(FirstJob::$ran);
         $this->assertFalse(SecondJob::$ran);
     }
+
+    public function testMaxJobsExceeded()
+    {
+        Queue::connection('database')->push(new FirstJob);
+        Queue::connection('database')->push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--max-jobs' => 1,
+        ])->assertExitCode(0);
+
+        // Memory limit isn't checked until after the first job is attempted.
+        $this->assertSame(1, Queue::connection('database')->size());
+        $this->assertTrue(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
+
+    public function testMaxTimeExceeded()
+    {
+        Queue::connection('database')->push(new ThirdJob());
+        Queue::connection('database')->push(new FirstJob);
+        Queue::connection('database')->push(new SecondJob);
+
+        $this->artisan('queue:work', [
+            'connection' => 'database',
+            '--daemon' => true,
+            '--stop-when-empty' => true,
+            '--max-time' => 1,
+        ])->assertExitCode(0);
+
+        // Memory limit isn't checked until after the first job is attempted.
+        $this->assertSame(2, Queue::connection('database')->size());
+        $this->assertTrue(ThirdJob::$ran);
+        $this->assertFalse(FirstJob::$ran);
+        $this->assertFalse(SecondJob::$ran);
+    }
 }
 
 class FirstJob implements ShouldQueue
@@ -119,6 +158,20 @@ class SecondJob implements ShouldQueue
 
     public function handle()
     {
+        static::$ran = true;
+    }
+}
+
+class ThirdJob implements ShouldQueue
+{
+    use Dispatchable, Queueable;
+
+    public static $ran = false;
+
+    public function handle()
+    {
+        sleep(1);
+
         static::$ran = true;
     }
 }

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -109,8 +109,7 @@ class WorkCommandTest extends TestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-jobs' => 1,
-            '--memory' => 1000,
-        ])->assertExitCode(0);
+        ]);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(1, Queue::connection('database')->size());
@@ -129,8 +128,7 @@ class WorkCommandTest extends TestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-time' => 1,
-            '--memory' => 1000,
-        ])->assertExitCode(0);
+        ]);
 
         // Memory limit isn't checked until after the first job is attempted.
         $this->assertSame(2, Queue::connection('database')->size());

--- a/tests/Integration/Queue/WorkCommandTest.php
+++ b/tests/Integration/Queue/WorkCommandTest.php
@@ -109,6 +109,7 @@ class WorkCommandTest extends TestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-jobs' => 1,
+            '--memory' => 1000,
         ])->assertExitCode(0);
 
         // Memory limit isn't checked until after the first job is attempted.
@@ -128,6 +129,7 @@ class WorkCommandTest extends TestCase
             '--daemon' => true,
             '--stop-when-empty' => true,
             '--max-time' => 1,
+            '--memory' => 1000,
         ])->assertExitCode(0);
 
         // Memory limit isn't checked until after the first job is attempted.


### PR DESCRIPTION
Using `--max-time=3600` will make the worker exit with status 0 if it runs more than an hour.

Using `--max-jobs=1000` will make the worker exit with status 0 if it processes 1000 jobs.