### PR TITLE
[6.x] Type annotation fix: in `newPivot(.. , string)` string should be Pivot

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1070,7 +1070,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  array  $attributes
      * @param  string  $table
      * @param  bool  $exists
-     * @param  string|null  $using
+     * @param  \Illuminate\Database\Eloquent\Relations\Pivot|null  $using
      * @return \Illuminate\Database\Eloquent\Relations\Pivot
      */
     public function newPivot(self $parent, array $attributes, $table, $exists, $using = null)


### PR DESCRIPTION
6.x version of the master branch patch: https://github.com/laravel/framework/pull/34485