### PR TITLE
[8.x] Build migration schema based on using incremental key or uuid

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -5,11 +5,13 @@ namespace Illuminate\Database\Schema;
 use BadMethodCallException;
 use Closure;
 use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Schema\Grammars\Grammar;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
 
 class Blueprint
 {
@@ -816,6 +818,32 @@ class Blueprint
     }
 
     /**
+     * Create a foreign key column on the table from a model.
+     *
+     * @param  string  $model
+     * @param  string|null  $column
+     * @return \Illuminate\Database\Schema\ColumnDefinition
+     */
+    public function entangle($model, $column = null)
+    {
+        if (\is_string($model)) {
+            $model = new $model();
+        }
+
+        if (! $model instanceof Model) {
+            throw new InvalidArgumentException(sprintf('Given $model is not an instance of [%s].', Model::class));
+        }
+
+        $column = $column ?? $model->getForeignKey();
+
+        if ($model->getKeyType() === 'int' && $model->incrementing === true) {
+            return $this->unsignedBigInteger($column);
+        } else {
+            return $this->uuid($column);
+        }
+    }
+
+    /**
      * Create a new unsigned big integer (8-byte) column on the table.
      *
      * @param  string  $column
@@ -1307,11 +1335,11 @@ class Blueprint
      */
     public function morphs($name, $indexName = null)
     {
-        $this->string("{$name}_type");
-
-        $this->unsignedBigInteger("{$name}_id");
-
-        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        if (Builder::$defaultMorphKeyType === 'uuid') {
+            $this->uuidMorphs($name, $indexName);
+        } else {
+            $this->idMorphs($name, $indexName);
+        }
     }
 
     /**
@@ -1322,6 +1350,38 @@ class Blueprint
      * @return void
      */
     public function nullableMorphs($name, $indexName = null)
+    {
+        if (Builder::$defaultMorphKeyType === 'uuid') {
+            $this->nullableUuidMorphs($name, $indexName);
+        } else {
+            $this->nullableIdMorphs($name, $indexName);
+        }
+    }
+
+    /**
+     * Add the proper columns for a polymorphic table using ID (incremental).
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function idMorphs($name, $indexName = null)
+    {
+        $this->string("{$name}_type");
+
+        $this->unsignedBigInteger("{$name}_id");
+
+        $this->index(["{$name}_type", "{$name}_id"], $indexName);
+    }
+
+    /**
+     * Add nullable columns for a polymorphic table using ID (incremental).
+     *
+     * @param  string  $name
+     * @param  string|null  $indexName
+     * @return void
+     */
+    public function nullableIdMorphs($name, $indexName = null)
     {
         $this->string("{$name}_type")->nullable();
 

--- a/src/Illuminate/Database/Schema/Builder.php
+++ b/src/Illuminate/Database/Schema/Builder.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Schema;
 use Closure;
 use Doctrine\DBAL\Types\Type;
 use Illuminate\Database\Connection;
+use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 
@@ -32,6 +33,13 @@ class Builder
     protected $resolver;
 
     /**
+     * The default relationship morph key type.
+     *
+     * @var string
+     */
+    public static $defaultMorphKeyType = 'int';
+
+    /**
      * The default string length for migrations.
      *
      * @var int
@@ -48,6 +56,21 @@ class Builder
     {
         $this->connection = $connection;
         $this->grammar = $connection->getSchemaGrammar();
+    }
+
+    /**
+     * Set the default string length for migrations.
+     *
+     * @param  string  $type
+     * @return void
+     */
+    public static function defaultMorphKeyType($type)
+    {
+        if (! in_array($type, ['int', 'uuid'])) {
+            throw new InvalidArgumentException('Expect morph key type to either be int or uuid.');
+        }
+
+        static::$defaultMorphKeyType = $type;
     }
 
     /**

--- a/tests/Database/stubs/EloquentModelUuidStub.php
+++ b/tests/Database/stubs/EloquentModelUuidStub.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+
+class EloquentModelUuidStub extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'model';
+
+    /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+}


### PR DESCRIPTION
Following changes will be useful in the context of Package Development where you will have no control over how the users of the package intent to use relationship between application Models with packages database migrations.

-------

```php
// Proposed
$table->entangle('App\Models\User')->nullable()->index();

// Accepted
$table->foreignIdFor('App\Models\User')->nullable()->index();
```

The command will check if the given model `$keyType` and `$incrementing` property to determine whether it should generate `foreignId()` or `foreignUuid()` column.

```php
Schema::defaultMorphKeyType('uuid');

// Alias helper
Schema::morphUsingUuids();
```

Above command will automatically generate uuid based `morphs()` and `nullableMorphs()` without having to manually use `uuidMorphs()` or `nullableUuidMorphs()`. By default the value will be `int` and going to resolved via `numericMorphs()` and `nullableNumericMorphs()`.

> At the moment, users are still limited to either use `uuid` or `id` for polymorphic relationship. 