### PR TITLE
[8.x] Add ability to delete pending and/or delayed jobs

### DIFF
--- a/src/Illuminate/Contracts/Queue/DeletableQueue.php
+++ b/src/Illuminate/Contracts/Queue/DeletableQueue.php
@@ -12,4 +12,13 @@ interface DeletableQueue
      * @return bool
      */
     public function deletePending($queue, $id);
+
+    /**
+     * Delete a delayed job from the queue.
+     *
+     * @param  string|null  $queue
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function deleteDelayed($queue, $id);
 }

--- a/src/Illuminate/Contracts/Queue/DeletableQueue.php
+++ b/src/Illuminate/Contracts/Queue/DeletableQueue.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Contracts\Queue;
+
+interface DeletableQueue
+{
+    /**
+     * Delete a pending job from the queue.
+     *
+     * @param  string|null  $queue
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function deletePending($queue, $id);
+}

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -58,7 +58,7 @@ use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
-use Illuminate\Queue\Console\DeletePendingCommand as QueueDeletePendingCommand;
+use Illuminate\Queue\Console\DeleteCommand as QueueDeleteCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Queue\Console\FlushFailedCommand as FlushFailedQueueCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
@@ -99,7 +99,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'OptimizeClear' => 'command.optimize.clear',
         'PackageDiscover' => 'command.package.discover',
         'QueueClear' => 'command.queue.clear',
-        'QueueDeletePending' => 'command.queue.delete-pending',
+        'QueueDelete' => 'command.queue.delete',
         'QueueFailed' => 'command.queue.failed',
         'QueueFlush' => 'command.queue.flush',
         'QueueForget' => 'command.queue.forget',
@@ -733,10 +733,10 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
      *
      * @return void
      */
-    protected function registerQueueDeletePendingCommand()
+    protected function registerQueueDeleteCommand()
     {
-        $this->app->singleton('command.queue.delete-pending', function () {
-            return new QueueDeletePendingCommand;
+        $this->app->singleton('command.queue.delete', function () {
+            return new QueueDeleteCommand;
         });
     }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -58,6 +58,7 @@ use Illuminate\Foundation\Console\ViewClearCommand;
 use Illuminate\Notifications\Console\NotificationTableCommand;
 use Illuminate\Queue\Console\BatchesTableCommand;
 use Illuminate\Queue\Console\ClearCommand as QueueClearCommand;
+use Illuminate\Queue\Console\DeletePendingCommand as QueueDeletePendingCommand;
 use Illuminate\Queue\Console\FailedTableCommand;
 use Illuminate\Queue\Console\FlushFailedCommand as FlushFailedQueueCommand;
 use Illuminate\Queue\Console\ForgetFailedCommand as ForgetFailedQueueCommand;
@@ -98,6 +99,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'OptimizeClear' => 'command.optimize.clear',
         'PackageDiscover' => 'command.package.discover',
         'QueueClear' => 'command.queue.clear',
+        'QueueDeletePending' => 'command.queue.delete-pending',
         'QueueFailed' => 'command.queue.failed',
         'QueueFlush' => 'command.queue.flush',
         'QueueForget' => 'command.queue.forget',
@@ -723,6 +725,18 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     {
         $this->app->singleton('command.queue.clear', function () {
             return new QueueClearCommand;
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerQueueDeletePendingCommand()
+    {
+        $this->app->singleton('command.queue.delete-pending', function () {
+            return new QueueDeletePendingCommand;
         });
     }
 

--- a/src/Illuminate/Queue/Console/DeleteCommand.php
+++ b/src/Illuminate/Queue/Console/DeleteCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Queue\DeletableQueue;
 use ReflectionClass;
 
-class DeletePendingCommand extends Command
+class DeleteCommand extends Command
 {
     use ConfirmableTrait;
 
@@ -16,7 +16,7 @@ class DeletePendingCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'queue:delete {id : The ID of the pending job}
+    protected $signature = 'queue:delete {id : The ID of the pending or delayed job}
                             {--connection= : The name of the queue connection}
                             {--queue= : The name of the queue}';
 
@@ -25,7 +25,7 @@ class DeletePendingCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Delete a pending job from the queue';
+    protected $description = 'Delete a pending or delayed job from the queue';
 
     /**
      * Execute the console command.
@@ -49,13 +49,14 @@ class DeletePendingCommand extends Command
         $queue = ($this->laravel['queue'])->connection($connection);
 
         if ($queue instanceof DeletableQueue) {
-            if ($queue->deletePending($queueName, $this->argument('id'))) {
-                $this->info('Pending job deleted successfully!');
+            if ($queue->deletePending($queueName, $this->argument('id')) ||
+                $queue->deleteDelayed($queueName, $this->argument('id'))) {
+                $this->info('Pending/delayed job deleted successfully!');
             } else {
-                $this->error('No pending job matches the given ID.');
+                $this->error('No pending/delayed job matches the given ID.');
             }
         } else {
-            $this->error('Deleting pending jobs is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
+            $this->error('Deleting pending/delayed jobs is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
         }
 
         return 0;

--- a/src/Illuminate/Queue/Console/DeletePendingCommand.php
+++ b/src/Illuminate/Queue/Console/DeletePendingCommand.php
@@ -17,8 +17,8 @@ class DeletePendingCommand extends Command
      * @var string
      */
     protected $signature = 'queue:delete {id : The ID of the pending job}
-                            {--connection= : The name of the queue connection to clear}
-                            {--queue= : The name of the queue to clear}';
+                            {--connection= : The name of the queue connection}
+                            {--queue= : The name of the queue}';
 
     /**
      * The console command description.
@@ -49,20 +49,20 @@ class DeletePendingCommand extends Command
         $queue = ($this->laravel['queue'])->connection($connection);
 
         if ($queue instanceof DeletableQueue) {
-            if($queue->deletePending($queueName, $this->argument('id'))) {
+            if ($queue->deletePending($queueName, $this->argument('id'))) {
                 $this->info('Pending job deleted successfully!');
             } else {
                 $this->error('No pending job matches the given ID.');
             }
         } else {
-            $this->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
+            $this->error('Deleting pending jobs is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
         }
 
         return 0;
     }
 
     /**
-     * Get the queue name to clear.
+     * Get the queue name.
      *
      * @param  string  $connection
      * @return string

--- a/src/Illuminate/Queue/Console/DeletePendingCommand.php
+++ b/src/Illuminate/Queue/Console/DeletePendingCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Illuminate\Queue\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Contracts\Queue\DeletableQueue;
+use ReflectionClass;
+
+class DeletePendingCommand extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'queue:delete {id : The ID of the pending job}
+                            {--connection= : The name of the queue connection to clear}
+                            {--queue= : The name of the queue to clear}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete a pending job from the queue';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return 1;
+        }
+
+        $connection = $this->option('connection')
+                        ?: $this->laravel['config']['queue.default'];
+
+        // We need to get the right queue for the connection which is set in the queue
+        // configuration file for the application. We will pull it based on the set
+        // connection being run for the queue operation currently being executed.
+        $queueName = $this->getQueue($connection);
+
+        $queue = ($this->laravel['queue'])->connection($connection);
+
+        if ($queue instanceof DeletableQueue) {
+            if($queue->deletePending($queueName, $this->argument('id'))) {
+                $this->info('Pending job deleted successfully!');
+            } else {
+                $this->error('No pending job matches the given ID.');
+            }
+        } else {
+            $this->error('Clearing queues is not supported on ['.(new ReflectionClass($queue))->getShortName().']');
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get the queue name to clear.
+     *
+     * @param  string  $connection
+     * @return string
+     */
+    protected function getQueue($connection)
+    {
+        return $this->option('queue') ?: $this->laravel['config']->get(
+            "queue.connections.{$connection}.queue", 'default'
+        );
+    }
+}

--- a/src/Illuminate/Queue/DatabaseQueue.php
+++ b/src/Illuminate/Queue/DatabaseQueue.php
@@ -320,8 +320,10 @@ class DatabaseQueue extends Queue implements QueueContract, ClearableQueue, Dele
                     ->whereNull('reserved_at')
                     ->lockForUpdate()->find($id)) {
                 $this->database->table($this->table)->where('id', $id)->delete();
+
                 return true;
             }
+
             return false;
         });
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -3,12 +3,13 @@
 namespace Illuminate\Queue;
 
 use Illuminate\Contracts\Queue\ClearableQueue;
+use Illuminate\Contracts\Queue\DeletableQueue;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Queue\Jobs\RedisJob;
 use Illuminate\Support\Str;
 
-class RedisQueue extends Queue implements QueueContract, ClearableQueue
+class RedisQueue extends Queue implements QueueContract, ClearableQueue, DeletableQueue
 {
     /**
      * The Redis factory implementation.
@@ -255,6 +256,20 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue
         }
 
         return [$job, $reserved];
+    }
+
+    /**
+     * Delete a pending job from the queue.
+     *
+     * @param  string|null  $queue
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function deletePending($queue, $id)
+    {
+        return $this->getConnection()->eval(
+            LuaScripts::deletePending(), 1, $this->getQueue($queue), $id
+        );
     }
 
     /**

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -267,7 +267,7 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue, Deletab
      */
     public function deletePending($queue, $id)
     {
-        return $this->getConnection()->eval(
+        return (bool) $this->getConnection()->eval(
             LuaScripts::deletePending(), 1, $this->getQueue($queue), $id
         );
     }

--- a/src/Illuminate/Queue/RedisQueue.php
+++ b/src/Illuminate/Queue/RedisQueue.php
@@ -273,6 +273,20 @@ class RedisQueue extends Queue implements QueueContract, ClearableQueue, Deletab
     }
 
     /**
+     * Delete a delayed job from the queue.
+     *
+     * @param  string|null  $queue
+     * @param  mixed  $id
+     * @return bool
+     */
+    public function deleteDelayed($queue, $id)
+    {
+        return (bool) $this->getConnection()->eval(
+            LuaScripts::deleteDelayed(), 1, $this->getQueue($queue).':delayed', $id
+        );
+    }
+
+    /**
      * Delete a reserved job from the queue.
      *
      * @param  string  $queue

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -148,6 +148,37 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
     }
 
     /**
+     * Test that the pending jobs can be deleted.
+     */
+    public function testThatPendingJobsCanBeDeleted()
+    {
+        $this->connection()
+            ->table('jobs')
+            ->insert([[
+                'id' => 1,
+                'queue' => $mock_queue_name = 'mock_queue_name',
+                'payload' => 'mock_payload',
+                'attempts' => 0,
+                'reserved_at' => Carbon::now()->addDay()->getTimestamp(),
+                'available_at' => Carbon::now()->subDay()->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ], [
+                'id' => 2,
+                'queue' => $mock_queue_name,
+                'payload' => 'mock_payload 2',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ]]);
+
+        $this->assertTrue($this->queue->deletePending($mock_queue_name, 2));
+        $this->assertEquals(1, $this->queue->size($mock_queue_name));
+        $this->assertFalse($this->queue->deletePending($mock_queue_name, 1));
+        $this->assertEquals(1, $this->queue->size($mock_queue_name));
+    }
+
+    /**
      * Test that the queue can be cleared.
      */
     public function testThatQueueCanBeCleared()
@@ -173,7 +204,7 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
             ]]);
 
         $this->assertEquals(2, $this->queue->clear($mock_queue_name));
-        $this->assertEquals(0, $this->queue->size());
+        $this->assertEquals(0, $this->queue->size($mock_queue_name));
     }
 
     /**

--- a/tests/Queue/QueueDatabaseQueueIntegrationTest.php
+++ b/tests/Queue/QueueDatabaseQueueIntegrationTest.php
@@ -170,12 +170,63 @@ class QueueDatabaseQueueIntegrationTest extends TestCase
                 'reserved_at' => null,
                 'available_at' => Carbon::now()->subSeconds(1)->getTimestamp(),
                 'created_at' => Carbon::now()->getTimestamp(),
+            ], [
+                'id' => 3,
+                'queue' => $mock_queue_name = 'mock_queue_name',
+                'payload' => 'mock_payload',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->addSeconds(60)->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
             ]]);
 
         $this->assertTrue($this->queue->deletePending($mock_queue_name, 2));
-        $this->assertEquals(1, $this->queue->size($mock_queue_name));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
         $this->assertFalse($this->queue->deletePending($mock_queue_name, 1));
-        $this->assertEquals(1, $this->queue->size($mock_queue_name));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
+        $this->assertFalse($this->queue->deletePending($mock_queue_name, 3));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
+    }
+
+    /**
+     * Test that the delayed jobs can be deleted.
+     */
+    public function testThatDelayedJobsCanBeDeleted()
+    {
+        $this->connection()
+            ->table('jobs')
+            ->insert([[
+                'id' => 1,
+                'queue' => $mock_queue_name = 'mock_queue_name',
+                'payload' => 'mock_payload',
+                'attempts' => 0,
+                'reserved_at' => Carbon::now()->addDay()->getTimestamp(),
+                'available_at' => Carbon::now()->subDay()->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ], [
+                'id' => 2,
+                'queue' => $mock_queue_name,
+                'payload' => 'mock_payload 2',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->addDay(1)->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ], [
+                'id' => 3,
+                'queue' => $mock_queue_name = 'mock_queue_name',
+                'payload' => 'mock_payload',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => Carbon::now()->subSeconds(60)->getTimestamp(),
+                'created_at' => Carbon::now()->getTimestamp(),
+            ]]);
+
+        $this->assertTrue($this->queue->deleteDelayed($mock_queue_name, 2));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
+        $this->assertFalse($this->queue->deleteDelayed($mock_queue_name, 1));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
+        $this->assertFalse($this->queue->deleteDelayed($mock_queue_name, 3));
+        $this->assertEquals(2, $this->queue->size($mock_queue_name));
     }
 
     /**

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -442,6 +442,29 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param  string  $driver
      */
+    public function testDeleteDelayed($driver)
+    {
+        $this->setQueue($driver);
+
+        $job1 = new RedisQueueIntegrationTestJob(30);
+        $job2 = new RedisQueueIntegrationTestJob(40);
+        $job3 = new RedisQueueIntegrationTestJob(50);
+
+        $id1 = $this->queue->push($job1);
+        $id2 = $this->queue->later(60, $job2);
+        $id3 = $this->queue->push($job3);
+
+        $this->assertTrue($this->queue->deleteDelayed(null, $id2));
+        $this->assertEquals(2, $this->queue->size());
+        $this->assertEquals($id1, $this->queue->pop()->getJobId());
+        $this->assertEquals($id3, $this->queue->pop()->getJobId());
+    }
+
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param  string  $driver
+     */
     public function testClear($driver)
     {
         $this->setQueue($driver);

--- a/tests/Queue/RedisQueueIntegrationTest.php
+++ b/tests/Queue/RedisQueueIntegrationTest.php
@@ -419,6 +419,29 @@ class RedisQueueIntegrationTest extends TestCase
      *
      * @param  string  $driver
      */
+    public function testDeletePending($driver)
+    {
+        $this->setQueue($driver);
+
+        $job1 = new RedisQueueIntegrationTestJob(30);
+        $job2 = new RedisQueueIntegrationTestJob(40);
+        $job3 = new RedisQueueIntegrationTestJob(50);
+
+        $id1 = $this->queue->push($job1);
+        $id2 = $this->queue->push($job2);
+        $id3 = $this->queue->push($job3);
+
+        $this->assertTrue($this->queue->deletePending(null, $id2));
+        $this->assertEquals(2, $this->queue->size());
+        $this->assertEquals($id1, $this->queue->pop()->getJobId());
+        $this->assertEquals($id3, $this->queue->pop()->getJobId());
+    }
+
+    /**
+     * @dataProvider redisDriverProvider
+     *
+     * @param  string  $driver
+     */
     public function testClear($driver)
     {
         $this->setQueue($driver);


### PR DESCRIPTION
This PR adds the ability to delete a pending job from a queue. Right now, if a user has to delete a pending job, the implementation would depend on the queue driver and there's no easy way to do so with the framework. 

I think if the framework directly supports this in the various drivers, it would be easier for packages like Horizon to delete pending jobs from the dashboard and also make it very convenient for Laravel users to do so in development / specific production environment cases.