### PR TITLE
[7.x] Add when method to Stringable class

### DIFF
--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -601,6 +601,25 @@ class Stringable
     }
 
     /**
+     * Apply the callback's string changes if the given "value" is true.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @param  callable|null  $default
+     * @return mixed|$this
+     */
+    public function when($value, $callback, $default = null)
+    {
+        if ($value) {
+            return $callback($this, $value) ?: $this;
+        } elseif ($default) {
+            return $default($this, $value) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
      * Execute the given callback if the string is empty.
      *
      * @param  callable  $callback

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -92,6 +92,32 @@ class SupportStringableTest extends TestCase
         }));
     }
 
+    public function testWhenFalse()
+    {
+        $this->assertSame('when', (string) $this->stringable('when')->when(false,function($stringable,$value){
+            return $stringable->append($value)->append('false');
+        }));
+        
+        $this->assertSame('when false fallbacks to default', (string) $this->stringable('when false ')->when(false,function($stringable,$value){
+            return $stringable->append($value);
+        },function($stringable){
+            return $stringable->append('fallbacks to default');
+        }));
+    }
+
+    public function testWhenTrue()
+    {
+        $this->assertSame('when true', (string) $this->stringable('when ')->when(true,function($stringable){
+            return $stringable->append('true');
+        }));
+        
+        $this->assertSame('gets a value from if', (string) $this->stringable('gets a value ')->when('from if',function($stringable,$value){
+            return $stringable->append($value);
+        },function($stringable){
+            return $stringable->append('fallbacks to default');
+        }));
+    }
+
     public function testTrimmedOnlyWhereNecessary()
     {
         $this->assertSame(' Taylor Otwell ', (string) $this->stringable(' Taylor Otwell ')->words(3));


### PR DESCRIPTION
Added when Method to Stringable class.

Use case:

For example i have restrict or limit some of the contents for unauthenticated users i can use auth check and based on that i can so that.

    $blogContent = 'Laravel Factories Reloaded is a package by Christoph Rumpel that generates class-based model factories that you can use instead of the factory files Laravel provides';

    //BEFORE
    $stringable = Str::of($blogContent);

    if(!Auth::check()){

        $stringable->limit(20,'.....')
                        ->append('To Continue reading ')
                        ->append(new HtmlString('<a href="#">Get a Subscription</a>'));
    }

    $stringable->__toString();


    //AFTER
    Str::of($blogContent)
        ->when(!Auth::check(),function($stringable){
            return $stringable->limit(20)
                            ->append('To Continue reading ')
                            ->append(new HtmlString('<a href="#">Get a Subscription</a>'));
        })
        ->__toString();

I have been using [when](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Database/Concerns/BuildsQueries.php#L154) method on query builder and its really cleans up some `if` `else` so same in the **Stringable**  too