### PR TITLE
[8.x] Updated loadJsonPaths() functionality in FileLoader.php

### DIFF
--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -127,8 +127,8 @@ class FileLoader implements Loader
     }
 
     /**
-     * Load a locale from the given JSON file path.
-     *
+     * Load all JSON files from the given directory path recursively.
+     * Date modified: 22 August 2020
      * @param  string  $locale
      * @return array
      *
@@ -136,16 +136,22 @@ class FileLoader implements Loader
      */
     protected function loadJsonPaths($locale)
     {
+
         return collect(array_merge($this->jsonPaths, [$this->path]))
             ->reduce(function ($output, $path) use ($locale) {
-                if ($this->files->exists($full = "{$path}/{$locale}.json")) {
-                    $decoded = json_decode($this->files->get($full), true);
 
-                    if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
-                        throw new RuntimeException("Translation file [{$full}] contains an invalid JSON structure.");
+                $files = $this->files->allFiles("{$path}/$locale");
+
+                foreach ($files as $file) {
+                    if ($this->files->exists($file) && $this->files->extension($file) === 'json') {
+                        $decoded = json_decode($this->files->get($file), true);
+
+                        if (is_null($decoded) || json_last_error() !== JSON_ERROR_NONE) {
+                            throw new RuntimeException("Translation file [{$file}] contains an invalid JSON structure.");
+                        }
                     }
-
-                    $output = array_merge($output, $decoded);
+                    // If $decoded return an empty string, replace with an empty array
+                    $output = array_merge($output, ($decoded ?? []));
                 }
 
                 return $output;

--- a/src/Illuminate/Translation/FileLoader.php
+++ b/src/Illuminate/Translation/FileLoader.php
@@ -128,7 +128,7 @@ class FileLoader implements Loader
 
     /**
      * Load all JSON files from the given directory path recursively.
-     * Date modified: 22 August 2020
+     * 
      * @param  string  $locale
      * @return array
      *


### PR DESCRIPTION
### Better organization of translation files in JSON format (Translation Strings As Keys)
Now you can create any folder structure under **/resources/lang/[$locale]/** folder and name **.json** files anything you want for ease to manage your application translations files.
Here are some examples of directory structure: 

- /resources/lang/de/de.json or
- /resources/lang/es/my_file.json or
- /resources/lang/pl/home/header.json or
- /resources/lang/ro/gallery/sliders/layers.json 

> Note: If you have **en.json** or any other locale **.json** file in **lang** folder, you have to move it into the coresponding locale folder.

