### PR TITLE
[7.x] Added expectsTable console test assertion

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithConsole.php
@@ -23,6 +23,13 @@ trait InteractsWithConsole
     public $expectedOutput = [];
 
     /**
+     * All of the expected ouput tables.
+     *
+     * @var array
+     */
+    public $expectedTables = [];
+
+    /**
      * All of the expected questions.
      *
      * @var array

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -10,9 +10,9 @@ use Illuminate\Support\Arr;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Helper\Table;
 
 class PendingCommand
 {

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -284,8 +284,8 @@ class PendingCommand
     private function createABufferedOutputMock()
     {
         $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
-            ->shouldAllowMockingProtectedMethods()
-            ->shouldIgnoreMissing();
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldIgnoreMissing();
 
         $this->applyOutputTableExpectations($mock);
 

--- a/src/Illuminate/Testing/PendingCommand.php
+++ b/src/Illuminate/Testing/PendingCommand.php
@@ -5,12 +5,14 @@ namespace Illuminate\Testing;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 use Mockery;
 use Mockery\Exception\NoMatchingExpectationException;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Helper\Table;
 
 class PendingCommand
 {
@@ -127,6 +129,27 @@ class PendingCommand
     public function expectsOutput($output)
     {
         $this->test->expectedOutput[] = $output;
+
+        return $this;
+    }
+
+    /**
+     * Specify a table that should be printed when the command runs.
+     *
+     * @param  array  $headers
+     * @param  \Illuminate\Contracts\Support\Arrayable|array  $rows
+     * @param  string  $tableStyle
+     * @param  array  $columnStyles
+     * @return $this
+     */
+    public function expectsTable($headers, $rows, $tableStyle = 'default', array $columnStyles = [])
+    {
+        $this->test->expectedTables[] = [
+            'headers' => (array) $headers,
+            'rows' => $rows instanceof Arrayable ? $rows->toArray() : $rows,
+            'tableStyle' => $tableStyle,
+            'columnStyles' => $columnStyles,
+        ];
 
         return $this;
     }
@@ -261,8 +284,10 @@ class PendingCommand
     private function createABufferedOutputMock()
     {
         $mock = Mockery::mock(BufferedOutput::class.'[doWrite]')
-                ->shouldAllowMockingProtectedMethods()
-                ->shouldIgnoreMissing();
+            ->shouldAllowMockingProtectedMethods()
+            ->shouldIgnoreMissing();
+
+        $this->applyOutputTableExpectations($mock);
 
         foreach ($this->test->expectedOutput as $i => $output) {
             $mock->shouldReceive('doWrite')
@@ -275,6 +300,36 @@ class PendingCommand
         }
 
         return $mock;
+    }
+
+    /**
+     * Apply the output table expectations to the mock.
+     *
+     * @param  \Mockery\MockInterface  $mock
+     * @return void
+     */
+    private function applyOutputTableExpectations($mock)
+    {
+        foreach ($this->test->expectedTables as $consoleTable) {
+            $table = (new Table($output = new BufferedOutput))
+                ->setHeaders($consoleTable['headers'])
+                ->setRows($consoleTable['rows'])
+                ->setStyle($consoleTable['tableStyle']);
+
+            foreach ($consoleTable['columnStyles'] as $columnIndex => $columnStyle) {
+                $table->setColumnStyle($columnIndex, $columnStyle);
+            }
+
+            $table->render();
+
+            $lines = array_filter(
+                preg_split("/\n/", $output->fetch())
+            );
+
+            foreach ($lines as $line) {
+                $this->expectsOutput($line);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
**Purpose:**

The addition of the `expectstTable()` method will allow you to easily assert the expectation of generated console table(s). 

Without this, you must determine the exact size of the table's output and assert the table structure line by line. This is really cumbersome, and this PR resolves this.

This PR also supports multiple console table expectations, so you're able assert as many tables as required.

I would define tests, but I wasn't able to locate any currently for the test artisan command assertions. Please let me know if this is necessary and I will resubmit.

**Example command:**

```php
use Illuminate\Console\Command;

class ListCommand extends Command
{
    protected $signature = 'command:list';

    public function handle()
    {
        $this->table(['ID', 'Name', 'Params'], [
            [1, 'Test', '{"foo":"bar"}'],
        ]);
    }
}
```

**Before this change:**

```php
public function testCommandList()
{
    $this->artisan('command:list')
        ->expectsOutput('+----+------+---------------+')
        ->expectsOutput('| ID | Name | Params        |')
        ->expectsOutput('+----+------+---------------+')
        ->expectsOutput('| 1  | Test | {"foo":"bar"} |')
        ->expectsOutput('+----+------+---------------+')
        ->assertExitCode(0);
}
```

**After this change:**

```php
public function testCommandList()
{
    $this->artisan('command:list')
        ->expectsTable(['ID', 'Name', 'Params'], [[1, 'Test', '{"foo":"bar"}']])
        ->assertExitCode(0);
}
```


**Related:** #29521

I aligned the arguments with their types in the `expectsTable()` method with the `table()` method in the `InteractsWithIO` trait:

https://github.com/laravel/framework/blob/17777a92da9b3cf0026f26462d289d596420e6d0/src/Illuminate/Console/Concerns/InteractsWithIO.php#L223

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
