### PR TITLE
[6.x] Resolve issues with silent Artisan failures & FileStore cache flushing

### DIFF
--- a/src/Illuminate/Cache/FileStore.php
+++ b/src/Illuminate/Cache/FileStore.php
@@ -179,7 +179,8 @@ class FileStore implements Store
         }
 
         foreach ($this->files->directories($this->directory) as $directory) {
-            if (! $this->files->deleteDirectory($directory)) {
+            $results = $this->files->deleteDirectory($directory);
+            if (! $results || $this->files->exists($directory)) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR has been created in response to #33310 and seeks to resolve that issue and an issue previously discussed as #1179. As well as being a follow up to PR #25254 - to more fully catch the issues that PR attempted to address.

The only flaw (for lack of better term) with the previous PR was that the underlying `FileStore::flush()` method wasn't reliably returning false as the result response. This is in turn due to how `Filesystem::deleteDirectory()` works, since this method simply silently fails if there are issues with removal.

Since Filesystem is such a fundamental component and changing `deleteDirectory` that much would surely break tests and be a BC issue. So solving the issue in the FileStore class seems like a good option, since we can be 'defensive' about the results of `deleteDirectory`.

While a more elegant solution may exists - and could be a long term goal - this addresses the new reported issue (#33310) and provides a more robust method to enable the previous fix (#25254) to work as intended. 