### PR TITLE
[7.x] Fix merge componemt attribute bag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -165,10 +165,10 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     /**
      * Merge additional attributes / values into the attribute bag.
      *
-     * @param  array  $attributeDefaults
+     * @param  mixed  $attributeDefaults
      * @return static
      */
-    public function merge(array $attributeDefaults = [])
+    public function merge($attributeDefaults = [])
     {
         $attributes = [];
 
@@ -178,7 +178,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
             }
 
             return e($value);
-        }, $attributeDefaults);
+        }, collect($attributeDefaults)->all());
 
         foreach ($this->attributes as $key => $value) {
             if ($key !== 'class') {

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -29,6 +29,7 @@ class ViewComponentAttributeBagTest extends TestCase
         $bag = new ComponentAttributeBag([]);
 
         $this->assertSame('class="mt-4"', (string) $bag->merge(['class' => 'mt-4']));
+        $this->assertSame('class="mt-4"', (string) $bag->merge(collect(['class' => 'mt-4'])));
 
         $bag = new ComponentAttributeBag([
             'test-string' => 'ok',


### PR DESCRIPTION
When using [components](https://laravel.com/docs/7.x/blade#components), I realized that we can only merge attributes with the array
```php
<div {{$attributes->merge(['class' => 'alert alert-'.$type])}}>
```
we cannot pass a collection
```php
<div {{$attributes->merge(collect(['class' => 'alert alert-'.$type]))}}>
```