### PR TITLE
[7.x] Update compileEnv() tests & param name

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -50,12 +50,12 @@ trait CompilesConditionals
     /**
      * Compile the env statements into valid PHP.
      *
-     * @param  string  $environment
+     * @param  string  $environments
      * @return string
      */
-    protected function compileEnv($environment)
+    protected function compileEnv($environments)
     {
-        return "<?php if(app()->environment{$environment}): ?>";
+        return "<?php if(app()->environment{$environments}): ?>";
     }
 
     /**

--- a/tests/View/Blade/BladeEnvironmentStatementsTest.php
+++ b/tests/View/Blade/BladeEnvironmentStatementsTest.php
@@ -19,6 +19,36 @@ boom
         $this->assertEquals($expected, $this->compiler->compileString($string));
     }
 
+    public function testEnvStatementsWithMultipleStringParamsAreCompiled()
+    {
+        $string = "@env('staging', 'production')
+breeze
+@else
+boom
+@endenv";
+        $expected = "<?php if(app()->environment('staging', 'production')): ?>
+breeze
+<?php else: ?>
+boom
+<?php endif; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
+    public function testEnvStatementsWithArrayParamAreCompiled()
+    {
+        $string = "@env(['staging', 'production'])
+breeze
+@else
+boom
+@endenv";
+        $expected = "<?php if(app()->environment(['staging', 'production'])): ?>
+breeze
+<?php else: ?>
+boom
+<?php endif; ?>";
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+
     public function testProductionStatementsAreCompiled()
     {
         $string = '@production


### PR DESCRIPTION
Adds tests for using `@env()` with multiple strings or an array, and makes the param plural in the function that the directive calls.

If this PR gets merged, I'll open one to update the corresponding docs in https://github.com/laravel/docs/blob/7.x/blade.md#control-structures