### PR TITLE
[8.x] Fixing the new maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -1,7 +1,7 @@
 <?php
 
 // Check if the application is in maintenance mode...
-if (! file_exists($down = __DIR__.'/../storage/framework/down')) {
+if (! file_exists($down = __DIR__.'/down')) {
     return;
 }
 


### PR DESCRIPTION
- Laravel Version: 8.x
- PHP Version: 7.4.9
- Database Driver & Version: none

### Description:

I can't use the new maintenance mode on my machine because it's caused by this [line](https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub#L4):

```php
<?php
// storage/framework/maintenance.php

// Check if the application is in maintenance mode...
if (! file_exists($down = __DIR__.'/../storage/framework/down')) { // <-------------- this one
    return;
}

// The rest of the file...
```

The `file_exists($down = __DIR__.'/../storage/framework/down')` always returns `false`.

### Steps To Reproduce:

* Disable/comment the `\App\Http\Middleware\PreventRequestsDuringMaintenance` middleware in Http Kernel
* Run `php artisan down --render="errors::503"`
* Visit the website
* You should see the maintenance page even the middleware is disabled

Related: #34085