### PR TITLE
[8.x] Check if method exists in the global namespace

### DIFF
--- a/src/Illuminate/Events/functions.php
+++ b/src/Illuminate/Events/functions.php
@@ -4,7 +4,7 @@ namespace Illuminate\Events;
 
 use Closure;
 
-if (! function_exists('Illuminate\Events\queueable')) {
+if (! function_exists('queueable')) {
     /**
      * Create a new queued Closure event listener.
      *


### PR DESCRIPTION
During this PR https://github.com/laravel/framework/pull/33463 Graham mentioned that the new function may conflict with a global one, if exists.

I guess the check was supposed to be if the method exists in the global namespace instead.