### PR TITLE
[9.x] Add absent validation rule

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -241,6 +241,18 @@ trait ValidatesAttributes
     }
 
     /**
+     * Validate that an attribute is absent.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateAbsent($attribute, $value)
+    {
+        return ! Arr::has($this->data, $attribute);
+    }
+
+    /**
      * Validate that an attribute contains only alphabetic characters.
      *
      * @param  string  $attribute

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -688,6 +688,20 @@ class ValidationValidatorTest extends TestCase
         $this->assertFalse($v->hasRule('bar', 'Required'));
     }
 
+    public function testValidateAbsent()
+    {
+        $trans = $this->getIlluminateArrayTranslator();
+
+        $v = new Validator($trans, [], ['name' => 'absent']);
+        $this->assertTrue($v->passes());
+
+        $v = new Validator($trans, ['name' => 'Taylor'], ['name' => 'absent']);
+        $this->assertFalse($v->passes());
+
+        $v = new Validator($trans, ['name' => false], ['name' => 'absent']);
+        $this->assertFalse($v->passes());
+    }
+
     public function testValidateArray()
     {
         $trans = $this->getIlluminateArrayTranslator();


### PR DESCRIPTION
This PR adds the `absent` validation rule, the opposite of the `present` validation rule.

This can be useful when you're using validation and passing the validated parameters to a model create call for instance, but you want to ensure a given field is only passed for a specific role.

For instance:

```
$validated = $request->validate([
    'name' => 'required',
    'public' => $user->isRole('admin') ? 'boolean' : 'absent',
]);

Book::create($validated);
```

PR for `laravel/laravel` for the validation rule translation can be found here: https://github.com/laravel/laravel/pull/5428

Targeted to master as someone can have a `absent` validation rule via macros.