### PR TITLE
[8.x] fixing the new maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -1,7 +1,7 @@
 <?php
 
 // Check if the application is in maintenance mode...
-if (! file_exists($down = __DIR__.'/../storage/framework/down')) {
+if (! file_exists($down = $_SERVER['DOCUMENT_ROOT'].'/../storage/framework/down')) {
     return;
 }
 


### PR DESCRIPTION
OS : window 10
Laravel Version: 8.x
PHP Version: 7.3.9
Database Driver & Version: none

Description:

according to this issue #34085
i cant use maintenance mode --render when it's down.
after change this line 

```
if (! file_exists($down = __DIR__.'/../storage/framework/down')) { // <-------------- this one
    return;
}
```
to this one
```
if (! file_exists($down = $_SERVER['DOCUMENT_ROOT'] .'/../storage/framework/down')) { // <-------------- this one
    return;
}
```
the problem fix for me.