### PR TITLE
[8.x] Consider timeouts when counting a jobs $maxExceptions

### DIFF
--- a/src/Illuminate/Queue/Worker.php
+++ b/src/Illuminate/Queue/Worker.php
@@ -192,7 +192,11 @@ class Worker
         pcntl_signal(SIGALRM, function () use ($job, $options) {
             if ($job) {
                 $this->markJobAsFailedIfWillExceedMaxAttempts(
-                    $job->getConnectionName(), $job, (int) $options->maxTries, $this->maxAttemptsExceededException($job)
+                    $job->getConnectionName(), $job, (int) $options->maxTries, $e = $this->maxAttemptsExceededException($job)
+                );
+
+                $this->markJobAsFailedIfWillExceedMaxExceptions(
+                    $job->getConnectionName(), $job, $e
                 );
             }
 


### PR DESCRIPTION
Based on the discussion in https://github.com/laravel/framework/discussions/33473#discussioncomment-36479

This PR counts timeouts as exceptions so people can fail the job if it timeouts using the `$maxExceptions` configurations.

That way people can `release` the job back to queue multiple times but fail it if it timeouts a specific number of times.