### PR TITLE
[8.x] add whenSelected() method to JsonResource

### DIFF
--- a/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
+++ b/src/Illuminate/Http/Resources/ConditionallyLoadsAttributes.php
@@ -191,6 +191,35 @@ trait ConditionallyLoadsAttributes
     }
 
     /**
+     * Retrieve an attribute when it has been selected.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $default
+     * @return \Illuminate\Http\Resources\MissingValue|mixed
+     */
+    protected function whenSelected($attribute, $value = null, $default = null)
+    {
+        if (func_num_args() < 3) {
+            $default = new MissingValue;
+        }
+
+        if (! array_key_exists($attribute, $this->resource->getOriginal())) {
+            return value($default);
+        }
+
+        if (func_num_args() === 1) {
+            return $this->resource->{$attribute};
+        }
+
+        if ($this->resource->{$attribute} === null) {
+            return;
+        }
+
+        return value($value);
+    }
+
+    /**
      * Execute a callback if the given pivot table has been loaded.
      *
      * @param  string  $table

--- a/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalAttributes.php
+++ b/tests/Integration/Http/Fixtures/AuthorResourceWithOptionalAttributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Http\Fixtures;
+
+class AuthorResourceWithOptionalAttributes extends PostResource
+{
+    public function toArray($request)
+    {
+        return [
+            'name' => $this->whenSelected('name'),
+            'email' => $this->whenSelected('email'),
+        ];
+    }
+}

--- a/tests/Integration/Http/ResourceTest.php
+++ b/tests/Integration/Http/ResourceTest.php
@@ -10,6 +10,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Tests\Integration\Http\Fixtures\Author;
+use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalAttributes;
 use Illuminate\Tests\Integration\Http\Fixtures\AuthorResourceWithOptionalRelationship;
 use Illuminate\Tests\Integration\Http\Fixtures\EmptyPostCollectionResource;
 use Illuminate\Tests\Integration\Http\Fixtures\ObjectResource;
@@ -326,6 +327,31 @@ class ResourceTest extends TestCase
                 'name' => 'jrrmartin',
                 'posts_count' => 'not loaded',
                 'latest_post_title' => 'not loaded',
+            ],
+        ]);
+    }
+
+    public function testResourcesMayHaveOptionalAttribute()
+    {
+        $this->partialMock(Author::class, function ($mock) {
+            $mock->shouldReceive('getOriginal')->andReturn(['name' => '']);
+            $mock->shouldReceive('getAttribute')->with('name')->andReturn('jrrmartin');
+            $mock->shouldReceive('getAttribute')->with('email')->andReturn('jrrmartin@demo.com');
+        });
+
+        Route::get('/', function () {
+            return new AuthorResourceWithOptionalAttributes($this->app->make(Author::class));
+        });
+
+        $response = $this->withoutExceptionHandling()->get(
+            '/', ['Accept' => 'application/json']
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertExactJson([
+            'data' => [
+                'name' => 'jrrmartin',
             ],
         ]);
     }


### PR DESCRIPTION
In some cases we need to select specific column from database. so this helper give ability to determine whether the column is already selected from database.

For Example:
```php
class AuthorResource extends JsonResource
{
    public function toArray($request)
    {
        return [
            'id' => $this->id,
            'name' => $this->whenSelected('name'),
            'email' => $this->whenSelected('email'),
        ];
    }
}
```
In controller :
```php
    public function index()
    {
        return AuthorResource::collection(
            Author::get(['id', 'name'])  
        );
    }
```
Response :
```json
{
    "data": [
        {
            "id": 1,
            "name": "Ahmed",
        },
        {
            "id": 2,
            "name": "Mohamed",
        },
    ]
}
```