### PR TITLE
[6.x] Serialize not stored model

### DIFF
--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -127,6 +127,19 @@ class ModelSerializationTest extends TestCase
         $this->assertSame('taylor@laravel.com', $unSerialized->users[1]->email);
     }
 
+    public function testItSerializesNotStoredUserModel()
+    {
+        $user = new ModelSerializationTestUser([
+            'email' => 'mohamed@laravel.com',
+        ]);
+
+        $serialized = serialize(new ModelSerializationTestClass($user));
+
+        $unSerialized = unserialize($serialized);
+
+        $this->assertSame('mohamed@laravel.com', $unSerialized->user->email);
+    }
+
     public function testItFailsIfModelsOnMultiConnections()
     {
         $this->expectException(LogicException::class);


### PR DESCRIPTION
Clone of #33655, but for 6.x

---

This PR provides a failing test if a to-be-serialized model is not stored to the database.

See this example code:
```php
class ProcessPodcast implements ShouldQueue
{
    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;

    // at serialization time, this is a fresh model instance, but it's not stored to database. So obviously it has no Key yet.
    // trying to get the key for serialization will fail.
    protected Podcast $podcast;

    public function __construct(Podcast $podcast)
    {
        $this->podcast = new Podcast();
    }

    public function handle(AudioProcessor $processor)
    {
        $this->podcast->save();
    }
}
```
It might be edge-case, but in our usecase we use temporary model instances, so instances that are never actually stored to the database.

I made the PR for the failing test first to provide a platform for a short discussion, as i did not yet get a response to my comment in #33637. I'm willing to realize the fix, but I'm not sure how to do it.

---
### Suggested Fix
I've got two possible solutions:
1. we check `getQueueableEntity()` for null [here](https://github.com/laravel/framework/blob/0b12ef19623c40e22eff91a4b48cb13b3b415b25/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php#L31)
2. we expand the interface for a `isQueuable()` method (breaking change)
