### PR TITLE
[7.x] Introduce MissingKeyException for missing APP_KEY

### DIFF
--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -77,9 +77,7 @@ class EncryptionServiceProvider extends ServiceProvider
     {
         return tap($config['key'], function ($key) {
             if (empty($key)) {
-                throw new RuntimeException(
-                    'No application encryption key has been specified.'
-                );
+                throw new MissingKeyException();
             }
         });
     }

--- a/src/Illuminate/Encryption/MissingKeyException.php
+++ b/src/Illuminate/Encryption/MissingKeyException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+class MissingKeyException extends \RuntimeException
+{
+    public function __construct($message = 'No application encryption key has been specified.')
+    {
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
This PR introduces a new MissingKeyException.
It offers an easy way to catch this specific error.

I am building an application with an interactive installer and this should be the trigger for the setup.
