### PR TITLE
[7.x] Update Authorizable contract parameter names

### DIFF
--- a/src/Illuminate/Contracts/Auth/Access/Authorizable.php
+++ b/src/Illuminate/Contracts/Auth/Access/Authorizable.php
@@ -7,9 +7,9 @@ interface Authorizable
     /**
      * Determine if the entity has a given ability.
      *
-     * @param  string  $ability
+     * @param  iterable|string  $abilities
      * @param  array|mixed  $arguments
      * @return bool
      */
-    public function can($ability, $arguments = []);
+    public function can($abilities, $arguments = []);
 }


### PR DESCRIPTION
There's a parameter mismatch found by Psalm in my new Laravel project. Base User class is using trait `Illuminate\Contracts\Auth\Access\Gate\Authorizable` with method `can` with signature `iterable|string $abilities`; interface is defined as `string $ability`. Different parameter naming could be a problem for named parameters in PHP 8.0. Inconsistent type hints could be a problem for mocking/extending/testing/whatever.

Error from Psalm:
```
ERROR: ParamNameMismatch - app/User.php:10:7 - Argument 1 of Illuminate\Foundation\Auth\Access\Authorizable::can has wrong name $abilities, expecting $ability as defined by Illuminate\Contracts\Auth\Access\Authorizable::can (see https://psalm.dev/230)
```
