### PR TITLE
[7.x] Allow to use ranges on artisan queue:retry command

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -77,7 +77,7 @@ class RetryCommand extends Command
             }
         }
 
-        return array_unique(array_filter(array_map('intval', $ids)));
+        return array_filter(array_unique($ids));
     }
 
     /**

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -53,10 +53,31 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
         }
 
-        return $ids;
+        return $this->getJobIdsByList($ids);
+    }
+
+    /**
+     * Get the job IDs to be retried from argument array list.
+     *
+     * @param  array $list
+     * @return array
+     */
+    protected function getJobIdsByList(array $list)
+    {
+        $ids = [];
+
+        foreach ($list as $id) {
+            if (preg_match('/^[0-9]+\-[0-9]+$/', $id)) {
+                $ids = array_merge($ids, range(...explode('-', $id)));
+            } else {
+                $ids[] = $id;
+            }
+        }
+
+        return array_unique(array_filter(array_map('intval', $ids)));
     }
 
     /**


### PR DESCRIPTION
Sometimes we need to send to queue retry several jobs and `artisan queue:retry` onyl allow a list of plain ids.

With this PR this command could accept a range of ids to retry on queue:

```
php artisan queue:retry all

/** DUMP
array:18 [
  0 => 42
  1 => 41
  2 => 40
  3 => 39
  4 => 38
  5 => 37
  6 => 36
  7 => 35
  8 => 34
  9 => 33
  10 => 32
  11 => 31
  12 => 30
  13 => 29
  14 => 28
  15 => 27
  16 => 22
  17 => 21
]
*/
```

```
php artisan queue:retry 1 2 3

/** DUMP
array:3 [
  0 => 1
  1 => 2
  2 => 3
]
*/
```

```
php artisan queue:retry 1-10

/** DUMP
array:10 [
  0 => 1
  1 => 2
  2 => 3
  3 => 4
  4 => 5
  5 => 6
  6 => 7
  7 => 8
  8 => 9
  9 => 10
]
*/
```

```
php artisan queue:retry 1 2 3 4 5 10-20

/** DUMP
array:16 [
  0 => 1
  1 => 2
  2 => 3
  3 => 4
  4 => 5
  5 => 10
  6 => 11
  7 => 12
  8 => 13
  9 => 14
  10 => 15
  11 => 16
  12 => 17
  13 => 18
  14 => 19
  15 => 20
]
*/
```

```
php artisan queue:retry 1-10 30-40

/** DUMP   
array:21 [
  0 => 1
  1 => 2
  2 => 3
  3 => 4
  4 => 5
  5 => 6
  6 => 7
  7 => 8
  8 => 9
  9 => 10
  10 => 30
  11 => 31
  12 => 32
  13 => 33
  14 => 34
  15 => 35
  16 => 36
  17 => 37
  18 => 38
  19 => 39
  20 => 40
]
*/
```

This PR is compatible with current command usage.