### PR TITLE
Makes Factories root namespace aware

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -65,9 +65,10 @@ class FactoryMakeCommand extends GeneratorCommand
                         : $this->qualifyModel($this->guessModelName($name));
 
         $model = class_basename($namespaceModel);
+        $modelsNamespace = $this->rootNamespace()."Models";
 
-        if (Str::startsWith($namespaceModel, 'App\\Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, 'App\\Models\\'), '\\');
+        if (Str::startsWith($namespaceModel, $modelsNamespace)) {
+            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $modelsNamespace.'\\'), '\\');
         } else {
             $namespace = 'Database\\Factories';
         }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -660,6 +660,16 @@ abstract class Factory
     {
         static::$factoryNameResolver = $callback;
     }
+    /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected static function rootNamespace()
+    {
+        return Container::getInstance()
+            ->getNamespace();
+    }
 
     /**
      * Get a new Faker instance.
@@ -680,9 +690,12 @@ abstract class Factory
     public static function resolveFactoryName(string $modelName)
     {
         $resolver = static::$factoryNameResolver ?: function (string $modelName) {
-            $modelName = Str::startsWith($modelName, 'App\\Models\\')
-                ? Str::after($modelName, 'App\\Models\\')
-                : Str::after($modelName, 'App\\');
+            $rootNamespace = self::rootNamespace();
+            $modelsNamespace = $rootNamespace."Models";
+
+            $modelName = Str::startsWith($modelName, $modelsNamespace)
+                ? Str::after($modelName, $modelsNamespace.'\\')
+                : Str::after($modelName, $rootNamespace);
 
             return static::$namespace.$modelName.'Factory';
         };


### PR DESCRIPTION
This makes factory creation and factories instantiation root namespace aware. I just steal this from ```Illuminate/Console/GeneratorCommand.php```
