### PR TITLE
[7.x] Cast primary key to string when $keyType is string

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -193,6 +193,10 @@ class Builder
             return $this;
         }
 
+        if ($this->model->getKeyType() === 'string') {
+            $id = (string) $id;
+        }
+
         return $this->where($this->model->getQualifiedKeyName(), '=', $id);
     }
 
@@ -208,6 +212,10 @@ class Builder
             $this->query->whereNotIn($this->model->getQualifiedKeyName(), $id);
 
             return $this;
+        }
+
+        if ($this->model->getKeyType() === 'string') {
+            $id = (string) $id;
         }
 
         return $this->where($this->model->getQualifiedKeyName(), '!=', $id);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -1043,6 +1043,19 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->whereKey($int);
     }
 
+    public function testWhereKeyMethodWithStringZero()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey();
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $int = 0;
+
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', (string) $int);
+
+        $builder->whereKey($int);
+    }
+
     public function testWhereKeyMethodWithArray()
     {
         $model = $this->getMockModel();
@@ -1068,6 +1081,19 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $builder->whereKey($collection);
     }
+
+    public function testWhereKeyNotMethodWithStringZero()
+    {
+        $model = new EloquentBuilderTestStubStringPrimaryKey();
+        $builder = $this->getBuilder()->setModel($model);
+        $keyName = $model->getQualifiedKeyName();
+
+        $int = 0;
+
+        $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string) $int);
+
+        $builder->whereKeyNot($int);
+   }
 
     public function testWhereKeyNotMethodWithInt()
     {
@@ -1444,4 +1470,13 @@ class EloquentBuilderTestStubWithoutTimestamp extends Model
     const UPDATED_AT = null;
 
     protected $table = 'table';
+}
+
+class EloquentBuilderTestStubStringPrimaryKey extends Model
+{
+    public $incrementing = false;
+
+    protected $table = 'foo_table';
+
+    protected $keyType = 'string';
 }

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -78,6 +78,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindOrNewMethodModelFound()
     {
         $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn('baz');
 
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
@@ -93,6 +94,7 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindOrNewMethodModelNotFound()
     {
         $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $model->shouldReceive('findOrNew')->once()->andReturn(m::mock(Model::class));
 
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
@@ -111,7 +113,9 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->expectException(ModelNotFoundException::class);
 
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
-        $builder->setModel($this->getMockModel());
+        $model = $this->getMockModel();
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
+        $builder->setModel($model);
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn(null);
         $builder->findOrFail('bar', ['column']);
@@ -1040,6 +1044,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 1;
 
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '=', $int);
 
         $builder->whereKey($int);
@@ -1105,6 +1110,7 @@ class DatabaseEloquentBuilderTest extends TestCase
 
         $int = 1;
 
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', $int);
 
         $builder->whereKeyNot($int);

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -31,7 +31,9 @@ class DatabaseEloquentBuilderTest extends TestCase
     public function testFindMethod()
     {
         $builder = m::mock(Builder::class.'[first]', [$this->getMockQueryBuilder()]);
-        $builder->setModel($this->getMockModel());
+        $model = $this->getMockModel();
+        $builder->setModel($model);
+        $model->shouldReceive('getKeyType')->once()->andReturn('int');
         $builder->getQuery()->shouldReceive('where')->once()->with('foo_table.foo', '=', 'bar');
         $builder->shouldReceive('first')->with(['column'])->andReturn('baz');
 
@@ -1093,7 +1095,7 @@ class DatabaseEloquentBuilderTest extends TestCase
         $builder->getQuery()->shouldReceive('where')->once()->with($keyName, '!=', (string) $int);
 
         $builder->whereKeyNot($int);
-   }
+    }
 
     public function testWhereKeyNotMethodWithInt()
     {


### PR DESCRIPTION
## Problem
Given a model with a string primary key:
```php
 public $incrementing = false;

 protected $keyType = 'string';
 ```

and then running  this on the model:

```php
PaymentProvider::find(0);
```

I expect a `null` result, but in fact I get the first row in the table. 

Looking at the underlying query, sure enough it runs `select * from payment_providers where id = 0`; MySQL seems to have a quirk where it will return all rows when comparing a string to a `0` integer. 

MySQL aside, I think Laravel should take care of casting the primary key according to `$keyType` to prevent unexpected results.

## Solution
This PR checks the primary key type, and casts to a string when required in `whereKey()` and `whereNotKey()`. 

## Caveats

```php
PaymentProvider::find([0]);
```
This query will return a collection of all rows in the table. I wasn't sure how to deal with an array of IDs, so I dealt with the singular lookup only.