### PR TITLE
add / fix PHPDocs + fix typos

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -139,7 +139,7 @@ class Collection extends BaseCollection implements QueueableCollection
     /**
      * Load a relationship path if it is not already eager loaded.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  static $models
      * @param  array  $path
      * @return void
      */

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1128,7 +1128,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     /**
      * Create a new pivot model instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $parent
+     * @param  self  $parent
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -599,7 +599,7 @@ class Builder
     /**
      * Get a new join clause.
      *
-     * @param  \Illuminate\Database\Query\Builder  $parentQuery
+     * @param  self  $parentQuery
      * @param  string  $type
      * @param  string  $table
      * @return \Illuminate\Database\Query\JoinClause
@@ -1382,7 +1382,7 @@ class Builder
     /**
      * Add another query builder as a nested where to the query builder.
      *
-     * @param  $this  $query
+     * @param  static  $query
      * @param  string  $boolean
      * @return $this
      */
@@ -1484,7 +1484,7 @@ class Builder
     /**
      * Add an exists clause to the query.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  self  $query
      * @param  string  $boolean
      * @param  bool  $not
      * @return $this
@@ -3004,7 +3004,7 @@ class Builder
     /**
      * Merge an array of bindings into our bindings.
      *
-     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  self  $query
      * @return $this
      */
     public function mergeBindings(self $query)

--- a/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/MySqlGrammar.php
@@ -17,9 +17,8 @@ class MySqlGrammar extends Grammar
     /**
      * Add a "where null" clause to the query.
      *
-     * @param  string|array  $columns
-     * @param  string  $boolean
-     * @param  bool  $not
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return $this
      */
     protected function whereNull(Builder $query, $where)
@@ -36,8 +35,8 @@ class MySqlGrammar extends Grammar
     /**
      * Add a "where not null" clause to the query.
      *
-     * @param  string|array  $columns
-     * @param  string  $boolean
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $where
      * @return $this
      */
     protected function whereNotNull(Builder $query, $where)

--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -141,8 +141,8 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array|null  $headers
-     * @param  string|null  $disposition
+     * @param  array  $headers
+     * @param  string  $disposition
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function response($path, $name = null, array $headers = [], $disposition = 'inline')
@@ -175,7 +175,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  string|null  $name
-     * @param  array|null  $headers
+     * @param  array  $headers
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
     public function download($path, $name = null, array $headers = [])

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -221,7 +221,7 @@ class Factory
     /**
      * Assert how many requests have been recorded.
      *
-     * @param $count
+     * @param int $count
      * @return void
      */
     public function assertSentCount($count)

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -59,7 +59,7 @@ class PendingRequest
     /**
      * The transfer stats for the request.
      *
-     * \GuzzleHttp\TransferStats
+     * @var \GuzzleHttp\TransferStats
      */
     protected $transferStats;
 

--- a/src/Illuminate/Notifications/NotificationSender.php
+++ b/src/Illuminate/Notifications/NotificationSender.php
@@ -171,7 +171,7 @@ class NotificationSender
      * Queue the given notification instances.
      *
      * @param  mixed  $notifiables
-     * @param  array[\Illuminate\Notifications\Channels\Notification]  $notification
+     * @param  mixed  $notification
      * @return void
      */
     protected function queueNotification($notifiables, $notification)

--- a/src/Illuminate/Pagination/Paginator.php
+++ b/src/Illuminate/Pagination/Paginator.php
@@ -16,7 +16,7 @@ class Paginator extends AbstractPaginator implements Arrayable, ArrayAccess, Cou
     /**
      * Determine if there are more items in the data source.
      *
-     * @return bool
+     * @var bool
      */
     protected $hasMore;
 

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -105,7 +105,7 @@ class SyncQueue extends Queue implements QueueContract
     /**
      * Handle an exception that occurred while processing a job.
      *
-     * @param  \Illuminate\Queue\Jobs\Job  $queueJob
+     * @param  \Illuminate\Contracts\Queue\Job  $queueJob
      * @param  \Throwable  $e
      * @return void
      *

--- a/src/Illuminate/Validation/Rules/In.php
+++ b/src/Illuminate/Validation/Rules/In.php
@@ -6,6 +6,8 @@ class In
 {
     /**
      * The name of the rule.
+     *
+     * @var string
      */
     protected $rule = 'in';
 

--- a/src/Illuminate/Validation/Rules/NotIn.php
+++ b/src/Illuminate/Validation/Rules/NotIn.php
@@ -6,6 +6,8 @@ class NotIn
 {
     /**
      * The name of the rule.
+     *
+     * @var string
      */
     protected $rule = 'not_in';
 


### PR DESCRIPTION
I tested my [```Simple PHP Code Parser```](https://github.com/voku/Simple-PHP-Code-Parser) project with ```laravel/framework``` and found a few typos and PHPDoc errors.

```./simple-php-code-parser.phar php-code-checker src/ vendor/autoload.php --skip-mixed-types-as-error```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/framework/33605)
<!-- Reviewable:end -->
