### PR TITLE
[7.x] Add when() method to InteractsWithInput trait

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -430,4 +430,20 @@ trait InteractsWithInput
 
         return $this->$source->get($key, $default);
     }
+
+    /**
+     * Apply the callback if the request contains a given input item key.
+     *
+     * @param  string  $key
+     * @param  callable|null  $callback
+     * @return $this
+     */
+    public function when($key, callable $callback)
+    {
+        if ($this->has($key)) {
+            $callback(data_get($this->all(), $key));
+        }
+
+        return $this;
+    }
 }

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -432,15 +432,31 @@ trait InteractsWithInput
     }
 
     /**
-     * Apply the callback if the request contains a given input item key.
+     * Apply the callback if the request contains the given input item key.
      *
      * @param  string    $key
      * @param  callable  $callback
      * @return $this
      */
-    public function when($key, callable $callback)
+    public function whenHas($key, callable $callback)
     {
         if ($this->has($key)) {
+            $callback(data_get($this->all(), $key));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback if the request contains a non-empty value for the given input item key.
+     *
+     * @param  string    $key
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function whenFilled($key, callable $callback)
+    {
+        if ($this->filled($key)) {
             $callback(data_get($this->all(), $key));
         }
 

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -434,8 +434,8 @@ trait InteractsWithInput
     /**
      * Apply the callback if the request contains a given input item key.
      *
-     * @param  string  $key
-     * @param  callable|null  $callback
+     * @param  string    $key
+     * @param  callable  $callback
      * @return $this
      */
     public function when($key, callable $callback)

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -300,35 +300,60 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
-    public function testWhenMethod()
+    public function testWhenHasMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
-        $name = null;
-        $age = null;
-        $city = '';
-        $foo = null;
+        $name = $age = $city = $foo = false;
 
-        $request->when('name', function ($value) use (&$name) {
+        $request->whenHas('name', function ($value) use (&$name) {
             $name = $value;
         });
 
-        $request->when('age', function ($value) use (&$age) {
+        $request->whenHas('age', function ($value) use (&$age) {
             $age = $value;
         });
 
-        $request->when('city', function ($value) use (&$city) {
+        $request->whenHas('city', function ($value) use (&$city) {
             $city = $value;
         });
 
-        $request->when('foo', function () use (&$foo) {
+        $request->whenHas('foo', function () use (&$foo) {
             $foo = 'test';
         });
 
         $this->assertSame('Taylor', $name);
         $this->assertSame('', $age);
         $this->assertNull($city);
-        $this->assertNull($foo);
+        $this->assertFalse($foo);
+    }
+
+    public function testWhenFilledMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+
+        $name = $age = $city = $foo = false;
+
+        $request->whenFilled('name', function ($value) use (&$name) {
+            $name = $value;
+        });
+
+        $request->whenFilled('age', function ($value) use (&$age) {
+            $age = 'test';
+        });
+
+        $request->whenFilled('city', function ($value) use (&$city) {
+            $city = 'test';
+        });
+
+        $request->whenFilled('foo', function () use (&$foo) {
+            $foo = 'test';
+        });
+
+        $this->assertSame('Taylor', $name);
+        $this->assertFalse($age);
+        $this->assertFalse($city);
+        $this->assertFalse($foo);
     }
 
     public function testMissingMethod()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -300,6 +300,37 @@ class HttpRequestTest extends TestCase
         $this->assertTrue($request->has('foo.baz'));
     }
 
+    public function testWhenMethod()
+    {
+        $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
+
+        $name = null;
+        $age  = null;
+        $city = '';
+        $foo  = null;
+
+        $request->when('name', function ($value) use (&$name) {
+            $name = $value;
+        });
+
+        $request->when('age', function ($value) use (&$age) {
+            $age = $value;
+        });
+
+        $request->when('city', function ($value) use (&$city) {
+            $city = $value;
+        });
+
+        $request->when('foo', function () use (&$foo) {
+            $foo = 'test';
+        });
+
+        $this->assertSame('Taylor', $name);
+        $this->assertSame('', $age);
+        $this->assertNull($city);
+        $this->assertNull($foo);
+    }
+
     public function testMissingMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -305,9 +305,9 @@ class HttpRequestTest extends TestCase
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);
 
         $name = null;
-        $age  = null;
+        $age = null;
         $city = '';
-        $foo  = null;
+        $foo = null;
 
         $request->when('name', function ($value) use (&$name) {
             $name = $value;


### PR DESCRIPTION
This PR adds a `when` method to the `InteractsWithInput` trait. It's inspired by the `when` method of the `Collection` class. The method checks if the request contains the given input item key, and then calls the callback with the input value. 

```php
$request->when('city', function($city) {
    //
});
```

The method returns the `Request` instance itself so you can easily chain it. One use-case is to apply scopes and constraints to a Query Builder or a similar repository:

```php
$request->when('city', function ($city) {
    $this->feed->city($city);
})->when('minimum_price', function ($minimumPrice) {
    $this->feed->minimumPrice($minimumPrice);
})->when('maximum_price', function ($maximumPrice) {
    $this->feed->maximumPrice($maximumPrice);
});
```

This is even prettier with the arrow functions introduced in PHP 7.4 😃

```php
$request->instance()
    ->when('city', fn ($city) => $feed->city($city))
    ->when('minimum_price', fn ($minimumPrice) => $feed->minimumPrice($minimumPrice))
    ->when('maximum_price', fn ($maximumPrice) => $feed->maximumPrice($maximumPrice));
```