### PR TITLE
[8.x] Show warning when view exists when using artisan make:component

### DIFF
--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -54,7 +54,7 @@ class ComponentMakeCommand extends GeneratorCommand
     protected function writeView()
     {
         $path = $this->viewPath(
-            str_replace('.', '/', 'components.'.$this->getView())
+            str_replace('.', '/', 'components.'.$this->getView()).'.blade.php'
         );
 
         if (! $this->files->isDirectory(dirname($path))) {
@@ -67,7 +67,7 @@ class ComponentMakeCommand extends GeneratorCommand
         }
 
         file_put_contents(
-            $path.'.blade.php',
+            $path,
             '<div>
     <!-- '.Inspiring::quote().' -->
 </div>'

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -63,6 +63,7 @@ class ComponentMakeCommand extends GeneratorCommand
 
         if ($this->files->exists($path) && ! $this->option('force')) {
             $this->warn('View already exists');
+
             return;
         }
 

--- a/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
+++ b/src/Illuminate/Foundation/Console/ComponentMakeCommand.php
@@ -61,6 +61,11 @@ class ComponentMakeCommand extends GeneratorCommand
             $this->files->makeDirectory(dirname($path), 0777, true, true);
         }
 
+        if ($this->files->exists($path) && ! $this->option('force')) {
+            $this->warn('View already exists');
+            return;
+        }
+
         file_put_contents(
             $path.'.blade.php',
             '<div>


### PR DESCRIPTION
When building views I often start building them with anonymous components, once I have the need for more logic I create the actual component class. I noticed however when using the `make:component` command it overwrites the already existing component view without any warning.

This change ensures a warning is shown to the user when the view already exists and prevents it from being overwritten. When the `--force` flag is used the exists check is ignored and the view is overwritten like before.