### PR TITLE
[9.x] Use provided table name as foreign key if present

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1592,7 +1592,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function getForeignKey()
     {
-        return Str::snake(class_basename($this)).'_'.$this->getKeyName();
+        return Str::singular($this->getTable()).'_'.$this->getKeyName();
     }
 
     /**

--- a/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasManyThroughIntegrationTest.php
@@ -393,9 +393,9 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     protected function resetDefault()
     {
-        $this->schema()->drop('users_default');
-        $this->schema()->drop('posts_default');
-        $this->schema()->drop('countries_default');
+        $this->schema()->drop('default_users');
+        $this->schema()->drop('default_posts');
+        $this->schema()->drop('default_countries');
     }
 
     /**
@@ -403,22 +403,22 @@ class DatabaseEloquentHasManyThroughIntegrationTest extends TestCase
      */
     protected function migrateDefault()
     {
-        $this->schema()->create('users_default', function ($table) {
+        $this->schema()->create('default_users', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
-            $table->unsignedInteger('has_many_through_default_test_country_id');
+            $table->unsignedInteger('default_country_id');
             $table->timestamps();
         });
 
-        $this->schema()->create('posts_default', function ($table) {
+        $this->schema()->create('default_posts', function ($table) {
             $table->increments('id');
-            $table->integer('has_many_through_default_test_user_id');
+            $table->integer('default_user_id');
             $table->string('title');
             $table->text('body');
             $table->timestamps();
         });
 
-        $this->schema()->create('countries_default', function ($table) {
+        $this->schema()->create('default_countries', function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
@@ -456,7 +456,7 @@ class HasManyThroughTestUser extends Eloquent
 
     public function posts()
     {
-        return $this->hasMany(HasManyThroughTestPost::class, 'user_id');
+        return $this->hasMany(HasManyThroughTestPost::class);
     }
 }
 
@@ -470,7 +470,7 @@ class HasManyThroughTestPost extends Eloquent
 
     public function owner()
     {
-        return $this->belongsTo(HasManyThroughTestUser::class, 'user_id');
+        return $this->belongsTo(HasManyThroughTestUser::class);
     }
 }
 
@@ -481,12 +481,12 @@ class HasManyThroughTestCountry extends Eloquent
 
     public function posts()
     {
-        return $this->hasManyThrough(HasManyThroughTestPost::class, HasManyThroughTestUser::class, 'country_id', 'user_id');
+        return $this->hasManyThrough(HasManyThroughTestPost::class, HasManyThroughTestUser::class);
     }
 
     public function users()
     {
-        return $this->hasMany(HasManyThroughTestUser::class, 'country_id');
+        return $this->hasMany(HasManyThroughTestUser::class);
     }
 }
 
@@ -495,7 +495,7 @@ class HasManyThroughTestCountry extends Eloquent
  */
 class HasManyThroughDefaultTestUser extends Eloquent
 {
-    protected $table = 'users_default';
+    protected $table = 'default_users';
     protected $guarded = [];
 
     public function posts()
@@ -509,7 +509,7 @@ class HasManyThroughDefaultTestUser extends Eloquent
  */
 class HasManyThroughDefaultTestPost extends Eloquent
 {
-    protected $table = 'posts_default';
+    protected $table = 'default_posts';
     protected $guarded = [];
 
     public function owner()
@@ -520,7 +520,7 @@ class HasManyThroughDefaultTestPost extends Eloquent
 
 class HasManyThroughDefaultTestCountry extends Eloquent
 {
-    protected $table = 'countries_default';
+    protected $table = 'default_countries';
     protected $guarded = [];
 
     public function posts()
@@ -546,7 +546,7 @@ class HasManyThroughIntermediateTestCountry extends Eloquent
 
     public function users()
     {
-        return $this->hasMany(HasManyThroughTestUser::class, 'country_id');
+        return $this->hasMany(HasManyThroughTestUser::class);
     }
 }
 
@@ -559,7 +559,7 @@ class HasManyThroughSoftDeletesTestUser extends Eloquent
 
     public function posts()
     {
-        return $this->hasMany(HasManyThroughSoftDeletesTestPost::class, 'user_id');
+        return $this->hasMany(HasManyThroughSoftDeletesTestPost::class);
     }
 }
 
@@ -573,7 +573,7 @@ class HasManyThroughSoftDeletesTestPost extends Eloquent
 
     public function owner()
     {
-        return $this->belongsTo(HasManyThroughSoftDeletesTestUser::class, 'user_id');
+        return $this->belongsTo(HasManyThroughSoftDeletesTestUser::class);
     }
 }
 
@@ -584,11 +584,11 @@ class HasManyThroughSoftDeletesTestCountry extends Eloquent
 
     public function posts()
     {
-        return $this->hasManyThrough(HasManyThroughSoftDeletesTestPost::class, HasManyThroughTestUser::class, 'country_id', 'user_id');
+        return $this->hasManyThrough(HasManyThroughSoftDeletesTestPost::class, HasManyThroughTestUser::class);
     }
 
     public function users()
     {
-        return $this->hasMany(HasManyThroughSoftDeletesTestUser::class, 'country_id');
+        return $this->hasMany(HasManyThroughSoftDeletesTestUser::class);
     }
 }

--- a/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentHasOneThroughIntegrationTest.php
@@ -287,9 +287,9 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     protected function resetDefault()
     {
-        $this->schema()->drop('users_default');
-        $this->schema()->drop('contracts_default');
-        $this->schema()->drop('positions_default');
+        $this->schema()->drop('default_users');
+        $this->schema()->drop('default_contracts');
+        $this->schema()->drop('default_positions');
     }
 
     /**
@@ -297,22 +297,22 @@ class DatabaseEloquentHasOneThroughIntegrationTest extends TestCase
      */
     protected function migrateDefault()
     {
-        $this->schema()->create('users_default', function ($table) {
+        $this->schema()->create('default_users', function ($table) {
             $table->increments('id');
             $table->string('email')->unique();
-            $table->unsignedInteger('has_one_through_default_test_position_id')->unique()->nullable();
+            $table->unsignedInteger('default_position_id')->unique()->nullable();
             $table->timestamps();
         });
 
-        $this->schema()->create('contracts_default', function ($table) {
+        $this->schema()->create('default_contracts', function ($table) {
             $table->increments('id');
-            $table->integer('has_one_through_default_test_user_id')->unique();
+            $table->integer('default_user_id')->unique();
             $table->string('title');
             $table->text('body');
             $table->timestamps();
         });
 
-        $this->schema()->create('positions_default', function ($table) {
+        $this->schema()->create('default_positions', function ($table) {
             $table->increments('id');
             $table->string('name');
             $table->timestamps();
@@ -350,7 +350,7 @@ class HasOneThroughTestUser extends Eloquent
 
     public function contract()
     {
-        return $this->hasOne(HasOneThroughTestContract::class, 'user_id');
+        return $this->hasOne(HasOneThroughTestContract::class);
     }
 }
 
@@ -364,7 +364,7 @@ class HasOneThroughTestContract extends Eloquent
 
     public function owner()
     {
-        return $this->belongsTo(HasOneThroughTestUser::class, 'user_id');
+        return $this->belongsTo(HasOneThroughTestUser::class);
     }
 }
 
@@ -375,12 +375,12 @@ class HasOneThroughTestPosition extends Eloquent
 
     public function contract()
     {
-        return $this->hasOneThrough(HasOneThroughTestContract::class, HasOneThroughTestUser::class, 'position_id', 'user_id');
+        return $this->hasOneThrough(HasOneThroughTestContract::class, HasOneThroughTestUser::class);
     }
 
     public function user()
     {
-        return $this->hasOne(HasOneThroughTestUser::class, 'position_id');
+        return $this->hasOne(HasOneThroughTestUser::class);
     }
 }
 
@@ -389,7 +389,7 @@ class HasOneThroughTestPosition extends Eloquent
  */
 class HasOneThroughDefaultTestUser extends Eloquent
 {
-    protected $table = 'users_default';
+    protected $table = 'default_users';
     protected $guarded = [];
 
     public function contract()
@@ -403,7 +403,7 @@ class HasOneThroughDefaultTestUser extends Eloquent
  */
 class HasOneThroughDefaultTestContract extends Eloquent
 {
-    protected $table = 'contracts_default';
+    protected $table = 'default_contracts';
     protected $guarded = [];
 
     public function owner()
@@ -414,7 +414,7 @@ class HasOneThroughDefaultTestContract extends Eloquent
 
 class HasOneThroughDefaultTestPosition extends Eloquent
 {
-    protected $table = 'positions_default';
+    protected $table = 'default_positions';
     protected $guarded = [];
 
     public function contract()
@@ -440,7 +440,7 @@ class HasOneThroughIntermediateTestPosition extends Eloquent
 
     public function user()
     {
-        return $this->hasOne(HasOneThroughTestUser::class, 'position_id');
+        return $this->hasOne(HasOneThroughTestUser::class);
     }
 }
 
@@ -453,7 +453,7 @@ class HasOneThroughSoftDeletesTestUser extends Eloquent
 
     public function contract()
     {
-        return $this->hasOne(HasOneThroughSoftDeletesTestContract::class, 'user_id');
+        return $this->hasOne(HasOneThroughSoftDeletesTestContract::class);
     }
 }
 
@@ -467,7 +467,7 @@ class HasOneThroughSoftDeletesTestContract extends Eloquent
 
     public function owner()
     {
-        return $this->belongsTo(HasOneThroughSoftDeletesTestUser::class, 'user_id');
+        return $this->belongsTo(HasOneThroughSoftDeletesTestUser::class);
     }
 }
 
@@ -478,11 +478,11 @@ class HasOneThroughSoftDeletesTestPosition extends Eloquent
 
     public function contract()
     {
-        return $this->hasOneThrough(HasOneThroughSoftDeletesTestContract::class, HasOneThroughTestUser::class, 'position_id', 'user_id');
+        return $this->hasOneThrough(HasOneThroughSoftDeletesTestContract::class, HasOneThroughTestUser::class);
     }
 
     public function user()
     {
-        return $this->hasOne(HasOneThroughSoftDeletesTestUser::class, 'position_id');
+        return $this->hasOne(HasOneThroughSoftDeletesTestUser::class);
     }
 }

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -1168,7 +1168,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasOne(EloquentModelSaveStub::class);
-        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1205,7 +1205,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
         $relation = $model->hasMany(EloquentModelSaveStub::class);
-        $this->assertSame('save_stub.eloquent_model_stub_id', $relation->getQualifiedForeignKeyName());
+        $this->assertSame('save_stub.stub_id', $relation->getQualifiedForeignKeyName());
 
         $model = new EloquentModelStub;
         $this->addMockConnection($model);
@@ -1279,8 +1279,8 @@ class DatabaseEloquentModelTest extends TestCase
         $this->addMockConnection($model);
 
         $relation = $model->belongsToMany(EloquentModelSaveStub::class);
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_stub_id', $relation->getQualifiedForeignPivotKeyName());
-        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.eloquent_model_save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.stub_id', $relation->getQualifiedForeignPivotKeyName());
+        $this->assertSame('eloquent_model_save_stub_eloquent_model_stub.save_stub_id', $relation->getQualifiedRelatedPivotKeyName());
         $this->assertSame($model, $relation->getParent());
         $this->assertInstanceOf(EloquentModelSaveStub::class, $relation->getQuery()->getModel());
         $this->assertEquals(__FUNCTION__, $relation->getRelationName());

--- a/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
+++ b/tests/Database/DatabaseEloquentPolymorphicRelationsIntegrationTest.php
@@ -47,7 +47,7 @@ class DatabaseEloquentPolymorphicRelationsIntegrationTest extends TestCase
         });
 
         $this->schema('default')->create('taggables', function ($table) {
-            $table->integer('eloquent_many_to_many_polymorphic_test_tag_id');
+            $table->integer('tag_id');
             $table->integer('taggable_id');
             $table->string('taggable_type');
         });

--- a/tests/Database/DatabaseSchemaBlueprintTest.php
+++ b/tests/Database/DatabaseSchemaBlueprintTest.php
@@ -288,7 +288,7 @@ class DatabaseSchemaBlueprintTest extends TestCase
         $blueprint = clone $base;
 
         $this->assertEquals([
-            'alter table `posts` add `eloquent_model_uuid_stub_id` char(36) not null',
+            'alter table `posts` add `model_id` char(36) not null',
         ], $blueprint->toSql($connection, new MySqlGrammar));
     }
 }


### PR DESCRIPTION
**TL;DR** — `getForeignKey()` method does not respect the `$table` property of model. To improve this, we use the power of `getTable()` method, also it has fallback support for the current approach ( _resolving from class basename_ ).

## Why?
 
Because, when you need to use a specific table name, you have to manually type the actual foreign key in each relation. I thought this make things more complicated, so I came up with this solution.

## What’s wrong about with tests?
 
As you can see from the tests, relation columns have named based on its models base class name, but at the same time, these models have a specific table name. As a result, column names would not match the provided table name.

To fix this, we could add the foreign keys to relations, but that's not the point of these tests, so I have decided to change these with proper convention as it should be.

## Example

```diff
class Reservation extends Model
{
  protected $table = 'flight_reservations';

  public function passengers()
  {
-    return $this->belongsToMany(Passenger::class, null, 'flight_reservation_id');
+    return $this->belongsToMany(Passenger::class);
  }
}
```

_This is probably breaking change for users who don’t follow proper naming conventions, but I believe that most people will get rid of these unnecessary definitions._