### PR TITLE
[8.x] Make more Builder/Grammar methods public

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -16,7 +16,7 @@ trait GuardsAttributes
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var array|bool
      */
     protected $guarded = ['*'];
 

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -3097,7 +3097,7 @@ class Builder
      * @param  array  $bindings
      * @return array
      */
-    protected function cleanBindings(array $bindings)
+    public function cleanBindings(array $bindings)
     {
         return array_values(array_filter($bindings, function ($binding) {
             return ! $binding instanceof Expression;

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -181,7 +181,7 @@ class Grammar extends BaseGrammar
      * @param  \Illuminate\Database\Query\Builder  $query
      * @return string
      */
-    protected function compileWheres(Builder $query)
+    public function compileWheres(Builder $query)
     {
         // Each type of where clauses has its own compiler function which is responsible
         // for actually creating the where clauses SQL. This helps keep the code nice


### PR DESCRIPTION
- Make Builder::cleanBindings public
- Make Grammar::compileWheres public

This is similar in spirit to https://github.com/laravel/framework/pull/33953 (which ultimately was only applied to 8.x via https://github.com/laravel/framework/pull/33984 )

I've use cases where I want to be able to re-use Builder/Grammar without having to extend them, as they might already be extended from other packages and thus makes compositing via replacing very hard.

By having those method public, they can be easier re-used from the outside. Some rational of this is explained in an issue over at https://github.com/staudenmeir/laravel-upsert/issues/21#issuecomment-686289383 about issues I faced using a package providing upsert, and using a different approach to implement this.

Thanks!