### PR TITLE
[7.x] Add support for SQL Server LoginTimeout to specify seconds to wait before failing connection attempt

### DIFF
--- a/src/Illuminate/Database/Connectors/SqlServerConnector.php
+++ b/src/Illuminate/Database/Connectors/SqlServerConnector.php
@@ -156,6 +156,10 @@ class SqlServerConnector extends Connector implements ConnectorInterface
             $arguments['KeyStoreSecret'] = $config['key_store_secret'];
         }
 
+        if (isset($config['login_timeout'])) {
+            $arguments['LoginTimeout'] = $config['login_timeout'];
+        }
+
         return $this->buildConnectString('sqlsrv', $arguments);
     }
 


### PR DESCRIPTION
The existing functionality for the SqlServerConnector class doesn't allow a developer to specify the number of seconds to wait before failing a connection attempt.  Without this support, a SQL Server connection attempt can take 30 seconds to fail.

Setting the connection timeout is done by adding the LoginTimeout connection option to the DSN string.  Example: "sqlsrv:Server=server;Database=dbname;LoginTimeout=5"

Resources:
* [PHP's PDO_SQLSRV DSN documentation](https://www.php.net/manual/en/ref.pdo-sqlsrv.connection.php)
* [Microsoft's Connection Options documentation](https://docs.microsoft.com/en-us/sql/connect/php/connection-options?view=sql-server-ver15)