### PR TITLE
[7.x] Add support for PhpRedis 5.3 options parameter

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -74,9 +74,9 @@ class PhpRedisConnector implements Connector
         return tap(new Redis, function ($client) use ($config) {
             if ($client instanceof RedisFacade) {
                 throw new LogicException(
-                        extension_loaded('redis')
-                                ? 'Please remove or rename the Redis facade alias in your "app" configuration file in order to avoid collision with the PHP Redis extension.'
-                                : 'Please make sure the PHP Redis extension is installed and enabled.'
+                    extension_loaded('redis')
+                        ? 'Please remove or rename the Redis facade alias in your "app" configuration file in order to avoid collision with the PHP Redis extension.'
+                        : 'Please make sure the PHP Redis extension is installed and enabled.'
                 );
             }
 

--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -127,6 +127,10 @@ class PhpRedisConnector implements Connector
             $parameters[] = Arr::get($config, 'read_timeout', 0.0);
         }
 
+        if (version_compare(phpversion('redis'), '5.3.0', '>=')) {
+            $parameters[] = Arr::get($config, 'context', []);
+        }
+
         $client->{($persistent ? 'pconnect' : 'connect')}(...$parameters);
     }
 
@@ -149,6 +153,10 @@ class PhpRedisConnector implements Connector
 
         if (version_compare(phpversion('redis'), '4.3.0', '>=')) {
             $parameters[] = $options['password'] ?? null;
+        }
+
+        if (version_compare(phpversion('redis'), '5.3.2', '>=')) {
+            $parameters[] = Arr::get($options, 'context', []);
         }
 
         return tap(new RedisCluster(...$parameters), function ($client) use ($options) {


### PR DESCRIPTION
PhpRedis added a 7th parameter to support stream context options and Redis 6 authentication. This is particularly useful when a certificate is required to connect to Redis, or certificate verification needs to be disabled.

```php
$redis = new Redis;

$redis->connect('127.0.0.1', 6379, 1, null, 0, 0, [
    'auth' => ['username', 'secret'],
    'stream' => [
        'verify_peer' => false,
    ],
]);
```

The `database` config would look like this (`context` should really be called `options`, but we already use that):

```php
return [

    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'phpredis'),
            'prefix' => env('REDIS_PREFIX'),
        ],

        'default' => [
            'host' => 'tls://127.0.0.1',
            'password' => 'secret',
            'port' => 6379,
            'database' => 0,

            // new:
            'context' => [
                'auth' => ['username', 'secret'],
                'stream' => [
                    'verify_peer' => false,
                ],
            ]
        ],

    ],

];
```

For cluster connections, the `context` would be pulled from `redis.options.context`.