### PR TITLE
[6.x] Fixed case where app.key is not base64 encoded

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php
@@ -561,8 +561,13 @@ trait MakesHttpRequests
             return array_merge($this->defaultCookies, $this->unencryptedCookies);
         }
 
-        return collect($this->defaultCookies)->map(function ($value, $key) {
-            return encrypt(CookieValuePrefix::create($key, base64_decode(substr(config('app.key'), 7))).$value, false);
+        $appKey = config('app.key');
+        if (Str::startsWith($appKey, 'base64:')) {
+            $appKey = base64_decode(substr($appKey, 7));
+        }
+
+        return collect($this->defaultCookies)->map(function ($value, $key) use ($appKey) {
+            return encrypt(CookieValuePrefix::create($key, $appKey).$value, false);
         })->merge($this->unencryptedCookies)->all();
     }
 


### PR DESCRIPTION
Several places in the code check for `base64:` in app key:
* https://github.com/laravel/framework/blob/62d8a0772553f3dff2d52a3ab062182c5efd75a2/src/Illuminate/Encryption/EncryptionServiceProvider.php#L61
* https://github.com/laravel/framework/blob/0b12ef19623c40e22eff91a4b48cb13b3b415b25/src/Illuminate/Auth/Passwords/PasswordBrokerManager.php#L87
* https://github.com/laravel/framework/blob/0b12ef19623c40e22eff91a4b48cb13b3b415b25/src/Illuminate/Queue/QueueServiceProvider.php#L259

I like to think this case should handle it too.