### PR TITLE
[8.0] Added reverse helper function to illuminate\Support\Stringable class

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -541,7 +541,11 @@ class Str
      */
     public static function reverse($value)
     {
-        return strrev($value);
+        $r = '';
+        for ($i = mb_strlen($value); $i>=0; $i--) {
+            $r .= mb_substr($value, $i, 1);
+        }
+        return $r;
     }
     
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -534,6 +534,17 @@ class Str
     }
 
     /**
+     * Reverse a string.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function reverse($value)
+    {
+        return strrev($value);
+    }
+    
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $value

--- a/src/Illuminate/Support/Stringable.php
+++ b/src/Illuminate/Support/Stringable.php
@@ -484,6 +484,16 @@ class Stringable
     }
 
     /**
+     * Reverse a string.
+     *
+     ** @return static
+     */
+    public function reverse()
+    {
+        return new static(Str::reverse($this->value));
+    }
+    
+    /**
      * Begin a string with a single instance of a given value.
      *
      * @param  string  $prefix

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -369,8 +369,12 @@ class SupportStrTest extends TestCase
     {
         $this->assertSame('fooqux foobar', Str::reverse('raboof xuqoof'));
         $this->assertSame('foo/qux? foo/bar?', Str::reverse('?rab/oof ?xuq/oof'));
+        $this->assertSame('火车票', Str::reverse('票车火'));
+        $this->assertSame('日、に、本、ほん、語、ご', Str::reverse('ご、語、んほ、本、に、日'));
+        $this->assertSame('Hallöle', Str::reverse('elöllaH'));
+        $this->assertSame('Weiße Rosen sind nicht grün!', Str::reverse('!nürg thcin dnis nesoR eßieW'));
     }
-    
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -365,6 +365,12 @@ class SupportStrTest extends TestCase
         $this->assertSame('Malmö Jönköping', Str::replaceLast('', 'yyy', 'Malmö Jönköping'));
     }
 
+    public function testReverse()
+    {
+        $this->assertSame('fooqux foobar', Str::reverse('raboof xuqoof'));
+        $this->assertSame('foo/qux? foo/bar?', Str::reverse('?rab/oof ?xuq/oof'));
+    }
+    
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', Str::snake('LaravelPHPFramework'));

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -435,6 +435,12 @@ class SupportStringableTest extends TestCase
         $this->assertSame('Malmö Jönköping', (string) $this->stringable('Malmö Jönköping')->replaceLast('', 'yyy'));
     }
 
+    public function testReverse()
+    {
+        $this->assertSame('fooqux foobar', (string) $this->stringable('raboof xuqoof')->reverse());
+        $this->assertSame('foo/qux? foo/bar?', (string) $this->stringable('?rab/oof ?xuq/oof')->reverse());
+    }
+    
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', (string) $this->stringable('LaravelPHPFramework')->snake());

--- a/tests/Support/SupportStringableTest.php
+++ b/tests/Support/SupportStringableTest.php
@@ -439,8 +439,12 @@ class SupportStringableTest extends TestCase
     {
         $this->assertSame('fooqux foobar', (string) $this->stringable('raboof xuqoof')->reverse());
         $this->assertSame('foo/qux? foo/bar?', (string) $this->stringable('?rab/oof ?xuq/oof')->reverse());
+        $this->assertSame('火车票', (string) $this->stringable('票车火')->reverse());
+        $this->assertSame('日、に、本、ほん、語、ご', (string) $this->stringable('ご、語、んほ、本、に、日')->reverse());
+        $this->assertSame('Hallöle', (string) $this->stringable('elöllaH')->reverse());
+        $this->assertSame('Weiße Rosen sind nicht grün!', (string) $this->stringable('!nürg thcin dnis nesoR eßieW')->reverse());
     }
-    
+
     public function testSnake()
     {
         $this->assertSame('laravel_p_h_p_framework', (string) $this->stringable('LaravelPHPFramework')->snake());


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This simply adds the reverse function to the Stringable class. I just assumed it was on there when reaching for it today, and it wasn't. It's my first time having a chance to contribute to the laravel framework, and this seemed like a small enough section to approach with confidence. The function itself is just a convenience function that wraps an existing php function that has a weird name.

