### PR TITLE
[7.x] Add .env variable to PackageManifest.php instead of using hardcoded path

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Foundation;
 
 use Exception;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Env;
 
 class PackageManifest
 {
@@ -55,7 +56,7 @@ class PackageManifest
         $this->files = $files;
         $this->basePath = $basePath;
         $this->manifestPath = $manifestPath;
-        $this->vendorPath = $basePath.'/vendor';
+        $this->vendorPath = Env::get('COMPOSER_VENDOR_DIR', $basePath.'/vendor');
     }
 
     /**


### PR DESCRIPTION
When the vendor directory is moved, the command "php artisan package: discover" no longer works because the vendor path is hard-coded.

This PR allows the user to configure an environment variable COMPOSER_VENDOR_DIR so that the change of folder location is taken into account.