### PR TITLE
[7.x] Support `tls://` scheme when using `url` in Redis config

### DIFF
--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -184,6 +184,11 @@ class RedisManager implements Factory
     protected function parseConnectionConfiguration($config)
     {
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
+        $driver = strtolower($parsed['driver'] ?? '');
+
+        if (in_array($driver, ['tcp', 'tls'])) {
+            $parsed['host'] = "{$driver}://" . $parsed['host'];
+        }
 
         return array_filter($parsed, function ($key) {
             return ! in_array($key, ['driver', 'username'], true);

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -184,6 +184,7 @@ class RedisManager implements Factory
     protected function parseConnectionConfiguration($config)
     {
         $parsed = (new ConfigurationUrlParser)->parseConfiguration($config);
+
         $driver = strtolower($parsed['driver'] ?? '');
 
         if (in_array($driver, ['tcp', 'tls'])) {

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -187,7 +187,7 @@ class RedisManager implements Factory
         $driver = strtolower($parsed['driver'] ?? '');
 
         if (in_array($driver, ['tcp', 'tls'])) {
-            $parsed['host'] = "{$driver}://" . $parsed['host'];
+            $parsed['host'] = "{$driver}://{$parsed['host']}";
         }
 
         return array_filter($parsed, function ($key) {


### PR DESCRIPTION
Currently, the protocol can't be specified when using the Redis `url` configuration. The config below would connect via TCP without any warning.

```php
return [

    'redis' => [

        'client' => env('REDIS_CLIENT', 'phpredis'),

        'default' => [
            'url' => 'tls://127.0.0.1:6379?database=0',
        ],
    ],

];
```

This PR adds support to specify protocols:

```php
return [
    'default' => [
        'url' => 'redis://127.0.0.1:6379?database=0', // scheme is ignored, connect via TCP
    ],

    'cache' => [
        'url' => 'tcp://127.0.0.1:6379?database=1', // connect via TCP
    ],

    'sessions' => [
        'url' => 'tls://127.0.0.1:6379?database=2', // connect via TLS
    ],
];
```