### PR TITLE
[8.x] Append database name for withCount 

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -339,6 +339,14 @@ class Builder
     protected function parseSub($query)
     {
         if ($query instanceof self || $query instanceof EloquentBuilder || $query instanceof Relation) {
+            if ($query->getConnection()->getDatabaseName() !== $this->getConnection()->getDatabaseName()) {
+                $databaseName = $query->getConnection()->getDatabaseName();
+
+                if (strpos($query->from, $databaseName) !== 0 && strpos($query->from, '.') === false) {
+                    $query->from($databaseName.'.'.$query->from);
+                }
+            }
+
             return [$query->toSql(), $query->getBindings()];
         } elseif (is_string($query)) {
             return [$query, []];

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1275,6 +1275,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $connection->shouldReceive('query')->andReturnUsing(function () use ($connection, $grammar, $processor) {
             return new BaseBuilder($connection, $grammar, $processor);
         });
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
         $resolver = m::mock(ConnectionResolverInterface::class, ['connection' => $connection]);
         $class = get_class($model);
         $class::setConnectionResolver($resolver);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3663,12 +3663,20 @@ SQL;
         $this->assertEquals(['1520652582'], $builder->getBindings());
     }
 
+    protected function getConnection()
+    {
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('getDatabaseName')->andReturn('database');
+
+        return $connection;
+    }
+
     protected function getBuilder()
     {
         $grammar = new Grammar;
         $processor = m::mock(Processor::class);
 
-        return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
+        return new Builder($this->getConnection(), $grammar, $processor);
     }
 
     protected function getPostgresBuilder()
@@ -3676,7 +3684,7 @@ SQL;
         $grammar = new PostgresGrammar;
         $processor = m::mock(Processor::class);
 
-        return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
+        return new Builder($this->getConnection(), $grammar, $processor);
     }
 
     protected function getMySqlBuilder()


### PR DESCRIPTION
This PR addresses #23042. When calling `withCount()` on a relationship with a different connection the database name will be prefixed to the subquery table name, if different.

This won't solve issues with calling `withCount()` on a relationship that exists on an entirely different server, only those that are on the same server but a different database.