### PR TITLE
[8.x] Consistent Morph Map Repository

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -725,13 +725,7 @@ trait HasRelationships
      */
     public function getMorphClass()
     {
-        $morphMap = Relation::morphMap();
-
-        if (! empty($morphMap) && in_array(static::class, $morphMap)) {
-            return array_search(static::class, $morphMap, true);
-        }
-
-        return static::class;
+        return Relation::getMorphedAlias(static::class);
     }
 
     /**

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -370,6 +370,21 @@ abstract class Relation
     }
 
     /**
+     * Get the alias associated with a custom polymorphic model.
+     *
+     * @param  string  $model
+     * @return string
+     */
+    public static function getMorphedAlias($model)
+    {
+        if (! empty(static::$morphMap) && in_array($model, static::$morphMap)) {
+            return array_search($model, static::$morphMap, true);
+        }
+
+        return $model;
+    }
+
+    /**
      * Handle dynamic method calls to the relationship.
      *
      * @param  string  $method

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1186,6 +1186,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertSame('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
+        $this->assertEquals(EloquentModelStub::class, Relation::getMorphedAlias(EloquentModelStub::class));
     }
 
     public function testCorrectMorphClassIsReturned()
@@ -1195,6 +1196,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         try {
             $this->assertEquals(EloquentModelStub::class, $model->getMorphClass());
+            $this->assertEquals(EloquentModelStub::class, Relation::getMorphedAlias(EloquentModelStub::class));
         } finally {
             Relation::morphMap([], false);
         }
@@ -1224,6 +1226,7 @@ class DatabaseEloquentModelTest extends TestCase
         $this->assertSame('save_stub.morph_id', $relation->getQualifiedForeignKeyName());
         $this->assertSame('save_stub.morph_type', $relation->getQualifiedMorphType());
         $this->assertEquals(EloquentModelStub::class, $relation->getMorphClass());
+        $this->assertEquals(EloquentModelStub::class, Relation::getMorphedAlias(EloquentModelStub::class));
     }
 
     public function testBelongsToCreatesProperRelation()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1196,6 +1196,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         try {
             $this->assertEquals(EloquentModelStub::class, $model->getMorphClass());
+            $this->assertEquals('alias', Relation::getMorphedAlias('AnotherModel'));
             $this->assertEquals(EloquentModelStub::class, Relation::getMorphedAlias(EloquentModelStub::class));
         } finally {
             Relation::morphMap([], false);


### PR DESCRIPTION
### Statement

Given we have registered a custom morph map,
```php
Relation::morphMap([
    'post' => App\Models\Post::class,
]);
```

While trying to get the Model name associated with a given Morph Alias, Laravel already has,

```php
Relation::getMorphedModel('post'); // -> 'App\Models\Post'
```

Which is perfect. But we cannot fetch the reverse the same way.

To fetch the reverse we would have to create a new instance of the Model and then get the morph alias from there.

```php
$post = new Post();

$post->getMorphClass(); // -> 'post'
```

Which feels a bit odd that trying to get value from a single `$morphMap` repository (which is just an array) we need 2 different ways.

### Proposal

In this PR I was hoping to add a small helper method on the `Relation` abstract class itself to get everything related to Morph Map in one place.

```php
Relation::getMorphedModel('post'); // -> 'App\Models\Post'

// Now:
Relation::getMorphedAlias(App\Models\Post::class); // -> 'post'
```
