### PR TITLE
[7.x] Validator contract throws docblock

### DIFF
--- a/src/Illuminate/Contracts/Validation/Validator.php
+++ b/src/Illuminate/Contracts/Validation/Validator.php
@@ -10,6 +10,8 @@ interface Validator extends MessageProvider
      * Run the validator's rules against its data.
      *
      * @return array
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function validate();
 
@@ -17,6 +19,8 @@ interface Validator extends MessageProvider
      * Get the attributes and values that were validated.
      *
      * @return array
+     *
+     * @throws \Illuminate\Validation\ValidationException
      */
     public function validated();
 


### PR DESCRIPTION
It seems that the implementation of the contract is directly throwing the validation exception.
I think the @throws should also be on the interface if I am not wrong.
