### PR TITLE
[7.x] Http client response UTF-8 without BOM (Remove BOM from response body)

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -56,7 +56,7 @@ class Response implements ArrayAccess
     public function utf8WithoutBom($string)
     {
         if (
-            mb_detect_encoding($string) === "UTF-8"
+            mb_detect_encoding($string) === 'UTF-8'
             && substr($string, 0, 3) === "\xEF\xBB\xBF"
         ) {
             return substr($string, 3);

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -44,7 +44,25 @@ class Response implements ArrayAccess
      */
     public function body()
     {
-        return (string) $this->response->getBody();
+        return $this->utf8WithoutBom((string) $this->response->getBody());
+    }
+
+    /**
+     * Get UTF-8 Without BOM string if UTF-8 string.
+     *
+     * @param  string  $string
+     * @return string
+     */
+    public function utf8WithoutBom($string)
+    {
+        if (
+            mb_detect_encoding($string) === "UTF-8"
+            && substr($string, 0, 3) === "\xEF\xBB\xBF"
+        ) {
+            return substr($string, 3);
+        }
+
+        return $string;
     }
 
     /**

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -470,4 +470,15 @@ class HttpClientTest extends TestCase
 
         $this->assertSame(json_encode(['page' => 'foo']), stream_get_contents($resource));
     }
+
+    public function testResponseUtf8WithoutBom()
+    {
+        $this->factory->fake([
+            '*' => $this->factory->response("\xEF\xBB\xBFFooBar"),
+        ]);
+
+        $response = $this->factory->get('https://laravel.com');
+
+        $this->assertSame('FooBar', $response->body());
+    }
 }


### PR DESCRIPTION
If response `UTF-8 with BOM`, `json_decode` return `null` with syntax error.
but BOM is not visible. It is not easy to find.

so I think, if response UTF-8 then need remove bom.