### PR TITLE
[7.x] Let mailables accept a simple array of email addresses as cc or bcc

### DIFF
--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -641,6 +641,10 @@ class Mailable implements MailableContract, Renderable
     protected function normalizeRecipient($recipient)
     {
         if (is_array($recipient)) {
+            if (array_values($recipient) === $recipient) {
+                return (object) array_map(fn ($email) => compact('email'), $recipient);
+            }
+
             return (object) $recipient;
         } elseif (is_string($recipient)) {
             return (object) ['email' => $recipient];

--- a/src/Illuminate/Mail/Mailable.php
+++ b/src/Illuminate/Mail/Mailable.php
@@ -642,7 +642,9 @@ class Mailable implements MailableContract, Renderable
     {
         if (is_array($recipient)) {
             if (array_values($recipient) === $recipient) {
-                return (object) array_map(fn ($email) => compact('email'), $recipient);
+                return (object) array_map(function ($email) {
+                    return compact('email');
+                }, $recipient);
             }
 
             return (object) $recipient;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -54,6 +54,118 @@ class MailMailableTest extends TestCase
         $this->assertTrue($mailable->hasTo('taylor@laravel.com'));
     }
 
+    public function testMailableSetsCcRecipientsCorrectly()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc('taylor@laravel.com');
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc('taylor@laravel.com', 'Taylor Otwell');
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(['taylor@laravel.com']);
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+        $this->assertFalse($mailable->hasCc('taylor@laravel.com', 'Taylor Otwell'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc([['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']]);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(new MailableTestUserStub);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(collect([new MailableTestUserStub]));
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->cc);
+        $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $this->assertEquals([
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+        ], $mailable->cc);
+        $this->assertTrue($mailable->hasCc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->cc(['taylor@laravel.com', 'not-taylor@laravel.com']);
+        $this->assertEquals([
+            ['name' => null, 'address' =>'taylor@laravel.com'],
+            ['name' => null, 'address' =>'not-taylor@laravel.com'],
+        ], $mailable->cc);
+        $this->assertTrue($mailable->hasCc('taylor@laravel.com'));
+        $this->assertTrue($mailable->hasCc('not-taylor@laravel.com'));
+    }
+
+    public function testMailableSetsBccRecipientsCorrectly()
+    {
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc('taylor@laravel.com');
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc('taylor@laravel.com', 'Taylor Otwell');
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(['taylor@laravel.com']);
+        $this->assertEquals([['name' => null, 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+        $this->assertFalse($mailable->hasBcc('taylor@laravel.com', 'Taylor Otwell'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc([['name' => 'Taylor Otwell', 'email' => 'taylor@laravel.com']]);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com', 'Taylor Otwell'));
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(new MailableTestUserStub);
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(collect([new MailableTestUserStub]));
+        $this->assertEquals([['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com']], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(collect([new MailableTestUserStub, new MailableTestUserStub]));
+        $this->assertEquals([
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+            ['name' => 'Taylor Otwell', 'address' => 'taylor@laravel.com'],
+        ], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc(new MailableTestUserStub));
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+
+        $mailable = new WelcomeMailableStub;
+        $mailable->bcc(['taylor@laravel.com', 'not-taylor@laravel.com']);
+        $this->assertEquals([
+            ['name' => null, 'address' =>'taylor@laravel.com',],
+            ['name' => null, 'address' =>'not-taylor@laravel.com',],
+        ], $mailable->bcc);
+        $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
+        $this->assertTrue($mailable->hasBcc('not-taylor@laravel.com'));
+    }
+
     public function testMailableSetsReplyToCorrectly()
     {
         $mailable = new WelcomeMailableStub;

--- a/tests/Mail/MailMailableTest.php
+++ b/tests/Mail/MailMailableTest.php
@@ -159,8 +159,8 @@ class MailMailableTest extends TestCase
         $mailable = new WelcomeMailableStub;
         $mailable->bcc(['taylor@laravel.com', 'not-taylor@laravel.com']);
         $this->assertEquals([
-            ['name' => null, 'address' =>'taylor@laravel.com',],
-            ['name' => null, 'address' =>'not-taylor@laravel.com',],
+            ['name' => null, 'address' =>'taylor@laravel.com'],
+            ['name' => null, 'address' =>'not-taylor@laravel.com'],
         ], $mailable->bcc);
         $this->assertTrue($mailable->hasBcc('taylor@laravel.com'));
         $this->assertTrue($mailable->hasBcc('not-taylor@laravel.com'));


### PR DESCRIPTION
Currently we can only set a single email address, an associative array, or an object as cc or bcc in Mailables.
I think it would be nice, if it were possible just to pass a simple array of email addresses as cc/bcc. As of now, if someone has a simple array, it has to be mapped to have an email key with the address.

Example:

```php
// This is valid
Mail::to('user@foo.com')->cc('john@doe.com')->send(new SomeMailable());

// This is valid
Mail::to('user@foo.com')->cc('john@doe.com')->send(new SomeMailable());

// This throws an exception: "Trying to get property 'email' of non-object"
Mail::to('user@foo.com')->cc(['john@doe.com', 'jane@doe.com'])->send(new SomeMailable());

// Possible workaround, me no gusta
Mail::to('user@foo.com')->cc(
  collect(['john@doe.com', 'jande@doe.com'])->map(fn ($email) => compact('email'))
)->send(new SomeMailable());
```

Since Mailable does not require a recipient name anywhere, and already accepts a single email address as cc/bcc, it would make sense if it accepted a simple array of addresses in my opinion.