### PR TITLE
[7.x] Str::wrap()

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -371,6 +371,21 @@ class Str
     }
 
     /**
+     * Wrap a string with a given value or values.
+     *
+     * @param  string  $value
+     * @param  string  $start
+     * @param  string|null  $end
+     * @return string
+     */
+    public static function wrap($value, $start, $end = null)
+    {
+        $end = $end !== null ? $end : $start;
+
+        return $start.$value.$end;
+    }
+
+    /**
      * Parse a Class[@]method style callback into class and method.
      *
      * @param  string  $callback

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -649,6 +649,18 @@ class Stringable
     }
 
     /**
+     * Wrap a string with a given value or values.
+     *
+     * @param  string  $start
+     * @param  string|null  $end
+     * @return string
+     */
+    public function wrap($start, $end = null)
+    {
+        return new static(Str::wrap($this->value, $start, $end));
+    }
+
+    /**
      * Dump the string.
      *
      * @return $this

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -8,6 +8,14 @@ use Ramsey\Uuid\UuidInterface;
 
 class SupportStrTest extends TestCase
 {
+    public function testStringCanBeWrapped()
+    {
+        $this->assertSame('"Illia"', Str::wrap('Illia', '"'));
+        $this->assertSame('(Sakovich)', Str::wrap('Sakovich', '(', ')'));
+        $this->assertSame('|Taylor|', Str::wrap('Taylor', '|'));
+        $this->assertSame('\\Otwell/', Str::wrap('Otwell', '\\', '/'));
+    }
+
     public function testStringCanBeLimitedByWords()
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -68,6 +68,14 @@ class SupportStringableTest extends TestCase
         $this->assertSame(' foo', (string) $this->stringable(' foo ')->rtrim());
     }
 
+    public function testCanBeWrapped()
+    {
+        $this->assertSame('"Illia"', (string) $this->stringable('Illia')->wrap('"'));
+        $this->assertSame('(Sakovich)', (string) $this->stringable('Sakovich')->wrap('(', ')'));
+        $this->assertSame('|Taylor|', (string) $this->stringable('Taylor')->wrap('|'));
+        $this->assertSame('\\Otwell/', (string) $this->stringable('Otwell')->wrap('\\', '/'));
+    }
+
     public function testCanBeLimitedByWords()
     {
         $this->assertSame('Taylor...', (string) $this->stringable('Taylor Otwell')->words(1));


### PR DESCRIPTION
```php
Str::wrap('Title', '-'); // "-Title-"
Str::wrap('Title', '(', ')'); // "(Title)"
```