### PR TITLE
[7.x] Allow to use alias of morphed model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -205,10 +205,10 @@ trait QueriesRelationships
 
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
-
-            foreach ($types as &$type) {
-                $type = Relation::getMorphedModel($type) ?? $type;
-            }
+        }
+        
+        foreach ($types as &$type) {
+            $type = Relation::getMorphedModel($type) ?? $type;
         }
 
         return $this->where(function ($query) use ($relation, $callback, $operator, $count, $types) {

--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -206,7 +206,7 @@ trait QueriesRelationships
         if ($types === ['*']) {
             $types = $this->model->newModelQuery()->distinct()->pluck($relation->getMorphType())->filter()->all();
         }
-        
+
         foreach ($types as &$type) {
             $type = Relation::getMorphedModel($type) ?? $type;
         }


### PR DESCRIPTION
At the moment if you use hasMorph() you need to use model class name and can't use alias, you need to use `Relation::getMorphedModel`.
But this is already done when you use `*` which auto discover morphed relations.

Moving this conversion for all case allow to use directly aliases.

Example now:


```php
        $morphable =  [
                "App\AnotherModel",
                Relation::getMorphedModel('alias')
        ];
        $dataset = MyModel::query()
            ->whereHasMorph('morphable', $morphable)
            ->with('morphable')
            ->orderBy('id')
            ->limit(50)
            ->get()
            ->groupBy('morphable_type');
```

With this change can be:

```php
        $morphable =  [
                "App\AnotherModel",
                'alias',
                'another',
                "App\YetAnotherModel",
        ];
        $dataset = MyModel::query()
            ->whereHasMorph('morphable', $morphable)
            ->with('morphable')
            ->orderBy('id')
            ->limit(50)
            ->get()
            ->groupBy('morphable_type');
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
