### PR TITLE
[7.x] Add helper for on update cascade

### DIFF
--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -23,4 +23,14 @@ class ForeignKeyDefinition extends Fluent
     {
         return $this->onDelete('cascade');
     }
+
+    /**
+     * Indicate that updates should cascade.
+     *
+     * @return $this
+     */
+    public function cascadeOnUpdate()
+    {
+        return $this->onUpdate('cascade');
+    }
 }

--- a/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
+++ b/src/Illuminate/Database/Schema/ForeignKeyDefinition.php
@@ -15,16 +15,6 @@ use Illuminate\Support\Fluent;
 class ForeignKeyDefinition extends Fluent
 {
     /**
-     * Indicate that deletes should cascade.
-     *
-     * @return $this
-     */
-    public function cascadeOnDelete()
-    {
-        return $this->onDelete('cascade');
-    }
-
-    /**
      * Indicate that updates should cascade.
      *
      * @return $this
@@ -32,5 +22,15 @@ class ForeignKeyDefinition extends Fluent
     public function cascadeOnUpdate()
     {
         return $this->onUpdate('cascade');
+    }
+
+    /**
+     * Indicate that deletes should cascade.
+     *
+     * @return $this
+     */
+    public function cascadeOnDelete()
+    {
+        return $this->onDelete('cascade');
     }
 }

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -388,6 +388,13 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
 
         $this->assertCount(1, $statements);
         $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on delete cascade', $statements[0]);
+
+        $blueprint = new Blueprint('users');
+        $blueprint->foreign('foo_id')->references('id')->on('orders')->cascadeOnUpdate();
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertCount(1, $statements);
+        $this->assertSame('alter table `users` add constraint `users_foo_id_foreign` foreign key (`foo_id`) references `orders` (`id`) on update cascade', $statements[0]);
     }
 
     public function testAddingIncrementingID()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Hello.

With this change I can use this in my migrations.
```php
$table->foreignId('user_id')->cascadeOnDelete()->cascadeOnUpdate();
```
