### PR TITLE
[6.x] Check no-interaction flag exists and is true for Artisan commands

### DIFF
--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -66,7 +66,7 @@ trait CallsCommands
     protected function createInputFromArguments(array $arguments)
     {
         return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
-            if ($input->hasParameterOption(['--no-interaction'], true)) {
+            if ($input->getParameterOption('--no-interaction') === true) {
                 $input->setInteractive(false);
             }
         });

--- a/src/Illuminate/Console/Concerns/CallsCommands.php
+++ b/src/Illuminate/Console/Concerns/CallsCommands.php
@@ -66,7 +66,7 @@ trait CallsCommands
     protected function createInputFromArguments(array $arguments)
     {
         return tap(new ArrayInput(array_merge($this->context(), $arguments)), function ($input) {
-            if ($input->getParameterOption('--no-interaction') === true) {
+            if ($input->getParameterOption('--no-interaction')) {
                 $input->setInteractive(false);
             }
         });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Go easy on me, this is my first contribution to open source.

This PR was made because I noticed a bug with the way that the CallsCommand concern handles how it checks if the command should be run with no-interaction i.e. does not prompt for user input.

It currently only checks if the option is present, rather than checks if it is true or false in the input array. So, rather than `hasParameterOption` in `createInputFromArguments`, I changed it to `getParameterOption` which still returns false if the option is not present. If not present === false; present in terminal === true; present but value is false === false.

I reproduced this bug when calling a deprecated Artisan command in a Laravel package which passed all of the arguments and options to the new Artisan command via `$this->call(...)`, PSB an example.
```php
    /**
     * Execute the console command.
     *
     * @return int
     */
    public function handle()
    {
        $options = collect($this->options())->mapWithKeys(function($value, $key) {
            return ["--{$key}" => $value];
        })->toArray();

        $this->call('prompt:real', $options);

        return 0;
    }
```

With this array of options, it passes a default value for no-interaction which is false. In its current state, the framework will take that option as: you want no prompt to appear as it runs through the command.

Here is an example of the real command that should prompt for input, but would not:
```php
    /**
     * Execute the console command.
     *
     * @return int
     */
    public function handle()
    {
        $this->ask('What is your name?');

        return 0;
    }
```

Thank you for taking the time to review this. I hope I have explained this clearly enough.