### PR TITLE
[8.x] Add the ability to pass parameters to Seeders call

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -28,9 +28,10 @@ abstract class Seeder
      *
      * @param  array|string  $class
      * @param  bool  $silent
+     * @param  mixed ...$params
      * @return $this
      */
-    public function call($class, $silent = false)
+    public function call($class, $silent = false, ...$params)
     {
         $classes = Arr::wrap($class);
 
@@ -45,7 +46,7 @@ abstract class Seeder
 
             $startTime = microtime(true);
 
-            $seeder->__invoke();
+            $seeder->__invoke(...$params);
 
             $runTime = round(microtime(true) - $startTime, 2);
 
@@ -61,11 +62,12 @@ abstract class Seeder
      * Silently seed the given connection from the given path.
      *
      * @param  array|string  $class
+     * @param  mixed ...$params
      * @return void
      */
-    public function callSilent($class)
+    public function callSilent($class, ...$params)
     {
-        $this->call($class, true);
+        $this->call($class, true, ...$params);
     }
 
     /**
@@ -120,18 +122,19 @@ abstract class Seeder
     /**
      * Run the database seeds.
      *
+     * @param  mixed ...$params
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public function __invoke()
+    public function __invoke(...$params)
     {
         if (! method_exists($this, 'run')) {
             throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
         return isset($this->container)
-                    ? $this->container->call([$this, 'run'])
-                    : $this->run();
+                    ? $this->container->call([$this, 'run'], $params)
+                    : $this->run(...$params);
     }
 }

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -20,7 +20,7 @@ class TestSeeder extends Seeder
 
 class TestDepsSeeder extends Seeder
 {
-    public function run(Mock $someDependency)
+    public function run(Mock $someDependency, $someParam = '')
     {
         //
     }
@@ -76,6 +76,19 @@ class DatabaseSeederTest extends TestCase
 
         $seeder->__invoke();
 
-        $container->shouldHaveReceived('call')->once()->with([$seeder, 'run']);
+        $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], []);
+    }
+
+    public function testSendParamsOnCallMethodWithDeps()
+    {
+        $container = m::mock(Container::class);
+        $container->shouldReceive('call');
+
+        $seeder = new TestDepsSeeder;
+        $seeder->setContainer($container);
+
+        $seeder->__invoke('test1', 'test2');
+
+        $container->shouldHaveReceived('call')->once()->with([$seeder, 'run'], ['test1', 'test2']);
     }
 }


### PR DESCRIPTION
Currently passing parameters to seeders call requires to go trough hoops and overwriting base methods of the seeders class
Eg: https://stackoverflow.com/questions/32342289/laravel-passing-variables-from-one-seed-file-to-another/32921227#32921227 

This PR allows to pass parameters when invoking seeders

```php
$this->call(UserTableSeeder::class, false, "Param1", "Param2");
$this->callSilent(UserTableSeeder::class, "Param1", "Param2");

class UserTableSeeder extends Seeder {
    public function run($param1 = null, $param2 = null) {
        // Do something according to $params
    }
}
```

Edit: For future readers this has been changed and is now
```php
$this->callWith(UserTableSeeder::class, ["Param1", "Param2"]);

class UserTableSeeder extends Seeder {
    public function run($param1 = null, $param2 = null) {
        // Do something according to $params
    }
}
```