### PR TITLE
[7.x] Fix doc-block param types for abort helpers

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -50,7 +50,7 @@ if (! function_exists('abort_if')) {
      * Throw an HttpException with the given data if the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  int  $code
+     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
      * @param  array  $headers
      * @return void
@@ -71,7 +71,7 @@ if (! function_exists('abort_unless')) {
      * Throw an HttpException with the given data unless the given condition is true.
      *
      * @param  bool  $boolean
-     * @param  int  $code
+     * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int  $code
      * @param  string  $message
      * @param  array  $headers
      * @return void


### PR DESCRIPTION
fix the doc-block param types for `abort_if()` and `abort_unless()` helpers to match the `abort()` one

```php
abort_if(
    empty($otp),
    response()->json(['message' => 'otp_required'], Response::HTTP_FORBIDDEN)
);
```

This is possible because `abort()` helper handles `\Symfony\Component\HttpFoundation\Response` and `\Illuminate\Contracts\Support\Responsable` properly. But static analyzers and IDEs will complain about it because `\Illuminate\Http\JsonResponse` isn't of type `int`.