### PR TITLE
[6.x] Prevent to serialize uninitialized properties

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -65,6 +65,12 @@ trait SerializesModels
                 continue;
             }
 
+            $property->setAccessible(true);
+
+            if (! $property->isInitialized($this)) {
+                continue;
+            }
+
             $name = $property->getName();
 
             if ($property->isPrivate()) {

--- a/tests/Integration/Queue/typed-properties.php
+++ b/tests/Integration/Queue/typed-properties.php
@@ -11,6 +11,8 @@ class TypedPropertyTestClass
 
     public ModelSerializationTestUser $user;
 
+    public ModelSerializationTestUser $unitializedUser;
+
     protected int $id;
 
     private array $names;


### PR DESCRIPTION
Fixes #33637

No need to serialize uninitialized properties.