### PR TITLE
[8.x] Define route regular expression constraints

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
 {
-    use Macroable, RouteDependencyResolverTrait;
+    use Macroable, RouteDependencyResolverTrait, RouteRegexConstraintTrait;
 
     /**
      * The URI pattern the route responds to.

--- a/src/Illuminate/Routing/RouteRegexConstraintTrait.php
+++ b/src/Illuminate/Routing/RouteRegexConstraintTrait.php
@@ -75,7 +75,7 @@ trait RouteRegexConstraintTrait
     /**
      * Set slash character as regular expression requirement on the route.
      *
-     * @param  string|array $parameter
+     * @param  string $parameter
      * @return $this
      */
     public function whereSlash(string $name)

--- a/src/Illuminate/Routing/RouteRegexConstraintTrait.php
+++ b/src/Illuminate/Routing/RouteRegexConstraintTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Illuminate\Routing;
+
+trait RouteRegexConstraintTrait
+{
+    /**
+     * Set a number as regular expression requirement on the route.
+     *
+     * @param  string $names
+     * @return $this
+     */
+    public function whereNumber(...$names)
+    {
+        foreach ($names as $name) {
+            is_string($name)
+                ? $this->where($name, '[0-9]+')
+                : $this->whereNumber(...$name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set any character as regular expression requirement on the route.
+     *
+     * @param  string|array $parameter
+     * @return $this
+     */
+    public function whereAnyChar(...$names)
+    {
+        foreach ($names as $name) {
+            is_string($name)
+                ? $this->where($name, '[A-Za-z]+')
+                : $this->whereAnyChar(...$name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set lower character as regular expression requirement on the route.
+     *
+     * @param  string|array $parameter
+     * @return $this
+     */
+    public function whereLowerChar(...$names)
+    {
+        foreach ($names as $name) {
+            is_string($name)
+                ? $this->where($name, '[a-z]+')
+                : $this->whereLowerChar(...$name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set upper character as regular expression requirement on the route.
+     *
+     * @param  string|array $parameter
+     * @return $this
+     */
+    public function whereUpperChar(...$names)
+    {
+        foreach ($names as $name) {
+            is_string($name)
+                ? $this->where($name, '[A-Z]+')
+                : $this->whereUpperChar(...$name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set slash character as regular expression requirement on the route.
+     *
+     * @param  string|array $parameter
+     * @return $this
+     */
+    public function whereSlash(string $name)
+    {
+        return $this->where($name, '.*');
+    }
+}

--- a/tests/Routing/RouteRegistrarTest.php
+++ b/tests/Routing/RouteRegistrarTest.php
@@ -575,6 +575,79 @@ class RouteRegistrarTest extends TestCase
         }
     }
 
+    public function testWhereNumberRegistration()
+    {
+        $wheres = ['foo' => '[0-9]+', 'bar' => '[0-9]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereNumber(['foo', 'bar']);
+        $this->router->get('/api/{bar}/{foo}')->whereNumber('bar', 'foo');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereSlashRegistration()
+    {
+        $wheres = ['search' => '.*'];
+
+        $this->router->get('/search/{search}')->whereSlash('search');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereAnyCharRegistration()
+    {
+        $wheres = ['foo' => '[A-Za-z]+', 'bar' => '[A-Za-z]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereAnyChar('foo', 'bar');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereLowerCharRegistration()
+    {
+        $wheres = ['foo' => '[a-z]+', 'bar' => '[a-z]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereLowerChar('foo', 'bar');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereUpperCharRegistration()
+    {
+        $wheres = ['foo' => '[A-Z]+', 'bar' => '[A-Z]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereUpperChar('foo', 'bar');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
+    public function testWhereNumberAndCharRegistration()
+    {
+        $wheres = ['foo' => '[0-9]+', 'bar' => '[A-Za-z]+'];
+
+        $this->router->get('/{foo}/{bar}')->whereNumber('foo')->whereAnyChar('bar');
+
+        /** @var \Illuminate\Routing\Route $route */
+        foreach ($this->router->getRoutes() as $route) {
+            $this->assertEquals($wheres, $route->wheres);
+        }
+    }
+
     public function testCanSetRouteName()
     {
         $this->router->as('users.index')->get('users', function () {


### PR DESCRIPTION
This allows us to define constraints for routes using whose regular expression is sometimes repetitive.

Instead of having something like this
```php
<?php

Route::get('/articles/{user}/{slug}')->where(['user' => '[0-9]+', 'slug' => '[A-Za-z]+']);
```

We would have something simpler like this.
```php
<?php
Route::get('/articles/{user}/{slug}')->whereNumber('user')->whereAnyChar('slug');
```

## Regular expression constraint methods added

```php
<?php

Route::get('/posts/{post}')->whereNumber('post');

Route::get('/posts/{post}')->whereAnyChar('post');
Route::get('/posts/{post}')->whereLowerChar('post');
Route::get('/posts/{post}')->whereUpperChar('post');

Route::get('/search/{search}')->whereSlash('search');
```