### PR TITLE
[7.x] Allow nested errors in json assertion

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -729,7 +729,7 @@ class TestResponse implements ArrayAccess
 
         PHPUnit::assertNotEmpty($errors, 'No validation errors were provided.');
 
-        $jsonErrors = $this->json()[$responseKey] ?? [];
+        $jsonErrors = Arr::get($this->json(), $responseKey) ?? [];
 
         $errorMessage = $jsonErrors
                 ? 'Response has the following JSON validation errors:'.

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -611,6 +611,20 @@ class TestResponseTest extends TestCase
         $testResponse->assertJsonValidationErrors('foo', 'data');
     }
 
+    public function testAssertJsonValidationErrorsCustomNestedErrorsName()
+    {
+        $data = [
+            'status' => 'ok',
+            'data' => ['errors' => ['foo' => 'oops']],
+        ];
+
+        $testResponse = TestResponse::fromBaseResponse(
+            (new Response)->setContent(json_encode($data))
+        );
+
+        $testResponse->assertJsonValidationErrors('foo', 'data.errors');
+    }
+
     public function testAssertJsonValidationErrorsCanFail()
     {
         $this->expectException(AssertionFailedError::class);


### PR DESCRIPTION
Hey, first proper PR so think I've got the correct branch.

Currently working with a legacy app and dealing with a custom error json structure and wanted to use existing nice json assertions, simple change but gives a bit more flexibility.