### PR TITLE
[8.x] Added concat method to ComponentAttributeBag

### DIFF
--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -201,6 +201,8 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     }
 
     /**
+     * Concatenate additional attributes/values into the attribute bag.
+     *
      * @param  array  $attributeDefaults
      * @param  bool   $escape
      * @return static
@@ -212,7 +214,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
         $attributeDefaults = $this->getDefaultAttributeValueArray($attributeDefaults, $escape);
 
         foreach ($this->attributes as $key => $value) {
-            if(array_key_exists($key, $attributeDefaults)) {
+            if (array_key_exists($key, $attributeDefaults)) {
                 $concatAttributes[$key] = implode(' ', array_unique(
                     array_filter([$attributeDefaults[$key] ?? '', $value])
                 ));

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -175,7 +175,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * Merge additional attributes / values into the attribute bag.
      *
      * @param  array  $attributeDefaults
-     * @param  bool   $escape
+     * @param  bool  $escape
      * @return static
      */
     public function merge(array $attributeDefaults = [], $escape = true)
@@ -203,7 +203,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * Concatenate additional attributes/values into the attribute bag.
      *
      * @param  array  $attributeDefaults
-     * @param  bool   $escape
+     * @param  bool  $escape
      * @return static
      */
     public function concat(array $attributeDefaults = [], $escape = true)
@@ -227,7 +227,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * Given array of attributes return the appropriate key value pair.
      *
      * @param  array  $attributes
-     * @param  bool   $escape
+     * @param  bool  $escape
      * @return array
      */
     public function getDefaultAttributeValueArray($attributes, $escape = true)

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -181,7 +181,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     public function merge(array $attributeDefaults = [], $escape = true)
     {
         $attributes = [];
-        
+
         $attributeDefaults = $this->getDefaultAttributeValueArray($attributeDefaults, $escape);
 
         foreach ($this->attributes as $key => $value) {

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -181,8 +181,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
     public function merge(array $attributeDefaults = [], $escape = true)
     {
         $attributes = [];
-
-
+        
         $attributeDefaults = $this->getDefaultAttributeValueArray($attributeDefaults, $escape);
 
         foreach ($this->attributes as $key => $value) {

--- a/tests/View/ViewComponentAttributeBagTest.php
+++ b/tests/View/ViewComponentAttributeBagTest.php
@@ -65,4 +65,31 @@ class ViewComponentAttributeBagTest extends TestCase
 
         $this->assertSame('test-string="ok" test-true="test-true" test-0="0" test-0-string="0" test-empty-string=""', (string) $bag);
     }
+
+    public function testAttributeConcatenationWithMerge()
+    {
+        $bag = new ComponentAttributeBag(['class' => 'p-2', 'data-controller' => 'autocomplete', 'data-id' => 'merged']);
+
+        $bag = $bag->concat(['class' => 'mb-3', 'data-controller' => 'item-select'])->merge(['data-id' => 'default']);
+
+        $this->assertSame('data-id="merged" class="mb-3 p-2" data-controller="item-select autocomplete"', (string) $bag);
+    }
+
+    public function testAttributeMergeWithConcatenation()
+    {
+        $bag = new ComponentAttributeBag(['class' => 'p-2', 'data-controller' => 'autocomplete', 'data-id' => 'merged']);
+
+        $bag = $bag->merge(['data-id' => 'default'])->concat(['class' => 'mb-3', 'data-controller' => 'item-select']);
+
+        $this->assertSame('data-id="merged" class="mb-3 p-2" data-controller="item-select autocomplete"', (string) $bag);
+    }
+
+    public function testAttributeMergeWithClassStillConcatenates()
+    {
+        $bag = new ComponentAttributeBag(['class' => 'p-2']);
+
+        $bag = $bag->merge(['class' => 'mb-4']);
+
+        $this->assertSame('class="mb-4 p-2"', (string) $bag);
+    }
 }


### PR DESCRIPTION
Added concat method to ComponentAttributeBag which allows for concatenating attributes that are not `class` instead of overwriting them. This leaves the original functionality in place so `class` method is special cased within `merge`.

I think the implementation is a bit wonky - if you think this has merit I can rework and resubmit. Or I can just use your original suggestion in laravel/framework#34541 to use an `$attributes->appendable()` method. I liked the idea of `ComponentAttributeBag` having methods that mapped to the same behavior on collection methods.

```blade
{{-- Component defined --}}
<button {{ $attributes->merge(['type' => 'button', 'data-id' => 'default'])->concat(['class' => 'btn', 'data-controller' => 'autocomplete' }}>
    {{ $slot }}
</button>

{{-- Component consumed --}}
<x-button type="submit" data-id="changed" data-controller="item-select" class="primary">
    Button
</x-button>

{{-- HTML output --}}
<button type="submit" data-id="changed" data-controller="autocomplete item-select" class="btn primary">
    Button
</button>
```