### PR TITLE
[7.x] Significant performance issue in Eloquent Collection loadCount() method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -79,19 +79,17 @@ class Collection extends BaseCollection implements QueueableCollection
             ->whereKey($this->modelKeys())
             ->select($this->first()->getKeyName())
             ->withCount(...func_get_args())
-            ->get();
+            ->get()
+            ->keyBy($this->first()->getKeyName());
 
         $attributes = Arr::except(
             array_keys($models->first()->getAttributes()),
             $models->first()->getKeyName()
         );
 
-        $models->each(function ($model) use ($attributes) {
-            $this->where($this->first()->getKeyName(), $model->getKey())
-                ->each
-                ->forceFill(Arr::only($model->getAttributes(), $attributes))
-                ->each
-                ->syncOriginalAttributes($attributes);
+        $this->each(function ($model) use ($models, $attributes) {
+            $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
+            $model->forceFill($extraAttributes)->syncOriginalAttributes($attributes);
         });
 
         return $this;

--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -89,6 +89,7 @@ class Collection extends BaseCollection implements QueueableCollection
 
         $this->each(function ($model) use ($models, $attributes) {
             $extraAttributes = Arr::only($models->get($model->getKey())->getAttributes(), $attributes);
+
             $model->forceFill($extraAttributes)->syncOriginalAttributes($attributes);
         });
 


### PR DESCRIPTION
It appears as though the performance of `\Illuminate\Database\Eloquent\Collection::loadCount()` has been significantly impacted by this change https://github.com/laravel/framework/commit/5ee0e4d41cb1d7f962298f64c1fe943889f56224

I was debugging a performance issue in one of our applications and noticed that a call to `loadCount()` was taking minutes. I profiled with Blackfire.io and saw hundreds of thousands of calls to the `getAttribute()` method on the Eloquent Model.

I've put together a repository to validate a performance fix: https://github.com/markokeeffe/laravel-load-count-performance

You can follow the steps in `README.md` to validate the performance impact. 

The repo essentially seeds 500 `Item` models, each with 1000 related `ItemLog` models. Then two console commands can be run to see the performance difference between the current method and the proposed fix in this PR:

**load-count-laraval**

```bash
blackfire run php artisan load-count-laravel

Wall Time   2min 5s
I/O Wait      29.9s
CPU Time   1min 35s
Memory       18.7MB
Network         n/a     n/a     n/a
SQL           28.5s     4rq
```

**load-count-improved**

```bash
blackfire run php artisan load-count-improved

Wall Time     23.9s
I/O Wait      22.9s
CPU Time      984ms
Memory       18.7MB
Network         n/a     n/a     n/a
SQL           22.4s     4rq
```

Check this screenshot from Blackfire.io to see how calling `loadCount()` on a collection of 500 models results in 501,000 calls to `getAttribute()`

<img width="257" alt="Screen Shot 2020-09-07 at 17 01 46" src="https://user-images.githubusercontent.com/1211393/92357953-0603f880-f12c-11ea-9d03-548dfd351706.png">

Here's a screenshot of the Blackfire.io profile after the fix is applied:

<img width="1483" alt="Screen Shot 2020-09-07 at 17 09 52" src="https://user-images.githubusercontent.com/1211393/92358622-1bc5ed80-f12d-11ea-9141-1f170c5a0999.png">
