### PR TITLE
Fix incompatible declaration on pivot models

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -88,7 +88,7 @@ trait AsPivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         if (isset($this->attributes[$this->getKeyName()])) {
             return parent::setKeysForSaveQuery($query);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -31,7 +31,7 @@ class MorphPivot extends Pivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $query->where($this->morphType, $this->morphClass);
 


### PR DESCRIPTION
A recent update [77db028](https://github.com/laravel/framework/commit/77db028225ccd6ec6bc3359f69482f2e4cc95faf) appears to have broken both MorphPivot and AsPivot.

I think this fixes it.