### PR TITLE
[9.x] Make setUser nullable in GuardHelpers

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -88,7 +88,7 @@ trait GuardHelpers
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function setUser(AuthenticatableContract $user)
+    public function setUser(?AuthenticatableContract $user)
     {
         $this->user = $user;
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -825,7 +825,7 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     public function setUser(?AuthenticatableContract $user)
     {
         if (is_null($user)) {
-            $this->logout(); 
+            $this->logout();
         } else {
             $this->user = $user;
 

--- a/src/Illuminate/Auth/SessionGuard.php
+++ b/src/Illuminate/Auth/SessionGuard.php
@@ -822,13 +822,17 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return $this
      */
-    public function setUser(AuthenticatableContract $user)
+    public function setUser(?AuthenticatableContract $user)
     {
-        $this->user = $user;
+        if (is_null($user)) {
+            $this->logout(); 
+        } else {
+            $this->user = $user;
 
-        $this->loggedOut = false;
+            $this->loggedOut = false;
 
-        $this->fireAuthenticatedEvent($user);
+            $this->fireAuthenticatedEvent($user);
+        }
 
         return $this;
     }

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -46,5 +46,5 @@ interface Guard
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
      * @return void
      */
-    public function setUser(Authenticatable $user);
+    public function setUser(?Authenticatable $user);
 }


### PR DESCRIPTION
Currently resetting the user of a Guard (eg: after a logout) requires rewriting a ton of the core code just because it doesn't allow `null` to be set as the user's value and the `user` variable is protected

The `SessionGuard` does set user to null in `logout()` but the `RequestGuard` does not have such methods and in long running processes (eg websocket) a user logged in by a `RequestGuard` cannot be removed easily and this becomes a security issue

This small breaking change in the method signature will allow to correctly set the user to null without php throwing an error

