### PR TITLE
[8.x] Add bootstrap to Kernel console interface

### DIFF
--- a/src/Illuminate/Contracts/Console/Kernel.php
+++ b/src/Illuminate/Contracts/Console/Kernel.php
@@ -5,6 +5,13 @@ namespace Illuminate\Contracts\Console;
 interface Kernel
 {
     /**
+     * Bootstrap the application for artisan commands.
+     *
+     * @return void
+     */
+    public function bootstrap();
+
+    /**
      * Handle an incoming console command.
      *
      * @param  \Symfony\Component\Console\Input\InputInterface  $input


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I'm adding `bootstrap` method to `Illuminate\Contracts\Console\Kernel` because in some cases, I just want to "load" the application and then call something (I mean the command). So because this method is public and called in all interface implementation methods (I mean `handle`/`call`/`queue`/`all`/`output` except `terminate`). 
Also it looks weird that I can `terminate` but I can't `bootstrap` the application.