### PR TITLE
Filesystem Exclude Files and Directories

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -504,29 +504,31 @@ class Filesystem
     /**
      * Get an array of all files in a directory.
      *
-     * @param  string  $directory
-     * @param  bool  $hidden
+     * @param string $directory
+     * @param bool $hidden
+     * @param array $exclude
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function files($directory, $hidden = false)
+    public function files($directory, $hidden = false, $exclude = [])
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0)->sortByName(),
-            false
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->exclude($exclude)->in($directory)->depth(0)
+                ->sortByName(), false
         );
     }
 
     /**
      * Get all of the files from the given directory (recursive).
      *
-     * @param  string  $directory
-     * @param  bool  $hidden
+     * @param string $directory
+     * @param bool $hidden
+     * @param array $exclude
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function allFiles($directory, $hidden = false)
+    public function allFiles($directory, $hidden = false, $exclude = [])
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->sortByName(),
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->exclude($exclude)->in($directory)->sortByName(),
             false
         );
     }
@@ -534,14 +536,15 @@ class Filesystem
     /**
      * Get all of the directories within a given directory.
      *
-     * @param  string  $directory
+     * @param string $directory
+     * @param array $exclude
      * @return array
      */
-    public function directories($directory)
+    public function directories($directory, $exclude = [])
     {
         $directories = [];
 
-        foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
+        foreach (Finder::create()->in($directory)->directories()->depth(0)->exclude($exclude)->sortByName() as $dir) {
             $directories[] = $dir->getPathname();
         }
 


### PR DESCRIPTION
Hi!
I do the following PR to modify the following 3 methods:

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L511-L517

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L526-L532

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L540-L549

Adding the option to pass as a parameter an ```array``` with the files or directories that you want to exclude when these methods are called.


Example:

User has the following structure in ```resources``` directory:

```
resources
├───...
├───js
│   ├───A
│   ├───B
│   └───C
├───...
```

And want to get all the directories in the ```js``` folder, but exclude the ```C``` directory.

```
use Illuminate\Filesystem\Filesystem;

class CustomClass
{
    public function example()
    {
        $filesystem = new Filesystem();

        $exclude = ['C'];

        $directories = $filesystem->directories(resource_path('js'), $exclude);

        return $directories;
    }
}
```

the result would be an array with the following content:

```
array:2 [
  0 => "/path/to/project/resources/js/A"
  0 => "/path/to/project/resources/js/B"
]
```

Similarly you can use the ```files``` method and the ```allFiles``` method
