### PR TITLE
[8.x] Add Num object

### DIFF
--- a/src/Illuminate/Support/Num.php
+++ b/src/Illuminate/Support/Num.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Illuminate\Support;
+
+use Illuminate\Support\Traits\Macroable;
+use InvalidArgumentException;
+
+class Num
+{
+    use Macroable;
+
+    protected $value;
+
+    /**
+     * Create a new instance of the class.
+     *
+     * @param int|float|string $value
+     * @return void
+     */
+    public function __construct($value = 0)
+    {
+        $this->validateValue($value);
+        $this->value = $value;
+    }
+
+    /**
+     * Get a new num object from the given numeric value.
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public static function of($value)
+    {
+        return new static($value);
+    }
+
+    /**
+     * Convert current value to absolute value.
+     *
+     * @return static
+     */
+    public function abs()
+    {
+        $this->value = abs($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Add value to current value
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public function add($value)
+    {
+        $this->validateValue($value);
+
+        $this->value += $value;
+
+        return $this;
+    }
+
+    /**
+     * Divide current value by passed value
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public function divide($value)
+    {
+        $this->validateValue($value);
+
+        $this->value /= $value;
+
+        return $this;
+    }
+
+    /**
+     * Format current value
+     *
+     * @param int $decimals
+     * @param string $decimalPoint
+     * @param string $thousandsSeparator
+     * @return string
+     */
+    public function format($decimals = 0, $decimalPoint = '.', $thousandsSeparator = ',')
+    {
+        return number_format($this->value, $decimals, $decimalPoint, $thousandsSeparator);
+    }
+
+    /**
+     * Check if current value is greater than passed value
+     *
+     * @param int|float|string $value
+     * @return bool
+     */
+    public function gt($value)
+    {
+        $this->validateValue($value);
+
+        return $this->value > $value;
+    }
+
+    /**
+     * Check if current value is greater than or equal to passed value
+     *
+     * @param int|float|string $value
+     * @return bool
+     */
+    public function gte($value)
+    {
+        $this->validateValue($value);
+
+        return $this->value >= $value;
+    }
+
+    /**
+     * Check if current value is float
+     *
+     * @return bool
+     */
+    public function isFloat()
+    {
+        return is_float($this->value);
+    }
+
+    /**
+     * Check if current value is integer
+     *
+     * @return bool
+     */
+    public function isInt()
+    {
+        return is_int($this->value);
+    }
+
+    /**
+     * Check if current value is negative
+     *
+     * @return bool
+     */
+    public function isNegative()
+    {
+        return $this->value < 0;
+    }
+
+    /**
+     * Check if current value is numeric
+     *
+     * @return bool
+     */
+    public function isNumeric()
+    {
+        return is_numeric($this->value);
+    }
+
+    /**
+     * Check if current value is positive
+     *
+     * @return bool
+     */
+    public function isPositive()
+    {
+        return $this->value > 0;
+    }
+
+    /**
+     * Check if current value is zero
+     *
+     * @return bool
+     */
+    public function isZero()
+    {
+        return $this->value == 0;
+    }
+
+    /**
+     * Natural logarithm
+     *
+     * @param int|float|null $base
+     * @return static
+     */
+    public function log($base = null)
+    {
+        $this->value = log($this->value, $base);
+
+        return $this;
+    }
+
+    /**
+     * Base-10 logarithm
+     *
+     * @return static
+     */
+    public function log10()
+    {
+        $this->value = log10($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Check if current value is less than passed value
+     *
+     * @param int|float|string $value
+     * @return bool
+     */
+    public function lt($value)
+    {
+        $this->validateValue($value);
+
+        return $this->value < $value;
+    }
+
+    /**
+     * Check if current value is less than or equal to passed value
+     *
+     * @param int|float|string $value
+     * @return bool
+     */
+    public function lte($value)
+    {
+        $this->validateValue($value);
+
+        return $this->value <= $value;
+    }
+
+    /**
+     * Multiply current value by passed value
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public function multiply($value)
+    {
+        $this->validateValue($value);
+
+        $this->value *= $value;
+
+        return $this;
+    }
+
+    /**
+     * Exponential current value by passed value
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public function pow($value)
+    {
+        $this->validateValue($value);
+
+        $this->value **= $value;
+
+        return $this;
+    }
+
+    /**
+     * Square root of current value
+     *
+     * @return static
+     */
+    public function sqrt()
+    {
+        $this->value = sqrt($this->value);
+
+        return $this;
+    }
+
+    /**
+     * Subtract value from current value
+     *
+     * @param int|float|string $value
+     * @return static
+     */
+    public function sub($value)
+    {
+        $this->validateValue($value);
+
+        $this->value -= $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the raw float value
+     *
+     * @return float
+     */
+    public function toFloat(): float
+    {
+        return (float)$this->value;
+    }
+
+    /**
+     * Get the raw int value
+     *
+     * @return int
+     */
+    public function toInt()
+    {
+        return (int)$this->value;
+    }
+
+    /**
+     * Validate provided value is numeric
+     *
+     * @param int|float|string $value
+     * @return void
+     *
+     * @throws \InvalidArgumentException
+     */
+    protected function validateValue($value)
+    {
+        if (!is_numeric($value)) {
+            throw new InvalidArgumentException('Invalid value provided. Please provide a integer, float, or numeric string.');
+        }
+    }
+}

--- a/src/Illuminate/Support/Num.php
+++ b/src/Illuminate/Support/Num.php
@@ -62,6 +62,16 @@ class Num
     }
 
     /**
+     * Check the current value
+     *
+     * @return void
+     */
+    public function dd()
+    {
+        dd($this->value);
+    }
+
+    /**
      * Divide current value by passed value
      *
      * @param int|float|string $value

--- a/tests/Support/SupportNumTest.php
+++ b/tests/Support/SupportNumTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Illuminate\Tests\Support;
+
+use Illuminate\Support\Num;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class SupportNumTest extends TestCase
+{
+    public function testNumberCanBeAbsolute(): void
+    {
+        $this->assertSame(10, Num::of(-10)->abs()->toInt());
+    }
+
+    public function testNumberCanBeAdded(): void
+    {
+        $this->assertSame(20, Num::of('10')->add('10')->toInt());
+        $this->assertSame(20, Num::of('10')->add(10)->toInt());
+        $this->assertSame(20, Num::of(10)->add('10')->toInt());
+        $this->assertSame(20, Num::of(10)->add(10)->toInt());
+    }
+
+    public function testNumberCanBeCastedToFloat(): void
+    {
+        $this->assertSame(-10.0, Num::of('-10')->toFloat());
+        $this->assertSame(10.0, Num::of('10')->toFloat());
+        $this->assertSame(10.0, Num::of(10)->toFloat());
+        $this->assertSame(10.10, Num::of('10.10')->toFloat());
+        $this->assertSame(10.10, Num::of(10.10)->toFloat());
+    }
+
+    public function testNumberCanBeCastedToInt(): void
+    {
+        $this->assertSame(-10, Num::of('-10')->toInt());
+        $this->assertSame(10, Num::of('10')->toInt());
+        $this->assertSame(10, Num::of('10.10')->toInt());
+        $this->assertSame(10, Num::of(10)->toInt());
+        $this->assertSame(10, Num::of(10.10)->toInt());
+    }
+
+    public function testNumberCanBeCheckedIfFloat(): void
+    {
+        $this->assertFalse(Num::of('10.0')->isFloat());
+        $this->assertFalse(Num::of(10)->isFloat());
+        $this->assertTrue(Num::of(10.0)->isFloat());
+    }
+
+    public function testNumberCanBeCheckedIfGreaterThan(): void
+    {
+        $this->assertFalse(Num::of(10)->gt(100));
+        $this->assertFalse(Num::of(10)->gt(10));
+        $this->assertTrue(Num::of(10)->gt(5));
+    }
+
+    public function testNumberCanBeCheckedIfGreaterThanOrEqual(): void
+    {
+        $this->assertFalse(Num::of(10)->gte(100));
+        $this->assertTrue(Num::of(10)->gte(10));
+        $this->assertTrue(Num::of(10)->gte(5));
+    }
+
+    public function testNumberCanBeCheckedIfInt(): void
+    {
+        $this->assertFalse(Num::of('10')->isInt());
+        $this->assertFalse(Num::of(10.0)->isInt());
+        $this->assertTrue(Num::of(10)->isInt());
+    }
+
+    public function testNumberCanBeCheckedIfLessThan(): void
+    {
+        $this->assertFalse(Num::of(10)->lt(10));
+        $this->assertFalse(Num::of(10)->lt(5));
+        $this->assertTrue(Num::of(10)->lt(100));
+    }
+
+    public function testNumberCanBeCheckedIfLessThanOrEqual(): void
+    {
+        $this->assertFalse(Num::of(10)->lte(5));
+        $this->assertTrue(Num::of(10)->lte(10));
+        $this->assertTrue(Num::of(10)->lte(100));
+    }
+
+    public function testNumberCanBeCheckedIfNegative(): void
+    {
+        $this->assertFalse(Num::of(10)->isNegative());
+        $this->assertTrue(Num::of(-10)->isNegative());
+    }
+
+    public function testNumberCanBeCheckedIfNumeric(): void
+    {
+        $this->assertTrue(Num::of('10.0')->isNumeric());
+        $this->assertTrue(Num::of(10)->isNumeric());
+        $this->assertTrue(Num::of(10.0)->isNumeric());
+    }
+
+    public function testNumberCanBeCheckedIfPositive(): void
+    {
+        $this->assertFalse(Num::of(-10)->isPositive());
+        $this->assertTrue(Num::of(10)->isPositive());
+    }
+
+    public function testNumberCanBeCheckedIfZero(): void
+    {
+        $this->assertFalse(Num::of(-10)->isZero());
+        $this->assertFalse(Num::of(10)->isZero());
+        $this->assertTrue(Num::of('0')->isZero());
+        $this->assertTrue(Num::of(0)->isZero());
+        $this->assertTrue(Num::of(0.0)->isZero());
+    }
+
+    public function testNumberCanBeDivided(): void
+    {
+        $this->assertSame(1, Num::of(10)->divide(10)->toInt());
+        $this->assertSame(1.0, Num::of(10)->divide(10)->toFloat());
+    }
+
+    public function testNumberCanBeFormatted(): void
+    {
+        $this->assertSame('10', Num::of('10.0')->format());
+        $this->assertSame('10', Num::of(10)->format());
+        $this->assertSame('10', Num::of(10.0)->format());
+        $this->assertSame('10,00', Num::of('10.0')->format(2, ','));
+        $this->assertSame('10,00', Num::of(10)->format(2, ','));
+        $this->assertSame('10,00', Num::of(10.0)->format(2, ','));
+        $this->assertSame('10.00', Num::of('10.0')->format(2));
+        $this->assertSame('10.00', Num::of(10)->format(2));
+        $this->assertSame('10.00', Num::of(10.0)->format(2));
+        $this->assertSame('1_000,00', Num::of('1000.0')->format(2, ',', '_'));
+        $this->assertSame('1_000,00', Num::of(1000)->format(2, ',', '_'));
+        $this->assertSame('1_000,00', Num::of(1000.0)->format(2, ',', '_'));
+    }
+
+    public function testNumberCanBeLog(): void
+    {
+        $this->assertSame(2, Num::of('100')->log('10')->toInt());
+        $this->assertSame(2, Num::of('100')->log(10)->toInt());
+        $this->assertSame(2, Num::of(100)->log('10')->toInt());
+        $this->assertSame(2, Num::of(100)->log(10)->toInt());
+    }
+
+    public function testNumberCanBeLog10(): void
+    {
+        $this->assertSame(2, Num::of('100')->log10()->toInt());
+        $this->assertSame(2, Num::of('100')->log10()->toInt());
+        $this->assertSame(2, Num::of(100)->log10()->toInt());
+        $this->assertSame(2, Num::of(100)->log10()->toInt());
+    }
+
+    public function testNumberCanBeMultiplied(): void
+    {
+        $this->assertSame(100, Num::of(10)->multiply(10)->toInt());
+        $this->assertSame(100.0, Num::of(10)->multiply(10)->toFloat());
+    }
+
+    public function testNumberCanBeSubtracted(): void
+    {
+        $this->assertSame(0, Num::of('10')->sub('10')->toInt());
+        $this->assertSame(0, Num::of('10')->sub(10)->toInt());
+        $this->assertSame(0, Num::of(10)->sub('10')->toInt());
+        $this->assertSame(0, Num::of(10)->sub(10)->toInt());
+    }
+
+    public function testNumberCanExponential(): void
+    {
+        $this->assertSame(100, Num::of('10')->pow('2')->toInt());
+        $this->assertSame(100, Num::of('10')->pow(2)->toInt());
+        $this->assertSame(100, Num::of(10)->pow('2')->toInt());
+        $this->assertSame(100, Num::of(10)->pow(2)->toInt());
+    }
+
+    public function testNumberCanSquareRoot(): void
+    {
+        $this->assertSame(10, Num::of('100')->sqrt()->toInt());
+        $this->assertSame(10, Num::of(100)->sqrt()->toInt());
+    }
+
+    public function testNumberThrowsAnInvalidArgumentExceptionWhenNonNumericValuePassed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Num::of('String');
+    }
+}


### PR DESCRIPTION
OOP approach for basic math operations

Right now if we want to do any manipulation with numbers we face the dreadful readability problem.

```php
$result = 5 + 5 * 5 ** 2 / 5 - 5;
```

With this new class we are able to drastically increase readability.

```php
$result = Num::of(5)->pow(2)->multiply(5)->divide(5)->add(5)->sub(5)->toInt();
```

Also having `dd()` is a must :D

```php
$result = Num::of(5)->pow(2)->multiply(5)->dd()->divide(5)->add(5)->sub(5)->toInt();
```

What do you guys think?