### PR TITLE
Small type annotation fix: @return PendingBroadcast|void -> PendingBroadcast

### DIFF
--- a/src/Illuminate/Broadcasting/BroadcastManager.php
+++ b/src/Illuminate/Broadcasting/BroadcastManager.php
@@ -95,7 +95,7 @@ class BroadcastManager implements FactoryContract
      * Begin broadcasting an event.
      *
      * @param  mixed|null  $event
-     * @return \Illuminate\Broadcasting\PendingBroadcast|void
+     * @return \Illuminate\Broadcasting\PendingBroadcast
      */
     public function event($event = null)
     {


### PR DESCRIPTION
Tooling often expects void to mean no return at all, and get a bit confused here.

And `return new PendingBroadcast(..)` cannot result in void/null as far as I know.