### PR TITLE
[8.x] Add computed column support (storedAs, virtualAs) to SQLite

### DIFF
--- a/src/Illuminate/Database/Schema/ColumnDefinition.php
+++ b/src/Illuminate/Database/Schema/ColumnDefinition.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Schema;
 
-use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Fluent;
 
 /**
@@ -21,12 +20,12 @@ use Illuminate\Support\Fluent;
  * @method $this persisted() Mark the computed generated column as persistent (SQL Server)
  * @method $this primary() Add a primary index
  * @method $this spatialIndex() Add a spatial index
- * @method $this storedAs(string $expression) Create a stored generated column (MySQL)
+ * @method $this storedAs(string $expression) Create a stored generated column (MySQL/SQLite)
  * @method $this type(string $type) Specify a type for the column
  * @method $this unique(string $indexName = null) Add a unique index
  * @method $this unsigned() Set the INTEGER column as UNSIGNED (MySQL)
  * @method $this useCurrent() Set the TIMESTAMP column to use CURRENT_TIMESTAMP as default value
- * @method $this virtualAs(string $expression) Create a virtual generated column (MySQL)
+ * @method $this virtualAs(string $expression) Create a virtual generated column (MySQL/SQLite)
  */
 class ColumnDefinition extends Fluent
 {

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -16,7 +16,7 @@ class SQLiteGrammar extends Grammar
      *
      * @var array
      */
-    protected $modifiers = ['Nullable', 'Default', 'Increment'];
+    protected $modifiers = ['VirtualAs', 'StoredAs', 'Nullable', 'Default', 'Increment'];
 
     /**
      * The columns available as serials.
@@ -823,6 +823,47 @@ class SQLiteGrammar extends Grammar
     }
 
     /**
+     * Create the column definition for a generated, computed column type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function typeComputed(Fluent $column)
+    {
+        throw new RuntimeException('This database driver requires a type, see the virtualAs / storedAs modifiers.');
+    }
+
+    /**
+     * Get the SQL for a generated virtual column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyVirtualAs(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->virtualAs)) {
+            return " as ({$column->virtualAs})";
+        }
+    }
+
+    /**
+     * Get the SQL for a generated stored column modifier.
+     *
+     * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string|null
+     */
+    protected function modifyStoredAs(Blueprint $blueprint, Fluent $column)
+    {
+        if (! is_null($column->storedAs)) {
+            return " as ({$column->storedAs}) stored";
+        }
+    }
+
+    /**
      * Get the SQL for a nullable column modifier.
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
@@ -831,7 +872,13 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyNullable(Blueprint $blueprint, Fluent $column)
     {
-        return $column->nullable ? ' null' : ' not null';
+        if (is_null($column->virtualAs) && is_null($column->storedAs)) {
+            return $column->nullable ? ' null' : ' not null';
+        }
+
+        if ($column->nullable === false) {
+            return ' not null';
+        }
     }
 
     /**
@@ -843,7 +890,7 @@ class SQLiteGrammar extends Grammar
      */
     protected function modifyDefault(Blueprint $blueprint, Fluent $column)
     {
-        if (! is_null($column->default)) {
+        if (! is_null($column->default) && is_null($column->virtualAs) && is_null($column->storedAs)) {
             return ' default '.$this->getDefaultValue($column->default);
         }
     }

--- a/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SQLiteGrammar.php
@@ -137,7 +137,9 @@ class SQLiteGrammar extends Grammar
     {
         $columns = $this->prefixArray('add column', $this->getColumns($blueprint));
 
-        return collect($columns)->map(function ($column) use ($blueprint) {
+        return collect($columns)->reject(function ($column) {
+            return preg_match('/as \(.*\) stored/', $column) > 0;
+        })->map(function ($column) use ($blueprint) {
             return 'alter table '.$this->wrapTable($blueprint).' '.$column;
         })->all();
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -836,23 +836,23 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint = new Blueprint('products');
         $blueprint->create();
         $blueprint->integer('price');
-        $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
-        $blueprint->integer('discounted_stored')->storedAs('price - 5');
+        $blueprint->integer('discounted_virtual')->virtualAs('"price" - 5');
+        $blueprint->integer('discounted_stored')->storedAs('"price" - 5');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(1, $statements);
-        $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as (price - 5), "discounted_stored" integer as (price - 5) stored)', $statements[0]);
+        $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as ("price" - 5), "discounted_stored" integer as ("price" - 5) stored)', $statements[0]);
 
         $blueprint = new Blueprint('products');
         $blueprint->integer('price');
-        $blueprint->integer('discounted_virtual')->virtualAs('price - 5')->nullable(false);
-        $blueprint->integer('discounted_stored')->storedAs('price - 5')->nullable(false);
+        $blueprint->integer('discounted_virtual')->virtualAs('"price" - 5')->nullable(false);
+        $blueprint->integer('discounted_stored')->storedAs('"price" - 5')->nullable(false);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
         $this->assertCount(2, $statements);
         $expected = [
             'alter table "products" add column "price" integer not null',
-            'alter table "products" add column "discounted_virtual" integer as (price - 5) not null',
+            'alter table "products" add column "discounted_virtual" integer as ("price" - 5) not null',
         ];
         $this->assertSame($expected, $statements);
     }

--- a/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteSchemaGrammarTest.php
@@ -834,18 +834,14 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
     public function testAddingGeneratedColumn()
     {
         $blueprint = new Blueprint('products');
+        $blueprint->create();
         $blueprint->integer('price');
         $blueprint->integer('discounted_virtual')->virtualAs('price - 5');
         $blueprint->integer('discounted_stored')->storedAs('price - 5');
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(3, $statements);
-        $expected = [
-            'alter table "products" add column "price" integer not null',
-            'alter table "products" add column "discounted_virtual" integer as (price - 5)',
-            'alter table "products" add column "discounted_stored" integer as (price - 5) stored',
-        ];
-        $this->assertSame($expected, $statements);
+        $this->assertCount(1, $statements);
+        $this->assertSame('create table "products" ("price" integer not null, "discounted_virtual" integer as (price - 5), "discounted_stored" integer as (price - 5) stored)', $statements[0]);
 
         $blueprint = new Blueprint('products');
         $blueprint->integer('price');
@@ -853,11 +849,10 @@ class DatabaseSQLiteSchemaGrammarTest extends TestCase
         $blueprint->integer('discounted_stored')->storedAs('price - 5')->nullable(false);
         $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
 
-        $this->assertCount(3, $statements);
+        $this->assertCount(2, $statements);
         $expected = [
             'alter table "products" add column "price" integer not null',
             'alter table "products" add column "discounted_virtual" integer as (price - 5) not null',
-            'alter table "products" add column "discounted_stored" integer as (price - 5) stored not null',
         ];
         $this->assertSame($expected, $statements);
     }


### PR DESCRIPTION
This PR adds the ability to use computed columns – `storedAs` and `virtualAs` – in SQLite.

Since version [3.31.0](https://www.sqlite.org/releaselog/3_31_0.html), which released on 2020-01-22, SQLite supports computed columns.

-----

Supporting features like [useful JSON functions](https://github.com/laravel/framework/pull/31492) or computed columns can help developers to build or test concepts or ideas. Of course, in production SQLite is not the best choice. But for quickly testing an idea or a concept it can be a nice tool, especially because it's fast and no configuration – or very little – is needed.

The `Blueprint` syntax is the same as in case of MySQL, however, due to its [limitations](https://www.sqlite.org/gencol.html#limitations), some modification is required:

- "Generated columns may not have a default value...": when using the `default()` method on the column definition, in case if it's a computed column, the `default` clause will be omitted from the SQL.
- "It is not possible to ALTER TABLE ADD COLUMN a STORED column...": the `alter table add column` clause that contains the `as (...) stored` string will be omitted from the SQL.

-----

The syntax is the same as for MySQL:

```php
Schema::create('products', function (Blueprint $table) {
    $table->id();
    $table->string('name');
    $table->integer('price');
    $table->integer('tax')->virtualAs('"price" * 0.27')->nullable();
    $table->integer('discount')->storedAs('"price" - 100')->nullable();
});
```

-----

This feature requires SQLite `3.31.0` or higher. According to the documentation, Laravel supports SQLite `3.8.8` – which released on 2015-01-16, more than 5 years ago – or higher. As I mentioned, we already support various JSON functionality for SQLite, which requires at least `3.9.0`. So the documentation is incorrect about the required version currently.

Since probably no one uses SQLite in production and using homebrew it can be updated easily on a local machine, it might worth bumping the minimum supported version of SQLite for Laravel 8.x, especially if we could gain features like computed columns.

If this PR gets merged, I'll create a PR for the documentation to update the minimum required version (and the migration guide as well?).
