### PR TITLE
[8.x] Generate unguarded models

### DIFF
--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -166,7 +166,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        $guardedReplacement = $this->option('unguard') ? "[]": "['*']";
+        $guardedReplacement = $this->option('unguard') ? "[]" : "['*']";
 
         $class = str_replace(
             ['{{ guarded }}', '{{guarded}}'],

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -157,6 +157,27 @@ class ModelMakeCommand extends GeneratorCommand
     }
 
     /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $class = parent::buildClass($name);
+
+        $guardedReplacement = $this->option('unguard') ? "[]": "['*']";
+
+        $class = str_replace(
+            ['{{ guarded }}', '{{guarded}}'],
+            $guardedReplacement,
+            $class
+        );
+
+        return $class;
+    }
+
+    /**
      * Get the default namespace for the class.
      *
      * @param  string  $rootNamespace
@@ -182,6 +203,7 @@ class ModelMakeCommand extends GeneratorCommand
             ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
             ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder file for the model'],
             ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
+            ['unguard', 'u', InputOption::VALUE_NONE, 'Indicates if the generated model should be unguarded'],
             ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
             ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
         ];

--- a/src/Illuminate/Foundation/Console/ModelMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ModelMakeCommand.php
@@ -166,7 +166,7 @@ class ModelMakeCommand extends GeneratorCommand
     {
         $class = parent::buildClass($name);
 
-        $guardedReplacement = $this->option('unguard') ? "[]" : "['*']";
+        $guardedReplacement = $this->option('unguard') ? '[]' : "['*']";
 
         $class = str_replace(
             ['{{ guarded }}', '{{guarded}}'],

--- a/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.pivot.stub
@@ -6,5 +6,12 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class {{ class }} extends Pivot
 {
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array|bool
+     */
+    protected $guarded = {{ guarded }};
+
     //
 }

--- a/src/Illuminate/Foundation/Console/stubs/model.stub
+++ b/src/Illuminate/Foundation/Console/stubs/model.stub
@@ -8,4 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 class {{ class }} extends Model
 {
     use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array|bool
+     */
+    protected $guarded = {{ guarded }};
 }


### PR DESCRIPTION
This PR adds a `-u` option in `make:model` to generate unguarded models.

```
php artisan make:model Comment -u
```

Generates:

```php
class Comment extends Model
{
    use HasFactory;

    /**
     * The attributes that aren't mass assignable.
     *
     * @var array|bool
     */
    protected $guarded = [];
}
```

Not using the `-u` option will generate a guarded model but the `$guarded` property will be in the class so people know it's there:

```
php artisan make:model Comment
```

Generates:

```php
class Comment extends Model
{
    use HasFactory;

    /**
     * The attributes that aren't mass assignable.
     *
     * @var array|bool
     */
    protected $guarded = ['*'];
}
```