### PR TITLE
[7.x] Add a base exception for Http exceptions

### DIFF
--- a/src/Illuminate/Http/Client/ConnectionException.php
+++ b/src/Illuminate/Http/Client/ConnectionException.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
-use Exception;
-
-class ConnectionException extends Exception
+class ConnectionException extends HttpClientException
 {
     //
 }

--- a/src/Illuminate/Http/Client/HttpClientException.php
+++ b/src/Illuminate/Http/Client/HttpClientException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Illuminate\Http\Client;
+
+use Exception;
+
+class HttpClientException extends Exception
+{
+    //
+}

--- a/src/Illuminate/Http/Client/RequestException.php
+++ b/src/Illuminate/Http/Client/RequestException.php
@@ -2,9 +2,7 @@
 
 namespace Illuminate\Http\Client;
 
-use Exception;
-
-class RequestException extends Exception
+class RequestException extends HttpClientException
 {
     /**
      * The response instance.


### PR DESCRIPTION
I suggest that we add a base exception that the exceptions thrown by the Http client can extend.

By doing that it's easy to catch any errors that will be thrown.

Here is a real-life Stripe portal integration before and after.

**Before**
``` php
try {
    $response = Http::asForm()
        ->retry(3, 500)
        ->timeout(5)
        ->withBasicAuth($secret, '')
        ->post('https://api.stripe.com/v1/billing_portal/sessions', [
            'customer' => $client->stripe_customer_id,
            'return_url' => $returnUrl,
        ])->throw();
} catch (RequestException $exception) {
    throw ClientBillingException::make('Failed to redirect to Stripe portal.', $exception);
} catch (ConnectionException $exception) {
    throw ClientBillingException::make('Failed to redirect to Stripe portal.', $exception);
}
```

**After**
``` php
try {
    $response = Http::asForm()
        ->retry(3, 500)
        ->timeout(5)
        ->withBasicAuth($secret, '')
        ->post('https://api.stripe.com/v1/billing_portal/sessions', [
            'customer' => $client->stripe_customer_id,
            'return_url' => $returnUrl,
        ])->throw();
} catch (HttpClientException $exception) {
    throw ClientBillingException::make('Failed to redirect to Stripe portal.', $exception);
}
```

This is a very simple addition which will not be a breaking change, as people can still catch the individual exceptions or the \Exception class.

I'm open to other names for the base exceptions.

I've called it "HttpClientException", but other names could be:
- ClientExecption
- HttpException
- BadResponseException

You could argue that we can just catch the \Exception class, but I don't want to do that in case that any exceptions are thrown by some other logic in the try-catch block. This could e.g. be an exception thrown by `$client->stripe_customer_id`