### PR TITLE
[8.x] Fix assertExactJson implementation

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -531,6 +531,44 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Assert that the response has the exact given JSON.
+     *
+     * @param  array  $data
+     * @return $this
+     */
+    public function assertExactJson(array $data)
+    {
+        $actual = $this->reorderAssocKeys((array) $this->decodeResponseJson());
+
+        $expected = $this->reorderAssocKeys($data);
+
+        PHPUnit::assertEquals(json_encode($expected), json_encode($actual));
+
+        return $this;
+    }
+
+    /**
+     * Reorder associative array keys to make it easy to compare arrays.
+     *
+     * @param array $data
+     *
+     * @return array
+     */
+    protected function reorderAssocKeys(array $data)
+    {
+        $data = Arr::dot($data);
+        ksort($data);
+
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            Arr::set($result, $key, $value);
+        }
+
+        return $result;
+    }
+
+    /**
      * Assert that the response has the similar JSON as given.
      *
      * @param  array  $data

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -531,12 +531,12 @@ class TestResponse implements ArrayAccess
     }
 
     /**
-     * Assert that the response has the exact given JSON.
+     * Assert that the response has the similar JSON as given.
      *
      * @param  array  $data
      * @return $this
      */
-    public function assertExactJson(array $data)
+    public function assertSimilarJson(array $data)
     {
         $actual = json_encode(Arr::sortRecursive(
             (array) $this->decodeResponseJson()
@@ -662,7 +662,7 @@ class TestResponse implements ArrayAccess
     public function assertJsonStructure(array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
-            return $this->assertExactJson($this->json());
+            return $this->assertSimilarJson($this->json());
         }
 
         if (is_null($responseData)) {

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -431,6 +431,33 @@ class TestResponseTest extends TestCase
         $response->assertSimilarJson($expected);
     }
 
+    public function testAssertExactJsonWithMixedWhenDataIsExactlySame()
+    {
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $resource = new JsonSerializableMixedResourcesStub;
+
+        $expected = $resource->jsonSerialize();
+
+        $response->assertExactJson($expected);
+    }
+
+    public function testAssertExactJsonWithMixedWhenDataIsSimilar()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that two strings are equal.');
+
+        $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
+
+        $resource = new JsonSerializableMixedResourcesStub;
+
+        $expected = $resource->jsonSerialize();
+        $expected['bars'][0] = ['bar' => 'foo 2', 'foo' => 'bar 2'];
+        $expected['bars'][2] = ['bar' => 'foo 0', 'foo' => 'bar 0'];
+
+        $response->assertExactJson($expected);
+    }
+
     public function testAssertJsonPath()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableSingleResourceStub));

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -415,13 +415,20 @@ class TestResponseTest extends TestCase
         $response->assertJson($resource->jsonSerialize());
     }
 
-    public function testAssertJsonWithMixed()
+    public function testAssertExactJsonWithMixed()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
         $resource = new JsonSerializableMixedResourcesStub;
 
-        $response->assertExactJson($resource->jsonSerialize());
+        $expected = $resource->jsonSerialize();
+
+        $response->assertExactJson($expected);
+
+        $expected['bars'][0] = ['bar' => 'foo 2', 'foo' => 'bar 2'];
+        $expected['bars'][2] = ['bar' => 'foo 0', 'foo' => 'bar 0'];
+
+        $response->assertExactJson($expected);
     }
 
     public function testAssertJsonPath()

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -415,7 +415,7 @@ class TestResponseTest extends TestCase
         $response->assertJson($resource->jsonSerialize());
     }
 
-    public function testAssertExactJsonWithMixed()
+    public function testAssertSimilarJsonWithMixed()
     {
         $response = TestResponse::fromBaseResponse(new Response(new JsonSerializableMixedResourcesStub));
 
@@ -423,12 +423,12 @@ class TestResponseTest extends TestCase
 
         $expected = $resource->jsonSerialize();
 
-        $response->assertExactJson($expected);
+        $response->assertSimilarJson($expected);
 
         $expected['bars'][0] = ['bar' => 'foo 2', 'foo' => 'bar 2'];
         $expected['bars'][2] = ['bar' => 'foo 0', 'foo' => 'bar 0'];
 
-        $response->assertExactJson($expected);
+        $response->assertSimilarJson($expected);
     }
 
     public function testAssertJsonPath()


### PR DESCRIPTION
The original problem - **assertExactJson** doesn't respect order of elements and it's name is very misleading - because it says this is exact json but in fact it's not. You can write test to make sure elements in response are in order you expect but this method really does not care about order and can give you false feeling your code covered in test is working as you expect.

As example when response looks like this:

```php
Route::get('/', function () {
    return response()->json([
        [
            'id' => 5,
            'name' => 'John Doe',
            'permissions' => [
                'write',
                'read',
            ]
        ],
        [
            'id' => 6,
            'name' => 'Jane Doe',
            'permissions' => [
                'first' => 'delete',
                'second' => 'update',
            ],
        ],
    ]);
});
```

Test like this:

```php
$response->assertStatus(200)->assertExactJson([
    [
        'id' => 6,
        'name' => 'Jane Doe',
        'permissions' => [
            'second' => 'update',
            'first' => 'delete',
        ],
    ],
    [
        'id' => 5,
        'name' => 'John Doe',
        'permissions' => [
            'read',
            'write',
        ]
    ],
]);
```

will pass although in original response John is 1st element and Jane 2nd and permissions for John are also in other order so for me this is definitelly not the exact same json.

What this PR does:

1. Rename current **assertExactJson** to **assertSimilarJson** (maybe other name should be used as for example **assertExactUnorderedJson** or something like this) - if someone doesn't care about order of elements in response or they will upgrade to Laravel 8, it will be pretty easy just to update all occurences to new method to avoid any failures when using new corrected method.

2. Update implementation of **assertExactJson** to respect numerical keys order but ignore associative keys order (so it does not matter if in test you give `name` or `id` first - it will still work)
