### PR TITLE
[8.x] Execute a callback when a request parameter is equals to a specific value

### DIFF
--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -196,6 +196,37 @@ trait InteractsWithInput
     }
 
     /**
+     * Apply the callback if the request contains a non-empty value equals to the expected input key.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @return $this|mixed
+     */
+    public function whenEquals($key, $value, callable $callback)
+    {
+        if ($this->filled($key) && $this->isEquals($key, $value)) {
+            return $callback(data_get($this->all(), $key)) ?: $this;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Determine if a given input value matches a given pattern.
+     *
+     * @param  string $key
+     * @param  string $value
+     * @return boolean
+     */
+    public function isEquals($key, $value)
+    {
+        $pattern = $this->input($key);
+
+        return Str::is($pattern, $value);
+    }
+
+    /**
      * Determine if the request is missing a given input item key.
      *
      * @param  string|array  $key

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -356,6 +356,36 @@ class HttpRequestTest extends TestCase
         $this->assertFalse($foo);
     }
 
+    public function testWhenEqualsMethod()
+    {
+        $parameters = ['name' => 'Taylor', 'age' => '', 'city' => null, 'foo' => 0];
+
+        $request = Request::create('/', 'GET', $parameters);
+
+        [$name, $age, $city, $foo] = array_values($parameters);
+
+        $request->whenEquals('name', 'Taylor', function ($value) use (&$name) {
+            $name = $value . ' ' . 'Otwell';
+        });
+
+        $request->whenEquals('age', '', function ($value) use (&$age) {
+            $age = 'test';
+        });
+
+        $request->whenEquals('city', null, function ($value) use (&$city) {
+            $city = 'test';
+        });
+
+        $request->whenEquals('foo', 0, function () use (&$foo) {
+            $foo = 10;
+        });
+
+        $this->assertSame('Taylor Otwell', $name);
+        $this->assertEmpty($age);
+        $this->assertNull($city);
+        $this->assertSame(10, $foo);
+    }
+
     public function testMissingMethod()
     {
         $request = Request::create('/', 'GET', ['name' => 'Taylor', 'age' => '', 'city' => null]);


### PR DESCRIPTION
Use case examples.

```php
<?php

$request->whenEquals('foo', 'bar', fn ($value) => /* foo value is filled and equals to bar */);
```

I also added a method to compare the parameter values based on the method of the `Str::is()` class. E.g.

```php
<?php

$request->isEquals('foo', 'bar'); // Returns true if foo parameter value is equals to bar...
```