### PR TITLE
[7.x] Add ServerTiming middleware

### DIFF
--- a/src/Illuminate/Foundation/Http/Middleware/ServerTiming.php
+++ b/src/Illuminate/Foundation/Http/Middleware/ServerTiming.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Illuminate\Foundation\Http\Middleware;
+
+use Closure;
+
+class ServerTiming
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+        $duration = round(1000 * (microtime(true) - $request->server->get('REQUEST_TIME_FLOAT')), 2);
+        $response->headers->set('Server-Timing', 'total;desc="Request execution time";dur=' . $duration, false);
+        return $response;
+    }
+}

--- a/tests/Foundation/Http/Middleware/ServerTimingTest.php
+++ b/tests/Foundation/Http/Middleware/ServerTimingTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Illuminate\Tests\Foundation\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\ServerTiming;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+class ServerTimingTest extends TestCase
+{
+    public function testServerTimingHeader()
+    {
+        $middleware = new ServerTiming();
+        $request = Request::createFromBase(new SymfonyRequest());
+
+        $response = $middleware->handle($request, function () {
+            return new Response();
+        });
+
+        self::assertMatchesRegularExpression('/^total;desc="Request execution time";dur=\d+/', $response->headers->get('Server-Timing'));
+    }
+}
+


### PR DESCRIPTION
The PR adds a middleware to set [Server-Timing](https://www.w3.org/TR/server-timing/) header for estimating server performance.

The code is based on the following Drupal patch.
https://www.drupal.org/project/drupal/issues/3104566

For more accurate testing we may consider adopting Symfony PHPUnit bridge which supports [clock mocking](https://symfony.com/doc/current/components/phpunit_bridge.html#clock-mocking).

I am not certain if the header needs to be set by default.