### PR TITLE
[8.x] Add `File::lines($path)` method

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -5,8 +5,10 @@ namespace Illuminate\Filesystem;
 use ErrorException;
 use FilesystemIterator;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Traits\Macroable;
 use RuntimeException;
+use SplFileObject;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Mime\MimeTypes;
@@ -82,6 +84,33 @@ class Filesystem
         }
 
         return $contents;
+    }
+
+    /**
+     * Get the contents of a file, one line at a time.
+     *
+     * @param  string  $path
+     * @return \Illuminate\Support\LazyCollection
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function lines($path)
+    {
+        if (! $this->isFile($path)) {
+            throw new FileNotFoundException(
+                "File does not exist at path {$path}."
+            );
+        }
+
+        return LazyCollection::make(function () use ($path) {
+            $file = new SplFileObject($path);
+
+            $file->setFlags(SplFileObject::DROP_NEW_LINE);
+
+            while (! $file->eof()) {
+                yield $file->fgets();
+            }
+        });
     }
 
     /**

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemManager;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Testing\Assert;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -54,6 +55,27 @@ class FilesystemTest extends TestCase
         $files = new Filesystem;
         $files->put(self::$tempDir.'/file.txt', 'Hello World');
         $this->assertStringEqualsFile(self::$tempDir.'/file.txt', 'Hello World');
+    }
+
+    public function testLines()
+    {
+        $path = self::$tempDir.'/file.txt';
+
+        $contents = LazyCollection::times(3)
+            ->map(function ($number) {
+                return "line-{$number}";
+            })
+            ->join("\n");
+
+        file_put_contents($path, $contents);
+
+        $files = new Filesystem;
+        $this->assertInstanceOf(LazyCollection::class, $files->lines($path));
+
+        $this->assertSame(
+            ['line-1', 'line-2', 'line-3'],
+            $files->lines($path)->all()
+        );
     }
 
     public function testReplaceCreatesFile()


### PR DESCRIPTION
Many of the most useful scenarios for using lazy collections involves reading files line by line ([see here for more details](https://josephsilber.com/posts/2020/07/29/lazy-collections-in-laravel#reading-files-lazily-with-a-lazy-collection)).

This PR adds a `lines` method to the `Filesystem` class, to lazily read the lines of a file:

```php
$collection = File::lines($path);
```

## Example

With this in place, you can easily read Laravel's logs lazily (using the new [`chunkWhile` method](https://github.com/laravel/framework/pull/33980)):

```php
$pattern = '/^[\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d]/'; // starts with e.g. [2020-09-07 00:24:11]

$logs = File::lines(storage_path('logs/laravel.log'))
    ->chunkWhile(fn ($line) => ! preg_match($pattern, $line));
```

The `$logs` variable will now be a lazy collection, from which we can pull out a single log entry at a time.

