### PR TITLE
[8.x] Don't alter $_ENV variables

### DIFF
--- a/src/Illuminate/Foundation/Console/ServeCommand.php
+++ b/src/Illuminate/Foundation/Console/ServeCommand.php
@@ -92,11 +92,7 @@ class ServeCommand extends Command
      */
     protected function startProcess()
     {
-        $process = new Process($this->serverCommand(), null, collect($_ENV)->mapWithKeys(function ($value, $key) {
-            return $key === 'APP_ENV'
-                    ? [$key => $value]
-                    : [$key => false];
-        })->all());
+        $process = new Process($this->serverCommand());
 
         $process->start(function ($type, $buffer) {
             $this->output->write($buffer);


### PR DESCRIPTION
This addresses #34472 whereby actual environment variables are not available when using `php artisan serve`. For my use-case this broke HerokuCI which provides database and other add-on configurations through environment variables.

This appears to have been introduced in 700b277ebfc5862128358bcdb2dc68edcbeb4bea which was designed to restart the server when an `.env` file changes, and switched to using `Process` to start the server. In doing so there's a loop over the environment variables that sets all their values to `false` - I can't tell what it's purpose is. It was later changed in `75e792d61871780f75ecb4eb170826b0ba2f305e` to support the `APP_ENV` variable only.

By removing the argument altogether (along with the second `null` argument which is no longer required) the environment variables appear to be loaded correctly as expected again. This fixes both projects I had that were moving from 7.x to 8.x and had failing Dusk suites.