### PR TITLE
[8.x] Let symfony/process build correct serve commandline

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -4,7 +4,6 @@ namespace Illuminate\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Env;
-use Illuminate\Support\ProcessUtils;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -93,7 +92,7 @@ class ServeCommand extends Command
      */
     protected function startProcess()
     {
-        $process = Process::fromShellCommandline($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) {
+        $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) {
             return [$key => false];
         })->all());
 
@@ -107,16 +106,16 @@ class ServeCommand extends Command
     /**
      * Get the full server command.
      *
-     * @return string
+     * @return array
      */
     protected function serverCommand()
     {
-        return sprintf('%s -S %s:%s %s',
-            ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false)),
-            $this->host(),
-            $this->port(),
-            ProcessUtils::escapeArgument(base_path('server.php'))
-        );
+        return [
+            (new PhpExecutableFinder)->find(false),
+            '-S',
+            $this->host() . ':' . $this->port(),
+            base_path('server.php')
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/laravel/framework/issues/34121 by letting *symfony/process* assemble the correct commandline for all platforms instead of building it up manually.