### PR TITLE
[7.x] Allow setting synchronous_commit for Postgres

### DIFF
--- a/src/Illuminate/Database/Connectors/PostgresConnector.php
+++ b/src/Illuminate/Database/Connectors/PostgresConnector.php
@@ -47,6 +47,8 @@ class PostgresConnector extends Connector implements ConnectorInterface
         // determine if the option has been specified and run a statement if so.
         $this->configureApplicationName($connection, $config);
 
+        $this->configureSynchronousCommit($connection, $config);
+
         return $connection;
     }
 
@@ -172,5 +174,21 @@ class PostgresConnector extends Connector implements ConnectorInterface
         }
 
         return $dsn;
+    }
+
+    /**
+     * Configure the synchronous_commit setting.
+     *
+     * @param  \PDO  $connection
+     * @param  array  $config
+     * @return void
+     */
+    protected function configureSynchronousCommit($connection, array $config)
+    {
+        if (! isset($config['synchronous_commit'])) {
+            return;
+        }
+
+        $connection->prepare("set synchronous_commit to '{$config['synchronous_commit']}'")->execute();
     }
 }


### PR DESCRIPTION
See https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
> Specifies whether transaction commit will wait for WAL records to be written to disk before the command returns a “success” indication to the client. Valid values are on, remote_apply, remote_write, local, and off
> …
> So, turning synchronous_commit off can be a useful alternative when performance is more important than exact certainty about the durability of a transaction.

----
My use-case is exact the last paragraph, so I can turn it `off`.

PR for showing the setting in the config => https://github.com/laravel/laravel/pull/5375