### PR TITLE
[8.x] [RFC] PoC for making chained jobs batchable

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -164,7 +164,7 @@ class Batch implements Arrayable, JsonSerializable
         $jobs->each->withBatchId($this->id);
 
         $this->repository->transaction(function () use ($jobs) {
-            $this->repository->incrementTotalJobs($this->id, count($jobs));
+            $this->repository->incrementTotalJobs($this->id, $this->countJobs($jobs));
 
             $this->queue->connection($this->options['connection'] ?? null)->bulk(
                 $jobs->all(),
@@ -426,5 +426,17 @@ class Batch implements Arrayable, JsonSerializable
     public function jsonSerialize()
     {
         return $this->toArray();
+    }
+
+    /**
+     * @param Collection $jobs
+     *
+     * @return int
+     */
+    private function countJobs(Collection $jobs)
+    {
+        return $jobs->reduce(function (int $count, $job) {
+            return $count + count($job->chained ?? []) + 1;
+        }, 0);
     }
 }

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -191,6 +191,10 @@ trait Queueable
     {
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
+                if ($this->batchId && method_exists($next, 'withBatchId')) {
+                    $next->withBatchId($this->batchId);
+                }
+
                 $next->chained = $this->chained;
 
                 $next->onConnection($next->connection ?: $this->chainConnection);

--- a/src/Illuminate/Bus/Queueable.php
+++ b/src/Illuminate/Bus/Queueable.php
@@ -191,7 +191,7 @@ trait Queueable
     {
         if (! empty($this->chained)) {
             dispatch(tap(unserialize(array_shift($this->chained)), function ($next) {
-                if ($this->batchId && method_exists($next, 'withBatchId')) {
+                if (property_exists($this, 'batchId') && method_exists($next, 'withBatchId')) {
                     $next->withBatchId($this->batchId);
                 }
 

--- a/src/Illuminate/Foundation/Bus/PendingChain.php
+++ b/src/Illuminate/Foundation/Bus/PendingChain.php
@@ -115,6 +115,22 @@ class PendingChain
      */
     public function dispatch()
     {
+        return app(Dispatcher::class)->dispatch($this->prepareFirstJob());
+    }
+
+    /**
+     * @return CallQueuedClosure
+     */
+    public function dispatchInBatch()
+    {
+        return $this->prepareFirstJob();
+    }
+
+    /**
+     * @return CallQueuedClosure|mixed
+     */
+    public function prepareFirstJob()
+    {
         if (is_string($this->job)) {
             $firstJob = new $this->job(...func_get_args());
         } elseif ($this->job instanceof Closure) {
@@ -128,6 +144,6 @@ class PendingChain
         $firstJob->chain($this->chain);
         $firstJob->chainCatchCallbacks = $this->catchCallbacks();
 
-        return app(Dispatcher::class)->dispatch($firstJob);
+        return $firstJob;
     }
 }


### PR DESCRIPTION
This is a proof-of-concept to allow chained jobs in a batch. I didn't write any new tests for now, but made sure the old tests still ran.

## What's the intention?

I want to be able to define complex processes that consist of multiple jobs. Some of them can happen in parallel but some of them have dependencies on each other. However, I still want to be able to treat the whole batch as one "process". This is similar to the Process Manager (or Saga) pattern. 

### Example

After adding a new employee to the system, we want to start an **onboarding** process that will set up all required accounts automatically. None of these steps really have anything to do with each other per se, but together they make up the onboarding process. The onboarding isn't completed unless all of these steps have finished (hence why I want to refer to them as one unit – the batch).

Some of these steps can run in parallel but some can't run unless other steps have finished. You would be able to model this process like this:

```php
Bus::batch([
    new AddUserToGsuite($newEmployee),
    new InstallProfiles($newEmployee),
    Bus::chain([
        new CreateActiveDirectoryUser($newEmployee),
        new SyncLocalActiveDirectoryWithAzure($newEmployee),
        new AssignOffice365LicenseToEmployee($newEmployee),
    ])
]);
```

## Changes

To allow for this, I added a new method `dispatchInBatch` to `PendingChain` that only returns the first job of the chain instead of directly dispatching it. This will essentially turn this

```php
Bus::batch([
    new Job1(),
    Bus::chain([
        new Job2(),
        new Job3(),
    ])->dispatchInBatch(),
]);
```

into this

```php
Bus::batch([
    new Job1(),
    // This job works like a regular chained job. Its $chained property is correctly 
    // filled with the jobs to run after it succeeded.
    new Job2(),
]);
```

In order for the batch to correctly calculate the number of jobs it needs to run, we can no longer simply count how many entries the `$jobs` array of the batch has. Instead, for each job we have to determine if it has chained jobs and add them to the total. Otherwise the batch would end too soon (or rather, the `then` callback would fire too soon. The remaining jobs in the chain would still be executed afterwards).

I want to ensure that the jobs in the chain are also aware that they're being run inside a batch. For this reason we need to ensure that every job in the chain has the reference to the batch set correctly. The first job in the chain gets handled automatically by the batch itself. For each subsequent job we have to manually set the `$batchId` to the previous job's batch id (if it exists).

---

This code probably has a bunch of issues and edge cases I might have overlooked. I'm also not sure how nesting this even deeper would behave. Treat this as a proof-of-concept so we can discuss the idea.
