### PR TITLE
[8.x] Pass the request to the renderable callback

### DIFF
--- a/src/Illuminate/Foundation/Exceptions/Handler.php
+++ b/src/Illuminate/Foundation/Exceptions/Handler.php
@@ -314,7 +314,7 @@ class Handler implements ExceptionHandlerContract
 
         foreach ($this->renderCallbacks as $renderCallback) {
             if (is_a($e, $this->firstClosureParameterType($renderCallback))) {
-                $response = $renderCallback($e);
+                $response = $renderCallback($e, $request);
 
                 if (! is_null($response)) {
                     return $response;

--- a/tests/Foundation/FoundationExceptionsHandlerTest.php
+++ b/tests/Foundation/FoundationExceptionsHandlerTest.php
@@ -111,11 +111,24 @@ class FoundationExceptionsHandlerTest extends TestCase
         $this->assertStringContainsString('"trace":', $response);
     }
 
-    public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
+    public function testReturnsCustomResponseFromRenderableCallback()
     {
+        $this->handler->renderable(function (CustomException $e, $request) {
+            $this->assertSame($this->request, $request);
+
+            return response()->json(['response' => 'My custom exception response']);
+        });
+
         $response = $this->handler->render($this->request, new CustomException)->getContent();
 
         $this->assertSame('{"response":"My custom exception response"}', $response);
+    }
+
+    public function testReturnsCustomResponseWhenExceptionImplementsResponsable()
+    {
+        $response = $this->handler->render($this->request, new ResponsableException)->getContent();
+
+        $this->assertSame('{"response":"My responsable exception response"}', $response);
     }
 
     public function testReturnsJsonWithoutStackTraceWhenAjaxRequestAndDebugFalseAndExceptionMessageIsMasked()
@@ -224,11 +237,15 @@ class FoundationExceptionsHandlerTest extends TestCase
     }
 }
 
-class CustomException extends Exception implements Responsable
+class CustomException extends Exception
+{
+}
+
+class ResponsableException extends Exception implements Responsable
 {
     public function toResponse($request)
     {
-        return response()->json(['response' => 'My custom exception response']);
+        return response()->json(['response' => 'My responsable exception response']);
     }
 }
 


### PR DESCRIPTION
The `render` method of the exception handler accepts the `$request` object but it's not available in renderable callbacks.

This PR passes the request as a second argument to the registered renderable callbacks.

I've added tests that cover the new renderable callback functionality as well as the request parameter.
I'll also make a PR to the docs if this gets merged.