### PR TITLE
[8.x] Added light mode meta tags tot layout.blade.php

### DIFF
--- a/src/Illuminate/Mail/resources/views/html/layout.blade.php
+++ b/src/Illuminate/Mail/resources/views/html/layout.blade.php
@@ -3,6 +3,8 @@
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="color-scheme" content="light">
+<meta name="supported-color-schemes" content="light">
 </head>
 <body>
 <style>


### PR DESCRIPTION
added both color-scheme and support-color-schemes meta tags with both only light as the default option.

This because most modern mail clients have build in dark mode support. When in dark mode the default template isn't show correctly and thus breaks the template because of the automated color changes each different mail client applies.

This has been tested and verified with macOs mail, iOS mail and Microsoft Outlook for Mac (latest).

tags that are added to the HEAD of the layout are:

<meta name="color-scheme" content="light">
<meta name="supported-color-schemes" content="light">
