### PR TITLE
The Optional of ArrayObject has Inconsistent behavior for `__get` and `__isset`.

### DIFF
--- a/tests/Support/SupportOptionalTest.php
+++ b/tests/Support/SupportOptionalTest.php
@@ -100,4 +100,17 @@ class SupportOptionalTest extends TestCase
 
         $this->assertFalse(isset($optional->item));
     }
+
+    public function testArrayObject()
+    {
+        $obj = new \ArrayObject(['id' => $id = uniqid()]);
+
+        $optional = new Optional($obj);
+
+        $this->assertTrue(isset($optional['id']));
+        $this->assertSame($id, $optional['id']);
+
+        $this->assertTrue(isset($optional->id));
+        $this->assertSame($id, $optional->id);
+    }
 }


### PR DESCRIPTION
```
$obj = new \ArrayObject(['id' => $id = uniqid()]);

$optional = new Optional($obj);

$this->assertTrue(isset($optional['id'])); // true
$this->assertSame($id, $optional['id']); // true

$this->assertTrue(isset($optional->id)); // true
$this->assertSame($id, $optional->id); // false
```