### PR TITLE
[7.x] Adds File::numberOfLines() method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -123,6 +123,21 @@ class Filesystem
     }
 
     /**
+     * Get the number of lines in a given file.
+     *
+     * @param  string  $path
+     * @return int
+     */
+    public function numberOfLines($path)
+    {
+        $file = new \SplFileObject($path, 'r');
+
+        $file->seek(PHP_INT_MAX);
+
+        return $file->key();
+    }
+
+    /**
      * Write the contents of a file.
      *
      * @param  string  $path


### PR DESCRIPTION
Example of use:

```php
>>> File::numberOfLines(storage_path('logs/laravel.log'))
=> 33
```