### PR TITLE
[6.x] Fix auto creating model by class name

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -62,11 +62,11 @@ trait DatabaseRule
             return $table;
         }
 
-        $model = new $table;
+        if (is_subclass_of($table, Model::class)) {
+            return (new $table)->getTable();
+        }
 
-        return $model instanceof Model
-                ? $model->getTable()
-                : $table;
+        return $table;
     }
 
     /**

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -58,6 +58,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule = new Exists(NoTableNameModel::class, 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:no_table_name_models,column,foo,"bar"', (string) $rule);
+
+        $rule = new Exists(ClassWithRequiredConstructorParameters::class, 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:'.ClassWithRequiredConstructorParameters::class.',column,foo,"bar"', (string) $rule);
     }
 
     public function testItChoosesValidRecordsUsingWhereInRule()
@@ -202,4 +206,16 @@ class NoTableNameModel extends Eloquent
 {
     protected $guarded = [];
     public $timestamps = false;
+}
+
+class ClassWithRequiredConstructorParameters
+{
+    private $bar;
+    private $baz;
+
+    public function __construct($bar, $baz)
+    {
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
 }

--- a/tests/Validation/ValidationUniqueRuleTest.php
+++ b/tests/Validation/ValidationUniqueRuleTest.php
@@ -26,6 +26,10 @@ class ValidationUniqueRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('unique:no_table_names,NULL,NULL,id,foo,"bar"', (string) $rule);
 
+        $rule = new Unique(ClassWithNonEmptyConstructor::class);
+        $rule->where('foo', 'bar');
+        $this->assertSame('unique:'.ClassWithNonEmptyConstructor::class.',NULL,NULL,id,foo,"bar"', (string) $rule);
+
         $rule = new Unique('table', 'column');
         $rule->ignore('Taylor, Otwell', 'id_column');
         $rule->where('foo', 'bar');
@@ -77,4 +81,16 @@ class NoTableName extends Model
 {
     protected $guarded = [];
     public $timestamps = false;
+}
+
+class ClassWithNonEmptyConstructor
+{
+    private $bar;
+    private $baz;
+
+    public function __construct($bar, $baz)
+    {
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
 }


### PR DESCRIPTION
I'm targeting `6.x` because it was broken in `6.x` by https://github.com/laravel/framework/pull/30653

There was an issue about this problem https://github.com/laravel/framework/issues/31180

as @driesvints said

> We only support Eloquent models for this rule. Because you're not using an Eloquent model, this rule won't work. You'll have to ask the maintainers of laravel doctrine to provide a custom database rule.

But the thing is `illuminate/database` is only suggestion, not the requirement of this library. Another thing is that  https://github.com/laravel-doctrine/ implements `PresenceVerifierInterface` which works perfectly fine.

The change that I've proposed does not break anyone else code, it just makes validation rule more general purpose and adds ability for other database ORM providers (the guaranties was given by `PresenceVerifierInterface`, I can implement it on my own and make `FilePresenceVerifier` if my persistence layer is in file, same way I can make `ExternalApiPresenceVerifier` and check external API for existence or uniqueness)

also saying that 

> We only support Eloquent models for this rule. Because you're not using an Eloquent model, this rule won't work. You'll have to ask the maintainers of laravel doctrine to provide a custom database rule.

Is not correct, since? as I have described you give `PresenceVerifierInterface`
