### PR TITLE
[7.x] Add plain mail to notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -90,7 +90,10 @@ class MailChannel
     protected function buildView($message)
     {
         if ($message->view) {
-            return $message->view;
+            return [
+                'html' => $message->view,
+                'text' => $message->textView,
+            ];
         }
 
         if (property_exists($message, 'theme') && ! is_null($message->theme)) {
@@ -115,7 +118,8 @@ class MailChannel
             '__laravel_notification_id' => $notification->id,
             '__laravel_notification' => get_class($notification),
             '__laravel_notification_queued' => in_array(
-                ShouldQueue::class, class_implements($notification)
+                ShouldQueue::class,
+                class_implements($notification)
             ),
         ];
     }

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -18,6 +18,13 @@ class MailMessage extends SimpleMessage implements Renderable
     public $view;
 
     /**
+     * The plain text view to use for the message.
+     *
+     * @var string
+     */
+    public $textView;
+
+    /**
      * The view data for the message.
      *
      * @var array
@@ -104,9 +111,24 @@ class MailMessage extends SimpleMessage implements Renderable
     public function view($view, array $data = [])
     {
         $this->view = $view;
-        $this->viewData = $data;
+        $this->viewData = array_merge($this->viewData, $data);
 
         $this->markdown = null;
+
+        return $this;
+    }
+
+    /**
+     * Set the plain text view for the message.
+     *
+     * @param  string  $textView
+     * @param  array  $data
+     * @return $this
+     */
+    public function text($textView, array $data = [])
+    {
+        $this->textView = $textView;
+        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -311,7 +333,8 @@ class MailMessage extends SimpleMessage implements Renderable
     {
         if (isset($this->view)) {
             return Container::getInstance()->make('mailer')->render(
-                $this->view, $this->data()
+                [$this->view, $this->textView],
+                $this->data()
             );
         }
 

--- a/tests/Integration/Notifications/Fixtures/html.blade.php
+++ b/tests/Integration/Notifications/Fixtures/html.blade.php
@@ -1,0 +1,1 @@
+htmlContent

--- a/tests/Integration/Notifications/Fixtures/plain.blade.php
+++ b/tests/Integration/Notifications/Fixtures/plain.blade.php
@@ -1,0 +1,1 @@
+plainContent

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -363,3 +363,18 @@ class TestMailNotificationWithMailable extends Notification
         return $mailable;
     }
 }
+
+class TestMailNotificationWithPlain extends Notification
+{
+    public function via($notifiable)
+    {
+        return [MailChannel::class];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->view('html')
+            ->text('plain');
+    }
+}

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -17,6 +17,36 @@ class NotificationMailMessageTest extends TestCase
 
         $this->assertSame('notifications::foo', $message->markdown);
     }
+    public function testHtmlView()
+    {
+        $message = new MailMessage;
+
+        $this->assertSame(null, $message->view);
+        $this->assertSame([], $message->viewData);
+
+        $message->view('notifications::foo', [
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame('notifications::foo', $message->view);
+        $this->assertSame(['foo' => 'bar'], $message->viewData);
+    }
+
+    public function testPlainView()
+    {
+        $message = new MailMessage;
+
+        $this->assertSame(null, $message->textView);
+        $this->assertSame([], $message->viewData);
+
+        $message->text('notifications::foo', [
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame('notifications::foo', $message->textView);
+        $this->assertSame(['foo' => 'bar'], $message->viewData);
+    }
+
 
     public function testCcIsSetCorrectly()
     {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This pull request introduces the possibility to add a plain version to an html mail which are send via notifications.

Tools like SpamAssassin give a lower score if no plain version is attached to an email. So it would be better to make it possible to attach a plain version to notifications.

It is also still possible to send pure html emails without a plain version.

#33699 as issue