### PR TITLE
[7.x] Fixing ambiguous output in storage linking command

### DIFF
--- a/src/Illuminate/Foundation/Console/StorageLinkCommand.php
+++ b/src/Illuminate/Foundation/Console/StorageLinkCommand.php
@@ -29,6 +29,8 @@ class StorageLinkCommand extends Command
      */
     public function handle()
     {
+        $linksCreated = 0;
+
         foreach ($this->links() as $link => $target) {
             if (file_exists($link)) {
                 $this->error("The [$link] link already exists.");
@@ -40,10 +42,12 @@ class StorageLinkCommand extends Command
                 $this->laravel->make('files')->link($target, $link);
 
                 $this->info("The [$link] link has been connected to [$target].");
+
+                $linksCreated++;
             }
         }
 
-        $this->info('The links have been created.');
+        $this->info($linksCreated . ' links have been created.');
     }
 
     /**


### PR DESCRIPTION
Hey Laravel Team,

while fixing an issue I had to re-link the storage and found the bash output:

```bash
$ php artisan storage:link
The [/home/forge/project.com/public/storage] link already exists.
The links have been created.
```

rather unclear. 

The supplied patch fixes this by clarifying the number of created links.

Happy to tweak as needed! Please let me know!

Cheers,
Peter
