### PR TITLE
[7.x] Scoped resource routes

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1581,6 +1581,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $relationship = $this->{Str::plural(Str::camel($childType))}();
 
+        $field = $field ?: $relationship->getRelated()->getRouteKeyName();
+
         if ($relationship instanceof HasManyThrough ||
             $relationship instanceof BelongsToMany) {
             return $relationship->where($relationship->getRelated()->getTable().'.'.$field, $value)->first();

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -37,7 +37,7 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            if ($parent instanceof UrlRoutable && $route->bindingFieldFor($parameterName)) {
+            if ($parent instanceof UrlRoutable) {
                 if (! $model = $parent->resolveChildRouteBinding(
                     $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
                 )) {

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -37,7 +37,7 @@ class ImplicitRouteBinding
 
             $parent = $route->parentOfParameter($parameterName);
 
-            if ($parent instanceof UrlRoutable) {
+            if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
                 if (! $model = $parent->resolveChildRouteBinding(
                     $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
                 )) {

--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -183,6 +183,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Indicate that the resource routes should be scoped using the given binding fields.
+     *
+     * @param  array  $fields
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function scoped(array $fields = [])
+    {
+        $this->options['bindingFields'] = $fields;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -95,9 +95,13 @@ class ResourceRegistrar
         $collection = new RouteCollection;
 
         foreach ($this->getResourceMethods($defaults, $options) as $m) {
-            $collection->add($this->{'addResource'.ucfirst($m)}(
+            $route = $this->{'addResource'.ucfirst($m)}(
                 $name, $base, $controller, $options
-            ));
+            );
+
+            $this->setResourceBindingFields($route, $options);
+
+            $collection->add($route);
         }
 
         return $collection;
@@ -311,6 +315,26 @@ class ResourceRegistrar
         return isset($options['shallow']) && $options['shallow']
                     ? last(explode('.', $name))
                     : $name;
+    }
+
+    /**
+     * Set the route's binding fields if the resource is scoped.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  array  $options
+     * @return void
+     */
+    protected function setResourceBindingFields($route, $options)
+    {
+        if (isset($options['bindingFields'])) {
+            preg_match_all('/(?<=\{).*?(?=\})/', $route->uri, $matches);
+
+            $fields = array_fill_keys($matches[0], null);
+
+            $route->setBindingFields(array_replace(
+                $fields, array_intersect_key($options['bindingFields'], $fields)
+            ));
+        }
     }
 
     /**

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -332,7 +332,7 @@ class ResourceRegistrar
             $fields = array_fill_keys($matches[0], null);
 
             $route->setBindingFields(array_replace(
-                $fields, array_intersect_key($options['bindingFields'], $fields)
+                $fields, array_intersect_key((array) $options['bindingFields'], $fields)
             ));
         }
     }

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -99,7 +99,9 @@ class ResourceRegistrar
                 $name, $base, $controller, $options
             );
 
-            $this->setResourceBindingFields($route, $options);
+            if (isset($options['bindingFields'])) {
+                $this->setResourceBindingFields($route, $options['bindingFields']);
+            }
 
             $collection->add($route);
         }
@@ -321,20 +323,18 @@ class ResourceRegistrar
      * Set the route's binding fields if the resource is scoped.
      *
      * @param  \Illuminate\Routing\Route  $route
-     * @param  array  $options
+     * @param  array  $bindingFields
      * @return void
      */
-    protected function setResourceBindingFields($route, $options)
+    protected function setResourceBindingFields($route, $bindingFields)
     {
-        if (isset($options['bindingFields'])) {
-            preg_match_all('/(?<=\{).*?(?=\})/', $route->uri, $matches);
+        preg_match_all('/(?<={).*?(?=})/', $route->uri, $matches);
 
-            $fields = array_fill_keys($matches[0], null);
+        $fields = array_fill_keys($matches[0], null);
 
-            $route->setBindingFields(array_replace(
-                $fields, array_intersect_key((array) $options['bindingFields'], $fields)
-            ));
-        }
+        $route->setBindingFields(array_replace(
+            $fields, array_intersect_key($bindingFields, $fields)
+        ));
     }
 
     /**

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -357,6 +357,31 @@ class RouteRegistrarTest extends TestCase
         $this->assertFalse($this->router->getRoutes()->hasNamedRoute('users.tasks.show'));
     }
 
+    public function testCanSetScopedOptionOnRegisteredResource()
+    {
+        $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped();
+        $this->assertSame(
+            ['user' => null],
+            $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
+        );
+        $this->assertSame(
+            ['user' => null, 'task' => null],
+            $this->router->getRoutes()->getByName('users.tasks.show')->bindingFields()
+        );
+
+        $this->router->resource('users.tasks', RouteRegistrarControllerStub::class)->scoped([
+            'task' => 'slug',
+        ]);
+        $this->assertSame(
+            ['user' => null],
+            $this->router->getRoutes()->getByName('users.tasks.index')->bindingFields()
+        );
+        $this->assertSame(
+            ['user' => null, 'task' => 'slug'],
+            $this->router->getRoutes()->getByName('users.tasks.show')->bindingFields()
+        );
+    }
+
     public function testCanExcludeMethodsOnRegisteredApiResource()
     {
         $this->router->apiResource('users', RouteRegistrarControllerStub::class)


### PR DESCRIPTION
This PR adds the ability to make resource routes scoped.

For a while, we have the ability to scope routes when using [Implicit Route Model Binding](https://laravel.com/docs/master/routing#implicit-binding). This is very useful because it provides a quick and easy route key customization and respects the parent-child relations as well:

```php
Route::get('api/users/{user}/posts/{post:slug}', function (User $user, Post $post) {
    return $post;
});
```

This PR implements the same, but for resource routes, so if we wish to use the same functionality for a resource URL structure, we don't need to define the routes one-by-one to use this feature or writing a custom route binding resolution logic for each model.

------

Usage:

```php
// Using the default route keys
Route::resource('users.tasks', TasksController::class)->scoped();

// Customizing some route keys (only the task gets replaced)
Route::resource('users.tasks', TasksController::class)->scoped([
    'task' => 'slug',
]);
```

If we type hint our models in the controller methods using implicit route model binding, it will behave the same as the closure-based route above.

```php
TasksController extends Controller
{
    // ...

    public function show(User $user, Task $task)
    {
        //
    }

   // ...
}
```

------

I don't think there is any breaking change so I chose the 7.x branch.

Also, if the PR is accepted, I'll open a PR for the docs as well.
