### PR TITLE
[7.x] Support custom message in all error views

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/views/401.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/401.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Unauthorized'))
 @section('code', '401')
-@section('message', __('Unauthorized'))
+@section('message', __($exception->getMessage() ?: 'Unauthorized'))

--- a/src/Illuminate/Foundation/Exceptions/views/404.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/404.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Not Found'))
 @section('code', '404')
-@section('message', __('Not Found'))
+@section('message', __($exception->getMessage() ?: 'Not Found'))

--- a/src/Illuminate/Foundation/Exceptions/views/419.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/419.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Page Expired'))
 @section('code', '419')
-@section('message', __('Page Expired'))
+@section('message', __($exception->getMessage() ?: 'Page Expired'))

--- a/src/Illuminate/Foundation/Exceptions/views/429.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/429.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Too Many Requests'))
 @section('code', '429')
-@section('message', __('Too Many Requests'))
+@section('message', __($exception->getMessage() ?: 'Too Many Requests'))

--- a/src/Illuminate/Foundation/Exceptions/views/500.blade.php
+++ b/src/Illuminate/Foundation/Exceptions/views/500.blade.php
@@ -2,4 +2,4 @@
 
 @section('title', __('Server Error'))
 @section('code', '500')
-@section('message', __('Server Error'))
+@section('message', __($exception->getMessage() ?: 'Server Error'))


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Purpose

This Pull Request will allow custom messages to be used in all existing error pages available by Laravel. 

All I'm doing is continuing the work that was done in the 404 page and extending it to the others.

![image](https://user-images.githubusercontent.com/22578748/88688006-f1612900-d0c6-11ea-9536-50220df81825.png)

## Why this is a safe update

This exact behaviour currently exists live for the 404 page. If the user decides not to provide a custom message, no behaviour will be changed, therefore this update is fully backwards compatible. 

## Additional comments

Since this is a very minor update with full backwards compatibility I am suggesting merging it to the latest stable branch (7.x). If anyone in the community disagrees with it, I'll be happy to change the base. 





