### PR TITLE
[7.x] Add `undot` array helper

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -122,6 +122,23 @@ class Arr
     }
 
     /**
+     * Expand a "dot" notated array into a multi-dimensional array.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    public static function undot($array)
+    {
+        $result = [];
+
+        foreach ($array as $key => $value) {
+            static::set($result, $key, $value);
+        }
+
+        return $result;
+    }
+
+    /**
      * Get all of the given array except for a specified array of keys.
      *
      * @param  array  $array

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -113,6 +113,27 @@ class SupportArrTest extends TestCase
         $this->assertEquals($array, ['name' => 'taylor', 'languages.php' => true]);
     }
 
+    public function testUndot()
+    {
+        $array = Arr::undot([]);
+        $this->assertEquals([], $array);
+
+        $array = Arr::undot(['foo' => []]);
+        $this->assertEquals(['foo' => []], $array);
+
+        $array = Arr::undot(['foo.bar' => []]);
+        $this->assertEquals(['foo' => ['bar' => []]], $array);
+
+        $array = Arr::undot(['foo.bar' => 'baz']);
+        $this->assertEquals(['foo' => ['bar' => 'baz']], $array);
+
+        $array = Arr::undot(['foo.bar.baz' => 'qux']);
+        $this->assertEquals(['foo' => ['bar' => ['baz' => 'qux']]], $array);
+
+        $array = Arr::undot(['name' => 'taylor', 'languages.php' => true]);
+        $this->assertEquals(['name' => 'taylor', 'languages' => ['php' => true]], $array);
+    }
+
     public function testExcept()
     {
         $array = ['name' => 'taylor', 'age' => 26];


### PR DESCRIPTION
Adds the inverse to the `dot` array helper by expanding array keys with "dot" notation into multi-dimensional arrays.

Besides adding the inverse functionality, there are times when certain functions/methods in your code may not allow multi-dimensional arrays and you need a way to pass flattened "dot" notated arrays to them (or maybe you find the syntax easier to write). For example, if you were to [add a message](https://laravel.com/api/7.x/Illuminate/Contracts/Support/MessageBag.html#method_add) with something like:

```php
$messages = new MessageBag([
    'error.code' => 403,
    'error.message' => 'Unauthorized request',
]);
```

You could store those messages correctly, and after retrieving them, simply `undot` the messages to get a proper array:

```php
[
  'error' => [
    'code' => 403,
    'message' => 'Unauthorized request'
  ]
]
```

This does not break existing functionality since it's a new helper and tests have been provided.

*This is my first pull request **ever** to a project that isn't work related, so hopefully I did this right (even watched Jeffrey Way's video on Laracasts). I think I spent more time writing the method's description than anything else* 😬