### PR TITLE
[8.x] Implement conditional dumps on TestResponse

### DIFF
--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1082,7 +1082,7 @@ class TestResponse implements ArrayAccess
      */
     public function dumpIf(callable $callback)
     {
-        if ($closure($this)) {
+        if ($callback($this)) {
             $this->dump();
         }
 

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1077,11 +1077,10 @@ class TestResponse implements ArrayAccess
     /**
      * Dump the content from the response when the given truth test passes.
      *
-     * @param \Closure $closure
-     *
-     * @return \Illuminate\Testing\TestResponse
+     * @param  callable  $callback
+     * @return $this
      */
-    public function dumpIf(Closure $closure)
+    public function dumpIf(callable $callback)
     {
         if ($closure($this)) {
             $this->dump();

--- a/src/Illuminate/Testing/TestResponse.php
+++ b/src/Illuminate/Testing/TestResponse.php
@@ -1075,6 +1075,22 @@ class TestResponse implements ArrayAccess
     }
 
     /**
+     * Dump the content from the response when the given truth test passes.
+     *
+     * @param \Closure $closure
+     *
+     * @return \Illuminate\Testing\TestResponse
+     */
+    public function dumpIf(Closure $closure)
+    {
+        if ($closure($this)) {
+            $this->dump();
+        }
+
+        return $this;
+    }
+
+    /**
      * Dump the headers from the response.
      *
      * @return $this


### PR DESCRIPTION
# What does this PR implement?

This pull request adds a new method to the `TestResponse` object: `dumpIf`. 

This method basically proxies to `TestResponse::dump`, but accepts a `Closure` that acts as a truth test.

# Why would we need this?

I _very_ often find myself debugging requests using the `dump()` method. When a test fails, in 99% of the use cases I want to see the response, but I do not want the response to clutter my test output if everything passes.

With this addition, things like this would be made possible:

```php
$response = $this->get(route('api.foo'));
$response->dumpIf(function($response) {
    return !$response->isOk();
})->assertOk();
```

Surely users can live without this utility method, but I think it could be useful to others.

Would love to hear if I any others are interested in this.