### PR TITLE
[8.x] Flush faked events

### DIFF
--- a/src/Illuminate/Support/Testing/Fakes/EventFake.php
+++ b/src/Illuminate/Support/Testing/Fakes/EventFake.php
@@ -193,7 +193,7 @@ class EventFake implements Dispatcher
      */
     public function flush($event)
     {
-        //
+        unset($this->events[$event]);
     }
 
     /**

--- a/tests/Support/SupportTestingEventFakeTest.php
+++ b/tests/Support/SupportTestingEventFakeTest.php
@@ -118,9 +118,38 @@ class SupportTestingEventFakeTest extends TestCase
         $fake->assertDispatched('Bar');
         $fake->assertNotDispatched('Baz');
     }
+
+    public function testFlushFakes()
+    {
+        $this->fake->dispatch(new EventStub);
+        $this->fake->dispatch(new Event2Stub);
+
+        $this->fake->assertDispatched(function (EventStub $event) {
+            return true;
+        });
+
+        $this->fake->assertDispatched(function (Event2Stub $event) {
+            return true;
+        });
+
+        $this->fake->flush(EventStub::class);
+
+        $this->fake->assertNotDispatched(function (EventStub $event) {
+            return true;
+        });
+
+        $this->fake->assertDispatched(function (Event2Stub $event) {
+            return true;
+        });
+    }
 }
 
 class EventStub
+{
+    //
+}
+
+class Event2Stub
 {
     //
 }


### PR DESCRIPTION
I have tried to mimic some events dispatching in one of my tests, but I wanted to use the same test for different roles (as I am using Jetstream) to test the permissions and if certain permissions are able to dispatch some events, and I needed to flush the faked events so they do not interact with each other, but I have seen it is not supported here.

It can be used like this, passing the tests:

```php
Event::fake();

broadcast(new SomeEvent);

Event::assertDispatched(SomeEvent::class);

Event::flush(SomeEvent::class);

Event::assertNotDispatched(SomeEvent::class);
```

However, the real use case is to test multiple users dispatching the events and clearing the dispatches between each one, without writing different tests.