### PR TITLE
Hide Model namespace in ModelNotFoundException class in production mode.

### DIFF
--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -33,9 +33,9 @@ class ModelNotFoundException extends RuntimeException
         $this->model = $model;
         $this->ids = Arr::wrap($ids);
 
-        $this->message = "No query results for model [{$model}]";
+        $this->message = app()->environment('production') ? "This record could not be found" : 'No query results for model [{$model}]';
 
-        if (count($this->ids) > 0) {
+        if (count($this->ids) > 0 && app()->environment('production')) {
             $this->message .= ' '.implode(', ', $this->ids);
         } else {
             $this->message .= '.';

--- a/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
+++ b/src/Illuminate/Database/Eloquent/ModelNotFoundException.php
@@ -33,7 +33,7 @@ class ModelNotFoundException extends RuntimeException
         $this->model = $model;
         $this->ids = Arr::wrap($ids);
 
-        $this->message = app()->environment('production') ? "This record could not be found" : 'No query results for model [{$model}]';
+        $this->message = app()->environment('production') ? 'This record could not be found' : 'No query results for model [{$model}]';
 
         if (count($this->ids) > 0 && app()->environment('production')) {
             $this->message .= ' '.implode(', ', $this->ids);


### PR DESCRIPTION
### Description:
I just want to suggest improvement in ModelNotFoundException class, because when the app is in production any one can send http request for non exist record and the app will response this:
```
{
"message": "No query results for model [App\\Models\\User] 1"
}
```
So the (developer or hacker) can understand how your app was developed and structure of your models ... and this is bad.
it's best to keep my app secure.

 **This message is good when app is in local env and this message the _normal user_ can't understand that namespace ...**

### Steps To Reproduce:

#### api.php
```
Route::get('/user/{user}', static function (\App\Models\User $user) {
return 'good';
});
```
use POSTMAN or INSOMNIA

and send http request for non exists user for example: `user/9999`
