### PR TITLE
remove unused parameter in check method

### DIFF
--- a/src/Illuminate/Contracts/Hashing/Hasher.php
+++ b/src/Illuminate/Contracts/Hashing/Hasher.php
@@ -26,10 +26,9 @@ interface Hasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array  $options
      * @return bool
      */
-    public function check($value, $hashedValue, array $options = []);
+    public function check($value, $hashedValue);
 
     /**
      * Check if the given hash has been hashed using the given options.

--- a/src/Illuminate/Hashing/AbstractHasher.php
+++ b/src/Illuminate/Hashing/AbstractHasher.php
@@ -20,10 +20,9 @@ abstract class AbstractHasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array  $options
      * @return bool
      */
-    public function check($value, $hashedValue, array $options = [])
+    public function check($value, $hashedValue)
     {
         if (strlen($hashedValue) === 0) {
             return false;

--- a/src/Illuminate/Hashing/Argon2IdHasher.php
+++ b/src/Illuminate/Hashing/Argon2IdHasher.php
@@ -11,12 +11,11 @@ class Argon2IdHasher extends ArgonHasher
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array  $options
      * @return bool
      *
      * @throws \RuntimeException
      */
-    public function check($value, $hashedValue, array $options = [])
+    public function check($value, $hashedValue)
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2id') {
             throw new RuntimeException('This password does not use the Argon2id algorithm.');

--- a/src/Illuminate/Hashing/ArgonHasher.php
+++ b/src/Illuminate/Hashing/ArgonHasher.php
@@ -88,18 +88,17 @@ class ArgonHasher extends AbstractHasher implements HasherContract
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array  $options
      * @return bool
      *
      * @throws \RuntimeException
      */
-    public function check($value, $hashedValue, array $options = [])
+    public function check($value, $hashedValue)
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'argon2i') {
             throw new RuntimeException('This password does not use the Argon2i algorithm.');
         }
 
-        return parent::check($value, $hashedValue, $options);
+        return parent::check($value, $hashedValue);
     }
 
     /**

--- a/src/Illuminate/Hashing/BcryptHasher.php
+++ b/src/Illuminate/Hashing/BcryptHasher.php
@@ -60,18 +60,17 @@ class BcryptHasher extends AbstractHasher implements HasherContract
      *
      * @param  string  $value
      * @param  string  $hashedValue
-     * @param  array  $options
      * @return bool
      *
      * @throws \RuntimeException
      */
-    public function check($value, $hashedValue, array $options = [])
+    public function check($value, $hashedValue)
     {
         if ($this->verifyAlgorithm && $this->info($hashedValue)['algoName'] !== 'bcrypt') {
             throw new RuntimeException('This password does not use the Bcrypt algorithm.');
         }
 
-        return parent::check($value, $hashedValue, $options);
+        return parent::check($value, $hashedValue);
     }
 
     /**


### PR DESCRIPTION
password_verify() function does not get an $options parameter and we shouldn't pass this because this is an unused parameter.
This function just gets two params.