### PR TITLE
[9.x] Added model information to database session

### DIFF
--- a/src/Illuminate/Session/Console/stubs/database.stub
+++ b/src/Illuminate/Session/Console/stubs/database.stub
@@ -16,6 +16,7 @@ class CreateSessionsTable extends Migration
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
+            $table->foreignId('user_type')->nullable();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->text('payload');

--- a/src/Illuminate/Session/DatabaseSessionHandler.php
+++ b/src/Illuminate/Session/DatabaseSessionHandler.php
@@ -198,6 +198,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     {
         if ($this->container->bound(Guard::class)) {
             $payload['user_id'] = $this->userId();
+            $payload['user_type'] = $this->userModel();
         }
 
         return $this;
@@ -211,6 +212,18 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
     protected function userId()
     {
         return $this->container->make(Guard::class)->id();
+    }
+
+    /**
+     * Get the currently authenticated user's Model.
+     *
+     * @return mixed
+     */
+    protected function userModel()
+    {
+        $user = $this->container->make(Guard::class)->user();
+
+        return is_null($user) ? null : $user->getMorphClass();
     }
 
     /**


### PR DESCRIPTION
Added the ability to check logged in session's user model in database session.

currently, with the session's `database` driver we only had the `user_id` field it is hard to keep track of the logged-in user if we are using multiple provider authentication. So if we have the `user_type` field in the sessions table it will be better. Like a polymorphic relationship. 