### PR TITLE
[8.x] Introduce MissingAppKeyException for missing APP_KEY

### DIFF
--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -77,7 +77,7 @@ class EncryptionServiceProvider extends ServiceProvider
     {
         return tap($config['key'], function ($key) {
             if (empty($key)) {
-                throw new MissingKeyException();
+                throw new MissingAppKeyException();
             }
         });
     }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -77,7 +77,7 @@ class EncryptionServiceProvider extends ServiceProvider
     {
         return tap($config['key'], function ($key) {
             if (empty($key)) {
-                throw new MissingAppKeyException();
+                throw new MissingAppKeyException;
             }
         });
     }

--- a/src/Illuminate/Encryption/EncryptionServiceProvider.php
+++ b/src/Illuminate/Encryption/EncryptionServiceProvider.php
@@ -77,9 +77,7 @@ class EncryptionServiceProvider extends ServiceProvider
     {
         return tap($config['key'], function ($key) {
             if (empty($key)) {
-                throw new RuntimeException(
-                    'No application encryption key has been specified.'
-                );
+                throw new MissingKeyException();
             }
         });
     }

--- a/src/Illuminate/Encryption/MissingAppKeyException.php
+++ b/src/Illuminate/Encryption/MissingAppKeyException.php
@@ -2,7 +2,9 @@
 
 namespace Illuminate\Encryption;
 
-class MissingAppKeyException extends \RuntimeException
+use RuntimeException;
+
+class MissingAppKeyException extends RuntimeException
 {
     public function __construct($message = 'No application encryption key has been specified.')
     {

--- a/src/Illuminate/Encryption/MissingAppKeyException.php
+++ b/src/Illuminate/Encryption/MissingAppKeyException.php
@@ -2,7 +2,7 @@
 
 namespace Illuminate\Encryption;
 
-class MissingKeyException extends \RuntimeException
+class MissingAppKeyException extends \RuntimeException
 {
     public function __construct($message = 'No application encryption key has been specified.')
     {

--- a/src/Illuminate/Encryption/MissingAppKeyException.php
+++ b/src/Illuminate/Encryption/MissingAppKeyException.php
@@ -6,6 +6,11 @@ use RuntimeException;
 
 class MissingAppKeyException extends RuntimeException
 {
+    /**
+     * Create a new exception instance.
+     *
+     * @return void
+     */
     public function __construct($message = 'No application encryption key has been specified.')
     {
         parent::__construct($message);

--- a/src/Illuminate/Encryption/MissingKeyException.php
+++ b/src/Illuminate/Encryption/MissingKeyException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Encryption;
+
+class MissingKeyException extends \RuntimeException
+{
+    public function __construct($message = 'No application encryption key has been specified.')
+    {
+        parent::__construct($message);
+    }
+}


### PR DESCRIPTION
This PR introduces a new MissingAppKeyException.
It offers an easy way to catch this specific error.

I am building an application with an interactive installer and this should be the trigger for the setup.