### PR TITLE
[7.x] Add exponential sleep option to retry helper

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -388,11 +388,12 @@ if (! function_exists('retry')) {
      * @param  callable  $callback
      * @param  int  $sleep
      * @param  callable|null  $when
+     * @param  bool  $exponential
      * @return mixed
      *
      * @throws \Exception
      */
-    function retry($times, callable $callback, $sleep = 0, $when = null)
+    function retry($times, callable $callback, $sleep = 0, $when = null, $exponential = false)
     {
         $attempts = 0;
 
@@ -408,7 +409,8 @@ if (! function_exists('retry')) {
             }
 
             if ($sleep) {
-                usleep($sleep * 1000);
+                $exponent = $exponential && $attempts != 1 ? pow(2, $attempts) : 1;
+                usleep($sleep * 1000 * $exponent);
             }
 
             goto beginning;

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -495,6 +495,24 @@ class SupportHelpersTest extends TestCase
         $this->assertEqualsWithDelta(0.1, microtime(true) - $startTime, 0.02);
     }
 
+    public function testRetryWithExponentialSleep()
+    {
+        $startTime = microtime(true);
+        $attempts = retry(3, function ($attempts) {
+            if ($attempts > 2) {
+                return $attempts;
+            }
+
+            throw new RuntimeException;
+        }, 50, null, true);
+
+        // Make sure we made three attempts
+        $this->assertEquals(3, $attempts);
+
+        // Make sure we waited 50ms for the first attempt and 50ms*(2^$attempt) in the second time
+        $this->assertEqualsWithDelta(0.05 + pow(2, 2) * 0.05, microtime(true) - $startTime, 0.02);
+    }
+
     public function testRetryWithPassingWhenCallback()
     {
         $startTime = microtime(true);


### PR DESCRIPTION
Adds exponential sleep to the retry helper, if enabled the new sleep strategy will be `(2^attempts) * sleepTime`, new parameter $exponential (defaulted to false) is added to the retry helper. 

## why is this Exponential backoff helpful?
when using the retry helper on a service call that might use some cloud resources and might fail for a few consecutive seconds randomly, providing a way to increase the waiting time between delays helps on decreasing the hits on the service and allowing it to breathe and for our code to eventually succeed.