### PR TITLE
[8.x] Append database name for withCount

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -339,6 +339,14 @@ class Builder
     protected function parseSub($query)
     {
         if ($query instanceof self || $query instanceof EloquentBuilder || $query instanceof Relation) {
+            if ($query->getConnection()->getDatabaseName() !== $this->getConnection()->getDatabaseName()) {
+                $databaseName = $query->getConnection()->getDatabaseName();
+
+                if (strpos($query->from, $databaseName) !== 0 && strpos($query->from, '.') === false) {
+                    $query->from($databaseName.'.'.$query->from);
+                }
+            }
+
             return [$query->toSql(), $query->getBindings()];
         } elseif (is_string($query)) {
             return [$query, []];


### PR DESCRIPTION
This PR addresses #23042. When calling `withCount()` on a relationship with a different connection the database name will be prefixed to the subquery table name, if different.

This won't solve issues with calling `withCount()` on a relationship that exists on an entirely different server, only those that are on the same server but a different database.
