### PR TITLE
[6.x] Add an UnfilledIf validation rule to Validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -505,4 +505,19 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+
+
+    /**
+     * Replace all place-holders for the unfilled_if rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceUnfilledIf($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceRequiredIf($message, $attribute, $rule, $parameters);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -506,7 +506,6 @@ trait ReplacesAttributes
         return str_replace(':values', implode(', ', $parameters), $message);
     }
 
-
     /**
      * Replace all place-holders for the unfilled_if rule.
      *

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1719,6 +1719,27 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the given attribute is unfilled if another field is present.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateUnfilledIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'unfilled_if');
+
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
+
+        if (!is_null($other)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is a valid URL.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1732,7 +1732,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (!is_null($other)) {
+        if (! is_null($other)) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -189,7 +189,7 @@ class Validator implements ValidatorContract
         'RequiredWith', 'RequiredWithAll', 'RequiredWithout', 'RequiredWithoutAll',
         'RequiredIf', 'RequiredUnless', 'Confirmed', 'Same', 'Different', 'Unique',
         'Before', 'After', 'BeforeOrEqual', 'AfterOrEqual', 'Gt', 'Lt', 'Gte', 'Lte',
-        'ExcludeIf', 'ExcludeUnless',
+        'ExcludeIf', 'ExcludeUnless', 'UnfilledIf',
     ];
 
     /**

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5417,6 +5417,24 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['data.1.date' => ['validation.date'], 'data.*.date' => ['validation.date']], $validator->messages()->toArray());
     }
 
+    public function testValidateUnfilledIf()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes', 'last_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'sometimes', 'first_name' => 'unfilled_if:name', 'last_name' => 'unfilled_if:name']);
+        $this->assertTrue($v->fails());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);


### PR DESCRIPTION
Adding this rule allows for validation rules that I don't believe are currently supported in L6-8. Specifically it allows creating a validation rule that says "Don't use field X if field Y is passed."

So for instance:
```
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            'size' => 'nullable|integer',
            'width' => [
                'unfilled_if:size',
            ],
            'height' => [
                'unfilled_if:size',
            ],
        ];
    }
```

Note: This is a super simplified example, instead of `nullable` you'd probably want to use `required_without_all:width,height` or something similar IRL depending on use-case.

Then if the URL uses: `http://myapp.test/avatar?name=Danno+Boone&size=96&width=64`

The error would be:
```
{
  "width": [
    "The width field must not be used when size field is passed."
  ]
}
```

PR also adds tests to cover new validation rule, and I have a translation string prepared to send to the main laravel repo.

```
    'unfilled_if' => 'The :attribute field must not be used when :other field is passed.',
```