### PR TITLE
[7.x] Fix the `dump` method for `LazyCollection`

### DIFF
--- a/src/Illuminate/Support/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Support/Traits/EnumeratesValues.php
@@ -181,8 +181,8 @@ trait EnumeratesValues
      */
     public function dump()
     {
-        (new static(func_get_args()))
-            ->push($this)
+        (new Collection(func_get_args()))
+            ->push($this->all())
             ->each(function ($item) {
                 VarDumper::dump($item);
             });

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -18,6 +18,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use stdClass;
+use Symfony\Component\VarDumper\VarDumper;
 
 class SupportCollectionTest extends TestCase
 {
@@ -3417,6 +3418,24 @@ class SupportCollectionTest extends TestCase
         $actual = $firstCollection->concat($thirdCollection)->toArray();
 
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testDump($collection)
+    {
+        $log = new Collection();
+
+        VarDumper::setHandler(function ($value) use ($log) {
+            $log->add($value);
+        });
+
+        (new $collection([1, 2, 3]))->dump('one', 'two');
+
+        $this->assertSame(['one', 'two', [1, 2, 3]], $log->all());
+
+        VarDumper::setHandler(null);
     }
 
     /**


### PR DESCRIPTION
The `dump` method is currently broken when called on a lazy collection.

This PR fixes it, with tests.

---

I made a small change: calling `dump` on a regular `Collection` will no longer dump the actual collection instance - only its values.

The reason I did this is because for lazy collections, it makes no sense to dump the collection instance, since it won't show you any of its values (they haven't been generated yet). For consistency, the regular collection class now also only dumps its values, which is probably anyhow what you're after.