### PR TITLE
[8.x] Proxy URL Generation in `VerifyEmail`

### DIFF
--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\URL;
 class VerifyEmail extends Notification
 {
     /**
-     * The callback that should be used to create the reset password URL.
+     * The callback that should be used to create the verify email URL.
      *
      * @var \Closure|null
      */
@@ -67,20 +67,20 @@ class VerifyEmail extends Notification
     {
         if (static::$createUrlCallback) {
             return call_user_func(static::$createUrlCallback, $notifiable);
-        } else {
-            return URL::temporarySignedRoute(
-                'verification.verify',
-                Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
-                [
-                    'id' => $notifiable->getKey(),
-                    'hash' => sha1($notifiable->getEmailForVerification()),
-                ]
-            );
         }
+
+        return URL::temporarySignedRoute(
+            'verification.verify',
+            Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
+            [
+                'id' => $notifiable->getKey(),
+                'hash' => sha1($notifiable->getEmailForVerification()),
+            ]
+        );
     }
 
     /**
-     * Set a callback that should be used when creating the reset password button URL.
+     * Set a callback that should be used when creating the verify email button URL.
      *
      * @param  \Closure  $callback
      * @return void


### PR DESCRIPTION
This is in relation to issue #28469 and idea #1635.

Provide a mechanism to create URLs in `VerifyEmail` similar to the mechanism in `ResetPassword`. This change increases interface consistency in the Notifications namespace. This change does not break compatability, as it adds a way to overwrite URL generation. If the developer does not provide a callback, the current URL generation is still used.

(Would I need to PR against 7.x if I wanted to propose a backport to the 7.x branch?)