### PR TITLE
[7.x] Add pagination first/last number of current page

### DIFF
--- a/src/Illuminate/Pagination/AbstractPaginator.php
+++ b/src/Illuminate/Pagination/AbstractPaginator.php
@@ -341,6 +341,26 @@ abstract class AbstractPaginator implements Htmlable
     }
 
     /**
+     * Get the first number of current page.
+     *
+     * @return int|null
+     */
+    public function firstNumber()
+    {
+        return count($this->items) ? ($this->currentPage - 1) * $this->perPage + 1 : null;
+    }
+
+    /**
+     * Get the last number of current page.
+     *
+     * @return int|null
+     */
+    public function lastNumber()
+    {
+        return count($this->items) > 0 ? $this->currentPage * $this->perPage : null;
+    }
+
+    /**
      * Get the query string variable used to store the page.
      *
      * @return string

--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -164,8 +164,10 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
         return [
             'current_page' => $this->currentPage(),
             'data' => $this->items->toArray(),
+            'first_number' => $this->firstNumber(),
             'first_page_url' => $this->url(1),
             'from' => $this->firstItem(),
+            'last_number' => $this->lastNumber(),
             'last_page' => $this->lastPage(),
             'last_page_url' => $this->url($this->lastPage()),
             'next_page_url' => $this->nextPageUrl(),

--- a/tests/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Pagination/LengthAwarePaginatorTest.php
@@ -40,6 +40,8 @@ class LengthAwarePaginatorTest extends TestCase
     {
         $this->assertEquals(2, $this->p->lastPage());
         $this->assertEquals(2, $this->p->currentPage());
+        $this->assertEquals(3, $this->p->firstNumber());
+        $this->assertEquals(4, $this->p->lastNumber());
         $this->assertTrue($this->p->hasPages());
         $this->assertFalse($this->p->hasMorePages());
         $this->assertEquals(['item1', 'item2', 'item3', 'item4'], $this->p->items());
@@ -51,6 +53,8 @@ class LengthAwarePaginatorTest extends TestCase
 
         $this->assertEquals(1, $paginator->lastPage());
         $this->assertEquals(1, $paginator->currentPage());
+        $this->assertEquals(null, $paginator->firstNumber());
+        $this->assertEquals(null, $paginator->lastNumber());
         $this->assertFalse($paginator->hasPages());
         $this->assertFalse($paginator->hasMorePages());
         $this->assertEmpty($paginator->items());


### PR DESCRIPTION
This PR will enable first and last number of current page. It will make easier to generate sequential number on a pagination.

On first page with 15 pagination per page, `firstNumber()` will be 1 and `lastNumber()` will be 15. But on second page, `firstNumber()` will be 16 and `lastNumber()` will be 30.

For example, to generate sequential number like this on page 2,

| No.  | Name        | 
|------|-------------|
|  16  | Lorem       |
|  17  | Ipsum       |
|  18  | Dolor       |

usually I use code like this

```blade
@foreach($items as $index => $item)
  {{ $items->currentPage() - 1) * $items->perPage() + 1 + $index }}
@endforeach
```

With this PR, the code can be

```blade
@foreach($items as $index => $item)
  {{ $items->firstNumber() + $index }}
@endforeach
```
