### PR TITLE
Fix JSON column guarding

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -241,7 +241,7 @@ trait GuardsAttributes
      */
     protected function isGuardableColumn($key)
     {
-        if ( ! isset(static::$guardableColumns[get_class($this)])) {
+        if (! isset(static::$guardableColumns[get_class($this)])) {
             static::$guardableColumns[get_class($this)] = $this->getConnection()
                 ->getSchemaBuilder()
                 ->getColumnListing($this->getTable());


### PR DESCRIPTION
Previously, the security fix introduced with #33777 broke support for mass assigning JSON columns when using `$guarded` instead of `$fillable` on an Eloquent Model.

The reason for this PR is that it is unpractical to put the name of the JSON column plus all possible keys and sub-keys and sub-sub-keys into the `$fillable` attribute, which would be required, because wildcards are not allowed. Thus, the only sane way to use such a structure is guarding the columns that should be guarded and leaving everything else open for mass assignment.

I know I could bypass the whole thing and just update via the Query Builder, but this means that all events, hooks and transformations applied will be bypassed too, which is not optimal.

This Pull Requests proposes a fix that allows for guarding JSON columns analogous to how it is used in the `$fillable` property, with the difference that all keys _and their sub-keys_ are guarded.

### Caveat

There is another issue I think needs to be discussed, which is not directly in the scope of this PR but should probably be addressed, because it makes any guarding of nested structures vulnerable. The way the mass assignment is handled right now, any key will overwrite any underlying structure in a JSON column. Any array or value you pass on any level of the nested JSON will overwrite whatever was there and not be merged. 

We took care of that ourselves by writing a trait that handles the manipulation of the structure. However, by default it's not possible to guard `'meta->languages->en'` effectively, because you can always update `['meta->languages' => ['en' => ['hello' => 'world']]]` anytime, not only bypassing the guarded key, but also deleting all other keys on that level.

The same is true for `$fillable`, albeit more restrictive. Say you want to allow adding new languages and make `'meta->languages'` fillable. Nothing keeps you from accessing or removing all language data below `meta->languages`. If you want to guard `meta->languages->private` from being overwritten, you're out of luck, because you can always do a `$model->fill(['meta->languages' => ['private' => 'boom']])` at the fillable level.



I personally think that this behavior was always there and documenting it might be enough.
The last possibility to efficiently use nested JSON fills using Eloquent should probably not be patched out, however.

I have seen other projects overriding the Model methods to change the behavior back, re-introducing the security issues the patch was supposed to mitigate. I'm not keen on following that example ;-)