### PR TITLE
[6.x] ArrayAccess::offsetExists should return true for null fields

### DIFF
--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -1547,7 +1547,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function offsetExists($offset)
     {
-        return ! is_null($this->getAttribute($offset));
+        return array_key_exists($offset, $this->attributes) || array_key_exists($offset, $this->relations);
     }
 
     /**


### PR DESCRIPTION
`ArrayAccess::offsetExists` should check if an offset exists and should not check for an offset value.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

### Description

The model has an implementation of `ArrayAccess::offsetExists` method. It uses the `is_null` function.
So when an attribute exists and has a NULL value, we can't check if the attribute exists or not.

In the end, we have different results when we check if an attribute exists on a model and on an array of model attributes.

### Example
```
class MyModel extends \Illuminate\Database\Eloquent\Model {};
$model = new MyModel();
$model->setAttribute('a', false);
$model->setAttribute('b', null);

dump(array_map(function ($attr) use ($model) {
    return "Model attribute \"$attr\" " . (\Illuminate\Support\Arr::exists($model, $attr) ? 'exists' : "doesn't exist") . '.';
}, ['a', 'b']));
//array:2 [
//  0 => "Model attribute "a" exists."
//  1 => "Model attribute "b" doesn't exist."
//]

$attributes = $model->attributesToArray();
dump(array_map(function ($attr) use ($attributes) {
    return "Array attribute \"$attr\" " . (\Illuminate\Support\Arr::exists($attributes, $attr) ? 'exists' : "doesn't exist") . '.';
}, ['a', 'b']));
//array:2 [
//  0 => "Attribute "a" exists."
//  1 => "Attribute "b" exists."
//]
```