### PR TITLE
[8.x] Fix spelling error in CHANGELOG-8x.md

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -13,7 +13,7 @@
 - Fixed problems with dots in validator ([#34355](https://github.com/laravel/framework/pull/34355))
 - Maintenance mode: Fix empty Retry-After header ([#34412](https://github.com/laravel/framework/pull/34412))
 - Fixed bug with error handling in closure scheduled tasks ([#34420](https://github.com/laravel/framework/pull/34420))
-- Dont double escape on ComponentTagCompiler.php ([12ba0d9](https://github.com/laravel/framework/commit/12ba0d937d54e81eccf8f0a80150f0d70604e1c2))
+- Don't double escape on ComponentTagCompiler.php ([12ba0d9](https://github.com/laravel/framework/commit/12ba0d937d54e81eccf8f0a80150f0d70604e1c2))
 - Fixed `mysqldump: unknown variable 'column-statistics=0` for MariaDB schema dump ([#34442](https://github.com/laravel/framework/pull/34442))
 
 


### PR DESCRIPTION
## Changes:

- Change word `dont` -> `don't`

## Context:

Fix a spelling error.