### PR TITLE
[6.x] Revert cascading truncations

### DIFF
--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -318,7 +318,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
     }
 
     /**


### PR DESCRIPTION
This PR reverses #26389 which introduces cascading truncations in postgres. The spirit of the original fix was to address a constraint of postgres in that disabling foreign key constrains does not allow a developer to a truncate a table that has foreign keys. However, the proposed and accepted solution results in all tables that have a column that references the table under question for truncation to be also truncated and further any tables that referenced the children of the first table. This can and has created a problematic situation when you discover that truncating a small table results in the loss of your entire database.

As that is not expected behavior for truncation of a table, I would propose that the word cascading be removed from truncation and that documentation be created in the laravel docs indicating that this was the behavior in postgres between version [initial release version] and [this release version].

Issue: #29506

As @crazyscience brought up yesterday: 
>  This code causes EVERY table to be truncated that has a related constraint to the one referenced in DB::truncate(). 
 So, if you follow a typical design pattern where all of your tables are constrained with foreign keys, DB::truncate('anything') results in large-scale data destruction. That's super dangerous and isn't expected behavior when someone is doing DB::truncate('just-one-table').
> 
> https://www.postgresql.org/docs/9.1/sql-truncate.html
>
> CASCADE
> 
> > Automatically truncate all tables that have foreign-key references to any of the named tables, or to any tables added to the group due to CASCADE.
> 
> As a note, this behavior OVERRIDES any ON DELETE that you may have set in the database.

This was merged yesterday in #34496 and then reverted without explanation in #34497. If this is supposed to be expected behavior I would urge that the docs be updated to reflect that in postgres, truncating a table will use a cascading truncate meaning that any related tables will be truncated without warning. I would also suggest that the cascading behavior be added to other sql truncate grammars so that truncations are at least consistent between sql languages and can provide that pull request. 

If requested, I can create an example environment for demonstrating the behavior.  