### PR TITLE
[7.x] Fix rendering plain text only notifications

### DIFF
--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -333,7 +333,10 @@ class MailMessage extends SimpleMessage implements Renderable
     {
         if (isset($this->view) || isset($this->textView)) {
             return Container::getInstance()->make('mailer')->render(
-                [$this->view, $this->textView],
+                [
+                    'html' => $this->view,
+                    'text' => $this->textView,
+                ],
                 $this->data()
             );
         }


### PR DESCRIPTION
The ability to send plain text versions of notifications alongside html version was introduced in https://github.com/laravel/framework/pull/33725. In https://github.com/laravel/framework/pull/33781 I've made small fixes that allow to send **plain text only** notifications.

When the notification is sent, the view is built as an **associative array** using the `buildView()` [method](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Notifications/Channels/MailChannel.php#L92-L97) of the `MailChannel` class. The array returned by this method is passed to the `Mailer` class, which parses this view array in the `parseView()` [method](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Mail/Mailer.php#L315).

However, when the notifications is rendered (for previewing in the browser), the view is built as a **numeric array** in the `render()` [method](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Notifications/Messages/MailMessage.php#L336). When it is passed to the `Mailer` class, it is parsed differently in the `parseView()` method. If the notifications has the html view set, it is not a problem, the result is the same. But it the html view is null, the result of `parseView()` is different.

This PR aims to fix this inconsistency, by building the view as an associative array in the `MailMessage::render()` method.