### PR TITLE
Fix factory modelName resolver so that it takes into consideration..

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -585,7 +585,7 @@ abstract class Factory
                         : 'App\\'.$factoryBasename;
         };
 
-        return $this->model ?: $resolver($this);
+        return $resolver($this);
     }
 
     /**


### PR DESCRIPTION
# Fix factory modelName resolver so that it takes into consideration classes that are not into the new models directory
I was upgrading an app to laravel 8.0, when following the upgrade guidelines, i stumbled accross this bug
![image](https://user-images.githubusercontent.com/32931114/92652217-00054780-f2e5-11ea-96f6-e51718726ad9.png)

## Steps to reproduce 
1-Uncomment the `// User::factory(10)->create();` line in database/seeders/DatabaseSeeder.php
2-Move the user class to the app directory, remove the models directory and change the namespace accordingly
3-Import the user class to DatabaseSeeder.php
4-Run the seeder

returning the $resolver directly did the trick, i don't see why we should even check $this->model