### PR TITLE
[6.x] Remove Model::setTable call from Model::newInstance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -398,8 +398,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             $this->getConnectionName()
         );
 
-        $model->setTable($this->getTable());
-
         return $model;
     }
 


### PR DESCRIPTION
This PR removes the `Model::setTable()` call from `Model::newInstance()`, addressing issue #33682.

When calling `Model::newInstance()` the method calls `Model::setTable()` with the return value of `Model::getTable()`. This causes an issue for anyone that has overridden the `getTable()` method to return a value not contained within the `Model::$table` property.

A prime example of this is when prefixing or suffixing a table name based on a config value, something that is often done for packages. Without this change, a developer has to also override the `setTable()` method so that it won't do anything, otherwise, prefixes or suffixes are duplicated.

I've dug around the codebase as much as I can, and while I somewhat understand the logic behind this line being present, I cannot find anything that would require it.