### PR TITLE
[8.x] Maintenance mode: Fix empty Retry-After header

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -41,7 +41,9 @@ if (isset($data['redirect']) && $_SERVER['REQUEST_URI'] !== $data['redirect']) {
 
 // Output the prerendered template...
 http_response_code($data['status'] ?? 503);
-header('Retry-After: '.$data['retry']);
+if (isset($data['retry'])) {
+    header('Retry-After: '.$data['retry']);
+}
 
 echo $data['template'];
 

--- a/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
+++ b/src/Illuminate/Foundation/Console/stubs/maintenance-mode.stub
@@ -41,6 +41,7 @@ if (isset($data['redirect']) && $_SERVER['REQUEST_URI'] !== $data['redirect']) {
 
 // Output the prerendered template...
 http_response_code($data['status'] ?? 503);
+
 if (isset($data['retry'])) {
     header('Retry-After: '.$data['retry']);
 }


### PR DESCRIPTION
When maintenance mode is enabled with a prerendered template, an empty `Retry-After` header is sent when the site is accessed.

This is because if `--render` is the only option set, the Retry-After header is always sent, regardless of whether `--retry` was set.

Let's check for the presence of a `retry` value before sending the `Retry-After` header.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
