### PR TITLE
[8.x] Resolve factories based on model hierarchy

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -618,11 +618,7 @@ abstract class Factory
      */
     public static function factoryForModel(string $modelName)
     {
-        $resolver = static::$factoryNameResolver ?: function ($modelName) {
-            return static::$namespace.Str::singular(class_basename($modelName)).'Factory';
-        };
-
-        $factory = $resolver($modelName);
+        $factory = static::resolveFactoryName($modelName);
 
         return $factory::new();
     }
@@ -646,6 +642,25 @@ abstract class Factory
     protected function withFaker()
     {
         return Container::getInstance()->make(Generator::class);
+    }
+
+    /**
+     * Get the factory name for the given model name.
+     *
+     * @param  string  $modelName
+     * @return string
+     */
+    public static function resolveFactoryName(string $modelName)
+    {
+        $resolver = static::$factoryNameResolver ?: function (string $modelName) {
+            $modelName = Str::startsWith($modelName, 'App\\Models\\')
+                ? Str::after($modelName, 'App\\Models\\')
+                : Str::after($modelName, 'App\\');
+
+            return static::$namespace.$modelName.'Factory';
+        };
+
+        return $resolver($modelName);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -259,6 +259,22 @@ class DatabaseEloquentFactoryTest extends TestCase
         }));
     }
 
+    public function test_resolve_nested_model_factories()
+    {
+        Factory::useNamespace('Factories\\');
+
+        $resolves = [
+            'App\\Foo' => 'Factories\\FooFactory',
+            'App\\Models\\Foo' => 'Factories\\FooFactory',
+            'App\\Models\\Nested\\Foo' => 'Factories\\Nested\\FooFactory',
+            'App\\Models\\Really\\Nested\\Foo' => 'Factories\\Really\\Nested\\FooFactory',
+        ];
+
+        foreach ($resolves as $model => $factory) {
+            $this->assertEquals($factory, Factory::resolveFactoryName($model));
+        }
+    }
+
     public function test_model_has_factory()
     {
         Factory::guessFactoryNamesUsing(function ($model) {


### PR DESCRIPTION
This PR allows the `database/Factories` directory to mirror the hierarchy of the `app/Models` directory.

Currently, Model Factory resolution only works when a Factory is directly under the `database/Factories` directory i.e. it is not possible (out of the box) to resolve a Factory if it exists in a subdirectory. This can be an issue when:
 
- models with the same class name exist but under different namespaces
- a user simply wants to organise their factories to mirror the `app/Models` directory
