### PR TITLE
[8.x] Allow clearing an SQS queue

### DIFF
--- a/src/Illuminate/Queue/SqsQueue.php
+++ b/src/Illuminate/Queue/SqsQueue.php
@@ -3,11 +3,12 @@
 namespace Illuminate\Queue;
 
 use Aws\Sqs\SqsClient;
+use Illuminate\Contracts\Queue\ClearableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Jobs\SqsJob;
 use Illuminate\Support\Str;
 
-class SqsQueue extends Queue implements QueueContract
+class SqsQueue extends Queue implements QueueContract, ClearableQueue
 {
     /**
      * The Amazon SQS instance.
@@ -137,6 +138,23 @@ class SqsQueue extends Queue implements QueueContract
                 $this->connectionName, $queue
             );
         }
+    }
+
+    /**
+     * Delete all of the jobs from the queue.
+     *
+     * @param  string  $queue
+     * @return int
+     */
+    public function clear($queue)
+    {
+        $size = $this->size($queue);
+
+        $this->sqs->purgeQueue([
+            'QueueUrl' => $this->getQueue($queue),
+        ]);
+
+        return $size;
     }
 
     /**


### PR DESCRIPTION
This PR allows using the `queue:clear` command to clear an SQS queue.

## Important Notice

Messages sent to the queue after you call PurgeQueue might be deleted while the queue is being purged. The message deletion process takes up to 60 seconds.

So in the docs we should hint about that so people make sure the don't enqueue any new jobs for 6o seconds after the clear an SQS queue. Otherwise those new jobs will be purged as well.

