### PR TITLE
[7.x] Can inject dependencies into custom rule.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -536,10 +536,14 @@ class Validator implements ValidatorContract
         // attribute is invalid and we will add a failure message for this failing attribute.
         $validatable = $this->isValidatable($rule, $attribute, $value);
 
-        if ($rule instanceof RuleContract) {
+        if (is_subclass_of($rule, RuleContract::class)) {
+            if (is_string($rule)) {
+                $rule = $this->container->make($rule);
+            }
+
             return $validatable
-                    ? $this->validateUsingCustomRule($attribute, $value, $rule)
-                    : null;
+                ? $this->validateUsingCustomRule($attribute, $value, $rule)
+                : null;
         }
 
         $method = "validate{$rule}";

--- a/tests/Validation/ValidationCustomRuleTest.php
+++ b/tests/Validation/ValidationCustomRuleTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Tests\Validation;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Validation\Factory;
+use Illuminate\Container\Container;
+use Illuminate\Tests\Validation\fixtures\CustomRule;
+use Illuminate\Tests\Validation\fixtures\RuleDependency;
+use Illuminate\Tests\Validation\fixtures\CustomRuleWithDependency;
+use Illuminate\Contracts\Translation\Translator as TranslatorInterface;
+
+class ValidationCustomRuleTest extends TestCase
+{
+    public function testUsingCustumRule()
+    {
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator);
+
+        $validator = $factory->make(['foo' => 'bar'], ['custom' => new CustomRule]);
+
+        $this->assertTrue($validator->passes());
+    }
+
+    public function testUsingCustumRuleWithDependency()
+    {
+        $container = tap(new Container, function ($container) {
+            $container->instance(
+                CustomRuleWithDependency::class,
+                new CustomRuleWithDependency(new RuleDependency())
+            );
+        });
+        $translator = m::mock(TranslatorInterface::class);
+        $factory = new Factory($translator, $container);
+
+        $validator = $factory->make(['foo' => 'bar'], ['custom' => CustomRuleWithDependency::class]);
+
+        $this->assertTrue($validator->passes());
+    }
+}

--- a/tests/Validation/fixtures/CustomRule.php
+++ b/tests/Validation/fixtures/CustomRule.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Illuminate\Tests\Validation\fixtures;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class CustomRule implements Rule
+{
+    public function passes($attribute, $value)
+    {
+        return true;
+    }
+
+    public function message()
+    {
+        return 'A custom message.';
+    }
+}

--- a/tests/Validation/fixtures/CustomRuleWithDependency.php
+++ b/tests/Validation/fixtures/CustomRuleWithDependency.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Illuminate\Tests\Validation\fixtures;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class CustomRuleWithDependency implements Rule
+{
+    /**
+     * @var \Illuminate\Tests\Validation\fixtures\RuleDependency
+     */
+    protected $dependency;
+
+    public function __construct(RuleDependency $dependency)
+    {
+        $this->dependency = $dependency;
+    }
+
+    public function passes($attribute, $value)
+    {
+        return $this->dependency->isOk();
+    }
+
+    public function message()
+    {
+        return 'A custom message with dependency.';
+    }
+}

--- a/tests/Validation/fixtures/RuleDependency.php
+++ b/tests/Validation/fixtures/RuleDependency.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Tests\Validation\fixtures;
+
+class RuleDependency
+{
+    public function isOk()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Hello folks,

Like suggested in https://github.com/laravel/ideas/issues/1079 and developed in #30293 for Laravel 6.x

I propose you to inject dependencies into custom rule for Laravel 7.x like this :

Declaration of the custom rule :

```php
<?php

namespace App\Rules;

use App\Services\Password;
use Illuminate\Contracts\Validation\Rule;

class PasswordStrength implements Rule
{
    /**
     * @var \App\Services\Password
     */
    protected $password;

    public function __construct(Password $password)
    {
        $this->password = $password;
    }

    /**
     * Determine if the validation rule passes.
     *
     * @param  string  $attribute
     * @param  mixed  $value
     * @return bool
     */
    public function passes($attribute, $value)
    {
        return $this->password->isStrong($value);
    }
}
```

After that, we can use our new custom rule into a controller or a form request like that :

```php
$request->validate([
    'password' => ['required', 'confirmed', \App\Rules\PasswordStrength::class],
]);
```

I made a test who reveal no breaking changes with a classic custom rule and a new one for a custom rule with dependency.

Thank you for reading.
