### PR TITLE
Add betweenBlockedAttemptsSleepFor to Cache/Lock Interface

### DIFF
--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -41,4 +41,12 @@ interface Lock
      * @return void
      */
     public function forceRelease();
+    
+    /**
+     * Specify the number of milliseconds to sleep in between blocked lock aquisition attempts.
+     *
+     * @param  int  $milliseconds
+     * @return $this
+     */
+    public function betweenBlockedAttemptsSleepFor($milliseconds);
 }

--- a/src/Illuminate/Contracts/Cache/Lock.php
+++ b/src/Illuminate/Contracts/Cache/Lock.php
@@ -41,7 +41,7 @@ interface Lock
      * @return void
      */
     public function forceRelease();
-    
+
     /**
      * Specify the number of milliseconds to sleep in between blocked lock aquisition attempts.
      *


### PR DESCRIPTION
Add forgiven `betweenBlockedAttemptsSleepFor` to interface because I can't change `vendor/laravel/framework/src/Illuminate/Cache/Lock.php -> $sleepMilliseconds` from 250 to different value. 
`Cache::lock($name, $seconds)->betweenBlockedAttemptsSleepFor(50);`