### PR TITLE
[8.x] Fix `Factory::resolveFactoryName` using hardcoded `App\\` root namespace

### DIFF
--- a/src/Illuminate/Database/Eloquent/Factories/Factory.php
+++ b/src/Illuminate/Database/Eloquent/Factories/Factory.php
@@ -5,6 +5,7 @@ namespace Illuminate\Database\Eloquent\Factories;
 use Closure;
 use Faker\Generator;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -680,9 +681,13 @@ abstract class Factory
     public static function resolveFactoryName(string $modelName)
     {
         $resolver = static::$factoryNameResolver ?: function (string $modelName) {
-            $modelName = Str::startsWith($modelName, 'App\\Models\\')
-                ? Str::after($modelName, 'App\\Models\\')
-                : Str::after($modelName, 'App\\');
+            $namespace = Container::getInstance()
+                        ->make(Application::class)
+                        ->getNamespace();
+
+            $modelName = Str::startsWith($modelName, $namespace.'Models\\')
+                ? Str::after($modelName, $namespace.'Models\\')
+                : Str::after($modelName, $namespace);
 
             return static::$namespace.$modelName.'Factory';
         };

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -3,14 +3,14 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
-use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\App;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
 
@@ -22,8 +22,8 @@ class DatabaseEloquentFactoryTest extends TestCase
             return \Faker\Factory::create('en_US');
         });
 
-        Container::getInstance()->singleton(ApplicationContract::class, function ($app, $parameters) {
-            $application = m::mock(ApplicationContract::class);
+        Container::getInstance()->singleton(Application::class, function ($app, $parameters) {
+            $application = m::mock(Application::class);
 
             $application->shouldReceive('getNamespace')->andReturn('App\\');
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -3,13 +3,16 @@
 namespace Illuminate\Tests\Database;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application as ApplicationContract;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Foundation\Application;
 use PHPUnit\Framework\TestCase;
+use Mockery as m;
 
 class DatabaseEloquentFactoryTest extends TestCase
 {
@@ -17,6 +20,14 @@ class DatabaseEloquentFactoryTest extends TestCase
     {
         Container::getInstance()->singleton(\Faker\Generator::class, function ($app, $parameters) {
             return \Faker\Factory::create('en_US');
+        });
+
+        Container::getInstance()->singleton(ApplicationContract::class, function ($app, $parameters) {
+            $application = m::mock(ApplicationContract::class);
+
+            $application->shouldReceive('getNamespace')->andReturn('App\\');
+
+            return $application;
         });
 
         $db = new DB;
@@ -82,6 +93,8 @@ class DatabaseEloquentFactoryTest extends TestCase
     protected function tearDown(): void
     {
         $this->schema()->drop('users');
+
+        m::close();
     }
 
     public function test_basic_model_can_be_created()


### PR DESCRIPTION
This PR changes the `Factory::resolveFactoryName` method, removing the hardcoded `App\\` namespace and instead uses `Application::getNamespace()` when building the namespace for the model.

This will allow any legacy applications that had previously used the `app:name` command to use the new class-based factories with their custom namespaces.