### PR TITLE
[6.x] Undeprecate Predis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-        "predis/predis": "Required to use the redis cache and queue drivers (^1.1.2).",
+        "predis/predis": "Required to use the predis connector (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",

--- a/composer.json
+++ b/composer.json
@@ -131,6 +131,7 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
+        "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
         "moontoast/math": "Required to use ordered UUIDs (^1.1).",
         "nyholm/psr7": "Required to use PSR-7 bridging features (^1.2).",
         "pda/pheanstalk": "Required to use the beanstalk queue driver (^4.0).",
-        "predis/predis": "Required to use the redis cache and queue drivers (^1.0).",
+        "predis/predis": "Required to use the redis cache and queue drivers (^1.1.2).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^4.3.4).",

--- a/src/Illuminate/Redis/Connections/PredisClusterConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisClusterConnection.php
@@ -2,9 +2,6 @@
 
 namespace Illuminate\Redis\Connections;
 
-/**
- * @deprecated Predis is no longer maintained by its original author
- */
 class PredisClusterConnection extends PredisConnection
 {
     //

--- a/src/Illuminate/Redis/Connections/PredisConnection.php
+++ b/src/Illuminate/Redis/Connections/PredisConnection.php
@@ -9,7 +9,6 @@ use Predis\Connection\Aggregate\ClusterInterface;
 
 /**
  * @mixin \Predis\Client
- * @deprecated Predis is no longer maintained by its original author
  */
 class PredisConnection extends Connection implements ConnectionContract
 {

--- a/src/Illuminate/Redis/Connectors/PredisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PredisConnector.php
@@ -8,9 +8,6 @@ use Illuminate\Redis\Connections\PredisConnection;
 use Illuminate\Support\Arr;
 use Predis\Client;
 
-/**
- * @deprecated Predis is no longer maintained by its original author
- */
 class PredisConnector implements Connector
 {
     /**

--- a/src/Illuminate/Redis/composer.json
+++ b/src/Illuminate/Redis/composer.json
@@ -25,7 +25,7 @@
     },
     "suggest": {
         "ext-redis": "Required to use the phpredis connector (^4.0|^5.0).",
-        "predis/predis": "Required to use the predis connector (^1.0)."
+        "predis/predis": "Required to use the predis connector (^1.1.2)."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Now that Predis is maintained again and 1.1.2 supports all latest PHP released and PHP 8, we can undeprecate it again. 

Basically partially reverts https://github.com/laravel/framework/pull/29688