### PR TITLE
[7.x] Fix validation rule 'required_unless' when other field value is boolean

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1532,11 +1532,9 @@ trait ValidatesAttributes
     {
         $this->requireParameterCount(2, $parameters, 'required_unless');
 
-        $data = Arr::get($this->data, $parameters[0]);
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        $values = array_slice($parameters, 1);
-
-        if (! in_array($data, $values)) {
+        if (! in_array($other, $values)) {
             return $this->validateRequired($attribute, $value);
         }
 


### PR DESCRIPTION
```
Validator::make(['a' => false ], [ 'b' => 'required_unless:a,false']);
```
This validator should pass, but fail, this PR fix it.