### PR TITLE
[7.x] Fix `@throws` in PHPDoc to use Throwable

### DIFF
--- a/src/Illuminate/Database/Connectors/Connector.php
+++ b/src/Illuminate/Database/Connectors/Connector.php
@@ -33,7 +33,7 @@ class Connector
      * @param  array  $options
      * @return \PDO
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function createConnection($dsn, array $config, array $options)
     {
@@ -92,7 +92,7 @@ class Connector
      * @param  array  $options
      * @return \PDO
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     protected function tryAgainIfCausedByLostConnection(Throwable $e, $dsn, $username, $password, $options)
     {

--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -94,7 +94,7 @@ class Handler implements ExceptionHandlerContract
      * @param  \Throwable  $e
      * @return void
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function report(Throwable $e)
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -525,7 +525,7 @@ class PendingRequest
      * @param  array  $options
      * @return \Illuminate\Http\Client\Response
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     public function send(string $method, string $url, array $options = [])
     {

--- a/src/Illuminate/Queue/SyncQueue.php
+++ b/src/Illuminate/Queue/SyncQueue.php
@@ -109,7 +109,7 @@ class SyncQueue extends Queue implements QueueContract
      * @param  \Throwable  $e
      * @return void
      *
-     * @throws \Exception
+     * @throws \Throwable
      */
     protected function handleException(Job $queueJob, Throwable $e)
     {


### PR DESCRIPTION
This PR fixes `@throws` in PHPDoc to correctly use `Throwable`.