### PR TITLE
[7.x] Prevent usage of get*AtColumn() when model has no timestamps

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -972,16 +972,16 @@ trait HasAttributes
      */
     public function getDates()
     {
-        if ($this->usesTimestamps()) {
-            $defaults = [
-                $this->getCreatedAtColumn(),
-                $this->getUpdatedAtColumn(),
-            ];
-
-            return array_unique(array_merge($this->dates, $defaults));
+        if (! $this->usesTimestamps()) {
+            return $this->dates;
         }
 
-        return $this->dates;
+        $defaults = [
+            $this->getCreatedAtColumn(),
+            $this->getUpdatedAtColumn(),
+        ];
+
+        return array_unique(array_merge($this->dates, $defaults));
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -977,6 +977,7 @@ trait HasAttributes
                 $this->getCreatedAtColumn(),
                 $this->getUpdatedAtColumn(),
             ];
+
             return array_unique(array_merge($this->dates, $defaults));
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -972,14 +972,15 @@ trait HasAttributes
      */
     public function getDates()
     {
-        $defaults = [
-            $this->getCreatedAtColumn(),
-            $this->getUpdatedAtColumn(),
-        ];
+        if ($this->usesTimestamps()) {
+            $defaults = [
+                $this->getCreatedAtColumn(),
+                $this->getUpdatedAtColumn(),
+            ];
+            return array_unique(array_merge($this->dates, $defaults));
+        }
 
-        return $this->usesTimestamps()
-                    ? array_unique(array_merge($this->dates, $defaults))
-                    : $this->dates;
+        return $this->dates;
     }
 
     /**


### PR DESCRIPTION
Althought it is uncommon, people may want to be able to reuse `Eloquent\Concern` traits to build their own model implementation. In my case, I used them to build models objects from multiple sources (XML mainly), and I did not want to use the `HasTimestamps` trait.
With the proposed modification, using the `HasAttributes` standalone will not require anymore to define `getCreatedAtColumn()` and `getUpdatedAtColumn()`, if `usesTimestamps()` returns `false`.

I do not know if I should add a test for this as existing usages inside framework are already tested. I can produce a test for the specific usage I mentionned if you ask me.