### PR TITLE
[7.x] Add foreignTinyId, foreignSmallId, foreignMediumId, foreignIntegerId to MySQL

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -905,7 +905,6 @@ class Blueprint
         return $column;
     }
 
-
     /**
      * Create a new float column on the table.
      *

--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -816,6 +816,78 @@ class Blueprint
     }
 
     /**
+     * Create a new unsigned tiny integer (1-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignTinyId($column)
+    {
+        $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
+            'type' => 'tinyInteger',
+            'name' => $column,
+            'autoIncrement' => false,
+            'unsigned' => true,
+        ]);
+
+        return $column;
+    }
+
+    /**
+     * Create a new unsigned small integer (2-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignSmallId($column)
+    {
+        $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
+            'type' => 'smallInteger',
+            'name' => $column,
+            'autoIncrement' => false,
+            'unsigned' => true,
+        ]);
+
+        return $column;
+    }
+
+    /**
+     * Create a new unsigned medium integer (3-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignMediumId($column)
+    {
+        $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
+            'type' => 'mediumInteger',
+            'name' => $column,
+            'autoIncrement' => false,
+            'unsigned' => true,
+        ]);
+
+        return $column;
+    }
+
+    /**
+     * Create a new unsigned integer (4-byte) column on the table.
+     *
+     * @param  string  $column
+     * @return \Illuminate\Database\Schema\ForeignIdColumnDefinition
+     */
+    public function foreignIntegerId($column)
+    {
+        $this->columns[] = $column = new ForeignIdColumnDefinition($this, [
+            'type' => 'integer',
+            'name' => $column,
+            'autoIncrement' => false,
+            'unsigned' => true,
+        ]);
+
+        return $column;
+    }
+
+    /**
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
@@ -832,6 +904,7 @@ class Blueprint
 
         return $column;
     }
+
 
     /**
      * Create a new float column on the table.

--- a/tests/Database/DatabaseMySqlSchemaGrammarTest.php
+++ b/tests/Database/DatabaseMySqlSchemaGrammarTest.php
@@ -434,6 +434,90 @@ class DatabaseMySqlSchemaGrammarTest extends TestCase
         $this->assertSame('alter table `users` add `foo` bigint unsigned not null auto_increment primary key', $statements[0]);
     }
 
+    public function testAddingForeignTinyID()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignId = $blueprint->foreignTinyId('foo');
+        $blueprint->foreignTinyId('company_id')->constrained();
+        $blueprint->foreignTinyId('laravel_idea_id')->constrained();
+        $blueprint->foreignTinyId('team_id')->references('id')->on('teams');
+        $blueprint->foreignTinyId('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table `users` add `foo` tinyint unsigned not null, add `company_id` tinyint unsigned not null, add `laravel_idea_id` tinyint unsigned not null, add `team_id` tinyint unsigned not null, add `team_column_id` tinyint unsigned not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingForeignSmallID()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignId = $blueprint->foreignSmallId('foo');
+        $blueprint->foreignSmallId('company_id')->constrained();
+        $blueprint->foreignSmallId('laravel_idea_id')->constrained();
+        $blueprint->foreignSmallId('team_id')->references('id')->on('teams');
+        $blueprint->foreignSmallId('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table `users` add `foo` smallint unsigned not null, add `company_id` smallint unsigned not null, add `laravel_idea_id` smallint unsigned not null, add `team_id` smallint unsigned not null, add `team_column_id` smallint unsigned not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingForeignMediumID()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignId = $blueprint->foreignMediumId('foo');
+        $blueprint->foreignMediumId('company_id')->constrained();
+        $blueprint->foreignMediumId('laravel_idea_id')->constrained();
+        $blueprint->foreignMediumId('team_id')->references('id')->on('teams');
+        $blueprint->foreignMediumId('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table `users` add `foo` mediumint unsigned not null, add `company_id` mediumint unsigned not null, add `laravel_idea_id` mediumint unsigned not null, add `team_id` mediumint unsigned not null, add `team_column_id` mediumint unsigned not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
+    public function testAddingForeignIntegerID()
+    {
+        $blueprint = new Blueprint('users');
+        $foreignId = $blueprint->foreignIntegerId('foo');
+        $blueprint->foreignIntegerId('company_id')->constrained();
+        $blueprint->foreignIntegerId('laravel_idea_id')->constrained();
+        $blueprint->foreignIntegerId('team_id')->references('id')->on('teams');
+        $blueprint->foreignIntegerId('team_column_id')->constrained('teams');
+
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertInstanceOf(ForeignIdColumnDefinition::class, $foreignId);
+        $this->assertSame([
+            'alter table `users` add `foo` int unsigned not null, add `company_id` int unsigned not null, add `laravel_idea_id` int unsigned not null, add `team_id` int unsigned not null, add `team_column_id` int unsigned not null',
+            'alter table `users` add constraint `users_company_id_foreign` foreign key (`company_id`) references `companies` (`id`)',
+            'alter table `users` add constraint `users_laravel_idea_id_foreign` foreign key (`laravel_idea_id`) references `laravel_ideas` (`id`)',
+            'alter table `users` add constraint `users_team_id_foreign` foreign key (`team_id`) references `teams` (`id`)',
+            'alter table `users` add constraint `users_team_column_id_foreign` foreign key (`team_column_id`) references `teams` (`id`)',
+        ], $statements);
+    }
+
     public function testAddingForeignID()
     {
         $blueprint = new Blueprint('users');


### PR DESCRIPTION
Create foreign keys with different MySQL integer types:

```php
Schema::create('table', function (Blueprint $table) {
    $table->foreignId('id')->constrained('mytable'); // unsinged big integer (default)

    $table->foreignTinyId('id')->constrained('mytable'); // unsinged tinyint

    $table->foreignSmallId('id')->constrained('mytable'); // unsinged smallint

    $table->foreignMediumId('id')->constrained('mytable'); // unsinged mediumint

    $table->foreignIntegerId('id')->constrained('mytable'); // unsinged integer
});
```