### PR TITLE
[8.x] Fix Issue #23218

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1470,6 +1470,8 @@ trait ValidatesAttributes
 
         if (is_bool($other)) {
             $values = $this->convertValuesToBoolean($values);
+        } elseif (is_null($other)) {
+            $values = $this->convertValuesToNull($values);
         }
 
         return [$values, $other];
@@ -1488,6 +1490,23 @@ trait ValidatesAttributes
                 return true;
             } elseif ($value === 'false') {
                 return false;
+            }
+
+            return $value;
+        }, $values);
+    }
+
+    /**
+     * Convert the given values to null if they are string "null".
+     *
+     * @param  array  $values
+     * @return array
+     */
+    protected function convertValuesToNull($values)
+    {
+        return array_map(function ($value) {
+            if (Str::lower($value) === 'null') {
+                return null;
             }
 
             return $value;


### PR DESCRIPTION
Allow `null` value validation in `exclude_if`, `exclude_unless`, `required_if` and `required_unless` as per Issue #23218. Check for lowercased interpretation of "null", so that developers can also still write "NULL" or even "NuLl".

As indicated in the issue, this PR will aid validation of mutual exclusive fields that are both present in the request. By the time the request has passed through stripping and trimming, the empty field evaluates to `null` in the request. Currently, this cannot be validated against.