### PR TITLE
[8.x] Add 'secret-time' argument to maintenance mode

### DIFF
--- a/src/Illuminate/Foundation/Console/DownCommand.php
+++ b/src/Illuminate/Foundation/Console/DownCommand.php
@@ -18,6 +18,7 @@ class DownCommand extends Command
                                  {--render= : The view that should be prerendered for display during maintenance mode}
                                  {--retry= : The number of seconds after which the request may be retried}
                                  {--secret= : The secret phrase that may be used to bypass maintenance mode}
+                                 {--secret-time=12 : The expiration time of bypass cookie (hours)}
                                  {--status=503 : The status code that should be used when returning the maintenance mode response}';
 
     /**
@@ -72,6 +73,7 @@ class DownCommand extends Command
             'redirect' => $this->redirectPath(),
             'retry' => $this->getRetryTime(),
             'secret' => $this->option('secret'),
+            'secret-time' => (int) $this->option('secret-time'),
             'status' => (int) $this->option('status', 503),
             'template' => $this->option('render') ? $this->prerenderView() : null,
         ];

--- a/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
+++ b/src/Illuminate/Foundation/Http/MaintenanceModeBypassCookie.php
@@ -11,11 +11,15 @@ class MaintenanceModeBypassCookie
      * Create a new maintenance mode bypass cookie.
      *
      * @param  string  $key
+     * @param  int  $time
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public static function create(string $key)
+    public static function create(string $key, int $time = 12)
     {
-        $expiresAt = Carbon::now()->addHours(12);
+        if ($time < 1) {
+            $time = 1;
+        }
+        $expiresAt = Carbon::now()->addHours($time);
 
         return new Cookie('laravel_maintenance', base64_encode(json_encode([
             'expires_at' => $expiresAt->getTimestamp(),

--- a/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -50,7 +50,7 @@ class PreventRequestsDuringMaintenance
             $data = json_decode(file_get_contents($this->app->storagePath().'/framework/down'), true);
 
             if (isset($data['secret']) && $request->path() === $data['secret']) {
-                return $this->bypassResponse($data['secret']);
+                return $this->bypassResponse($data['secret'], $data['secret-time'] ?? 12);
             }
 
             if ($this->hasValidBypassCookie($request, $data) ||
@@ -129,12 +129,13 @@ class PreventRequestsDuringMaintenance
      * Redirect the user back to the root of the application with a maintenance mode bypass cookie.
      *
      * @param  string  $secret
+     * @param  int  $time
      * @return \Illuminate\Http\RedirectResponse
      */
-    protected function bypassResponse(string $secret)
+    protected function bypassResponse(string $secret, int $time)
     {
         return redirect('/')->withCookie(
-            MaintenanceModeBypassCookie::create($secret)
+            MaintenanceModeBypassCookie::create($secret, $time)
         );
     }
 }


### PR DESCRIPTION
This PR adds a new argument to the `down` command.

Improved maintenance mode in Laravel 8 has a feature to bypass maintenance mode. At the moment, this feature creates a secret route that creates a cookie including a payload. This payload contains the expiration timestamp of bypass cookie. Unfortunately, the timestamp is hardcoded to current timestamp + 12 hours. It means that if you want to bypass maintenance mode for a long time, you'll have to send a request to the secret bypass route every 12 hours.

This PR adds a new argument (called `secret-time`) to the `down` command, which by using it you can change the timestamp included in the bypass cookie. For example, if you want the bypass cookie to expire after 24 hours (not after 12 hours), you can call the `down` command like this:

```
php artisan down --secret=czYgEazEVikRaT8JdcGF --secret-time=24
```

Also, the expiration time will automatically set to 1 hour if the given value of `secret-time` is less than 1.