### PR TITLE
[8.x] Change to X-Message-ID in mail transport

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -72,8 +72,13 @@ class MailgunTransport extends Transport
             $this->payload($message, $to)
         );
 
+        $messageId = $this->getMessageId($response);
         $message->getHeaders()->addTextHeader(
-            'X-Mailgun-Message-ID', $this->getMessageId($response)
+            'X-Message-ID', $messageId,
+            /**
+             * @deprecated Use the "X-Message-ID" header
+             */
+            'X-Mailgun-Message-ID', $messageId
         );
 
         $message->setBcc($bcc);

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -52,7 +52,14 @@ class SesTransport extends Transport
             )
         );
 
-        $message->getHeaders()->addTextHeader('X-SES-Message-ID', $result->get('MessageId'));
+        $messageId = $result->get('MessageId');
+        $message->getHeaders()->addTextHeader(
+            'X-Message-ID', $messageId,
+            /**
+             * @deprecated Use the "X-Message-ID" header
+             */
+            'X-SES-Message-ID', $messageId
+        );
 
         $this->sendPerformed($message);
 


### PR DESCRIPTION
This adds a more usable `X-Message-ID` header to a sent message containing the response `id` from the third-party.

The `X-Message-ID` can be retrieved and used to keep track of upcoming triggered web-hook events from the same third-party.

Fully backwards compatible, however the existing `X-Mailgun-Message-ID` is deprecated now and could be removed in the next major version.
