### PR TITLE
[8.x] Fix View type declarations for blade components

### DIFF
--- a/src/Illuminate/Foundation/Console/stubs/view-component.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-component.stub
@@ -19,7 +19,7 @@ class DummyClass extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\Contracts\View\View|string
      */
     public function render()
     {

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -673,7 +673,7 @@ if (! function_exists('response')) {
     /**
      * Return a new response from the application.
      *
-     * @param  \Illuminate\View\View|string|array|null  $content
+     * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
@@ -884,7 +884,7 @@ if (! function_exists('view')) {
      * @param  string|null  $view
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  array  $mergeData
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -5,6 +5,7 @@ namespace Illuminate\View;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -50,20 +51,20 @@ abstract class Component
     /**
      * Get the view / view contents that represent the component.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     abstract public function render();
 
     /**
      * Resolve the Blade view or view file that should be used when rendering the component.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     public function resolveView()
     {
         $view = $this->render();
 
-        if ($view instanceof View) {
+        if ($view instanceof ViewContract) {
             return $view;
         }
 

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -42,7 +42,7 @@ trait ManagesComponents
     /**
      * Start a component rendering process.
      *
-     * @param  \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
+     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -42,7 +42,7 @@ class DynamicComponent extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\Contracts\View\View|string
      */
     public function render()
     {


### PR DESCRIPTION
Blade named class-based components uses `\Illuminate\View\View` as type, but View Factory returns `\Illuminate\Contracts\View\View`. Developers can use their own View Factory and `\Illuminate\Contracts\View\View` implementations, so we need to use a contract instead.

It also solves vimeo/psalm `LessSpecificImplementedReturnType` errors when developers use DI to inject View factory or use View Facade:
```php
    public function render()
    {
       //  Facade
        return View::make('components.info-icon');

        //  or DI (\Illuminate\Contracts\View\Factory::make has \Illuminate\Contracts\View\View return type)
        return $this->view->make('components.info-icon');
    }
```
