### PR TITLE
Fixed typo in Session Contract doc block

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -56,7 +56,7 @@ interface Session
     public function exists($key);
 
     /**
-     * Checks if an a key is present and not null.
+     * Checks if a key is present and not null.
      *
      * @param  string|array  $key
      * @return bool


### PR DESCRIPTION
I think the sentence can convey the meaning but I felt it would be more correct to say “If a key is present” rather than “if an a key present”.