### PR TITLE
[7.x] Added string casting to contains and endsWith

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -174,7 +174,7 @@ class Str
     public static function contains($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && mb_strpos($haystack, $needle) !== false) {
+            if ((string) $needle !== '' && mb_strpos($haystack, $needle) !== false) {
                 return true;
             }
         }
@@ -210,7 +210,7 @@ class Str
     public static function endsWith($haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
-            if ($needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
+            if ((string) $needle !== '' && substr($haystack, -strlen($needle)) === (string) $needle) {
                 return true;
             }
         }


### PR DESCRIPTION
I have noticed two missing casts to type string when comparing the needle to an empty string, which are applied in the same way as the startsWith method does. 