### PR TITLE
[8.x] Add `castAsJson` method for database assertions

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -122,11 +122,13 @@ trait InteractsWithDatabase
     /**
      * Cast a JSON string to a database compatible type.
      *
-     * @param  string  $value
+     * @param  array|string  $value
      * @return \Illuminate\Database\Query\Expression
      */
     public function castAsJson($value)
     {
+        $value = is_array($value) ? json_encode($value) : $value;
+
         return DB::raw("CAST('$value' AS JSON)");
     }
 

--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -5,6 +5,7 @@ namespace Illuminate\Foundation\Testing\Concerns;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\Constraints\CountInDatabase;
 use Illuminate\Testing\Constraints\HasInDatabase;
 use Illuminate\Testing\Constraints\SoftDeletedInDatabase;
@@ -116,6 +117,17 @@ trait InteractsWithDatabase
     {
         return $model instanceof Model
             && in_array(SoftDeletes::class, class_uses_recursive($model));
+    }
+
+    /**
+     * Cast a JSON string to a database compatible type.
+     *
+     * @param  string  $value
+     * @return \Illuminate\Database\Query\Expression
+     */
+    public function castAsJson($value)
+    {
+        return DB::raw("CAST('$value' AS JSON)");
     }
 
     /**


### PR DESCRIPTION
database fields of type 'json' cannot be evaluated using strings, they must be cast to a database specific JSON type.

```php
$this->assertDatabaseHas('users', [
    'name' => 'Peter Parker',
    'email' => 'spidey@yahoo.com',
    'skills' => $this->castAsJson(json_encode(['web slinging', 'spidey-sense', 'sticky feet'])),
]);
```