### PR TITLE
[7.x] Normalize scheme in Redis connections

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -56,7 +56,7 @@ class PhpRedisConnector implements Connector
      */
     protected function buildClusterConnectionString(array $server)
     {
-        return $server['host'].':'.$server['port'].'?'.Arr::query(Arr::only($server, [
+        return $this->formatHost($server).':'.$server['port'].'?'.Arr::query(Arr::only($server, [
             'database', 'password', 'prefix', 'read_timeout',
         ]));
     }
@@ -116,7 +116,7 @@ class PhpRedisConnector implements Connector
         $persistent = $config['persistent'] ?? false;
 
         $parameters = [
-            $config['host'],
+            $this->formatHost($config),
             $config['port'],
             Arr::get($config, 'timeout', 0.0),
             $persistent ? Arr::get($config, 'persistent_id', null) : null,
@@ -172,5 +172,20 @@ class PhpRedisConnector implements Connector
                 $client->setOption(RedisCluster::OPT_SLAVE_FAILOVER, $options['failover']);
             }
         });
+    }
+
+    /**
+     * Format the host using the scheme if available.
+     *
+     * @param  array  $options
+     * @return string
+     */
+    protected function formatHost(array $options)
+    {
+        if (isset($options['scheme'])) {
+            return "{$options['scheme']}://{$options['host']}";
+        }
+
+        return $options['host'];
     }
 }

--- a/src/Illuminate/Redis/RedisManager.php
+++ b/src/Illuminate/Redis/RedisManager.php
@@ -188,7 +188,7 @@ class RedisManager implements Factory
         $driver = strtolower($parsed['driver'] ?? '');
 
         if (in_array($driver, ['tcp', 'tls'])) {
-            $parsed['host'] = "{$driver}://{$parsed['host']}";
+            $parsed['scheme'] = $driver;
         }
 
         return array_filter($parsed, function ($key) {

--- a/src/Illuminate/Support/ConfigurationUrlParser.php
+++ b/src/Illuminate/Support/ConfigurationUrlParser.php
@@ -17,6 +17,8 @@ class ConfigurationUrlParser
         'postgres' => 'pgsql',
         'postgresql' => 'pgsql',
         'sqlite3' => 'sqlite',
+        'redis' => 'tcp',
+        'rediss' => 'tls',
     ];
 
     /**

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -77,7 +77,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient = $phpRedis->connection()->client();
-        $this->assertEquals($host, $phpRedisClient->getHost());
+        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
     }
 

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Illuminate\Tests\Redis;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Illuminate\Redis\RedisManager;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class RedisConnectorTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRedis();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->tearDownRedis();
+
+        m::close();
+    }
+
+    public function testDefaultConfiguration()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predisClient = $this->redis['predis']->connection()->client();
+        $parameters = $predisClient->getConnection()->getParameters();
+        $this->assertEquals('tcp', $parameters->scheme);
+        $this->assertEquals($host, $parameters->host);
+        $this->assertEquals($port, $parameters->port);
+
+        $phpRedisClient = $this->redis['phpredis']->connection()->client();
+        $this->assertEquals($host, $phpRedisClient->getHost());
+        $this->assertEquals($port, $phpRedisClient->getPort());
+    }
+
+    public function testUrl()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predis = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'url' => "redis://{$host}:{$port}",
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $predisClient = $predis->connection()->client();
+        $parameters = $predisClient->getConnection()->getParameters();
+        $this->assertEquals('tcp', $parameters->scheme);
+        $this->assertEquals($host, $parameters->host);
+        $this->assertEquals($port, $parameters->port);
+
+        $phpRedis = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'url' => "redis://{$host}:{$port}",
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $phpRedisClient = $phpRedis->connection()->client();
+        $this->assertEquals($host, $phpRedisClient->getHost());
+        $this->assertEquals($port, $phpRedisClient->getPort());
+    }
+
+    public function testUrlWithScheme()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predis = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'url' => "tls://{$host}:{$port}",
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $predisClient = $predis->connection()->client();
+        $parameters = $predisClient->getConnection()->getParameters();
+        $this->assertEquals('tls', $parameters->scheme);
+        $this->assertEquals($host, $parameters->host);
+        $this->assertEquals($port, $parameters->port);
+
+        $phpRedis = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'url' => "tcp://{$host}:{$port}",
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $phpRedisClient = $phpRedis->connection()->client();
+        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
+        $this->assertEquals($port, $phpRedisClient->getPort());
+    }
+
+    public function testScheme()
+    {
+        $host = env('REDIS_HOST', '127.0.0.1');
+        $port = env('REDIS_PORT', 6379);
+
+        $predis = new RedisManager(new Application, 'predis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tls',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $predisClient = $predis->connection()->client();
+        $parameters = $predisClient->getConnection()->getParameters();
+        $this->assertEquals('tls', $parameters->scheme);
+        $this->assertEquals($host, $parameters->host);
+        $this->assertEquals($port, $parameters->port);
+
+        $phpRedis = new RedisManager(new Application, 'phpredis', [
+            'cluster' => false,
+            'options' => [
+                'prefix' => 'test_',
+            ],
+            'default' => [
+                'scheme' => 'tcp',
+                'host' => $host,
+                'port' => $port,
+                'database' => 5,
+                'timeout' => 0.5,
+            ],
+        ]);
+        $phpRedisClient = $phpRedis->connection()->client();
+        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
+        $this->assertEquals($port, $phpRedisClient->getPort());
+    }
+}

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -380,6 +380,23 @@ class ConfigurationUrlParserTest extends TestCase
                     'password' => 'asdfqwer1234asdf',
                 ],
             ],
+            'Redis Example with scheme' => [
+                [
+                    'url' => 'tls://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111',
+                    'host' => '127.0.0.1',
+                    'password' =>  null,
+                    'port' =>  6379,
+                    'database' => 0,
+                ],
+                [
+                    'driver' => 'tls',
+                    'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
+                    'port' => 111,
+                    'database' => 0,
+                    'username' => 'h',
+                    'password' => 'asdfqwer1234asdf',
+                ],
+            ],
         ];
     }
 }

--- a/tests/Support/ConfigurationUrlParserTest.php
+++ b/tests/Support/ConfigurationUrlParserTest.php
@@ -23,6 +23,8 @@ class ConfigurationUrlParserTest extends TestCase
             'postgres' => 'pgsql',
             'postgresql' => 'pgsql',
             'sqlite3' => 'sqlite',
+            'redis' => 'tcp',
+            'rediss' => 'tls',
         ], ConfigurationUrlParser::getDriverAliases());
 
         ConfigurationUrlParser::addDriverAlias('some-particular-alias', 'mysql');
@@ -33,6 +35,8 @@ class ConfigurationUrlParserTest extends TestCase
             'postgres' => 'pgsql',
             'postgresql' => 'pgsql',
             'sqlite3' => 'sqlite',
+            'redis' => 'tcp',
+            'rediss' => 'tls',
             'some-particular-alias' => 'mysql',
         ], ConfigurationUrlParser::getDriverAliases());
 
@@ -355,7 +359,7 @@ class ConfigurationUrlParserTest extends TestCase
                     'database' => 0,
                 ],
                 [
-                    'driver' => 'redis',
+                    'driver' => 'tcp',
                     'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
                     'port' => 111,
                     'database' => 0,
@@ -367,12 +371,12 @@ class ConfigurationUrlParserTest extends TestCase
                 [
                     'url' => 'redis://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111/',
                     'host' => '127.0.0.1',
-                    'password' =>  null,
-                    'port' =>  6379,
+                    'password' => null,
+                    'port' => 6379,
                     'database' => 2,
                 ],
                 [
-                    'driver' => 'redis',
+                    'driver' => 'tcp',
                     'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
                     'port' => 111,
                     'database' => 2,
@@ -380,9 +384,26 @@ class ConfigurationUrlParserTest extends TestCase
                     'password' => 'asdfqwer1234asdf',
                 ],
             ],
-            'Redis Example with scheme' => [
+            'Redis Example with tls scheme' => [
                 [
                     'url' => 'tls://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111',
+                    'host' => '127.0.0.1',
+                    'password' =>  null,
+                    'port' =>  6379,
+                    'database' => 0,
+                ],
+                [
+                    'driver' => 'tls',
+                    'host' => 'ec2-111-1-1-1.compute-1.amazonaws.com',
+                    'port' => 111,
+                    'database' => 0,
+                    'username' => 'h',
+                    'password' => 'asdfqwer1234asdf',
+                ],
+            ],
+            'Redis Example with rediss scheme' => [
+                [
+                    'url' => 'rediss://h:asdfqwer1234asdf@ec2-111-1-1-1.compute-1.amazonaws.com:111',
                     'host' => '127.0.0.1',
                     'password' =>  null,
                     'port' =>  6379,


### PR DESCRIPTION
## Description

This PR attempts to improve the consistency between `Predis` and `PhpRedis` drivers regarding the configuration of the `scheme`.

## Current behavior

By default both drivers are connecting to the Redis server using `tcp`. It is possible to configure the scheme but each driver requires a different setup:

- The Predis client accepts a `scheme` key in the `$parameters` array of its constructor. E.g. `'scheme' => 'tls'`.
- The PhpRedis client needs to have the scheme prefixed to the `$host` string of its constructor. E.g. `tls://127.0.0.1`.

In Laravel that means we have to use different configurations in `database.php`:
```php
// predis
'default' => [
    'scheme' => 'tls',
    'host' => '127.0.0.1',
    'port' => '6379',
]

// phpredis
'default' => [
    'host' => 'tls://127.0.0.1',
    'port' => '6379',
]
```

Since #33800 was merged, it is possible to define the scheme using the `url` key for `phpredis`. The `url` being parsed transforms the `host` in the correct format as `tls://127.0.0.1`:
```php
// phpredis
'default' => [
    'url' => 'tls://127.0.0.1:6379',
]
```

But using the `url` key for the predis driver results in a connection error, because the `host` is again formatted as `tls://127.0.0.1` but the client has its scheme as `tcp` internally, so it tries to connect to `tcp://tls://127.0.0.1:6379` which is invalid.

## Proposed changes

With this PR, it is possible to use the `scheme` key as well as the `url` key for **both** drivers, thus improving the consistency in the configuration and allowing to switch drivers more easily:

```php
// scheme using url (predis / phpredis)
'default' => [
    'url' => 'tls://127.0.0.1:6379',
]

// scheme using key (predis / phpredis)
'default' => [
    'scheme' => 'tls',
    'host' => '127.0.0.1',
    'port' => '6379',
]
```

Instead of formatting the `host` in `RedisManager` like the aforementioned PR does, it assigns the `scheme` key in the configuration, which will be handled in the connectors: The `PredisConnector` will pass it to the client's constructor, and the `PhpRedisConnector` will format the `host` using the `scheme` if it was defined in the configuration or parsed from the `url`.

This change has no breaking changes, as it follows the functionality of the previous PR, allowing `redis://` protocols as well as `tcp://` and `tls://` in the `url` key. It's also compatible with the existing functionality regarding the `scheme` key for the predis driver.

## Summary

- Add support for defining the `scheme` in  the `url` key for `predis`
- Add support for defining the `scheme` key for `phpredis`
- Functionality for defining the `scheme` in the `url` key for `phpredis` remains the same
- Functionality for defining the `scheme` key for `predis` remains the same
- All functionality also apply to `clusters`
- Add tests asserting both drivers are connecting correctly with `scheme` or `url`
- Add test asserting the `ConfigurationUrlParser` returns the correct `driver` for Redis URLs with scheme