### PR TITLE
[8.x] Translate linkCollection

### DIFF
--- a/src/Illuminate/Pagination/LengthAwarePaginator.php
+++ b/src/Illuminate/Pagination/LengthAwarePaginator.php
@@ -115,11 +115,11 @@ class LengthAwarePaginator extends AbstractPaginator implements Arrayable, Array
             });
         })->prepend([
             'url' => $this->previousPageUrl(),
-            'label' => 'Previous',
+            'label' => app()->bound('translator') ? app('translator')->get('pagination.previous') : 'Previous',
             'active' => false,
         ])->push([
             'url' => $this->nextPageUrl(),
-            'label' => 'Next',
+            'label' => app()->bound('translator') ? app('translator')->get('pagination.next') : 'Next',
             'active' => false,
         ]);
     }


### PR DESCRIPTION
This translates the labels of the linkCollection added to LengthAwarePaginator in 8.0.3 by 13751a187834fabe515c14fb3ac1dc008fd23f37

I couldn't find a place where translation happens on a framework level so don't know if this is the proper way of doing or if you would rather not have any translation happen