### PR TITLE
[7.x] Removed quotes when setting isolation level for mysql connections

### DIFF
--- a/src/Illuminate/Database/Connectors/MySqlConnector.php
+++ b/src/Illuminate/Database/Connectors/MySqlConnector.php
@@ -55,7 +55,7 @@ class MySqlConnector extends Connector implements ConnectorInterface
         }
 
         $connection->prepare(
-            "SET SESSION TRANSACTION ISOLATION LEVEL '{$config['isolation_level']}'"
+            "SET SESSION TRANSACTION ISOLATION LEVEL {$config['isolation_level']}"
         )->execute();
     }
 


### PR DESCRIPTION
Removed unnecessary quotes, which cause mysql error if `isolation_level`-config is provided.