### PR TITLE
[7.x] Add notify helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
     "autoload": {
         "files": [
             "src/Illuminate/Foundation/helpers.php",
+            "src/Illuminate/Notifications/helpers.php",
             "src/Illuminate/Support/helpers.php"
         ],
         "psr-4": {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -18,7 +18,6 @@ use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -569,20 +568,6 @@ if (! function_exists('mix')) {
     function mix($path, $manifestDirectory = '')
     {
         return app(Mix::class)(...func_get_args());
-    }
-}
-
-if (! function_exists('notify')) {
-    /**
-     * Send the given notification to the given notifiable entities.
-     *
-     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
-     * @param  \Illuminate\Notifications\Notification  $notification
-     * @return void
-     */
-    function notify($notifiables, \Illuminate\Notifications\Notification $notification)
-    {
-        Notification::send($notifiables, $notification);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -18,6 +18,7 @@ use Illuminate\Foundation\Mix;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Queue\CallQueuedClosure;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\HtmlString;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -568,6 +569,20 @@ if (! function_exists('mix')) {
     function mix($path, $manifestDirectory = '')
     {
         return app(Mix::class)(...func_get_args());
+    }
+}
+
+if (! function_exists('notify')) {
+    /**
+     * Send the given notification to the given notifiable entities.
+     *
+     * @param  \Illuminate\Support\Collection|array|mixed  $notifiables
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return void
+     */
+    function notify($notifiables, \Illuminate\Notifications\Notification $notification)
+    {
+        return Notification::send($notifiables, $notification);
     }
 }
 

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -582,7 +582,7 @@ if (! function_exists('notify')) {
      */
     function notify($notifiables, \Illuminate\Notifications\Notification $notification)
     {
-        return Notification::send($notifiables, $notification);
+        Notification::send($notifiables, $notification);
     }
 }
 

--- a/src/Illuminate/Notifications/helpers.php
+++ b/src/Illuminate/Notifications/helpers.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+if (!function_exists('notify')) {
+    /**
+     * Send the given notification to the given notifiable entities.
+     *
+     * @param  Collection|array|mixed  $notifiables
+     * @param  Notification  $notification
+     * @return void
+     */
+    function notify($notifiables, Notification $notification): void
+    {
+        NotificationFacade::send($notifiables, $notification);
+    }
+}

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -53,7 +53,7 @@ class FoundationHelpersTest extends TestCase
 
         touch(public_path($file));
 
-        $this->assertSame('/' . $file, elixir($file));
+        $this->assertSame('/'.$file, elixir($file));
 
         unlink(public_path($file));
     }
@@ -117,7 +117,7 @@ class FoundationHelpersTest extends TestCase
         $app['config'] = m::mock(Repository::class);
         $app['config']->shouldReceive('get')->with('app.mix_url');
 
-        mkdir($directory = __DIR__ . '/mix');
+        mkdir($directory = __DIR__.'/mix');
         $manifest = $this->makeManifest('mix');
 
         $result = mix('unversioned.css', 'mix');
@@ -130,7 +130,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixManifestDirectoryMissingStartingSlashHasItAdded()
     {
-        mkdir($directory = __DIR__ . '/mix');
+        mkdir($directory = __DIR__.'/mix');
         $manifest = $this->makeManifest('/mix');
 
         $result = mix('unversioned.css', 'mix');
@@ -165,7 +165,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixHotModuleReloadingGetsUrlFromFileWithManifestDirectoryAndHttps()
     {
-        mkdir($directory = __DIR__ . '/mix');
+        mkdir($directory = __DIR__.'/mix');
         $path = $this->makeHotModuleReloadFile('https://laravel.com/docs', 'mix');
 
         $result = mix('unversioned.css', 'mix');
@@ -178,7 +178,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixHotModuleReloadingGetsUrlFromFileWithManifestDirectoryAndHttp()
     {
-        mkdir($directory = __DIR__ . '/mix');
+        mkdir($directory = __DIR__.'/mix');
         $path = $this->makeHotModuleReloadFile('http://laravel.com/docs', 'mix');
 
         $result = mix('unversioned.css', 'mix');
@@ -202,7 +202,7 @@ class FoundationHelpersTest extends TestCase
 
     public function testMixHotModuleReloadingWithManifestDirectoryUsesLocalhostIfNoHttpScheme()
     {
-        mkdir($directory = __DIR__ . '/mix');
+        mkdir($directory = __DIR__.'/mix');
         $path = $this->makeHotModuleReloadFile('', 'mix');
 
         $result = mix('unversioned.css', 'mix');
@@ -219,7 +219,7 @@ class FoundationHelpersTest extends TestCase
             return __DIR__;
         });
 
-        $path = public_path(Str::finish($directory, '/') . 'hot');
+        $path = public_path(Str::finish($directory, '/').'hot');
 
         // Laravel mix when run 'hot' has a new line after the
         // url, so for consistency this "\n" is added.
@@ -234,7 +234,7 @@ class FoundationHelpersTest extends TestCase
             return __DIR__;
         });
 
-        $path = public_path(Str::finish($directory, '/') . 'mix-manifest.json');
+        $path = public_path(Str::finish($directory, '/').'mix-manifest.json');
 
         touch($path);
 

--- a/tests/Foundation/FoundationHelpersTest.php
+++ b/tests/Foundation/FoundationHelpersTest.php
@@ -6,9 +6,6 @@ use Exception;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Mix;
-use Illuminate\Notifications\AnonymousNotifiable;
-use Illuminate\Notifications\Notification;
-use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Str;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -257,39 +254,5 @@ class FoundationHelpersTest extends TestCase
         });
 
         $this->assertSame('expected', mix('asset.png'));
-    }
-
-    public function testNotifySendNotificationToNotifiableEntity()
-    {
-        NotificationFacade::fake(TestMailNotificationForAnonymousNotifiable::class);
-
-        $notifiableEntity = new AnonymousNotifiable();
-        notify($notifiableEntity, new TestMailNotificationForAnonymousNotifiable());
-
-        NotificationFacade::assertSentTo($notifiableEntity, TestMailNotificationForAnonymousNotifiable::class);
-    }
-}
-
-class TestMailNotificationForAnonymousNotifiable extends Notification
-{
-    public function via($notifiable)
-    {
-        return [TestCustomChannel::class, AnotherTestCustomChannel::class];
-    }
-}
-
-class TestCustomChannel
-{
-    public function send($notifiable, $notification)
-    {
-        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('testchannel');
-    }
-}
-
-class AnotherTestCustomChannel
-{
-    public function send($notifiable, $notification)
-    {
-        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('anothertestchannel');
     }
 }

--- a/tests/Notifications/NotificationHelpersTest.php
+++ b/tests/Notifications/NotificationHelpersTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use PHPUnit\Framework\TestCase;
+
+class NotificationHelpersTest extends TestCase
+{
+    public function testNotifySendNotificationToNotifiableEntity()
+    {
+        NotificationFacade::fake(TestMailNotificationForAnonymousNotifiable::class);
+
+        $notifiableEntity = new AnonymousNotifiable();
+        notify($notifiableEntity, new TestMailNotificationForAnonymousNotifiable());
+
+        NotificationFacade::assertSentTo($notifiableEntity, TestMailNotificationForAnonymousNotifiable::class);
+    }
+}
+
+class TestMailNotificationForAnonymousNotifiable extends Notification
+{
+    public function via($notifiable)
+    {
+        return [TestCustomChannel::class, AnotherTestCustomChannel::class];
+    }
+}
+
+class TestCustomChannel
+{
+    public function send($notifiable, $notification)
+    {
+        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('testchannel');
+    }
+}
+
+class AnotherTestCustomChannel
+{
+    public function send($notifiable, $notification)
+    {
+        $_SERVER['__notifiable.route'][] = $notifiable->routeNotificationFor('anothertestchannel');
+    }
+}


### PR DESCRIPTION
Hello people!

Working with Laravel, I really enjoy using the helpers he provides. Today we have `dispatch()` for `Jobs`, `event()` for `Events`, among others.

However, I think that `notify()` for `Notifications` was still missing, so I decided to create this helper, which I believe will be very useful when sending notifications with Laravel.

Instead of having to use:

``` php
use Illuminate \ Support \ Facades \ Notification;

...

Notification :: send ($ notifiable, new NotificationInstance ());
```

It will be possible to do the same thing using:

``` php
notify ($ notifiable, new NotificationInstance ());
```

I also created a unit test for this helper! 😄 