### PR TITLE
add Request typehint to findRoute

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -640,7 +640,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Routing\Route
      */
-    protected function findRoute($request)
+    protected function findRoute(Request $request)
     {
         $this->current = $route = $this->routes->match($request);
 


### PR DESCRIPTION
It is not a BC break for cases where the findRoute has been overridden because of the parameter type widening, introduced in php 7.2.

