### PR TITLE
[7.x] Added range option to queue:retry command

### DIFF
--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -12,7 +12,9 @@ class RetryCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:retry {id* : The ID of the failed job or "all" to retry all jobs}';
+    protected $signature = 'queue:retry
+                            {id?* : The ID of the failed job or "all" to retry all jobs}
+                            {--range=* : Range of ids (only numeric are allowed) to be retried}';
 
     /**
      * The console command description.
@@ -53,7 +55,30 @@ class RetryCommand extends Command
         $ids = (array) $this->argument('id');
 
         if (count($ids) === 1 && $ids[0] === 'all') {
-            $ids = Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+            return Arr::pluck($this->laravel['queue.failer']->all(), 'id');
+        }
+
+        if ($ranges = (array) $this->option('range')) {
+            $ids = array_merge($ids, $this->getJobIdsByRanges($ranges));
+        }
+
+        return array_values(array_filter(array_unique($ids)));
+    }
+
+    /**
+     * Get the job IDs from range option.
+     *
+     * @param  array $ranges
+     * @return array
+     */
+    protected function getJobIdsByRanges(array $ranges)
+    {
+        $ids = [];
+
+        foreach ($ranges as $range) {
+            if (preg_match('/^[0-9]+\-[0-9]+$/', $range)) {
+                $ids = array_merge($ids, range(...explode('-', $range)));
+            }
         }
 
         return $ids;

--- a/src/Illuminate/Queue/Console/RetryCommand.php
+++ b/src/Illuminate/Queue/Console/RetryCommand.php
@@ -14,7 +14,7 @@ class RetryCommand extends Command
      */
     protected $signature = 'queue:retry
                             {id?* : The ID of the failed job or "all" to retry all jobs}
-                            {--range=* : Range of ids (only numeric are allowed) to be retried}';
+                            {--range=* : Range of job IDs (numeric) to be retried}';
 
     /**
      * The console command description.
@@ -66,9 +66,9 @@ class RetryCommand extends Command
     }
 
     /**
-     * Get the job IDs from range option.
+     * Get the job IDs ranges, if applicable.
      *
-     * @param  array $ranges
+     * @param  array  $ranges
      * @return array
      */
     protected function getJobIdsByRanges(array $ranges)


### PR DESCRIPTION
Sometimes we need to send to queue retry several jobs and artisan queue:retry onyl allow a list of plain ids.

With this PR this command could accept a range of ids to retry on queue on new option `--range=*`.

This new option only allow integers as value:

```
$ php artisan queue:retry all
array:4 [
  0 => 50
  1 => 49
  2 => 48
  3 => 47
]
```
```
$ php artisan queue:retry 1
array:1 [
  0 => "1"
]
```
```
$ php artisan queue:retry 1 2
array:2 [
  0 => "1"
  1 => "2"
]
```
```
$ php artisan queue:retry a-a
array:1 [
  0 => "a-a"
]
```
```
$ php artisan queue:retry --range 10-20
array:11 [
  0 => 10
  1 => 11
  2 => 12
  3 => 13
  4 => 14
  5 => 15
  6 => 16
  7 => 17
  8 => 18
  9 => 19
  10 => 20
]
```
```
$ php artisan queue:retry 1 2 --range 10-20
array:13 [
  0 => "1"
  1 => "2"
  2 => 10
  3 => 11
  4 => 12
  5 => 13
  6 => 14
  7 => 15
  8 => 16
  9 => 17
  10 => 18
  11 => 19
  12 => 20
]
```
```
$ php artisan queue:retry 1 2 --range 10-15 --range 20-25
array:14 [
  0 => "1"
  1 => "2"
  2 => 10
  3 => 11
  4 => 12
  5 => 13
  6 => 14
  7 => 15
  8 => 20
  9 => 21
  10 => 22
  11 => 23
  12 => 24
  13 => 25
]
```
```
$ php artisan queue:retry 1 2 3 4 --range=10-10
array:5 [
  0 => "1"
  1 => "2"
  2 => "3"
  3 => "4"
  4 => 10
]
```
```
$ php artisan queue:retry 1 2 --range 15-10
array:8 [
  0 => "1"
  1 => "2"
  2 => 15
  3 => 14
  4 => 13
  5 => 12
  6 => 11
  7 => 10
]
```
This PR is compatible with current command options and don't break with custom IDs.