### PR TITLE
[7.x] use getTouchedRelations when touching owners

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -682,7 +682,7 @@ trait HasRelationships
      */
     public function touches($relation)
     {
-        return in_array($relation, $this->touches);
+        return in_array($relation, $this->getTouchedRelations());
     }
 
     /**
@@ -692,7 +692,7 @@ trait HasRelationships
      */
     public function touchOwners()
     {
-        foreach ($this->touches as $relation) {
+        foreach ($this->getTouchedRelations() as $relation) {
             $this->$relation()->touch();
 
             if ($this->$relation instanceof self) {


### PR DESCRIPTION
This allows overriding `getTouchedRelations()`

I want to update certain polymorphic parents. 

Using the example from the [documentation](https://laravel.com/docs/7.x/eloquent-relationships#one-to-many-polymorphic-relations): if a `comment` is updated it should update `post`, but never `video`

```php
class Comment extends Model
{
    protected $touches = ['commentable'];
    /**
     * Get the owning commentable model.
     */
    public function commentable()
    {
        return $this->morphTo();
    }

    public function getTouchedRelations()
    {
        return $this->commentable_type === 'video' ? [] : $this->touches;
    }
}
```

`getTouchedRelations()` isn't currently used in the framework anywhere, overriding it has no affect, it's simply a getter.

The alternative solution to my problem is to use `setTouchedRelations()` when the model is booted. However, overriding most `get*()` methods in the framework actually have an affect, whereas this one doesn't.

This is backwards compatible as the base `getTouchedRelations()` on `HasRelationships` simply returns `$this->touches`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
