### PR TITLE
[8.x] Fix ImplicitToStringCast error

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1088,7 +1088,7 @@ class Builder
     /**
      * Add a where between statement to the query.
      *
-     * @param  string  $column
+     * @param  string|\Illuminate\Database\Query\Expression  $column
      * @param  array  $values
      * @param  string  $boolean
      * @param  bool  $not


### PR DESCRIPTION
Argument 1 of `Illuminate\Database\Eloquent\Builder::whereBetween` expects `string`, `Illuminate\Database\Query\Expression` provided with a `__toString` method (see https://psalm.dev/060)
example:
```
                $query->whereBetween(DB::raw('CAST(`tasks`.`created_at` AS DATE)'), [
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
