### PR TITLE
[7.x] Improve assertions for classes on Auth folder

### DIFF
--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -328,7 +328,7 @@ class AuthAccessGateTest extends TestCase
         $gate = $this->getBasicGate();
 
         $gate->define('foo', function ($user) {
-            $this->assertEquals(1, $user->id);
+            $this->assertSame(1, $user->id);
 
             return true;
         });
@@ -519,7 +519,7 @@ class AuthAccessGateTest extends TestCase
 
         // Assert that the callback receives the new user with ID of 2 instead of ID of 1...
         $gate->define('foo', function ($user) {
-            $this->assertEquals(2, $user->id);
+            $this->assertSame(2, $user->id);
 
             return true;
         });
@@ -541,16 +541,16 @@ class AuthAccessGateTest extends TestCase
         };
         $gate->guessPolicyNamesUsing($guesserCallback);
         $gate->getPolicyFor('fooClass');
-        $this->assertEquals(1, $counter);
+        $this->assertSame(1, $counter);
 
         // now the guesser callback should be present on the new gate as well
         $newGate = $gate->forUser((object) ['id' => 1]);
 
         $newGate->getPolicyFor('fooClass');
-        $this->assertEquals(2, $counter);
+        $this->assertSame(2, $counter);
 
         $newGate->getPolicyFor('fooClass');
-        $this->assertEquals(3, $counter);
+        $this->assertSame(3, $counter);
     }
 
     /**

--- a/tests/Auth/AuthDatabaseUserProviderTest.php
+++ b/tests/Auth/AuthDatabaseUserProviderTest.php
@@ -28,7 +28,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $user = $provider->retrieveById(1);
 
         $this->assertInstanceOf(GenericUser::class, $user);
-        $this->assertEquals(1, $user->getAuthIdentifier());
+        $this->assertSame(1, $user->getAuthIdentifier());
         $this->assertSame('Dayle', $user->name);
     }
 
@@ -98,7 +98,7 @@ class AuthDatabaseUserProviderTest extends TestCase
         $user = $provider->retrieveByCredentials(['username' => 'dayle', 'password' => 'foo', 'group' => ['one', 'two']]);
 
         $this->assertInstanceOf(GenericUser::class, $user);
-        $this->assertEquals(1, $user->getAuthIdentifier());
+        $this->assertSame(1, $user->getAuthIdentifier());
         $this->assertSame('taylor', $user->name);
     }
 

--- a/tests/Auth/AuthPasswordBrokerTest.php
+++ b/tests/Auth/AuthPasswordBrokerTest.php
@@ -26,7 +26,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker = $this->getMockBuilder(PasswordBroker::class)->setMethods(['getUser', 'makeErrorRedirect'])->setConstructorArgs(array_values($mocks))->getMock();
         $broker->expects($this->once())->method('getUser')->willReturn(null);
 
-        $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
+        $this->assertSame(PasswordBrokerContract::INVALID_USER, $broker->sendResetLink(['credentials']));
     }
 
     public function testIfTokenIsRecentlyCreated()
@@ -37,7 +37,7 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks['tokens']->shouldReceive('recentlyCreatedToken')->once()->with($user)->andReturn(true);
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
-        $this->assertEquals(PasswordBrokerContract::RESET_THROTTLED, $broker->sendResetLink(['foo']));
+        $this->assertSame(PasswordBrokerContract::RESET_THROTTLED, $broker->sendResetLink(['foo']));
     }
 
     public function testGetUserThrowsExceptionIfUserDoesntImplementCanResetPassword()
@@ -68,7 +68,7 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks['tokens']->shouldReceive('create')->once()->with($user)->andReturn('token');
         $user->shouldReceive('sendPasswordResetNotification')->with('token');
 
-        $this->assertEquals(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
+        $this->assertSame(PasswordBrokerContract::RESET_LINK_SENT, $broker->sendResetLink(['foo']));
     }
 
     public function testRedirectIsReturnedByResetWhenUserCredentialsInvalid()
@@ -76,7 +76,7 @@ class AuthPasswordBrokerTest extends TestCase
         $broker = $this->getBroker($mocks = $this->getMocks());
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(['creds'])->andReturn(null);
 
-        $this->assertEquals(PasswordBrokerContract::INVALID_USER, $broker->reset(['creds'], function () {
+        $this->assertSame(PasswordBrokerContract::INVALID_USER, $broker->reset(['creds'], function () {
             //
         }));
     }
@@ -88,7 +88,7 @@ class AuthPasswordBrokerTest extends TestCase
         $mocks['users']->shouldReceive('retrieveByCredentials')->once()->with(Arr::except($creds, ['token']))->andReturn($user = m::mock(CanResetPassword::class));
         $mocks['tokens']->shouldReceive('exists')->with($user, 'token')->andReturn(false);
 
-        $this->assertEquals(PasswordBrokerContract::INVALID_TOKEN, $broker->reset($creds, function () {
+        $this->assertSame(PasswordBrokerContract::INVALID_TOKEN, $broker->reset($creds, function () {
             //
         }));
     }
@@ -105,7 +105,7 @@ class AuthPasswordBrokerTest extends TestCase
             return 'foo';
         };
 
-        $this->assertEquals(PasswordBrokerContract::PASSWORD_RESET, $broker->reset(['password' => 'password', 'token' => 'token'], $callback));
+        $this->assertSame(PasswordBrokerContract::PASSWORD_RESET, $broker->reset(['password' => 'password', 'token' => 'token'], $callback));
         $this->assertEquals(['user' => $user, 'password' => 'password'], $_SERVER['__password.reset.test']);
     }
 

--- a/tests/Auth/AuthTokenGuardTest.php
+++ b/tests/Auth/AuthTokenGuardTest.php
@@ -27,10 +27,10 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
         $this->assertTrue($guard->check());
         $this->assertFalse($guard->guest());
-        $this->assertEquals(1, $guard->id());
+        $this->assertSame(1, $guard->id());
     }
 
     public function testTokenCanBeHashed()
@@ -45,10 +45,10 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
         $this->assertTrue($guard->check());
         $this->assertFalse($guard->guest());
-        $this->assertEquals(1, $guard->id());
+        $this->assertSame(1, $guard->id());
     }
 
     public function testUserCanBeRetrievedByAuthHeaders()
@@ -61,7 +61,7 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
     }
 
     public function testUserCanBeRetrievedByBearerToken()
@@ -74,7 +74,7 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
     }
 
     public function testValidateCanDetermineIfCredentialsAreValid()
@@ -124,7 +124,7 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
     }
 
     public function testUserCanBeRetrievedByBearerTokenWithCustomKey()
@@ -137,7 +137,7 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
     }
 
     public function testUserCanBeRetrievedByQueryStringVariableWithCustomKey()
@@ -152,10 +152,10 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
         $this->assertTrue($guard->check());
         $this->assertFalse($guard->guest());
-        $this->assertEquals(1, $guard->id());
+        $this->assertSame(1, $guard->id());
     }
 
     public function testUserCanBeRetrievedByAuthHeadersWithCustomField()
@@ -168,7 +168,7 @@ class AuthTokenGuardTest extends TestCase
 
         $user = $guard->user();
 
-        $this->assertEquals(1, $user->id);
+        $this->assertSame(1, $user->id);
     }
 
     public function testValidateCanDetermineIfCredentialsAreValidWithCustomKey()


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make equals assertion strict on `Auth` folder.