### PR TITLE
[7.x] Revert changes to MailMessage

### DIFF
--- a/src/Illuminate/Notifications/Channels/MailChannel.php
+++ b/src/Illuminate/Notifications/Channels/MailChannel.php
@@ -89,11 +89,8 @@ class MailChannel
      */
     protected function buildView($message)
     {
-        if ($message->view || $message->textView) {
-            return [
-                'html' => $message->view,
-                'text' => $message->textView,
-            ];
+        if ($message->view) {
+            return $message->view;
         }
 
         if (property_exists($message, 'theme') && ! is_null($message->theme)) {

--- a/src/Illuminate/Notifications/Messages/MailMessage.php
+++ b/src/Illuminate/Notifications/Messages/MailMessage.php
@@ -18,13 +18,6 @@ class MailMessage extends SimpleMessage implements Renderable
     public $view;
 
     /**
-     * The plain text view to use for the message.
-     *
-     * @var string
-     */
-    public $textView;
-
-    /**
      * The view data for the message.
      *
      * @var array
@@ -111,24 +104,9 @@ class MailMessage extends SimpleMessage implements Renderable
     public function view($view, array $data = [])
     {
         $this->view = $view;
-        $this->viewData = array_merge($this->viewData, $data);
+        $this->viewData = $data;
 
         $this->markdown = null;
-
-        return $this;
-    }
-
-    /**
-     * Set the plain text view for the message.
-     *
-     * @param  string  $textView
-     * @param  array  $data
-     * @return $this
-     */
-    public function text($textView, array $data = [])
-    {
-        $this->textView = $textView;
-        $this->viewData = array_merge($this->viewData, $data);
 
         return $this;
     }
@@ -331,13 +309,9 @@ class MailMessage extends SimpleMessage implements Renderable
      */
     public function render()
     {
-        if (isset($this->view) || isset($this->textView)) {
+        if (isset($this->view)) {
             return Container::getInstance()->make('mailer')->render(
-                [
-                    'html' => $this->view,
-                    'text' => $this->textView,
-                ],
-                $this->data()
+                $this->view, $this->data()
             );
         }
 

--- a/tests/Integration/Notifications/SendingMailNotificationsTest.php
+++ b/tests/Integration/Notifications/SendingMailNotificationsTest.php
@@ -259,7 +259,7 @@ class SendingMailNotificationsTest extends TestCase
         ]);
 
         $this->mailer->shouldReceive('send')->once()->with(
-            ['html' => 'html', 'text' => 'plain'],
+            ['html', 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
@@ -291,7 +291,7 @@ class SendingMailNotificationsTest extends TestCase
         ]);
 
         $this->mailer->shouldReceive('send')->once()->with(
-            ['html' => 'html', 'text' => null],
+            'html',
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
@@ -323,7 +323,7 @@ class SendingMailNotificationsTest extends TestCase
         ]);
 
         $this->mailer->shouldReceive('send')->once()->with(
-            ['html' => null, 'text' => 'plain'],
+            [null, 'plain'],
             array_merge($notification->toMail($user)->toArray(), [
                 '__laravel_notification_id' => $notification->id,
                 '__laravel_notification' => get_class($notification),
@@ -438,8 +438,7 @@ class TestMailNotificationWithHtmlAndPlain extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->view('html')
-            ->text('plain');
+            ->view(['html', 'plain']);
     }
 }
 
@@ -453,8 +452,7 @@ class TestMailNotificationWithHtmlOnly extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->view('html')
-            ->text(null);
+            ->view('html');
     }
 }
 
@@ -468,7 +466,6 @@ class TestMailNotificationWithPlainOnly extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->view(null)
-            ->text('plain');
+            ->view([null, 'plain']);
     }
 }

--- a/tests/Notifications/NotificationMailMessageTest.php
+++ b/tests/Notifications/NotificationMailMessageTest.php
@@ -18,11 +18,27 @@ class NotificationMailMessageTest extends TestCase
         $this->assertSame('notifications::foo', $message->markdown);
     }
 
+    public function testHtmlAndPlainView()
+    {
+        $message = new MailMessage;
+
+        $this->assertNull($message->view);
+        $this->assertSame([], $message->viewData);
+
+        $message->view(['notifications::foo', 'notifications::bar'], [
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame('notifications::foo', $message->view[0]);
+        $this->assertSame('notifications::bar', $message->view[1]);
+        $this->assertSame(['foo' => 'bar'], $message->viewData);
+    }
+
     public function testHtmlView()
     {
         $message = new MailMessage;
 
-        $this->assertSame(null, $message->view);
+        $this->assertNull($message->view);
         $this->assertSame([], $message->viewData);
 
         $message->view('notifications::foo', [
@@ -37,14 +53,14 @@ class NotificationMailMessageTest extends TestCase
     {
         $message = new MailMessage;
 
-        $this->assertSame(null, $message->textView);
+        $this->assertNull($message->view);
         $this->assertSame([], $message->viewData);
 
-        $message->text('notifications::foo', [
+        $message->view([null, 'notifications::foo'], [
             'foo' => 'bar',
         ]);
 
-        $this->assertSame('notifications::foo', $message->textView);
+        $this->assertSame('notifications::foo', $message->view[1]);
         $this->assertSame(['foo' => 'bar'], $message->viewData);
     }
 

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Tests\Notifications;
 
 use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
+use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Support\Collection;
-use Illuminate\Tests\Integration\Notifications\NotifiableUser;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -51,4 +52,12 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertStringContainsString($serializedNotifiable, $serialized);
     }
+}
+
+class NotifiableUser extends Model
+{
+    use Notifiable;
+
+    public $table = 'users';
+    public $timestamps = false;
 }


### PR DESCRIPTION
This PR reverts https://github.com/laravel/framework/pull/33725, https://github.com/laravel/framework/pull/33781 & https://github.com/laravel/framework/pull/33803. It turns out that you could already send plain text emails but that it was undocumented and untested. The PRs that were sent in broke the previous behavior which caused breakage for some people. See https://github.com/laravel/framework/pull/33725#issuecomment-671696219

What I've done is reverted the sent-in PRs but kept the tests and adjusted them to the previous way of working so that behavior is now tested. When this PR gets merged I'll also send in a PR to the docs to make sure it's documented.