### PR TITLE
Allow string length validation on numeric strings

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1799,15 +1799,13 @@ trait ValidatesAttributes
      */
     protected function getSize($attribute, $value)
     {
-        $hasNumeric = $this->hasRule($attribute, $this->numericRules);
-
         // This method will determine if the attribute is a number, string, or file and
         // return the proper size accordingly. If the attrbute must validate as a string,
         // the length of the string is returned. If it is a number, then number itself
         // is the size. If it is a file, we take kilobytes, for all others a string is
         // assumed and the entire length of the string will be considered the attribute size.
         if (! $this->hasRule($attribute, ['String'])) {
-            if (is_numeric($value) && $hasNumeric) {
+            if (is_numeric($value) && $this->hasRule($attribute, $this->numericRules)) {
                 return $value;
             } elseif (is_array($value)) {
                 return count($value);

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1802,15 +1802,18 @@ trait ValidatesAttributes
         $hasNumeric = $this->hasRule($attribute, $this->numericRules);
 
         // This method will determine if the attribute is a number, string, or file and
-        // return the proper size accordingly. If it is a number, then number itself
-        // is the size. If it is a file, we take kilobytes, and for a string the
-        // entire length of the string will be considered the attribute size.
-        if (is_numeric($value) && $hasNumeric) {
-            return $value;
-        } elseif (is_array($value)) {
-            return count($value);
-        } elseif ($value instanceof File) {
-            return $value->getSize() / 1024;
+        // return the proper size accordingly. If the attrbute must validate as a string,
+        // the length of the string is returned. If it is a number, then number itself
+        // is the size. If it is a file, we take kilobytes, for all others a string is
+        // assumed and the entire length of the string will be considered the attribute size.
+        if (! $this->hasRule($attribute, ['String'])) {
+            if (is_numeric($value) && $hasNumeric) {
+                return $value;
+            } elseif (is_array($value)) {
+                return count($value);
+            } elseif ($value instanceof File) {
+                return $value->getSize() / 1024;
+            }
         }
 
         return mb_strlen($value);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -1797,6 +1797,24 @@ class ValidationValidatorTest extends TestCase
         $v = new Validator($trans, ['foo' => [1, 2]], ['foo' => 'Array|Min:3']);
         $this->assertFalse($v->passes());
 
+        $v = new Validator($trans, ['foo' => '3'], ['foo' => 'String|Min:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'anc'], ['foo' => 'String|Min:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '01'], ['foo' => 'String|Numeric|Min:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'anc'], ['foo' => 'String|Numeric|Min:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '12'], ['foo' => 'String|Numeric|Min:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'String|Numeric|Min:3']);
+        $this->assertTrue($v->passes());
+
         $file = $this->getMockBuilder(File::class)->setMethods(['getSize'])->setConstructorArgs([__FILE__, false])->getMock();
         $file->expects($this->any())->method('getSize')->willReturn(3072);
         $v = new Validator($trans, ['photo' => $file], ['photo' => 'Min:2']);
@@ -1828,6 +1846,21 @@ class ValidationValidatorTest extends TestCase
 
         $v = new Validator($trans, ['foo' => [1, 2, 3]], ['foo' => 'Array|Max:2']);
         $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'aslksd'], ['foo' => 'String|Max:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'anc'], ['foo' => 'String|Max:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => 'anc'], ['foo' => 'String|Numeric|Max:3']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['foo' => '12'], ['foo' => 'String|Numeric|Max:3']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['foo' => '123'], ['foo' => 'String|Numeric|Max:3']);
+        $this->assertTrue($v->passes());
 
         $file = $this->getMockBuilder(UploadedFile::class)->setMethods(['isValid', 'getSize'])->setConstructorArgs([__FILE__, basename(__FILE__)])->getMock();
         $file->expects($this->any())->method('isValid')->willReturn(true);


### PR DESCRIPTION
Don't try to be smart about the attribute type when validating an attribute explicitly marked as "string".

This allows a validator like: ```'string|numeric|min:4|max:10'``` to evaluate the min/max as string length instead of numeric value.
