### PR TITLE
[6.x] FIX - Add Symfony Response to $response phpdoc in RequestHandled.php

### DIFF
--- a/src/Illuminate/Foundation/Http/Events/RequestHandled.php
+++ b/src/Illuminate/Foundation/Http/Events/RequestHandled.php
@@ -14,7 +14,7 @@ class RequestHandled
     /**
      * The response instance.
      *
-     * @var \Illuminate\Http\Response
+     * @var \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\Response
      */
     public $response;
 
@@ -22,7 +22,7 @@ class RequestHandled
      * Create a new event instance.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \Illuminate\Http\Response  $response
+     * @param  \Illuminate\Http\Response|\Symfony\Component\HttpFoundation\Response  $response
      * @return void
      */
     public function __construct($request, $response)


### PR DESCRIPTION
Currently, in `RequestHandled.php`, it mentions that `$response` is of type `\Illuminate\Http\Response` 

but in `Laravel/Cors` package (preflight request) or in `src/Illuminate/Foundation/Http/Kernel.php:114`->`renderException()` returns `\Symfony\Component\HttpFoundation\Response`.

This addition could reduce bugs to end users side:

- if would listen to `Illuminate\Foundation\Http\Events\RequestHandled` and would always rely that `$this->event->response` as `\Illuminate\Http\Response`. 

Example:
- calling `header()` on Response of type `\Symfony\Component\HttpFoundation\Response` would through a fatal error as this method not declared.
