### PR TITLE
allow mergeConfigFrom to overwrite config files

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -127,7 +127,7 @@ abstract class ServiceProvider
             $config = $this->app->make('config');
 
             $config->set($key, array_merge(
-                require $path, $config->get($key, [])
+                $config->get($key, []), require $path
             ));
         }
     }


### PR DESCRIPTION
Hey, I'm developing a custom package which uses other vendor packages and of course vendor config files. So I wanted to change some vendor config values.

It turns out that I couldn't overwrite config values, I was just able to add new key/values to the array.

I think overwriting and merging is more useful than just merging.

Changing `array_merge` parameters order at `mergeConfigFrom` does the trick.
