### PR TITLE
[7.x] Allow class instances as model casts to enable dependency injection on custom casts

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,19 +2,20 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use Carbon\CarbonInterface;
-use DateTimeInterface;
-use Illuminate\Contracts\Database\Eloquent\Castable;
-use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
-use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Database\Eloquent\JsonEncodingException;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Str;
 use LogicException;
+use DateTimeInterface;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Database\Eloquent\Castable;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 
 trait HasAttributes
 {
@@ -128,14 +129,16 @@ trait HasAttributes
         );
 
         $attributes = $this->addMutatedAttributesToArray(
-            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
+            $attributes,
+            $mutatedAttributes = $this->getMutatedAttributes()
         );
 
         // Next we will handle any casts that have been setup for this model and cast
         // the values to their appropriate type. If the attribute has a mutator we
         // will not perform the cast on those attributes to avoid any confusion.
         $attributes = $this->addCastAttributesToArray(
-            $attributes, $mutatedAttributes
+            $attributes,
+            $mutatedAttributes
         );
 
         // Here we will grab all of the appended, calculated attributes to this model
@@ -190,7 +193,8 @@ trait HasAttributes
             // mutated attribute's actual values. After we finish mutating each of the
             // attributes we will return this final array of the mutated attributes.
             $attributes[$key] = $this->mutateAttributeForArray(
-                $key, $attributes[$key]
+                $key,
+                $attributes[$key]
             );
         }
 
@@ -216,7 +220,8 @@ trait HasAttributes
             // then we will serialize the date for the array. This will convert the dates
             // to strings based on the date format specified for these Eloquent models.
             $attributes[$key] = $this->castAttribute(
-                $key, $attributes[$key]
+                $key,
+                $attributes[$key]
             );
 
             // If the attribute cast was a date or a datetime, we will serialize the date as
@@ -436,12 +441,16 @@ trait HasAttributes
         if (! $relation instanceof Relation) {
             if (is_null($relation)) {
                 throw new LogicException(sprintf(
-                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?', static::class, $method
+                    '%s::%s must return a relationship instance, but "null" was returned. Was the "return" keyword used?',
+                    static::class,
+                    $method
                 ));
             }
 
             throw new LogicException(sprintf(
-                '%s::%s must return a relationship instance.', static::class, $method
+                '%s::%s must return a relationship instance.',
+                static::class,
+                $method
             ));
         }
 
@@ -589,6 +598,10 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
+        if (is_subclass_of($cast = $this->getCasts()[$key], CastsAttributes::class)) {
+            return trim(strtolower(get_class($cast)));
+        }
+
         if ($this->isCustomDateTimeCast($this->getCasts()[$key])) {
             return 'custom_datetime';
         }
@@ -715,7 +728,9 @@ trait HasAttributes
         [$key, $path] = explode('->', $key, 2);
 
         $this->attributes[$key] = $this->asJson($this->getArrayAttributeWithValue(
-            $path, $key, $value
+            $path,
+            $key,
+            $value
         ));
 
         return $this;
@@ -737,14 +752,20 @@ trait HasAttributes
                 function () {
                 },
                 $this->normalizeCastClassResponse($key, $caster->set(
-                    $this, $key, $this->{$key}, $this->attributes
+                    $this,
+                    $key,
+                    $this->{$key},
+                    $this->attributes
                 ))
             ));
         } else {
             $this->attributes = array_merge(
                 $this->attributes,
                 $this->normalizeCastClassResponse($key, $caster->set(
-                    $this, $key, $value, $this->attributes
+                    $this,
+                    $key,
+                    $value,
+                    $this->attributes
                 ))
             );
         }
@@ -796,7 +817,9 @@ trait HasAttributes
 
         if ($value === false) {
             throw JsonEncodingException::forAttribute(
-                $this, $key, json_last_error_msg()
+                $this,
+                $key,
+                json_last_error_msg()
             );
         }
 
@@ -889,7 +912,8 @@ trait HasAttributes
         // when checking the field. We will just return the DateTime right away.
         if ($value instanceof DateTimeInterface) {
             return Date::parse(
-                $value->format('Y-m-d H:i:s.u'), $value->getTimezone()
+                $value->format('Y-m-d H:i:s.u'),
+                $value->getTimezone()
             );
         }
 
@@ -1067,6 +1091,10 @@ trait HasAttributes
      */
     protected function isClassCastable($key)
     {
+        if (is_subclass_of($this->getCasts()[$key], CastsAttributes::class)) {
+            return true;
+        }
+
         return array_key_exists($key, $this->getCasts()) &&
                 class_exists($class = $this->parseCasterClass($this->getCasts()[$key])) &&
                 ! in_array($class, static::$primitiveCastTypes);
@@ -1188,7 +1216,8 @@ trait HasAttributes
     public function getOriginal($key = null, $default = null)
     {
         return (new static)->setRawAttributes(
-            $this->original, $sync = true
+            $this->original,
+            $sync = true
         )->getOriginalWithoutRewindingModel($key, $default);
     }
 
@@ -1203,7 +1232,8 @@ trait HasAttributes
     {
         if ($key) {
             return $this->transformModelValue(
-                $key, Arr::get($this->original, $key, $default)
+                $key,
+                Arr::get($this->original, $key, $default)
             );
         }
 
@@ -1304,7 +1334,8 @@ trait HasAttributes
     public function isDirty($attributes = null)
     {
         return $this->hasChanges(
-            $this->getDirty(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getDirty(),
+            is_array($attributes) ? $attributes : func_get_args()
         );
     }
 
@@ -1328,7 +1359,8 @@ trait HasAttributes
     public function wasChanged($attributes = null)
     {
         return $this->hasChanges(
-            $this->getChanges(), is_array($attributes) ? $attributes : func_get_args()
+            $this->getChanges(),
+            is_array($attributes) ? $attributes : func_get_args()
         );
     }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -598,7 +598,8 @@ trait HasAttributes
      */
     protected function getCastType($key)
     {
-        if (is_subclass_of($cast = $this->getCasts()[$key], CastsAttributes::class)) {
+        if (is_subclass_of($cast = $this->getCasts()[$key], CastsAttributes::class)
+            && !is_string($this->getCasts()[$key])) {
             return trim(strtolower(get_class($cast)));
         }
 
@@ -1091,7 +1092,7 @@ trait HasAttributes
      */
     protected function isClassCastable($key)
     {
-        if (is_subclass_of($this->getCasts()[$key], CastsAttributes::class)) {
+        if (is_subclass_of($this->getCasts()[$key] ?? null, CastsAttributes::class)) {
             return true;
         }
 

--- a/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasAttributes.php
@@ -2,20 +2,20 @@
 
 namespace Illuminate\Database\Eloquent\Concerns;
 
-use LogicException;
-use DateTimeInterface;
 use Carbon\CarbonInterface;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Date;
-use Illuminate\Contracts\Support\Arrayable;
+use DateTimeInterface;
 use Illuminate\Contracts\Database\Eloquent\Castable;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use LogicException;
 
 trait HasAttributes
 {
@@ -599,7 +599,7 @@ trait HasAttributes
     protected function getCastType($key)
     {
         if (is_subclass_of($cast = $this->getCasts()[$key], CastsAttributes::class)
-            && !is_string($this->getCasts()[$key])) {
+            && ! is_string($this->getCasts()[$key])) {
             return trim(strtolower(get_class($cast)));
         }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3,35 +3,35 @@
 namespace Illuminate\Tests\Database;
 
 use DateTime;
-use stdClass;
-use Exception;
-use Mockery as m;
-use LogicException;
-use ReflectionClass;
 use DateTimeImmutable;
 use DateTimeInterface;
-use InvalidArgumentException;
-use Illuminate\Support\Carbon;
-use PHPUnit\Framework\TestCase;
-use Illuminate\Database\Connection;
-use Illuminate\Database\Eloquent\Model;
+use Exception;
 use Foo\Bar\EloquentModelNamespacedStub;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\InteractsWithTime;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Query\Grammars\Grammar;
-use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Database\Connection;
 use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Collection as BaseCollection;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\JsonEncodingException;
 use Illuminate\Database\Eloquent\MassAssignmentException;
-use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
-use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as BaseBuilder;
+use Illuminate\Database\Query\Grammars\Grammar;
+use Illuminate\Database\Query\Processors\Processor;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\InteractsWithTime;
+use InvalidArgumentException;
+use LogicException;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use stdClass;
 
 class DatabaseEloquentModelTest extends TestCase
 {
@@ -1907,7 +1907,7 @@ class DatabaseEloquentModelTest extends TestCase
     public function testModelSetAttributeCastingWithInstanceOfCastsAttributes()
     {
         $cast = m::mock(new EloquentCastsAttributesInstanceStub);
-        
+
         $model = new EloquentModelCastingStub;
         $model->mergeCasts(['foo' => $cast]);
 
@@ -2564,6 +2564,7 @@ class EloquentCastsAttributesInstanceStub implements CastsAttributes
     public function get($model, $key, $value, $attributes)
     {
     }
+
     public function set($model, $key, $value, $attributes)
     {
     }


### PR DESCRIPTION
This PR adds support for cast instances when merging custom casts to a model like so:

```php
$model->mergeCasts([
    'foo' => new MyCast('bar')
]);
```

This allows to inject dependencies or arguments to the constructor of a cast before binding it to a Model. The following example shows a cast whose task it is to format amounts in a given currency.

```php
class MoneyCast implements CastsAttributes
{
    public function __construct($currency = 'USD', $locale = 'en_US')
    {
        $this->currency = $currency;
        $this->formatter = new NumberFormatter($locale, NumberFormatter::CURRENCY);
    }

    public function get($model, $key, $value, $attributes)
    {        
        return $this->formatter->formatCurrency($value, $this->currency);
    }

    // ...
}
```

This cast can be given a currency and a locale when adding it:

```php
$model->mergeCasts(['amount' => new MoneyCast('EUR', 'de_DE')]);
```

Generally this feature offers the possibility to create more flexible casts. This can be especially helpful for packet development.
