### PR TITLE
[8.x] Create Faker when a Factory is created

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -126,6 +126,7 @@ abstract class Factory
         $this->afterMaking = $afterMaking ?: new Collection;
         $this->afterCreating = $afterCreating ?: new Collection;
         $this->connection = $connection;
+        $this->faker = $this->withFaker();
     }
 
     /**
@@ -346,8 +347,6 @@ abstract class Factory
      */
     protected function getRawAttributes(?Model $parent)
     {
-        $this->faker = $this->withFaker();
-
         return $this->states->pipe(function ($states) {
             return $this->for->isEmpty() ? $states : new Collection(array_merge([function () {
                 return $this->parentResolvers();


### PR DESCRIPTION
when we create a new Factory object, let's resolve the Faker instance and assign it to the local `$faker` property.

this allows us to access it everywhere in the Factory, including states, without the need for a closure.
