### PR TITLE
[7.x] fix 2 bugs that caused defaultTimezone not to be respected in scheduled Events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "doctrine/inflector": "^1.4|^2.0",
-        "dragonmantank/cron-expression": "^2.0",
+        "dragonmantank/cron-expression": "^3.0",
         "egulias/email-validator": "^2.1.10",
         "league/commonmark": "^1.3",
         "league/flysystem": "^1.0.34",

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -28,11 +28,12 @@ class CallbackEvent extends Event
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $callback
      * @param  array  $parameters
+     * @param  \DateTimeZone|string|null  $timezone
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(EventMutex $mutex, $callback, array $parameters = [])
+    public function __construct(EventMutex $mutex, $callback, array $parameters = [], $timezone = null)
     {
         if (! is_string($callback) && ! is_callable($callback)) {
             throw new InvalidArgumentException(
@@ -43,6 +44,7 @@ class CallbackEvent extends Event
         $this->mutex = $mutex;
         $this->callback = $callback;
         $this->parameters = $parameters;
+        $this->timezone = $timezone;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -91,7 +91,7 @@ class Schedule
     public function call($callback, array $parameters = [])
     {
         $this->events[] = $event = new CallbackEvent(
-            $this->eventMutex, $callback, $parameters
+            $this->eventMutex, $callback, $parameters, $this->timezone
         );
 
         return $event;

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -90,6 +90,19 @@ class ConsoleEventSchedulerTest extends TestCase
         $this->assertSame('Asia/Tokyo', $events[0]->timezone);
     }
 
+    public function testCallCreatesNewJobWithTimezone()
+    {
+        $schedule = new Schedule('UTC');
+        $schedule->call('path/to/command');
+        $events = $schedule->events();
+        $this->assertSame('UTC', $events[0]->timezone);
+
+        $schedule = new Schedule('Asia/Tokyo');
+        $schedule->call('path/to/command');
+        $events = $schedule->events();
+        $this->assertSame('Asia/Tokyo', $events[0]->timezone);
+    }
+
     public function testCommandCreatesNewArtisanCommand()
     {
         $escape = '\\' === DIRECTORY_SEPARATOR ? '"' : '\'';

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -96,4 +96,12 @@ class EventTest extends TestCase
 
         $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());
     }
+
+    public function testBetweenFilter()
+    {
+        $event = new Event(m::mock(EventMutex::class), 'php -i');
+        $event->dailyAt('10:15');
+
+        $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());
+    }
 }

--- a/tests/Console/Scheduling/EventTest.php
+++ b/tests/Console/Scheduling/EventTest.php
@@ -96,12 +96,4 @@ class EventTest extends TestCase
 
         $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());
     }
-
-    public function testBetweenFilter()
-    {
-        $event = new Event(m::mock(EventMutex::class), 'php -i');
-        $event->dailyAt('10:15');
-
-        $this->assertSame('10:15:00', $event->nextRunDate()->toTimeString());
-    }
 }


### PR DESCRIPTION
Version Bump dragonmantank/cron-expression
-> fixes a bug that causes cron schedules to drop timezone settings (see changelog: https://github.com/dragonmantank/cron-expression/blob/master/CHANGELOG.md)

Update CallbackEvent
-> CallbackEvents were not injected with the timezone on construction making them ignore the schedulers timezone on $event->between() settings
