### PR TITLE
[7.x] Add dynamic slot name support

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -311,8 +311,14 @@ class ComponentTagCompiler
      */
     public function compileSlots(string $value)
     {
-        $value = preg_replace_callback('/<\s*x[\-\:]slot\s+name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+))\s*>/', function ($matches) {
-            return " @slot('".$this->stripQuotes($matches['name'])."') ";
+        $value = preg_replace_callback('/<\s*x[\-\:]slot\s+(:?)name=(?<name>(\"[^\"]+\"|\\\'[^\\\']+\\\'|[^\s>]+))\s*>/', function ($matches) {
+            $name = $this->stripQuotes($matches['name']);
+
+            if ($matches[1] !== ':') {
+                $name = "'{$name}'";
+            }
+
+            return " @slot({$name}) ";
         }, $value);
 
         return preg_replace('/<\/\s*x[\-\:]slot[^>]*>/', ' @endslot', $value);

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -26,6 +26,14 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $this->assertSame("@slot('foo') \n".' @endslot', trim($result));
     }
 
+    public function testDynamicSlotsCanBeCompiled()
+    {
+        $result = $this->compiler()->compileSlots('<x-slot :name="$foo">
+</x-slot>');
+
+        $this->assertSame("@slot(\$foo) \n".' @endslot', trim($result));
+    }
+
     public function testBasicComponentParsing()
     {
         $this->mockViewFactory();


### PR DESCRIPTION
This pr adds support for dynamic slot names using the `:` prefix:

```php
<x-slot :name="$foo">
    {{-- ... --}}
</x-slot>
```