### PR TITLE
[7.x] Throw a TypeError if concrete is not a string or closure

### DIFF
--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -218,8 +218,6 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function bind($abstract, $concrete = null, $shared = false)
     {
@@ -237,7 +235,7 @@ class Container implements ArrayAccess, ContainerContract
         // up inside its own Closure to give us more convenience when extending.
         if (! $concrete instanceof Closure) {
             if (! is_string($concrete)) {
-                throw new \InvalidArgumentException('Concrete implementation must be a string or closure');
+                throw new \TypeError(self::class.'::bind(): Argument #2 ($concrete) must be of type Closure|string|null');
             }
 
             $concrete = $this->getClosure($abstract, $concrete);
@@ -343,8 +341,6 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function bindIf($abstract, $concrete = null, $shared = false)
     {
@@ -359,8 +355,6 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function singleton($abstract, $concrete = null)
     {
@@ -387,8 +381,6 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
-     *
-     * @throws \InvalidArgumentException
      */
     public function extend($abstract, Closure $closure)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -218,6 +218,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function bind($abstract, $concrete = null, $shared = false)
     {
@@ -234,6 +236,10 @@ class Container implements ArrayAccess, ContainerContract
         // bound into this container to the abstract type and we will just wrap it
         // up inside its own Closure to give us more convenience when extending.
         if (! $concrete instanceof Closure) {
+            if (! is_string($concrete)) {
+                throw new \InvalidArgumentException('Concrete implementation must be a string or closure');
+            }
+
             $concrete = $this->getClosure($abstract, $concrete);
         }
 
@@ -337,6 +343,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|string|null  $concrete
      * @param  bool  $shared
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function bindIf($abstract, $concrete = null, $shared = false)
     {
@@ -351,6 +359,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  \Closure|string|null  $concrete
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function singleton($abstract, $concrete = null)
     {

--- a/src/Illuminate/Container/Container.php
+++ b/src/Illuminate/Container/Container.php
@@ -381,6 +381,8 @@ class Container implements ArrayAccess, ContainerContract
      * @param  string  $abstract
      * @param  \Closure  $closure
      * @return void
+     *
+     * @throws \InvalidArgumentException
      */
     public function extend($abstract, Closure $closure)
     {

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -122,7 +122,7 @@ class ContainerTest extends TestCase
 
     public function testBindFailsLoudlyWithInvalidArgument()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         $container = new Container;
 
         $concrete = new ContainerConcreteStub();

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -120,6 +120,15 @@ class ContainerTest extends TestCase
         $this->assertSame($var1, $var2);
     }
 
+    public function testBindFailsLoudlyWithInvalidArgument()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $container = new Container;
+
+        $concrete = new ContainerConcreteStub();
+        $container->bind(ContainerConcreteStub::class, $concrete);
+    }
+
     public function testAbstractToConcreteResolution()
     {
         $container = new Container;


### PR DESCRIPTION
There is currently an assumption that if the `concrete` parameter passed to `bind` is not a `Closure`, then it is a string. Let's fail loudly if that is not the case.

Problem surfaced here: https://github.com/facade/ignition/pull/291


