### PR TITLE
[8.x] Pass an instance of the job to queued closures

### DIFF
--- a/src/Illuminate/Queue/CallQueuedClosure.php
+++ b/src/Illuminate/Queue/CallQueuedClosure.php
@@ -66,7 +66,7 @@ class CallQueuedClosure implements ShouldQueue
      */
     public function handle(Container $container)
     {
-        $container->call($this->closure->getClosure());
+        $container->call($this->closure->getClosure(), ['job' => $this]);
     }
 
     /**


### PR DESCRIPTION
This PR passes an instance of the CallQueuedClosure job to queued closures:

```php
Bus::batch([
    new ProcessPodcast,
    function($job){
        // $job->batch()
    },
    new ReleasePodcast
])->dispatch();
```