### PR TITLE
Improve signature for HasFactory::factory()

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/HasFactory.php
@@ -7,13 +7,14 @@ trait HasFactory
     /**
      * Get a new factory instance for the model.
      *
-     * @param  mixed  $parameters
+     * @param  callable|array|int|null  $count
+     * @param  callable|array  $state
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */
-    public static function factory(...$parameters)
+    public static function factory($count = null, $state = [])
     {
         return Factory::factoryForModel(get_called_class())
-                    ->count(is_numeric($parameters[0] ?? null) ? $parameters[0] : null)
-                    ->state(is_array($parameters[0] ?? null) ? $parameters[0] : ($parameters[1] ?? []));
+                    ->count(is_numeric($count) ? $count : null)
+                    ->state(is_callable($count) || is_array($count) ? $count : $state);
     }
 }


### PR DESCRIPTION
The factory method can be called in a number of ways:

```php
// Without arguments
User::factory();

// With count
User::factory(3);

// With count and array state
User::factory(3, ['account_status' => 'suspended']);

// With count and closure state
User::factory(3, function (array $attributes) {
    return ['account_status' => 'suspended'];
});

// With array state
User::factory(['account_status' => 'suspended']);

// With closure state
User::factory(function (array $attributes) {
    return ['account_status' => 'suspended'];
});
```

This PR adds docblocks for the possible arguments and cleans up the parameter overloading.