### PR TITLE
[7.x ] Fix key composition for attribute with dot at validation error messages

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -776,7 +776,11 @@ class Validator implements ValidatorContract
             $this->passes();
         }
 
-        $attribute = str_replace('__asterisk__', '*', $attribute);
+        $attribute = str_replace(
+            [$this->dotPlaceholder, '__asterisk__'],
+            ['.', '*'],
+            $attribute
+        );
 
         if (in_array($rule, $this->excludeRules)) {
             return $this->excludeAttribute($attribute);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3956,7 +3956,7 @@ class ValidationValidatorTest extends TestCase
         $this->assertArrayHasKey('foo.bar', $v->errors()->getMessages());
 
         $v = new Validator($trans, [
-            'foo.bar' => 'valid'
+            'foo.bar' => 'valid',
         ], [
             'foo\.bar' => 'required|in:valid',
         ]);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -3953,6 +3953,15 @@ class ValidationValidatorTest extends TestCase
             'foo\.bar' => 'required|in:valid',
         ]);
         $this->assertTrue($v->fails());
+        $this->assertArrayHasKey('foo.bar', $v->errors()->getMessages());
+
+        $v = new Validator($trans, [
+            'foo.bar' => 'valid'
+        ], [
+            'foo\.bar' => 'required|in:valid',
+        ]);
+        $this->assertTrue($v->passes());
+        $this->assertArrayHasKey('foo.bar', $v->validated());
     }
 
     public function testCoveringEmptyKeys()


### PR DESCRIPTION
Relates to #33357 (finalizes the fix).

Fix key composition for attribute with dot at validation error messages.
