### PR TITLE
[8.x] Fix Client\Response `throw` method

### DIFF
--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -225,14 +225,14 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
-        $callback = func_get_arg(0);
+        $callback = func_get_args()[0] ?? null;
 
         if ($this->serverError() || $this->clientError()) {
-            if ($callback && is_callable($callback)) {
-                $callback($this, $exception = new RequestException($this));
-            }
-
-            throw $exception;
+            throw tap(new RequestException($this), function ($exception) use ($callback) {
+                if ($callback && is_callable($callback)) {
+                    $callback($this, $exception);
+                }
+            });
         }
 
         return $this;


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Closes #34591 

---

Commit d034e2c55c6502fa0c2bebb6cbf99c5e685beaa5 changed the `Illuminate\Http\Client\Response@throw` method to accept an optional callback. But code started failing when the `throw` method was being called without any parameters. 

According to PHP docs on `func_get_arg` https://www.php.net/manual/en/function.func-get-arg.php

> Generates a warning if called from outside of a user-defined function, **or if `arg_num` is greater than the number of arguments actually passed**. 

This PR fixes that by changing that statement to `$callback = func_get_args()[0] ?? null`.

While testing locally I noticed the same commit also created an `$exception` variable inside a `if` block and throw it outside. In the case a `$callback` was not provided the code would fail due to a undefined `$exception` variable. This PR addresses that case too.
