### PR TITLE
[8.x] Revert "[8.x] Fix Logger docblocks"

### DIFF
--- a/src/Illuminate/Log/Logger.php
+++ b/src/Illuminate/Log/Logger.php
@@ -42,7 +42,7 @@ class Logger implements LoggerInterface
     /**
      * Log an emergency message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -54,7 +54,7 @@ class Logger implements LoggerInterface
     /**
      * Log an alert message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -66,7 +66,7 @@ class Logger implements LoggerInterface
     /**
      * Log a critical message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -78,7 +78,7 @@ class Logger implements LoggerInterface
     /**
      * Log an error message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -90,7 +90,7 @@ class Logger implements LoggerInterface
     /**
      * Log a warning message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -102,7 +102,7 @@ class Logger implements LoggerInterface
     /**
      * Log a notice to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -114,7 +114,7 @@ class Logger implements LoggerInterface
     /**
      * Log an informational message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -126,7 +126,7 @@ class Logger implements LoggerInterface
     /**
      * Log a debug message to the logs.
      *
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -139,7 +139,7 @@ class Logger implements LoggerInterface
      * Log a message to the logs.
      *
      * @param  string  $level
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -152,7 +152,7 @@ class Logger implements LoggerInterface
      * Dynamically pass log calls into the writer.
      *
      * @param  string  $level
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */
@@ -165,7 +165,7 @@ class Logger implements LoggerInterface
      * Write a message to the log.
      *
      * @param  string  $level
-     * @param  mixed  $message
+     * @param  string  $message
      * @param  array  $context
      * @return void
      */


### PR DESCRIPTION
Reverts laravel/framework#34468 because it violates both the PSR contract and the laravel logger contract.