### PR TITLE
[8.x] Add native broadcast driver for Larasocket

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Broadcasting;
 
 use Closure;
+use Illuminate\Broadcasting\Broadcasters\LarasocketBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\LogBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\NullBroadcaster;
 use Illuminate\Broadcasting\Broadcasters\PusherBroadcaster;
@@ -218,6 +219,17 @@ class BroadcastManager implements FactoryContract
         }
 
         return new PusherBroadcaster($pusher);
+    }
+
+    /**
+     * Create an instance of the driver.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Contracts\Broadcasting\Broadcaster
+     */
+    protected function createLarasocketDriver(array $config)
+    {
+        return new LarasocketBroadcaster($config);
     }
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/LarasocketBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/LarasocketBroadcaster.php
@@ -12,7 +12,6 @@ class LarasocketBroadcaster extends Broadcaster
 
     private const LARASOCKET_HOST = 'https://larasocket.com';
 
-    protected $larasocketHost;
     protected $larasocketToken;
 
     /**

--- a/src/Illuminate/Broadcasting/Broadcasters/LarasocketBroadcaster.php
+++ b/src/Illuminate/Broadcasting/Broadcasters/LarasocketBroadcaster.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Illuminate\Broadcasting\Broadcasters;
+
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+
+class LarasocketBroadcaster extends Broadcaster
+{
+    use UsePusherChannelConventions;
+
+    private const LARASOCKET_HOST = 'https://larasocket.com';
+
+    protected $larasocketHost;
+    protected $larasocketToken;
+
+    /**
+     * Create a new broadcaster instance.
+     */
+    public function __construct(array $config)
+    {
+        $this->larasocketToken = $config['token'];
+    }
+
+    /**
+     * Authenticate the incoming request for a given channel.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     *
+     * @return mixed
+     */
+    public function auth($request)
+    {
+        $channelName = $this->normalizeChannelName($request->channel_name);
+
+        if ($this->isGuardedChannel($request->channel_name) &&
+            ! $this->retrieveUser($request, $channelName)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return parent::verifyUserCanAccessChannel(
+            $request,
+            $channelName
+        );
+    }
+
+    /**
+     * Return the valid authentication response.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param mixed                    $result
+     *
+     * @return mixed
+     */
+    public function validAuthenticationResponse($request, $result)
+    {
+        if (0 === strncmp($request->channel_name, 'private', strlen('private'))) {
+            return $this->authPrivate(
+                $request->channel_name,
+                $request->socket_id
+            );
+        }
+
+        $channelName = $this->normalizeChannelName($request->channel_name);
+
+        return $this->authPresence(
+            $request->channel_name,
+            $request->socket_id,
+            $this->retrieveUser($request, $channelName)->getAuthIdentifier(),
+            $result
+        );
+    }
+
+    /**
+     * Broadcast the given event.
+     *
+     * @param array $channels
+     * @param string $event
+     * @param array $payload
+     *
+     * @return \Illuminate\Http\Client\Response
+     * @throws \Illuminate\Broadcasting\BroadcastException
+     */
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+        $socket = Arr::pull($payload, 'socket');
+
+        $response = $this->trigger(
+            $this->formatChannels($channels),
+            $event,
+            $payload,
+            $socket
+        );
+
+        if ($response->status() >= 200
+            && $response->status() <= 299
+            && ($json = $response->json())) {
+            return $response;
+        }
+
+        throw new BroadcastException(
+            is_bool($response) ? 'Failed to connect to Laravel Websockets.' : $response
+        );
+    }
+
+    /**
+     * A broadcast-ed event has been triggered. We need to send it over to Larasocket servers for processing and then
+     * dispatching to listening clients.
+     *
+     * @param $channels
+     * @param $event
+     * @param $data
+     * @param $connectionId
+     *
+     * @return \Illuminate\Http\Client\Response
+     */
+    public function trigger($channels, $event, $data, $connectionId)
+    {
+        if (true === is_string($channels)) {
+            $channels = [$channels];
+        }
+
+        $url = self::LARASOCKET_HOST.'/api/broadcast';
+
+        return Http::
+        withToken($this->larasocketToken)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post($url, [
+                'event' => $event,
+                'channels' => $channels,
+                'payload' => json_encode($data),
+                'connection_id' => $connectionId,
+            ])
+            ;
+    }
+
+    /**
+     * @param string $channel
+     * @param $connectionId
+     *
+     * @return array
+     */
+    public function authPrivate(string $channel, $connectionId)
+    {
+        return [
+            'connection_id' => $connectionId,
+            'channel' => $channel,
+        ];
+    }
+
+    /**
+     * @param string $channel
+     * @param $connectionId
+     * @param $uid
+     * @param $authResults
+     *
+     * @return array
+     */
+    public function authPresence(string $channel, $connectionId, $uid, $authResults)
+    {
+        return $authResults;
+    }
+}

--- a/tests/Broadcasting/LarasocketBroadcasterTest.php
+++ b/tests/Broadcasting/LarasocketBroadcasterTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Illuminate\Tests\Broadcasting;
+
+use Illuminate\Broadcasting\Broadcasters\LarasocketBroadcaster;
+use Illuminate\Broadcasting\Broadcasters\PusherBroadcaster;
+use Illuminate\Broadcasting\Broadcasters\RedisBroadcaster;
+use Illuminate\Config\Repository as Config;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class LarasocketBroadcasterTest extends TestCase
+{
+    /**
+     * @var \Illuminate\Broadcasting\Broadcasters\LarasocketBroadcaster
+     */
+    public $broadcaster;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->broadcaster = m::mock(LarasocketBroadcaster::class)->makePartial();
+        $container = Container::setInstance(new Container);
+
+        $container->singleton('config', function () {
+            return $this->createConfig();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPrivateChannelWhenCallbackReturnTrue()
+    {
+        $this->broadcaster->channel('test', function () {
+            return true;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+            ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenCallbackReturnFalse()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return false;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('private-test')
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPrivateChannelWhenRequestUserNotFound()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return true;
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('private-test')
+        );
+    }
+
+    public function testAuthCallValidAuthenticationResponseWithPresenceChannelWhenCallbackReturnAnArray()
+    {
+        $returnData = [1, 2, 3, 4];
+        $this->broadcaster->channel('test', function () use ($returnData) {
+            return $returnData;
+        });
+
+        $this->broadcaster->shouldReceive('validAuthenticationResponse')
+            ->once();
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenCallbackReturnNull()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            //
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithUserForChannel('presence-test')
+        );
+    }
+
+    public function testAuthThrowAccessDeniedHttpExceptionWithPresenceChannelWhenRequestUserNotFound()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+
+        $this->broadcaster->channel('test', function () {
+            return [1, 2, 3, 4];
+        });
+
+        $this->broadcaster->auth(
+            $this->getMockRequestWithoutUserForChannel('presence-test')
+        );
+    }
+
+    public function testValidAuthenticationResponseWithPrivateChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('private-test');
+
+        $this->assertEquals(
+            json_encode(true),
+            $this->broadcaster->validAuthenticationResponse($request, true)
+        );
+    }
+
+    public function testValidAuthenticationResponseWithPresenceChannel()
+    {
+        $request = $this->getMockRequestWithUserForChannel('presence-test');
+
+        $this->assertEquals(
+            json_encode([
+                'channel_data' => [
+                    'user_id' => 42,
+                    'user_info' => [
+                        'a' => 'b',
+                        'c' => 'd',
+                    ],
+                ],
+            ]),
+            $this->broadcaster->validAuthenticationResponse($request, [
+                'a' => 'b',
+                'c' => 'd',
+            ])
+        );
+    }
+
+    /**
+     * Create a new config repository instance.
+     *
+     * @return \Illuminate\Config\Repository
+     */
+    protected function createConfig()
+    {
+        return new Config([]);
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithUserForChannel($channel)
+    {
+        $request = m::mock(Request::class);
+        $request->channel_name = $channel;
+
+        $user = m::mock('User');
+        $user->shouldReceive('getAuthIdentifier')
+            ->andReturn(42);
+
+        $request->shouldReceive('user')
+            ->andReturn($user);
+
+        return $request;
+    }
+
+    /**
+     * @param  string  $channel
+     * @return \Illuminate\Http\Request
+     */
+    protected function getMockRequestWithoutUserForChannel($channel)
+    {
+        $request = m::mock(Request::class);
+        $request->channel_name = $channel;
+
+        $request->shouldReceive('user')
+            ->andReturn(null);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
**Problem:** Pusher is amazing. However, for indie developers and low budgets, its pricing is harsh.

**Solution:** [Larasocket](https://larasocket.com), a new broadcasting solution for Laravel that starts free and charges users based on connection minutes and requests. The developer experience is no different than Pusher.

This PR adds a native Broadcaster for Larasocket.

Other related repositories:
1. [laravel/laravel](https://github.com/larasocket/laravel) fork
1. [echo driver](https://github.com/larasocket/larasocket-js)

I'll happily update the Laravel broadcasting documentation with Larasocket information as well.

Curious more than anything, is this something the Laravel community would be interested in? I don't want to overstep any bounds.