### PR TITLE
[7.x] Make LazyCollection#countBy be lazy

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1307,6 +1307,17 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Count the number of items in the collection by a field or using a callback.
+     *
+     * @param  callable|string  $countBy
+     * @return static
+     */
+    public function countBy($countBy = null)
+    {
+        return new static($this->lazy()->countBy($countBy)->all());
+    }
+
+    /**
      * Add an item to the collection.
      *
      * @param  mixed  $item

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -241,6 +241,35 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Count the number of items in the collection by a field or using a callback.
+     *
+     * @param  callable|string  $countBy
+     * @return static
+     */
+    public function countBy($countBy = null)
+    {
+        if (is_null($countBy)) {
+            $countBy = $this->identity();
+        }
+
+        return new static(function () use ($countBy) {
+            $counts = [];
+
+            foreach ($this as $key => $value) {
+                $group = $countBy($value, $key);
+
+                if (empty($counts[$group])) {
+                    $counts[$group] = 0;
+                }
+
+                $counts[$group]++;
+            }
+
+            yield from $counts;
+        });
+    }
+
+    /**
      * Get the items that are not present in the given items.
      *
      * @param  mixed  $items

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -412,13 +412,9 @@ trait EnumeratesValues
      */
     public function sum($callback = null)
     {
-        if (is_null($callback)) {
-            $callback = function ($value) {
-                return $value;
-            };
-        } else {
-            $callback = $this->valueRetriever($callback);
-        }
+        $callback = is_null($callback)
+            ? $this->identity()
+            : $this->valueRetriever($callback);
 
         return $this->reduce(function ($result, $item) use ($callback) {
             return $result + $callback($item);
@@ -815,9 +811,7 @@ trait EnumeratesValues
     public function countBy($countBy = null)
     {
         if (is_null($countBy)) {
-            $countBy = function ($value) {
-                return $value;
-            };
+            $countBy = $this->identity();
         }
 
         return new static($this->groupBy($countBy)->map(function ($value) {
@@ -975,6 +969,18 @@ trait EnumeratesValues
     {
         return function ($item) use ($value) {
             return $item === $value;
+        };
+    }
+
+    /**
+     * Make a function that returns what's passed to it.
+     *
+     * @return \Closure
+     */
+    protected function identity()
+    {
+        return function ($value) {
+            return $value;
         };
     }
 

--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -803,23 +803,6 @@ trait EnumeratesValues
     }
 
     /**
-     * Count the number of items in the collection by a field or using a callback.
-     *
-     * @param  array|callable|string $countBy
-     * @return static
-     */
-    public function countBy($countBy = null)
-    {
-        if (is_null($countBy)) {
-            $countBy = $this->identity();
-        }
-
-        return new static($this->groupBy($countBy)->map(function ($value) {
-            return $value->count();
-        }));
-    }
-
-    /**
      * Convert the collection to its string representation.
      *
      * @return string


### PR DESCRIPTION
The collection's current `countBy` implementation uses `groupBy`.

`groupBy` is inherently not lazy (being a form of bucket sort). This means that in order to count occurrences, we need to pull the whole dataset into memory at once.

We can do better.

The code in this PR only pulls a single item at a time, and increases the counter. The actual item is then promptly discarded, so that we never keep more than a single item in memory.