### PR TITLE
[8.x] Guess relation name in model factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -395,9 +395,22 @@ abstract class Factory
     {
         return $this->newInstance([
             'has' => $this->has->concat([new Relationship(
-                $factory, $relationship ?: Str::camel(Str::plural(class_basename($factory->modelName())))
+                $factory, $relationship ?: $this->guessRelationship($factory->modelName())
             )]),
         ]);
+    }
+
+    /**
+     * Guess relation name between the model and the related.
+     *
+     * @param string $related
+     * @return string
+     */
+    protected function guessRelationship(string $related)
+    {
+        $guess = Str::camel(Str::plural(class_basename($related)));
+
+        return method_exists($this->modelName(), $guess) ? $guess : Str::singular($guess);
     }
 
     /**


### PR DESCRIPTION
I think we could improve the way relationship are guessed.

Actually, the relationship is always pluralized and singular form of HasOne cannot be guessed. For example, a `User` having a has one `subscription` relation we always have to write 
 
```php
UserFactory::new()
    ->has(SubscriptionFactory::new(), 'subscription')
    ->create();
```

This PR resolves correctly the relation just doing

```php
UserFactory::new()
    ->has(SubscriptionFactory::new())
    ->create();
```

I don't know if this should be used also on `hasAttached` method to be honest...

If this needs tests, I would be happy to add them.