### PR TITLE
[8.x] Makes Factories root namespace aware

### DIFF
--- a/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
+++ b/src/Illuminate/Database/Console/Factories/FactoryMakeCommand.php
@@ -65,9 +65,10 @@ class FactoryMakeCommand extends GeneratorCommand
                         : $this->qualifyModel($this->guessModelName($name));
 
         $model = class_basename($namespaceModel);
+        $modelsNamespace = $this->rootNamespace().'Models';
 
-        if (Str::startsWith($namespaceModel, 'App\\Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, 'App\\Models\\'), '\\');
+        if (Str::startsWith($namespaceModel, $modelsNamespace)) {
+            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $modelsNamespace.'\\'), '\\');
         } else {
             $namespace = 'Database\\Factories';
         }

--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -607,9 +607,12 @@ abstract class Factory
         $resolver = static::$modelNameResolver ?: function (self $factory) {
             $factoryBasename = Str::replaceLast('Factory', '', class_basename($factory));
 
-            return class_exists('App\\Models\\'.$factoryBasename)
-                        ? 'App\\Models\\'.$factoryBasename
-                        : 'App\\'.$factoryBasename;
+            $rootNamespace = self::rootNamespace();
+            $modelsNamespace = $rootNamespace.'Models\\';
+
+            return class_exists($modelsNamespace.$factoryBasename)
+                        ? $modelsNamespace.$factoryBasename
+                        : $rootNamespace.'\\'.$factoryBasename;
         };
 
         return $this->model ?: $resolver($this);
@@ -662,6 +665,17 @@ abstract class Factory
     }
 
     /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected static function rootNamespace()
+    {
+        return Container::getInstance()
+            ->getNamespace();
+    }
+
+    /**
      * Get a new Faker instance.
      *
      * @return \Faker\Generator
@@ -680,9 +694,12 @@ abstract class Factory
     public static function resolveFactoryName(string $modelName)
     {
         $resolver = static::$factoryNameResolver ?: function (string $modelName) {
-            $modelName = Str::startsWith($modelName, 'App\\Models\\')
-                ? Str::after($modelName, 'App\\Models\\')
-                : Str::after($modelName, 'App\\');
+            $rootNamespace = self::rootNamespace();
+            $modelsNamespace = $rootNamespace.'Models';
+
+            $modelName = Str::startsWith($modelName, $modelsNamespace)
+                ? Str::after($modelName, $modelsNamespace.'\\')
+                : Str::after($modelName, $rootNamespace);
 
             return static::$namespace.$modelName.'Factory';
         };

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -290,6 +290,12 @@ class DatabaseEloquentFactoryTest extends TestCase
 
     public function test_resolve_nested_model_factories()
     {
+        $container = \Mockery::mock(Container::class)->makePartial();
+
+        $container->shouldReceive('getNamespace')->andReturn('App\\');
+
+        Container::setInstance($container);
+
         Factory::useNamespace('Factories\\');
 
         $resolves = [


### PR DESCRIPTION
This makes factory creation and factories instantiation root namespace aware. I just steal this from Illuminate/Console/GeneratorCommand.php to be consistent with the generation and use and with other parts of the framework where is not hard coded App\ for example php artisan make:model that uses the root namespace.