### PR TITLE
[7.x] sectionMissing Blade Directive

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php
@@ -136,6 +136,17 @@ trait CompilesConditionals
     }
 
     /**
+     * Compile the section-missing statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileSectionMissing($expression)
+    {
+        return "<?php if (empty(trim(\$__env->yieldContent{$expression}))): ?>";
+    }
+
+    /**
      * Compile the if statements into valid PHP.
      *
      * @param  string  $expression

--- a/src/Illuminate/View/Concerns/ManagesLayouts.php
+++ b/src/Illuminate/View/Concerns/ManagesLayouts.php
@@ -186,6 +186,17 @@ trait ManagesLayouts
     }
 
     /**
+     * Check if section does not exist.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function sectionMissing($name)
+    {
+        return ! $this->hasSection($name);
+    }
+
+    /**
      * Get the contents of a section.
      *
      * @param  string  $name

--- a/tests/View/Blade/BladeSectionMissingTest.php
+++ b/tests/View/Blade/BladeSectionMissingTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\View\Blade;
+
+class BladeSectionMissingTest extends AbstractBladeTestCase
+{
+    public function testSectionMissingStatementsAreCompiled()
+    {
+        $string = '@sectionMissing("section")
+breeze
+@endif';
+        $expected = '<?php if (empty(trim($__env->yieldContent("section")))): ?>
+breeze
+<?php endif; ?>';
+        $this->assertEquals($expected, $this->compiler->compileString($string));
+    }
+}

--- a/tests/View/ViewFactoryTest.php
+++ b/tests/View/ViewFactoryTest.php
@@ -442,6 +442,17 @@ class ViewFactoryTest extends TestCase
         $this->assertFalse($factory->hasSection('bar'));
     }
 
+    public function testSectionMissing()
+    {
+        $factory = $this->getFactory();
+        $factory->startSection('foo');
+        echo 'hello world';
+        $factory->stopSection();
+
+        $this->assertTrue($factory->sectionMissing('bar'));
+        $this->assertFalse($factory->sectionMissing('foo'));
+    }
+
     public function testGetSection()
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds an easy to use `sectionMissing()` blade directive. This is useful in situations where you only need the inverse of `hasSection()`.

Purposed:

```blade
@sectionMissing('hero_image')
    @include('layout.alt_navigation')
@endif
```

Current:

```blade
@if (! trim($__env->yieldContent('hero_image')))
    @include('layout.alt_navigation')
@endif
```
