### PR TITLE
[7.x] Only prepend scheme to PhpRedis host when necessary

### DIFF
--- a/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
+++ b/src/Illuminate/Redis/Connectors/PhpRedisConnector.php
@@ -7,6 +7,7 @@ use Illuminate\Redis\Connections\PhpRedisClusterConnection;
 use Illuminate\Redis\Connections\PhpRedisConnection;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Redis as RedisFacade;
+use Illuminate\Support\Str;
 use LogicException;
 use Redis;
 use RedisCluster;
@@ -183,7 +184,7 @@ class PhpRedisConnector implements Connector
     protected function formatHost(array $options)
     {
         if (isset($options['scheme'])) {
-            return "{$options['scheme']}://{$options['host']}";
+            return Str::start($options['host'], "{$options['scheme']}://");
         }
 
         return $options['host'];


### PR DESCRIPTION
# Description
Since https://github.com/laravel/framework/pull/33871 was released in v7.26.0, there are cases where connections via PhpRedisConnector are broken. 

In cases where users may be using a different connector between development/staging/prod, or from blindly copy-pasting config from StackOverflow, the following configuration may be possible:

```
REDIS_HOST=tls://myproductionredis.cache.amazonaws.com
```

```
'default' => [
    'scheme'   => 'tls',
    'host'       => env('REDIS_HOST', '127.0.0.1'),
    'password'   => env('REDIS_PASSWORD', null),
    'port'       => env('REDIS_PORT', 6379),
    'database'   => env('REDIS_DB', 0),
],
```

The resulting scheme will be `tls://tls://myproductionredis.cache.amazonaws.com`

# Proposed changes
My change uses the `Str::start` helper to only add the scheme if the host does not start with it already
