### PR TITLE
[8.x] Fix type declaration for RouteRegistrar namespace method's parameter

### DIFF
--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -19,7 +19,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
- * @method \Illuminate\Routing\RouteRegistrar namespace(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
  */


### PR DESCRIPTION
Hello,

Starting with Laravel 8, the RouteServiceProvider::$namespace is `null` by default. Some static analysis tools can fail, so this PR adds `null` type declaration in phpDoc for the `namespace` method.

Thanks,
Otto