### PR TITLE
[8.x] Adds "schedule:work" command

### DIFF
--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+
+class ScheduleWorkCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:work';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Start the schedule worker';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info('Schedule worker started successfully.');
+
+        while (true) {
+            if (now()->second === 0) {
+                $this->call('schedule:run');
+            }
+
+            sleep(1);
+        }
+    }
+}

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -2,8 +2,8 @@
 
 namespace Illuminate\Console\Scheduling;
 
-use Illuminate\Support\Carbon;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 
 class ScheduleWorkCommand extends Command
 {

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Console\Scheduling;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Console\Command;
 
 class ScheduleWorkCommand extends Command
@@ -30,7 +31,7 @@ class ScheduleWorkCommand extends Command
         $this->info('Schedule worker started successfully.');
 
         while (true) {
-            if (now()->second === 0) {
+            if (Carbon::now()->second === 0) {
                 $this->call('schedule:run');
             }
 

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
+use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
@@ -113,6 +114,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Seed' => 'command.seed',
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
+        'ScheduleWork' => ScheduleWorkCommand::class,
         'StorageLink' => 'command.storage.link',
         'Up' => 'command.up',
         'ViewCache' => 'command.view.cache',
@@ -912,6 +914,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleRunCommand()
     {
         $this->app->singleton(ScheduleRunCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleWorkCommand()
+    {
+        $this->app->singleton(ScheduleWorkCommand::class);
     }
 
     /**


### PR DESCRIPTION
Right now there are 2 options to test the scheduler:

- run `schedule:run` by hand every minute (that's annoying);
- add the Cron entry to the system (you probably don't want to do that just to test the things).

This new `schedule:work` command emulates the second option by running `schedule:run` command every minute under the hood.
When you want to stop the worker, just use `Ctrl`+`C`.

_Inspired by https://github.com/laravel/ideas/issues/2338_