### PR TITLE
[8.x] Add new `Pipeline::setContainer` method

### DIFF
--- a/src/Illuminate/Pipeline/Pipeline.php
+++ b/src/Illuminate/Pipeline/Pipeline.php
@@ -219,6 +219,19 @@ class Pipeline implements PipelineContract
     }
 
     /**
+     * Set the container instance.
+     *
+     * @param  \Illuminate\Contracts\Container\Container  $container
+     * @return $this
+     */
+    public function setContainer(Container $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    /**
      * Handle the value returned from each pipe before passing it to the next.
      *
      * @param  mixed  $carry


### PR DESCRIPTION
This pull request adds a new `Pipeline::setContainer(Container $container)` method that allows setting the container instance after initial instantiation of the `Pipeline` class, useful since the `$container` argument in the constructor is nullable / not required so it only makes sense to allow setting it after instantiation.
