### PR TITLE
[7.x] Cast needle once for good, to avoid missing needed casts

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -174,6 +174,7 @@ class Str
     public static function contains($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
+            $needle = (string) $needle;
             if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
@@ -210,7 +211,8 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
+            $needle = (string) $needle;
+            if ($needle !== '' && substr($haystack, -strlen($needle)) === $needle) {
                 return true;
             }
         }
@@ -604,7 +606,8 @@ class Str
     public static function startsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ((string) $needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
+            $needle = (string) $needle;
+            if ($needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0) {
                 return true;
             }
         }

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -186,6 +186,9 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::contains('taylor', ['xxx']));
         $this->assertFalse(Str::contains('taylor', ''));
         $this->assertFalse(Str::contains('', ''));
+        $this->assertFalse(Str::contains('taylor', [null]));
+        $this->assertFalse(Str::contains('taylor', null));
+        $this->assertFalse(Str::contains('taylor', 'YLO'));
     }
 
     public function testStrContainsAll()

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -58,7 +58,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::startsWith('jason', [null]));
         $this->assertFalse(Str::startsWith('0123', [null]));
         $this->assertTrue(Str::startsWith('0123', 0));
-        $this->assertFalse(Str::startsWith('jason', 'J'));
+        $this->assertFalse(Str::startsWith('jason', 'JAS'));
         $this->assertFalse(Str::startsWith('jason', ''));
         $this->assertFalse(Str::startsWith('', ''));
         $this->assertFalse(Str::startsWith('7', ' 7'));
@@ -91,7 +91,7 @@ class SupportStrTest extends TestCase
         $this->assertFalse(Str::endsWith('', ''));
         $this->assertFalse(Str::endsWith('jason', [null]));
         $this->assertFalse(Str::endsWith('jason', null));
-        $this->assertFalse(Str::endsWith('jason', 'N'));
+        $this->assertFalse(Str::endsWith('jason', 'ON'));
         $this->assertFalse(Str::endsWith('7', ' 7'));
         $this->assertTrue(Str::endsWith('a7', '7'));
         $this->assertTrue(Str::endsWith('a7', 7));


### PR DESCRIPTION
Follow-up to #30364.

Basically, cast to string is needed for direct comparisons (e.g. `$needle !== ''` or `substr(...) === $needle`). Simply casting `$needle` at the beginning, rather than here and there, avoids subtle issues like I exposed in https://github.com/laravel/framework/pull/30364#issuecomment-653837683, and makes the code clearer.

`$haystack` doesn't need such cast, so I avoided extra processing.

In addition to `null` values, this also brings support for passing instances of [Stringable](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Support/Stringable.php), though I haven't added tests for these (because it would become very long...).

<br>ping @SjorsO