### PR TITLE
[7.x] Corrected the session store's pull function docblock

### DIFF
--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -222,7 +222,7 @@ class Store implements Session
      * Get the value of a given key and then forget it.
      *
      * @param  string  $key
-     * @param  string|null  $default
+     * @param  mixed  $default
      * @return mixed
      */
     public function pull($key, $default = null)


### PR DESCRIPTION
The docblock for the `pull` function in the `Session\Store` class is currently incorrect, and is causing psalm static analysis to throw an error.

The type for `$default` should be mixed, as it is on the `get` method.

This has also been reported here, along with the steps needed to reproduce: #33626