### PR TITLE
[8.x] Simplify encryption mac validation

### DIFF
--- a/src/Illuminate/Encryption/Encrypter.php
+++ b/src/Illuminate/Encryption/Encrypter.php
@@ -222,24 +222,8 @@ class Encrypter implements EncrypterContract
      */
     protected function validMac(array $payload)
     {
-        $calculated = $this->calculateMac($payload, $bytes = random_bytes(16));
-
         return hash_equals(
-            hash_hmac('sha256', $payload['mac'], $bytes, true), $calculated
-        );
-    }
-
-    /**
-     * Calculate the hash of the given payload.
-     *
-     * @param  array  $payload
-     * @param  string  $bytes
-     * @return string
-     */
-    protected function calculateMac($payload, $bytes)
-    {
-        return hash_hmac(
-            'sha256', $this->hash($payload['iv'], $payload['value']), $bytes, true
+            $this->hash($payload['iv'], $payload['value']), $payload['mac']
         );
     }
 


### PR DESCRIPTION
This started as a discussion (https://github.com/laravel/framework/discussions/33691), but all necessary information is mentioned in this PR.

Currently, `Illuminate\Encryption\Encrypter.php` uses two different measures to defend against [timing attacks](https://en.wikipedia.org/wiki/Timing_attack) when performing MAC (Message Authentication Code) validation.
 1) It uses `hash_equals()`, which is a timing safe string comparison function that was added in php 5.6.0.
 2) It uses a randomized double HMAC technique.

This PR simply removes (2) since (1) should be sufficient. See for instance [this article](https://paragonie.com/blog/2015/11/preventing-timing-attacks-on-string-comparison-with-double-hmac-strategy) which explains both methods and also mentions that (1) is preferable where available. I'm guessing (2) is still there for historic reasons (secure implementation before php 5.6 was required).

The changes are non-breaking and only affects the validation side. The validation is performed in a simpler way by re-caculating the deterministic MAC and comparing with the received value.

### Why making this change?
 1) Performance is improved by removing two `hash_hmac()` computations and one call to `random_bytes()` for each MAC validation. This might be negligible in applications and no performance measurements are provided here, since performance optimization is not the main point of this PR. If requested, I can try to make some comparisons.

 2) The MAC validation code is simplified quite a lot. Since `Encrypter.php` implements cryptography, simplicity and clarity is very important. Using built-in well-tested functionality and avoiding custom implementations is key in cryptographic implementations.
