### PR TITLE
[7.x] Fix issue where Storage::path breaks when using cache due to missing method in CachedAdapter

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -116,7 +116,11 @@ class FilesystemAdapter implements CloudFilesystemContract
      */
     public function path($path)
     {
-        return $this->driver->getAdapter()->getPathPrefix().$path;
+        $adapter = $this->driver->getAdapter();
+        if ($adapter instanceof CachedAdapter) {
+             $adapter = $adapter->getAdapter();
+        }
+        return $adapter->getPathPrefix().$path;
     }
 
     /**

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -118,7 +118,7 @@ class FilesystemAdapter implements CloudFilesystemContract
     {
         $adapter = $this->driver->getAdapter();
         if ($adapter instanceof CachedAdapter) {
-             $adapter = $adapter->getAdapter();
+            $adapter = $adapter->getAdapter();
         }
         return $adapter->getPathPrefix().$path;
     }

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -117,9 +117,11 @@ class FilesystemAdapter implements CloudFilesystemContract
     public function path($path)
     {
         $adapter = $this->driver->getAdapter();
+
         if ($adapter instanceof CachedAdapter) {
             $adapter = $adapter->getAdapter();
         }
+
         return $adapter->getPathPrefix().$path;
     }
 


### PR DESCRIPTION
PR title sums everything up simply.