### PR TITLE
#fix calling when method in model instance

### DIFF
--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Database\Concerns;
 
 use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 
@@ -153,13 +154,25 @@ trait BuildsQueries
      */
     public function when($value, $callback, $default = null)
     {
-        if ($value) {
-            return $callback($this, $value) ?: $this;
-        } elseif ($default) {
-            return $default($this, $value) ?: $this;
+        [$one, $two, $class] = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
+
+        $instance = $this;
+        
+        if (
+            isset($class['object']) &&
+            $class['object'] instanceof Model &&
+            $class['object']->exists
+            ) {
+            $instance = $class['object'];
         }
 
-        return $this;
+        if ($value) {
+            return $callback($instance, $value) ?: $instance;
+        } elseif ($default) {
+            return $default($instance, $value) ?: $instance;
+        }
+
+        return $instance;
     }
 
     /**

--- a/src/Illuminate/Database/Concerns/BuildsQueries.php
+++ b/src/Illuminate/Database/Concerns/BuildsQueries.php
@@ -157,7 +157,6 @@ trait BuildsQueries
         [$one, $two, $class] = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
 
         $instance = $this;
-        
         if (
             isset($class['object']) &&
             $class['object'] instanceof Model &&

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -83,13 +83,15 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 
         $model = Model1::find($one->id);
 
-        $callback = function ($model, $condition) { 
+        $callback = function ($model, $condition) {
             $this->assertTrue($condition);
+
             return $model->load('threes');
         };
 
         $default = function ($model, $condition) {
             $this->assertFalse($condition);
+
             return $model->load('fours');
         };
 
@@ -117,7 +119,7 @@ class Model1 extends Model
     {
         return $this->hasMany(Model3::class, 'one_id');
     }
-    
+
     public function fours()
     {
         return $this->hasMany(Model4::class, 'one_id');

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -65,6 +65,7 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 
         $callback = function ($model, $condition) {
             $this->assertTrue($condition);
+
             return $model->load('threes');
         };
 

--- a/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
+++ b/tests/Integration/Database/EloquentLazyEagerLoadingTest.php
@@ -53,7 +53,6 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
         $model->load('threes');
 
         $this->assertCount(1, DB::getQueryLog());
-
         $this->assertTrue($model->relationLoaded('threes'));
     }
 
@@ -66,7 +65,6 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 
         $callback = function ($model, $condition) {
             $this->assertTrue($condition);
-
             return $model->load('threes');
         };
 
@@ -85,7 +83,7 @@ class EloquentLazyEagerLoadingTest extends DatabaseTestCase
 
         $model = Model1::find($one->id);
 
-        $callback = function ($model, $condition) {
+        $callback = function ($model, $condition) { 
             $this->assertTrue($condition);
             return $model->load('threes');
         };
@@ -119,6 +117,7 @@ class Model1 extends Model
     {
         return $this->hasMany(Model3::class, 'one_id');
     }
+    
     public function fours()
     {
         return $this->hasMany(Model4::class, 'one_id');
@@ -148,7 +147,6 @@ class Model3 extends Model
         return $this->belongsTo(Model1::class, 'one_id');
     }
 }
-
 
 class Model4 extends Model
 {


### PR DESCRIPTION
I have a situation that I wanted to load different relations depending on a condition .
but when i call `when` method it returns a  brand new instance of QueryBuilder not even querying  the selected model .
so i had to manually select the model again like this . 
 
 ```
$tour->when($tour->isWon(),
    function ($query) use ($tour) {
        $query->with(['wonOffer' => function ($query) use ($tour) {
            $query->where('tour_id', $tour->id); //selecting the tour again 
        }]);
    },
    function ($query) use ($tour) {
        $query->with(['offers' => function ($query) use ($tour) {
           $query->where('tour_id', $tour->id); //selecting the tour again 
        }]);
   }
)->first();

```

after this PR:  `when` method will return the model instance **in case of  called  by a  single model instance**   

```
$tour->when($tour->isWon(),
    function ($tour) {
        $tour->load('wonOffer')
    },
    function ($tour) {
        $tour->load('offers');
    }
);
```
