### PR TITLE
[8.x] Add model factory trait to disable model events

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
+++ b/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
@@ -21,7 +21,7 @@ trait DisablesEvents
     }
 
     /**
-     * Enables events during creation
+     * Enables events during creation.
      *
      * @return self
      */

--- a/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
+++ b/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Illuminate\Database\Eloquent\Factories;
+
+use Illuminate\Support\Collection;
+
+trait DisablesEvents
+{
+    protected bool $disableEvents;
+
+    /**
+     * Disables events during creation.
+     *
+     * @return self
+     */
+    public function withoutEvents()
+    {
+        $this->disableEvents = true;
+
+        return $this;
+    }
+
+    /**
+     * Enables events during creation
+     *
+     * @return self
+     */
+    public function withEvents()
+    {
+        $this->disableEvents = false;
+
+        return $this;
+    }
+
+    /**
+     * Checks if events should be disabled for creation.
+     */
+    protected function shouldDisableEvents(): bool
+    {
+        if (isset($this->disableEvents) && ! is_null($this->disableEvents)) {
+            return $this->disableEvents;
+        }
+
+        return false;
+    }
+
+    /**
+     * Set the connection name on the results and store them.
+     *
+     * @param  \Illuminate\Support\Collection  $results
+     *
+     * @return void
+     */
+    protected function store(Collection $results)
+    {
+        $this->shouldDisableEvents()
+            ? $this->model::withoutEvents(function () use ($results) {
+                return parent::store($results);
+            })
+            : parent::store($results);
+    }
+
+    /**
+     * Create a new instance of the factory builder with the given mutated properties.
+     * This propagates the event disabler across states.
+     *
+     * @param  array  $arguments
+     *
+     * @return static
+     */
+    protected function newInstance(array $arguments = [])
+    {
+        $newInstance = parent::newInstance($arguments);
+
+        return $this->shouldDisableEvents()
+            ? $newInstance->withoutEvents()
+            : $newInstance->withEvents();
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
+++ b/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 
 trait DisablesEvents
 {
-    protected bool $disableEvents;
+    protected $disableEvents;
 
     /**
      * Disables events during creation.

--- a/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
+++ b/src/Illuminate/Database/Eloquent/Factories/DisablesEvents.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Collection;
 
 trait DisablesEvents
 {
+    /**
+     * Tracks if events should be disabled in this factory instance.
+     *
+     * @var mixed
+     */
     protected $disableEvents;
 
     /**
@@ -34,6 +39,8 @@ trait DisablesEvents
 
     /**
      * Checks if events should be disabled for creation.
+     *
+     * @return bool
      */
     protected function shouldDisableEvents(): bool
     {
@@ -48,7 +55,6 @@ trait DisablesEvents
      * Set the connection name on the results and store them.
      *
      * @param  \Illuminate\Support\Collection  $results
-     *
      * @return void
      */
     protected function store(Collection $results)
@@ -62,10 +68,10 @@ trait DisablesEvents
 
     /**
      * Create a new instance of the factory builder with the given mutated properties.
+     *
      * This propagates the event disabler across states.
      *
      * @param  array  $arguments
-     *
      * @return static
      */
     protected function newInstance(array $arguments = [])

--- a/tests/Database/DatabaseEloquentFactoryDisablesEventsTest.php
+++ b/tests/Database/DatabaseEloquentFactoryDisablesEventsTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Illuminate\Database\Eloquent\Factories\DisablesEvents;
+
+class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    private const ALL_MODEL_EVENTS = [
+        'retrieved' => 'dispatch',
+        'creating' => 'until',
+        'created' => 'dispatch',
+        'updating' => 'until',
+        'updated' => 'dispatch',
+        'saving' => 'until',
+        'saved' => 'dispatch',
+        'deleting' => 'until',
+        'deleted' => 'dispatch',
+        'restoring' => 'until',
+        'restored' => 'dispatch',
+    ];
+
+    private const CREATE_MODEL_EVENTS = [
+        'creating' => 'until',
+        'created' => 'dispatch',
+        'saving' => 'until',
+        'saved' => 'dispatch',
+    ];
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function createSchema()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('options')->nullable();
+            $table->timestamps();
+        });
+
+        $this->schema()->create('posts', function ($table) {
+            $table->increments('id');
+            $table->foreignId('user_id');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function test_factory_creates_without_events()
+    {
+        $dispatcher = Mockery::spy(Dispatcher::class);
+        FactoryTestUser::setEventDispatcher($dispatcher);
+
+        $user = FactoryTestUserFactory::new()->withoutEvents()->create();
+
+        foreach (self::ALL_MODEL_EVENTS as $event => $method) {
+            $dispatcher->shouldNotHaveReceived(
+                $method,
+                [
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    Mockery::on(function ($arg) use ($user) {
+                        return $arg->is($user);
+                    }),
+                ]
+            );
+        }
+
+        $this->assertInstanceOf(FactoryTestUser::class, $user);
+    }
+
+    public function test_factory_creates_with_events()
+    {
+        $dispatcher = Mockery::spy(Dispatcher::class);
+        FactoryTestUser::setEventDispatcher($dispatcher);
+
+        $user = FactoryTestUserFactory::new()->create();
+
+        foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
+            $dispatcher->shouldHaveReceived($method)
+                ->with(
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    Mockery::on(function ($arg) use ($user) {
+                        return $arg->is($user);
+                    }),
+                );
+        }
+
+        $this->assertInstanceOf(FactoryTestUser::class, $user);
+    }
+
+    public function test_factory_creates_without_events_and_relationship()
+    {
+        $dispatcher = Mockery::spy(Dispatcher::class);
+        FactoryTestPost::setEventDispatcher($dispatcher);
+        FactoryTestUser::setEventDispatcher($dispatcher);
+
+        $post = FactoryTestPostFactory::new()->withoutEvents()->create();
+
+        foreach (self::ALL_MODEL_EVENTS as $event => $method) {
+            $dispatcher->shouldNotHaveReceived(
+                $method,
+                [
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestPost",
+                    Mockery::type(FactoryTestPost::class),
+                ]
+            );
+        }
+
+        foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
+            $dispatcher->shouldHaveReceived($method)
+                ->with(
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    Mockery::type(FactoryTestUser::class)
+                );
+        }
+
+        $this->assertInstanceOf(FactoryTestPost::class, $post);
+        $this->assertInstanceOf(FactoryTestUser::class, $post->user);
+    }
+
+    public function test_factory_creates_with_events_and_relationship()
+    {
+        $dispatcher = Mockery::spy(Dispatcher::class);
+        FactoryTestPost::setEventDispatcher($dispatcher);
+        FactoryTestUser::setEventDispatcher($dispatcher);
+
+        $post = FactoryTestPostFactory::new()->withEvents()->create();
+
+        foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
+            $dispatcher->shouldHaveReceived($method)
+                ->with(
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestPost",
+                    Mockery::type(FactoryTestPost::class)
+                );
+            $dispatcher->shouldHaveReceived($method)
+                ->with(
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    Mockery::type(FactoryTestUser::class)
+                );
+        }
+
+        $this->assertInstanceOf(FactoryTestPost::class, $post);
+        $this->assertInstanceOf(FactoryTestUser::class, $post->user);
+    }
+
+    protected function setUp(): void
+    {
+        Container::getInstance()->singleton(\Faker\Generator::class, function ($app, $parameters) {
+            return \Faker\Factory::create('en_US');
+        });
+
+        $db = new DB;
+
+        $db->addConnection([
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+
+        $this->createSchema();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->schema()->drop('users');
+    }
+
+    /**
+     * Get a database connection instance.
+     *
+     * @return \Illuminate\Database\ConnectionInterface
+     */
+    protected function connection()
+    {
+        return Eloquent::getConnectionResolver()->connection();
+    }
+
+    /**
+     * Get a schema builder instance.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return $this->connection()->getSchemaBuilder();
+    }
+}
+
+class FactoryTestUserFactory extends Factory
+{
+    use DisablesEvents;
+
+    protected $model = FactoryTestUser::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name,
+            'options' => null,
+        ];
+    }
+}
+
+class FactoryTestUser extends Eloquent
+{
+    use HasFactory;
+
+    protected $table = 'users';
+
+    public function posts()
+    {
+        return $this->hasMany(FactoryTestPost::class, 'user_id');
+    }
+}
+
+class FactoryTestPostFactory extends Factory
+{
+    use DisablesEvents;
+
+    protected $model = FactoryTestPost::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => FactoryTestUserFactory::new(),
+            'title' => $this->faker->name,
+        ];
+    }
+}
+
+class FactoryTestPost extends Eloquent
+{
+    protected $table = 'posts';
+
+    public function user()
+    {
+        return $this->belongsTo(FactoryTestUser::class, 'user_id');
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(FactoryTestUser::class, 'user_id');
+    }
+}

--- a/tests/Database/DatabaseEloquentFactoryDisablesEventsTest.php
+++ b/tests/Database/DatabaseEloquentFactoryDisablesEventsTest.php
@@ -2,16 +2,16 @@
 
 namespace Illuminate\Tests\Database;
 
-use Mockery;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Capsule\Manager as DB;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Illuminate\Database\Eloquent\Factories\DisablesEvents;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
 class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
 {
@@ -63,15 +63,15 @@ class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
     public function test_factory_creates_without_events()
     {
         $dispatcher = Mockery::spy(Dispatcher::class);
-        FactoryTestUser::setEventDispatcher($dispatcher);
+        FactoryEventTestUser::setEventDispatcher($dispatcher);
 
-        $user = FactoryTestUserFactory::new()->withoutEvents()->create();
+        $user = FactoryEventTestUserFactory::new()->withoutEvents()->create();
 
         foreach (self::ALL_MODEL_EVENTS as $event => $method) {
             $dispatcher->shouldNotHaveReceived(
                 $method,
                 [
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestUser",
                     Mockery::on(function ($arg) use ($user) {
                         return $arg->is($user);
                     }),
@@ -79,43 +79,43 @@ class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
             );
         }
 
-        $this->assertInstanceOf(FactoryTestUser::class, $user);
+        $this->assertInstanceOf(FactoryEventTestUser::class, $user);
     }
 
     public function test_factory_creates_with_events()
     {
         $dispatcher = Mockery::spy(Dispatcher::class);
-        FactoryTestUser::setEventDispatcher($dispatcher);
+        FactoryEventTestUser::setEventDispatcher($dispatcher);
 
-        $user = FactoryTestUserFactory::new()->create();
+        $user = FactoryEventTestUserFactory::new()->create();
 
         foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
             $dispatcher->shouldHaveReceived($method)
                 ->with(
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestUser",
                     Mockery::on(function ($arg) use ($user) {
                         return $arg->is($user);
                     }),
                 );
         }
 
-        $this->assertInstanceOf(FactoryTestUser::class, $user);
+        $this->assertInstanceOf(FactoryEventTestUser::class, $user);
     }
 
     public function test_factory_creates_without_events_and_relationship()
     {
         $dispatcher = Mockery::spy(Dispatcher::class);
-        FactoryTestPost::setEventDispatcher($dispatcher);
-        FactoryTestUser::setEventDispatcher($dispatcher);
+        FactoryEventTestPost::setEventDispatcher($dispatcher);
+        FactoryEventTestUser::setEventDispatcher($dispatcher);
 
-        $post = FactoryTestPostFactory::new()->withoutEvents()->create();
+        $post = FactoryEventTestPostFactory::new()->withoutEvents()->create();
 
         foreach (self::ALL_MODEL_EVENTS as $event => $method) {
             $dispatcher->shouldNotHaveReceived(
                 $method,
                 [
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestPost",
-                    Mockery::type(FactoryTestPost::class),
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestPost",
+                    Mockery::type(FactoryEventTestPost::class),
                 ]
             );
         }
@@ -123,38 +123,38 @@ class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
         foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
             $dispatcher->shouldHaveReceived($method)
                 ->with(
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
-                    Mockery::type(FactoryTestUser::class)
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestUser",
+                    Mockery::type(FactoryEventTestUser::class)
                 );
         }
 
-        $this->assertInstanceOf(FactoryTestPost::class, $post);
-        $this->assertInstanceOf(FactoryTestUser::class, $post->user);
+        $this->assertInstanceOf(FactoryEventTestPost::class, $post);
+        $this->assertInstanceOf(FactoryEventTestUser::class, $post->user);
     }
 
     public function test_factory_creates_with_events_and_relationship()
     {
         $dispatcher = Mockery::spy(Dispatcher::class);
-        FactoryTestPost::setEventDispatcher($dispatcher);
-        FactoryTestUser::setEventDispatcher($dispatcher);
+        FactoryEventTestPost::setEventDispatcher($dispatcher);
+        FactoryEventTestUser::setEventDispatcher($dispatcher);
 
-        $post = FactoryTestPostFactory::new()->withEvents()->create();
+        $post = FactoryEventTestPostFactory::new()->withEvents()->create();
 
         foreach (self::CREATE_MODEL_EVENTS as $event => $method) {
             $dispatcher->shouldHaveReceived($method)
                 ->with(
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestPost",
-                    Mockery::type(FactoryTestPost::class)
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestPost",
+                    Mockery::type(FactoryEventTestPost::class)
                 );
             $dispatcher->shouldHaveReceived($method)
                 ->with(
-                    "eloquent.${event}: Illuminate\Tests\Database\FactoryTestUser",
-                    Mockery::type(FactoryTestUser::class)
+                    "eloquent.${event}: Illuminate\Tests\Database\FactoryEventTestUser",
+                    Mockery::type(FactoryEventTestUser::class)
                 );
         }
 
-        $this->assertInstanceOf(FactoryTestPost::class, $post);
-        $this->assertInstanceOf(FactoryTestUser::class, $post->user);
+        $this->assertInstanceOf(FactoryEventTestPost::class, $post);
+        $this->assertInstanceOf(FactoryEventTestUser::class, $post->user);
     }
 
     protected function setUp(): void
@@ -207,11 +207,11 @@ class DatabaseEloquentFactoryDisablesEventsTest extends TestCase
     }
 }
 
-class FactoryTestUserFactory extends Factory
+class FactoryEventTestUserFactory extends Factory
 {
     use DisablesEvents;
 
-    protected $model = FactoryTestUser::class;
+    protected $model = FactoryEventTestUser::class;
 
     public function definition()
     {
@@ -222,7 +222,7 @@ class FactoryTestUserFactory extends Factory
     }
 }
 
-class FactoryTestUser extends Eloquent
+class FactoryEventTestUser extends Eloquent
 {
     use HasFactory;
 
@@ -230,36 +230,36 @@ class FactoryTestUser extends Eloquent
 
     public function posts()
     {
-        return $this->hasMany(FactoryTestPost::class, 'user_id');
+        return $this->hasMany(FactoryEventTestPost::class, 'user_id');
     }
 }
 
-class FactoryTestPostFactory extends Factory
+class FactoryEventTestPostFactory extends Factory
 {
     use DisablesEvents;
 
-    protected $model = FactoryTestPost::class;
+    protected $model = FactoryEventTestPost::class;
 
     public function definition()
     {
         return [
-            'user_id' => FactoryTestUserFactory::new(),
+            'user_id' => FactoryEventTestUserFactory::new(),
             'title' => $this->faker->name,
         ];
     }
 }
 
-class FactoryTestPost extends Eloquent
+class FactoryEventTestPost extends Eloquent
 {
     protected $table = 'posts';
 
     public function user()
     {
-        return $this->belongsTo(FactoryTestUser::class, 'user_id');
+        return $this->belongsTo(FactoryEventTestUser::class, 'user_id');
     }
 
     public function author()
     {
-        return $this->belongsTo(FactoryTestUser::class, 'user_id');
+        return $this->belongsTo(FactoryEventTestUser::class, 'user_id');
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Benefits to end users
For users who make use of model events, especially the `creating`/`created` or `saving`/`saved` events, it is often desirable to skip those events for the sake of narrowing the scope of test in factories for tests or preventing incidental processing during seeders, etc. This PR adds a trait which allows for a fluent interface to skip model events during the factory creation of the model.

## Intended usage
After adding the `DisablesEvents` trait onto a model factory, a user can skip model events during the creation process by calling `ModelFactory::new()->withoutEvents()->create()`. Or, with the model trait: `Model::factory()->withoutEvents()->create()`

### Relationships
The scope of the `withoutEvents()` method only applies to the factory it is directly called on. To apply this to related models as well, one can do so in the definition by applying the method to the related model factory. It could also be applied to any other situation (states, etc) where a model factory could be present.

## Non-breaking feature
This addition is encapsulated in a trait which users can choose to add to their model factories if they wish. There are no impacts to any users who do not apply the trait.

## Makes readability better
This addition is primarily an ease-of-testing situation. There is nothing that it does that cannot currently be done using `Model::withoutEvents(...)` but it allows for better readability by doing so via the factory's fluent interface.
