### PR TITLE
[8.x] Add `chunkWhile()` collection method

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1081,6 +1081,7 @@ class Collection implements ArrayAccess, Enumerable
         $chunks = [];
 
         $chunk = [];
+
         foreach ($this->items as $current) {
             if (isset($previous) && ! $callback($previous, $current)) {
                 $chunks[] = new static($chunk);
@@ -1090,7 +1091,8 @@ class Collection implements ArrayAccess, Enumerable
             $chunk[] = $current;
             $previous = $current;
         }
-        // Add the last chunk before closing.
+
+
         $chunks[] = new static($chunk);
 
         return new static($chunks);

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1071,6 +1071,32 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback)
+    {
+        $chunks = [];
+
+        $chunk = [];
+        foreach ($this->items as $current) {
+            if (isset($previous) && !$callback($previous, $current)) {
+                $chunks[] = new static($chunk);
+                $chunk = [];
+            }
+
+            $chunk[] = $current;
+            $previous = $current;
+        }
+        // Add the last chunk before closing.
+        $chunks[] = new static($chunk);
+
+        return new static($chunks);
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|int|null  $callback

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -1082,7 +1082,7 @@ class Collection implements ArrayAccess, Enumerable
 
         $chunk = [];
         foreach ($this->items as $current) {
-            if (isset($previous) && !$callback($previous, $current)) {
+            if (isset($previous) && ! $callback($previous, $current)) {
                 $chunks[] = new static($chunk);
                 $chunk = [];
             }

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -753,6 +753,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function chunk($size);
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback);
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null|int  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1083,6 +1083,33 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Chunk the collection into chunks with a callback.
+     *
+     * @param  callable  $callback
+     * @return static
+     */
+    public function chunkWhile(callable $callback)
+    {
+        return new static(function () use ($callback) {
+            $iterator = $this->getIterator();
+
+            $chunk = [];
+            while ($iterator->valid()) {
+                if (isset($previous) && !$callback($previous, $iterator->current())) {
+                    yield new static($chunk);
+                    $chunk = [];
+                }
+
+                $chunk[] = $iterator->current();
+                $previous = $iterator->current();
+
+                $iterator->next();
+            }
+            yield new static($chunk);
+        });
+    }
+
+    /**
      * Sort through each item with a callback.
      *
      * @param  callable|null|int  $callback

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1095,7 +1095,7 @@ class LazyCollection implements Enumerable
 
             $chunk = [];
             while ($iterator->valid()) {
-                if (isset($previous) && !$callback($previous, $iterator->current())) {
+                if (isset($previous) && ! $callback($previous, $iterator->current())) {
                     yield new static($chunk);
                     $chunk = [];
                 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1094,9 +1094,11 @@ class LazyCollection implements Enumerable
             $iterator = $this->getIterator();
 
             $chunk = [];
+
             while ($iterator->valid()) {
                 if (isset($previous) && ! $callback($previous, $iterator->current())) {
                     yield new static($chunk);
+
                     $chunk = [];
                 }
 
@@ -1105,6 +1107,7 @@ class LazyCollection implements Enumerable
 
                 $iterator->next();
             }
+
             yield new static($chunk);
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1646,6 +1646,42 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testChunkWhileOnEqualElements($collection)
+    {
+        $data = (new $collection(['A', 'A', 'B', 'B', 'C', 'C', 'C']))
+            ->chunkWhile(function ($previous, $current) {
+                return $previous === $current;
+            });
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertEquals(['A', 'A'], $data->first()->toArray());
+        $this->assertEquals(['B','B'], $data->get(1)->toArray());
+        $this->assertEquals(['C', 'C', 'C'], $data->last()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testChunkWhileOnContiguouslyIncreasingIntegers($collection)
+    {
+        $data = (new $collection([1, 4, 9, 10, 11, 12, 15, 16, 19, 20, 21]))
+            ->chunkWhile(function ($previous, $current) {
+                return $previous + 1 == $current;
+            });
+
+        $this->assertInstanceOf($collection, $data);
+        $this->assertInstanceOf($collection, $data->first());
+        $this->assertEquals([1], $data->first()->toArray());
+        $this->assertEquals([4], $data->get(1)->toArray());
+        $this->assertEquals([9, 10, 11, 12], $data->get(2)->toArray());
+        $this->assertEquals([15, 16], $data->get(3)->toArray());
+        $this->assertEquals([19, 20, 21], $data->last()->toArray());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testEvery($collection)
     {
         $c = new $collection([]);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -1656,7 +1656,7 @@ class SupportCollectionTest extends TestCase
         $this->assertInstanceOf($collection, $data);
         $this->assertInstanceOf($collection, $data->first());
         $this->assertEquals(['A', 'A'], $data->first()->toArray());
-        $this->assertEquals(['B','B'], $data->get(1)->toArray());
+        $this->assertEquals(['B', 'B'], $data->get(1)->toArray());
         $this->assertEquals(['C', 'C', 'C'], $data->last()->toArray());
     }
 


### PR DESCRIPTION
This is inspired by the similar method in [Ruby’s Enumerable](https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-chunk_while). It allows breaking up a collection into chunks based on evaluating a callback rather than just a given size. 

An example application is for implementing [Run-length encoding](https://en.wikipedia.org/wiki/Run-length_encoding) where you need to group together consecutive elements of equal nature:

```php
$chunks = collect(str_split('AABBCCCD'))->chunkWhile(fn ($prev, $curr) => $prev === $curr));
// $chunks->toArray() is [ ['A', 'A'], ['B', 'B'], ['C', 'C', 'C'], ['D'] ]

$chunks->reduce(function($sequence, $chunk) {
    $size = $chunk->count();
    $element = $chunk->first();
    return $size > 1 ? "$sequence$size$element" : "$sequence$element";
}, '');
// returns '2A2B3CD'
```

I’ll gladly write a documentation PR as well if this gets merged. 
Please be kind, this is my first code PR to Laravel 😍, I took the time to read the contribution guide and take inspiration from other tests while writing mine but I could have missed something. Collections is my favourite part of the framework, this was a very nice learning experience anyhow. 👍
