### PR TITLE
[8.x] Remove `--column-statistics` for MariaDB schema dump

### DIFF
--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -81,9 +81,10 @@ class MySqlSchemaState extends SchemaState
      */
     protected function baseDumpCommand()
     {
+        $columnStatistics = $this->connection->isMaria() ? '' : '--column-statistics=0';
         $gtidPurged = $this->connection->isMaria() ? '' : '--set-gtid-purged=OFF';
 
-        return 'mysqldump '.$gtidPurged.' --column-statistics=0 --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" "${:LARAVEL_LOAD_DATABASE}"';
+        return 'mysqldump '.$gtidPurged.' '.$columnStatistics.' --skip-add-drop-table --skip-add-locks --skip-comments --skip-set-charset --tz-utc --host="${:LARAVEL_LOAD_HOST}" --port="${:LARAVEL_LOAD_PORT}" --user="${:LARAVEL_LOAD_USER}" --password="${:LARAVEL_LOAD_PASSWORD}" "${:LARAVEL_LOAD_DATABASE}"';
     }
 
     /**


### PR DESCRIPTION
Fixes #32552.

When `php artisan schema:dump` is run with a MariaDB connection, the warning message
```
mysqldump: unknown variable 'column-statistics=0'
```
appears, but the dump is otherwise successful.

This is because the [`--column-statistics` flag is MySQL specific](https://dev.mysql.com/doc/refman/8.0/en/mysqldump.html#option_mysqldump_column-statistics), and [does not exist in MariaDB's version of `mysqldump`](https://mariadb.com/kb/en/mysqldump/#options).

Let's remove the `--column-statistics` flag from the `schema:dump` command when it is run against a MariaDB connection.

There should be no issues with removing the flag in MariaDB as the flag has no effect otherwise and `schema:dump` still functions correctly with MariaDB even with the flag removed.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
