### PR TITLE
[8.x] Add support for 'dot' notation for json() in HTTP Client Response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -50,15 +50,21 @@ class Response implements ArrayAccess
     /**
      * Get the JSON decoded body of the response as an array or scalar value.
      *
+     * @param  string|null  $key
+     * @param  mixed  $default
      * @return mixed
      */
-    public function json()
+    public function json($key = null, $default = null)
     {
         if (! $this->decoded) {
             $this->decoded = json_decode($this->body(), true);
         }
 
-        return $this->decoded;
+        if (is_null($key)) {
+            return $this->decoded;
+        }
+
+        return data_get($this->decoded, $key, $default);
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -43,6 +43,9 @@ class HttpClientTest extends TestCase
         $this->assertSame('{"result":{"foo":"bar"}}', (string) $response);
         $this->assertIsArray($response->json());
         $this->assertSame(['foo' => 'bar'], $response->json()['result']);
+        $this->assertSame(['foo' => 'bar'], $response->json('result'));
+        $this->assertSame('bar', $response->json('result.foo'));
+        $this->assertSame('default', $response->json('missing_key', 'default'));
         $this->assertSame(['foo' => 'bar'], $response['result']);
         $this->assertIsObject($response->object());
         $this->assertSame('bar', $response->object()->result->foo);


### PR DESCRIPTION
This add simple support for 'dot' notation in HTTP Client Response json() method, like in HTTP Request json() method.

It's make easier to get a specific data from a JSON response, or use a default value if the key is missing.

```php
// Before
$data = $response->json()['data']['key'] ?? null;
$data = $response['data']['key'] ?? null;

// After
$data = $response->json('data.key');
```

The current behavior is the same when no arguments are provided.