### PR TITLE
[7.x] Add Collection::sortUsing method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1151,7 +1151,7 @@ class Collection implements ArrayAccess, Enumerable
     /**
      * Sort the collection using the given callbacks.
      *
-     * @param mixed ...$parameters
+     * @param  mixed  ...$parameters
      * @return static
      */
     public function sortByMany(...$parameters)

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1157,21 +1157,9 @@ class Collection implements ArrayAccess, Enumerable
      */
     public function sortUsing(Closure $callback)
     {
-        $items = $this->items;
-
-        $sorts = tap(new Sort, $callback)->all();
-
-        $parameters = [];
-
-        foreach ($sorts as [$callback, $options, $direction]) {
-            $column = $this->map($this->valueRetriever($callback))->toArray();
-
-            $parameters = array_merge($parameters, [$column, $options, $direction]);
-        }
-
-        $parameters[] = &$items;
-
-        array_multisort(...$parameters);
+        $items = tap(new Sort($this->items, function ($key) {
+            return $this->valueRetriever($key);
+        }), $callback)->get();
 
         return new static($items);
     }

--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1149,6 +1149,32 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Sort the collection using the given callbacks.
+     *
+     * @param mixed ...$parameters
+     * @return static
+     */
+    public function sortByMany(...$parameters)
+    {
+        $parameters = array_map(function ($parameter) {
+            if (is_bool($parameter)) {
+                return $parameter ? SORT_DESC : SORT_ASC;
+            }
+            if (is_int($parameter)) {
+                return $parameter;
+            }
+
+            return $this->map($this->valueRetriever($parameter))->toArray();
+        }, $parameters);
+
+        $parameters[] = $this->items;
+
+        array_multisort(...$parameters);
+
+        return new static(Arr::last($parameters));
+    }
+
+    /**
      * Sort the collection keys.
      *
      * @param  int  $options

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1103,7 +1103,7 @@ class LazyCollection implements Enumerable
     /**
      * Sort the collection using the given callbacks.
      *
-     * @param mixed ...$parameters
+     * @param  mixed  ...$parameters
      * @return static
      */
     public function sortByMany(...$parameters)

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1101,6 +1101,17 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Sort the collection using the given callbacks.
+     *
+     * @param mixed ...$parameters
+     * @return static
+     */
+    public function sortByMany(...$parameters)
+    {
+        return $this->passthru('sortByMany', func_get_args());
+    }
+
+    /**
      * Sort the collection keys.
      *
      * @param  int  $options

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1101,14 +1101,14 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Sort the collection using the given callbacks.
+     * Sort the collection on one or more attributes using the given callback.
      *
-     * @param  mixed  ...$parameters
+     * @param  Closure  $callback
      * @return static
      */
-    public function sortByMany(...$parameters)
+    public function sortUsing(Closure $callback)
     {
-        return $this->passthru('sortByMany', func_get_args());
+        return $this->passthru('sortUsing', func_get_args());
     }
 
     /**

--- a/src/Illuminate/Support/Sort.php
+++ b/src/Illuminate/Support/Sort.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Illuminate\Support;
+
+class Sort
+{
+    protected $parameters = [];
+
+    /**
+     * Add a sort in ascending order using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @return static
+     */
+    public function asc($callback, $options = SORT_REGULAR)
+    {
+        return $this->sort($callback, $options);
+    }
+
+    /**
+     * Add a sort in descending order using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @return static
+     */
+    public function desc($callback, $options = SORT_REGULAR)
+    {
+        return $this->sort($callback, $options, true);
+    }
+
+    /**
+     * Add a sort using the given callback.
+     *
+     * @param  callable|string  $callback
+     * @param  int  $options
+     * @param  bool  $descending
+     * @return static
+     */
+    public function sort($callback, $options = SORT_REGULAR, $descending = false)
+    {
+        $this->parameters[] = [$callback, $options, $descending ? SORT_DESC : SORT_ASC];
+
+        return $this;
+    }
+
+    /**
+     * Get all of the sort parameters as an array.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Illuminate/Support/Sort.php
+++ b/src/Illuminate/Support/Sort.php
@@ -4,7 +4,36 @@ namespace Illuminate\Support;
 
 class Sort
 {
+    /**
+     * The items to be sorted.
+     *
+     * @var array
+     */
+    protected $items = [];
+
+    /**
+     * The sort parameters.
+     *
+     * @var array
+     */
     protected $parameters = [];
+
+    /**
+     * @var callable
+     */
+    private $valueRetriever;
+
+    /**
+     * Create a new sort.
+     *
+     * @param  array  $items
+     * @param  callable  $valueRetriever
+     */
+    public function __construct(array $items, callable $valueRetriever)
+    {
+        $this->items = $items;
+        $this->valueRetriever = $valueRetriever;
+    }
 
     /**
      * Add a sort in ascending order using the given callback.
@@ -46,12 +75,27 @@ class Sort
     }
 
     /**
-     * Get all of the sort parameters as an array.
+     * Get the sorted items.
      *
      * @return array
      */
-    public function all()
+    public function get()
     {
-        return $this->parameters;
+        $parameters = [];
+
+        foreach ($this->parameters as [$callback, $options, $direction]) {
+            $column = array_map(
+                ($this->valueRetriever)($callback),
+                $this->items,
+                array_keys($this->items)
+            );
+
+            $parameters = array_merge($parameters, [$column, $options, $direction]);
+        }
+        $parameters[] = &$this->items;
+
+        array_multisort(...$parameters);
+
+        return $this->items;
     }
 }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1527,14 +1527,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testSortByMany($collection)
+    public function testSortUsing($collection)
     {
         $data = new $collection([
             ['price' => 5.00, 'rating' => 5],
             ['price' => 4.00, 'rating' => 5],
             ['price' => 4.00, 'rating' => 4],
         ]);
-        $data = $data->sortByMany('rating', true, 'price');
+        $data = $data->sortUsing(function ($sort) {
+            $sort->desc('rating')->asc('price');
+        });
 
         $this->assertEquals([
             ['price' => 4.00, 'rating' => 5],
@@ -1546,14 +1548,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testSortByManyWithOptions($collection)
+    public function testSortUsingWithOptions($collection)
     {
         $data = new $collection([
             ['price' => '$5.00', 'rating' => 5],
             ['price' => '$14.00', 'rating' => 5],
             ['price' => '$4.00', 'rating' => 4],
         ]);
-        $data = $data->sortByMany('rating', SORT_DESC, 'price', SORT_NATURAL);
+        $data = $data->sortUsing(function ($sort) {
+            $sort->desc('rating')->asc('price', SORT_NATURAL);
+        });
 
         $this->assertEquals([
             ['price' => '$5.00', 'rating' => 5],
@@ -1565,16 +1569,17 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testSortByManyWithCallback($collection)
+    public function testSortUsingWithCallback($collection)
     {
-        // todo
         $data = new $collection([
             ['price' => 4.00, 'rating' => 4, 'markup' => 1.20],
             ['price' => 4.00, 'rating' => 5, 'markup' => 1.50],
             ['price' => 5.00, 'rating' => 5, 'markup' => 1.10],
         ]);
-        $data = $data->sortByMany('rating', true, function ($item) {
-            return $item['price'] * $item['markup'];
+        $data = $data->sortUsing(function ($sort) {
+            $sort->desc('rating')->asc(function ($item) {
+                return $item['price'] * $item['markup'];
+            });
         });
 
         $this->assertEquals([

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1527,6 +1527,66 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testSortByMany($collection)
+    {
+        $data = new $collection([
+            ['price' => 5.00, 'rating' => 5],
+            ['price' => 4.00, 'rating' => 5],
+            ['price' => 4.00, 'rating' => 4],
+        ]);
+        $data = $data->sortByMany('rating', true, 'price');
+
+        $this->assertEquals([
+            ['price' => 4.00, 'rating' => 5],
+            ['price' => 5.00, 'rating' => 5],
+            ['price' => 4.00, 'rating' => 4],
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortByManyWithOptions($collection)
+    {
+        $data = new $collection([
+            ['price' => '$5.00', 'rating' => 5],
+            ['price' => '$14.00', 'rating' => 5],
+            ['price' => '$4.00', 'rating' => 4],
+        ]);
+        $data = $data->sortByMany('rating', SORT_DESC, 'price', SORT_NATURAL);
+
+        $this->assertEquals([
+            ['price' => '$5.00', 'rating' => 5],
+            ['price' => '$14.00', 'rating' => 5],
+            ['price' => '$4.00', 'rating' => 4],
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testSortByManyWithCallback($collection)
+    {
+        // todo
+        $data = new $collection([
+            ['price' => 4.00, 'rating' => 4, 'markup' => 1.20],
+            ['price' => 4.00, 'rating' => 5, 'markup' => 1.50],
+            ['price' => 5.00, 'rating' => 5, 'markup' => 1.10],
+        ]);
+        $data = $data->sortByMany('rating', true, function ($item) {
+            return $item['price'] * $item['markup'];
+        });
+
+        $this->assertEquals([
+            ['price' => 5.00, 'rating' => 5, 'markup' => 1.10],
+            ['price' => 4.00, 'rating' => 5, 'markup' => 1.50],
+            ['price' => 4.00, 'rating' => 4, 'markup' => 1.20],
+        ], $data->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testSortKeys($collection)
     {
         $data = new $collection(['b' => 'dayle', 'a' => 'taylor']);


### PR DESCRIPTION
### Overview

This pull request adds a new collection method, `sortByMany`.

The `sortByMany` method sorts the collection by the given keys.

```php
$collection = collect([
    ['price' => 5.00, 'rating' => 5],
    ['price' => 4.00, 'rating' => 5],
    ['price' => 4.00, 'rating' => 4]
]);

$sorted = $collection->sortByMany('rating', SORT_DESC, 'price');

$sorted->values()->all();

/*
    [
        ['price' => 4.00, 'rating' => 5],
        ['price' => 5.00, 'rating' => 5],
        ['price' => 4.00, 'rating' => 4],
    ]
*/
```

You may pass as many keys as necessary. The collection is sorted in ascending order by default. To sort in descending order you may pass the constant `SORT_DESC` or boolean `false` immediately following the sort key. If you would like to provide any sort options you can specify those after the key as well.

You can also pass your own callback to determine how to sort the collection values:

```php
$collection = collect([
    ['price' => 4.00, 'rating' => 4, 'markup' => 1.20],
    ['price' => 4.00, 'rating' => 5, 'markup' => 1.50],
    ['price' => 5.00, 'rating' => 5, 'markup' => 1.10],
]);

$sorted = $collection->sortByMany('rating', SORT_DESC, fn ($item) => $item['price'] * $item['markup']);

$sorted->values()->all();

/*
    [
        ['price' => 5.00, 'rating' => 5, 'markup' => 1.10],
        ['price' => 4.00, 'rating' => 5, 'markup' => 1.50],
        ['price' => 4.00, 'rating' => 4, 'markup' => 1.20],
    ]
*/
```

### Alternatives

You can see examples of the alternatives developers are using now in [this laravel/ideas thread](https://github.com/laravel/ideas/issues/11).

Many developers attempt to chain multiple sort methods in reverse order to accomplish this, but that doesn't work reliably.

```php
$collection = collect([
    ['price' => 5.00, 'rating' => 5],
    ['price' => 4.00, 'rating' => 5],
    ['price' => 4.00, 'rating' => 4]
]);

$sorted = $collection->sortBy('price')->sortByDesc('rating');

$sorted->values()->all();

/*
    [
        ['price' => 5.00, 'rating' => 5],
        ['price' => 4.00, 'rating' => 5],
        ['price' => 4.00, 'rating' => 4]
    ]
*/
```

If you are sorting every key in the same direction you can use sortBy or sortByDesc with a callback that returns an array:

```php
$sorted = $collection->sortBy(fn ($item) => [$item->rating, $item->price]);
```

If you need to sort with different directions per key you must write a sort function:

```php
$sorted = $collection->sort(
    fn ($a, $b) => [$b['rating'], $a['price']] <=> [$a['rating'], $b['price']]
);
```

If you need to sort by multiple keys and use sort flags such as `SORT_LOCALE_STRING`, you can't -- your must either emulate the behavior of the flag within your sort function or write your own macro.

### How it works

Under the hood the sortByMany method uses [`array_multisort`](https://www.php.net/manual/en/function.array-multisort.php). How it works is very similar to the 'Sorting database results' example from the PHP manual.

If the key is a string it's converted to a [value retriever callback](https://github.com/laravel/framework/blob/6023f696ddf0bd26c7f2257df38d246b8d391753/src/Illuminate/Support/Traits/EnumeratesValues.php#L957). The collection is then mapped to retrieve the values for that key, because `array_multisort` requires an array of columns. The sort order and any sort flags are passed through to `array_multisort`. The collection items are provided as the last argument to sort by the common key. A new collection is then returned using the sorted items.

### Design Notes

I opted to add a new method instead of making `sortBy` variadic because the signature for `sortBy` is too restrictive. `sortby` requires passing the `$options` and `$descending` boolean after each key/callback. `sortByMany` does not -- you can omit the options and the descending parameter entirely, only provide one or the other, or swap the order. We could extend `sortBy` to support this but it would be hard to do without making the code complicated and slow. `array_multisort` will always be slower and use more memory than `asort`, so even if we did make `sortBy` variadic there would be two distinct code paths depending on the # of arguments.

I chose to support boolean arguments for descending for consistency with the `sortBy` method.

Only `string` or `callable` types are supported for the key/callback argument. If you attempt to pass an integer it will be interpreted as a sort flag. To avoid this cast it to a string.

The name was chosen for consistency with the config repository, cache store, and other Laravel interfaces that use the `*Many` naming convention.

This should not be a breaking change as it's adding a brand new method without altering the behavior of any existing methods.