### PR TITLE
[8.x] Allow public access to `$value`

### DIFF
--- a/src/Illuminate/Support/Optional.php
+++ b/src/Illuminate/Support/Optional.php
@@ -17,7 +17,7 @@ class Optional implements ArrayAccess
      *
      * @var mixed
      */
-    protected $value;
+    public $value;
 
     /**
      * Create a new optional instance.


### PR DESCRIPTION
usage scenarios

- when using `!$model` the value was always truthy & the alternative was testing against an attribute existence ex.`!$model->id`, now we can check if the optional item exists or null against an always available attribute. `!$model->value`

- it wasn't possible to test the instance of the underlaying model inside optional, at least there isnt a know-how in the docs or api, now we can ex.`get_class($model->value)`

if all good, you can give me the link to the docs and i will update it as well.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
