### PR TITLE
[8.x] Add getDatabaseName method to ConnectionInterface

### DIFF
--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -160,4 +160,11 @@ interface ConnectionInterface
      * @return array
      */
     public function pretend(Closure $callback);
+    
+    /**
+     * Get the name of the connected database.
+     *
+     * @return string
+     */
+    public function getDatabaseName();
 }

--- a/src/Illuminate/Database/ConnectionInterface.php
+++ b/src/Illuminate/Database/ConnectionInterface.php
@@ -160,7 +160,7 @@ interface ConnectionInterface
      * @return array
      */
     public function pretend(Closure $callback);
-    
+
     /**
      * Get the name of the connected database.
      *


### PR DESCRIPTION
All of Laravels first party connections extend `Illuminate\Database\Connection` which adds a method called `getDatabaseName()`.

Scanning the codebase for usage I came up with the following situations where the method is used:

- [When getting a doctrine connection](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Connection.php#L909)
- [When getting a MySQL column listing](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/MySqlBuilder.php#L18)
- [When checking if MySQL has a table](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/MySqlBuilder.php#L33)
- [When dropping all SQLite tables](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/SQLiteBuilder.php#L14)
- [When refreshing SQLite database files](https://github.com/laravel/framework/blob/master/src/Illuminate/Database/Schema/SQLiteBuilder.php#L50)

When searching through GitHub I found a number of third-party repositories that define their own connection using only the interface. A number of those define their own `getDatabaseName`, while some don't. Most of those that I found would have a value that can be returned from this method, but it would be a breaking change.

I can't find any reason or issues with adding this method outside of third-party packages having to add the method if they haven't already.

This PR is intended to support the fix I proposed in #33747 which fails the tests because the `ConnectionInterface` contract is used to create a mock, and it relies on the presence of the `getDatabaseName` method.