### PR TITLE
Fix `get()` return type of `FilesystemAdapter`

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -123,7 +123,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * Get the contents of a file.
      *
      * @param  string  $path
-     * @return string
+     * @return string|false
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */


### PR DESCRIPTION
The `get()` May return `false`  
*FilesystemInterface.php*
```php
    /**
     * Read a file.
     *
     * @param string $path The path to the file.
     *
     * @throws FileNotFoundException
     *
     * @return string|false The file contents or false on failure.
     */
    public function read($path);
```

https://github.com/thephpleague/flysystem/blob/11003337245c4626bbe849f221c2f9e5ca604e83/src/FilesystemInterface.php#L25