### PR TITLE
[8.x] Allow custom names for queued notifications

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -101,7 +101,8 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
-        return get_class($this->notification);
+        return method_exists($this->notification, 'displayName')
+                        ? $this->notification->displayName() : get_class($this->notification);
     }
 
     /**


### PR DESCRIPTION
Since this value shows up in the output for the queue worker, it would be nice to be able to customise it. Previous behaviour remains intact if no `displayName()` method is set on the Notification instance.

I wasn't able to find any tests for the existing function. Please point me in the right direction if I've missed something, but this seems like very low-level stuff not really needing a test.