### PR TITLE
[8.x] Add ability to define related model on model factory

### DIFF
--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -232,6 +232,32 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertCount(3, FactoryTestComment::all());
     }
 
+    public function test_of_belongs_to_relationship()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactory::times(3)
+            ->of($user, 'user')
+            ->create();
+
+        $this->assertCount(3, $user->posts);
+
+        $this->assertCount(1, FactoryTestUser::all());
+        $this->assertCount(3, FactoryTestPost::all());
+    }
+
+    public function test_of_morph_to_relationship()
+    {
+        $post = FactoryTestPostFactory::new(['title' => 'Test Title'])->create();
+        $comments = FactoryTestCommentFactory::times(3)
+            ->of($post, 'commentable')
+            ->create();
+
+        $this->assertCount(3, $post->comments);
+
+        $this->assertCount(1, FactoryTestPost::all());
+        $this->assertCount(3, FactoryTestComment::all());
+    }
+
     public function test_belongs_to_many_relationship()
     {
         $users = FactoryTestUserFactory::times(3)
@@ -331,6 +357,23 @@ class DatabaseEloquentFactoryTest extends TestCase
         $this->assertInstanceOf(FactoryTestUser::class, $post->author);
         $this->assertEquals('Taylor Otwell', $post->author->name);
         $this->assertCount(2, $post->comments);
+    }
+
+    public function test_dynamic_of_method()
+    {
+        $user = FactoryTestUserFactory::new(['name' => 'Taylor Otwell'])->create();
+        $posts = FactoryTestPostFactory::times(3)
+            ->ofAuthor($user)
+            ->create();
+
+        $this->assertCount(3, $user->posts);
+
+        $post = FactoryTestPostFactory::new(['title' => 'Test Title'])->create();
+        $comments = FactoryTestCommentFactory::times(3)
+            ->ofCommentable($post)
+            ->create();
+
+        $this->assertCount(3, $post->comments);
     }
 
     /**


### PR DESCRIPTION
Sometimes we need to use both a model and its related models in a test.

Actually, if both of them have to be created in the test, we can do 
```php
$posts = PostFactory::times(3)->for(UserFactory::new())->create();
$user = $posts->first()->user;

// do some work using $user and $posts
```
or 
```php
$user = UserFactory::new()->has(PostFactory::times(3))->create();
$posts = $user->posts;
```
If the user already exists, we need to explicitly define the attribute :
```php
// previously defined $user, could be with $user = UserFactory::new()->create();
$posts = PostFactory::times(3)->create(['user_id' => $user]);
```

This PR add the ability to define the relation in a more convenient way
```php
$user = UserFactory::new()->create();
$posts = PostFactory::times(3)->of($user)->create();
```

In case the relation cannot be guessed directly from the model, we can define it explicitly : 
```php
$posts = PostFactory::times(3)->of($user, 'author')->create();
```

This PR also adds a dynamic call for `of` method : 
```php
$posts = PostFactory::times(3)->ofUser($user)->create();

// or $posts = PostFactory::times(3)->ofAuthor($user)->create();
```

All of this also works for `MorphTo` relations : 
```php
$comments = CommentFactory::times(3)->of($post, 'commentable')->create();
// or $comments = CommentFactory::times(3)->ofCommentable($post)->create();
```
