### PR TITLE
[8.x] Make method has public access

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -577,7 +577,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  array  $extra
      * @return int
      */
-    protected function increment($column, $amount = 1, array $extra = [])
+    public function increment($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'increment');
     }
@@ -590,7 +590,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  array  $extra
      * @return int
      */
-    protected function decrement($column, $amount = 1, array $extra = [])
+    public function decrement($column, $amount = 1, array $extra = [])
     {
         return $this->incrementOrDecrement($column, $amount, $extra, 'decrement');
     }
@@ -1717,10 +1717,6 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function __call($method, $parameters)
     {
-        if (in_array($method, ['increment', 'decrement'])) {
-            return $this->$method(...$parameters);
-        }
-
         if ($resolver = (static::$relationResolvers[get_class($this)][$method] ?? null)) {
             return $resolver($this);
         }

--- a/tests/Integration/Database/EloquentUpdateTest.php
+++ b/tests/Integration/Database/EloquentUpdateTest.php
@@ -127,7 +127,7 @@ class EloquentUpdateTest extends TestCase
             'counter' => 0,
         ])->delete();
 
-        TestUpdateModel3::increment('counter');
+        TestUpdateModel3::first()->increment('counter');
 
         $models = TestUpdateModel3::withoutGlobalScopes()->get();
         $this->assertEquals(1, $models[0]->counter);


### PR DESCRIPTION

<!-- DO NOT THROW THIS AWAY -->
<!-- Fill out the FULL versions with patch versions -->

- Laravel Version: 7.x
- PHP Version: 7.4
- Database Driver & Version: mysql8.0

### Description:

Hello , I have the following question.


```php
            $course = Course::query()->first();
            $course->increment('total_star_score', $star);
```

the phpStorm tip `Member has protected access, but class has magic method __call`.

I don't understand why this method needs protected.

![image](https://user-images.githubusercontent.com/9365514/92104929-a6001000-ee14-11ea-81c6-87d32365fffa.png)

### Steps To Reproduce:


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
