### PR TITLE
[7.x] Testing JsonResource responses

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1152,6 +1152,17 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response is a JsonResource.
+     *
+     * @param  \Illuminate\Http\Resources\Json\JsonResource  $jsonResource
+     * @return $this
+     */
+    public function assertJsonResource($jsonResource)
+    {
+        return $this->assertExactJson($jsonResource->toResponse(app('request'))->getData(true));
+    }
+
+    /**
      * Get the current session store.
      *
      * @return \Illuminate\Session\Store

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1159,7 +1159,7 @@ class TestResponse implements ArrayAccess
      */
     public function assertJsonResource($jsonResource)
     {
-        return $this->assertExactJson($jsonResource->toResponse(app('request'))->getData(true));
+        return $this->assertExactJson($jsonResource->response()->getData(true));
     }
 
     /**

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -866,8 +866,7 @@ class TestResponseTest extends TestCase
     public function testAssertJsonResource()
     {
         $data = ['foo' => 'bar'];
-        $jsonResource = new class($data) extends JsonResource
-        {
+        $jsonResource = new class($data) extends JsonResource {
             public function toArray($request)
             {
                 return ['resource_foo' => $this->foo];

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -5,6 +5,8 @@ namespace Illuminate\Tests\Foundation;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use JsonSerializable;
@@ -859,6 +861,22 @@ class TestResponseTest extends TestCase
         );
 
         $testResponse->assertJsonMissingValidationErrors('bar', 'data');
+    }
+
+    public function testAssertJsonResource()
+    {
+        $data = ['foo' => 'bar'];
+        $jsonResource = new class($data) extends JsonResource
+        {
+            public function toArray($request)
+            {
+                return ['resource_foo' => $this->foo];
+            }
+        };
+
+        $testResponse = TestResponse::fromBaseResponse($jsonResource->toResponse(new Request()));
+
+        $testResponse->assertJsonResource($jsonResource);
     }
 
     public function testMacroable()


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds `assertJsonResource()` to `TestResponse`. This is a convenience method for asserting that the `TestResponse`'s JSON matches the JSON that a `JsonResource` would create, similar to `assertViewIs()` and `assertViewHas()`.

```php
$jsonResource = new FooResource(Foo::first());

$this->getJson(route('foo'))->assertJsonResource($jsonResource);
```

-----

I'm keeping this as a draft for now since the test doesn't pass currently. I need to boot the appropriate bits of the framework so that `response()` will work, but I'm not sure how best to do that.