### PR TITLE
[7.x] Add channel in scheduler

### DIFF
--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -155,7 +155,7 @@ class Event
     public $exitCode;
 
     /**
-     * The channel name of the command
+     * The channel name of the command.
      *
      * @var int|null
      */

--- a/src/Illuminate/Console/Scheduling/Event.php
+++ b/src/Illuminate/Console/Scheduling/Event.php
@@ -155,6 +155,13 @@ class Event
     public $exitCode;
 
     /**
+     * The channel name of the command
+     *
+     * @var int|null
+     */
+    public $channel = 'default';
+
+    /**
      * Create a new event instance.
      *
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
@@ -894,6 +901,19 @@ class Event
     public function preventOverlapsUsing(EventMutex $mutex)
     {
         $this->mutex = $mutex;
+
+        return $this;
+    }
+
+    /**
+     * Set the channel name of the command.
+     *
+     * @param  string $channel
+     * @return $this
+     */
+    public function channel($channel)
+    {
+        $this->channel = $channel;
 
         return $this;
     }

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -19,7 +19,7 @@ class ScheduleRunCommand extends Command
      *
      * @var string
      */
-    protected $name = 'schedule:run';
+    protected $signature = 'schedule:run {channel=default}';
 
     /**
      * The console command description.
@@ -89,10 +89,16 @@ class ScheduleRunCommand extends Command
         $this->dispatcher = $dispatcher;
         $this->handler = $handler;
 
+        $currentChannel = $this->argument('channel');
+
         foreach ($this->schedule->dueEvents($this->laravel) as $event) {
             if (! $event->filtersPass($this->laravel)) {
                 $this->dispatcher->dispatch(new ScheduledTaskSkipped($event));
 
+                continue;
+            }
+
+            if($event->channel !== $currentChannel) {
                 continue;
             }
 

--- a/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleRunCommand.php
@@ -98,7 +98,7 @@ class ScheduleRunCommand extends Command
                 continue;
             }
 
-            if($event->channel !== $currentChannel) {
+            if ($event->channel !== $currentChannel) {
                 continue;
             }
 


### PR DESCRIPTION
### Scenario

I have a lot of scheduled tasks. One of them must run every 10 minutes and it takes 5 minutes to complete.

```php
$schedule->command('long:task')->everyTenMinutes();
$schedule->command('veryfast:task1')->dailyAt('10:00');
$schedule->command('veryfast:task2')->dailyAt('11:00');
$schedule->command('veryfast:task3')->everyHour();
$schedule->command('veryfast:task4')->hourly();
$schedule->command('veryfast:task5')->hourlyAt('30');
```

In this scenario, at minutes 0, 10, 20, 30, 40 and 50 the `long:task` is run but it will slow down even all the other tasks. This is because the script that triggers `scheduler:run` is single and if it found more tasks, it will run them sequentially.


### Solution

This PR introduces an optional concept: **task scheduling channels**. 
_Please note that this change is completely retro-compatible thanks to the `default` channel that is enabled, as the name, by default._

When you define scheduled command, you can add a channel to a command. 
If you do not add `channel` method, task will have `default` as channel.

```php
$schedule->command('long:task')->everyTenMinutes()->channel('longy')
$schedule->command('veryfast:task1')->dailyAt('10:00');
$schedule->command('veryfast:task2')->dailyAt('11:00');
$schedule->command('veryfast:task3')->everyHour();
$schedule->command('veryfast:task4')->hourly();
$schedule->command('veryfast:task5')->hourlyAt('30');
```

After that, you have to add a new line in your crontab:

```shell
#run laravel default scheduled tasks
* * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1 

#run laravel 'longy' scheduled tasks
* * * * * cd /path-to-your-project && php artisan schedule:run longy >> /dev/null 2>&1
```

In this case, I have two parallel "channels" triggered by crontab:
- the default channel that runs all the task without a custom channel (in the example from `veryfast:task1` to `very:task5`)
- a longy channel dedicated to the `long:task` that does not interfere with the other tasks

Obviously you can even have more channels and more tasks per channel.
Please remind that for every channel you need to create a row in crontab.
