### PR TITLE
[7.x] Support Collection#countBy($key)

### DIFF
--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -248,9 +248,9 @@ class LazyCollection implements Enumerable
      */
     public function countBy($countBy = null)
     {
-        if (is_null($countBy)) {
-            $countBy = $this->identity();
-        }
+        $countBy = is_null($countBy)
+            ? $this->identity()
+            : $this->valueRetriever($countBy);
 
         return new static(function () use ($countBy) {
             $counts = [];

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -478,7 +478,7 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testCountableByWithoutPredicate($collection)
+    public function testCountByStandalone($collection)
     {
         $c = new $collection(['foo', 'foo', 'foo', 'bar', 'bar', 'foobar']);
         $this->assertEquals(['foo' => 3, 'bar' => 2, 'foobar' => 1], $c->countBy()->all());
@@ -493,7 +493,19 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
-    public function testCountableByWithPredicate($collection)
+    public function testCountByWithKey($collection)
+    {
+        $c = new $collection([
+            ['key' => 'a'], ['key' => 'a'], ['key' => 'a'], ['key' => 'a'],
+            ['key' => 'b'], ['key' => 'b'], ['key' => 'b'],
+        ]);
+        $this->assertEquals(['a' => 4, 'b' => 3], $c->countBy('key')->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testCountableByWithCallback($collection)
     {
         $c = new $collection(['alice', 'aaron', 'bob', 'carla']);
         $this->assertEquals(['a' => 2, 'b' => 1, 'c' => 1], $c->countBy(function ($name) {


### PR DESCRIPTION
#33801 broke the usage of the collection's `countBy` method when passed a key as a string.

There was obviously no test for it.

This PR fixes it and adds the relevant test.

Closes #33847.