### PR TITLE
[7.x] Added ability to simulate "withCredentials" in test requests

### DIFF
--- a/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
+++ b/tests/Foundation/Testing/Concerns/MakesHttpRequestsTest.php
@@ -103,6 +103,17 @@ class MakesHttpRequestsTest extends TestCase
         $this->assertSame('baz', $this->unencryptedCookies['foo']);
         $this->assertSame('new-value', $this->unencryptedCookies['new-cookie']);
     }
+
+    public function testWithoutAndWithCredentials()
+    {
+        $this->encryptCookies = false;
+
+        $this->assertSame([], $this->prepareCookiesForJsonRequest());
+
+        $this->withCredentials();
+        $this->defaultCookies = ['foo' => 'bar'];
+        $this->assertSame(['foo' => 'bar'], $this->prepareCookiesForJsonRequest());
+    }
 }
 
 class MyMiddleware


### PR DESCRIPTION
Hi all

I stumbled over a missing functionality in the test cases. As stated [here](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials), XMLHttpRequests allow a flag which is named "withCredentials" to include cookies in the requests.

> The XMLHttpRequest.withCredentials property is a Boolean that indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.

By default, all JSON-requests implicit use an empty cookies-array. But with the knowledge of this flag, in my opinion it makes sense to make it configurable whether json requests should include cookies or not.

This PR adds a method to test cases, which allow to use `$this->withCredentials()` in a test to make all `json()`-calls include the cookie-jars, which are available anyway.