### PR TITLE
[8.x] Cast linkCollection to array

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -198,7 +198,7 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             'from' => $this->firstItem(),
             'last_page' => $this->lastPage(),
             'last_page_url' => $this->url($this->lastPage()),
-            'links' => $this->linkCollection(),
+            'links' => $this->linkCollection()->toArray(),
             'next_page_url' => $this->nextPageUrl(),
             'path' => $this->path(),
             'per_page' => $this->perPage(),


### PR DESCRIPTION
The new `linksCollection` method stays a collection instance when calling `paginate()->toArray()`.
The genererated JSON will be the same, so this should not affect anything.

Some tests can fail because it expects an array and gets a collection. For example in my inertia app:

```php
$response->assertPropValue('results', function ($results) {
    $this->assertEquals(
        $results,
        $this->user->addresses()->paginate(25)->toArray()
     );
});
```

```
--- Expected
+++ Actual
@@ @@
     'from' => 1
     'last_page' => 1
     'last_page_url' => 'http://localhost/bazar/users/...page=1'
-    'links' => Array (...)
+    'links' => Illuminate\Support\Collection Object (...)
     'next_page_url' => null
     'path' => 'http://localhost/bazar/users/...resses'
     'per_page' => 25
```