### PR TITLE
Add castTo method in request.

### DIFF
--- a/src/Illuminate/Http/Concerns/CastToObject.php
+++ b/src/Illuminate/Http/Concerns/CastToObject.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Illuminate\Http\Concerns;
+
+use Illuminate\Support\Str;
+
+trait CastToObject
+{
+    /**
+     * @var mixed
+     */
+    private $castClassVars;
+
+    /**
+     * Cast the request to specified class or object.
+     * 
+     * @param class $class
+     * @param array $overwrite
+     * @return object
+     */
+    public function castTo($class, $overwrite = [])
+    {
+        $object = is_object($class) ? $class : (new $class);
+
+        foreach (array_replace($this->all(), $overwrite) as $property => $value) {
+
+            // exact version.
+            if ($this->propertyExistsAndWasPublic($object, $property)) {
+                $object->$property = $value;
+                continue;
+            }
+
+            // camel case version.
+            if ($this->propertyExistsAndWasPublic($object, $property =  Str::camel($property))) {
+                $object->$property = $value;
+                continue;
+            }
+
+            // setter version.
+            $methodName = "set" . Str::ucfirst((Str::camel($property)));
+            if (method_exists($object, $methodName)) {
+                $object->$methodName($value);
+                continue;
+            }
+        }
+
+        $this->castClassVars = null;
+
+        return $object;
+    }
+
+    /**
+     * @param mixed $object
+     * @param string $property
+     * @return boolean
+     */
+    private function isPublicProperty($object, $property)
+    {
+        $classVars = function ($object) {
+            if ($this->castClassVars) {
+                return $this->castClassVars;
+            }
+
+            return $this->castClassVars = array_keys(
+                get_class_vars(
+                    get_class($object)
+                )
+            );
+        };
+
+        if (in_array($property, $classVars($object))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param object $object
+     * @param string $property
+     * @return bool
+     */
+    private function propertyExistsAndWasPublic($object, $property)
+    {
+        if (property_exists($object, $property) && $this->isPublicProperty($object, $property)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Illuminate/Http/Request.php
+++ b/src/Illuminate/Http/Request.php
@@ -5,6 +5,7 @@ namespace Illuminate\Http;
 use ArrayAccess;
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Http\Concerns\CastToObject;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
@@ -22,7 +23,8 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     use Concerns\InteractsWithContentTypes,
         Concerns\InteractsWithFlashData,
         Concerns\InteractsWithInput,
-        Macroable;
+        Macroable,
+        CastToObject;
 
     /**
      * The decoded JSON content for the request.

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1112,4 +1112,37 @@ class HttpRequestTest extends TestCase
         $request->setLaravelSession($session);
         $request->flashExcept(['email']);
     }
+    
+    public function testCastToMethod() 
+    {
+        $postDTO = new class
+        {
+            public $title;
+            private $body;
+        
+            public function setBody($body) 
+            {
+                $this->body = $body;
+        
+                return $this;
+            }
+        
+            public function getBody() 
+            {
+                return $this->body;
+            }
+        };
+
+        $request = Request::create('/', 'GET', ['title' => 'Laravel', 'body' => 'is awesome!']);
+        $DTO = $request->castTo($postDTO);
+
+        $this->assertEquals('Laravel', $DTO->title);
+        $this->assertEquals('is awesome!', $DTO->getBody());
+
+        $request = Request::create('/', 'POST', ['title' => 'JS', 'body' => 'ES']);
+        $DTO = $request->castTo(new $postDTO, ['body' => 'ES6']);
+
+        $this->assertEquals('JS', $DTO->title);
+        $this->assertEquals('ES6', $DTO->getBody());
+    }
 }


### PR DESCRIPTION
This PR will add `castTo` method to the Request object, the `castTo` method hydrate given class or object using request data.
public properties and setter methods will be used to hydrate the given class.


```php        
$DTO = $request->castTo(PostDTO::class);
$DTO = $request->castTo(new PostDTO());
```