### PR TITLE
[7.x] Adjust CastsAttributes::set's expected return type

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -22,7 +22,7 @@ interface CastsAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @return array|string
+     * @return array|string|null
      */
     public function set($model, string $key, $value, array $attributes);
 }


### PR DESCRIPTION
`NULL` is an expected underlying model values, but it's not specified in the PHPDoc of method `CastsAttributes::set`. Thus, errors will be reported by static analyzers tool if we return `NULL` when creating a custom cast like this:

```
    public function set($model, string $key, $value, array $attributes)
    {
        if (! $value) {
            return null;
        }

        return new ValueCasted($value);
    }
```

This PR add `NULL` to the expected values of the method `CastsAttributes::set`