### PR TITLE
Added except method to Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1202,7 +1202,7 @@ trait HasAttributes
     public function except($attributes)
     {
         $attributes = is_array($attributes) ? $attributes : func_get_args();
-        $results    = [];
+        $results = [];
 
         foreach (array_diff(array_keys($this->attributes), $attributes) as $attribute) {
             $results[$attribute] = $this->getAttribute($attribute);

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -1194,6 +1194,24 @@ trait HasAttributes
     }
 
     /**
+     * Get all attributes except the specified ones.
+     *
+     * @param  array|mixed  $attributes
+     * @return array
+     */
+    public function except($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+        $results    = [];
+
+        foreach (array_diff(array_keys($this->attributes), $attributes) as $attribute) {
+            $results[$attribute] = $this->getAttribute($attribute);
+        }
+
+        return $results;
+    }
+
+    /**
      * Get a subset of the model's attributes.
      *
      * @param  array|mixed  $attributes

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -189,6 +189,18 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertFalse(isset($model['with']));
     }
 
+    public function testExcept()
+    {
+        $model = new EloquentModelStub;
+        $model->first_name = 'taylor';
+        $model->last_name = 'otwell';
+        $model->project = 'laravel';
+
+        $this->assertEquals(['first_name' => 'taylor', 'last_name' => 'otwell'], $model->except('project'));
+        $this->assertEquals(['project' => 'laravel'], $model->except('first_name', 'last_name'));
+        $this->assertEquals(['project' => 'laravel'], $model->except(['first_name', 'last_name']));
+    }
+
     public function testOnly()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
closes #33537 

I think that this will benefit the developer because instead of having to write out all attributes in the `only([])` method the user can specify which attributes they're not interested in.

Example scenario would be testing that the api response includes all our specified attributes
```php
$user = factory(User::class)->create();

$response = $this->postJson(route('store-route'), $user->getAttributes());

$response->assertJsonFragment($user->only([
            'first_name',
            'last_name'
       ]);
``` 

vs 

```php
$response->assertJsonFragment($user->except(['project']);
```
