### PR TITLE
Add crossJoinSub method to the query builder

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -619,6 +619,26 @@ class Builder
     }
 
     /**
+     * Add a subquery cross join to the query.
+     *
+     * @param  \Closure|\Illuminate\Database\Query\Builder|string  $query
+     * @param  string  $as
+     * @return $this
+     */
+    public function crossJoinSub($query, $as)
+    {
+        [$query, $bindings] = $this->createSub($query);
+
+        $expression = '('.$query.') as '.$this->grammar->wrapTable($as);
+
+        $this->addBinding($bindings, 'join');
+
+        $this->joins[] = $this->newJoinClause($this, 'cross', new Expression($expression));
+
+        return $this;
+    }
+
+    /**
      * Get a new join clause.
      *
      * @param  \Illuminate\Database\Query\Builder  $parentQuery

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1502,6 +1502,13 @@ class DatabaseQueryBuilderTest extends TestCase
         $this->assertSame('select * from "tableB" cross join "tableA" on "tableA"."column1" = "tableB"."column2"', $builder->toSql());
     }
 
+    public function testCrossJoinSubs()
+    {
+        $builder = $this->getBuilder();
+        $builder->selectRaw("(sale / overall.sales) * 100 AS percent_of_total")->from('sales')->crossJoinSub($this->getBuilder()->selectRaw('SUM(sale) AS sales')->from('sales'), 'overall');
+        $this->assertSame('select (sale / overall.sales) * 100 AS percent_of_total from "sales" cross join (select SUM(sale) AS sales from "sales") as "overall"', $builder->toSql());
+    }
+
     public function testComplexJoin()
     {
         $builder = $this->getBuilder();


### PR DESCRIPTION
The builder contains a leftJoinSub and rightJoinSub but is missing a crossJoinSub. I needed this as I was building a query similar to the one I added to the test. I assume I'm not the only one who will find this method useful.

My previous pull request merge was failing because I did not select master branch 🤦🏻‍♂️ sorry about that.