### PR TITLE
[7.x] Apply model connection name to Database validation rules

### DIFF
--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -63,7 +63,11 @@ trait DatabaseRule
         }
 
         if (is_subclass_of($table, Model::class)) {
-            return (new $table)->getTable();
+            $model = new $table;
+            
+            return implode('.', array_filter(
+                [$model->getConnectionName(), $model->getTable()]
+            ));
         }
 
         return $table;

--- a/src/Illuminate/Validation/Rules/DatabaseRule.php
+++ b/src/Illuminate/Validation/Rules/DatabaseRule.php
@@ -64,7 +64,7 @@ trait DatabaseRule
 
         if (is_subclass_of($table, Model::class)) {
             $model = new $table;
-            
+
             return implode('.', array_filter(
                 [$model->getConnectionName(), $model->getTable()]
             ));

--- a/tests/Validation/ValidationExistsRuleTest.php
+++ b/tests/Validation/ValidationExistsRuleTest.php
@@ -51,6 +51,10 @@ class ValidationExistsRuleTest extends TestCase
         $rule->where('foo', 'bar');
         $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
 
+        $rule = new Exists(UserWithConnection::class, 'column');
+        $rule->where('foo', 'bar');
+        $this->assertSame('exists:mysql.users,column,foo,"bar"', (string) $rule);
+
         $rule = new Exists('Illuminate\Tests\Validation\User', 'column');
         $rule->where('foo', 'bar');
         $this->assertSame('exists:users,column,foo,"bar"', (string) $rule);
@@ -200,6 +204,11 @@ class User extends Eloquent
     protected $table = 'users';
     protected $guarded = [];
     public $timestamps = false;
+}
+
+class UserWithConnection extends User
+{
+    protected $connection = 'mysql';
 }
 
 class NoTableNameModel extends Eloquent


### PR DESCRIPTION
This change applies the connection name (if it is not `null`) to database validation rules, where a `Model` class is given.

This really helps when working with multiple databases in the same application and having to create rules on models that do not use the default application connection.

**Without this change**:

```php
use App\Sqlsrv\Transaction;
use Illuminate\Validation\Rule;

$model = new Transaction;

$rule = implode('.', [$model->getConnectionName(), $model->getTable()]);

Rule::exists($rule, 'id');
```

**With this change**:

```php
use App\Sqlsrv\Transaction;
use Illuminate\Validation\Rule;

Rule::exists(Transaction::class, 'id');
```

If the connection name is `null` on the model, the connection name is not applied. There is no BC break with this change.

Please let me know if anything needs to be modified for styling rules. Thanks!

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
