### PR TITLE
[8.x] Support reverse ranges in LazyCollection::range()

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -47,8 +47,14 @@ class LazyCollection implements Enumerable
     public static function range($from, $to)
     {
         return new static(function () use ($from, $to) {
-            for (; $from <= $to; $from++) {
-                yield $from;
+            if ($from <= $to) {
+                for (; $from <= $to; $from++) {
+                    yield $from;
+                }
+            } else {
+                for (; $from >= $to; $from--) {
+                    yield $from;
+                }
             }
         });
     }

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2212,6 +2212,26 @@ class SupportCollectionTest extends TestCase
             [-2, -1, 0, 1, 2],
             $collection::range(-2, 2)->all()
         );
+
+        $this->assertSame(
+            [-4, -3, -2],
+            $collection::range(-4, -2)->all()
+        );
+
+        $this->assertSame(
+            [5, 4, 3, 2, 1],
+            $collection::range(5, 1)->all()
+        );
+
+        $this->assertSame(
+            [2, 1, 0, -1, -2],
+            $collection::range(2, -2)->all()
+        );
+
+        $this->assertSame(
+            [-2, -3, -4],
+            $collection::range(-2, -4)->all()
+        );
     }
 
     /**


### PR DESCRIPTION
```php
LazyCollection::range(4, 2)->all(); // [4, 3, 2]
```

The native `range` function supports this, so the regular `Collection` automatically supports this.