### PR TITLE
[7.x]  Using "public static property" in View Component causes an error

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -134,6 +134,9 @@ abstract class Component
 
             static::$propertyCache[$class] = collect($reflection->getProperties(ReflectionProperty::IS_PUBLIC))
                 ->reject(function (ReflectionProperty $property) {
+                    return $property->isStatic();
+                })
+                ->reject(function (ReflectionProperty $property) {
                     return $this->shouldIgnore($property->getName());
                 })
                 ->map(function (ReflectionProperty $property) {

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -23,8 +23,10 @@ class ViewComponentTest extends TestCase
         $component = new TestSampleViewComponent;
 
         $this->assertEquals(0, $component->counter);
+        $this->assertEquals(0, TestSampleViewComponent::$publicStaticCounter);
         $variables = $component->data();
         $this->assertEquals(0, $component->counter);
+        $this->assertEquals(0, TestSampleViewComponent::$publicStaticCounter);
 
         $this->assertSame('noArgs val', $variables['noArgs']());
         $this->assertSame('noArgs val', (string) $variables['noArgs']);
@@ -36,6 +38,7 @@ class ViewComponentTest extends TestCase
         $this->assertArrayNotHasKey('protectedHello', $variables);
         $this->assertArrayNotHasKey('privateHello', $variables);
 
+        $this->assertArrayNotHasKey('publicStaticCounter', $variables);
         $this->assertArrayNotHasKey('protectedCounter', $variables);
         $this->assertArrayNotHasKey('privateCounter', $variables);
 
@@ -91,6 +94,8 @@ class TestViewComponent extends Component
 class TestSampleViewComponent extends Component
 {
     public $counter = 0;
+
+    public static $publicStaticCounter = 0;
 
     protected $protectedCounter = 0;
 


### PR DESCRIPTION
Currently "View Component" cannot use "public static property".
This PR fixes it, with tests.

error details:

```
Accessing static property Illuminate\Tests\View\TestSampleViewComponent::$publicStaticCounter as non static
```

Thx.😄