### PR TITLE
[8.x] Simulate exit code for closure scheduled tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -5,6 +5,7 @@ namespace Illuminate\Console\Scheduling;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use LogicException;
+use Exception;
 
 class CallbackEvent extends Event
 {
@@ -76,11 +77,17 @@ class CallbackEvent extends Event
             $response = is_object($this->callback)
                         ? $container->call([$this->callback, '__invoke'], $this->parameters)
                         : $container->call($this->callback, $this->parameters);
+        } catch(Exception $e) {
+            $this->exitCode = 1;
+
+            throw $e;
         } finally {
             $this->removeMutex();
 
             parent::callAfterCallbacks($container);
         }
+
+        $this->exitCode = $response === false ? 1 : 0;
 
         return $response;
     }

--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -2,10 +2,10 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Exception;
 use Illuminate\Contracts\Container\Container;
 use InvalidArgumentException;
 use LogicException;
-use Exception;
 
 class CallbackEvent extends Event
 {
@@ -77,7 +77,7 @@ class CallbackEvent extends Event
             $response = is_object($this->callback)
                         ? $container->call([$this->callback, '__invoke'], $this->parameters)
                         : $container->call($this->callback, $this->parameters);
-        } catch(Exception $e) {
+        } catch (Exception $e) {
             $this->exitCode = 1;
 
             throw $e;

--- a/tests/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Console/Scheduling/CallbackEventTest.php
@@ -2,11 +2,11 @@
 
 namespace Illuminate\Tests\Console\Scheduling;
 
+use Exception;
 use Illuminate\Console\Scheduling\CallbackEvent;
 use Illuminate\Console\Scheduling\EventMutex;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
-use Exception;
 
 class CallbackEventTest extends TestCase
 {
@@ -17,7 +17,8 @@ class CallbackEventTest extends TestCase
 
     public function testDefaultResultIsSuccess()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function() {});
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
+        });
 
         $event->run($this->app);
 
@@ -26,7 +27,7 @@ class CallbackEventTest extends TestCase
 
     public function testFalseResponseIsFailure()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
             return false;
         });
 
@@ -37,20 +38,21 @@ class CallbackEventTest extends TestCase
 
     public function testExceptionIsFailure()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
             throw new \Exception;
         });
 
         try {
             $event->run($this->app);
-        } catch(Exception $e) {}
+        } catch (Exception $e) {
+        }
 
         $this->assertSame(1, $event->exitCode);
     }
 
     public function testExceptionBubbles()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
             throw new Exception;
         });
 

--- a/tests/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Console/Scheduling/CallbackEventTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Illuminate\Tests\Console\Scheduling;
+
+use Illuminate\Console\Scheduling\CallbackEvent;
+use Illuminate\Console\Scheduling\EventMutex;
+use Mockery as m;
+use Orchestra\Testbench\TestCase;
+use Exception;
+
+class CallbackEventTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testDefaultResultIsSuccess()
+    {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function() {});
+
+        $event->run($this->app);
+
+        $this->assertSame(0, $event->exitCode);
+    }
+
+    public function testFalseResponseIsFailure()
+    {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+            return false;
+        });
+
+        $event->run($this->app);
+
+        $this->assertSame(1, $event->exitCode);
+    }
+
+    public function testExceptionIsFailure()
+    {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+            throw new \Exception;
+        });
+
+        try {
+            $event->run($this->app);
+        } catch(Exception $e) {}
+
+        $this->assertSame(1, $event->exitCode);
+    }
+
+    public function testExceptionBubbles()
+    {
+        $event = new CallbackEvent(m::mock(EventMutex::class), function() {
+            throw new Exception;
+        });
+
+        $this->expectException(Exception::class);
+
+        $event->run($this->app);
+    }
+}


### PR DESCRIPTION
Currently, the `onSuccess` and `onFailure` hooks do not work for closure scheduled tasks. This is because these hooks rely on the `exitCode`, which is only tracked for [external process calls](https://github.com/laravel/framework/blob/0abd5f3963fa26fedce1583f53f54e7360584c8c/src/Illuminate/Console/Scheduling/Event.php#L223).

That means in this case...

```
$schedule->call(function() {
    info('hello world');
})->onFailure(function() {
    info('task failed');
})->everyMinute();
```

... you will always find that the "task failed".

This PR aims to simulate a 0 (success) or 1 (general failure) exit code for closure tasks. An exit code of 1 is set if an exception is thrown OR `false` is returned from the closure. All other results are considered successful.

This allows the `onSuccess` and `onFailure` hooks (along with the related `emailOutputOnFailure` type methods) to work with closure tasks.