### PR TITLE
[8.x] Consistent boolean behaviour

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -331,9 +331,11 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        if ($value === null) {
+            return false;
+        }
 
-        return in_array($value, $acceptable, true);
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null;
     }
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1546,17 +1546,26 @@ class ValidationValidatorTest extends TestCase
     public function testValidateBoolean()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean']);
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Boolean']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'off'], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Boolean']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Boolean']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Boolean']);
         $this->assertTrue($v->passes());
@@ -1583,17 +1592,26 @@ class ValidationValidatorTest extends TestCase
     public function testValidateBool()
     {
         $trans = $this->getIlluminateArrayTranslator();
-        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool']);
+        $v = new Validator($trans, ['foo' => null], ['foo' => 'Bool']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'no'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'yes'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'off'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'on'], ['foo' => 'Bool']);
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'false'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, ['foo' => 'true'], ['foo' => 'Bool']);
-        $this->assertFalse($v->passes());
+        $this->assertTrue($v->passes());
 
         $v = new Validator($trans, [], ['foo' => 'Bool']);
         $this->assertTrue($v->passes());


### PR DESCRIPTION
Currently `boolean` validation rule differs from how request's boolean helper method works. This PR aligns the behaviour of both. More at: #33692.

PR for docs: https://github.com/laravel/docs/pull/6210