### PR TITLE
[7.x] Make HasTimestamps::updateTimestamps public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasTimestamps.php
@@ -34,7 +34,7 @@ trait HasTimestamps
      *
      * @return void
      */
-    protected function updateTimestamps()
+    public function updateTimestamps()
     {
         $time = $this->freshTimestamp();
 


### PR DESCRIPTION
## Summary
I've a use-case where I construct models but can't save them yet but
they should reflect the state of new models as good as it gets,
including the timestamps for created/updated, which I want to do from
outside the model

Similar to the `touch()` method:
```php
    public function touch()
    {
        if (! $this->usesTimestamps()) {
            return false;
        }

        $this->updateTimestamps();

        return $this->save();
    }
```
But I don't want to save the model _yet_.

I can call `usesTimestamps()` from outside the model as its
already public but not yet `updateTimestamps`, thus the PR.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
