### PR TITLE
[8.x] Component attribute bag now defines a set of attributes to implode

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -23,7 +23,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     protected $attributes = [];
 
     /**
-     * Array of attributes that should be imploded. 'class' is still hard coded
+     * Array of attributes that should be imploded. 'class' is still hard coded.
      *
      * @var array
      */
@@ -41,9 +41,10 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Set our list of imploded attributes
+     * Set our list of imploded attributes.
      *
-     * @param  array $attrs
+     * @param  array  $attrs
+     * @return void
      */
     public static function implodedAttributes($attrs)
     {
@@ -214,9 +215,9 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Determine where or not to implode a merged attribute instead of overwriting it
+     * Determine where or not to implode a merged attribute instead of overwriting it.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return bool
      */
     protected function attributeShouldBeImploded($key)
@@ -225,9 +226,9 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
-     * Determine which character to use when imploding a merged attribute
+     * Determine which character to use when imploding a merged attribute.
      *
-     * @param  string $key
+     * @param  string  $key
      * @return string
      */
     protected function getAttributeImplodeGlueCharacter($key)

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -70,6 +70,6 @@ class ViewComponentAttributeBagTest extends TestCase
     {
         ComponentAttributeBag::implodedAttributes(['data-id', 'data-test' => '*']);
         $bag = new ComponentAttributeBag(['class' => 'p-1', 'data-id' => 'test', 'data-test' => 'example']);
-        $this->assertSame('class="mb-4 p-1" data-id="id test" data-test="test*example"', (string) $bag->merge(['class' => 'mb-4','data-id' => 'id', 'data-test' => 'test']));
+        $this->assertSame('class="mb-4 p-1" data-id="id test" data-test="test*example"', (string) $bag->merge(['class' => 'mb-4', 'data-id' => 'id', 'data-test' => 'test']));
     }
 }

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -65,4 +65,11 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }
+
+    public function testImplodedAttributesAreImploded()
+    {
+        ComponentAttributeBag::implodedAttributes(['data-id', 'data-test' => '*']);
+        $bag = new ComponentAttributeBag(['class' => 'p-1', 'data-id' => 'test', 'data-test' => 'example']);
+        $this->assertSame('class="mb-4 p-1" data-id="id test" data-test="test*example"', (string) $bag->merge(['class' => 'mb-4','data-id' => 'id', 'data-test' => 'test']));
+    }
 }


### PR DESCRIPTION
Added static property to ComponentAttributeBag that defines additional attributes to implode rather than overwrite. Origin of this idea is in laravel/ideas#2345, and documentation update yesterday laravel/docs#6415.

`class` attribute is still hard coded, so nothing changes there (and it can't accidentally be broken).

My use case is to create blade components that will work with multiple [Stimulus](https://stimulusjs.org) controllers and targets.

If this is merged I can submit a pull request this afternoon to to the documentation.

Use attributes
```blade
{{-- Whitelist attributes to implode --}}
ComponentBagAttribute::implodedAttributes(['data-target']);

{{-- Defining component input.blade.php --}}
<input type="text" {{ $attributes->merge(['data-target' => 'autocomplete.input']) }} >

{{--Using component with more than one Stimulus controller--}}
<x-input data-target="item-form.item" />

{{-- Outputs this HTML --}}
<input type="text" data-target="item-form.item autocomplete.input" />
```