### PR TITLE
[8.x] Fixes DatabaseUuidFailedJobProvider::find() job record structure

### DIFF
--- a/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
+++ b/src/Illuminate/Queue/Failed/DatabaseUuidFailedJobProvider.php
@@ -89,7 +89,12 @@ class DatabaseUuidFailedJobProvider implements FailedJobProviderInterface
      */
     public function find($id)
     {
-        return $this->getTable()->where('uuid', $id)->first();
+        if ($record = $this->getTable()->where('uuid', $id)->first()) {
+            $record->id = $record->uuid;
+            unset($record->uuid);
+        }
+
+        return $record;
     }
 
     /**


### PR DESCRIPTION
This pull request may be consider a breaking change or a bug fix. 👍🏻

Looking at the `DatabaseUuidFailedJobProvider::all()`, this method overrides the job record `id` by the job record `uuid`:

```php
public function all()
{
    return $this->getTable()->orderBy('id', 'desc')->get()->map(function ($record) {
        $record->id = $record->uuid; // here
        unset($record->uuid); // here

        return $record;
    })->all();
}
```

This pull request adds the same behaviour for consistency to the method `DatabaseUuidFailedJobProvider::find()`:

```php
public function find($id)
{
    if ($record = $this->getTable()->where('uuid', $id)->first()) {
        $record->id = $record->uuid; // added this
        unset($record->uuid); // added this
    }

    return $record;
}
```

Before:
```
{
  "id": 7
  "uuid": "78ec04ae-3e31-4d7d-9ade-846fff307a71"
  "connection": "database"
  "queue": "default"
  "payload": "{"uuid":"78ec04ae-3e31-4d7d-9ade-846fff307a71", "...
```

After: 
```
{
  "id": "a0bd8c87-f48f-41ed-9512-3ddbf7d76c23"
  "connection": "database"
  "queue": "default"
  "payload": "{"uuid":"78ec04ae-3e31-4d7d-9ade-846fff307a71", "...
``` 