### PR TITLE
[7.x] Add withoutEagerLoads function

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -1103,6 +1103,16 @@ class Builder
     }
 
     /**
+     * Prevent all relations from being eager loaded.
+     *
+     * @return $this
+     */
+    public function withoutEagerLoads()
+    {
+        return $this->setEagerLoads([]);
+    }
+
+    /**
      * Create a new instance of the model being queried.
      *
      * @param  array  $attributes

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1255,6 +1255,20 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->withCasts(['foo' => 'bar']);
     }
 
+    public function testWithoutEagerLoads()
+    {
+        $builder = $this->getBuilder();
+        $builder->with(['orders', 'orders.lines']);
+        $eagers = $builder->getEagerLoads();
+        $this->assertEquals(['orders', 'orders.lines'], array_keys($eagers));
+
+
+        $builder->withoutEagerLoads();
+        $eagers = $builder->getEagerLoads();
+
+        $this->assertEquals([], array_keys($eagers));
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1262,7 +1262,6 @@ class DatabaseEloquentBuilderTest extends TestCase
         $eagers = $builder->getEagerLoads();
         $this->assertEquals(['orders', 'orders.lines'], array_keys($eagers));
 
-
         $builder->withoutEagerLoads();
         $eagers = $builder->getEagerLoads();
 


### PR DESCRIPTION
I have some models which use the `$with` property to automatically load related media

In one situation I have to store only the object without the eager loads I found that I can use the method `without(['media'])`
but what if in the future I added some loaded relations to so I have to update the `without(['media', 'anotherRelation])` too

I found laravel has a method called `setEagerLoads($arr)` and I can pass an empty array `[]` to clear all loaded relations 
but I think if the method name is similar to `without` method name would be easy to remember and more descriptive.

<img width="850" alt="Screen Shot 2020-07-28 at 4 22 27 AM" src="https://user-images.githubusercontent.com/29691074/88611805-213e0b80-d08a-11ea-9b57-2a552f2ae002.png">
