### PR TITLE
[8.x] Accept callable and listener class names as batch handler functions

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\SerializableClosure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use JsonSerializable;
+use Throwable;
 
 class Batch implements Arrayable, JsonSerializable
 {
@@ -420,7 +421,7 @@ class Batch implements Arrayable, JsonSerializable
      * @param  \Throwable|null  $e
      * @return void
      */
-    protected function invoke($handler, Batch $batch, \Throwable $e = null)
+    protected function invoke($handler, Batch $batch, Throwable $e = null)
     {
         if ($handler instanceof SerializableClosure) {
             $handler->__invoke($batch, $e);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -415,10 +415,9 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * Invoke the handler of the batch.
      *
-     * @param SerializableClosure|string $handler
-     * @param Batch $batch
-     * @param \Throwable|null $e
-     *
+     * @param  \Illuminate\Queue\SerializableClosure|string  $handler
+     * @param  \Illuminate\Bus  $batch
+     * @param  \Throwable|null  $e
      * @return void
      */
     protected function invoke($handler, Batch $batch, \Throwable $e = null)

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -428,11 +428,13 @@ class Batch implements Arrayable, JsonSerializable
 
             return;
         }
+
         if (is_string($handler) && class_exists($handler)) {
             dispatch(new $handler($batch, $e));
 
             return;
         }
+
         call_user_func($handler, $batch, $e);
     }
 }

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -57,12 +57,12 @@ class PendingBatch
     /**
      * Add a callback to be executed after all jobs in the batch have executed successfully.
      *
-     * @param  \Closure  $callback
+     * @param  callable|string  $callback
      * @return $this
      */
-    public function then(Closure $callback)
+    public function then($callback)
     {
-        $this->options['then'][] = new SerializableClosure($callback);
+        $this->options['then'][] = $callback instanceof Closure ? new SerializableClosure($callback) : $callback;
 
         return $this;
     }
@@ -80,12 +80,12 @@ class PendingBatch
     /**
      * Add a callback to be executed after the first failing job in the batch.
      *
-     * @param  \Closure  $callback
+     * @param  callable|string  $callback
      * @return $this
      */
-    public function catch(Closure $callback)
+    public function catch($callback)
     {
-        $this->options['catch'][] = new SerializableClosure($callback);
+        $this->options['catch'][] = $callback instanceof Closure ? new SerializableClosure($callback) : $callback;
 
         return $this;
     }
@@ -103,12 +103,12 @@ class PendingBatch
     /**
      * Add a callback to be executed after the batch has finished executing.
      *
-     * @param  \Closure  $callback
+     * @param  callable|string  $callback
      * @return $this
      */
-    public function finally(Closure $callback)
+    public function finally($callback)
     {
-        $this->options['finally'][] = new SerializableClosure($callback);
+        $this->options['finally'][] = $callback instanceof Closure ? new SerializableClosure($callback) : $callback;
 
         return $this;
     }


### PR DESCRIPTION
Batch is using closures for then, catch, finally handlers. Because I was afraid serializing closures might have some limitations, I thought it is not a bad idea to allow to users the feature without closure serializations.
This PR is trying to let users to use php-serializable callables  as well as listener classes for handlers:

```php

Bus::batch([
    new ProcessPodcast(Podcast::find(1)),
    new ProcessPodcast(Podcast::find(2)),
    new ProcessPodcast(Podcast::find(3)),
])->then(SomeListener::class)
->catch([SomeClass::class, 'staticFunction'])
->finally('someFunctionName')
->dispatch();

class SomeListener
{
    function __construct(Batch $batch) {
        //...
    }
    function handle() {
        //...
    }
}
class SomeClass {
    static function staticFunction(Batch $batch, Throwable $e) {
        //
    }
}
someFunctionName(Batch $batch, Thrwoable $e = null) {
    //...
}

```

Let me know if you agree with this.