### PR TITLE
[8.x] Add forget method for all guards

### DIFF
--- a/src/Illuminate/Auth/GuardHelpers.php
+++ b/src/Illuminate/Auth/GuardHelpers.php
@@ -96,6 +96,18 @@ trait GuardHelpers
     }
 
     /**
+     * Forget the current user.
+     *
+     * @return $this
+     */
+    public function forget()
+    {
+        $this->user = null;
+
+        return $this;
+    }
+
+    /**
      * Get the user provider used by the guard.
      *
      * @return \Illuminate\Contracts\Auth\UserProvider

--- a/src/Illuminate/Contracts/Auth/Guard.php
+++ b/src/Illuminate/Contracts/Auth/Guard.php
@@ -19,6 +19,13 @@ interface Guard
     public function guest();
 
     /**
+     * Forget the current user.
+     *
+     * @return $this
+     */
+    public function forget();
+
+    /**
      * Get the currently authenticated user.
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable|null


### PR DESCRIPTION
Superseeds #34453 

Add a `forget` method on all guards to be able to reset the cached user in the singleton to force the login to re-execute on the next `check()`