### PR TITLE
[8.x] Validation: Stop requiring translation package

### DIFF
--- a/src/Illuminate/Validation/composer.json
+++ b/src/Illuminate/Validation/composer.json
@@ -22,7 +22,6 @@
         "illuminate/contracts": "^8.0",
         "illuminate/macroable": "^8.0",
         "illuminate/support": "^8.0",
-        "illuminate/translation": "^8.0",
         "symfony/http-foundation": "^5.1",
         "symfony/mime": "^5.1"
     },


### PR DESCRIPTION
As far as I can tell, the code only relies on the contracts (which is good).

This lets me use a custom translator implementation with the validation package (already the case) without loading the `illuminate/translation` package.