### PR TITLE
[8.x] Add getData method to Validator contract

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -58,4 +58,11 @@ interface Validator extends MessageProvider
      * @return \Illuminate\Support\MessageBag
      */
     public function errors();
+
+    /**
+     * Get the data under validation.
+     *
+     * @return array
+     */
+    public function getData();
 }


### PR DESCRIPTION
Right now it's rather difficult to register dependent validation rules from a package, this is because two methods required by this feature are not present on their respective contracts:
- `Illuminate\Validation\Factory::extendDependent`
- `Illuminate\Validation\Validator::getData`

This PR aims to partially fix this by adding `getData` to the `\Illuminate\Contracts\Validation\Validator` contract, allowing dependent extensions to retrieve the data under validation.

I left the Factory contract unchanged, because unlike getData its quite easy to work around not having extendDependent on the Factory contract, and forcing every custom factory to implement dependent validation seems overkill. 

This is a breaking change because it changes contracts, and as such may break custom implementations of these contracts.