### PR TITLE
[8.x] Use DB session id as primary key, remove unique

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -14,7 +14,7 @@ class CreateSessionsTable extends Migration
     public function up()
     {
         Schema::create('sessions', function (Blueprint $table) {
-            $table->string('id')->unique();
+            $table->string('id')->primary();
             $table->foreignId('user_id')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();


### PR DESCRIPTION
## Reason
I've been getting emails from DigitalOcean[1] about my [MySQL DBaaS](https://www.digitalocean.com/products/managed-databases-mysql) stating:

> "Our systems have indicated that your MySQL cluster, XYZ, has tables without primary keys. We have identified that MySQL tables without primary keys can lead to service replication issues that jeopardize performance and availability. If primary keys are not present for database tables exceeding 5,000 rows, data-loss can occur."

Obviously that's easily reached in the `sessions` table of big installation.

The MySQL versions are all 8.0.17.

## Research
Is there any reason the `id` of the `sessions` table is only `UNIQUE` but not the primary key? In fact, one of the few differences is that `UNIQUE` would allow `null` but PK doesn't and we can't have session id == `null` anyway.

Any advantage of [unclustered index vs. clustered](https://www.mysqltutorial.org/mysql-index/mysql-clustered-index) in this case? If anything it should be faster to do `SELECT` statements, or did I misunderstand?

I've tried contacting @taylorotwell [in Discord](https://discordapp.com/channels/297040613688475649/486650494790402061/744934591474827355) but haven't gotten an answer so far, so here's my first simple PR to Laravel ;)

---

[1]

![image](https://user-images.githubusercontent.com/516807/90467011-3da00600-e167-11ea-9e0c-ed863afcc4d9.png)
