### PR TITLE
[8.x] Add the Countable interface to AssertableJsonString

### DIFF
--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -3,13 +3,14 @@
 namespace Illuminate\Testing;
 
 use ArrayAccess;
+use Countable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Assert as PHPUnit;
 use JsonSerializable;
 
-class AssertableJsonString implements ArrayAccess
+class AssertableJsonString implements ArrayAccess, Countable
 {
     /**
      * The original encoded json.
@@ -327,6 +328,16 @@ class AssertableJsonString implements ArrayAccess
             $needle.'}',
             $needle.',',
         ];
+    }
+    
+    /**
+     * Get the total number of items.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->decoded);
     }
 
     /**

--- a/src/Illuminate/Testing/AssertableJsonString.php
+++ b/src/Illuminate/Testing/AssertableJsonString.php
@@ -329,7 +329,7 @@ class AssertableJsonString implements ArrayAccess, Countable
             $needle.',',
         ];
     }
-    
+
     /**
      * Get the total number of items.
      *


### PR DESCRIPTION
This pr adds the [Countable](https://www.php.net/manual/de/class.countable.php) interface to the new `Illuminate\Testing\AssertableJsonString` class. This adds downgrade compatibility to tests counting the decoded json response:

```php
$this->assertCount(1, $response->decodeJsonResponse());
```