### PR TITLE
[7.x] Allow calling invokable classes using FQN

### DIFF
--- a/src/Illuminate/Container/BoundMethod.php
+++ b/src/Illuminate/Container/BoundMethod.php
@@ -24,6 +24,10 @@ class BoundMethod
      */
     public static function call($container, $callback, array $parameters = [], $defaultMethod = null)
     {
+        if (is_string($callback) && !$defaultMethod && method_exists($callback, '__invoke')) {
+            $defaultMethod = '__invoke';
+        }
+
         if (static::isCallableWithAtSign($callback) || $defaultMethod) {
             return static::callClass($container, $callback, $parameters, $defaultMethod);
         }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -175,6 +175,7 @@ class ContainerCallTest extends TestCase
         $result = $container->call(ContainerCallCallableClassStringStub::class);
         $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
         $this->assertSame('jeffrey', $result[1]);
+        $this->assertInstanceOf(ContainerTestCallStub::class, $result[2]);
     }
 
     public function testCallWithoutRequiredParamsThrowsException()
@@ -254,8 +255,8 @@ class ContainerCallCallableClassStringStub
         $this->default = $default;
     }
 
-    public function __invoke()
+    public function __invoke(ContainerTestCallStub $dependency)
     {
-        return [$this->stub, $this->default];
+        return [$this->stub, $this->default, $dependency];
     }
 }

--- a/tests/Container/ContainerCallTest.php
+++ b/tests/Container/ContainerCallTest.php
@@ -169,6 +169,14 @@ class ContainerCallTest extends TestCase
         $this->assertSame('jeffrey', $result[1]);
     }
 
+    public function testCallWithCallableClassString()
+    {
+        $container = new Container;
+        $result = $container->call(ContainerCallCallableClassStringStub::class);
+        $this->assertInstanceOf(ContainerCallConcreteStub::class, $result[0]);
+        $this->assertSame('jeffrey', $result[1]);
+    }
+
     public function testCallWithoutRequiredParamsThrowsException()
     {
         $this->expectException(BindingResolutionException::class);
@@ -231,5 +239,23 @@ class ContainerCallCallableStub
     public function __invoke(ContainerCallConcreteStub $stub, $default = 'jeffrey')
     {
         return func_get_args();
+    }
+}
+
+class ContainerCallCallableClassStringStub
+{
+    public $stub;
+
+    public $default;
+
+    public function __construct(ContainerCallConcreteStub $stub, $default = 'jeffrey')
+    {
+        $this->stub = $stub;
+        $this->default = $default;
+    }
+
+    public function __invoke()
+    {
+        return [$this->stub, $this->default];
     }
 }


### PR DESCRIPTION
The container `call` method currently supports passing in an object and invoking it, but it does not support something more convenient like calling an invokable class by passing in the FQN.

**Before:**

```php
$action = app()->make(Action::class);
$result = app()->call($action);
```

**After:**

```php
$result = app()->call(Action::class);
```

This is more a quality of life change, especially in instances such as above where you need to resolve some dependencies for the class.