### PR TITLE
[8.x] Bumped minimum vlucas/phpdotenv version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/routing": "^5.1",
         "symfony/var-dumper": "^5.1",
         "tijsverkoyen/css-to-inline-styles": "^2.2.2",
-        "vlucas/phpdotenv": "^5.0",
+        "vlucas/phpdotenv": "^5.2",
         "voku/portable-ascii": "^1.4.8"
     },
     "replace": {

--- a/src/Illuminate/Support/composer.json
+++ b/src/Illuminate/Support/composer.json
@@ -45,7 +45,7 @@
         "ramsey/uuid": "Required to use Str::uuid() (^4.0).",
         "symfony/process": "Required to use the composer class (^5.1).",
         "symfony/var-dumper": "Required to use the dd function (^5.1).",
-        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.0)."
+        "vlucas/phpdotenv": "Required to use the Env class and env helper (^5.2)."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Fixes all known issues with the 5.x series, including, in particular https://github.com/laravel/laravel/pull/5409.