### PR TITLE
[7.x] Add isNotFilled() method to Request

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -126,6 +126,25 @@ trait InteractsWithInput
     }
 
     /**
+     * Determine if the request contains an empty value for an input item.
+     *
+     * @param  string|array  $key
+     * @return bool
+     */
+    public function empty($key)
+    {
+        $keys = is_array($key) ? $key : func_get_args();
+
+        foreach ($keys as $value) {
+            if (! $this->isEmptyString($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Determine if the request contains a non-empty value for any of the given inputs.
      *
      * @param  string|array  $keys

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -131,7 +131,7 @@ trait InteractsWithInput
      * @param  string|array  $key
      * @return bool
      */
-    public function empty($key)
+    public function isNotFilled($key)
     {
         $keys = is_array($key) ? $key : func_get_args();
 

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -368,21 +368,21 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->filled('foo.bar'));
     }
 
-    public function testEmptyMethod()
+    public function testIsNotFilledMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
-        $this->assertFalse($request->empty('name'));
-        $this->assertTrue($request->empty('age'));
-        $this->assertTrue($request->empty('city'));
-        $this->assertTrue($request->empty('foo'));
-        $this->assertFalse($request->empty(['name', 'email']));
-        $this->assertTrue($request->empty(['foo', 'age']));
-        $this->assertTrue($request->empty(['age', 'city']));
+        $this->assertFalse($request->isNotFilled('name'));
+        $this->assertTrue($request->isNotFilled('age'));
+        $this->assertTrue($request->isNotFilled('city'));
+        $this->assertTrue($request->isNotFilled('foo'));
+        $this->assertFalse($request->isNotFilled(['name', 'email']));
+        $this->assertTrue($request->isNotFilled(['foo', 'age']));
+        $this->assertTrue($request->isNotFilled(['age', 'city']));
 
         $request = Request::create('/', 'GET', ['foo' => ['bar', 'baz' => '0']]);
-        $this->assertFalse($request->empty('foo'));
-        $this->assertTrue($request->empty('foo.bar'));
-        $this->assertFalse($request->empty('foo.baz'));
+        $this->assertFalse($request->isNotFilled('foo'));
+        $this->assertTrue($request->isNotFilled('foo.bar'));
+        $this->assertFalse($request->isNotFilled('foo.baz'));
     }
 
     public function testFilledAnyMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -368,6 +368,23 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->filled('foo.bar'));
     }
 
+    public function testEmptyMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+        $this->assertFalse($request->empty('name'));
+        $this->assertTrue($request->empty('age'));
+        $this->assertTrue($request->empty('city'));
+        $this->assertTrue($request->empty('foo'));
+        $this->assertFalse($request->empty(['name', 'email']));
+        $this->assertTrue($request->empty(['foo', 'age']));
+        $this->assertTrue($request->empty(['age', 'city']));
+
+        $request = Request::create('/', 'GET', ['foo' => ['bar', 'baz' => '0']]);
+        $this->assertFalse($request->empty('foo'));
+        $this->assertTrue($request->empty('foo.bar'));
+        $this->assertFalse($request->empty('foo.baz'));
+    }
+
     public function testFilledAnyMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
Very often, I use `! $request->filled()`, and it's ok, I can live with it. But I would love to have an `empty()` method. So, instead of:

```php
if (! $request->filled('recaptcha')) {
    // TODO
}
```

Would be possible to use:

```php
if ($request->empty('recaptcha')) {
    // TODO
}
```

The `empty()` method here is just the opposite of `filled()` (in the sense of behavior) to maintain the cognitive consistency when using one or another.

About the name, if `empty()` isn't that good, we can choose another one, but I prefer the first one.

Ps: I know I can use a macro if this gets rejected. :grin: 