### PR TITLE
[8.x] Fix incompatible declaration of `setKeysForSaveQuery` on Pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -811,7 +811,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery($query)
+    protected function setKeysForSaveQuery(Builder $query)
     {
         $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
 


### PR DESCRIPTION
An update broke Pivot models due to incompatible declaration of the setKeysForSaveQuery function:
https://github.com/laravel/framework/commit/77db028225ccd6ec6bc3359f69482f2e4cc95faf

Not too sure if there was a reason why the typehint was removed?

`Declaration of Illuminate\Database\Eloquent\Relations\Concerns\AsPivot::setKeysForSaveQuery(Illuminate\Database\Eloquent\Builder $query) should be compatible with Illuminate\Database\Eloquent\Model::setKeysForSaveQuery($query)`