### PR TITLE
[7.x] Add select method to Collection

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -947,7 +947,7 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Return a new collection where each item only contains the selected keys
+     * Return a new collection where each item only contains the selected keys.
      *
      * @param  array  $keys
      * @return static

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -947,6 +947,25 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Return a new collection where each item only contains the selected keys
+     *
+     * @param  array  $keys
+     * @return static
+     */
+    public function select($keys)
+    {
+        if ($keys instanceof Enumerable) {
+            $keys = $keys->all();
+        }
+
+        $keys = is_array($keys) ? $keys : func_get_args();
+
+        return $this->map(function ($item) use ($keys) {
+            return Arr::only($item, $keys);
+        });
+    }
+
+    /**
      * Get and remove the first item from the collection.
      *
      * @return mixed

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -914,6 +914,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Return a new collection where each item only contains the selected keys
+     *
+     * @param  array  $keys
+     * @return static
+     */
+    public function select($keys)
+    {
+        return $this->passthru('select', func_get_args());
+    }
+
+    /**
      * Shuffle the items in the collection.
      *
      * @param  int|null  $seed

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -914,7 +914,7 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Return a new collection where each item only contains the selected keys
+     * Return a new collection where each item only contains the selected keys.
      *
      * @param  array  $keys
      * @return static

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3024,6 +3024,55 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSelect($collection)
+    {
+        $people = new $collection([
+            [
+                'first' => 'John',
+                'last' => 'Doe',
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'first' => 'Jane',
+                'last' => 'Doe',
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'first' => 'John',
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'first' => 'Jane',
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ], $people->select(['first', 'name', 'email'])->all());
+
+        $this->assertEquals([
+            [
+                'name' => 'John Doe',
+                'email' => 'john.doe@gmail.com',
+            ],
+            [
+                'name' => 'Jane Doe',
+                'email' => 'jane.doe@gmail.com',
+            ],
+        ], $people->select(['missing-key', 'name', 'email'])->all());
+
+        $this->assertEquals($people->all(), $people->select('first', 'last', 'name', 'email')->all());
+        $this->assertEquals($people->all(), $people->select(['first', 'last', 'name', 'email'])->all());
+        $this->assertEquals($people->all(), $people->select(collect(['first', 'last', 'name', 'email']))->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testKeys($collection)
     {
         $c = new $collection(['name' => 'taylor', 'framework' => 'laravel']);


### PR DESCRIPTION
The `select` method will return a collection with the specified keys.

After considering different names for this method I decided to go with `select` since it's also used in the query builder to select columns.

Explained in detail on this discussion https://github.com/laravel/framework/discussions/32991

```php
$people = collect([
    [
        'first' => 'John',
        'last' => 'Doe',
        'name' => 'John Doe',
        'email' => 'john.doe@gmail.com',
    ],
    [
        'first' => 'Jane',
        'last' => 'Doe',
        'name' => 'Jane Doe',
        'email' => 'jane.doe@gmail.com',
    ],
]);

$people->select(['first', 'last', 'email'])->all();
// or ...
$people->select('first', 'last', 'email')->all();

//=> [
//=>     [
//=>         'first' => 'John',
//=>         'last' => 'Doe',
//=>         'email' => 'john.doe@gmail.com',
//=>     ],
//=>     [
//=>         'first' => 'Jane',
//=>         'last' => 'Doe',
//=>         'email' => 'jane.doe@gmail.com',
//=>     ],
//=> ]
```

