### PR TITLE
[8.x] Callable attributes are called with expanded definition

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -341,18 +341,20 @@ abstract class Factory
      */
     protected function expandAttributes(array $definition)
     {
-        return collect($definition)->map(function ($attribute) use ($definition) {
+        return collect($definition)->map(function ($attribute, $key) use (&$definition) {
             if (is_callable($attribute) && ! is_string($attribute) && ! is_array($attribute)) {
                 $attribute = $attribute($definition);
             }
 
             if ($attribute instanceof self) {
-                return $attribute->create()->getKey();
+                $attribute = $attribute->create()->getKey();
             } elseif ($attribute instanceof Model) {
-                return $attribute->getKey();
-            } else {
-                return $attribute;
+                $attribute = $attribute->getKey();
             }
+
+            $definition[$key] = $attribute;
+
+            return $attribute;
         })->all();
     }
 


### PR DESCRIPTION
On Laravel 7 and under, it is possible to define fatories like this : 

```php
$factory->define(MyModel::class, function(Faker $faker) {
    return [
        'total' => $faker->numberBetween(100, 1000),
        'part' => fn($attributes) => $faker->numberBetween(0, $attributes['total']),
        'rate' => fn($attributes) => $attributes['part'] / $attributes['total'],
    ];
});
```
Under Laravel 8, defining the factory with

```php
public function definition() 
{
    return [
        'total' => $this->faker->numberBetween(100, 1000),
        'part' => fn($attributes) => $this->faker->numberBetween(0, $attributes['total']),
        'rate' => fn($attributes) => $attributes['part'] / $attributes['total'],
    ];
}
```

will fail because in `rate` callback, `$attributes['part'] ` is the callback, not the actual value.

This example is maybe not very good but we have the same issue with 

```php
public function definition() 
{
    return [
        'user_id' => UserFactory::new(),
        'team_id' => fn($attributes) => User::find($attributes['user_id'])->team_id,
    ];
}
```
(here the `$attributes['user_id']` is the factory)

