### PR TITLE
[7.x] Change CastAttributes and CastsInboundAttributes set method return type to mixed

### DIFF
--- a/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsAttributes.php
@@ -22,7 +22,7 @@ interface CastsAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @return array|string|null
+     * @return mixed
      */
     public function set($model, string $key, $value, array $attributes);
 }

--- a/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
+++ b/src/Illuminate/Contracts/Database/Eloquent/CastsInboundAttributes.php
@@ -11,7 +11,7 @@ interface CastsInboundAttributes
      * @param  string  $key
      * @param  mixed  $value
      * @param  array  $attributes
-     * @return array
+     * @return mixed
      */
     public function set($model, string $key, $value, array $attributes);
 }


### PR DESCRIPTION
Follow-up of #34142

`set` method of custom cast interfaces are used only with `HasAttributes::normalizeCastClassResponse` method, which expects value returned by setter to be mixed. To prevent errors from tools (e.g. PHPStan) about wrong return types in custom cast interfaces I propose to change them also to mixed.

Also return type of method `CastsInboundAttributes::set` is only array, which is wrong. For example code from documentation returns string from this contract implementation (https://laravel.com/docs/7.x/eloquent-mutators#custom-casts):

```php
    /**
     * Prepare the given value for storage.
     *
     * @param  \Illuminate\Database\Eloquent\Model  $model
     * @param  string  $key
     * @param  array  $value
     * @param  array  $attributes
     * @return string
     */
    public function set($model, $key, $value, $attributes)
    {
        return is_null($this->algorithm)
                    ? bcrypt($value)
                    : hash($this->algorithm, $value);
    }
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
