### PR TITLE
[7.x] Add oldestNotifications to HasDatabaseNotifications

### DIFF
--- a/src/Illuminate/Notifications/HasDatabaseNotifications.php
+++ b/src/Illuminate/Notifications/HasDatabaseNotifications.php
@@ -15,6 +15,16 @@ trait HasDatabaseNotifications
     }
 
     /**
+     * Get the entity's oldest notifications.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphMany
+     */
+    public function oldestNotifications()
+    {
+        return $this->morphMany(DatabaseNotification::class, 'notifiable')->orderBy('created_at', 'asc');
+    }
+
+    /**
      * Get the entity's read notifications.
      *
      * @return \Illuminate\Database\Query\Builder


### PR DESCRIPTION
This relation is useful to get notifications in the opposite order.