### PR TITLE
[7.x] Add AssertSentByIndex

### DIFF
--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -190,10 +190,10 @@ class Factory
             'An expected request was not recorded.'
         );
     }
-    
+
     /**
      * Assert that a specific request / response pair was recorded matching a given truth test.
-     * 
+     *
      * @param callable $callback
      * @param int $index
      * @return void

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -190,6 +190,21 @@ class Factory
             'An expected request was not recorded.'
         );
     }
+    
+    /**
+     * Assert that a specific request / response pair was recorded matching a given truth test.
+     * 
+     * @param callable $callback
+     * @param int $index
+     * @return void
+     */
+    public function assertSentByIndex($callback, $index)
+    {
+        PHPUnit::assertTrue(
+            $callback($this->recorded[$index][0], $this->recorded[$index][1]),
+            'An expected request was not recorded.'
+        );
+    }
 
     /**
      * Assert that a request / response pair was not recorded matching a given truth test.

--- a/src/Illuminate/Http/Client/Factory.php
+++ b/src/Illuminate/Http/Client/Factory.php
@@ -202,7 +202,7 @@ class Factory
     {
         PHPUnit::assertTrue(
             $callback($this->recorded[$index][0], $this->recorded[$index][1]),
-            'An expected request was not recorded.'
+            "An expected request was not recorded at index {$index}."
         );
     }
 


### PR DESCRIPTION
Check assert sent for specific request/response pair.

Using assertSent will check all the requests sent which can be clumsy or error prone in a long sequence. 

This proposal allows checking at a specific index using assertSentByIndex.

If interested, I'll be happy to add tests.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
