### PR TITLE
Add `chunkWhile()` collection method

### DIFF
--- a/src/Illuminate/Support/Collection.php
+++ b/src/Illuminate/Support/Collection.php
@@ -1071,6 +1071,32 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback)
+    {
+        $chunks = [];
+
+        $chunk = [];
+        foreach ($this->items as $current) {
+            if (isset($previous) && !$callback($previous, $current)) {
+                $chunks[] = new static($chunk);
+                $chunk = [];
+            }
+
+            $chunk[] = $current;
+            $previous = $current;
+        }
+        // Add the last chunk before closing.
+        $chunks[] = new static($chunk);
+
+        return new static($chunks);
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|int|null  $callback

--- a/src/Illuminate/Support/Enumerable.php
+++ b/src/Illuminate/Support/Enumerable.php
@@ -753,6 +753,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function chunk($size);
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback);
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null|int  $callback

--- a/src/Illuminate/Support/LazyCollection.php
+++ b/src/Illuminate/Support/LazyCollection.php
@@ -1083,6 +1083,33 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback)
+    {
+        return new static(function () use ($callback) {
+            $iterator = $this->getIterator();
+
+            $chunk = [];
+            while ($iterator->valid()) {
+                if (isset($previous) && !$callback($previous, $iterator->current())) {
+                    yield new static($chunk);
+                    $chunk = [];
+                }
+
+                $chunk[] = $iterator->current();
+                $previous = $iterator->current();
+
+                $iterator->next();
+            }
+            yield new static($chunk);
+        });
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null|int  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1626,6 +1626,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkWhileOnEqualElements($collection)
+    {
+        $data = (new $collection(['A', 'A', 'B', 'B', 'C', 'C', 'C']))
+            ->chunkWhile(function ($previous, $current) {
+                return $previous === $current;
+            });
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertEquals(['A', 'A'], $data->first()->toArray());
+        $this->assertEquals(['B','B'], $data->get(1)->toArray());
+        $this->assertEquals(['C', 'C', 'C'], $data->last()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunkWhileOnContiguouslyIncreasingIntegers($collection)
+    {
+        $data = (new $collection([1, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21]))
+            ->chunkWhile(function ($previous, $current) {
+                return $previous + 1 == $current;
+            });
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertEquals([1], $data->first()->toArray());
+        $this->assertEquals([4], $data->get(1)->toArray());
+        $this->assertEquals([9, 10, 11, 12], $data->get(2)->toArray());
+        $this->assertEquals([15, 16], $data->get(3)->toArray());
+        $this->assertEquals([19, 20, 21], $data->last()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testEvery($collection)
     {
         $c = new $collection([]);


### PR DESCRIPTION
This is inspired by the similar method in [Ruby’s Enumerable](https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-chunk_while). It allows breaking up a collections into chunks based on evaluating a callback rather than just a given size. 

An example application is for implementing [Run-length encoding](https://en.wikipedia.org/wiki/Run-length_encoding) where you need to group together consecutive elements of equal nature:

```php
$chunks = collect(str_split('AABBCCC'))->chunkWhile(fn ($prev, $curr) => $prev !== $curr));
// $chunks->toArray() is [ ['A', 'A'], ['B', 'B'], ['C', 'C', 'C'] ]

$chunks->reduce(function($chunk) {
    if ($chunk->count() == 1) {
        return $sequence . $chunk->first();
    }

    [$count, $element] = $chunk->chunkWhile(fn ($prev, $el) => is_numeric($el));
    return "$sequence" . str_repeat(implode($element), (int) implode($count));
});
// $chunks is '2A2B3C'
```

I’ll gladly write a documentation PR as well if this gets merged. 
Please be kind, this is my first code PR to Laravel 😍, I took the time to read the contribution guide and take inspiration from other tests while writing mine but I could have missed something. Collections is my favourite part of the framework, this was a very nice learning experience anyhow. 👍
