### PR TITLE
[8.x] Added 'pipeInto' method to EnumeratesValues trait

### DIFF
--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -689,6 +689,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Pass the collection into a new class.
+     *
+     * @param  string  $class
+     * @return static
+     */
+    public function pipeInto($class)
+    {
+        return new $class($this);
+    }
+
+    /**
      * Pass the collection to the given callback and then return it.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -692,7 +692,7 @@ trait EnumeratesValues
      * Pass the collection into a new class.
      *
      * @param  string  $class
-     * @return static
+     * @return mixed
      */
     public function pipeInto($class)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3602,6 +3602,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testPipeInto($collection)
+    {
+        $data = new $collection([
+            'first', 'second',
+        ]);
+
+        $instance = $data->pipeInto(TestCollectionMapIntoObject::class);
+
+        $this->assertSame($data, $instance->value);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMedianValueWithArrayCollection($collection)
     {
         $data = new $collection([1, 2, 2, 4]);


### PR DESCRIPTION
There is already a `mapInto` method to map each value into a new class, but with this method, you can pass the collection instance into a new class. Works great when combined with API Resources.

Before:
```php
$categories = Category::query()
    ->orderBy('name')
    ->get()
    ->pipe(function (Collection $categories) {
        return new CategoryCollection($categories);
    });
```

After:

```php
$categories = Category::query()
    ->orderBy('name')
    ->get()
    ->pipeInto(CategoryCollection::class);
```