### PR TITLE
[8.x] auto handle `Jsonable` values passed to `castAsJson()`

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithDatabase.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Foundation\Testing\Concerns;
 
+use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
@@ -127,7 +128,11 @@ trait InteractsWithDatabase
      */
     public function castAsJson($value)
     {
-        $value = is_array($value) ? json_encode($value) : $value;
+        if ($value instanceof Jsonable) {
+            $value = $value->toJson();
+        } elseif (is_array($value)) {
+            $value = json_encode($value);
+        }
 
         return DB::raw("CAST('$value' AS JSON)");
     }


### PR DESCRIPTION
My most common use case for using the `castAsJson()` method is for fields I have cast as `Collection`s on my Model.

```php
$this->assertDatabaseHas('users', [
    'name' => $user->name,
    'email' => $user->email,
    'nicknames' => $this->castAsJson($user->nicknames->toJson()),
];
```

With this change, the `toJson()` method will be called for the user automatically if the value is a `Jsonable` object.
