### PR TITLE
[7.x]: Fix offset error on invalid remember token

### DIFF
--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -40,9 +40,9 @@ class AuthenticateSession
         }
 
         if ($this->auth->viaRemember()) {
-            $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2];
+            $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2] ?? null;
 
-            if ($passwordHash != $request->user()->getAuthPassword()) {
+            if (!$passwordHash || $passwordHash != $request->user()->getAuthPassword()) {
                 $this->logout($request);
             }
         }

--- a/src/Illuminate/Session/Middleware/AuthenticateSession.php
+++ b/src/Illuminate/Session/Middleware/AuthenticateSession.php
@@ -42,7 +42,7 @@ class AuthenticateSession
         if ($this->auth->viaRemember()) {
             $passwordHash = explode('|', $request->cookies->get($this->auth->getRecallerName()))[2] ?? null;
 
-            if (!$passwordHash || $passwordHash != $request->user()->getAuthPassword()) {
+            if (! $passwordHash || $passwordHash != $request->user()->getAuthPassword()) {
                 $this->logout($request);
             }
         }


### PR DESCRIPTION
Sending a request with an invalidly formed remember token throws an error. This ensures that the error is avoided, and the user will just be logged out, if the remember token contains an invalid format.