### PR TITLE
[8.x] Add value($key) function to collections

### DIFF
--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1004,7 +1004,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * Get a single property from the first element in the collection.
      *
      * @param  string  $key
-     * @return  mixed
+     * @return mixed
      */
     public function value($key);
 

--- a/src/Illuminate/Collections/Enumerable.php
+++ b/src/Illuminate/Collections/Enumerable.php
@@ -1001,6 +1001,14 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
     public function collect();
 
     /**
+     * Get a single property from the first element in the collection.
+     *
+     * @param  string  $key
+     * @return  mixed
+     */
+    public function value($key);
+
+    /**
      * Convert the collection to its string representation.
      *
      * @return string

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -773,6 +773,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Get a single property from the first element in the collection.
+     *
+     * @param  string  $key
+     * @return  mixed
+     */
+    public function value($key)
+    {
+        return data_get($this->first(), $key);
+    }
+
+    /**
      * Get the collection of items as a plain array.
      *
      * @return array

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -776,7 +776,7 @@ trait EnumeratesValues
      * Get a single property from the first element in the collection.
      *
      * @param  string  $key
-     * @return  mixed
+     * @return mixed
      */
     public function value($key)
     {

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -4473,6 +4473,24 @@ class SupportCollectionTest extends TestCase
     }
 
     /**
+     * @dataProvider collectionClassProvider
+     */
+    public function testValue($collection)
+    {
+        $object1 = new stdClass();
+        $object1->prop = 1;
+        $object2 = new stdClass();
+        $object2->prop = 2;
+
+        $data = $collection::make([
+            $object1,
+            $object2,
+        ])->collect();
+
+        $this->assertEquals(1, $data->value('prop'));
+    }
+
+    /**
      * Provides each collection class, respectively.
      *
      * @return array


### PR DESCRIPTION
This pr adds a `value($key)` function to collections that corresponds with the `value($column)` function on the query builder. The function will return a single property of the first element in the collection.

The function is a shortcut to get a value from the collection without having to map the entire collection using `pluck()`.

## Use case
In one of my projects, I get a group of products to process based on the date the group was last processed. The query will also return the `group_id` for each product which in this case will be the same for every product in the collection. The function `value('group_id')` would be a handy way to get the `group_id` for this collection.