### PR TITLE
[9.x] Fix scoped implicit route binding query

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlRoutable.php
+++ b/src/Illuminate/Contracts/Routing/UrlRoutable.php
@@ -23,9 +23,10 @@ interface UrlRoutable
      *
      * @param  mixed  $value
      * @param  string|null  $field
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveRouteBinding($value, $field = null);
+    public function resolveRouteBinding($value, $field = null, $query = null);
 
     /**
      * Retrieve the child model for a bound value.
@@ -35,5 +36,5 @@ interface UrlRoutable
      * @param  string|null  $field
      * @return \Illuminate\Database\Eloquent\Model|null
      */
-    public function resolveChildRouteBinding($childType, $value, $field);
+    public function resolveChildRouteBinding($childType, $value, $field = null);
 }

--- a/src/Illuminate/Http/Resources/DelegatesToResource.php
+++ b/src/Illuminate/Http/Resources/DelegatesToResource.php
@@ -34,11 +34,12 @@ trait DelegatesToResource
      *
      * @param  mixed  $value
      * @param  string|null  $field
+     * @param  \Illuminate\Database\Eloquent\Builder|null  $query
      * @return void
      *
      * @throws \Exception
      */
-    public function resolveRouteBinding($value, $field = null)
+    public function resolveRouteBinding($value, $field = null, $query = null)
     {
         throw new Exception('Resources may not be implicitly resolved from route bindings.');
     }

--- a/tests/Integration/Routing/UrlSigningTest.php
+++ b/tests/Integration/Routing/UrlSigningTest.php
@@ -126,7 +126,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'routable';
     }
 
-    public function resolveRouteBinding($routeKey, $field = null)
+    public function resolveRouteBinding($routeKey, $field = null, $query = null)
     {
         //
     }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -698,7 +698,7 @@ class RoutableInterfaceStub implements UrlRoutable
         return 'key';
     }
 
-    public function resolveRouteBinding($routeKey, $field = null)
+    public function resolveRouteBinding($routeKey, $field = null, $query = null)
     {
         //
     }


### PR DESCRIPTION
This PR provides a fix for scoped implicit route bindings.

------

Let's say we have **scoped** route binding definition like the following:

```php
Route::get('api/users/{user}/posts/{post:slug}', function (User $user, Post $post) {
    return $post;
});
```

The `resolveChildRouteBinding` method never calls the `resolveRouteBinding`  method on the child model, while it should (in my opinion). This means we can't customize the binding logic for the child model using the `resolveRouteBinding` method.

I was trying different solutions, but for now, it looks the only way is passing the relationship query when resolving the model, and use that as the base query.

------

This is definitely a BC, and probably too late for Laravel 8.x, so I targeted 9.x

~~I did not find any tests for the route-binding, so I did not write any for now. If this gets merged, I'm thinking about writing some.~~
