### PR TITLE
[8.x] Added pull method to the session contract

### DIFF
--- a/src/Illuminate/Contracts/Session/Session.php
+++ b/src/Illuminate/Contracts/Session/Session.php
@@ -81,6 +81,15 @@ interface Session
     public function get($key, $default = null);
 
     /**
+     * Get the value of a given key and then forget it.
+     *
+     * @param  string  $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function pull($key, $default = null);
+
+    /**
      * Put a key / value pair or array of key / value pairs in the session.
      *
      * @param  string|array  $key


### PR DESCRIPTION
So that people can use this method. NB the cache repository contract also already has the `pull` method, as a comparison.