### PR TITLE
Columns are now sorted according to ordinal_position

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/MySqlGrammar.php
@@ -43,7 +43,7 @@ class MySqlGrammar extends Grammar
      */
     public function compileColumnListing()
     {
-        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ?';
+        return 'select column_name as `column_name` from information_schema.columns where table_schema = ? and table_name = ? order by ordinal_position asc';
     }
 
     /**


### PR DESCRIPTION
I've noticed that in MySQL 8, SchemaBuilder's `getColumnListing()` returned the column names in in alphabetical order.

In MySQL 5.7 this was in the order that I defined it in the migration.

This pull request will allow MySQL 8 to return the columns according to `ordinal_position` which is the expected behaviour.