### PR TITLE
[7.x] Bootable trait for Artisan commands

### DIFF
--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -84,18 +84,6 @@ class Command extends SymfonyCommand
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }
-
-        $this->boot();
-    }
-
-    /**
-     * Bootstrap the command and its traits.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->bootTraits();
     }
 
     /**
@@ -165,6 +153,8 @@ class Command extends SymfonyCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->bootTraits();
+
         return (int) $this->laravel->call([$this, 'handle']);
     }
 

--- a/src/Illuminate/Console/Command.php
+++ b/src/Illuminate/Console/Command.php
@@ -84,6 +84,40 @@ class Command extends SymfonyCommand
         if (! isset($this->signature)) {
             $this->specifyParameters();
         }
+
+        $this->boot();
+    }
+
+    /**
+     * Bootstrap the command and its traits.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->bootTraits();
+    }
+
+    /**
+     * Boot all of the bootable traits on the command.
+     *
+     * @return void
+     */
+    protected function bootTraits()
+    {
+        $class = $this;
+
+        $booted = [];
+
+        foreach (class_uses_recursive($class) as $trait) {
+            $method = 'boot'.class_basename($trait);
+
+            if (method_exists($class, $method) && ! in_array($method, $booted)) {
+                call_user_func([$class, $method]);
+
+                $booted[] = $method;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to have bootable traits in console command.

Just like Eloquent models, wherein you can have a custom trait and the trait can contain a method `bootTraitClassName` which will be executed just like boot function in Eloquent model. This adds a similar behaviour for console commands.

This can be very helpful when you would like to add some functionality at the start of commands, some examples can be : 

- All commands are to be run when user provides a passkey which are given to them
- Log all console command executed from which server & when etc to a centralized logging location
- Can add global messages like if you are running a command on production environment, you can add a warning etc..

Example : 

```
<?php

namespace App\Console\Commands;

trait LogsCommands
{
    public function bootLogsCommands()
    {
        $this->info('Logging...')
        // Do some logging
    }
}
```

and then in your command, you can just use the trait.. 