### PR TITLE
[6.x] JoinClause::on $second also supports Expression

### DIFF
--- a/src/Illuminate/Database/Query/JoinClause.php
+++ b/src/Illuminate/Database/Query/JoinClause.php
@@ -84,7 +84,7 @@ class JoinClause extends Builder
      *
      * @param  \Closure|string  $first
      * @param  string|null  $operator
-     * @param  string|null  $second
+     * @param  \Illuminate\Database\Query\Expression|string|null  $second
      * @param  string  $boolean
      * @return $this
      *


### PR DESCRIPTION
While it might seem it supports anything which is supported by `\Illuminate\Database\Query\Builder::where`, in fact it doesn't. E.g. you can't pass literal values (string or int _values_); string is strictly interpreted as column name.

_However_ expression is correctly accepted to work this around and pass a literal integer like this:
```php
            ->join('other_table', function (JoinClause $join) use ($someId): void {
                $join
                    ->on('other_table.my_table_id', '=', 'my_table.id')
                    ->on('other_table.some_id', '=', DB::raw($someId));
```