### PR TITLE
[8.x] Fix the whereDoesntStartWith method

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -126,8 +126,8 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function whereDoesntStartWith($string)
     {
-        return $this->reject(function ($value, $key) use ($string) {
-            return Str::startsWith($key, $string);
+        return $this->filter(function ($value, $key) use ($string) {
+            return ! Str::startsWith($key, $string);
         });
     }
 

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -13,6 +13,8 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('class="font-bold"', (string) $bag->whereStartsWith('class'));
         $this->assertSame('font-bold', (string) $bag->whereStartsWith('class')->first());
+        $this->assertSame('name="test"', (string) $bag->whereDoesntStartWith('class'));
+        $this->assertSame('test', (string) $bag->whereDoesntStartWith('class')->first());
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4']));
         $this->assertSame('class="mt-4 font-bold" name="test"', (string) $bag->merge(['class' => 'mt-4', 'name' => 'foo']));
         $this->assertSame('class="mt-4 font-bold" id="bar" name="test"', (string) $bag->merge(['class' => 'mt-4', 'id' => 'bar']));


### PR DESCRIPTION
When `$attributes->whereDoesntStartWith()` is called from the Blade template, an exception is thrown because the `ComponentAttributeBag` class tries to use a `reject` method, but that method does not exist on the class. So this PR changes from `reject` to `filter` with negated callback.