### PR TITLE
[8.x] Add raw() method to factory

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -283,6 +283,17 @@ abstract class Factory
     }
 
     /**
+     * Get the raw attributes generated from the factory.
+     *
+     * @param  array  $attributes
+     * @return array
+     */
+    public function raw($attributes = [])
+    {
+        return $this->state($attributes)->getExpandedAttributes(null);
+    }
+
+    /**
      * Make an instance of the model with the given attributes.
      *
      * @param  \Illuminate\Database\Eloquent\Model|null  $parent

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -286,11 +286,13 @@ abstract class Factory
      * Get the raw attributes generated from the factory.
      *
      * @param  array  $attributes
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
      * @return array
      */
-    public function raw($attributes = [])
+    public function raw($attributes = [], ?Model $parent = null)
     {
-        return $this->state($attributes)->getExpandedAttributes(null);
+        return $this->state($attributes)
+            ->getExpandedAttributes($parent);
     }
 
     /**

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -125,6 +125,27 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(0, FactoryTestUser::all());
     }
 
+    public function test_basic_model_attributes_can_be_created()
+    {
+        $user = FactoryTestUserFactory::new()->raw();
+        $this->assertIsArray($user);
+
+        $user = FactoryTestUserFactory::new()->raw(['name' => 'Taylor Otwell']);
+        $this->assertIsArray($user);
+        $this->assertEquals('Taylor Otwell', $user['name']);
+    }
+
+    public function test_expanded_model_attributes_can_be_created()
+    {
+        $post = FactoryTestPostFactory::new()->raw();
+        $this->assertIsArray($post);
+
+        $post = FactoryTestPostFactory::new()->raw(['title' => 'Test Title']);
+        $this->assertIsArray($post);
+        $this->assertIsInt($post['user_id']);
+        $this->assertEquals('Test Title', $post['title']);
+    }
+
     public function test_after_creating_and_making_callbacks_are_called()
     {
         $user = FactoryTestUserFactory::new()


### PR DESCRIPTION
This re-introduces the `raw()` method which was previously available on model factories. 

I personally find this useful for when testing requests and I want to pass through valid model data, I can just get the raw attributes in an array and pass them straight into the request.

It looks like I'm not the only one who misses `raw()`:
* #34166
* https://laracasts.com/discuss/channels/testing/what-is-the-laravel-8-replacement-for-factory-raw

Thanks 🙂