### PR TITLE
[8.x] Add perHour and perDay methods to RateLimiting

### DIFF
--- a/src/Illuminate/Cache/RateLimiting/Limit.php
+++ b/src/Illuminate/Cache/RateLimiting/Limit.php
@@ -59,6 +59,30 @@ class Limit
     }
 
     /**
+     * Create a new rate limit using hours as decay time.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayHours
+     * @return static
+     */
+    public static function perHour($maxAttempts, $decayHours = 1)
+    {
+        return new static('', $maxAttempts, 60 * $decayHours);
+    }
+
+    /**
+     * Create a new rate limit using days as decay time.
+     *
+     * @param  int  $maxAttempts
+     * @param  int  $decayDays
+     * @return static
+     */
+    public static function perDay($maxAttempts, $decayDays = 1)
+    {
+        return new static('', $maxAttempts, 60 * 24 * $decayDays);
+    }
+
+    /**
      * Create a new unlimited rate limit.
      *
      * @return static


### PR DESCRIPTION
I have found my self using rate-limiting with hours and days quite often, in API subscriptions to be precise.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
