### PR TITLE
[7.x] validate email with custom class

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -656,6 +656,8 @@ trait ValidatesAttributes
                     return new FilterEmailValidation();
                 } elseif ($validation === 'filter_unicode') {
                     return FilterEmailValidation::unicode();
+                } elseif (is_string($validation) && class_exists($validation)) {
+                    return $this->container->make($validation);
                 }
             })
             ->values()

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -4,6 +4,7 @@ namespace Illuminate\Tests\Validation;
 
 use DateTime;
 use DateTimeImmutable;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Guard;
@@ -2419,6 +2420,17 @@ class ValidationValidatorTest extends TestCase
         $this->assertTrue($v->passes());
 
         $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'exämple@exämple.com'], ['x' => 'email:filter_unicode']);
+        $this->assertFalse($v->passes());
+    }
+
+    public function testValidateEmailWithCustomClassCheck()
+    {
+        $container = m::mock(Container::class);
+        $container->shouldReceive('make')->with(NoRFCWarningsValidation::class)->andReturn(new NoRFCWarningsValidation());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['x' => 'foo@bar '], ['x' => 'email:'.NoRFCWarningsValidation::class]);
+        $v->setContainer($container);
+
         $this->assertFalse($v->passes());
     }
 


### PR DESCRIPTION
The underlying [egulias/email-validator](https://github.com/egulias/EmailValidator#how-to-extend) package allows to add custom validators by implementing the `Egulias\EmailValidator\Validation\EmailValidation` interface.
But right now it's not possible to use the existing `email` rule to call these custom validators.

This PR allows to pass in a FQCN which is resolved by the container and returned.

```php
use App\Validation\Email\MyCustomValidator;

Validator::make(
  ['email' => 'foo@bar.de'], 
  ['email' => 'email:rfc,dns,'.MyCustomValidator::class]
)->passes();
```

This example will call the `rfc` and `dns` validator like before but also call `MyCustomValidator`.
That's useful if you want to limit registration to a given email domain, filter trashmails or whatever you want to add on top.