### PR TITLE
[8.x] Arr::random add preserve keys option

### DIFF
--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -498,11 +498,12 @@ class Arr
      *
      * @param  array  $array
      * @param  int|null  $number
+     * @param  bool|false  $preserveKeys
      * @return mixed
      *
      * @throws \InvalidArgumentException
      */
-    public static function random($array, $number = null)
+    public static function random($array, $number = null, $preserveKeys = false)
     {
         $requested = is_null($number) ? 1 : $number;
 
@@ -526,8 +527,8 @@ class Arr
 
         $results = [];
 
-        foreach ((array) $keys as $key) {
-            $results[] = $array[$key];
+        foreach ((array) $keys as $index => $key) {
+            $results[$preserveKeys ? $key : $index] = $array[$key];
         }
 
         return $results;

--- a/src/Illuminate/Collections/Arr.php
+++ b/src/Illuminate/Collections/Arr.php
@@ -527,8 +527,14 @@ class Arr
 
         $results = [];
 
-        foreach ((array) $keys as $index => $key) {
-            $results[$preserveKeys ? $key : $index] = $array[$key];
+        if ($preserveKeys) {
+            foreach ((array) $keys as $key) {
+                $results[$key] = $array[$key];
+            }
+        } else {
+            foreach ((array) $keys as $key) {
+                $results[] = $array[$key];
+            }
         }
 
         return $results;

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -630,6 +630,12 @@ class SupportArrTest extends TestCase
         $this->assertCount(2, $random);
         $this->assertContains($random[0], ['foo', 'bar', 'baz']);
         $this->assertContains($random[1], ['foo', 'bar', 'baz']);
+
+        // preserve keys
+        $random = Arr::random(['one' => 'foo', 'two' => 'bar', 'three' => 'baz'], 2, true);
+        $this->assertIsArray($random);
+        $this->assertCount(2, $random);
+        $this->assertCount(2, array_intersect_assoc(['one' => 'foo', 'two' => 'bar', 'three' => 'baz'], $random));
     }
 
     public function testRandomOnEmptyArray()


### PR DESCRIPTION
This PR adds a new option `$preserveKeys = false` to the `Arr::random` method, allowing it to preserve keys for associative arrays.

It is helpful if you need random values from associative array and you want to keep original keys:

Array example:
```
$array = [
    'one' => 'foo',
    'two' => 'bar',
    'three' => 'baz'
];
```
Before: `Arr::random($array, 2)`, returns:
```
$array = [
    0 => 'foo',
    1 => 'baz'
];
```

After: `Arr::random($array, 2, true)`, returns:
```
$array = [
    'one' => 'foo',
    'three' => 'baz'
];
```