### PR TITLE
[7.x] Fix PHPdoc for decay param

### DIFF
--- a/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/Illuminate/Redis/Limiters/DurationLimiterBuilder.php
@@ -73,7 +73,7 @@ class DurationLimiterBuilder
     /**
      * Set the amount of time the lock window is maintained.
      *
-     * @param  int  $decay
+     * @param  \DateTimeInterface|\DateInterval|int  $decay
      * @return $this
      */
     public function every($decay)


### PR DESCRIPTION
The `$decay` param from `DurationLimiterBuilder::every($decay)` should also accept `\DateTimeInterface` and `\DateInterval` to match `InteractsWithTime::secondsUntil($delay)`.

Current code for quick review:

```php
    /**
     * Set the amount of time the lock window is maintained.
     *
     * @param  int  $decay
     * @return $this
     */
    public function every($decay)
    {
        $this->decay = $this->secondsUntil($decay);

        return $this;
    }

    /**
     * Get the number of seconds until the given DateTime.
     *
     * @param  \DateTimeInterface|\DateInterval|int  $delay
     * @return int
     */
    protected function secondsUntil($delay)
    {
        $delay = $this->parseDateInterval($delay);

        return $delay instanceof DateTimeInterface
                            ? max(0, $delay->getTimestamp() - $this->currentTime())
                            : (int) $delay;
    }

```