### PR TITLE
[8.x] Fix #33620 Simplify testNow handling

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -14,7 +14,6 @@ use Egulias\EmailValidator\Validation\SpoofCheckValidation;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
@@ -185,19 +184,9 @@ trait ValidatesAttributes
      */
     protected function getDateTimestamp($value)
     {
-        if ($value instanceof DateTimeInterface) {
-            return $value->getTimestamp();
-        }
+        $date = is_null($value) ? null : $this->getDateTime($value);
 
-        if ($this->isTestingRelativeDateTime($value)) {
-            $date = $this->getDateTime($value);
-
-            if (! is_null($date)) {
-                return $date->getTimestamp();
-            }
-        }
-
-        return strtotime($value);
+        return $date ? $date->getTimestamp() : null;
     }
 
     /**
@@ -245,27 +234,10 @@ trait ValidatesAttributes
     protected function getDateTime($value)
     {
         try {
-            if ($this->isTestingRelativeDateTime($value)) {
-                return Date::parse($value);
-            }
-
-            return date_create($value) ?: null;
+            return Date::parse($value);
         } catch (Exception $e) {
             //
         }
-    }
-
-    /**
-     * Check if the given value should be adjusted to Carbon::getTestNow().
-     *
-     * @param  mixed  $value
-     * @return bool
-     */
-    protected function isTestingRelativeDateTime($value)
-    {
-        return Carbon::hasTestNow() && is_string($value) && (
-            $value === 'now' || Carbon::hasRelativeKeywords($value)
-        );
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -121,7 +121,7 @@ class ValidationValidatorTest extends TestCase
         $trans = $this->getIlluminateArrayTranslator();
         $v = new Validator($trans, ['foo' => 'bar'], ['foo' => 'required']);
 
-        $v->validate();
+        $this->assertSame(['foo' => 'bar'], $v->validate());
     }
 
     public function testHasFailedValidationRules()


### PR DESCRIPTION
As mentioned in https://github.com/laravel/framework/issues/33620#issuecomment-662710044 there is no particular reason to handle differently cases with or without testNow instance and return different type of instance regarding if it's relative time + testNow in use. The `getDateTime()` could simply always return a `Carbon` instance (or the class chosen by the user via the `Date` facade). And `getDateTimestamp()` could simply rely of this previous method `getDateTime()` to calculate the timestamp from it.

So we could get rid of `isTestingRelativeDateTime()` which is redundant with what Carbon does internally to detect the testNow instance and reduce the methods complexity.

This could be picked in 7.x and 6.x.

Fix #33620