### PR TITLE
[7.x] Prevent to serialize uninitialized properties

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -65,6 +65,8 @@ trait SerializesModels
                 continue;
             }
 
+            $property->setAccessible(true);
+
             if (! $property->isInitialized($this)) {
                 continue;
             }

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -65,7 +65,7 @@ trait SerializesModels
                 continue;
             }
             
-            if(! $property->isInitialized($this)) {
+            if (! $property->isInitialized($this)) {
                 continue;
             }
 

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -64,6 +64,10 @@ trait SerializesModels
             if ($property->isStatic()) {
                 continue;
             }
+            
+            if(! $property->isInitialized($this)) {
+                continue;
+            }
 
             $name = $property->getName();
 

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -64,7 +64,7 @@ trait SerializesModels
             if ($property->isStatic()) {
                 continue;
             }
-            
+
             if (! $property->isInitialized($this)) {
                 continue;
             }


### PR DESCRIPTION
Fixes #33637

No need to serialize uninitialized properties.