### PR TITLE
[8.x] Update isGuarded to evaluate column names before "->"

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -203,6 +203,10 @@ trait GuardsAttributes
             return false;
         }
 
+        if (strpos($key, '->') !== false) {
+            $key = Str::before($key, '->');
+        }
+
         return $this->getGuarded() == ['*'] ||
                ! empty(preg_grep('/^'.preg_quote($key).'$/i', $this->getGuarded())) ||
                ! $this->isGuardableColumn($key);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->


As discussed in https://github.com/laravel/framework/issues/34630, the update in https://github.com/laravel/framework/pull/33777/files removed the ability to update nested attributes using "->" as the comparison of the updating attribute and guarded columns are not done using the key that existed before "->" inside the updating attribute.

This PR is to allow it by restoring the previous code: Use the key that are before  "->" of the updating attribute when comparing it with the guarded columns.