### PR TITLE
[7.x] Broadcaster interface @throws docblock

### DIFF
--- a/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
+++ b/src/Illuminate/Contracts/Broadcasting/Broadcaster.php
@@ -28,6 +28,8 @@ interface Broadcaster
      * @param  string  $event
      * @param  array  $payload
      * @return void
+     *
+     * @throws \Illuminate\Broadcasting\BroadcastException
      */
     public function broadcast(array $channels, $event, array $payload = []);
 }


### PR DESCRIPTION
It seems that broadcasting is mainly a network operation and there is always a possibility to fail and I see the pusher implementation (of the `Broadcaster interface`) docblock is documented to throw an exception in case of failure and it directly throws that in the code.
So, maybe the interface also needs to document what to throw in case of failure.
