### PR TITLE
[8.x] Call the booting/booted callbacks from the container

### DIFF
--- a/src/Illuminate/Support/ServiceProvider.php
+++ b/src/Illuminate/Support/ServiceProvider.php
@@ -98,7 +98,7 @@ abstract class ServiceProvider
     public function callBootingCallbacks()
     {
         foreach ($this->bootingCallbacks as $callback) {
-            $callback();
+            $this->app->call($callback);
         }
     }
 
@@ -110,7 +110,7 @@ abstract class ServiceProvider
     public function callBootedCallbacks()
     {
         foreach ($this->bootedCallbacks as $callback) {
-            $callback();
+            $this->app->call($callback);
         }
     }
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR makes the booting/booted callbacks in a Service Provider to be called by the container, so any dependencies on those callbacks gets resolved.

This will make those methods similar to the new `RouteServiceProvider`'s `routes` method, which accepts a callback that  is resolved from the container.

It is also an alternative to PR #34260 by allowing to resolve dependencies from the container on `RouteSeviceProvider` and `AuthServiceProvider` which cannot change theirs' parent classes' `boot` methods signature.

As the callbacks were previously invoked with no parameters, I believe this is not a BC, that is why I target the 8.x branch.
