### PR TITLE
[8.x] Don't guard models by default

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -16,7 +16,7 @@ trait GuardsAttributes
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var array|bool
      */
     protected $guarded = ['*'];
 

--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -18,7 +18,7 @@ trait GuardsAttributes
      *
      * @var array|bool
      */
-    protected $guarded = ['*'];
+    protected $guarded = false;
 
     /**
      * Indicates if all mass assignment is enabled.


### PR DESCRIPTION
If you have `$user->update(request()->all())` in one of your controllers, a user can make himself an admin by sending `is_admin = true` in the request. For that reason, Laravel had all model attributes guarded by default and you need to tell Laravel which attributes are fillable.

```php
protected $fillable = ['name', 'email'];
```

Now if the user sends `is_admin = true`, a MassAssignmentException will be thrown and the model will not get updated.

---

In a different controller, an admin is allowed to make other users admins so we will need to allow `is_admin = true`. To get around the mass assignment protection we'll have to do something like:

```php
$user->forceFill(
    request()->all()
)->save();
```

But here, a user can send `id = 1000` in the request and change the user ID in the database. Obviously this shouldn't be allowed.

To prevent this, we need to change our code to this:

```php
if(request('is_admin')){
    $user->is_admin = request('is_admin');
}

if(request('name')){
    $user->name = request('name');
}

if(request('email')){
    $user->email = request('email');
}

$user->save();
```

---

Since we explicitly have to set each and every attribute anyway to safely update the model attributes depending on the business logic, mass assignment protection on the model level is not really useful.

This PR makes models mass assignable by default. The recommended way to update a model from a request is by filling each attribute explicitly or by passing only the validated attributes:

```php
$user->update(
    $request->validate([
        'name' => 'string',
        'email' => 'email',
        'is_admin' => 'bool'
    ])
);
```