### PR TITLE
[8.x] Added method in Mail facade doc block

### DIFF
--- a/src/Illuminate/Support/Facades/Mail.php
+++ b/src/Illuminate/Support/Facades/Mail.php
@@ -5,6 +5,7 @@ namespace Illuminate\Support\Facades;
 use Illuminate\Support\Testing\Fakes\MailFake;
 
 /**
+ * @method static \Illuminate\Mail\Mailer mailer(string|null $name = null)
  * @method static \Illuminate\Mail\PendingMail bcc($users)
  * @method static \Illuminate\Mail\PendingMail to($users)
  * @method static \Illuminate\Support\Collection queued(string $mailable, \Closure|string $callback = null)


### PR DESCRIPTION
This PR adds missing method in Mail facade to _switch_ mailer. This helps IDE like PhpStorm to correctly handle facade method.
