### PR TITLE
[8.x] Return response from named limiter

### DIFF
--- a/src/Illuminate/Routing/Middleware/ThrottleRequests.php
+++ b/src/Illuminate/Routing/Middleware/ThrottleRequests.php
@@ -85,7 +85,7 @@ class ThrottleRequests
         $limiterResponse = call_user_func($limiter, $request);
 
         if ($limiterResponse instanceof Response) {
-            return $limit;
+            return $limiterResponse;
         } elseif ($limiterResponse instanceof Unlimited) {
             return $next($request);
         }


### PR DESCRIPTION
If a named limiter returns a Response object, the `handleRequestUsingNamedLimiter` tried to return the unset variable `$limit`.

Instead, it should return the actual response created by the named limiter.
