### PR TITLE
[7.x] Fix "Maximum function nesting level" error in `trait_uses_recursive()` if two traits use each other

### DIFF
--- a/src/Illuminate/Support/helpers.php
+++ b/src/Illuminate/Support/helpers.php
@@ -482,15 +482,20 @@ if (! function_exists('trait_uses_recursive')) {
     /**
      * Returns all traits used by a trait and its traits.
      *
-     * @param  string  $trait
+     * @param  string  $trait    The trait name to check.
+     * @param  array   $checked  An array of trait names that have already been
+     *                           checked.
      * @return array
      */
-    function trait_uses_recursive($trait)
+    function trait_uses_recursive($trait, &$checked = [])
     {
         $traits = class_uses($trait);
 
         foreach ($traits as $trait) {
-            $traits += trait_uses_recursive($trait);
+            if (!in_array($trait, $checked)) {
+                $checked[] = $trait;
+                $traits += trait_uses_recursive($trait, $checked);
+            }
         }
 
         return $traits;

--- a/tests/Support/Declarations/SupportTestTraitRecursiveA.php
+++ b/tests/Support/Declarations/SupportTestTraitRecursiveA.php
@@ -1,0 +1,7 @@
+<?php
+namespace Illuminate\Tests\Support\Declarations;
+
+trait SupportTestTraitRecursiveA
+{
+    use SupportTestTraitRecursiveB;
+}

--- a/tests/Support/Declarations/SupportTestTraitRecursiveB.php
+++ b/tests/Support/Declarations/SupportTestTraitRecursiveB.php
@@ -1,0 +1,7 @@
+<?php
+namespace Illuminate\Tests\Support\Declarations;
+
+trait SupportTestTraitRecursiveB
+{
+    use SupportTestTraitRecursiveA;
+}

--- a/tests/Support/SupportHelpersTest.php
+++ b/tests/Support/SupportHelpersTest.php
@@ -349,6 +349,14 @@ class SupportHelpersTest extends TestCase
         class_uses_recursive(SupportTestClassThree::class));
     }
 
+    public function testTraitUsesRecursiveHandlesRecursiveTraits()
+    {
+        $this->assertContains(
+            \Illuminate\Tests\Support\Declarations\SupportTestTraitRecursiveA::class,
+            trait_uses_recursive(\Illuminate\Tests\Support\Declarations\SupportTestTraitRecursiveB::class)
+        );
+    }
+
     public function testTap()
     {
         $object = (object) ['id' => 1];


### PR DESCRIPTION
If I have 2 traits, and they both use each other, `trait_uses_recursive()` ends up in a recursive loop and we get a "Maximum function nesting level" error.  

This PR fixes the problem by keeping a list of traits that have already been checked by `trait_uses_recursive()` and not calling `trait_uses_recursive()` on a trait that's already been checked. 
A test has been added that uses `trait_uses_recursive()` to check if the trait `SupportTestTraitRecursiveB` uses the trait `SupportTestTraitRecursiveA`. If `trait_uses_recursive()` can't handle the recursion there will be a Maximum function nesting level error when running the test.

I think this is against the right branch. If not please let me know.

### Test implementation notes:
I had to add the two traits for the test in their own files because PHP wouldn't let me use a trait that hadn't been declared yet when trying to add them to the bottom of SupportHelpersTest.php. If I should put them elsewhere please let me know.  Also, I couldn't find an "assertDoesNotCauseError()" assertion for PHPUnit, (I'm pretty new to testing), so if I did it wrong I'm happy to learn!

## Use Case
I realize that two traits pointing at each other seems weird, and maybe I should code around the problem, but I believe there are legitimate times when it could happen. In my app I have a traits that update Contacts and Accounts in a separate CRM. When updating an Account sometimes related Contacts need to be updated, and vice-versa, so the `UpdatesCrmContacts` and `UpdatesCrmAccounts` traits point at each other. 

> In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.

It doesn't break existing features because the new 2nd parameter for `trait_uses_recursive()` is optional and a default is provided.

It makes building apps easier by handling another possible configuration of traits dependencies.


