### PR TITLE
[7.x] Fix exception message

### DIFF
--- a/src/Illuminate/Filesystem/FilesystemAdapter.php
+++ b/src/Illuminate/Filesystem/FilesystemAdapter.php
@@ -138,7 +138,7 @@ class FilesystemAdapter implements CloudFilesystemContract
         try {
             return $this->driver->read($path);
         } catch (FileNotFoundException $e) {
-            throw new ContractFileNotFoundException($path, $e->getCode(), $e);
+            throw new ContractFileNotFoundException($e->getMessage(), $e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
For some reason the path instead of the exception message is passed here which seems off. There's an exact same other use case in this class where the message does gets passed correctly. Path is available anyway in the passed-through exception.

Fixes https://github.com/laravel/framework/issues/33824