### PR TITLE
[8.x] Schema Dump: check error message with command option instead of table name

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,7 +116,7 @@ class MySqlSchemaState extends SchemaState
         try {
             $process->mustRun($output, $variables);
         } catch (Exception $e) {
-            if (Str::contains($e->getMessage(), 'column_statistics')) {
+            if (Str::contains($e->getMessage(), 'column-statistics')) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(
                     str_replace(' --column-statistics=0', '', $process->getCommandLine())
                 ), $output, $variables);

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,7 +116,7 @@ class MySqlSchemaState extends SchemaState
         try {
             $process->mustRun($output, $variables);
         } catch (Exception $e) {
-            if (Str::contains($e->getMessage(), 'column-statistics')) {
+            if (Str::contains($e->getMessage(), ['column-statistics', 'column_statistics'])) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(
                     str_replace(' --column-statistics=0', '', $process->getCommandLine())
                 ), $output, $variables);


### PR DESCRIPTION
Short version: fix typo in message error

Long version: if the first try in the command line is to use "_--column-statistics=0_" and you have an error because the option is not supported by your client (too old) you will have a  message about the missing option (column-statistics)
Instead, if the first try is to not use "_--column-statistics=0_" option and you have an error because you have a new client and a old server (mysql5.7) you will have a message about the missing table ("_column_statistics_")
So with this implementation (where it is used with "_--column-statistics=0_") the error will be about "_column-statistics_"

Command option: column-statistics
Table name :  column_statistics


Tested with mysqldump 5.7 , mysqldump 8, mysqld 5.7, mysqld8

