### PR TITLE
[7.x] Extract parameter route binding into separate function

### DIFF
--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -20,35 +20,53 @@ class ImplicitRouteBinding
      */
     public static function resolveForRoute($container, $route)
     {
-        $parameters = $route->parameters();
-
         foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-            if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
+            if (! $parameterName = static::getParameterName($parameter->getName(), $route->parameters())) {
                 continue;
             }
 
-            $parameterValue = $parameters[$parameterName];
-
-            if ($parameterValue instanceof UrlRoutable) {
-                continue;
-            }
-
-            $instance = $container->make(Reflector::getParameterClassName($parameter));
-
-            $parent = $route->parentOfParameter($parameterName);
-
-            if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
-                if (! $model = $parent->resolveChildRouteBinding(
-                    $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
-                )) {
-                    throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
-                }
-            } elseif (! $model = $instance->resolveRouteBinding($parameterValue, $route->bindingFieldFor($parameterName))) {
-                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
-            }
-
+            $model = static::resolveForRouteParameter(
+                $container, $route, $parameterName, Reflector::getParameterClassName($parameter)
+            );
+            
             $route->setParameter($parameterName, $model);
         }
+    }
+
+    /**
+     * Resolve the implicit route bindings for the given route parameter and type.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  string  $parameterName
+     * @param  string  $parameterClass
+     * @return UrlRoutable
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public static function resolveForRouteParameter($container, $route, $parameterName, $parameterClass)
+    {
+        $parameterValue = $route->parameter($parameterName);
+
+        if ($parameterValue instanceof UrlRoutable) {
+            return $parameterValue;
+        }
+
+        $instance = $container->make($parameterClass);
+
+        $parent = $route->parentOfParameter($parameterName);
+
+        if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
+            if (! $model = $parent->resolveChildRouteBinding(
+                $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
+            )) {
+                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+            }
+        } elseif (! $model = $instance->resolveRouteBinding($parameterValue, $route->bindingFieldFor($parameterName))) {
+            throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+        }
+
+        return $model;
     }
 
     /**

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -10,6 +10,13 @@ use Illuminate\Support\Str;
 class ImplicitRouteBinding
 {
     /**
+     * The container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
      * Resolve the implicit route bindings for the given route.
      *
      * @param  \Illuminate\Container\Container  $container
@@ -20,53 +27,7 @@ class ImplicitRouteBinding
      */
     public static function resolveForRoute($container, $route)
     {
-        foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
-            if (! $parameterName = static::getParameterName($parameter->getName(), $route->parameters())) {
-                continue;
-            }
-
-            $model = static::resolveForRouteParameter(
-                $container, $route, $parameterName, Reflector::getParameterClassName($parameter)
-            );
-
-            $route->setParameter($parameterName, $model);
-        }
-    }
-
-    /**
-     * Resolve the implicit route bindings for the given route parameter and type.
-     *
-     * @param  \Illuminate\Container\Container  $container
-     * @param  \Illuminate\Routing\Route  $route
-     * @param  string  $parameterName
-     * @param  string  $parameterClass
-     * @return UrlRoutable
-     *
-     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
-     */
-    public static function resolveForRouteParameter($container, $route, $parameterName, $parameterClass)
-    {
-        $parameterValue = $route->parameter($parameterName);
-
-        if ($parameterValue instanceof UrlRoutable) {
-            return $parameterValue;
-        }
-
-        $instance = $container->make($parameterClass);
-
-        $parent = $route->parentOfParameter($parameterName);
-
-        if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
-            if (! $model = $parent->resolveChildRouteBinding(
-                $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
-            )) {
-                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
-            }
-        } elseif (! $model = $instance->resolveRouteBinding($parameterValue, $route->bindingFieldFor($parameterName))) {
-            throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
-        }
-
-        return $model;
+        (new static($container))->resolveSignatureParameters($route);
     }
 
     /**
@@ -85,5 +46,74 @@ class ImplicitRouteBinding
         if (array_key_exists($snakedName = Str::snake($name), $parameters)) {
             return $snakedName;
         }
+    }
+
+    /**
+     * Create an implicit route binding instance.
+     *
+     * @param  \Illuminate\Container\Container  $container
+     */
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Resolve the implicit route bindings for the given route.
+     *
+     * @param  \Illuminate\Routing\Route  $route
+     * @return void
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    public function resolveSignatureParameters($route)
+    {
+        foreach ($route->signatureParameters(UrlRoutable::class) as $parameter) {
+            if (! $parameterName = static::getParameterName($parameter->getName(), $route->parameters())) {
+                continue;
+            }
+
+            $model = $this->resolveParameter(
+                $route, $parameterName, Reflector::getParameterClassName($parameter)
+            );
+
+            $route->setParameter($parameterName, $model);
+        }
+    }
+
+    /**
+     * Resolve the implicit route bindings for the given route parameter and type.
+     *
+     * @param  \Illuminate\Routing\Route $route
+     * @param  string                    $parameterName
+     * @param  string                    $parameterClassName
+     *
+     * @return \Illuminate\Database\Eloquent\Model|\Illuminate\Contracts\Routing\UrlRoutable
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
+     */
+    protected function resolveParameter($route, $parameterName, $parameterClassName)
+    {
+        $parameterValue = $route->parameter($parameterName);
+
+        if ($parameterValue instanceof UrlRoutable) {
+            return $parameterValue;
+        }
+
+        $instance = $this->container->make($parameterClassName);
+
+        $parent = $route->parentOfParameter($parameterName);
+
+        if ($parent instanceof UrlRoutable && in_array($parameterName, array_keys($route->bindingFields()))) {
+            if (! $model = $parent->resolveChildRouteBinding(
+                $parameterName, $parameterValue, $route->bindingFieldFor($parameterName)
+            )) {
+                throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+            }
+        } elseif (! $model = $instance->resolveRouteBinding($parameterValue, $route->bindingFieldFor($parameterName))) {
+            throw (new ModelNotFoundException)->setModel(get_class($instance), [$parameterValue]);
+        }
+
+        return $model;
     }
 }

--- a/src/Illuminate/Routing/ImplicitRouteBinding.php
+++ b/src/Illuminate/Routing/ImplicitRouteBinding.php
@@ -28,7 +28,7 @@ class ImplicitRouteBinding
             $model = static::resolveForRouteParameter(
                 $container, $route, $parameterName, Reflector::getParameterClassName($parameter)
             );
-            
+
             $route->setParameter($parameterName, $model);
         }
     }

--- a/src/Illuminate/Support/Reflector.php
+++ b/src/Illuminate/Support/Reflector.php
@@ -10,7 +10,7 @@ class Reflector
     /**
      * Get the class name of the given parameter's type, if possible.
      *
-     * @param  \ReflectionParameter  $parameter
+     * @param  \ReflectionParameter|\ReflectionProperty  $parameter
      * @return string|null
      */
     public static function getParameterClassName($parameter)


### PR DESCRIPTION
We're currently working on [bringing implicit route-model binding to Livewire's component properties](https://github.com/livewire/livewire/issues/1429) and we're trying to keep the implementation as close to Laravel's as possible. Right now, `ImplicitRouteBinding` is called statically and very coupled to Laravel controllers. This PR breaks up the logic in a way that allows for re-use.

This is admittedly a very specific use-case, but I thought I'd risk opening a PR because the alternative options are much worse!