### PR TITLE
[7.x] Adds array and collections handling to the contains() Collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -177,6 +177,10 @@ class Collection implements ArrayAccess, Enumerable
                 return $this->first($key, $placeholder) !== $placeholder;
             }
 
+            if (is_array($key) || $key instanceof self) {
+                return empty(array_diff($this->getArrayableItems($key), $this->items));
+            }
+
             return in_array($key, $this->items);
         }
 

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2791,6 +2791,19 @@ class SupportCollectionTest extends TestCase
         }));
     }
 
+    public function testContainsArrayOrCollection()
+    {
+        $c1 = new Collection([1, 3, 5]);
+        $c2 = new Collection([3, 5]);
+        $this->assertTrue($c1->contains($c2));
+
+        $c2 = new Collection([1, 4, 3]);
+        $this->assertFalse($c1->contains($c2));
+
+        $this->assertTrue($c1->contains([1, 3]));
+        $this->assertFalse($c1->contains([1, 4]));
+    }
+
     /**
      * @dataProvider collectionClassProvider
      */


### PR DESCRIPTION
I realized that the Collection support class doesn't allow to check if a collection contains an array or another collection. Here is my solution suggestion. Implemented only for regular Collection class, not for LazyCollection.

Regards