### PR TITLE
[8.x] Autowiring Blade Class Component Properties

### DIFF
--- a/src/Illuminate/View/Compilers/ComponentTagCompiler.php
+++ b/src/Illuminate/View/Compilers/ComponentTagCompiler.php
@@ -229,7 +229,8 @@ class ComponentTagCompiler
         }
 
         return " @component('{$class}', '{$component}', [".$this->attributesToString($parameters, $escapeBound = false).'])
-<?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>';
+<?php $component->withAttributes(['.$this->attributesToString($attributes->all()).']); ?>
+<?php $__env->setData($component->autowireProperties()); ?>';
     }
 
     /**

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -236,6 +236,8 @@ abstract class Component
         return array_merge([
             'data',
             'render',
+            'mount',
+            'autowireProperties',
             'resolveView',
             'shouldRender',
             'view',
@@ -280,5 +282,10 @@ abstract class Component
     public function shouldRender()
     {
         return true;
+    }
+
+    public function autowireProperties()
+    {
+        return $this->data();
     }
 }

--- a/src/Illuminate/View/Concerns/AutowiresProperties.php
+++ b/src/Illuminate/View/Concerns/AutowiresProperties.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\View\Concerns;
+
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+use Illuminate\Support\Str;
+
+trait AutowiresProperties
+{
+    /**
+     * Automatically assign values to any properties on the class whose name
+     * exists in the supplied attributes, then call the mount() method.
+     *
+     * @return array
+     */
+    public function autowireProperties()
+    {
+        $class = new ReflectionClass($this);
+        $allAttributes = $this->attributes->getAttributes();
+
+        $properties = collect($class->getProperties(ReflectionMethod::IS_PUBLIC))
+            ->filter(function (ReflectionProperty $property) {
+                return !in_array($property->name, ['componentName', 'attributes']);
+            })
+            ->map(function (ReflectionProperty $property) {
+                return Str::camel($property->getName());
+            })
+            ->toArray();
+
+        foreach ($properties as $property) {
+            if (isset($this->attributes[$property])) {
+                $this->{$property} = $this->attributes[$property];
+                unset($this->attributes[$property]);
+            }
+        }
+
+        if (method_exists($this, 'mount')) {
+            app()->call([$this, 'mount'], $allAttributes);
+        }
+
+        return $this->data();
+    }
+}

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -164,4 +164,15 @@ trait ManagesComponents
     {
         return count($this->componentStack) - 1;
     }
+
+    /**
+     * Set the data passed to the current component's view.
+     *
+     * @param  array  $data
+     * @return void
+     */
+    public function setData(array $data = [])
+    {
+        $this->componentData[$this->currentComponent()] = $data;
+    }
 }

--- a/tests/View/Blade/BladeComponentTagCompilerTest.php
+++ b/tests/View/Blade/BladeComponentTagCompilerTest.php
@@ -41,10 +41,12 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="foo" limit="5" @click="foo" wire:click="changePlan(\'{{ $plan }}\')" required /><x-alert /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>\n".
-"@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+<?php \$component->withAttributes(['type' => 'foo','limit' => '5','@click' => 'foo','wire:click' => 'changePlan(\''.e(\$plan).'\')','required' => true]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass  @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass </div>", trim($result));
     }
 
     public function testBasicComponentWithEmptyAttributesParsing()
@@ -52,8 +54,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert type="" limit=\'\' @click="" required /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+<?php \$component->withAttributes(['type' => '','limit' => '','@click' => '','required' => true]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass </div>", trim($result));
     }
 
     public function testDataCamelCasing()
@@ -61,7 +64,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => '1'])
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonData()
@@ -69,7 +73,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :user-id="1"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', ['userId' => 1])
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonAttributesIsEscapedIfStrings()
@@ -77,7 +82,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile :src="\'foo\'"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
-<?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes(['src' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('foo')]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonNestedComponentParsing()
@@ -85,7 +91,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x-foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass", trim($result));
     }
 
     public function testColonStartingNestedComponentParsing()
@@ -93,7 +100,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['foo:alert' => TestAlertComponent::class])->compileTags('<x:foo:alert></x-foo:alert>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'foo:alert', [])
-<?php \$component->withAttributes([]); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass", trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiled()
@@ -101,8 +109,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert/></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass </div>', trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?> @endcomponentClass </div>", trim($result));
     }
 
     public function testClassNamesCanBeGuessed()
@@ -140,7 +148,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert class="bar" wire:model="foo" x-on:click="bar" @click="baz" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo','x-on:click' => 'bar','@click' => 'baz']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>\n".
 '@endcomponentClass', trim($result));
     }
 
@@ -149,7 +158,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert title="foo" class="bar" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
-<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','wire:model' => 'foo']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>\n".
 '@endcomponentClass', trim($result));
     }
 
@@ -159,7 +169,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['profile' => TestProfileComponent::class])->compileTags('<x-profile class="bar" {{ $attributes }} wire:model="foo"></x-profile>');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestProfileComponent', 'profile', [])
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?> @endcomponentClass", trim($result));
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes),'wire:model' => 'foo']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass", trim($result));
     }
 
     public function testSelfClosingComponentCanReceiveAttributeBag()
@@ -169,7 +181,8 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<div><x-alert title="foo" class="bar" {{ $attributes->merge([\'class\' => \'test\']) }} wire:model="foo" /></div>');
 
         $this->assertSame("<div> @component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => 'foo'])
-<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>\n".
+<?php \$component->withAttributes(['class' => 'bar','attributes' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(\$attributes->merge(['class' => 'test'])),'wire:model' => 'foo']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>\n".
             '@endcomponentClass </div>', trim($result));
     }
 
@@ -186,8 +199,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert/>Words');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
-<?php \$component->withAttributes([]); ?>\n".
-'@endcomponentClass Words', trim($result));
+<?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass Words", trim($result));
     }
 
     public function testSelfClosingComponentsCanBeCompiledWithBoundData()
@@ -195,8 +209,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler(['alert' => TestAlertComponent::class])->compileTags('<x-alert :title="$title" class="bar" />');
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', ['title' => \$title])
-<?php \$component->withAttributes(['class' => 'bar']); ?>\n".
-'@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['class' => 'bar']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass", trim($result));
     }
 
     public function testPairedComponentTags()
@@ -206,6 +221,7 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
 
         $this->assertSame("@component('Illuminate\Tests\View\Blade\TestAlertComponent', 'alert', [])
 <?php \$component->withAttributes([]); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
  @endcomponentClass", trim($result));
     }
 
@@ -221,8 +237,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileTags('<x-anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\View\AnonymousComponent', 'anonymous-component', ['view' => 'components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
-'@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass", trim($result));
     }
 
     public function testPackagesClasslessComponents()
@@ -237,8 +254,9 @@ class BladeComponentTagCompilerTest extends AbstractBladeTestCase
         $result = $this->compiler()->compileTags('<x-package::anonymous-component :name="\'Taylor\'" :age="31" wire:model="foo" />');
 
         $this->assertSame("@component('Illuminate\View\AnonymousComponent', 'package::anonymous-component', ['view' => 'package::components.anonymous-component','data' => ['name' => 'Taylor','age' => 31,'wire:model' => 'foo']])
-<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>\n".
-'@endcomponentClass', trim($result));
+<?php \$component->withAttributes(['name' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute('Taylor'),'age' => 31,'wire:model' => 'foo']); ?>
+<?php \$__env->setData(\$component->autowireProperties()); ?>
+@endcomponentClass", trim($result));
     }
 
     public function testAttributeSanitization()

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -4,13 +4,14 @@ namespace Illuminate\Tests\View;
 
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
+use Illuminate\View\Concerns\AutowiresProperties;
 use PHPUnit\Framework\TestCase;
 
 class ViewComponentTest extends TestCase
 {
     public function testDataExposure()
     {
-        $component = new TestViewComponent;
+        $component = new TestViewComponent();
 
         $variables = $component->data();
 
@@ -21,7 +22,7 @@ class ViewComponentTest extends TestCase
 
     public function testAttributeParentInheritance()
     {
-        $component = new TestViewComponent;
+        $component = new TestViewComponent();
 
         $component->withAttributes(['class' => 'foo', 'attributes' => new ComponentAttributeBag(['class' => 'bar', 'type' => 'button'])]);
 
@@ -30,7 +31,7 @@ class ViewComponentTest extends TestCase
 
     public function testPublicMethodsWithNoArgsAreConvertedToStringableCallablesInvokedAndNotCached()
     {
-        $component = new TestSampleViewComponent;
+        $component = new TestSampleViewComponent();
 
         $this->assertEquals(0, $component->counter);
         $this->assertEquals(0, TestSampleViewComponent::$publicStaticCounter);
@@ -83,6 +84,22 @@ class ViewComponentTest extends TestCase
         // protected methods do not override public properties.
         $this->assertArrayHasKey('world', $variables);
         $this->assertSame('world property', $variables['world']);
+    }
+
+    public function testPropertiesCanBeAutowired()
+    {
+        $component = new TestAutowiringPropertiesViewComponent();
+
+        $this->assertEquals('', $component->foo);
+        $this->assertSame(false, isset($component->abc));
+
+        $component->withAttributes(['foo' => 'bar', 'abc' => 'xyz']);
+        $component->autowireProperties();
+
+        $this->assertSame(false, isset($component->attributes['foo']));
+        $this->assertSame(true, isset($component->attributes['abc']));
+        $this->assertEquals('bar', $component->foo);
+        $this->assertSame(false, isset($component->abc));
     }
 }
 
@@ -195,5 +212,17 @@ class TestDefaultAttributesComponent extends Component
     public function render()
     {
         return $this->attributes->get('id');
+    }
+}
+
+class TestAutowiringPropertiesViewComponent extends Component
+{
+    use AutowiresProperties;
+
+    public $foo = '';
+
+    public function render()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
Edit: Oops, just noticed that I branched from master instead of 8.x - will fix the conflicts and point the base to 8.x once that's sorted out. Pointed the base to master for now so it's easy to see the diff.

## What is this?

**This pull request introduces "autowiring" of properties on Blade component classes when a class component uses the new `AutowiresProperties` trait.**

This allows properties on the component class to be automatically set from the provided data, instead of needing to go through the constructor just to be set.

```php
// Class component
class Input extends Component
{
    use AutowiresProperties;

    public $type = 'text';

    public function render()
    {
        <<<'BLADE'
            <input type="{{ $type }}" {{ $attributes }}>
        BLADE;
    }
}

// Component Usage
<x-input type="email" class="form-input" />
```

Following the same convention as Livewire v2, it also now lets you define a `mount()` on the component class. If present, it will be called AFTER the autowiring step (while `__construct()` is called BEFORE autowiring the properties), accepting parameters of any attribute that was passed through, or injecting dependencies from the container.

This lets us do extra logic if we need to after the autowiring step.

```php
// Class component
class Input extends Component
{
    // ...

    public function mount($type = 'text')
    {
        if (!in_array($type, ['text', 'email', 'number', 'password'])) {
            $this->type = 'text';
        }
    }
}

// Component Usage
<x-input type="invalid-type" />
```

## Why do we need this?

Personally, when writing certain Blade component classes, I have ended up having to repeat properties 3 times over; once to define the property, once to accept it in the constructor, and once to set the property value in the constructor.

That's okay for one or two parameters/properties, but on larger components it becomes unbearable. This is something that's bugged me quite a lot and would love to be able to move away from to clean up some unneeded code.

Livewire recently addressed this in the v2 release through the same approach; automatically wiring any properties with the named values that would normally just be manually set.

## How could this behaviour be improved in future versions?

Currently, this PR forces users to use the `AutowiresProperties` trait on their component to enable this functionality, just to make it available. This is because I can't find a good way to make it implicit on the base component class without being a breaking change in some way; notably that properties already set in an existing constructor could be overridden by the autowiring logic, and I don't believe there's a way to check if a class property is "dirty" through reflection to prevent that.

If we wanted to make this behaviour implicit in a future major version like 9.x, the trait method could be moved directly to the base component class instead, and tell people to always use the `mount()` method instead of `__construct()` to handle property values they want to manually set.

## Thoughts?

Keen to hear feedback on the PR or if other people want this kind of functionality too.

There's a couple of failing tests at the time of writing but I'll sort them out.