### PR TITLE
[8.x] Queued closure listeners

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
     },
     "autoload": {
         "files": [
+            "src/Illuminate/Events/functions.php",
             "src/Illuminate/Foundation/helpers.php",
             "src/Illuminate/Support/helpers.php"
         ],

--- a/src/Illuminate/Events/CallQueuedListener.php
+++ b/src/Illuminate/Events/CallQueuedListener.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Events;
 
+use Illuminate\Bus\Queueable;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -9,7 +10,7 @@ use Illuminate\Queue\InteractsWithQueue;
 
 class CallQueuedListener implements ShouldQueue
 {
-    use InteractsWithQueue;
+    use InteractsWithQueue, Queueable;
 
     /**
      * The listener class name.

--- a/src/Illuminate/Events/Dispatcher.php
+++ b/src/Illuminate/Events/Dispatcher.php
@@ -77,6 +77,10 @@ class Dispatcher implements DispatcherContract
     {
         if ($events instanceof Closure) {
             return $this->listen($this->firstClosureParameterType($events), $events);
+        } elseif ($events instanceof QueuedClosure) {
+            return $this->listen($this->firstClosureParameterType($events->closure), $events->resolve());
+        } elseif ($listener instanceof QueuedClosure) {
+            $listener = $listener->resolve();
         }
 
         foreach ((array) $events as $event) {

--- a/src/Illuminate/Events/InvokeQueuedClosure.php
+++ b/src/Illuminate/Events/InvokeQueuedClosure.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Events;
 
-class InvokeQueuedClosureForEvent
+class InvokeQueuedClosure
 {
     /**
      * Handle the event.

--- a/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
+++ b/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
@@ -15,4 +15,20 @@ class InvokeQueuedClosureForEvent
     {
         call_user_func($closure->getClosure(), ...$arguments);
     }
+
+    /**
+     * Handle a job failure.
+     *
+     * @param  \Closure  $closure
+     * @param  array  $arguments
+     * @param  array  $catchCallbacks
+     * @param  \Throwable  $exception
+     * @return void
+     */
+    public function failed($closure, array $arguments, array $catchCallbacks, $exception)
+    {
+        $arguments[] = $exception;
+
+        collect($catchCallbacks)->each->__invoke(...$arguments);
+    }
 }

--- a/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
+++ b/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Events;
+
+class InvokeQueuedClosureForEvent
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Closure  $closure
+     * @param  array  $arguments
+     * @return void
+     */
+    public function handle($closure, array $arguments)
+    {
+        call_user_func($closure->getClosure(), ...$arguments);
+    }
+}

--- a/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
+++ b/src/Illuminate/Events/InvokeQueuedClosureForEvent.php
@@ -7,7 +7,7 @@ class InvokeQueuedClosureForEvent
     /**
      * Handle the event.
      *
-     * @param  \Closure  $closure
+     * @param  \Illuminate\Queue\SerializableClosure  $closure
      * @param  array  $arguments
      * @return void
      */
@@ -19,7 +19,7 @@ class InvokeQueuedClosureForEvent
     /**
      * Handle a job failure.
      *
-     * @param  \Closure  $closure
+     * @param  \Illuminate\Queue\SerializableClosure  $closure
      * @param  array  $arguments
      * @param  array  $catchCallbacks
      * @param  \Throwable  $exception

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -113,7 +113,7 @@ class QueuedClosure
     public function resolve()
     {
         return function (...$arguments) {
-            dispatch(new CallQueuedListener(InvokeQueuedClosureForEvent::class, 'handle', [
+            dispatch(new CallQueuedListener(InvokeQueuedClosure::class, 'handle', [
                 'closure' => new SerializableClosure($this->closure),
                 'arguments' => $arguments,
                 'catch' => collect($this->catchCallbacks)->map(function ($callback) {

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Closure;
+use Illuminate\Queue\SerializableClosure;
+
+class QueuedClosure
+{
+    /**
+     * The underlying Closure.
+     *
+     * @var \Closure
+     */
+    public $closure;
+
+    /**
+     * Create a new queued closure event listener resolver.
+     *
+     * @param  \Closure  $closure
+     * @return void
+     */
+    public function __construct(Closure $closure)
+    {
+        $this->closure = $closure;
+    }
+
+    /**
+     * Resolve the actual event listener callback.
+     *
+     * @return \Closure
+     */
+    public function resolve()
+    {
+        return function (...$arguments) {
+            dispatch(new CallQueuedListener(InvokeQueuedClosureForEvent::class, 'handle', [
+                'closure' => new SerializableClosure($this->closure),
+                'arguments' => $arguments,
+            ]));
+        };
+    }
+}

--- a/src/Illuminate/Events/QueuedClosure.php
+++ b/src/Illuminate/Events/QueuedClosure.php
@@ -15,6 +15,34 @@ class QueuedClosure
     public $closure;
 
     /**
+     * The name of the connection the job should be sent to.
+     *
+     * @var string|null
+     */
+    public $connection;
+
+    /**
+     * The name of the queue the job should be sent to.
+     *
+     * @var string|null
+     */
+    public $queue;
+
+    /**
+     * The number of seconds before the job should be made available.
+     *
+     * @var \DateTimeInterface|\DateInterval|int|null
+     */
+    public $delay;
+
+    /**
+     * All of the "catch" callbacks for the queued closure.
+     *
+     * @var array
+     */
+    public $catchCallbacks = [];
+
+    /**
      * Create a new queued closure event listener resolver.
      *
      * @param  \Closure  $closure
@@ -23,6 +51,58 @@ class QueuedClosure
     public function __construct(Closure $closure)
     {
         $this->closure = $closure;
+    }
+
+    /**
+     * Set the desired connection for the job.
+     *
+     * @param  string|null  $connection
+     * @return $this
+     */
+    public function onConnection($connection)
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Set the desired queue for the job.
+     *
+     * @param  string|null  $queue
+     * @return $this
+     */
+    public function onQueue($queue)
+    {
+        $this->queue = $queue;
+
+        return $this;
+    }
+
+    /**
+     * Set the desired delay for the job.
+     *
+     * @param  \DateTimeInterface|\DateInterval|int|null  $delay
+     * @return $this
+     */
+    public function delay($delay)
+    {
+        $this->delay = $delay;
+
+        return $this;
+    }
+
+    /**
+     * Specify a callback that should be invoked if the queued listener job fails.
+     *
+     * @param  \Closure  $closure
+     * @return $this
+     */
+    public function catch(Closure $closure)
+    {
+        $this->catchCallbacks[] = $closure;
+
+        return $this;
     }
 
     /**
@@ -36,7 +116,10 @@ class QueuedClosure
             dispatch(new CallQueuedListener(InvokeQueuedClosureForEvent::class, 'handle', [
                 'closure' => new SerializableClosure($this->closure),
                 'arguments' => $arguments,
-            ]));
+                'catch' => collect($this->catchCallbacks)->map(function ($callback) {
+                    return new SerializableClosure($callback);
+                })->all(),
+            ]))->onConnection($this->connection)->onQueue($this->queue)->delay($this->delay);
         };
     }
 }

--- a/src/Illuminate/Events/composer.json
+++ b/src/Illuminate/Events/composer.json
@@ -15,6 +15,7 @@
     ],
     "require": {
         "php": "^7.3",
+        "illuminate/bus": "^8.0",
         "illuminate/collections": "^8.0",
         "illuminate/container": "^8.0",
         "illuminate/contracts": "^8.0",

--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Events;
+
+use Closure;
+
+function queueable(Closure $closure)
+{
+    return new QueuedClosure($closure);
+}

--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -4,6 +4,12 @@ namespace Illuminate\Events;
 
 use Closure;
 
+/**
+ * Create a new queued Closure event listener.
+ *
+ * @param  \Closure  $closure
+ * @return \Illuminate\Events\QueuedClosure
+ */
 function queueable(Closure $closure)
 {
     return new QueuedClosure($closure);

--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -4,13 +4,15 @@ namespace Illuminate\Events;
 
 use Closure;
 
-/**
- * Create a new queued Closure event listener.
- *
- * @param  \Closure  $closure
- * @return \Illuminate\Events\QueuedClosure
- */
-function queueable(Closure $closure)
-{
-    return new QueuedClosure($closure);
+if (! function_exists('Illuminate\Events\queueable')) {
+    /**
+     * Create a new queued Closure event listener.
+     *
+     * @param  \Closure  $closure
+     * @return \Illuminate\Events\QueuedClosure
+     */
+    function queueable(Closure $closure)
+    {
+        return new QueuedClosure($closure);
+    }
 }

--- a/tests/Integration/Events/QueuedClosureListenerTest.php
+++ b/tests/Integration/Events/QueuedClosureListenerTest.php
@@ -3,7 +3,7 @@
 namespace Illuminate\Tests\Integration\Events;
 
 use Illuminate\Events\CallQueuedListener;
-use Illuminate\Events\InvokeQueuedClosureForEvent;
+use Illuminate\Events\InvokeQueuedClosure;
 use function Illuminate\Events\queueable;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
@@ -24,7 +24,7 @@ class QueuedClosureListenerTest extends TestCase
         Event::dispatch(new TestEvent);
 
         Bus::assertDispatched(CallQueuedListener::class, function ($job) {
-            return $job->class == InvokeQueuedClosureForEvent::class;
+            return $job->class == InvokeQueuedClosure::class;
         });
     }
 }

--- a/tests/Integration/Events/QueuedClosureListenerTest.php
+++ b/tests/Integration/Events/QueuedClosureListenerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Events;
+
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Events\InvokeQueuedClosureForEvent;
+use function Illuminate\Events\queueable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Orchestra\Testbench\TestCase;
+
+class QueuedClosureListenerTest extends TestCase
+{
+    public function testAnonymousQueuedListenerIsQueued()
+    {
+        Bus::fake();
+
+        Event::listen(queueable(function (TestEvent $event) {
+            //
+        })->catch(function (TestEvent $event) {
+            //
+        })->onConnection(null)->onQueue(null));
+
+        Event::dispatch(new TestEvent);
+
+        Bus::assertDispatched(CallQueuedListener::class, function ($job) {
+            return $job->class == InvokeQueuedClosureForEvent::class;
+        });
+    }
+}
+
+class TestEvent
+{
+    //
+}


### PR DESCRIPTION
It is currently impossible to define a Closure based event listener that should also be queued. This adds that functionality.

This is also the first addition of a namespaced function to Laravel.

```php
use function Illuminate\Events\queueable;

Event::listen(queueable(function (Something $event) {
    //
});
```

In addition, `catch`, `onConnection`, `onQueue`, and `delay` methods are available:

```php
Event::listen(queueable(function (Something $event) {
    //
})->catch(function (Something $event, $exception) {
    //
})->onConnection(null)->onQueue(null)->delay(now()->addSeconds(10)));
```

This may also be used with model event listeners:

```php
App\User::created(queueable(function ($user) {
    info($user->name);
}));
```