### PR TITLE
[7.x] Fix @param $options type of FilesystemAdapter::putFile

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -236,7 +236,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      *
      * @param  string  $path
      * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $file
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function putFile($path, $file, $options = [])
@@ -252,7 +252,7 @@ class FilesystemAdapter implements CloudFilesystemContract
      * @param  string  $path
      * @param  \Illuminate\Http\File|\Illuminate\Http\UploadedFile|string  $file
      * @param  string  $name
-     * @param  array  $options
+     * @param  array|string  $options
      * @return string|false
      */
     public function putFileAs($path, $file, $name, $options = [])


### PR DESCRIPTION
Currently, if I set `FilesystemAdapter::putFile`'s argument `$options` as `'public'`, it makes warning.

```php
FilesystemAdapter::putFile('photos', new File('/path/to/photo'), 'public');
// => Parameter #3 $options of method Illuminate\Filesystem\FilesystemAdapter::putFile() expects array, string given.
```

This PR fixes it by adding `string` to `@param`.