### PR TITLE
[7.x] Add blade attribute method `whereDoesNotStartsWith(string)`

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -119,15 +119,15 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
     
     /**
-     * Return a bag of attributes that have keys not starting with the given value / pattern.
+     * Return a bag of attributes with keys that do not start with the given value / pattern.
      *
      * @param  string  $string
      * @return static
      */
-    public function whereDoesNotStartsWith($string)
+    public function whereDoesntStartWith($string)
     {
-        return $this->filter(function ($value, $key) use ($string) {
-            return ! Str::startsWith($key, $string);
+        return $this->reject(function ($value, $key) use ($string) {
+            return Str::startsWith($key, $string);
         });
     }
 

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -117,6 +117,19 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             return Str::startsWith($key, $string);
         });
     }
+    
+    /**
+     * Return a bag of attributes that have keys not starting with the given value / pattern.
+     *
+     * @param  string  $string
+     * @return static
+     */
+    public function whereDoesNotStartsWith($string)
+    {
+        return $this->filter(function ($value, $key) use ($string) {
+            return ! Str::startsWith($key, $string);
+        });
+    }
 
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.


### PR DESCRIPTION
This PR adds a method `whereDoesNotStartsWith($string)` which complements the `whereStartsWith($string)` for handling blade component attribute bags.

## What is this used for?
In general this complements the `whereStartsWith($string)` so that one can easily split the attribute bag into two portions that can be handled differently.

One great example would be a Livewire compatible component like:

```html
<x-custom-input wire:model="input" value="123"/>
```
Now a completely simplified version of this component could be something like:
```html
// resources/views/components/custom-input.blade.php

<div {{-- This is an outer div and this is the one livewire should operate on - so all livewire stuff here --}}
    {{ $attributes->whereStartsWith('wire:') }}
>
    {{--
            Here can be any kind of stuff maybe using a lot of livewire, dispatching events
            and stopping other events from bubbling up.
    --}}

   <input {{ $attributes->whereDoesNotStartsWith('wire:')->merge(['class' => 'some-class']) }}/>
</div>
```

## Alternatives
There is already a filter method, so essentially these two are identical:

```html
{{ $attributes->whereDoesNotStartsWith('wire:') }}<!-- New proposed syntax -->
{{ $attributes->filter(fn ($value, $key) => ! \Illuminate\Support\Str::startsWith($key, 'wire:')) }}<!-- Already available -->
```
