### PR TITLE
[8.x] Add unfilled_if & unfilled_with validation rules to Validator

### DIFF
--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -519,4 +519,18 @@ trait ReplacesAttributes
     {
         return $this->replaceRequiredIf($message, $attribute, $rule, $parameters);
     }
+
+    /**
+     * Replace all place-holders for the unfilled_with rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceUnfilledWith($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceRequiredWith($message, $attribute, $rule, $parameters);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -505,4 +505,19 @@ trait ReplacesAttributes
 
         return str_replace(':values', implode(', ', $parameters), $message);
     }
+
+
+    /**
+     * Replace all place-holders for the unfilled_if rule.
+     *
+     * @param  string  $message
+     * @param  string  $attribute
+     * @param  string  $rule
+     * @param  array  $parameters
+     * @return string
+     */
+    protected function replaceUnfilledIf($message, $attribute, $rule, $parameters)
+    {
+        return $this->replaceRequiredIf($message, $attribute, $rule, $parameters);
+    }
 }

--- a/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ReplacesAttributes.php
@@ -506,7 +506,6 @@ trait ReplacesAttributes
         return str_replace(':values', implode(', ', $parameters), $message);
     }
 
-
     /**
      * Replace all place-holders for the unfilled_if rule.
      *

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1727,7 +1727,7 @@ trait ValidatesAttributes
     }
 
     /**
-     * Validate the given attribute is unfilled if another field is present.
+     * Validate that an attribute is unfilled when another attribute has a given value.
      *
      * @param  string  $attribute
      * @param  mixed  $value
@@ -1740,8 +1740,27 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (! is_null($other)) {
-            return false;
+        if (in_array($other, $values)) {
+            return ! $this->validateRequired($attribute, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that an attribute is unfilled when any other attribute exists.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateUnfilledWith($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'unfilled_with');
+
+        if (! $this->allFailingRequired($parameters)) {
+            return ! $this->validateRequired($attribute, $value);
         }
 
         return true;

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1740,7 +1740,7 @@ trait ValidatesAttributes
 
         [$values, $other] = $this->prepareValuesAndOther($parameters);
 
-        if (!is_null($other)) {
+        if (! is_null($other)) {
             return false;
         }
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -1727,6 +1727,27 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate the given attribute is unfilled if another field is present.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  mixed  $parameters
+     * @return bool
+     */
+    public function validateUnfilledIf($attribute, $value, $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'unfilled_if');
+
+        [$values, $other] = $this->prepareValuesAndOther($parameters);
+
+        if (!is_null($other)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Validate that an attribute is a valid URL.
      *
      * @param  string  $attribute

--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -221,6 +221,7 @@ class Validator implements ValidatorContract
         'RequiredWithout',
         'RequiredWithoutAll',
         'Same',
+        'UnfilledIf',
         'Unique',
     ];
 

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5571,6 +5571,24 @@ class ValidationValidatorTest extends TestCase
         $this->assertSame(['data.1.date' => ['validation.date'], 'data.*.date' => ['validation.date']], $validator->messages()->toArray());
     }
 
+    public function testValidateUnfilledIf()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes', 'last_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'sometimes', 'first_name' => 'unfilled_if:name', 'last_name' => 'unfilled_if:name']);
+        $this->assertTrue($v->fails());
+    }
+
     protected function getTranslator()
     {
         return m::mock(TranslatorContract::class);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -5573,20 +5573,76 @@ class ValidationValidatorTest extends TestCase
 
     public function testValidateUnfilledIf()
     {
-        $v = new Validator($this->getIlluminateArrayTranslator(), [], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $basicUnfilledRules = [
+            'mode' => 'required',
+            'full_name' => 'unfilled_if:mode,split',
+            'first_name' => 'required_if:mode,split',
+            'last_name' => 'required_if:mode,split',
+        ];
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['mode' => 'none'], $basicUnfilledRules);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'mode' => 'split',
+            'first_name' => 'Richard',
+            'last_name' => 'Bobby',
+        ], $basicUnfilledRules);
         $this->assertTrue($v->passes());
 
-        $v = new Validator($this->getIlluminateArrayTranslator(), ['first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes', 'last_name' => 'sometimes']);
-        $this->assertTrue($v->passes());
-
-        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'unfilled_if:first_name', 'first_name' => 'sometimes']);
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'mode' => 'split',
+            'full_name' => 'Ricky Bobby',
+            'first_name' => 'Richard',
+            'last_name' => 'Bobby',
+        ], $basicUnfilledRules);
         $this->assertTrue($v->fails());
 
-        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'sometimes', 'first_name' => 'unfilled_if:name', 'last_name' => 'unfilled_if:name']);
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'mode' => 'split',
+            'full_name' => 'Ricky Bobby',
+            'last_name' => 'Bobby',
+        ], $basicUnfilledRules);
         $this->assertTrue($v->fails());
+
+        $basicUnfilledRules = [
+            'mode' => 'required',
+            'full_name' => 'required_if:mode,single',
+            'first_name' => 'unfilled_if:mode,single',
+            'last_name' => 'unfilled_if:mode,single',
+        ];
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'mode' => 'single',
+            'full_name' => 'Ricky Bobby',
+        ], $basicUnfilledRules);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), [
+            'mode' => 'single',
+            'full_name' => 'Ricky Bobby',
+            'last_name' => 'Bobby',
+        ], $basicUnfilledRules);
+        $this->assertTrue($v->fails());
+    }
+
+    public function testValidateUnfilledWith()
+    {
+        $v = new Validator($this->getIlluminateArrayTranslator(), [], ['name' => 'unfilled_with:first_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby'], ['name' => 'unfilled_with:first_name,last_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robertson'], ['name' => 'unfilled_with:first_name,last_name', 'first_name' => 'sometimes', 'last_name' => 'sometimes']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'last_name' => 'Robertson'], ['name' => 'unfilled_with:first_name,last_name', 'first_name' => 'sometimes']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['name' => 'Ricky Bobby', 'first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'sometimes', 'first_name' => 'unfilled_with:name', 'last_name' => 'unfilled_with:name']);
+        $this->assertTrue($v->fails());
+
+        $v = new Validator($this->getIlluminateArrayTranslator(), ['first_name' => 'Richard', 'last_name' => 'Robert'], ['name' => 'sometimes', 'first_name' => 'unfilled_with:name', 'last_name' => 'unfilled_with:name']);
+        $this->assertTrue($v->passes());
     }
 
     protected function getTranslator()


### PR DESCRIPTION
# New Rules
* `unfilled_if`: A rule to refuse a field's input when another field is a given value. Complements: `required_if` & `filled`.
* `unfilled_with`: A to refuse a fields's input when other fields are passed. Complements: `required_with` & `filled`.

Adding these rules can help add more utility to validation to disallow field input when other specific field values, or fields, are passed.

# Example

## Rule usages:
```
    /**
     * Get the validation rules that apply to the request.
     *
     * @return array
     */
    public function rules()
    {
        return [
            'shape' => 'sometimes',
            'size' => 'nullable|integer',
            'width' => [
                'unfilled_with:size|unfilled_if:shape,square',
            ],
            'height' => [
                'unfilled_with:size|unfilled_if:shape,square',
            ],
        ];
    }
```

Note: This is a super simplified example, instead of `nullable` you'd probably want to use `required_without_all:width,height` or something similar IRL depending on use-case.

## URL
Examples Request URL: `http://myapp.test/avatar?name=Danno+Boone&size=96&width=64`

## Error
```
{
  "width": [
    "The width field must not be used when size field is passed."
  ]
}
```

PR also adds tests to cover new validation rules, and I have a translation string prepared to send to the main laravel repo.

```
    'unfilled_if' => 'The :attribute field must not be used when :other field is :value.',
    'unfilled_with' => 'The :attribute field must not be used when :values is present.',
```