### PR TITLE
Revert cascading truncations

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -318,7 +318,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
     }
 
     /**


### PR DESCRIPTION

This PR reverses #26389 which introduces cascading truncations in postgres. The spirit of the original fix was to address a constraint of postgres in that disabling foreign key constrains does not allow a developer to a truncate a table that has foreign keys. However, the proposed and accepted solution results in all tables that have a column that references the table under question for truncation to be also truncated and further any tables that referenced the children of the first table. This can and has created a problematic situation when you discover that truncating a small table results in the loss of your entire database. 

As that is not expected behavior for truncation of a table, I would propose that the word `cascading` be removed from truncation and that documentation be created in the laravel docs indicating that this was the behavior in postgres between version [initial release version] and [this release version].  

Issue: #29506
