### PR TITLE
[7.x] Add Attribute Validation to Models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/ValidatesAttributes.php
@@ -7,21 +7,21 @@ use Illuminate\Support\Facades\Validator;
 trait ValidatesAttributes
 {
     /**
-     * Whether the model should automatically validate on saving event
+     * Whether the model should automatically validate on saving event.
      *
      * @var bool
      */
     protected $validateOnSaving = true;
 
     /**
-     * Model attribute validation rules
+     * Model attribute validation rules.
      *
      * @var array
      */
     protected $validationRules = [];
 
     /**
-     * Model attribute validation messages
+     * Model attribute validation messages.
      *
      * @var array
      */

--- a/src/Illuminate/Database/Eloquent/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/ValidatesAttributes.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Concerns;
+
+use Illuminate\Support\Facades\Validator;
+
+trait ValidatesAttributes
+{
+    /**
+     * Whether the model should automatically validate on saving event
+     *
+     * @var bool
+     */
+    protected $validateOnSaving = true;
+
+    /**
+     * Model attribute validation rules
+     *
+     * @var array
+     */
+    protected $validationRules = [];
+
+    /**
+     * Model attribute validation messages
+     *
+     * @var array
+     */
+    protected $validationMessages = [];
+
+    /**
+     * Get whether the model should automatically validate on saving event.
+     *
+     * @return bool
+     */
+    public function getValidateOnSaving(): bool
+    {
+        return $this->validateOnSaving;
+    }
+
+    /**
+     * Get all validation rules for the model.
+     *
+     * @return array
+     */
+    public function getValidationRules(): array
+    {
+        return $this->validationRules;
+    }
+
+    /**
+     * Get all validation messages for the model.
+     *
+     * @return array
+     */
+    public function getValidationMessages(): array
+    {
+        return $this->validationMessages;
+    }
+
+    /**
+     * Execute validation on the model.
+     *
+     * @return array
+     * @throws \Illuminate\Validation\ValidationException
+     */
+    public function validate(): array
+    {
+        return Validator::make(
+            $this->getAttributes(),
+            $this->getValidationRules(),
+            $this->getValidationMessages()
+        )->validate();
+    }
+
+    /**
+     * Register validation on model saving event.
+     * Validation will only be performed if $validateOnSaving is enabled (enabled by default).
+     */
+    public static function bootValidatesAttributes()
+    {
+        static::saving(function ($model) {
+            if ($model->getValidateOnSaving()) {
+                $model->validate();
+            }
+        });
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -29,6 +29,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
         Concerns\HasTimestamps,
         Concerns\HidesAttributes,
         Concerns\GuardsAttributes,
+        Concerns\ValidatesAttributes,
         ForwardsCalls;
 
     /**

--- a/tests/Database/DatabaseEloquentConcernsValidatesAttributesTraitTest.php
+++ b/tests/Database/DatabaseEloquentConcernsValidatesAttributesTraitTest.php
@@ -11,12 +11,12 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
     public function testValidate()
     {
         /**
-         * Test validation error
+         * Test validation error.
          */
         $model = new EloquentModelWithValidatesAttributesStub([
             'foo' => null,
             'bar' => 'abc',
-            'baz' => 'abc'
+            'baz' => 'abc',
         ]);
 
         try {
@@ -40,12 +40,11 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
         }
 
         /**
-         * Test error after update
+         * Test error after update.
          */
         $model->foo = 123;
 
         try {
-
             $model->validate();
         } catch (ValidationException $e) {
             $messages = $e->validator->errors()->toArray();
@@ -64,7 +63,7 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
         }
 
         /**
-         * Test success
+         * Test success.
          */
         $model->foo = 'abc';
         $model->bar = 123;
@@ -91,7 +90,7 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
             EloquentModelWithValidatesAttributesStub::create([
                 'foo' => 123,
                 'bar' => 'abc',
-                'baz' => 'abc'
+                'baz' => 'abc',
             ]);
         } catch (ValidationException $e) {
             $messages = $e->validator->errors()->toArray();
@@ -102,7 +101,7 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
             $model = EloquentModelWithValidatesAttributesStub::make([
                 'foo' => 123,
                 'bar' => 'abc',
-                'baz' => 'abc'
+                'baz' => 'abc',
             ]);
 
             $model->save();
@@ -114,7 +113,7 @@ class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestC
         $model = EloquentModelWithValidatesAttributesStub::make([
             'foo' => 'abc',
             'bar' => 123,
-            'baz' => 123
+            'baz' => 123,
         ]);
 
         $model->save();
@@ -131,7 +130,7 @@ class EloquentModelWithValidatesAttributesStub extends Model
     protected $validationRules = [
         'foo' => 'required|string',
         'bar' => 'required|integer',
-        'baz' => 'nullable|integer'
+        'baz' => 'nullable|integer',
     ];
 
     protected $validationMessages = [
@@ -139,7 +138,7 @@ class EloquentModelWithValidatesAttributesStub extends Model
         'foo.string' => 'The foo attribute must be a string.',
         'bar.required' => 'The bar attribute is required.',
         'bar.integer' => 'The bar attribute must be an integer.',
-        'baz.integer' => 'The baz attribute must be an integer.'
+        'baz.integer' => 'The baz attribute must be an integer.',
     ];
 
     protected $guarded = [];
@@ -160,4 +159,3 @@ class EloquentModelWithValidatesAttributesStub extends Model
         $this->fireModelEvent('saved', false);
     }
 }
-

--- a/tests/Database/DatabaseEloquentConcernsValidatesAttributesTraitTest.php
+++ b/tests/Database/DatabaseEloquentConcernsValidatesAttributesTraitTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+use Illuminate\Validation\ValidationException;
+
+class DatabaseEloquentConcernsValidatesAttributesTraitTest extends DatabaseTestCase
+{
+    public function testValidate()
+    {
+        /**
+         * Test validation error
+         */
+        $model = new EloquentModelWithValidatesAttributesStub([
+            'foo' => null,
+            'bar' => 'abc',
+            'baz' => 'abc'
+        ]);
+
+        try {
+            $model->validate();
+
+            $this->assertFalse(true);
+        } catch (ValidationException $e) {
+            $messages = $e->validator->errors()->toArray();
+
+            $this->assertArrayHasKey('foo', $messages);
+            $this->assertCount(1, $messages['foo']);
+            $this->assertEquals('The foo attribute is required.', $messages['foo'][0]);
+
+            $this->assertArrayHasKey('bar', $messages);
+            $this->assertCount(1, $messages['bar']);
+            $this->assertEquals('The bar attribute must be an integer.', $messages['bar'][0]);
+
+            $this->assertArrayHasKey('baz', $messages);
+            $this->assertCount(1, $messages['baz']);
+            $this->assertEquals('The baz attribute must be an integer.', $messages['baz'][0]);
+        }
+
+        /**
+         * Test error after update
+         */
+        $model->foo = 123;
+
+        try {
+
+            $model->validate();
+        } catch (ValidationException $e) {
+            $messages = $e->validator->errors()->toArray();
+
+            $this->assertArrayHasKey('foo', $messages);
+            $this->assertCount(1, $messages['foo']);
+            $this->assertEquals('The foo attribute must be a string.', $messages['foo'][0]);
+
+            $this->assertArrayHasKey('bar', $messages);
+            $this->assertCount(1, $messages['bar']);
+            $this->assertEquals('The bar attribute must be an integer.', $messages['bar'][0]);
+
+            $this->assertArrayHasKey('baz', $messages);
+            $this->assertCount(1, $messages['baz']);
+            $this->assertEquals('The baz attribute must be an integer.', $messages['baz'][0]);
+        }
+
+        /**
+         * Test success
+         */
+        $model->foo = 'abc';
+        $model->bar = 123;
+        $model->baz = 123;
+
+        $validated = $model->validate();
+
+        $this->assertIsArray($validated);
+        $this->assertCount(3, $validated);
+
+        $this->assertArrayHasKey('foo', $validated);
+        $this->assertEquals($model->foo, $validated['foo']);
+
+        $this->assertArrayHasKey('bar', $validated);
+        $this->assertEquals($model->bar, $validated['bar']);
+
+        $this->assertArrayHasKey('baz', $validated);
+        $this->assertEquals($model->baz, $validated['baz']);
+    }
+
+    public function testValidateOnSaving()
+    {
+        try {
+            EloquentModelWithValidatesAttributesStub::create([
+                'foo' => 123,
+                'bar' => 'abc',
+                'baz' => 'abc'
+            ]);
+        } catch (ValidationException $e) {
+            $messages = $e->validator->errors()->toArray();
+            $this->assertEquals(3, count($messages));
+        }
+
+        try {
+            $model = EloquentModelWithValidatesAttributesStub::make([
+                'foo' => 123,
+                'bar' => 'abc',
+                'baz' => 'abc'
+            ]);
+
+            $model->save();
+        } catch (ValidationException $e) {
+            $messages = $e->validator->errors()->toArray();
+            $this->assertCount(3, $messages);
+        }
+
+        $model = EloquentModelWithValidatesAttributesStub::make([
+            'foo' => 'abc',
+            'bar' => 123,
+            'baz' => 123
+        ]);
+
+        $model->save();
+
+        $this->assertTrue($model->exists);
+    }
+}
+
+class EloquentModelWithValidatesAttributesStub extends Model
+{
+    public $connection;
+    protected $table = 'stub';
+
+    protected $validationRules = [
+        'foo' => 'required|string',
+        'bar' => 'required|integer',
+        'baz' => 'nullable|integer'
+    ];
+
+    protected $validationMessages = [
+        'foo.required' => 'The foo attribute is required.',
+        'foo.string' => 'The foo attribute must be a string.',
+        'bar.required' => 'The bar attribute is required.',
+        'bar.integer' => 'The bar attribute must be an integer.',
+        'baz.integer' => 'The baz attribute must be an integer.'
+    ];
+
+    protected $guarded = [];
+
+    public function disableValidatesOnSaving()
+    {
+        $this->validateOnSaving = false;
+    }
+
+    public function save(array $options = [])
+    {
+        if ($this->fireModelEvent('saving') === false) {
+            return false;
+        }
+
+        $this->exists = true;
+
+        $this->fireModelEvent('saved', false);
+    }
+}
+


### PR DESCRIPTION
Hello! This PR is for an adaptation of a feature which I developed for my job, and I thought it might be useful to the larger Laravel community. We have been using and improving this feature for almost a year, and now it's in a place where I'm pretty happy with it.

### Benefit To Users
**TLDR: It's easy and decreases the likelihood of invalid data being saved to the database.**

This feature gives users the ability to validate data automatically at the model level, rather than manually at the controller. 

Laravel's validation system is already pretty robust, but it requires a lot of code to validate every incoming request, either by manually creating a validator in-line, or by creating an entirely separate request object class. Plus, once the request is validated, there's still a danger of storing invalid data if you have code that modifies the payload in any way before it gets saved into the database.

By declaring an array of validation rules directly on your model class, not only do you cut out all of the boilerplate traditionally required to run Validation in Laravel, but you also ensure that all of your data is validated just before it gets saved to the database, meaning that you're safe from errors that might be caused by working with the data before it gets saved.

### Non-Breaking
This addition will not break existing eloquent models or the current Laravel framework at large. Although `$validatesOnSaving` is enabled by default, the default array of validation rules is empty. For models which do not set the `protected $validationRules` array, validation is effectively _disabled_.