### PR TITLE
[7.x] Adds type definition to ColumnDefinition

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Fluent;
  * @method $this primary() Add a primary index
  * @method $this spatialIndex() Add a spatial index
  * @method $this storedAs(string $expression) Create a stored generated column (MySQL)
+ * @method $this type(string $type) Specify a type for the column
  * @method $this unique(string $indexName = null) Add a unique index
  * @method $this unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value


### PR DESCRIPTION
Sometimes need to specify another type for foreignId column
```php
$table->foreignId('type_id')
    ->type('tinyInteger')
    ->constrained('shop4_payments_types')
    ->cascadeOnDelete();
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
