### PR TITLE
[5.5] change array_key_exists to isset

### DIFF
--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -46,7 +46,7 @@ trait DelegatesToResource
      */
     public function offsetExists($offset)
     {
-        return array_key_exists($offset, $this->resource);
+        return isset($offset, $this->resource);
     }
 
     /**


### PR DESCRIPTION
Because array_key_exists are deprecated on PHP latest version

![image](https://user-images.githubusercontent.com/8466308/89132488-c3546c80-d53e-11ea-944a-0c28e5cccd49.png)

