### PR TITLE
[8.x] Allow for dynamic calls of anonymous component with varied attributes

### DIFF
--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -30,13 +30,6 @@ class DynamicComponent extends Component
     protected static $componentClasses = [];
 
     /**
-     * The cached binding keys for component classes.
-     *
-     * @var array
-     */
-    protected static $bindings = [];
-
-    /**
      * Create a new component instance.
      *
      * @return void
@@ -153,13 +146,9 @@ EOF;
      */
     protected function bindings(string $class)
     {
-        if (! isset(static::$bindings[$class])) {
-            [$data, $attributes] = $this->compiler()->partitionDataAndAttributes($class, $this->attributes->getAttributes());
+        [$data, $attributes] = $this->compiler()->partitionDataAndAttributes($class, $this->attributes->getAttributes());
 
-            static::$bindings[$class] = array_keys($data->all());
-        }
-
-        return static::$bindings[$class];
+        return array_keys($data->all());
     }
 
     /**

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -35,6 +35,19 @@ class BladeTest extends TestCase
 </div>', trim($view));
     }
 
+    public function test_rendering_the_same_dynamic_component_with_different_attributes()
+    {
+        $view = View::make('varied-dynamic-calls')->render();
+
+        $this->assertEquals('<span class="text-medium">
+    Hello Taylor
+</span>
+  
+ <span >
+    Hello Samuel
+</span>', trim($view));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/templates/components/hello-span.blade.php
+++ b/tests/Integration/View/templates/components/hello-span.blade.php
@@ -1,0 +1,7 @@
+@props([
+    'name',
+])
+
+<span {{ $attributes }}>
+    Hello {{ $name }}
+</span>

--- a/tests/Integration/View/templates/varied-dynamic-calls.blade.php
+++ b/tests/Integration/View/templates/varied-dynamic-calls.blade.php
@@ -1,0 +1,2 @@
+<x-dynamic-component component="hello-span" name="Taylor" class="text-medium" />
+<x-dynamic-component component="hello-span" name="Samuel" />


### PR DESCRIPTION
Fixes #34469 

This removes the binding caching for dynamic components. And adds a regression test for the linked issue.

Here's proof of regression test failing before the fix:

![Screen Shot 2020-09-23 at 18 33 13](https://user-images.githubusercontent.com/33033094/94043071-a1ec6000-fdcc-11ea-92a4-5c30c4ffb42a.png)
