### PR TITLE
[7.x] Load anonymous components from packages

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Illuminate\View\AnonymousComponent;
+use Illuminate\View\ViewFinderInterface;
 use InvalidArgumentException;
 use ReflectionClass;
 
@@ -237,7 +238,7 @@ class ComponentTagCompiler
             return $class;
         }
 
-        if ($viewFactory->exists($view = "components.{$component}")) {
+        if ($viewFactory->exists($view = $this->guessViewName($component))) {
             return $view;
         }
 
@@ -263,6 +264,25 @@ class ComponentTagCompiler
         }, explode('.', $component));
 
         return $namespace.'View\\Components\\'.implode('\\', $componentPieces);
+    }
+
+    /**
+     * Guess the view name for the given component.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    public function guessViewName($name)
+    {
+        $prefix = 'components.';
+
+        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
+
+        if (Str::contains($name, $delimiter)) {
+            return Str::replaceFirst($delimiter, $delimiter.$prefix, $name);
+        }
+
+        return $prefix.$name;
     }
 
     /**

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -205,6 +205,22 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 '@endcomponentClass', trim($result));
     }
 
+    public function testPackagesClasslessComponents()
+    {
+        $container = new Container;
+        $container->instance(Application::class, $app = Mockery::mock(Application::class));
+        $container->instance(Factory::class, $factory = Mockery::mock(Factory::class));
+        $app->shouldReceive('getNamespace')->andReturn('App\\');
+        $factory->shouldReceive('exists')->andReturn(true);
+        Container::setInstance($container);
+
+        $result = $this->compiler()->compileTags('<x-package::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
+
+        $this->assertSame("@component('Illuminate\View\AnonymousComponent', 'package::anonymous-component', ['view' => 'package::components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
+'@endcomponentClass', trim($result));
+    }
+
     public function testAttributeSanitization()
     {
         $class = new class {


### PR DESCRIPTION
This PR extends this https://github.com/laravel/framework/pull/31363.

This will enable packages' developers to render their anonymous components in a similar way to rendering views.

**PackageServiceProvider** https://laravel.com/docs/7.x/packages#views
```
$this->loadViewsFrom(__DIR__.'/path/to/views', 'courier');
```

**welcome.blade.php**
```
<x-courier::avatar size="60" />
```

**will look for the**
`/path/to/views/components/avatar.blade.php`