### PR TITLE
[6.x] Reduces function calls.

### DIFF
--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -80,7 +80,7 @@ trait SerializesModels
             }
 
             $values[$name] = $this->getSerializedPropertyValue(
-                $this->getValue($this)
+                $property->getValue($this)
             );
         }
 

--- a/src/Illuminate/Queue/SerializesModels.php
+++ b/src/Illuminate/Queue/SerializesModels.php
@@ -80,7 +80,7 @@ trait SerializesModels
             }
 
             $values[$name] = $this->getSerializedPropertyValue(
-                $this->getPropertyValue($property)
+                $this->getValue($this)
             );
         }
 


### PR DESCRIPTION
No need to call getPropertyValue because accessible already set on the property.
