### PR TITLE
[7.x] Add plain text only notifications

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -89,7 +89,7 @@ class MailChannel
      */
     protected function buildView($message)
     {
-        if ($message->view) {
+        if ($message->view || $message->textView) {
             return [
                 'html' => $message->view,
                 'text' => $message->textView,

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -331,7 +331,7 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function render()
     {
-        if (isset($this->view)) {
+        if (isset($this->view) || isset($this->textView)) {
             return Container::getInstance()->make('mailer')->render(
                 [$this->view, $this->textView],
                 $this->data()

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -251,7 +251,7 @@ class SendingMailNotificationsTest extends TestCase
 
     public function testMailIsSentUsingMailMessageWithHtmlAndPlain()
     {
-        $notification = new TestMailNotificationWithPlain;
+        $notification = new TestMailNotificationWithHtmlAndPlain;
         $notification->id = Str::uuid()->toString();
 
         $user = NotifiableUser::forceCreate([
@@ -270,7 +270,7 @@ class SendingMailNotificationsTest extends TestCase
 
                 $message->shouldReceive('to')->once()->with(['taylor@laravel.com']);
 
-                $message->shouldReceive('subject')->once()->with('Test Mail Notification With Plain');
+                $message->shouldReceive('subject')->once()->with('Test Mail Notification With Html And Plain');
 
                 $closure($message);
 
@@ -428,7 +428,7 @@ class TestMailNotificationWithMailable extends Notification
     }
 }
 
-class TestMailNotificationWithPlain extends Notification
+class TestMailNotificationWithHtmlAndPlain extends Notification
 {
     public function via($notifiable)
     {


### PR DESCRIPTION
The ability to add a plain text version of a notification alongside the html version was introduced in https://github.com/laravel/framework/pull/33725 which was released in 7.23.0.

In this PR I've added two small fixes that will allow to send **plain text only** notifications.