### PR TITLE
[7.x] Align (fix) nested arrays support for `assertViewHas` & `assertViewMissing`

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -870,7 +870,7 @@ class TestResponse implements ArrayAccess
         $this->ensureResponseHasView();
 
         if (is_null($value)) {
-            PHPUnit::assertArrayHasKey($key, $this->original->gatherData());
+            PHPUnit::assertTrue(Arr::has($this->original->gatherData(), $key));
         } elseif ($value instanceof Closure) {
             PHPUnit::assertTrue($value(Arr::get($this->original->gatherData(), $key)));
         } elseif ($value instanceof Model) {

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -924,7 +924,7 @@ class TestResponse implements ArrayAccess
     {
         $this->ensureResponseHasView();
 
-        PHPUnit::assertArrayNotHasKey($key, $this->original->gatherData());
+        PHPUnit::assertFalse(Arr::has($this->original->gatherData(), $key));
 
         return $this;
     }

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -106,6 +106,30 @@ class TestResponseTest extends TestCase
         $response->assertViewHas('foo.nested', 'bar');
     }
 
+    public function testAssertViewMissing()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertViewMissing('baz');
+    }
+
+    public function testAssertViewMissingNested()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => [
+                'foo' => [
+                    'nested' => 'bar',
+                ],
+            ],
+        ]);
+
+        $response->assertViewMissing('foo.baz');
+    }
+
     public function testAssertSeeInOrder()
     {
         $response = $this->makeMockResponse([

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -78,6 +78,20 @@ class TestResponseTest extends TestCase
         $response->assertViewHas('foo', 'bar');
     }
 
+    public function testAssertViewHasNested()
+    {
+        $response = $this->makeMockResponse([
+            'render' => 'hello world',
+            'gatherData' => [
+                'foo' => [
+                    'nested' => 'bar',
+                ],
+            ],
+        ]);
+
+        $response->assertViewHas('foo.nested');
+    }
+
     public function testAssertViewHasWithNestedValue()
     {
         $response = $this->makeMockResponse([


### PR DESCRIPTION
This PR completes/fixes the inconsistent behaviour regarding nested array support introduced in https://github.com/laravel/framework/pull/30837

It also re-aligns the `assertViewMissing` method in a similar fashion, to be compatible with the `assertViewHas` changes proposed in this PR.

---

## assertViewHas

These were already possible:
```php
$response->assertViewHas('foo');
$response->assertViewHas('foo', 'bar');
$response->assertViewHas('foo.nested', 'bar');
```

However, this one wasn't:
```php
$response->assertViewHas('foo.nested');
```

## assertViewMissing

Similarly, this was already possible:
```php
$response->assertViewMissing('foo');
```

But this one wasn't:
```php
$response->assertViewMissing('foo.nested');
```