### PR TITLE
[8.x] Allows assertJsonValidationErrors to validate deeper error paths on $responseKey

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -727,7 +727,7 @@ class TestResponse implements ArrayAccess
 
         PHPUnit::assertNotEmpty($errors, 'No validation errors were provided.');
 
-        $jsonErrors = $this->json()[$responseKey] ?? [];
+        $jsonErrors = Arr::get($this->json(), $responseKey) ?? [];
 
         $errorMessage = $jsonErrors
                 ? 'Response has the following JSON validation errors:'.


### PR DESCRIPTION
Given that it's possible to pass the `$responseKey` parameters to `assertJsonValidationErrors`, allowing the assert to access deeper paths would be great. In our case we're responding a GraphQL response and the validation errors lives within `errors.extensions`. Passing `errors.extensions.validation` doesn't validate properly because it doesn't support deeper paths.
