### PR TITLE
[8.x] Allow schema path option on migrate:fresh

### DIFF
--- a/src/Illuminate/Database/Console/Migrations/FreshCommand.php
+++ b/src/Illuminate/Database/Console/Migrations/FreshCommand.php
@@ -48,6 +48,7 @@ class FreshCommand extends Command
             '--database' => $database,
             '--path' => $this->input->getOption('path'),
             '--realpath' => $this->input->getOption('realpath'),
+            '--schema-path' => $this->input->getOption('schema-path'),
             '--force' => true,
             '--step' => $this->option('step'),
         ]));
@@ -98,6 +99,7 @@ class FreshCommand extends Command
             ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
             ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
             ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+            ['schema-path', null, InputOption::VALUE_OPTIONAL, 'The path to a schema dump file'],
             ['seed', null, InputOption::VALUE_NONE, 'Indicates if the seed task should be re-run'],
             ['seeder', null, InputOption::VALUE_OPTIONAL, 'The class name of the root seeder'],
             ['step', null, InputOption::VALUE_NONE, 'Force the migrations to be run so they can be rolled back individually'],


### PR DESCRIPTION
The `migrate:fresh` command creates the database from scratch, it will use the schema dump file if available.

Since the base `migrate` command supports an argument to the path of the schema file, the `migrate:fresh` command can also accept that argument.