### PR TITLE
add storedAsset method and helper

### DIFF
--- a/src/Illuminate/Contracts/Routing/UrlGenerator.php
+++ b/src/Illuminate/Contracts/Routing/UrlGenerator.php
@@ -48,6 +48,15 @@ interface UrlGenerator
     public function asset($path, $secure = null);
 
     /**
+     * Generate the URL to an application stored asset.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function storedAsset($path, $secure = null);
+
+    /**
      * Get the URL to a named route.
      *
      * @param  string  $name

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -147,6 +147,20 @@ if (! function_exists('asset')) {
     }
 }
 
+if (! function_exists('stored_asset')) {
+    /**
+     * Generate a stored asset path for the application.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    function stored_asset($path, $secure = null)
+    {
+        return app('url')->storedAsset($path, $secure);
+    }
+}
+
 if (! function_exists('auth')) {
     /**
      * Get the available auth instance.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -284,7 +284,7 @@ class UrlGenerator implements UrlGeneratorContract
      */
     public function storedAsset($path, $secure = null)
     {
-        return $this->asset('storage/' . $path, $secure);
+        return $this->asset('storage/'.$path, $secure);
     }
 
     /**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -276,6 +276,18 @@ class UrlGenerator implements UrlGeneratorContract
     }
 
     /**
+     * Generate the URL to an application stored asset.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    public function storedAsset($path, $secure = null)
+    {
+        return $this->asset('storage/' . $path, $secure);
+    }
+
+    /**
      * Remove the index.php file from a path.
      *
      * @param  string  $root

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -47,6 +47,17 @@ class RoutingUrlGeneratorTest extends TestCase
 
         $this->assertSame('http://www.foo.com/foo/bar', $url->asset('foo/bar'));
         $this->assertSame('https://www.foo.com/foo/bar', $url->asset('foo/bar', true));
+
+        /*
+         * Test stored asset URL generation...
+         */
+        $url = new UrlGenerator(
+            new RouteCollection,
+            Request::create('http://www.foo.com/index.php/')
+        );
+
+        $this->assertSame('http://www.foo.com/storage/foo/bar', $url->storedAsset('foo/bar'));
+        $this->assertSame('https://www.foo.com/storage/foo/bar', $url->storedAsset('foo/bar', true));
     }
 
     public function testBasicGenerationWithHostFormatting()


### PR DESCRIPTION
I often give administrator the chance to upload their custom assets using Nova (or eventually some custom crafted backoffice).

In this case, I (or Nova) save in my database the relative path of those assets starting from the folder next to `storage`.

After that in my blade file i use something like `{{ asset('storage/' . $model->uploaded_image) }}`.


This PR add a new method in UrlGeneration class and in helpers.php to automatically prefix saved path with `storage` folder. The previous example could be rewritten using `{{ stored_asset($model->uploaded_image) }}` avoiding any string concatenations or interpolations
