### PR TITLE
[8.x] Autoload class components

### DIFF
--- a/src/Illuminate/Support/Facades/Blade.php
+++ b/src/Illuminate/Support/Facades/Blade.php
@@ -15,6 +15,7 @@ namespace Illuminate\Support\Facades;
  * @method static void compile(string|null $path = null)
  * @method static void component(string $class, string|null $alias = null, string $prefix = '')
  * @method static void components(array $components, string $prefix = '')
+ * @method static void componentNamespace(string $namespace)
  * @method static void directive(string $name, callable $handler)
  * @method static void extend(callable $compiler)
  * @method static void if(string $name, callable $callback)

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -616,7 +616,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
      */
     public function include($path, $alias = null)
     {
-        return $this->aliasInclude($path, $alias);
+        $this->aliasInclude($path, $alias);
     }
 
     /**

--- a/src/Illuminate/View/Compilers/BladeCompiler.php
+++ b/src/Illuminate/View/Compilers/BladeCompiler.php
@@ -121,6 +121,13 @@ class BladeCompiler extends Compiler implements CompilerInterface
     protected $classComponentAliases = [];
 
     /**
+     * The array of class component namespaces to autoload from.
+     *
+     * @var array
+     */
+    protected $classComponentNamespaces = [];
+
+    /**
      * Indicates if component tags should be compiled.
      *
      * @var bool
@@ -318,7 +325,7 @@ class BladeCompiler extends Compiler implements CompilerInterface
         }
 
         return (new ComponentTagCompiler(
-            $this->classComponentAliases, $this
+            $this->classComponentAliases, $this->classComponentNamespaces, $this
         ))->compile($value);
     }
 
@@ -583,6 +590,28 @@ class BladeCompiler extends Compiler implements CompilerInterface
     public function getClassComponentAliases()
     {
         return $this->classComponentAliases;
+    }
+
+    /**
+     * Register a class-based component namespace.
+     *
+     * @param  string  $namespace
+     * @param  string  $prefix
+     * @return void
+     */
+    public function componentNamespace($namespace, $prefix)
+    {
+        $this->classComponentNamespaces[$prefix] = $namespace;
+    }
+
+    /**
+     * Get the registered class component namespaces.
+     *
+     * @return array
+     */
+    public function getClassComponentNamespaces()
+    {
+        return $this->classComponentNamespaces;
     }
 
     /**

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -172,6 +172,7 @@ EOF;
         if (! static::$compiler) {
             static::$compiler = new ComponentTagCompiler(
                 Container::getInstance()->make('blade.compiler')->getClassComponentAliases(),
+                Container::getInstance()->make('blade.compiler')->getClassComponentNamespaces(),
                 Container::getInstance()->make('blade.compiler')
             );
         }


### PR DESCRIPTION
Use `Blade::componentNamespace` to register a package namespace with class based components to autoload them. This allows package maintainers to not manually register every component anymore.

For example, a package with a namespace of `Package\Components` has a class based component at `src/Components/FooBar/Baz.php`.

Register the component's namespace together with the package name:

```php
Blade::componentNamespace('Package\\Components', 'package');
```

Usage:

```html
<x-package::foo-bar.baz />
```

This takes precedence over loading anonymous components: https://github.com/laravel/framework/pull/33954