### PR TITLE
[8.x] Add throwWith to the HTTP client response

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -209,7 +209,24 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
+        return $this->throwWith(function () {
+            //
+        });
+    }
+
+    /**
+     * Execute the callback and throw an exception if a server of client error occurred.
+     *
+     * @param \Closure $callback
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwWith($callback)
+    {
         if ($this->serverError() || $this->clientError()) {
+            $callback($this);
+
             throw new RequestException($this);
         }
 

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -209,9 +209,11 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
-        return $this->throwWith(function () {
-            //
-        });
+        if ($this->serverError() || $this->clientError()) {
+            throw new RequestException($this);
+        }
+
+        return $this;
     }
 
     /**
@@ -219,15 +221,11 @@ class Response implements ArrayAccess
      *
      * @param \Closure $callback
      * @return $this
-     *
-     * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwWith($callback)
+    public function onError($callback)
     {
         if ($this->serverError() || $this->clientError()) {
             $callback($this);
-
-            throw new RequestException($this);
         }
 
         return $this;

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -476,6 +476,42 @@ class HttpClientTest extends TestCase
         throw new RequestException(new Response($response));
     }
 
+    public function testThrowWithCallsClosureOnError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+        $response = $client->get('laravel.com');
+
+        try {
+            $response->throwWith(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+        } catch (RequestException $e) {
+            //
+        }
+
+        $this->assertSame(401, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testThrowWithDoesntCallClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+        $response = $client->get('laravel.com');
+
+        $response->throwWith(function ($response) use (&$status) {
+            $status = $response->status();
+        });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(201, $response->status());
+    }
+
     public function testSinkToFile()
     {
         $this->factory->fakeSequence()->push('abc123');


### PR DESCRIPTION
Implementation updated: https://github.com/laravel/framework/pull/34558#issuecomment-699911645

Because:
- There is a repeated pattern where you want to perform a particular action if the response has failed, such as logging an error, **but still have the exception throw afterwards**.


Before...
```php
$response = $client->withHeaders($headers)->post($url, $payload);

if ($response->failed()) {
    Log::error('Twitter API failed posting Tweet', [
        'url' => $url,
        'payload' => $payload,
        'headers' => $headers,
        'response' => $response->body(),
    ]);

    $response->throw();
}

return $response->json();
```

After...
```php
return $client->withHeaders($headers)
    ->post($url, $payload)
    ->throwWith(fn ($response) =>
        Log::error('Twitter API failed posting Tweet', [
            'url' => $url,
            'payload' => $payload,
            'headers' => $headers,
            'response' => $response->body(),
        ])
    )->json();
```

This commit:
- Adds the `throwWith` method to the response.
- Updates the `throw` method to utilise the new `throwWith` method, just with an empty closure.

Notes:
- I'm not convinced this is the best name for this method.
- I'm also wondering if the method should be a `tap` method of some kind. `tapWhenThrowing` or something along those lines.