### PR TITLE
[7.x] RefreshDatabase migration commands parameters moved to methods

### DIFF
--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -37,7 +37,7 @@ trait RefreshDatabase
      */
     protected function migrateCommandParameters()
     {
-        return [ ];
+        return [];
     }
 
     /**
@@ -53,7 +53,7 @@ trait RefreshDatabase
     }
 
     /**
-     * Parameters used on migrate fresh conventional database
+     * Parameters used on migrate fresh conventional database.
      *
      * @return array
      */

--- a/src/Illuminate/Foundation/Testing/RefreshDatabase.php
+++ b/src/Illuminate/Foundation/Testing/RefreshDatabase.php
@@ -31,15 +31,38 @@ trait RefreshDatabase
     }
 
     /**
+     * Parameters used on refresh in-memory database.
+     *
+     * @return array
+     */
+    protected function migrateCommandParameters()
+    {
+        return [ ];
+    }
+
+    /**
      * Refresh the in-memory database.
      *
      * @return void
      */
     protected function refreshInMemoryDatabase()
     {
-        $this->artisan('migrate');
+        $this->artisan('migrate', $this->migrateCommandParameters());
 
         $this->app[Kernel::class]->setArtisan(null);
+    }
+
+    /**
+     * Parameters used on migrate fresh conventional database
+     *
+     * @return array
+     */
+    protected function migrateFreshCommandParameters()
+    {
+        return [
+            '--drop-views' => $this->shouldDropViews(),
+            '--drop-types' => $this->shouldDropTypes(),
+        ];
     }
 
     /**
@@ -50,10 +73,7 @@ trait RefreshDatabase
     protected function refreshTestDatabase()
     {
         if (! RefreshDatabaseState::$migrated) {
-            $this->artisan('migrate:fresh', [
-                '--drop-views' => $this->shouldDropViews(),
-                '--drop-types' => $this->shouldDropTypes(),
-            ]);
+            $this->artisan('migrate:fresh', $this->migrateFreshCommandParameters());
 
             $this->app[Kernel::class]->setArtisan(null);
 


### PR DESCRIPTION
Using the Framework could be useful to customize the parameters used by migration commands without extending every time the `refreshTestDatabase` or `refreshInMemoryDatabase` methods from `RefreshDatabase`.

For example, if you use a conventional database but your migrations aren't in the default path, or if you use a connection different than the ones specified by the environment.