### PR TITLE
[7.x] Updating the make commands to use a custom views path

### DIFF
--- a/src/Illuminate/Console/GeneratorCommand.php
+++ b/src/Illuminate/Console/GeneratorCommand.php
@@ -367,6 +367,19 @@ abstract class GeneratorCommand extends Command
     }
 
     /**
+     * Get the views directory's path.
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function viewsDirectory($path = '')
+    {
+        $views = $this->laravel['config']['view.paths'][0] ?? resource_path('views');
+
+        return $views.($path ? DIRECTORY_SEPARATOR.$path : $path);
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -53,9 +53,9 @@ class ComponentMakeCommand extends GeneratorCommand
      */
     protected function writeView()
     {
-        $view = $this->getView();
-
-        $path = resource_path('views').'/'.str_replace('.', '/', 'components.'.$view);
+        $path = $this->viewsDirectory(
+            str_replace('.', '/', 'components.'.$this->getView())
+        );
 
         if (! $this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0777, true, true);

--- a/src/Illuminate/Foundation/Console/MailMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/MailMakeCommand.php
@@ -51,7 +51,9 @@ class MailMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
-        $path = resource_path('views/'.str_replace('.', '/', $this->option('markdown'))).'.blade.php';
+        $path = $this->viewsDirectory(
+            str_replace('.', '/', $this->option('markdown')).'.blade.php'
+        );
 
         if (! $this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0755, true);

--- a/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/NotificationMakeCommand.php
@@ -51,7 +51,9 @@ class NotificationMakeCommand extends GeneratorCommand
      */
     protected function writeMarkdownTemplate()
     {
-        $path = resource_path('views/'.str_replace('.', '/', $this->option('markdown'))).'.blade.php';
+        $path = $this->viewsDirectory(
+            str_replace('.', '/', $this->option('markdown')).'.blade.php'
+        );
 
         if (! $this->files->isDirectory(dirname($path))) {
             $this->files->makeDirectory(dirname($path), 0755, true);


### PR DESCRIPTION
This PR fix an issue when using a custom folder structure. In my case, the `views` folder is located in the **base path**.

This can be achieved by setting the custom `views` folder in config file:

```php
<?php

// config/view.php

return [

    //...

    'paths' => [
        base_path('views'), // Instead of the default: resource_path('views')
    ],

    //...
];
```

When running commands like:

```shell
php artisan make:component CustomComponent
php artisan make:mail InvoicePaid --markdown=mails.invoice.paid
php artisan make:notification InvoicePaid --markdown=notifications.invoice.paid
```

It creates the `resources/views/{new-blade-files}` instead of `views/{new-blade-files}`

**NOTE:** Let me know if i've missed a console commad that generates blade files :+1: 

Old PR: #34050