### PR TITLE
Resolve issues with silent Artisan failures & FileStore cache flushing

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -179,7 +179,8 @@ class FileStore implements Store
         }
 
         foreach ($this->files->directories($this->directory) as $directory) {
-            if (! $this->files->deleteDirectory($directory)) {
+            $results = $this->files->deleteDirectory($directory);
+            if (! $results || $this->files->exists($directory)) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR has been created in response to #33310 and seeks to resolve that issue and an issue previously discussed as #1179. As well as being a follow up to PR #25254 - to more fully catch the issues that PR attempted to address.

The only _flaw_ (for lack of better term) with the previous PR was that the underlying `FileStore::flush()` method wasn't reliably returning false as the result response. This is in turn due to how `Filesystem::deleteDirectory()` works, since this method simply silently fails if there are issues with removal.

Since Filesystem is such a fundamental component and changing `deleteDirectory` that much would surely break tests and be a BC issue. So solving the issue in the FileStore class seems like a good option, since we can be 'defensive' about the results of `deleteDirectory`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
