### PR TITLE
[7.x] Authorizing seeders

### DIFF
--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -139,7 +139,7 @@ abstract class Seeder
         }
 
         if (! $this->authorize()) {
-            throw new SeederNotAuthorizedException();
+            throw new SeederNotAuthorizedException(get_class($this) . ' was not authorized to run.');
         }
 
         return isset($this->container)

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -114,7 +114,7 @@ abstract class Seeder
     /**
      * Set the console command instance.
      *
-     * @param \Illuminate\Console\Command $command
+     * @param  \Illuminate\Console\Command  $command
      * @return $this
      */
     public function setCommand(Command $command)
@@ -134,11 +134,11 @@ abstract class Seeder
      */
     public function __invoke()
     {
-        if (!method_exists($this, 'run')) {
+        if (! method_exists($this, 'run')) {
             throw new InvalidArgumentException('Method [run] missing from ' . get_class($this));
         }
 
-        if (!$this->authorize()) {
+        if (! $this->authorize()) {
             throw new SeederNotAuthorizedException();
         }
 

--- a/src/Illuminate/Database/Seeder.php
+++ b/src/Illuminate/Database/Seeder.php
@@ -135,11 +135,11 @@ abstract class Seeder
     public function __invoke()
     {
         if (! method_exists($this, 'run')) {
-            throw new InvalidArgumentException('Method [run] missing from ' . get_class($this));
+            throw new InvalidArgumentException('Method [run] missing from '.get_class($this));
         }
 
         if (! $this->authorize()) {
-            throw new SeederNotAuthorizedException(get_class($this) . ' was not authorized to run.');
+            throw new SeederNotAuthorizedException(get_class($this).' was not authorized to run.');
         }
 
         return isset($this->container)
@@ -148,7 +148,7 @@ abstract class Seeder
     }
 
     /**
-     * Authorize call
+     * Authorizes call.
      *
      * @return bool
      */
@@ -158,7 +158,7 @@ abstract class Seeder
     }
 
     /**
-     * Checks if anything should be written in the console output
+     * Checks if anything should be written in the console output.
      *
      * @param  bool  $silent
      * @return $this

--- a/src/Illuminate/Database/SeederNotAuthorizedException.php
+++ b/src/Illuminate/Database/SeederNotAuthorizedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Illuminate\Database;
+
+use Exception;
+
+class SeederNotAuthorizedException extends Exception
+{
+}

--- a/tests/Database/DatabaseSeederTest.php
+++ b/tests/Database/DatabaseSeederTest.php
@@ -5,6 +5,7 @@ namespace Illuminate\Tests\Database;
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
 use Illuminate\Database\Seeder;
+use Illuminate\Database\SeederNotAuthorizedException;
 use Mockery as m;
 use Mockery\Mock;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,19 @@ class TestSeeder extends Seeder
     public function run()
     {
         //
+    }
+}
+
+class DisabledTestSeeder extends Seeder
+{
+    public function run()
+    {
+        //
+    }
+
+    protected function authorize(): bool
+    {
+        return false;
     }
 }
 
@@ -77,5 +91,16 @@ class DatabaseSeederTest extends TestCase
         $seeder->__invoke();
 
         $container->shouldHaveReceived('call')->once()->with([$seeder, 'run']);
+    }
+
+    public function testDisabledSeeder()
+    {
+        $container = m::mock(Container::class);
+
+        $seeder = new DisabledTestSeeder();
+        $seeder->setContainer($container);
+
+        $this->expectException(SeederNotAuthorizedException::class);
+        $seeder->__invoke();
     }
 }


### PR DESCRIPTION
Relatively often I need to put some logic into seeders and run them accordingly to some conditions (eg. I don't want to duplicate or overwrite some data, I just want to run it once, I just want to run it only on some testing environment, etc.) Putting these conditions into `run()` method is making these seeders less readable and putting them into `DatabaseSeeder` is dangerous enough (because someone could just ran it from console).

I added a method `authorize()` to an abstract `Seeder`. Method is returning `true` by default, so it should be completely backward compatible with existing seeders. Conditionally disabling any seeder from running would be extremely easy:

```php
class DisabledTestSeeder extends Seeder
{
    public function run(): void
    {
        // (...)
    }

    protected function authorize(): bool
    {
        return false;
    }
}
```

Of course it could look like this (to ensure that it will fire only when users table would be empty):


```php
protected function authorize(): bool
{
    return User::count() === 0;
}
```

The only thing I'm not sure is throwing `SeederNotAuthorizedException` in `__invoke()` method of `Seeder` class. I was trying to duplicate behaviour of not existing `run()` method. It's covered in calling `php artisan db:seed`, but it will be maybe little unreadable when someone would call `php artisan db:seed --class=SomeDisabledSeeder`

Tests are provided.