### PR TITLE
[8.x] add models_path helper

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -507,6 +507,19 @@ if (! function_exists('mix')) {
     }
 }
 
+if (!function_exists('models_path')) {
+    /**
+     * Get the path to the models folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function models_path($path = '')
+    {
+        return app_path('Models' . ($path ? DIRECTORY_SEPARATOR . $path : $path));
+    }
+}
+
 if (! function_exists('now')) {
     /**
      * Create a new Carbon instance for the current time.


### PR DESCRIPTION
Since Laravel 8.x moved models directory from **App/** to **App/Models/** it will be nice to have this helper to use `models_path($path)` instead of `app_path('Models')`
