### PR TITLE
[8.x] Add Json path expression object

### DIFF
--- a/src/Illuminate/Database/Query/JsonPath.php
+++ b/src/Illuminate/Database/Query/JsonPath.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Illuminate\Database\Query;
+
+use Illuminate\Support\Str;
+
+class JsonPath extends Expression implements \ArrayAccess
+{
+    public const SEPARATOR = '.';
+
+    /**
+     * Create a new instance of the JsonPath expression.
+     *
+     * @param string|null $scope
+     *
+     * @return static
+     */
+    public static function make(?string $scope = null): self
+    {
+        return new static($scope);
+    }
+
+    /**
+     * The Json path.
+     *
+     * @var array
+     */
+    protected $path = [];
+
+    /**
+     * @var string|null
+     */
+    protected $scope;
+
+    /**
+     * @param string|null $scope
+     */
+    public function __construct(?string $scope = null)
+    {
+        parent::__construct(null);
+        $this->scope = $scope ?? '$';
+    }
+
+    /**
+     * Allows for a member leg path to be set using magic properties.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function __get(string $name): self
+    {
+        return $this->member($name);
+    }
+
+    /**
+     *
+     * Add a path leg for all cells.
+     *
+     * Uses the asterisk wildcard to select all child cells.
+     * Creates paths like `$.foo[*].name`.
+     *
+     * @return static
+     */
+    public function allCells(): self
+    {
+        return $this->cell('*');
+    }
+
+    /**
+     * Add a path leg for all members.
+     *
+     * Uses the asterisk wildcard to select all child members.
+     * Creates paths like `$.foo[0].*`.
+     *
+     * @return static
+     */
+    public function allMembers(): self
+    {
+        return $this->identifier('*');
+    }
+
+    /**
+     * Add a cell index path leg.
+     *
+     * Cell indexes are Json array keys. In the example
+     * `$.foo[0].name` the 0 in `[0]` is the cell index.
+     *
+     * @param string|int $index Should be either a positive index or an asterisk
+     *
+     * @return static
+     */
+    public function cell($index): self
+    {
+        return $this->addPathLeg('cell', $index);
+    }
+
+    /**
+     * Get the value of the expression.
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return array_reduce($this->path, static function ($carry, array $item) {
+            switch ($item['type']) {
+                case 'member':
+                    return $carry . self::SEPARATOR . '"' . $item['name'] . '"';
+                case 'identifier':
+                    return $carry . self::SEPARATOR . $item['name'];
+                case 'cell':
+                    return $carry . '[' . $item['name'] . ']';
+                case 'match':
+                    return $carry . self::SEPARATOR . ($item['prefix'] ? '[' . $item['prefix'] . ']' : '') . '**' . $item['suffix'];
+            }
+
+            return $carry;
+        }, $this->scope);
+    }
+
+    /**
+     * Add a path for an ECMAScript identifier.
+     *
+     * @param string $name
+     *
+     * @return $this
+     *
+     * @link http://www.ecma-international.org/ecma-262/5.1/#sec-7.6
+     */
+    public function identifier(string $name): self
+    {
+        return $this->addPathLeg('identifier', $name);
+    }
+
+    /**
+     * Add a match path leg for a suffix and optional prefix.
+     *
+     * Generates paths using the `**` token. Paths generated are like
+     * `$.foo[0].[prefix]**suffix` and `$.foo[0].**suffix`.
+     *
+     * @param string      $suffix
+     * @param string|null $prefix
+     *
+     * @return $this
+     */
+    public function matches(string $suffix, ?string $prefix = null): self
+    {
+        return $this->addPathLeg('match', [
+            'prefix' => $prefix,
+            'suffix' => $suffix,
+        ]);
+    }
+
+    /**
+     * Add a member path leg.
+     *
+     * Member path legs are Json object keys. In the example
+     * `$.foo[0].name` both `foo` and `name` are members.
+     *
+     * @param string $name
+     *
+     * @return static
+     */
+    public function member(string $name): self
+    {
+        // If the member is an asterisk we want to select all members.
+        if ($name === '*') {
+            return $this->allMembers();
+        }
+
+        // If the member contains a double asterisk it's a match path leg
+        // so we're going to want to pass that where appropriate.
+        if (Str::contains($name, '**')) {
+            return $this->matches(...array_reverse(explode('**', $name)));
+        }
+
+        return $this->addPathLeg('member', $name);
+    }
+
+    /**
+     * Always returns false as there's no real reason to
+     * check whether an index exists.
+     *
+     * @param mixed $offset
+     *
+     * @return bool
+     */
+    public function offsetExists($offset): bool
+    {
+        return false;
+    }
+
+    /**
+     * Allows for the setting of cell index as if accessing the object as
+     * an array.
+     *
+     * @param mixed $offset
+     *
+     * @return static
+     */
+    public function offsetGet($offset)
+    {
+        return $this->cell($offset);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        // This method is intentionally empty
+    }
+
+    public function offsetUnset($offset): void
+    {
+        // This method is intentionally empty
+    }
+
+    /**
+     * Adds a leg to the Json path.
+     *
+     * @param string       $type
+     * @param string|array $details
+     *
+     * @return static
+     */
+    protected function addPathLeg(string $type, $details): self
+    {
+        $path = compact('type');
+
+        if (is_array($details)) {
+            $path = array_merge($path, $details);
+        } else {
+            $path['name'] = $details;
+        }
+
+        $this->path[] = $path;
+
+        return $this;
+    }
+}

--- a/src/Illuminate/Database/Query/JsonPath.php
+++ b/src/Illuminate/Database/Query/JsonPath.php
@@ -15,7 +15,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public static function make(?string $scope = null): self
+    public static function make(?string $scope = null)
     {
         return new static($scope);
     }
@@ -50,7 +50,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public function __get(string $name): self
+    public function __get(string $name)
     {
         return $this->member($name);
     }
@@ -64,7 +64,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public function allCells(): self
+    public function allCells()
     {
         return $this->cell('*');
     }
@@ -77,7 +77,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public function allMembers(): self
+    public function allMembers()
     {
         return $this->identifier('*');
     }
@@ -92,7 +92,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public function cell($index): self
+    public function cell($index)
     {
         return $this->addPathLeg('cell', $index);
     }
@@ -137,7 +137,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @link http://www.ecma-international.org/ecma-262/5.1/#sec-7.6
      */
-    public function identifier(string $name): self
+    public function identifier(string $name)
     {
         return $this->addPathLeg('identifier', $name);
     }
@@ -152,7 +152,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return $this
      */
-    public function matches(string $suffix): self
+    public function matches(string $suffix)
     {
         return $this->addPathLeg('match', $suffix);
     }
@@ -167,7 +167,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    public function member(string $name): self
+    public function member(string $name)
     {
         // If the member is an asterisk we want to select all members.
         if ($name === '*') {
@@ -197,7 +197,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset): bool
+    public function offsetExists($offset)
     {
         return false;
     }
@@ -215,12 +215,23 @@ class JsonPath extends Expression implements \ArrayAccess
         return $this->cell($offset);
     }
 
-    public function offsetSet($offset, $value): void
+    /**
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     * @return void
+     */
+    public function offsetSet($offset, $value)
     {
         // This method is intentionally empty
     }
 
-    public function offsetUnset($offset): void
+    /**
+     *
+     * @param mixed $offset
+     * @return void
+     */
+    public function offsetUnset($offset)
     {
         // This method is intentionally empty
     }
@@ -233,7 +244,7 @@ class JsonPath extends Expression implements \ArrayAccess
      *
      * @return static
      */
-    protected function addPathLeg(string $type, string $name): self
+    protected function addPathLeg(string $type, string $name)
     {
         $this->path[] = [
             'type' => $type,


### PR DESCRIPTION
This PR adds the `JsonPath` expression that I suggested as a fix in #26415.

The `JsonPath` expression provides a fluent builder for building MySQL Json paths and avoiding the ambiguity in the current method. The terminology within this object matches that of the MySQL implementation.

## Creating

This object can be created either with a column name or nothing. If no argument is provided the default current scope identifier of `$` will be used instead.

```php
// With column
JsonPath::make('column'); // column

// Use default current scope
JsonPath::make();         // $
```

## Members

There are 3 ways to provide a member (Json object key).

```php
// Using the method
JsonPath::make('column')->member('foo');     // column."foo"

// Using the magic __get method
JsonPath::make('column')->foo;               // column."foo"

// Using the ECMA identifier method
JsonPath::make('column')->identifier('foo'); // column.foo
```

All members, unless ECMA identifiers, will be escaped using `"`. Because of the ambiguity between a member string and an identifier, they can only be provided using the method. See [this](http://www.ecma-international.org/ecma-262/5.1/#sec-7.6) for more information.

## Cells
There are 2 ways to provide a cell (Json array index).

```php
// Using the method
JsonPath::make('column')->member('foo')->cell(0); // column."foo"[0]

// Using the ArrayAccess implementation
JsonPath::make('column')->foo[0];                 // column."foo"[0]
```

To achieve the second of these I implemented `ArrayAccess`. The `offsetExists` method always returns false because it isn't needed, and both `offsetSet` and `offsetUnset` are intentionally empty.

## Matches
You can also provide a match based on suffix and prefix as per the MySQL spec.

```php
// Using the method
JsonPath::make('column')->matches('suffix');                    // column**"suffix"

// Using the method with a prefix
JsonPath::make('column')->method('prefix')->matches('suffix');  // column."prefix"**"suffix"

// Using the __get magic method
JsonPath::make('column')->{'**suffix'};                         // column**"suffix"

// Using the __get magic method with a prefix
JsonPath::make('column')->{'prefix**suffix'};                   // column."prefix"**"suffix"
```

If the preceding leg of the path is a cell (`[0]`) or another match a `.` separator will be added.

## All
You can select all members or all cells in one of 2 ways.

```php
// Using the methods
JsonPath::make('column')->member('foo')->allCells();    // column."foo"[*]
JsonPath::make('column')->member('foo')->allMembers();  // column."foo".*

// Using the magic __get and ArrayAccess methods methods
JsonPath::make('column')->foo['*'];                     // column."foo"[*]
JsonPath::make('column')->foo->{'*'};                   // column."foo".*
```

### Side notes
I've commented where possible and add the types for the primitives where possible, though I don't recall if this is something I should be avoiding.