### PR TITLE
[7.x] allow to reset forced scheme and root-url

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -616,25 +616,25 @@ class UrlGenerator implements UrlGeneratorContract
     /**
      * Force the scheme for URLs.
      *
-     * @param  string  $scheme
+     * @param  string|null  $scheme
      * @return void
      */
     public function forceScheme($scheme)
     {
         $this->cachedScheme = null;
 
-        $this->forceScheme = $scheme.'://';
+        $this->forceScheme = $scheme ? $scheme . '://' : null;
     }
 
     /**
      * Set the forced root URL.
      *
-     * @param  string  $root
+     * @param  string|null  $root
      * @return void
      */
     public function forceRootUrl($root)
     {
-        $this->forcedRoot = rtrim($root, '/');
+        $this->forcedRoot = $root ? rtrim($root, '/') : null;
 
         $this->cachedRoot = null;
     }

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -623,7 +623,7 @@ class UrlGenerator implements UrlGeneratorContract
     {
         $this->cachedScheme = null;
 
-        $this->forceScheme = $scheme ? $scheme . '://' : null;
+        $this->forceScheme = $scheme ? $scheme.'://' : null;
     }
 
     /**


### PR DESCRIPTION
Right now it's not possible to clear/reset a forced scheme or root-url.
This is one way to create links to different URLs - for example in emails a link to a dedicated frontend.
https://twitter.com/m1guelpf/status/1283175178961387520

```php
url()->to('/'); // http://localhost:8000

url()->forceScheme('https');
url()->forceRootUrl('https://frontend.local');

url()->to('/'); // https://frontend.local

url()->forceScheme(null);
url()->forceRootUrl(null);

url()->to('/'); // ://localhost:8000
```

I would expect the last one to be equal to the first one - instead I get an URL without any scheme.

This PR fixes this by setting `null` to the property if the forced value is empty/null/false.
