### PR TITLE
[8.x] Add rename table check

### DIFF
--- a/src/Illuminate/Database/Schema/Blueprint.php
+++ b/src/Illuminate/Database/Schema/Blueprint.php
@@ -469,6 +469,12 @@ class Blueprint
      */
     public function rename($to)
     {
+        if (count(func_get_args()) > 1) {
+            throw new BadMethodCallException(
+                "It only accept one argument! You should use 'renameColumn' method if you want to rename the column name!"
+            );
+        }
+
         return $this->addCommand('rename', compact('to'));
     }
 


### PR DESCRIPTION
This PR is adding a `BadMethodCallException` exception when the user tries to add more than one argument to the `rename` method!

Sometimes people get mistaken with `rename` and `renameColumn`! That issue helped make a huge production error before!

With this fix, we tell the user that you wanted to user `renameColumn` not `rename` since they entered two args or more! You can help me change the exception message if you feel like it needs too! 