### PR TITLE
[8.x] Remove redundant use for Str from factory stub

### DIFF
--- a/src/Illuminate/Database/Console/Factories/stubs/factory.stub
+++ b/src/Illuminate/Database/Console/Factories/stubs/factory.stub
@@ -3,7 +3,6 @@
 namespace {{ factoryNamespace }};
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use {{ namespacedModel }};
 
 class {{ model }}Factory extends Factory


### PR DESCRIPTION
Looks like this stub has been derived from the `UserFactory` factory class, which needs `Str` for `'remember_token' => Str::random(10),` .. however, this isn't likely to be needed in most other factories developers create.