### PR TITLE
[7.x] Support the `sink` option when using Http::fake()

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -695,9 +695,9 @@ class PendingRequest
 
                 if (is_null($response)) {
                     return $handler($request, $options);
-                } elseif (is_array($response)) {
-                    return Factory::response($response);
                 }
+
+                $response = is_array($response) ? Factory::response($response) : $response;
 
                 $sink = $options['sink'] ?? null;
 

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -354,6 +354,19 @@ class PendingRequest
     }
 
     /**
+     * Specify where the body of the response will be saved.
+     *
+     * @param  $to  string|resource
+     * @return $this
+     */
+    public function sink($to)
+    {
+        return tap($this, function ($request) use ($to) {
+            return $this->options['sink'] = $to;
+        });
+    }
+
+    /**
      * Specify the timeout (in seconds) for the request.
      *
      * @param  int  $seconds
@@ -684,6 +697,23 @@ class PendingRequest
                     return $handler($request, $options);
                 } elseif (is_array($response)) {
                     return Factory::response($response);
+                }
+
+                $sink = $options['sink'] ?? null;
+
+                if ($sink) {
+                    $response->then(function ($response) use ($sink) {
+                        $body = $response->getBody()->getContents();
+
+                        if (is_string($sink)) {
+                            file_put_contents($sink, $body);
+
+                            return;
+                        }
+
+                        fwrite($sink, $body);
+                        rewind($sink);
+                    });
                 }
 
                 return $response;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -457,4 +457,17 @@ class HttpClientTest extends TestCase
         $this->assertSame(0, ftell($resource));
         $this->assertSame('abc123', stream_get_contents($resource));
     }
+
+    public function testSinkWhenStubbedByPath()
+    {
+        $this->factory->fake([
+            'foo.com/*' => ['page' => 'foo'],
+        ]);
+
+        $resource = fopen('php://temp', 'w');
+
+        $this->factory->sink($resource)->get('http://foo.com/test');
+
+        $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
+    }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -427,4 +427,34 @@ class HttpClientTest extends TestCase
                    $request->hasHeaders('X-Test-Header');
         });
     }
+
+    public function testSinkToFile()
+    {
+        $this->factory->fakeSequence()->push('abc123');
+
+        $destination = __DIR__.'/fixtures/sunk.txt';
+
+        if (file_exists($destination)) {
+            unlink($destination);
+        }
+
+        $this->factory->withOptions(['sink' => $destination])->get('https://example.com');
+
+        $this->assertFileExists($destination);
+        $this->assertSame('abc123', file_get_contents($destination));
+
+        unlink($destination);
+    }
+
+    public function testSinkToResource()
+    {
+        $this->factory->fakeSequence()->push('abc123');
+
+        $resource = fopen('php://temp', 'w');
+
+        $this->factory->sink($resource)->get('https://example.com');
+
+        $this->assertSame(0, ftell($resource));
+        $this->assertSame('abc123', stream_get_contents($resource));
+    }
 }


### PR DESCRIPTION
The [Guzzle `sink` option](http://docs.guzzlephp.org/en/stable/request-options.html#sink) allows you to save the body of the response directly to a file or resource. When using the `Http` client, sink works normally. As soon as you call `Http::fake()`, the sink option stops working, making it impossible to test code that uses the `sink` option.

This PR adds support for two common sink use-cases: saving to a file and writing to a stream. There might be more ways to use the sink option, but I couldn't figure out exactly how Guzzle handles sinking. We can fix other use-cases once people run into them.

This PR also adds a `sink()` method to the `PendingRequest` class. This makes it easier to use the option, and allows IDEs to help with auto completion.

---

Fixes https://github.com/laravel/framework/issues/33557
