### PR TITLE
[8.x] Add support for relative links in filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
         "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^4.0).",
         "symfony/cache": "Required to PSR-6 cache bridge (^5.1).",
-        "symfony/filesystem": "Required to create relative storage directory symbolic links (^5.1).",
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1).",
         "symfony/psr-http-message-bridge": "Required to use PSR-7 bridging features (^2.0).",
         "wildbit/swiftmailer-postmark": "Required to use Postmark mail driver (^3.0)."
     },

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -294,8 +294,8 @@ class Filesystem
     /**
      * Create a relative symlink to the target file or directory.
      *
-     * @param string $target
-     * @param string $link
+     * @param  string  $target
+     * @param  string  $link
      * @return void
      */
     public function relativeLink($target, $link)

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -7,6 +7,7 @@ use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Mime\MimeTypes;
 
@@ -277,10 +278,21 @@ class Filesystem
      *
      * @param  string  $target
      * @param  string  $link
+     * @param  bool  $relative
      * @return void
      */
-    public function link($target, $link)
+    public function link($target, $link, $relative = false)
     {
+        if ($relative) {
+            if (! class_exists(SymfonyFilesystem::class)) {
+                throw new RuntimeException(
+                    'To enable support for relative links, please install the symfony/filesystem package.'
+                );
+            }
+
+            $target = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
+        }
+
         if (! windows_os()) {
             return symlink($target, $link);
         }

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -278,21 +278,10 @@ class Filesystem
      *
      * @param  string  $target
      * @param  string  $link
-     * @param  bool  $relative
      * @return void
      */
-    public function link($target, $link, $relative = false)
+    public function link($target, $link)
     {
-        if ($relative) {
-            if (! class_exists(SymfonyFilesystem::class)) {
-                throw new RuntimeException(
-                    'To enable support for relative links, please install the symfony/filesystem package.'
-                );
-            }
-
-            $target = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
-        }
-
         if (! windows_os()) {
             return symlink($target, $link);
         }
@@ -300,6 +289,26 @@ class Filesystem
         $mode = $this->isDirectory($target) ? 'J' : 'H';
 
         exec("mklink /{$mode} ".escapeshellarg($link).' '.escapeshellarg($target));
+    }
+
+    /**
+     * Create a relative symlink to the target file or directory.
+     *
+     * @param string $target
+     * @param string $link
+     * @return void
+     */
+    public function relativeLink($target, $link)
+    {
+        if (! class_exists(SymfonyFilesystem::class)) {
+            throw new RuntimeException(
+                'To enable support for relative links, please install the symfony/filesystem package.'
+            );
+        }
+
+        $relativeTarget = (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
+
+        $this->link($relativeTarget, $link);
     }
 
     /**

--- a/src/Illuminate/Filesystem/composer.json
+++ b/src/Illuminate/Filesystem/composer.json
@@ -39,7 +39,8 @@
         "league/flysystem-cached-adapter": "Required to use the Flysystem cache (^1.0).",
         "league/flysystem-sftp": "Required to use the Flysystem SFTP driver (^1.0).",
         "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
-        "symfony/mime": "Required to enable support for guessing extensions (^5.0)."
+        "symfony/filesystem": "Required to enable support for relative symbolic links (^5.1).",
+        "symfony/mime": "Required to enable support for guessing extensions (^5.1)."
     },
     "config": {
         "sort-packages": true

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -3,8 +3,6 @@
 namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
-use RuntimeException;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 
 class StorageLinkCommand extends Command
 {
@@ -29,15 +27,13 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
+        $relative = $this->option('relative');
+
         foreach ($this->links() as $link => $target) {
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
             } else {
-                if ($this->option('relative')) {
-                    $target = $this->getRelativeTarget($link, $target);
-                }
-
-                $this->laravel->make('files')->link($target, $link);
+                $this->laravel->make('files')->link($target, $link, $relative);
 
                 $this->info("The [$link] link has been connected to [$target].");
             }
@@ -55,21 +51,5 @@ class StorageLinkCommand extends Command
     {
         return $this->laravel['config']['filesystems.links'] ??
                [public_path('storage') => storage_path('app/public')];
-    }
-
-    /**
-     * Get the relative path to the target.
-     *
-     * @param  string  $link
-     * @param  string  $target
-     * @return string
-     */
-    protected function getRelativeTarget($link, $target)
-    {
-        if (! class_exists(SymfonyFilesystem::class)) {
-            throw new RuntimeException('To enable support for relative links, please install the symfony/filesystem package.');
-        }
-
-        return (new SymfonyFilesystem)->makePathRelative($target, dirname($link));
     }
 }

--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -32,11 +32,16 @@ class StorageLinkCommand extends Command
         foreach ($this->links() as $link => $target) {
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
-            } else {
-                $this->laravel->make('files')->link($target, $link, $relative);
-
-                $this->info("The [$link] link has been connected to [$target].");
+                continue;
             }
+
+            if ($relative) {
+                $this->laravel->make('files')->relativeLink($target, $link);
+            } else {
+                $this->laravel->make('files')->link($target, $link);
+            }
+
+            $this->info("The [$link] link has been connected to [$target].");
         }
 
         $this->info('The links have been created.');

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -39,7 +39,8 @@ namespace Illuminate\Support\Facades;
  * @method static string type(string $path)
  * @method static string|false mimeType(string $path)
  * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
- * @method static void link(string $target, string $link, bool $relative)
+ * @method static void link(string $target, string $link)
+ * @method static void relativeLink(string $target, string $link)
  * @method static void replace(string $path, string $content)
  *
  * @see \Illuminate\Filesystem\Filesystem

--- a/src/Illuminate/Support/Facades/File.php
+++ b/src/Illuminate/Support/Facades/File.php
@@ -39,7 +39,7 @@ namespace Illuminate\Support\Facades;
  * @method static string type(string $path)
  * @method static string|false mimeType(string $path)
  * @method static void ensureDirectoryExists(string $path, int $mode = 0755, bool $recursive = true)
- * @method static void link(string $target, string $link)
+ * @method static void link(string $target, string $link, bool $relative)
  * @method static void replace(string $path, string $content)
  *
  * @see \Illuminate\Filesystem\Filesystem


### PR DESCRIPTION
This PR add support for relative symlinks in Filesystem, simply by moving the code from StorageLinkCommand to Filesystem so it's reusable. 

With this, relative links can be directly created in the framework or in an Laravel application without the need to add the same code to make relatives links outside of the StorageLinkCommand.

```php
// Before 
$target = (new \Symfony\Component\Filesystem\Filesystem())->makePathRelative($target, dirname($link));
File::link($target, $link);

// After
File::relativeLink($target, $link);
```