### PR TITLE
[7.x] Added support to use `where` in `apiResource` method

### DIFF
--- a/src/Illuminate/Routing/PendingResourceRegistration.php
+++ b/src/Illuminate/Routing/PendingResourceRegistration.php
@@ -183,6 +183,19 @@ class PendingResourceRegistration
     }
 
     /**
+     * Add wheres to the resource routes.
+     *
+     * @param  mixed  $wheres
+     * @return \Illuminate\Routing\PendingResourceRegistration
+     */
+    public function wheres($wheres)
+    {
+        $this->options['wheres'] = $wheres;
+
+        return $this;
+    }
+
+    /**
      * Register the resource route.
      *
      * @return \Illuminate\Routing\RouteCollection

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -393,8 +393,8 @@ class ResourceRegistrar
             $action['excluded_middleware'] = $options['excluded_middleware'];
         }
 
-        if (isset($options['where'])) {
-            $action['where'] = $options['where'];
+        if (isset($options['wheres'])) {
+            $action['where'] = $options['wheres'];
         }
 
         return $action;

--- a/src/Illuminate/Routing/ResourceRegistrar.php
+++ b/src/Illuminate/Routing/ResourceRegistrar.php
@@ -393,6 +393,10 @@ class ResourceRegistrar
             $action['excluded_middleware'] = $options['excluded_middleware'];
         }
 
+        if (isset($options['where'])) {
+            $action['where'] = $options['where'];
+        }
+
         return $action;
     }
 

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -525,6 +525,22 @@ class RouteRegistrarTest extends TestCase
         $this->assertEquals(['one'], $this->getRoute()->excludedMiddleware());
     }
 
+    public function testResourceWheres()
+    {
+        $wheres = [
+            'user' => '\d+',
+            'test' => '[a-z]+',
+        ];
+
+        $this->router->resource('users', RouteRegistrarControllerStub::class)
+                     ->wheres($wheres);
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {


### PR DESCRIPTION
This PR adds the possibility to use `where` option in `apiResource` method:

```php
Route::apiResource('tests', TestController::class, [
   'where' => [
      'test' => '\d+'
   ]
]);
```