### PR TITLE
[9.x] Add absent validation rule

### DIFF
--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -27,7 +27,7 @@
 - Added `Illuminate\Session\Store::passwordConfirmed()` ([fb3f45a](https://github.com/laravel/framework/commit/fb3f45aa0142764c5c29b97e8bcf8328091986e9))
 
 ### Changed
-- check for view existence first in `Illuminate\Mail\Markdown::render()` ([5f78c90](https://github.com/laravel/framework/commit/5f78c90a7af118dd07703a78da06586016973a66))
+- Check for view existence first in `Illuminate\Mail\Markdown::render()` ([5f78c90](https://github.com/laravel/framework/commit/5f78c90a7af118dd07703a78da06586016973a66))
 - Guess the model name when using the make:factory command ([#34373](https://github.com/laravel/framework/pull/34373))
 
 
@@ -39,7 +39,7 @@
 
 ### Fixed
 - Fixed `minimal.blade.php` ([#34379](https://github.com/laravel/framework/pull/34379))
-- Dont double escape on ComponentTagCompiler.php ([ec75487](https://github.com/laravel/framework/commit/ec75487062506963dd27a4302fe3680c0e3681a3))
+- Don't double escape on ComponentTagCompiler.php ([ec75487](https://github.com/laravel/framework/commit/ec75487062506963dd27a4302fe3680c0e3681a3))
 - Fixed dots in attribute names in `DynamicComponent` ([2d1d962](https://github.com/laravel/framework/commit/2d1d96272a94bce123676ed742af2d80ba628ba4))
 
 ### Changed

--- a/src/Illuminate/Database/Schema/MySqlSchemaState.php
+++ b/src/Illuminate/Database/Schema/MySqlSchemaState.php
@@ -116,7 +116,7 @@ class MySqlSchemaState extends SchemaState
     protected function executeDumpProcess(Process $process, $output, array $variables)
     {
         try {
-            $process->mustRun($output, $variables);
+            $process->setTimeout(null)->mustRun($output, $variables);
         } catch (Exception $e) {
             if (Str::contains($e->getMessage(), ['column-statistics', 'column_statistics'])) {
                 return $this->executeDumpProcess(Process::fromShellCommandLine(

--- a/src/Illuminate/Database/Schema/PostgresSchemaState.php
+++ b/src/Illuminate/Database/Schema/PostgresSchemaState.php
@@ -31,7 +31,7 @@ class PostgresSchemaState extends SchemaState
     {
         with($process = $this->makeProcess(
             $this->baseDumpCommand().' --table=migrations --data-only --inserts'
-        ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
+        ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));
 

--- a/src/Illuminate/Database/Schema/SqliteSchemaState.php
+++ b/src/Illuminate/Database/Schema/SqliteSchemaState.php
@@ -15,7 +15,7 @@ class SqliteSchemaState extends SchemaState
     {
         with($process = $this->makeProcess(
             $this->baseCommand().' .schema'
-        ))->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
+        ))->setTimeout(null)->mustRun(null, array_merge($this->baseVariables($this->connection->getConfig()), [
             //
         ]));
 

--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -241,6 +241,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is absent.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAbsent($attribute, $value)
+    {
+        return ! Arr::has($this->data, $attribute);
+    }
+
+    /**
      * Validate that an attribute contains only alphabetic characters.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -688,6 +688,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->hasRule('bar', 'Required'));
     }
 
+    public function testValidateAbsent()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [], ['name' => 'absent']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'Taylor'], ['name' => 'absent']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => false], ['name' => 'absent']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateArray()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds the `absent` validation rule, the opposite of the `present` validation rule.

This can be useful when you're using validation and passing the validated parameters to a model create call for instance, but you want to ensure a given field is only passed for a specific role.

For instance:

```
$validated = $request->validate([
    'name' => 'required',
    'public' => $user->isRole('admin') ? 'boolean' : 'absent',
]);

Book::create($validated);
```