### PR TITLE
[7.x] Update Model.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -396,7 +396,8 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @param  string  $key
      * @return string
-     * @deprecated Use of this method is deprecated and will be removed in a future Laravel version.
+     *
+     * @deprecated This method is deprecated and will be removed in a future Laravel version.
      */
     protected function removeTableFromKey($key)
     {

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -396,6 +396,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      *
      * @param  string  $key
      * @return string
+     * @deprecated Use of this method is deprecated and will be removed in a future Laravel version.
      */
     protected function removeTableFromKey($key)
     {


### PR DESCRIPTION
Since this method has become shallow after the recent security updates, there's little point in keeping it. We can deprecate it on 7.x so that anyone on 7.x can still overwrite it if they need the previous behavior but in a future Laravel version (preferable v8) we should discourage usage of it entirely by removing the method.