### PR TITLE
Refactor ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -95,7 +95,7 @@ class ComponentAttributeBag extends Collection implements Arrayable, Htmlable, I
      * @param  mixed  $attributes
      * @return static
      */
-    public function setAttributes(array $attributes = [])
+    public function setAttributes($attributes = [])
     {
         return new static($attributes);
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -129,7 +129,7 @@ class ComponentAttributeBag extends Collection implements Arrayable, Htmlable, I
     public function __toString()
     {
         return trim($this->filter(function ($value) {
-            return !($value === false || is_null($value));
+            return ! ($value === false || is_null($value));
         })->map(function ($value, $key) {
             return $key.'="'.str_replace('"', '\\"', trim($value === true ? $key : $value)).'"';
         })->join(' '));

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -2,109 +2,15 @@
 
 namespace Illuminate\View;
 
-use ArrayAccess;
-use ArrayIterator;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
 
-class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
+class ComponentAttributeBag extends Collection implements Arrayable, Htmlable, IteratorAggregate
 {
-    use Macroable;
-
-    /**
-     * The raw array of attributes.
-     *
-     * @var array
-     */
-    protected $attributes = [];
-
-    /**
-     * Create a new component attribute bag instance.
-     *
-     * @param  array  $attributes
-     * @return void
-     */
-    public function __construct(array $attributes = [])
-    {
-        $this->attributes = $attributes;
-    }
-
-    /**
-     * Get the first attribute's value.
-     *
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public function first($default = null)
-    {
-        return $this->getIterator()->current() ?? value($default);
-    }
-
-    /**
-     * Get a given attribute from the attribute array.
-     *
-     * @param  string  $key
-     * @param  mixed  $default
-     * @return mixed
-     */
-    public function get($key, $default = null)
-    {
-        return $this->attributes[$key] ?? value($default);
-    }
-
-    /**
-     * Only include the given attribute from the attribute array.
-     *
-     * @param  mixed|array  $keys
-     * @return static
-     */
-    public function only($keys)
-    {
-        if (is_null($keys)) {
-            $values = $this->attributes;
-        } else {
-            $keys = Arr::wrap($keys);
-
-            $values = Arr::only($this->attributes, $keys);
-        }
-
-        return new static($values);
-    }
-
-    /**
-     * Exclude the given attribute from the attribute array.
-     *
-     * @param  mixed|array  $keys
-     * @return static
-     */
-    public function except($keys)
-    {
-        if (is_null($keys)) {
-            $values = $this->attributes;
-        } else {
-            $keys = Arr::wrap($keys);
-
-            $values = Arr::except($this->attributes, $keys);
-        }
-
-        return new static($values);
-    }
-
-    /**
-     * Filter the attributes, returning a bag of attributes that pass the filter.
-     *
-     * @param  callable  $callback
-     * @return static
-     */
-    public function filter($callback)
-    {
-        return new static(collect($this->attributes)->filter($callback)->all());
-    }
-
     /**
      * Return a bag of attributes that have keys starting with the given value / pattern.
      *
@@ -165,45 +71,33 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Merge additional attributes / values into the attribute bag.
      *
-     * @param  array  $attributeDefaults
+     * @param  mixed  $attributeDefaults
      * @return static
      */
-    public function merge(array $attributeDefaults = [])
+    public function merge($attributeDefaults)
     {
-        $attributes = [];
+        $attributeDefaults = Collection::make($attributeDefaults)->map(function ($value) {
+            return is_null($value) || is_bool($value) ? $value : e($value);
+        });
 
-        $attributeDefaults = array_map(function ($value) {
-            if (is_null($value) || is_bool($value)) {
-                return $value;
-            }
+        $attributes = $this->map(function ($value, $key) use ($attributeDefaults) {
+            return $key === 'class'
+                ? implode(' ', array_unique(array_filter([$attributeDefaults->get($key, ''), $value])))
+                : $value;
+        });
 
-            return e($value);
-        }, $attributeDefaults);
-
-        foreach ($this->attributes as $key => $value) {
-            if ($key !== 'class') {
-                $attributes[$key] = $value;
-
-                continue;
-            }
-
-            $attributes[$key] = implode(' ', array_unique(
-                array_filter([$attributeDefaults[$key] ?? '', $value])
-            ));
-        }
-
-        return new static(array_merge($attributeDefaults, $attributes));
+        return new static($attributeDefaults->merge($attributes));
     }
 
     /**
      * Set the underlying attributes.
      *
-     * @param  array  $attributes
-     * @return void
+     * @param  mixed  $attributes
+     * @return static
      */
-    public function setAttributes(array $attributes)
+    public function setAttributes(array $attributes = [])
     {
-        $this->attributes = $attributes;
+        return new static($attributes);
     }
 
     /**
@@ -219,67 +113,12 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Merge additional attributes / values into the attribute bag.
      *
-     * @param  array  $attributeDefaults
+     * @param  mixed  $attributeDefaults
      * @return \Illuminate\Support\HtmlString
      */
-    public function __invoke(array $attributeDefaults = [])
+    public function __invoke($attributeDefaults = [])
     {
         return new HtmlString((string) $this->merge($attributeDefaults));
-    }
-
-    /**
-     * Determine if the given offset exists.
-     *
-     * @param  string  $offset
-     * @return bool
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->attributes[$offset]);
-    }
-
-    /**
-     * Get the value at the given offset.
-     *
-     * @param  string  $offset
-     * @return mixed
-     */
-    public function offsetGet($offset)
-    {
-        return $this->get($offset);
-    }
-
-    /**
-     * Set the value at a given offset.
-     *
-     * @param  string  $offset
-     * @param  mixed  $value
-     * @return void
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->attributes[$offset] = $value;
-    }
-
-    /**
-     * Remove the value at the given offset.
-     *
-     * @param  string  $offset
-     * @return void
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->attributes[$offset]);
-    }
-
-    /**
-     * Get an iterator for the items.
-     *
-     * @return \ArrayIterator
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->attributes);
     }
 
     /**
@@ -289,20 +128,10 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function __toString()
     {
-        $string = '';
-
-        foreach ($this->attributes as $key => $value) {
-            if ($value === false || is_null($value)) {
-                continue;
-            }
-
-            if ($value === true) {
-                $value = $key;
-            }
-
-            $string .= ' '.$key.'="'.str_replace('"', '\\"', trim($value)).'"';
-        }
-
-        return trim($string);
+        return trim($this->filter(function ($value) {
+            return !($value === false || is_null($value));
+        })->map(function ($value, $key) {
+            return $key.'="'.str_replace('"', '\\"', trim($value === true ? $key : $value)).'"';
+        })->join(' '));
     }
 }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -41,7 +41,6 @@ class ViewComponentAttributeBagTest extends TestCase
         ]);
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
-        $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag->merge());
 
         $bag = (new ComponentAttributeBag)
             ->merge([


### PR DESCRIPTION
When using [components](https://laravel.com/docs/7.x/blade#components), I realized that we can only merge attributes with the array
```php
<div {{$attributes->merge(['class' => 'alert alert-'.$type])}}>
```
we cannot pass a collection
```php
<div {{$attributes->merge(collection(['class' => 'alert alert-'.$type]))}}>
```
This PR is a refactoring of `ComponentAttributeBag`