### PR TITLE
[8.x] Eager loading MorphTo relationship does not honor each models $keyType

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -150,7 +150,9 @@ class MorphTo extends BelongsTo
     protected function gatherKeysByType($type, $keyType)
     {
         if ( $keyType === 'string' ) {
-            return array_map(function($modelId) { return (string) $modelId; }, array_keys($this->dictionary[$type]));
+            return array_map(function ($modelId) {
+                return (string) $modelId;
+            }, array_keys($this->dictionary[$type]));
         }
 
         return array_keys($this->dictionary[$type]);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -136,7 +136,7 @@ class MorphTo extends BelongsTo
         $whereIn = $this->whereInMethod($instance, $ownerKey);
 
         return $query->{$whereIn}(
-            $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type)
+            $instance->getTable().'.'.$ownerKey, $this->gatherKeysByType($type, $instance->getKeyType())
         )->get();
     }
 
@@ -144,10 +144,15 @@ class MorphTo extends BelongsTo
      * Gather all of the foreign keys for a given type.
      *
      * @param  string  $type
+     * @param  string  $keyType
      * @return array
      */
-    protected function gatherKeysByType($type)
+    protected function gatherKeysByType($type, $keyType)
     {
+        if ( $keyType === 'string' ) {
+            return array_map(function($modelId) { return (string) $modelId; }, array_keys($this->dictionary[$type]));
+        }
+
         return array_keys($this->dictionary[$type]);
     }
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -149,7 +149,7 @@ class MorphTo extends BelongsTo
      */
     protected function gatherKeysByType($type, $keyType)
     {
-        if ( $keyType === 'string' ) {
+        if ($keyType === 'string') {
             return array_map(function ($modelId) {
                 return (string) $modelId;
             }, array_keys($this->dictionary[$type]));


### PR DESCRIPTION
When eager loading a morphTo relationship that could contain models using a $keyType of 'string' each query that is built is not making sure the bound parameter is cast to string due to the dictionary being built using each model's ID as an array key.

Table A has morphTo "owner" relationship.

Table B is a related model that has a $keyType of string.  Even though some of its values can be "numeric" at times.

Entries in table A for B include id values of [1,2,3]

When building the whereIn query for the database if you are not casting to a string MySQL will not use the index for that query when the column type is a char requiring a full table scan of Table B.

I really want to write tests for this but am not smart enough figure out a refactor that would give me the raw query before it's executed in ```getResultsByType($type)``` or even mock the query builder to catch the whereIn() call and examine the parameters passed in.

Thanks for your consideration.