### PR TITLE
[8.x] Adds onFail parameter to validate method

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -9,9 +9,10 @@ interface Validator extends MessageProvider
     /**
      * Run the validator's rules against its data.
      *
+     * @param  \Closure|null  $onFail
      * @return array
      */
-    public function validate();
+    public function validate($onFail = null);
 
     /**
      * Get the attributes and values that were validated.

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -435,13 +435,16 @@ class Validator implements ValidatorContract
     /**
      * Run the validator's rules against its data.
      *
-     * @return array
-     *
+     * @param  \Closure|null  $onFail
      * @throws \Illuminate\Validation\ValidationException
+     * @return array
      */
-    public function validate()
+    public function validate($onFail = null)
     {
         if ($this->fails()) {
+            if ($onFail) {
+                $onFail($this);
+            }
             throw new ValidationException($this);
         }
 


### PR DESCRIPTION
This allows us to pass a closure, so in case the validation fails we can run some code to log something or raise an event.
(It also encourages functional style) The way the validation exception is currently caught in Exception class is only good to set a global handler for all validations errors, but if we want the code to be run for only one validation, it would be problematic.

Example Usage:
![image](https://user-images.githubusercontent.com/6961695/90321975-e3832300-df63-11ea-9c92-f02d4a3d3683.png)

- Notes:
1- Obviously it is not fully backward compatible since the contract signature changes, but it is rare that anyone has a custom implementation.
2- I will add the needed tests if accepted.
3- `$onFail` can also be called by App::call(), instead of `$onFail($this);` so that it would be more flexible.
4- It can be rewritten like below, but I did not do it so that it was easier to judge the changes. (Taylor may do it if he likes to)

![image](https://user-images.githubusercontent.com/6961695/90318739-cb9da600-df47-11ea-83df-0664ef98c666.png)


