### PR TITLE
[6.x] Fatal error handling memory limit increase

### DIFF
--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -34,7 +34,7 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
-        self::$reservedMemory = str_repeat('x', 10240);
+        self::$reservedMemory = str_repeat('x', 5 * 1024 * 1024);
 
         $this->app = $app;
 

--- a/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
+++ b/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php
@@ -34,7 +34,7 @@ class HandleExceptions
      */
     public function bootstrap(Application $app)
     {
-        self::$reservedMemory = str_repeat('x', 5 * 1024 * 1024);
+        self::$reservedMemory = str_repeat('x', 512 * 1024);
 
         $this->app = $app;
 


### PR DESCRIPTION
When an `Out of Memory` Fatal error occurs the `$reservedMemory` allocated is not enough when the memory limit is hit due to a large DB query (both Sentry and BugSnag were unable to report many of our `Out of Memory` errors until we increased this value).

If you don't think the default should be updated, then it should at least be user-configurable as it's very important that memory limit errors not go unnoticed/unreported. Thanks!