### PR TITLE
[8.x] Fix bug with error handling in closure scheduled tasks

### DIFF
--- a/src/Illuminate/Console/Scheduling/CallbackEvent.php
+++ b/src/Illuminate/Console/Scheduling/CallbackEvent.php
@@ -77,6 +77,8 @@ class CallbackEvent extends Event
             $response = is_object($this->callback)
                         ? $container->call([$this->callback, '__invoke'], $this->parameters)
                         : $container->call($this->callback, $this->parameters);
+
+            $this->exitCode = $response === false ? 1 : 0;
         } catch (Throwable $e) {
             $this->exitCode = 1;
 
@@ -86,8 +88,6 @@ class CallbackEvent extends Event
 
             parent::callAfterCallbacks($container);
         }
-
-        $this->exitCode = $response === false ? 1 : 0;
 
         return $response;
     }

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -25,7 +25,6 @@ class CallbackEventTest extends TestCase
         $success = null;
 
         $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
-
         }))->onSuccess(function () use (&$success) {
             $success = true;
         })->onFailure(function () use (&$success) {

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -22,29 +22,48 @@ class CallbackEventTest extends TestCase
 
     public function testDefaultResultIsSuccess()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
+        $success = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
+
+        }))->onSuccess(function () use ( &$success ) {
+            $success = true;
+        })->onFailure(function () use ( &$success ) {
+            $success = false;
         });
 
         $event->run($this->app);
 
-        $this->assertSame(0, $event->exitCode);
+        $this->assertTrue($success);
     }
 
     public function testFalseResponseIsFailure()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
+        $success = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
             return false;
+        }))->onSuccess(function () use ( &$success ) {
+            $success = true;
+        })->onFailure(function () use ( &$success ) {
+            $success = false;
         });
 
         $event->run($this->app);
 
-        $this->assertSame(1, $event->exitCode);
+        $this->assertFalse($success);
     }
 
     public function testExceptionIsFailure()
     {
-        $event = new CallbackEvent(m::mock(EventMutex::class), function () {
+        $success = null;
+
+        $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
             throw new \Exception;
+        }))->onSuccess(function () use ( &$success ) {
+            $success = true;
+        })->onFailure(function () use ( &$success ) {
+            $success = false;
         });
 
         try {
@@ -52,7 +71,7 @@ class CallbackEventTest extends TestCase
         } catch (Exception $e) {
         }
 
-        $this->assertSame(1, $event->exitCode);
+        $this->assertFalse($success);
     }
 
     public function testExceptionBubbles()

--- a/tests/Integration/Console/Scheduling/CallbackEventTest.php
+++ b/tests/Integration/Console/Scheduling/CallbackEventTest.php
@@ -26,9 +26,9 @@ class CallbackEventTest extends TestCase
 
         $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
 
-        }))->onSuccess(function () use ( &$success ) {
+        }))->onSuccess(function () use (&$success) {
             $success = true;
-        })->onFailure(function () use ( &$success ) {
+        })->onFailure(function () use (&$success) {
             $success = false;
         });
 
@@ -43,9 +43,9 @@ class CallbackEventTest extends TestCase
 
         $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
             return false;
-        }))->onSuccess(function () use ( &$success ) {
+        }))->onSuccess(function () use (&$success) {
             $success = true;
-        })->onFailure(function () use ( &$success ) {
+        })->onFailure(function () use (&$success) {
             $success = false;
         });
 
@@ -60,9 +60,9 @@ class CallbackEventTest extends TestCase
 
         $event = (new CallbackEvent(m::mock(EventMutex::class), function () {
             throw new \Exception;
-        }))->onSuccess(function () use ( &$success ) {
+        }))->onSuccess(function () use (&$success) {
             $success = true;
-        })->onFailure(function () use ( &$success ) {
+        })->onFailure(function () use (&$success) {
             $success = false;
         });
 


### PR DESCRIPTION
This PR fixes a bug with #33914. Previously I was setting the `exitCode` at the end, right before returning `$response`. This means though that the `afterCallbacks` including `onSuccess` and `onFailure` were run _before_ the exit code was set. Oops.

https://github.com/laravel/framework/blob/5a748eecae35fd453e0b1e4d4b6f4fadf0d3e7ac/src/Illuminate/Console/Scheduling/CallbackEvent.php#L87-L90

This PR moves just the one line of code so that the `exitCode` is set right away, inside the main `try` block. I've also updated the integration test to actually test with callbacks, instead of just checking the `exitCode`.