### PR TITLE
[7.x] Remove dead code from Arr::get

### DIFF
--- a/src/Illuminate/Support/Arr.php
+++ b/src/Illuminate/Support/Arr.php
@@ -294,7 +294,7 @@ class Arr
         }
 
         if (strpos($key, '.') === false) {
-            return $array[$key] ?? value($default);
+            return value($default);
         }
 
         foreach (explode('.', $key) as $segment) {

--- a/tests/Support/SupportArrTest.php
+++ b/tests/Support/SupportArrTest.php
@@ -324,6 +324,7 @@ class SupportArrTest extends TestCase
 
         // Test return default value for non-existing key.
         $array = ['names' => ['developer' => 'taylor']];
+        $this->assertSame('dayle', Arr::get($array, 'name', 'dayle'));
         $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', 'dayle'));
         $this->assertSame('dayle', Arr::get($array, 'names.otherDeveloper', function () {
             return 'dayle';


### PR DESCRIPTION
The left part of the null coalescing operator is unreachable as the function would already return in the previous if statement if the key is present. So if the key isn't nested, we can return the default value directly.

Also adds an additional test for default values with non-nested keys.

(cc pterodactyl/panel#2261)