### PR TITLE
[8.x] Collection <=> LazyCollection feature parity

### DIFF
--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -51,6 +51,18 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
+     * Create a collection with the given range.
+     *
+     * @param  int  $from
+     * @param  int  $to
+     * @return static
+     */
+    public static function range($from, $to)
+    {
+        return new static(range($from, $to));
+    }
+
+    /**
      * Get all of the items in the collection.
      *
      * @return array

--- a/src/Illuminate/Collections/Collection.php
+++ b/src/Illuminate/Collections/Collection.php
@@ -31,26 +31,6 @@ class Collection implements ArrayAccess, Enumerable
     }
 
     /**
-     * Create a new collection by invoking the callback a given amount of times.
-     *
-     * @param  int  $number
-     * @param  callable|null  $callback
-     * @return static
-     */
-    public static function times($number, callable $callback = null)
-    {
-        if ($number < 1) {
-            return new static;
-        }
-
-        if (is_null($callback)) {
-            return new static(range(1, $number));
-        }
-
-        return (new static(range(1, $number)))->map($callback);
-    }
-
-    /**
      * Create a collection with the given range.
      *
      * @param  int  $from

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -44,6 +44,13 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public static function unwrap($value);
 
     /**
+     * Create a new instance with no items.
+     *
+     * @return static
+     */
+    public static function empty();
+
+    /**
      * Get all items in the enumerable.
      *
      * @return array

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -28,6 +28,15 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public static function times($number, callable $callback = null);
 
     /**
+     * Create a collection with the given range.
+     *
+     * @param  int  $from
+     * @param  int  $to
+     * @return static
+     */
+    public static function range($from, $to);
+
+    /**
      * Wrap the given value in a collection if applicable.
      *
      * @param  mixed  $value

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -38,16 +38,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Create a new instance with no items.
-     *
-     * @return static
-     */
-    public static function empty()
-    {
-        return new static([]);
-    }
-
-    /**
      * Create a new instance by invoking the callback a given amount of times.
      *
      * @param  int  $number

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -60,7 +60,7 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Create an enumerable with the given range.
+     * Create a collection with the given range.
      *
      * @param  int  $from
      * @param  int  $to

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -38,28 +38,6 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Create a new instance by invoking the callback a given amount of times.
-     *
-     * @param  int  $number
-     * @param  callable|null  $callback
-     * @return static
-     */
-    public static function times($number, callable $callback = null)
-    {
-        if ($number < 1) {
-            return new static;
-        }
-
-        $instance = new static(function () use ($number) {
-            for ($current = 1; $current <= $number; $current++) {
-                yield $current;
-            }
-        });
-
-        return is_null($callback) ? $instance : $instance->map($callback);
-    }
-
-    /**
      * Create a collection with the given range.
      *
      * @param  int  $from

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -120,6 +120,24 @@ trait EnumeratesValues
     }
 
     /**
+     * Create a new collection by invoking the callback a given amount of times.
+     *
+     * @param  int  $number
+     * @param  callable|null  $callback
+     * @return static
+     */
+    public static function times($number, callable $callback = null)
+    {
+        if ($number < 1) {
+            return new static;
+        }
+
+        return static::range(1, $number)
+            ->when($callback)
+            ->map($callback);
+    }
+
+    /**
      * Alias for the "avg" method.
      *
      * @param  callable|string|null  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -110,6 +110,16 @@ trait EnumeratesValues
     }
 
     /**
+     * Create a new instance with no items.
+     *
+     * @return static
+     */
+    public static function empty()
+    {
+        return new static([]);
+    }
+
+    /**
      * Alias for the "avg" method.
      *
      * @param  callable|string|null  $callback

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2201,6 +2201,22 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testRangeMethod($collection)
+    {
+        $this->assertSame(
+            [1, 2, 3, 4, 5],
+            $collection::range(1, 5)->all()
+        );
+
+        $this->assertSame(
+            [-2, -1, 0, 1, 2],
+            $collection::range(-2, 2)->all()
+        );
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testConstructMakeFromObject($collection)
     {
         $object = new stdClass;

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2166,6 +2166,16 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testEmptyMethod($collection)
+    {
+        $collection = $collection::empty();
+
+        $this->assertCount(0, $collection->all());
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testTimesMethod($collection)
     {
         $two = $collection::times(2, function ($number) {


### PR DESCRIPTION
This PR adds the `empty` and `range` methods to the `Collection` class and `Enumerable` interface, to bring more feature parity between the `Collection` and `LazyCollection` classes.

This also allows us to unify the `times` method, moving it to the `EnumeratesValues` trait :+1: 