### PR TITLE
[7.x] Allow route helper to return the router instance on empty arguments.

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -758,13 +758,17 @@ if (! function_exists('route')) {
     /**
      * Generate the URL to a named route.
      *
-     * @param  array|string  $name
+     * @param  array|string|null  $name
      * @param  mixed  $parameters
      * @param  bool  $absolute
-     * @return string
+     * @return string|\Illuminate\Routing\Router
      */
-    function route($name, $parameters = [], $absolute = true)
+    function route($name = null, $parameters = [], $absolute = true)
     {
+        if (is_null($name)) {
+            return app('router');
+        }
+
         return app('url')->route($name, $parameters, $absolute);
     }
 }


### PR DESCRIPTION
This PR will allow route helper to return the router instance on empty arguments.

One simple use case is for checking if a route exists inside a view. This PR addresses the warning on IDE when using the Route facade. It will also help the IDE for the auto-completion of methods available in the Route.

Instead of using the facade in view, we can now use the helper to eliminate an IDE warning `Undefined class Route`.

```php
@if(Route::has('login'))
...
@endif
```

to

```php
@if(route()->has('login'))
...
@endif
```
