### PR TITLE
[8.x] Guess the model name when using the make:factory command

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -62,7 +62,7 @@ class FactoryMakeCommand extends GeneratorCommand
     {
         $namespaceModel = $this->option('model')
                         ? $this->qualifyModel($this->option('model'))
-                        : $this->qualifyModel('Model');
+                        : $this->qualifyModel($this->guessModelName($name));
 
         $model = class_basename($namespaceModel);
 
@@ -100,6 +100,31 @@ class FactoryMakeCommand extends GeneratorCommand
         $name = Str::finish($this->argument('name'), 'Factory');
 
         return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Guess the model name from the Factory name or return a default model name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function guessModelName($name)
+    {
+        if (Str::endsWith($name, 'Factory')) {
+            $name = substr($name, 0, -7);
+        }
+
+        $modelName = $this->qualifyModel(class_basename($name));
+
+        if (class_exists($modelName)) {
+            return $modelName;
+        }
+
+        if (is_dir(app_path('Models/'))) {
+            return 'App\Models\Model';
+        }
+
+        return 'App\Model';
     }
 
     /**


### PR DESCRIPTION
`php artisan make:factory Profession`  will attempt to find the `Profession` model in `app/` or `app/Models`.

If the model is found then the previous command will be the equivalent of typing:

`php artisan make:factory Profession --model=Profession`

If the model is not found in the models directory (either `app/Models` or `app/`) then: the default `app\Models\Model` will be used if the `app/Models` directory exists, otherwise `app\Model` will be used. 
