### PR TITLE
[7.x] SqlServer: compileColumnListing for tables with schema

### DIFF
--- a/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
+++ b/src/Illuminate/Database/Schema/Grammars/SqlServerGrammar.php
@@ -48,7 +48,7 @@ class SqlServerGrammar extends Grammar
     {
         return "select col.name from sys.columns as col
                 join sys.objects as obj on col.object_id = obj.object_id
-                where obj.type = 'U' and obj.name = '$table'";
+                where obj.type = 'U' and obj.object_id = object_id('$table')";
     }
 
     /**


### PR DESCRIPTION
The compileColumnListing method for SqlServer's schema grammar did not work for tables in a non-default database schema. It also listed too many columns for tables that appear in more than one schema.

Using SQL Server's object_id-function, in stead of obj.name, fixes these issues.