### PR TITLE
[8.x] Add `takeUntilTimeout` method to the lazy collection

### DIFF
--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -1215,7 +1215,7 @@ class LazyCollection implements Enumerable
     }
 
     /**
-     * Take items in the collection until it reaches the given time.
+     * Take items in the collection until a given point in time.
      *
      * @param  \DateTimeInterface  $timeout
      * @return static

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -4,6 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayIterator;
 use Closure;
+use DateTime;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -1214,6 +1215,21 @@ class LazyCollection implements Enumerable
     }
 
     /**
+     * Take items in the collection until it reaches the given time.
+     *
+     * @param  \DateTime  $timeout
+     * @return static
+     */
+    public function takeUntilTimeout(DateTime $timeout)
+    {
+        $timeout = $timeout->getTimestamp();
+
+        return $this->takeWhile(function () use ($timeout) {
+            return $this->now() < $timeout;
+        });
+    }
+
+    /**
      * Take items in the collection while the given condition is met.
      *
      * @param  mixed  $value
@@ -1384,5 +1400,15 @@ class LazyCollection implements Enumerable
         return new static(function () use ($method, $params) {
             yield from $this->collect()->$method(...$params);
         });
+    }
+
+    /**
+     * Get the current time.
+     *
+     * @return int
+     */
+    protected function now()
+    {
+        return time();
     }
 }

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -4,7 +4,7 @@ namespace Illuminate\Support;
 
 use ArrayIterator;
 use Closure;
-use DateTime;
+use DateTimeInterface;
 use Illuminate\Support\Traits\EnumeratesValues;
 use Illuminate\Support\Traits\Macroable;
 use IteratorAggregate;
@@ -1217,10 +1217,10 @@ class LazyCollection implements Enumerable
     /**
      * Take items in the collection until it reaches the given time.
      *
-     * @param  \DateTime  $timeout
+     * @param  \DateTimeInterface  $timeout
      * @return static
      */
-    public function takeUntilTimeout(DateTime $timeout)
+    public function takeUntilTimeout(DateTimeInterface $timeout)
     {
         $timeout = $timeout->getTimestamp();
 


### PR DESCRIPTION
This PR adds a `takeUntilTimeout` to the `LazyCollection` class, which lets you stop a long running process after a given timeout:

```php
$lazyCollection
    ->takeUntilTimeout(now()->add(2, 'minutes'))
    ->each(fn ($item) => doSomethingThatMayTakeSomeTime($item));

// ^^ This will only process items for up to 2 minutes ^^
```

---

This is **especially useful for Laravel Vapor apps**, since AWS will kill any long-running processes (after 15 minutes). See [here](https://twitter.com/freekmurze/status/1306181930824667136) for an example.

Imagine you have a huge list of invoices in your DB, which need to be submitted one by one:

```php
class SendInvoices implements ShouldQueue
{
    use InteractsWithQueue, Queueable;

    public function handle()
    {
        Invoice::pending()->cursor()
            ->takeUntilTimeout(Carbon::createFromTimestamp(LARAVEL_START)->add(14, 'minutes'))
            ->each(fn ($invoice) => $invoice->submit());

        if (Invoice::pending()->exists()) {
            $this->release();
        }
    }
}
```

This will submit as many invoices as there is time for, and then dispatch the job again to keep going.

---

If you can submit invoices in bulk, you can even chunk them before the `takeUntilTimeout` call:

```php
Invoice::pending()->cursor()
    ->chunk(100)
    ->takeUntilTimeout(Carbon::createFromTimestamp(LARAVEL_START)->add(14, 'minutes'))
    ->each(fn ($invoices) => submit_invoices($invoices->all()));
```

---

**P.S.** This would've been _ssoooo_ much easier to test with `Carbon`, especially with the new time travel stuff. But it makes no sense to add `Carbon` as a dependency to `illuminate/collections` just for this.

I really hate all that stupid Mockery code I had to write, but I see no other way. Gives you a new level of appreciation for proper time travel :smile: 