### PR TITLE
[8.x] Add doc blocks for HTTP facade assertions

### DIFF
--- a/src/Illuminate/Support/Facades/Http.php
+++ b/src/Illuminate/Support/Facades/Http.php
@@ -37,6 +37,11 @@ use Illuminate\Http\Client\Factory;
  * @method static \Illuminate\Http\Client\Response put(string $url, array $data = [])
  * @method static \Illuminate\Http\Client\Response send(string $method, string $url, array $options = [])
  * @method static \Illuminate\Http\Client\ResponseSequence fakeSequence(string $urlPattern = '*')
+ * @method static void assertSent(callable $callback)
+ * @method static void assertNotSent(callable $callback)
+ * @method static void assertNothingSent()
+ * @method static void assertSentCount(int $count)
+ * @method static void assertSequencesAreEmpty()
  *
  * @see \Illuminate\Http\Client\Factory
  */


### PR DESCRIPTION
This allows IDEs like PHPStorm to autocomplete the assertion helpers on the HTTP facade