### PR TITLE
[6.x] Fix defaultTimezone not respected in scheduled Events

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -28,11 +28,12 @@ class CallbackEvent extends Event
      * @param  \Illuminate\Console\Scheduling\EventMutex  $mutex
      * @param  string  $callback
      * @param  array  $parameters
+     * @param  \DateTimeZone|string|null  $timezone
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(EventMutex $mutex, $callback, array $parameters = [])
+    public function __construct(EventMutex $mutex, $callback, array $parameters = [], $timezone = null)
     {
         if (! is_string($callback) && ! is_callable($callback)) {
             throw new InvalidArgumentException(
@@ -43,6 +44,7 @@ class CallbackEvent extends Event
         $this->mutex = $mutex;
         $this->callback = $callback;
         $this->parameters = $parameters;
+        $this->timezone = $timezone;
     }
 
     /**

--- a/src/Illuminate/Console/Scheduling/Schedule.php
+++ b/src/Illuminate/Console/Scheduling/Schedule.php
@@ -91,7 +91,7 @@ class Schedule
     public function call($callback, array $parameters = [])
     {
         $this->events[] = $event = new CallbackEvent(
-            $this->eventMutex, $callback, $parameters
+            $this->eventMutex, $callback, $parameters, $this->timezone
         );
 
         return $event;

--- a/tests/Console/ConsoleEventSchedulerTest.php
+++ b/tests/Console/ConsoleEventSchedulerTest.php
@@ -117,6 +117,19 @@ class ConsoleEventSchedulerTest extends TestCase
         $binary = $escape.PHP_BINARY.$escape;
         $this->assertEquals($binary.' artisan foo:bar --force', $events[0]->command);
     }
+
+    public function testCallCreatesNewJobWithTimezone()
+    {
+        $schedule = new Schedule('UTC');
+        $schedule->call('path/to/command');
+        $events = $schedule->events();
+        $this->assertSame('UTC', $events[0]->timezone);
+
+        $schedule = new Schedule('Asia/Tokyo');
+        $schedule->call('path/to/command');
+        $events = $schedule->events();
+        $this->assertSame('Asia/Tokyo', $events[0]->timezone);
+    }
 }
 
 class FooClassStub


### PR DESCRIPTION
Update CallbackEvent
-> CallbackEvents were not injected with the timezone on construction making them ignore the schedulers timezone on $event->between() settings