### PR TITLE
[8.x] Add createMany() method to factories

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -208,9 +208,9 @@ abstract class Factory
     /**
      * Create a collection of models and persist them to the database.
      *
-     * @param array $attributes
-     *
-     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|mixed
+     * @param  array  $records
+     * @param  \Illuminate\Database\Eloquent\Model|null  $parent
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public function createMany(array $records, ?Model $parent = null)
     {

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -206,6 +206,22 @@ abstract class Factory
     }
 
     /**
+     * Create a collection of models and persist them to the database.
+     *
+     * @param array $attributes
+     *
+     * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|mixed
+     */
+    public function createMany(array $records, ?Model $parent = null)
+    {
+        $instances = array_map(function ($attribute) use ($parent) {
+            return $this->create($attribute, $parent);
+        }, $records);
+
+        return new Collection($instances);
+    }
+
+    /**
      * Set the connection name on the results and store them.
      *
      * @param  \Illuminate\Support\Collection  $results

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -121,7 +121,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             ['name' => 'Dries Vints'],
         ]);
 
-        $this->assertCount(6, $users->flatten(1)->count());
+        $this->assertCount(6, $users->flatten(1));
     }
 
     public function test_expanded_closure_attributes_are_resolved_and_passed_to_closures()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentFactoryTest extends TestCase

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -99,6 +99,30 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(10, $users);
     }
 
+    /**
+     * @test
+     */
+    public function basic_model_can_create_many()
+    {
+        $users = FactoryTestUserFactory::new()->createMany([
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Mohammed Said'],
+            ['name' => 'Dries Vints'],
+        ]);
+
+        $this->assertInstanceOf(Collection::class, $users);
+        $this->assertCount(3, $users);
+        $this->assertEquals(['Taylor Otwell', 'Mohammed Said', 'Dries Vints'], $users->pluck('name')->toArray());
+
+        $users = FactoryTestUserFactory::new()->times(2)->createMany([
+            ['name' => 'Taylor Otwell'],
+            ['name' => 'Mohammed Said'],
+            ['name' => 'Dries Vints'],
+        ]);
+
+        $this->assertCount(6, $users->flatten(1)->count());
+    }
+
     public function test_expanded_closure_attributes_are_resolved_and_passed_to_closures()
     {
         $user = FactoryTestUserFactory::new()->create([


### PR DESCRIPTION
This might be possible with the new methods added to factories in 8.x, but I see no documentation mentioning how to go about this.

My use case for this is basically to create multiple models with same attributes.

For example:
```php
$products = Product::factory()->count(10)->createMany([
    ['product_code' => 1],
    ['product_code' => 2],
]);
```