### PR TITLE
[7.x] Redundant @var tag

### DIFF
--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -33,7 +33,6 @@ class MailSesTransportTest extends TestCase
         /** @var \Illuminate\Mail\Transport\SesTransport $transport */
         $transport = $manager->createTransport(['transport' => 'ses']);
 
-        /** @var \Aws\Ses\SesClient $ses */
         $ses = $transport->ses();
 
         $this->assertSame('us-east-1', $ses->getRegion());


### PR DESCRIPTION
var tag specifies the type already inferred from source code