### PR TITLE
[7.x] Improve patterns used in guessing DB table name

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/TableGuesser.php
+++ b/src/Illuminate/Database/Console/Migrations/TableGuesser.php
@@ -10,8 +10,8 @@ class TableGuesser
     ];
 
     const CHANGE_PATTERNS = [
-        '/_(to|from|in)_(\w+)_table$/',
-        '/_(to|from|in)_(\w+)$/',
+        '/_(to|from|in)(?!_(?:to|from|in)_)_(\w+)_table$/',
+        '/_(to|from|in)(?!_(?:to|from|in)_)_(\w+)$/',
     ];
 
     /**


### PR DESCRIPTION
Adding a column with a name that ends with either `_to`, `_from`, or `_in` to an existing table using the `make:migration` command, produces a wrong table name on the migration file when no table is indicated with argument `--table`.

#### Example:
Let suppose we already have a table called `checks`, and we want to add a new column called `payable_to`.
```
php artisan make:migration add_payable_to_to_checks_table
```
the previous command creates the following migration file:
```php
class AddPayableToToChecksTable extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::table('to_checks', function (Blueprint $table) {
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::table('to_checks', function (Blueprint $table) {
        });
    }
}

```
We can see here that the table name `to_checks` is wrong.

I can't think of any table name that will start with `to_`, `from_`, or `in_`, but column names do end with `_to`, `_from`, or `_in`. 

Currently, the table name guessing method takes the words after the first `_to_` keyword, but actually it should take the words after the last one. To do that I used the regex's negative lookahead.

Regex without negative lookahead: [https://regexr.com/5934n](https://regexr.com/5934n)
Regex with negative lookahead: [https://regexr.com/5934q](https://regexr.com/5934q)