### PR TITLE
[9.x] Adding --column-statistics-off for php artisan schema:dump

### DIFF
--- a/src/Illuminate/Database/Console/DumpCommand.php
+++ b/src/Illuminate/Database/Console/DumpCommand.php
@@ -19,7 +19,8 @@ class DumpCommand extends Command
     protected $signature = 'schema:dump
                 {--database= : The database connection to use}
                 {--path= : The path where the schema dump file should be stored}
-                {--prune : Delete all existing migration files}';
+                {--prune : Delete all existing migration files}
+                {--column-statistics-off : use column-statics off in case of mysqldump 8 against mysqld 5.7}';
 
     /**
      * The console command description.
@@ -35,9 +36,12 @@ class DumpCommand extends Command
      */
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher)
     {
-        $this->schemaState(
+        $schemaState = $this->schemaState(
             $connection = $connections->connection($database = $this->input->getOption('database'))
-        )->dump($path = $this->path($connection));
+        );
+        $schemaState->columnStatisticsOff = $this->option('column-statistics-off');
+
+        $schemaState->dump($path = $this->path($connection));
 
         $dispatcher->dispatch(new SchemaDumped($connection, $path));
 

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -4,7 +4,6 @@ namespace Illuminate\Database\Schema;
 
 class MySqlSchemaState extends SchemaState
 {
-
     public $columnStatisticsOff = false;
 
     /**

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -4,6 +4,9 @@ namespace Illuminate\Database\Schema;
 
 class MySqlSchemaState extends SchemaState
 {
+
+    public $columnStatisticsOff = false;
+
     /**
      * Dump the database's schema into a file.
      *
@@ -78,8 +81,9 @@ class MySqlSchemaState extends SchemaState
     protected function baseDumpCommand()
     {
         $gtidPurged = $this->connection->isMaria() ? '' : '--set-gtid-purged=OFF';
+        $columnStatisticsOption = ($this->columnStatisticsOff) ? ' --column-statistics=0' : '';
 
-        return 'mysqldump '.$gtidPurged.' --column-statistics=0 --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD $LARAVEL_LOAD_DATABASE';
+        return 'mysqldump '.$gtidPurged.$columnStatisticsOption.' --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host=$LARAVEL_LOAD_HOST --port=$LARAVEL_LOAD_PORT --user=$LARAVEL_LOAD_USER --password=$LARAVEL_LOAD_PASSWORD $LARAVEL_LOAD_DATABASE';
     }
 
     /**


### PR DESCRIPTION
In some specific case like mysqdump 8 and mysqlserver version 5.7 the command failed. It is  added  --column-statistics-off option to mitigate this issue. The issue is : #34078

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
