### PR TITLE
[7.x] Introduced basic padding (both, left, right) methods to Str and Stringable…

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -371,7 +371,7 @@ class Str
     }
 
     /**
-     * Pad both sides of a string with another
+     * Pad both sides of a string with another.
      *
      * @param  string  $value
      * @param  int  $length
@@ -384,7 +384,7 @@ class Str
     }
 
     /**
-     * Pad the left side of a string with another
+     * Pad the left side of a string with another.
      *
      * @param  string  $value
      * @param  int  $length
@@ -397,7 +397,7 @@ class Str
     }
 
     /**
-     * Pad the right side of a string with another
+     * Pad the right side of a string with another.
      *
      * @param  string  $value
      * @param  int  $length

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -371,6 +371,45 @@ class Str
     }
 
     /**
+     * Pad both sides of a string with another
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padBoth($value, $length, $pad = ' ')
+    {
+        return str_pad($value, $length, $pad, STR_PAD_BOTH);
+    }
+
+    /**
+     * Pad the left side of a string with another
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padLeft($value, $length, $pad = ' ')
+    {
+        return str_pad($value, $length, $pad, STR_PAD_LEFT);
+    }
+
+    /**
+     * Pad the right side of a string with another
+     *
+     * @param  string  $value
+     * @param  int  $length
+     * @param  string  $pad
+     * @return string
+     */
+    public static function padRight($value, $length, $pad = ' ')
+    {
+        return str_pad($value, $length, $pad, STR_PAD_RIGHT);
+    }
+
+    /**
      * Parse a Class[@]method style callback into class and method.
      *
      * @param  string  $callback

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -339,6 +339,42 @@ class Stringable
     }
 
     /**
+     * Pad both sides of the string with another
+     *
+     * @param  int  $length
+     * @param  string  $pad
+     * @return static
+     */
+    public function padBoth($length, $pad = ' ')
+    {
+        return new static(Str::padBoth($this->value, $length, $pad));
+    }
+
+    /**
+     * Pad the left side of the string with another
+     *
+     * @param  int  $length
+     * @param  string  $pad
+     * @return static
+     */
+    public function padLeft($length, $pad = ' ')
+    {
+        return new static(Str::padLeft($this->value, $length, $pad));
+    }
+
+    /**
+     * Pad the right side of the string with another
+     *
+     * @param  int  $length
+     * @param  string  $pad
+     * @return static
+     */
+    public function padRight($length, $pad = ' ')
+    {
+        return new static(Str::padRight($this->value, $length, $pad));
+    }
+
+    /**
      * Parse a Class@method style callback into class and method.
      *
      * @param  string|null  $default

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -339,7 +339,7 @@ class Stringable
     }
 
     /**
-     * Pad both sides of the string with another
+     * Pad both sides of the string with another.
      *
      * @param  int  $length
      * @param  string  $pad
@@ -351,7 +351,7 @@ class Stringable
     }
 
     /**
-     * Pad the left side of the string with another
+     * Pad the left side of the string with another.
      *
      * @param  int  $length
      * @param  string  $pad
@@ -363,7 +363,7 @@ class Stringable
     }
 
     /**
-     * Pad the right side of the string with another
+     * Pad the right side of the string with another.
      *
      * @param  int  $length
      * @param  string  $pad

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -462,6 +462,24 @@ class SupportStrTest extends TestCase
         $this->assertSame('', Str::slug(null));
     }
 
+    public function testPadBoth()
+    {
+        $this->assertSame('__Alien___', Str::padBoth('Alien', 10, '_'));
+        $this->assertSame('  Alien   ', Str::padBoth('Alien', 10));
+    }
+
+    public function testPadLeft()
+    {
+        $this->assertSame('-=-=-Alien', Str::padLeft('Alien', 10, '-='));
+        $this->assertSame('     Alien', Str::padLeft('Alien', 10));
+    }
+
+    public function testPadRight()
+    {
+        $this->assertSame('Alien-----', Str::padRight('Alien', 10, '-'));
+        $this->assertSame('Alien     ', Str::padRight('Alien', 10));
+    }
+
     public function validUuidList()
     {
         return [

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -510,4 +510,22 @@ class SupportStringableTest extends TestCase
         $this->assertSame(3, $this->stringable('laravelPHPFramework')->substrCount('a', 1, -2));
         $this->assertSame(1, $this->stringable('laravelPHPFramework')->substrCount('a', -10, -3));
     }
+
+    public function testPadBoth()
+    {
+        $this->assertSame('__Alien___', (string) $this->stringable('Alien')->padBoth(10, '_'));
+        $this->assertSame('  Alien   ', (string) $this->stringable('Alien')->padBoth(10));
+    }
+
+    public function testPadLeft()
+    {
+        $this->assertSame('-=-=-Alien', (string) $this->stringable('Alien')->padLeft(10, '-='));
+        $this->assertSame('     Alien', (string) $this->stringable('Alien')->padLeft(10));
+    }
+
+    public function testPadRight()
+    {
+        $this->assertSame('Alien-----', (string) $this->stringable('Alien')->padRight(10, '-'));
+        $this->assertSame('Alien     ', (string) $this->stringable('Alien')->padRight(10));
+    }
 }


### PR DESCRIPTION
Basically, this brings PHP's `str_pad()` into Laravel's `Str` and `Stringable` classes.  I looked quickly for such support in the code and the docs and couldn't find any.  Likewise, I couldn't find any previous PRs (accepted or rejected) that mentioned `str_pad`.

I added tests, but no documentation.  I don't mind updating the docs once I know it's likely to be accepted.  Hopefully that makes sense.

I explicitly provided the pad type argument when it matches the default.  I thought about removing it, but decided that being explicit might be the better choice after all.

Any feedback is welcome.

Thx.  🤓 