### PR TITLE
[9.x] Allow user-land typehinting on boot

### DIFF
--- a/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php
@@ -45,16 +45,6 @@ class EventServiceProvider extends ServiceProvider
     }
 
     /**
-     * Boot any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
      * Get the events and handlers.
      *
      * @return array

--- a/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
+++ b/src/Illuminate/Foundation/Support/Providers/RouteServiceProvider.php
@@ -53,16 +53,6 @@ class RouteServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
      * Register the callback that will be used to load the application's routes.
      *
      * @param  \Closure  $routesCallback


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR removes the `boot` method from `EventServiceProvider` and `RouteServiceProvider` classes in the `\Illuminate\Foundation\Support\Providers` namespace.

This allows users to add type-hinted dependencies on this method on the user-land Providers that extend those.

As these methods on Laravel 8 have empty bodies, and as previously you could not override them by changing their parameters signatures, this should not be a breaking change.