### PR TITLE
[8.x] Change to X-Message-ID in Mailgun and Ses Transport

### DIFF
--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -73,13 +73,12 @@ class MailgunTransport extends Transport
         );
 
         $messageId = $this->getMessageId($response);
-        $message->getHeaders()->addTextHeader(
-            'X-Message-ID', $messageId,
-            /**
-             * @deprecated Use the "X-Message-ID" header
-             */
-            'X-Mailgun-Message-ID', $messageId
-        );
+        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
+
+        /**
+        * @deprecated Use the "X-Message-ID" header
+        */
+        $message->getHeaders()->addTextHeader('X-Mailgun-Message-ID', $messageId);
 
         $message->setBcc($bcc);
 

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -76,8 +76,8 @@ class MailgunTransport extends Transport
         $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
 
         /**
-        * @deprecated Use the "X-Message-ID" header
-        */
+         * @deprecated Use the "X-Message-ID" header
+         */
         $message->getHeaders()->addTextHeader('X-Mailgun-Message-ID', $messageId);
 
         $message->setBcc($bcc);

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -72,8 +72,13 @@ class MailgunTransport extends Transport
             $this->payload($message, $to)
         );
 
+        $messageId = $this->getMessageId($response);
         $message->getHeaders()->addTextHeader(
-            'X-Mailgun-Message-ID', $this->getMessageId($response)
+            'X-Message-ID', $messageId,
+            /**
+             * @deprecated Use the "X-Message-ID" header
+             */
+            'X-Mailgun-Message-ID', $messageId
         );
 
         $message->setBcc($bcc);

--- a/src/Illuminate/Mail/Transport/MailgunTransport.php
+++ b/src/Illuminate/Mail/Transport/MailgunTransport.php
@@ -73,11 +73,8 @@ class MailgunTransport extends Transport
         );
 
         $messageId = $this->getMessageId($response);
-        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
 
-        /**
-         * @deprecated Use the "X-Message-ID" header
-         */
+        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
         $message->getHeaders()->addTextHeader('X-Mailgun-Message-ID', $messageId);
 
         $message->setBcc($bcc);

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -53,13 +53,12 @@ class SesTransport extends Transport
         );
 
         $messageId = $result->get('MessageId');
-        $message->getHeaders()->addTextHeader(
-            'X-Message-ID', $messageId,
-            /**
-             * @deprecated Use the "X-Message-ID" header
-             */
-            'X-SES-Message-ID', $messageId
-        );
+        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
+
+        /**
+        * @deprecated Use the "X-Message-ID" header
+        */
+        $message->getHeaders()->addTextHeader('X-SES-Message-ID', $messageId);
 
         $this->sendPerformed($message);
 

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -56,8 +56,8 @@ class SesTransport extends Transport
         $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
 
         /**
-        * @deprecated Use the "X-Message-ID" header
-        */
+         * @deprecated Use the "X-Message-ID" header
+         */
         $message->getHeaders()->addTextHeader('X-SES-Message-ID', $messageId);
 
         $this->sendPerformed($message);

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -53,11 +53,8 @@ class SesTransport extends Transport
         );
 
         $messageId = $result->get('MessageId');
-        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
 
-        /**
-         * @deprecated Use the "X-Message-ID" header
-         */
+        $message->getHeaders()->addTextHeader('X-Message-ID', $messageId);
         $message->getHeaders()->addTextHeader('X-SES-Message-ID', $messageId);
 
         $this->sendPerformed($message);

--- a/src/Illuminate/Mail/Transport/SesTransport.php
+++ b/src/Illuminate/Mail/Transport/SesTransport.php
@@ -52,7 +52,14 @@ class SesTransport extends Transport
             )
         );
 
-        $message->getHeaders()->addTextHeader('X-SES-Message-ID', $result->get('MessageId'));
+        $messageId = $result->get('MessageId');
+        $message->getHeaders()->addTextHeader(
+            'X-Message-ID', $messageId,
+            /**
+             * @deprecated Use the "X-Message-ID" header
+             */
+            'X-SES-Message-ID', $messageId
+        );
 
         $this->sendPerformed($message);
 

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -67,8 +67,8 @@ class MailSesTransportTest extends TestCase
 
         $this->assertEquals($messageId, $message->getHeaders()->get('X-Message-ID')->getFieldBody());
         /**
-        * @deprecated Switch to using "X-Message-ID" header
-        */
+         * @deprecated Switch to using "X-Message-ID" header
+         */
         $this->assertEquals($messageId, $message->getHeaders()->get('X-SES-Message-ID')->getFieldBody());
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -64,6 +64,11 @@ class MailSesTransportTest extends TestCase
             ->willReturn($sendRawEmailMock);
 
         $transport->send($message);
+
+        $this->assertEquals($messageId, $message->getHeaders()->get('X-Message-ID')->getFieldBody());
+        /**
+        * @deprecated Switch to using "X-Message-ID" header
+        */
         $this->assertEquals($messageId, $message->getHeaders()->get('X-SES-Message-ID')->getFieldBody());
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -66,9 +66,6 @@ class MailSesTransportTest extends TestCase
         $transport->send($message);
 
         $this->assertEquals($messageId, $message->getHeaders()->get('X-Message-ID')->getFieldBody());
-        /**
-         * @deprecated Switch to using "X-Message-ID" header
-         */
         $this->assertEquals($messageId, $message->getHeaders()->get('X-SES-Message-ID')->getFieldBody());
     }
 }

--- a/tests/Mail/MailSesTransportTest.php
+++ b/tests/Mail/MailSesTransportTest.php
@@ -52,7 +52,7 @@ class MailSesTransportTest extends TestCase
         $transport = new SesTransport($client);
 
         // Generate a messageId for our mock to return to ensure that the post-sent message
-        // has X-SES-Message-ID in its headers
+        // has X-Message-ID in its headers
         $messageId = Str::random(32);
         $sendRawEmailMock = new sendRawEmailMock($messageId);
         $client->expects($this->once())


### PR DESCRIPTION
This adds a more usable X-Message-ID header to a sent message containing the response id from the third-party.

The X-Message-ID can be retrieved and used to keep track of upcoming triggered web-hook events from the same third-party.

Fully backwards compatible, however the existing headers could be removed in the next major version. These are:
 - X-Mailgun-Message-ID
 - X-SES-Message-ID