### PR TITLE
[8.x] Fix canceled and canceling spelling

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -82,11 +82,11 @@ class Batch implements Arrayable, JsonSerializable
     public $createdAt;
 
     /**
-     * The date indicating when the batch was cancelled.
+     * The date indicating when the batch was canceled.
      *
      * @var \Illuminate\Support\CarbonImmutable|null
      */
-    public $cancelledAt;
+    public $canceledAt;
 
     /**
      * The date indicating when the batch was finished.
@@ -108,7 +108,7 @@ class Batch implements Arrayable, JsonSerializable
      * @param  array  $failedJobIds
      * @param  array  $options
      * @param  \Illuminate\Support\CarbonImmutable  $createdAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $cancelledAt
+     * @param  \Illuminate\Support\CarbonImmutable|null  $canceledAt
      * @param  \Illuminate\Support\CarbonImmutable|null  $finishedAt
      * @return void
      */
@@ -122,7 +122,7 @@ class Batch implements Arrayable, JsonSerializable
                                 array $failedJobIds,
                                 array $options,
                                 CarbonImmutable $createdAt,
-                                ?CarbonImmutable $cancelledAt = null,
+                                ?CarbonImmutable $canceledAt = null,
                                 ?CarbonImmutable $finishedAt = null)
     {
         $this->queue = $queue;
@@ -135,7 +135,7 @@ class Batch implements Arrayable, JsonSerializable
         $this->failedJobIds = $failedJobIds;
         $this->options = $options;
         $this->createdAt = $createdAt;
-        $this->cancelledAt = $cancelledAt;
+        $this->canceledAt = $canceledAt;
         $this->finishedAt = $finishedAt;
     }
 
@@ -253,7 +253,7 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
-     * Determine if the batch allows jobs to fail without cancelling the batch.
+     * Determine if the batch allows jobs to fail without canceling the batch.
      *
      * @return bool
      */
@@ -342,23 +342,23 @@ class Batch implements Arrayable, JsonSerializable
     }
 
     /**
-     * Determine if the batch has been cancelled.
+     * Determine if the batch has been canceled.
      *
      * @return bool
      */
     public function canceled()
     {
-        return $this->cancelled();
+        return ! is_null($this->canceledAt);
     }
 
     /**
-     * Determine if the batch has been cancelled.
+     * Determine if the batch has been canceled.
      *
      * @return bool
      */
     public function cancelled()
     {
-        return ! is_null($this->cancelledAt);
+        return $this->canceled();
     }
 
     /**
@@ -388,7 +388,7 @@ class Batch implements Arrayable, JsonSerializable
             'failedJobs' => $this->failedJobs,
             'options' => $this->options,
             'createdAt' => $this->createdAt,
-            'cancelledAt' => $this->cancelledAt,
+            'canceledAt' => $this->canceledAt,
             'finishedAt' => $this->finishedAt,
         ];
     }

--- a/src/Illuminate/Bus/BatchFactory.php
+++ b/src/Illuminate/Bus/BatchFactory.php
@@ -37,7 +37,7 @@ class BatchFactory
      * @param  array  $failedJobIds
      * @param  array  $options
      * @param  \Illuminate\Support\CarbonImmutable  $createdAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $cancelledAt
+     * @param  \Illuminate\Support\CarbonImmutable|null  $canceledAt
      * @param  \Illuminate\Support\CarbonImmutable|null  $finishedAt
      * @return \Illuminate\Bus\Batch
      */
@@ -50,9 +50,9 @@ class BatchFactory
                          array $failedJobIds,
                          array $options,
                          CarbonImmutable $createdAt,
-                         ?CarbonImmutable $cancelledAt,
+                         ?CarbonImmutable $canceledAt,
                          ?CarbonImmutable $finishedAt)
     {
-        return new Batch($this->queue, $repository, $id, $name, $totalJobs, $pendingJobs, $failedJobs, $failedJobIds, $options, $createdAt, $cancelledAt, $finishedAt);
+        return new Batch($this->queue, $repository, $id, $name, $totalJobs, $pendingJobs, $failedJobs, $failedJobIds, $options, $createdAt, $canceledAt, $finishedAt);
     }
 }

--- a/src/Illuminate/Bus/Batchable.php
+++ b/src/Illuminate/Bus/Batchable.php
@@ -34,7 +34,7 @@ trait Batchable
     {
         $batch = $this->batch();
 
-        return $batch && ! $batch->cancelled();
+        return $batch && ! $batch->canceled();
     }
 
     /**

--- a/src/Illuminate/Bus/DatabaseBatchRepository.php
+++ b/src/Illuminate/Bus/DatabaseBatchRepository.php
@@ -103,7 +103,7 @@ class DatabaseBatchRepository implements BatchRepository
             'failed_job_ids' => '[]',
             'options' => serialize($batch->options),
             'created_at' => time(),
-            'cancelled_at' => null,
+            'canceled_at' => null,
             'finished_at' => null,
         ]);
 
@@ -214,7 +214,7 @@ class DatabaseBatchRepository implements BatchRepository
     public function cancel(string $batchId)
     {
         $this->connection->table($this->table)->where('id', $batchId)->update([
-            'cancelled_at' => time(),
+            'canceled_at' => time(),
             'finished_at' => time(),
         ]);
     }
@@ -261,7 +261,7 @@ class DatabaseBatchRepository implements BatchRepository
             json_decode($batch->failed_job_ids, true),
             unserialize($batch->options),
             CarbonImmutable::createFromTimestamp($batch->created_at),
-            $batch->cancelled_at ? CarbonImmutable::createFromTimestamp($batch->cancelled_at) : $batch->cancelled_at,
+            $batch->canceled_at ? CarbonImmutable::createFromTimestamp($batch->canceled_at) : $batch->canceled_at,
             $batch->finished_at ? CarbonImmutable::createFromTimestamp($batch->finished_at) : $batch->finished_at
         );
     }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -124,7 +124,7 @@ class PendingBatch
     }
 
     /**
-     * Indicate that the batch should not be cancelled when a job within the batch fails.
+     * Indicate that the batch should not be canceled when a job within the batch fails.
      *
      * @param  bool  $allowFailures
      * @return $this
@@ -137,7 +137,7 @@ class PendingBatch
     }
 
     /**
-     * Determine if the pending batch allows jobs to fail without cancelling the batch.
+     * Determine if the pending batch allows jobs to fail without canceling the batch.
      *
      * @return bool
      */

--- a/src/Illuminate/Queue/Console/stubs/batches.stub
+++ b/src/Illuminate/Queue/Console/stubs/batches.stub
@@ -21,7 +21,7 @@ class Create{{tableClassName}}Table extends Migration
             $table->integer('failed_jobs');
             $table->text('failed_job_ids');
             $table->text('options')->nullable();
-            $table->integer('cancelled_at')->nullable();
+            $table->integer('canceled_at')->nullable();
             $table->integer('created_at');
             $table->integer('finished_at')->nullable();
         });

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -52,7 +52,7 @@ class BusBatchTest extends TestCase
             $table->integer('failed_jobs');
             $table->text('failed_job_ids');
             $table->text('options')->nullable();
-            $table->integer('cancelled_at')->nullable();
+            $table->integer('canceled_at')->nullable();
             $table->integer('created_at');
             $table->integer('finished_at')->nullable();
         });
@@ -185,7 +185,7 @@ class BusBatchTest extends TestCase
         $this->assertEquals(2, $batch->pendingJobs);
         $this->assertEquals(2, $batch->failedJobs);
         $this->assertTrue($batch->finished());
-        $this->assertTrue($batch->cancelled());
+        $this->assertTrue($batch->canceled());
         $this->assertEquals(1, $_SERVER['__finally.count']);
         $this->assertEquals(1, $_SERVER['__catch.count']);
         $this->assertEquals('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
@@ -224,12 +224,12 @@ class BusBatchTest extends TestCase
         $this->assertEquals(2, $batch->pendingJobs);
         $this->assertEquals(2, $batch->failedJobs);
         $this->assertFalse($batch->finished());
-        $this->assertFalse($batch->cancelled());
+        $this->assertFalse($batch->canceled());
         $this->assertEquals(1, $_SERVER['__catch.count']);
         $this->assertEquals('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
-    public function test_batch_can_be_cancelled()
+    public function test_batch_can_be_canceled()
     {
         $queue = m::mock(Factory::class);
 
@@ -239,7 +239,7 @@ class BusBatchTest extends TestCase
 
         $batch = $batch->fresh();
 
-        $this->assertTrue($batch->cancelled());
+        $this->assertTrue($batch->canceled());
     }
 
     public function test_batch_can_be_deleted()
@@ -283,9 +283,9 @@ class BusBatchTest extends TestCase
         $batch->options['catch'] = [1];
         $this->assertTrue($batch->hasCatchCallbacks());
 
-        $this->assertFalse($batch->cancelled());
-        $batch->cancelledAt = now();
-        $this->assertTrue($batch->cancelled());
+        $this->assertFalse($batch->canceled());
+        $batch->canceledAt = now();
+        $this->assertTrue($batch->canceled());
 
         $this->assertTrue(is_string(json_encode($batch)));
     }


### PR DESCRIPTION
Use the American English spelling instead of the British English spelling (see [#31356](https://github.com/laravel/framework/pull/31356)).

Makes `cancelled()` the aliased function instead (debatable if that should even exist since it introduces the possibility of other aliases like *colour*, *organise*, *humour*, *flavour*, etc.).

https://www.grammarly.com/blog/canceled-vs-cancelled/