### PR TITLE
[6.x] Fix missing statement preventing deletion

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -45,6 +45,10 @@ class MorphPivot extends Pivot
      */
     public function delete()
     {
+        if (isset($this->attributes[$this->getKeyName()])) {
+            return (int) parent::delete();
+        }
+        
         if ($this->fireModelEvent('deleting') === false) {
             return 0;
         }

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -48,7 +48,7 @@ class MorphPivot extends Pivot
         if (isset($this->attributes[$this->getKeyName()])) {
             return (int) parent::delete();
         }
-        
+
         if ($this->fireModelEvent('deleting') === false) {
             return 0;
         }


### PR DESCRIPTION
The MorphPivot delete method was missing a statement which prevented the deletion of many to many polymorphic custom pivot models.
This pull request is related to #33647 and should fix the issue.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
