### PR TITLE
[7.x] Methods added for next and previous record finding by passing the current id, just like find

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -112,6 +112,29 @@ class Builder
     {
         return $this->newModelInstance($attributes);
     }
+    
+    /**
+     * This will return the next available record
+     * @param int $id
+     * @param null|default ['*'] $columns
+     * @return \Illuminate\Database\Eloquent\Builder|Model
+     */
+    public function next($id, $columns = ['*'])
+    {
+        return $this->where('id', '>', $id)->firstOrFail($columns);
+    }
+    
+    /**
+     * This will return the previous available record
+     * @param int $id
+     * @param null|default ['*'] $columns
+     * @return \Illuminate\Database\Eloquent\Builder|Model
+     */
+
+    public function previous($id, $columns = ['*'])
+    {
+        return $this->where('id', '<', $id)->firstOrFail($columns);
+    }
 
     /**
      * Register a new global scope.

--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -114,7 +114,6 @@ class Builder
     }
     
     /**
-     * This will return the next available record
      * @param int $id
      * @param null|default ['*'] $columns
      * @return \Illuminate\Database\Eloquent\Builder|Model
@@ -125,7 +124,6 @@ class Builder
     }
     
     /**
-     * This will return the previous available record
      * @param int $id
      * @param null|default ['*'] $columns
      * @return \Illuminate\Database\Eloquent\Builder|Model

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -377,7 +377,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
     
     /**
-     * This will return the next available record
      * @param int $id
      * @param null|default ['*'] $columns
      * @return \Illuminate\Database\Eloquent\Builder|Model
@@ -388,7 +387,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     }
     
     /**
-     * This will return the previous available record
      * @param int $id
      * @param null|default ['*'] $columns
      * @return \Illuminate\Database\Eloquent\Builder|Model

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -375,6 +375,28 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return $this->fill($attributes);
         });
     }
+    
+    /**
+     * This will return the next available record
+     * @param int $id
+     * @param null|default ['*'] $columns
+     * @return \Illuminate\Database\Eloquent\Builder|Model
+     */
+    public static function next($id, $columns = ['*'])
+    {
+        return static::query()->next($id, $columns = ['*']);
+    }
+    
+    /**
+     * This will return the previous available record
+     * @param int $id
+     * @param null|default ['*'] $columns
+     * @return \Illuminate\Database\Eloquent\Builder|Model
+     */
+    public static function previous($id, $columns = ['*'])
+    {
+        return static::query()->previous($id, $columns = ['*']);
+    }
 
     /**
      * Qualify the given column name by the model's table.


### PR DESCRIPTION
### Methods added for next and previous record finding by passing the current id, just like find.

Sometimes we need to find the **next** and/or the **previous** record of the database, so i added two methods named **next()** and **previous()**