### PR TITLE
[7.x] revert PR #33430

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php
@@ -324,19 +324,6 @@ class SqlServerGrammar extends Grammar
     }
 
     /**
-     * Compile an insert and get ID statement into SQL.
-     *
-     * @param  \Illuminate\Database\Query\Builder  $query
-     * @param  array  $values
-     * @param  string  $sequence
-     * @return string
-     */
-    public function compileInsertGetId(Builder $query, $values, $sequence)
-    {
-        return 'set nocount on;'.$this->compileInsert($query, $values).';select scope_identity() as '.$this->wrap($sequence ?: 'id');
-    }
-
-    /**
      * Compile an update statement with joins into SQL.
      *
      * @param  \Illuminate\Database\Query\Builder  $query

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -2130,7 +2130,7 @@ class DatabaseQueryBuilderTest extends TestCase
         $builder->from('users')->insertGetId([]);
 
         $builder = $this->getSqlServerBuilder();
-        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'set nocount on;insert into [users] default values;select scope_identity() as [id]', [], null);
+        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into [users] default values', [], null);
         $builder->from('users')->insertGetId([]);
     }
 
@@ -2470,14 +2470,6 @@ class DatabaseQueryBuilderTest extends TestCase
     {
         $builder = $this->getPostgresBuilder();
         $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'insert into "users" ("email") values (?) returning "id"', ['foo'], 'id')->andReturn(1);
-        $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
-        $this->assertEquals(1, $result);
-    }
-
-    public function testSqlServerInsertGetId()
-    {
-        $builder = $this->getSqlServerBuilder();
-        $builder->getProcessor()->shouldReceive('processInsertGetId')->once()->with($builder, 'set nocount on;insert into [users] ([email]) values (?);select scope_identity() as [id]', ['foo'], 'id')->andReturn(1);
         $result = $builder->from('users')->insertGetId(['email' => 'foo'], 'id');
         $this->assertEquals(1, $result);
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As noted by issue #33485 PR #33430 breaks a Laravel app when using the freeTDS driver to connect to SQL Server.

PR #33430 was sent to address issue #32883, but when implementing it I didn't test it against freeTDS drivers. I only tested against Microsoft official drivers ( https://github.com/Microsoft/msphpsql ). It seems freeTDS ise widely used , specially with older versions of SQL Server.

After the issue was reported I started investigating a solution that could solve both issues #33485 and #32883 but I could not find one. 

So I am sending this PR to revert the changes made. Issue #32883 will still need to be addressed after reverting it.

I shared some of my findings on a comment on PR #33430 discussion and also presented some alternatives. Please refer to comment https://github.com/laravel/framework/pull/33430#commitcomment-40493561 to have more details about it.

There I said I would send PR for both 6.x and 7.x branches, but I will wait on feedback on this one before sending the second one as maintainers could have a different workflow on back porting features and fixes.

If someone has a better suggestion on how to address this I would be glad to help.
