### PR TITLE
[8.x] Bind state to current factory instance

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -325,7 +325,7 @@ abstract class Factory
                 return $this->parentResolvers();
             }], $states->all()));
         })->reduce(function ($carry, $state) use ($parent) {
-            if (is_callable($state)) {
+            if ($state instanceof Closure) {
                 $state = $state->bindTo($this);
             }
 

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -325,7 +325,7 @@ abstract class Factory
                 return $this->parentResolvers();
             }], $states->all()));
         })->reduce(function ($carry, $state) use ($parent) {
-            if (is_callable($parent)) {
+            if (is_callable($state)) {
                 $state = $state->bindTo($this);
             }
 


### PR DESCRIPTION
This fixes #34069 and corrects #34074 which contains a typo.

Edit: I also changed the `is_callable` check to` instanceof Closure`, because `Sequence` is callable and will otherwise break