### PR TITLE
[8.x] Allow for chains to be added to batches

### DIFF
--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -180,6 +180,7 @@ class Batch implements Arrayable, JsonSerializable
                 $jobTotal += count($jobChain);
 
                 $chainHead = array_shift($jobChain);
+
                 return $chainHead->chain($jobChain);
             } else {
                 $job->withBatchId($this->id);

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -169,9 +169,13 @@ class Batch implements Arrayable, JsonSerializable
 
             if (is_array($job)) {
                 $jobChain = $job;
-                foreach ($jobChain as $j) {
-                    $j->withBatchId($this->id);
-                }
+                $batchId = $this->id;
+                array_walk($jobChain, function (&$job) use ($batchId) {
+                    if ($job instanceof Closure) {
+                        $job = CallQueuedClosure::create($job);
+                    }
+                    $job->withBatchId($batchId);
+                });
 
                 $jobTotal += count($jobChain);
 

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -311,17 +311,11 @@ class BusBatchTest extends TestCase
 
         $batch = $this->createTestBatch($queue);
 
-        $chainHeadJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $chainHeadJob = new ChainHeadJob();
 
-        $secondJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $secondJob = new SecondTestJob();
 
-        $thirdJob = new class implements ShouldQueue {
-            use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, Batchable;
-        };
+        $thirdJob = new ThirdTestJob();
 
         $queue->shouldReceive('connection')->once()
             ->with('test-connection')
@@ -390,4 +384,19 @@ class BusBatchTest extends TestCase
     {
         return $this->connection()->getSchemaBuilder();
     }
+}
+
+class ChainHeadJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
+}
+
+class SecondTestJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
+}
+
+class ThirdTestJob implements ShouldQueue
+{
+    use Dispatchable, Queueable, Batchable;
 }

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -16,8 +16,6 @@ use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\CallQueuedClosure;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -335,7 +335,7 @@ class BusBatchTest extends TestCase
         }), '', 'test-queue');
 
         $batch = $batch->add([
-            [$chainHeadJob, $secondJob, $thirdJob]
+            [$chainHeadJob, $secondJob, $thirdJob],
         ]);
 
         $this->assertEquals(3, $batch->totalJobs);


### PR DESCRIPTION
This adds functionality to batching that allows you to pass in a sub array of job classes that will create a job chain included in the batch.

The first item in the array will be the "chain head" and be the job that the other jobs are chained onto.

It would be used as so:

```php
$batch = Bus::batch([
            new Test1Job(),
            [
                new Test2Job(),
                new Test3Job(),
                new Test4Job(),
            ]
        ])->then(function (Batch $batch) {
            Log::info('Test Complete!');
        })->name('Test')->dispatch();
```

Each job is given a batchId just as they normally would and the `then` only fires once all are completed.

In the above example `Test3Job` and `Test4Job` are chained onto `Test2Job`.

`Test1Job` executes on it's own NOT in the chain with the other 3 just as batching works now.

This benefits users as batching, as it works now ,provides amazing support for doing a bunch of things and doing something when they are completed.
But sometimes some of those things have to happen in a particular order BUT others can happen at any time.
This makes that easier without having to add the job to the batch from within another job. Making it easier to track, at a high level, what is happening and in what, if any, sequence.