### PR TITLE
[8.x] Allow dynamic factory methods to obey newFactory method on model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -705,9 +705,9 @@ abstract class Factory
 
         $relationship = Str::camel(Str::substr($method, 3));
 
-        $factory = static::factoryForModel(
-            get_class($this->newModel()->{$relationship}()->getRelated())
-        );
+        $relationshipClass = get_class($this->newModel()->{$relationship}()->getRelated());
+
+        $factory = $relationshipClass::newFactory() ?: static::factoryForModel($relationshipClass);
 
         if (Str::startsWith($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -707,7 +707,9 @@ abstract class Factory
 
         $relationshipClass = get_class($this->newModel()->{$relationship}()->getRelated());
 
-        $factory = $relationshipClass::newFactory() ?: static::factoryForModel($relationshipClass);
+        $factory = method_exists($relationshipClass, 'newFactory') && $relationshipClass::newFactory()
+            ? $relationshipClass::newFactory()
+            : static::factoryForModel($relationshipClass);
 
         if (Str::startsWith($method, 'for')) {
             return $this->for($factory->state($parameters[0] ?? []), $relationship);

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -399,6 +399,8 @@ class FactoryTestPostFactory extends Factory
 
 class FactoryTestPost extends Eloquent
 {
+    use HasFactory;
+
     protected $table = 'posts';
 
     public function user()
@@ -433,6 +435,8 @@ class FactoryTestCommentFactory extends Factory
 
 class FactoryTestComment extends Eloquent
 {
+    use HasFactory;
+
     protected $table = 'comments';
 
     public function commentable()
@@ -455,6 +459,8 @@ class FactoryTestRoleFactory extends Factory
 
 class FactoryTestRole extends Eloquent
 {
+    use HasFactory;
+
     protected $table = 'roles';
 
     public function users()

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -399,8 +399,6 @@ class FactoryTestPostFactory extends Factory
 
 class FactoryTestPost extends Eloquent
 {
-    use HasFactory;
-
     protected $table = 'posts';
 
     public function user()
@@ -435,8 +433,6 @@ class FactoryTestCommentFactory extends Factory
 
 class FactoryTestComment extends Eloquent
 {
-    use HasFactory;
-
     protected $table = 'comments';
 
     public function commentable()
@@ -459,8 +455,6 @@ class FactoryTestRoleFactory extends Factory
 
 class FactoryTestRole extends Eloquent
 {
-    use HasFactory;
-
     protected $table = 'roles';
 
     public function users()


### PR DESCRIPTION
PR is for issue #34490

Benefit is that models that have to define a factory via the newFactory method can utilise the magic factory methods for has and for.