### PR TITLE
[8.x] Support operators containing a question mark

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -249,8 +249,14 @@ class Grammar extends BaseGrammar
     protected function whereBasic(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
+        $operator = $where['operator'];
 
-        return $this->wrap($where['column']).' '.$where['operator'].' '.$value;
+        // @see https://wiki.php.net/rfc/pdo_escape_placeholders
+        if (Str::contains(strtolower($operator), '?')) {
+            $operator = str_replace('?', '??', $operator);
+        }
+
+        return $this->wrap($where['column']).' '.$operator.' '.$value;
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -249,12 +249,9 @@ class Grammar extends BaseGrammar
     protected function whereBasic(Builder $query, $where)
     {
         $value = $this->parameter($where['value']);
-        $operator = $where['operator'];
 
         // @see https://wiki.php.net/rfc/pdo_escape_placeholders
-        if (Str::contains(strtolower($operator), '?')) {
-            $operator = str_replace('?', '??', $operator);
-        }
+        $operator = str_replace('?', '??', $where['operator']);
 
         return $this->wrap($where['column']).' '.$operator.' '.$value;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3696,6 +3696,14 @@ SQL;
         $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
+    protected function getConnection()
+    {
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        return $connection;
+    }
+
     protected function getBuilder()
     {
         $grammar = new Grammar;

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3681,12 +3681,19 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
-    protected function getConnection()
+    public function testFromQuestionMarkOperatorOnPostgres()
     {
-        $connection = m::mock(ConnectionInterface::class);
-        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('roles', '?', 'superuser');
+        $this->assertSame('select * from "users" where "roles" ?? ?', $builder->toSql());
 
-        return $connection;
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('roles', '?|', 'superuser');
+        $this->assertSame('select * from "users" where "roles" ??| ?', $builder->toSql());
+
+        $builder = $this->getPostgresBuilder();
+        $builder->select('*')->from('users')->where('roles', '?&', 'superuser');
+        $this->assertSame('select * from "users" where "roles" ??& ?', $builder->toSql());
     }
 
     protected function getBuilder()


### PR DESCRIPTION
Follows #32515.

---

Since the arrival of PHP 7.4, it is now possible to use special PostgreSQL operators such as `?`, `?|` or `?&`. This PR, therefore, includes the use of these operators by doubling the question mark.

```php
\App\User::where('roles', '?', 'admin')->get();

// ->toSql()       select * from "users" where "roles" ?? ?
// ->getBindings() ['admin']
```

For PHP < 7.4, operators don't work anyway, the use of operator functions is mandatory.

---

- https://wiki.php.net/rfc/pdo_escape_placeholders ;