### PR TITLE
[8.x] Add messageId method to Message class

### DIFF
--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -314,7 +314,7 @@ class Message
     {
         return $this->swift;
     }
-    
+
     /**
      * @return string|int|null
      */

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -314,6 +314,15 @@ class Message
     {
         return $this->swift;
     }
+    
+    /**
+     * @return \Swift_Mime_Header|null
+     */
+    public function messageId()
+    {
+        $headers = $this->swift->getHeaders();
+        return $headers->get('X-Message-ID');
+    }
 
     /**
      * Dynamically pass missing methods to the Swift instance.

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -321,6 +321,7 @@ class Message
     public function messageId()
     {
         $headers = $this->swift->getHeaders();
+
         return $headers->get('X-Message-ID');
     }
 

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -316,6 +316,8 @@ class Message
     }
 
     /**
+     * Get the message id set by the Transporter after sending.
+     *
      * @return string|int|null
      */
     public function messageId()

--- a/src/Illuminate/Mail/Message.php
+++ b/src/Illuminate/Mail/Message.php
@@ -316,7 +316,7 @@ class Message
     }
     
     /**
-     * @return \Swift_Mime_Header|null
+     * @return string|int|null
      */
     public function messageId()
     {


### PR DESCRIPTION
Added helper function `messageId` to retrieve X-Message-ID function from the headers of the swift message.