### PR TITLE
[7.x] Alias StatefulGuard as an auth.driver so it can be injected

### DIFF
--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -1236,7 +1236,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
         foreach ([
             'app'                  => [self::class, \Illuminate\Contracts\Container\Container::class, \Illuminate\Contracts\Foundation\Application::class, \Psr\Container\ContainerInterface::class],
             'auth'                 => [\Illuminate\Auth\AuthManager::class, \Illuminate\Contracts\Auth\Factory::class],
-            'auth.driver'          => [\Illuminate\Contracts\Auth\Guard::class],
+            'auth.driver'          => [\Illuminate\Contracts\Auth\Guard::class, \Illuminate\Contracts\Auth\StatefulGuard::class],
             'blade.compiler'       => [\Illuminate\View\Compilers\BladeCompiler::class],
             'cache'                => [\Illuminate\Cache\CacheManager::class, \Illuminate\Contracts\Cache\Factory::class],
             'cache.store'          => [\Illuminate\Cache\Repository::class, \Illuminate\Contracts\Cache\Repository::class, \Psr\SimpleCache\CacheInterface::class],


### PR DESCRIPTION
Currently, it is not possible to inject `\Illuminate\Contracts\Auth\StatefulGuard` through the service container, you can only inject the parent Guard contract.  The issue is stateful methods like `login` are only available on StatefulGuards, so using them with an injected Guard breaks the contract (which can be reported by IDEs and static analysis tools).

This simply adds `StatefulGuard` as an alias for the 'auth.driver' binding.