### PR TITLE
[8.x] Update Factory.php

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -407,13 +407,11 @@ abstract class Factory
      */
     public function state($state)
     {
-        return $this->newInstance([
-            'states' => $this->states->concat([
-                is_callable($state) ? $state : function () use ($state) {
-                    return $state;
-                },
-            ]),
-        ]);
+        $this->states->push(is_callable($state) ? $state : function () use ($state) {
+            return $state;
+        });
+
+        return $this;
     }
 
     /**
@@ -436,11 +434,11 @@ abstract class Factory
      */
     public function has(self $factory, $relationship = null)
     {
-        return $this->newInstance([
-            'has' => $this->has->concat([new Relationship(
-                $factory, $relationship ?: $this->guessRelationship($factory->modelName())
-            )]),
-        ]);
+        $this->has->push(
+            new Relationship($factory, $relationship ?: $this->guessRelationship($factory->modelName()))
+        );
+
+        return $this;
     }
 
     /**
@@ -466,13 +464,13 @@ abstract class Factory
      */
     public function hasAttached(self $factory, $pivot = [], $relationship = null)
     {
-        return $this->newInstance([
-            'has' => $this->has->concat([new BelongsToManyRelationship(
-                $factory,
-                $pivot,
-                $relationship ?: Str::camel(Str::plural(class_basename($factory->modelName())))
-            )]),
-        ]);
+        $this->has->push(new BelongsToManyRelationship(
+            $factory,
+            $pivot,
+            $relationship ?: Str::camel(Str::plural(class_basename($factory->modelName())))
+        ));
+        
+        return $this;
     }
 
     /**
@@ -484,10 +482,11 @@ abstract class Factory
      */
     public function for(self $factory, $relationship = null)
     {
-        return $this->newInstance(['for' => $this->for->concat([new BelongsToRelationship(
-            $factory,
-            $relationship ?: Str::camel(class_basename($factory->modelName()))
-        )])]);
+        $this->for->push(
+            new BelongsToRelationship($factory, $relationship ?: Str::camel(class_basename($factory->modelName())))
+        );
+
+        return $this;
     }
 
     /**
@@ -498,7 +497,9 @@ abstract class Factory
      */
     public function afterMaking(Closure $callback)
     {
-        return $this->newInstance(['afterMaking' => $this->afterMaking->concat([$callback])]);
+        $this->afterMaking->push($callback);
+
+        return $this;
     }
 
     /**
@@ -509,7 +510,9 @@ abstract class Factory
      */
     public function afterCreating(Closure $callback)
     {
-        return $this->newInstance(['afterCreating' => $this->afterCreating->concat([$callback])]);
+        $this->afterCreating->push($callback);
+
+        return $this;
     }
 
     /**
@@ -551,7 +554,9 @@ abstract class Factory
      */
     public function count(?int $count)
     {
-        return $this->newInstance(['count' => $count]);
+        $this->count = $count;
+
+        return $this;
     }
 
     /**
@@ -562,26 +567,9 @@ abstract class Factory
      */
     public function connection(string $connection)
     {
-        return $this->newInstance(['connection' => $connection]);
-    }
+        $this->connection = $connection;
 
-    /**
-     * Create a new instance of the factory builder with the given mutated properties.
-     *
-     * @param  array  $arguments
-     * @return static
-     */
-    protected function newInstance(array $arguments = [])
-    {
-        return new static(...array_values(array_merge([
-            'count' => $this->count,
-            'states' => $this->states,
-            'has' => $this->has,
-            'for' => $this->for,
-            'afterMaking' => $this->afterMaking,
-            'afterCreating' => $this->afterCreating,
-            'connection' => $this->connection,
-        ], $arguments)));
+        $this;
     }
 
     /**


### PR DESCRIPTION
No longer creating a new factory when editing properties throught their respective methods.

This is causes issues when trying to implement an OOP style structure in your factories.
E.g. when an afterCreate Closure (registered in the `configure()` method) gets called, the $this->faker property is null because `$this->faker = $this->withFaker()` (inside `getRawAttributes()`) got called on a different instance of the factory.
Furthermore when setting (custom)properties to the factory within e.g. `definition()` those properties are not visible within the in `configure()` registerd closures because those properties would have been set on a different instance.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
