### PR TITLE
[8.x] cast `Expression` as string so it can be encoded

### DIFF
--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -111,6 +111,10 @@ class HasInDatabase extends Constraint
      */
     public function toString($options = 0): string
     {
-        return json_encode($this->data, $options);
+        foreach ($this->data as $key => $data) {
+            $output[$key] = $data instanceof Expression ? (string) $data : $data;
+        }
+
+        return json_encode($output ?? [], $options);
     }
 }


### PR DESCRIPTION
If we pass an `Expression` to our database assertion, because it contains no public properties, when it is JSON encoded it will always return '{}', which is unhelpful to us in debugging.

this PR is far from an ideal solution, as the entire expression will be returned to the output, but it's better than the empty object it currently returns.

for example:

```php
$this->assertDatabaseHas('users', [
    'name' => 'Andy',
    'skills' => $this->castAsJson(['laravel', 'vue', 'tailwind']),
];
```

If this is not found in the database it would currently output:

```
Failed asserting that a row in the table [dealers] matches the attributes {
    "name": "Andy",
    "skills": {},
}.
```

With this PR, it will instead output:

```
Failed asserting that a row in the table [dealers] matches the attributes {
    "name": "Andy",
    "skills": "CAST('[\"laravel\",\"vue\",\"tailwind\"]' AS JSON)",
}.
```

Again, not ideal, but at least the data is there for us to compare against.