### PR TITLE
Fix grammar ran -> run

### DIFF
--- a/src/Illuminate/Bus/UpdatedBatchJobCounts.php
+++ b/src/Illuminate/Bus/UpdatedBatchJobCounts.php
@@ -32,11 +32,11 @@ class UpdatedBatchJobCounts
     }
 
     /**
-     * Determine if all jobs have ran exactly once.
+     * Determine if all jobs have run exactly once.
      *
      * @return bool
      */
-    public function allJobsHaveRanExactlyOnce()
+    public function allJobsHaveRunExactlyOnce()
     {
         return ($this->pendingJobs - $this->failedJobs) === 0;
     }


### PR DESCRIPTION
"Run" is the correct grammar for the past participle here.

According to Grammarly, for the sentence "All jobs have ran exactly once", "ran" should be corrected to "run".

![image](https://user-images.githubusercontent.com/185187/91084332-d62bff80-e619-11ea-98e0-7df3affc72b0.png)

