### PR TITLE
[8.x] Remove app assignment

### DIFF
--- a/src/Illuminate/Support/Manager.php
+++ b/src/Illuminate/Support/Manager.php
@@ -44,7 +44,6 @@ abstract class Manager
      */
     public function __construct(Container $container)
     {
-        $this->app = $container;
         $this->container = $container;
         $this->config = $container->make('config');
     }


### PR DESCRIPTION
This was forgotten in https://github.com/laravel/framework/pull/32092 but has an impact on things like Socialite that'll need patching (still possible).