### PR TITLE
[7.x] Composer v2 fix

### DIFF
--- a/src/Illuminate/Foundation/PackageManifest.php
+++ b/src/Illuminate/Foundation/PackageManifest.php
@@ -127,7 +127,7 @@ class PackageManifest
 
         $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
-        $this->write(collect($packages)->mapWithKeys(function ($package) {
+        $this->write(collect($packages['packages'] ?? $packages)->mapWithKeys(function ($package) {
             return [$this->format($package['name']) => $package['extra']['laravel'] ?? []];
         })->each(function ($configuration) use (&$ignore) {
             $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);


### PR DESCRIPTION
The `vendor/composer/installed.json` format changes for composer v2. Due to the new format, detecting packages results in the following exception.

<img width="1330" alt="Bildschirmfoto 2020-08-17 um 14 48 58" src="https://user-images.githubusercontent.com/29352871/90397883-d3b92b00-e098-11ea-877e-03f4b0b11e85.png">

This pr fixes the issue.

