### PR TITLE
Filesystem add exclude files and directories

### DIFF
--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 6.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v6.18.40...6.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v6.18.41...6.x)
+
+
+## [v6.18.41 (2020-09-29)](https://github.com/laravel/framework/compare/v6.18.40...v6.18.41)
+
+### Fixed
+- Added support for stream reads in FileManager for S3 driver ([#34480](https://github.com/laravel/framework/pull/34480))
 
 
 ## [v6.18.40 (2020-09-09)](https://github.com/laravel/framework/compare/v6.18.39...v6.18.40)

--- a/CHANGELOG-6.x.md
+++ b/CHANGELOG-6.x.md
@@ -49,7 +49,7 @@
 
 ### Fixed
 - Fixed `Illuminate\Support\Arr::query()` ([c6f9ae2](https://github.com/laravel/framework/commit/c6f9ae2b6fdc3c1716938223de731b97f6a5a255))
-- Dont allow mass filling with table names ([9240404](https://github.com/laravel/framework/commit/9240404b22ef6f9e827577b3753e4713ddce7471), [f5fa6e3](https://github.com/laravel/framework/commit/f5fa6e3a0fbf9a93eab45b9ae73265b4dbfc3ad7))
+- Don't allow mass filling with table names ([9240404](https://github.com/laravel/framework/commit/9240404b22ef6f9e827577b3753e4713ddce7471), [f5fa6e3](https://github.com/laravel/framework/commit/f5fa6e3a0fbf9a93eab45b9ae73265b4dbfc3ad7))
 
 
 ## [v6.18.33 (2020-08-06)](https://github.com/laravel/framework/compare/v6.18.32...v6.18.33)
@@ -93,7 +93,7 @@
 ## [v6.18.27 (2020-07-27)](https://github.com/laravel/framework/compare/v6.18.26...v6.18.27)
 
 ### Fixed
-- Dont decrement transaction below 0 in `Illuminate\Database\Concerns\ManagesTransactions::handleCommitTransactionException()` ([7681795](https://github.com/laravel/framework/commit/768179578e5492b5f80c391bd43b233938e16e27))
+- Don't decrement transaction below 0 in `Illuminate\Database\Concerns\ManagesTransactions::handleCommitTransactionException()` ([7681795](https://github.com/laravel/framework/commit/768179578e5492b5f80c391bd43b233938e16e27))
 - Fixed transaction problems on closure transaction ([c4cdfc7](https://github.com/laravel/framework/commit/c4cdfc7c54127b772ef10f37cfc9ef8e9d6b3227))
 - Prevent to serialize uninitialized properties ([#33644](https://github.com/laravel/framework/pull/33644))
 - Fixed missing statement preventing deletion in `Illuminate\Database\Eloquent\Relations\MorphPivot::delete()` ([#33648](https://github.com/laravel/framework/pull/33648))
@@ -442,7 +442,7 @@
 
 ### Changed
 - Use SKIP LOCKED for mysql 8.1 and pgsql 9.5 queue workers ([#31287](https://github.com/laravel/framework/pull/31287))
-- Dont merge middleware from method and property in `Illuminate\Bus\Queueable::middleware()` ([#31301](https://github.com/laravel/framework/pull/31301))
+- Don't merge middleware from method and property in `Illuminate\Bus\Queueable::middleware()` ([#31301](https://github.com/laravel/framework/pull/31301))
 - Split `specifyParameter()` from `Illuminate\Console\Command` to `HasParameters` trait ([#31254](https://github.com/laravel/framework/pull/31254))
 - Make sure changing a database field to json does not include charset ([#31343](https://github.com/laravel/framework/pull/31343))
 
@@ -581,7 +581,7 @@
 - Fixed `Builder::withCount()` binding error when a scope is added into related model with binding in a sub-select ([#30869](https://github.com/laravel/framework/pull/30869))
 
 ### Changed
--  Dont throw exception when session is not set in `AuthenticateSession` middleware ([4de1d24](https://github.com/laravel/framework/commit/4de1d24cf390f07d4f503973e5556f73060fbb31))
+-  Don't throw exception when session is not set in `AuthenticateSession` middleware ([4de1d24](https://github.com/laravel/framework/commit/4de1d24cf390f07d4f503973e5556f73060fbb31))
 
 
 ## [v6.8.0 (2019-12-17)](https://github.com/laravel/framework/compare/v6.7.0...v6.8.0)

--- a/CHANGELOG-7.x.md
+++ b/CHANGELOG-7.x.md
@@ -44,7 +44,7 @@
 - RefreshDatabase migration commands parameters moved to methods ([#34007](https://github.com/laravel/framework/pull/34007), [8b35c8e](https://github.com/laravel/framework/commit/8b35c8e6ba5879e71fd81fd03b5687ee2b46c55a), [256f71c](https://github.com/laravel/framework/commit/256f71c1f81da2d4bb3e327b18389ac43fa97a72))
 
 ### Changed
-- allow to reset forced scheme and root-url in UrlGenerator ([#34039](https://github.com/laravel/framework/pull/34039))
+- Allow to reset forced scheme and root-url in UrlGenerator ([#34039](https://github.com/laravel/framework/pull/34039))
 - Updating the make commands to use a custom views path ([#34060](https://github.com/laravel/framework/pull/34060), [b593c62](https://github.com/laravel/framework/commit/b593c6242942623fcc12638d0390da7c58dbbb11))
 - Using "public static property" in View Component causes an error ([#34058](https://github.com/laravel/framework/pull/34058))
 - Changed postgres processor ([#34055](https://github.com/laravel/framework/pull/34055))
@@ -121,7 +121,7 @@
 
 ### Fixed
 - Fixed `Illuminate\Support\Arr::query()` ([c6f9ae2](https://github.com/laravel/framework/commit/c6f9ae2b6fdc3c1716938223de731b97f6a5a255))
-- Dont allow mass filling with table names ([9240404](https://github.com/laravel/framework/commit/9240404b22ef6f9e827577b3753e4713ddce7471), [f5fa6e3](https://github.com/laravel/framework/commit/f5fa6e3a0fbf9a93eab45b9ae73265b4dbfc3ad7))
+- Don't allow mass filling with table names ([9240404](https://github.com/laravel/framework/commit/9240404b22ef6f9e827577b3753e4713ddce7471), [f5fa6e3](https://github.com/laravel/framework/commit/f5fa6e3a0fbf9a93eab45b9ae73265b4dbfc3ad7))
 
 
 ## [v7.23.1 (2020-08-06)](https://github.com/laravel/framework/compare/v7.23.0...v7.23.1)
@@ -179,7 +179,7 @@
 
 ### Fixed
 - Prevent usage of get*AtColumn() when model has no timestamps ([#33634](https://github.com/laravel/framework/pull/33634))
-- Dont decrement transaction below 0 in `Illuminate\Database\Concerns\ManagesTransactions::handleCommitTransactionException()` ([7681795](https://github.com/laravel/framework/commit/768179578e5492b5f80c391bd43b233938e16e27))
+- Don't decrement transaction below 0 in `Illuminate\Database\Concerns\ManagesTransactions::handleCommitTransactionException()` ([7681795](https://github.com/laravel/framework/commit/768179578e5492b5f80c391bd43b233938e16e27))
 - Fixed transaction problems on closure transaction ([c4cdfc7](https://github.com/laravel/framework/commit/c4cdfc7c54127b772ef10f37cfc9ef8e9d6b3227))
 - Prevent to serialize uninitialized properties ([#33644](https://github.com/laravel/framework/pull/33644))
 - Fixed missing statement preventing deletion in `Illuminate\Database\Eloquent\Relations\MorphPivot::delete()` ([#33648](https://github.com/laravel/framework/pull/33648))
@@ -394,7 +394,7 @@
 - Fixed `Illuminate\Cache\ArrayStore::increment()` bug that changes expiration to forever ([#32875](https://github.com/laravel/framework/pull/32875))
 
 ### Changed
-- Dont cache non objects in `Illuminate/Database/Eloquent/Concerns/HasAttributes::getClassCastableAttributeValue()` ([894fe22](https://github.com/laravel/framework/commit/894fe22c6c111b224de5bada24dcbba4c93f0305))
+- Don't cache non objects in `Illuminate/Database/Eloquent/Concerns/HasAttributes::getClassCastableAttributeValue()` ([894fe22](https://github.com/laravel/framework/commit/894fe22c6c111b224de5bada24dcbba4c93f0305))
 - Added explicit `symfony/polyfill-php73` dependency ([5796b1e](https://github.com/laravel/framework/commit/5796b1e43dfe14914050a7e5dd24ddf803ec99b8))
 - Set `Cache\FileStore` file permissions only once ([#32845](https://github.com/laravel/framework/pull/32845), [11c533b](https://github.com/laravel/framework/commit/11c533b9aa062f4cba1dd0fe3673bf33d275480f))
 - Added alias as key of package's view components ([#32863](https://github.com/laravel/framework/pull/32863))
@@ -885,7 +885,7 @@
 - Fixed `trim` of the prefix in the `CompiledRouteCollection::newRoute()` ([ce0355c](https://github.com/laravel/framework/commit/ce0355c72bf4defb93ae80c7bf7812bd6532031a), [b842c65](https://github.com/laravel/framework/commit/b842c65ecfe1ea7839d61a46b177b6b5887fd4d2))
 
 ### Changed
-- remove comments before compiling components in the `BladeCompiler` ([2964d2d](https://github.com/laravel/framework/commit/2964d2dfd3cc50f7a709effee0af671c86587915))
+- Remove comments before compiling components in the `BladeCompiler` ([2964d2d](https://github.com/laravel/framework/commit/2964d2dfd3cc50f7a709effee0af671c86587915))
 
 
 ## [v7.0.1 (2020-03-03)](https://github.com/laravel/framework/compare/v7.0.0...v7.0.1)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,12 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.7.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.7.1...8.x)
+
+
+## [v8.7.1 (2020-09-29)](https://github.com/laravel/framework/compare/v8.7.0...v8.7.1)
+
+### Fixed
+- Remove type hints ([1b3f62a](https://github.com/laravel/framework/commit/1b3f62aaeced2c9761a6052a7f0d3c1a046851c9))
 
 
 ## [v8.7.0 (2020-09-29)](https://github.com/laravel/framework/compare/v8.6.0...v8.7.0)

--- a/CHANGELOG-8.x.md
+++ b/CHANGELOG-8.x.md
@@ -1,6 +1,28 @@
 # Release Notes for 8.x
 
-## [Unreleased](https://github.com/laravel/framework/compare/v8.6.0...8.x)
+## [Unreleased](https://github.com/laravel/framework/compare/v8.7.0...8.x)
+
+
+## [v8.7.0 (2020-09-29)](https://github.com/laravel/framework/compare/v8.6.0...v8.7.0)
+
+### Added
+- Added tg:// protocol in "url" validation rule ([#34464](https://github.com/laravel/framework/pull/34464))
+- Allow dynamic factory methods to obey newFactory method on model ([#34492](https://github.com/laravel/framework/pull/34492), [4708e9e](https://github.com/laravel/framework/commit/4708e9ef8f7cde617a5820f07cfd350daaba0e0f))
+- Added `no-reload` option to `serve` command ([9cc2622](https://github.com/laravel/framework/commit/9cc2622a9122f5108a694856055c13db8a5f80dc))
+- Added `perHour` and `perDay` methods to `Illuminate\Cache\RateLimiting\Limit` ([#34530](https://github.com/laravel/framework/pull/34530))
+- Added `Illuminate\Http\Client\Response::onError()` ([#34558](https://github.com/laravel/framework/pull/34558), [d034e2c](https://github.com/laravel/framework/commit/d034e2c55c6502fa0c2bebb6cbf99c5e685beaa5))
+- Added `X-Message-ID` to `Mailgun` and `Ses Transport` ([#34567](https://github.com/laravel/framework/pull/34567)) 
+
+### Fixed
+- Fixed incompatibility with Lumen route function in `Illuminate\Session\Middleware\StartSession` ([#34491](https://github.com/laravel/framework/pull/34491))
+- Fixed: Eager loading MorphTo relationship does not honor each models $keyType ([#34531](https://github.com/laravel/framework/pull/34531), [c3f44c7](https://github.com/laravel/framework/commit/c3f44c712833d83061452e9a362a5e10fa424863))
+- Fixed translation label ("Pagination Navigation") for the Tailwind blade ([#34568](https://github.com/laravel/framework/pull/34568))
+- Fixed save keys on increment / decrement in Model ([77db028](https://github.com/laravel/framework/commit/77db028225ccd6ec6bc3359f69482f2e4cc95faf))
+
+### Changed
+- Allow modifiers in date format in Model ([#34507](https://github.com/laravel/framework/pull/34507))
+- Allow for dynamic calls of anonymous component with varied attributes ([#34498](https://github.com/laravel/framework/pull/34498))
+- Cast `Expression` as string so it can be encoded ([#34569](https://github.com/laravel/framework/pull/34569))
 
 
 ## [v8.6.0 (2020-09-22)](https://github.com/laravel/framework/compare/v8.5.0...v8.6.0)

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -80,7 +80,7 @@ class VerifyEmail extends Notification
     }
 
     /**
-     * Set a callback that should be used when creating the verify email button URL.
+     * Set a callback that should be used when creating the email verification URL.
      *
      * @param  \Closure  $callback
      * @return void

--- a/src/Illuminate/Auth/Notifications/VerifyEmail.php
+++ b/src/Illuminate/Auth/Notifications/VerifyEmail.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\URL;
 class VerifyEmail extends Notification
 {
     /**
-     * The callback that should be used to create the reset password URL.
+     * The callback that should be used to create the verify email URL.
      *
      * @var \Closure|null
      */
@@ -67,20 +67,20 @@ class VerifyEmail extends Notification
     {
         if (static::$createUrlCallback) {
             return call_user_func(static::$createUrlCallback, $notifiable);
-        } else {
-            return URL::temporarySignedRoute(
-                'verification.verify',
-                Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
-                [
-                    'id' => $notifiable->getKey(),
-                    'hash' => sha1($notifiable->getEmailForVerification()),
-                ]
-            );
         }
+
+        return URL::temporarySignedRoute(
+            'verification.verify',
+            Carbon::now()->addMinutes(Config::get('auth.verification.expire', 60)),
+            [
+                'id' => $notifiable->getKey(),
+                'hash' => sha1($notifiable->getEmailForVerification()),
+            ]
+        );
     }
 
     /**
-     * Set a callback that should be used when creating the reset password button URL.
+     * Set a callback that should be used when creating the verify email button URL.
      *
      * @param  \Closure  $callback
      * @return void

--- a/src/Illuminate/Bus/Batch.php
+++ b/src/Illuminate/Bus/Batch.php
@@ -81,21 +81,21 @@ class Batch implements Arrayable, JsonSerializable
     /**
      * The date indicating when the batch was created.
      *
-     * @var \Illuminate\Support\CarbonImmutable
+     * @var \Carbon\CarbonImmutable
      */
     public $createdAt;
 
     /**
      * The date indicating when the batch was cancelled.
      *
-     * @var \Illuminate\Support\CarbonImmutable|null
+     * @var \Carbon\CarbonImmutable|null
      */
     public $cancelledAt;
 
     /**
      * The date indicating when the batch was finished.
      *
-     * @var \Illuminate\Support\CarbonImmutable|null
+     * @var \Carbon\CarbonImmutable|null
      */
     public $finishedAt;
 
@@ -111,9 +111,9 @@ class Batch implements Arrayable, JsonSerializable
      * @param  int  $failedJobs
      * @param  array  $failedJobIds
      * @param  array  $options
-     * @param  \Illuminate\Support\CarbonImmutable  $createdAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $cancelledAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $finishedAt
+     * @param  \Carbon\CarbonImmutable  $createdAt
+     * @param  \Carbon\CarbonImmutable|null  $cancelledAt
+     * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return void
      */
     public function __construct(QueueFactory $queue,
@@ -239,7 +239,7 @@ class Batch implements Arrayable, JsonSerializable
      * Decrement the pending jobs for the batch.
      *
      * @param  string  $jobId
-     * @return int
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
      */
     public function decrementPendingJobs(string $jobId)
     {
@@ -322,7 +322,7 @@ class Batch implements Arrayable, JsonSerializable
      * Increment the failed jobs for the batch.
      *
      * @param  string  $jobId
-     * @return int
+     * @return \Illuminate\Bus\UpdatedBatchJobCounts
      */
     public function incrementFailedJobs(string $jobId)
     {
@@ -393,7 +393,7 @@ class Batch implements Arrayable, JsonSerializable
      * Invoke a batch callback handler.
      *
      * @param  \Illuminate\Queue\SerializableClosure|callable  $handler
-     * @param  \Illuminate\Bus  $batch
+     * @param  \Illuminate\Bus\Batch  $batch
      * @param  \Throwable|null  $e
      * @return void
      */

--- a/src/Illuminate/Bus/BatchFactory.php
+++ b/src/Illuminate/Bus/BatchFactory.php
@@ -36,9 +36,9 @@ class BatchFactory
      * @param  int  $failedJobs
      * @param  array  $failedJobIds
      * @param  array  $options
-     * @param  \Illuminate\Support\CarbonImmutable  $createdAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $cancelledAt
-     * @param  \Illuminate\Support\CarbonImmutable|null  $finishedAt
+     * @param  \Carbon\CarbonImmutable  $createdAt
+     * @param  \Carbon\CarbonImmutable|null  $cancelledAt
+     * @param  \Carbon\CarbonImmutable|null  $finishedAt
      * @return \Illuminate\Bus\Batch
      */
     public function make(BatchRepository $repository,

--- a/src/Illuminate/Bus/PendingBatch.php
+++ b/src/Illuminate/Bus/PendingBatch.php
@@ -215,6 +215,7 @@ class PendingBatch
      * Dispatch the batch.
      *
      * @return \Illuminate\Bus\Batch
+     * @throws \Throwable
      */
     public function dispatch()
     {

--- a/src/Illuminate/Collections/Traits/EnumeratesValues.php
+++ b/src/Illuminate/Collections/Traits/EnumeratesValues.php
@@ -689,6 +689,17 @@ trait EnumeratesValues
     }
 
     /**
+     * Pass the collection into a new class.
+     *
+     * @param  string  $class
+     * @return mixed
+     */
+    public function pipeInto($class)
+    {
+        return new $class($this);
+    }
+
+    /**
      * Pass the collection to the given callback and then return it.
      *
      * @param  callable  $callback

--- a/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
+++ b/src/Illuminate/Console/Scheduling/ScheduleWorkCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Illuminate\Console\Scheduling;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class ScheduleWorkCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'schedule:work';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Start the schedule worker';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info('Schedule worker started successfully.');
+
+        while (true) {
+            if (Carbon::now()->second === 0) {
+                $this->call('schedule:run');
+            }
+
+            sleep(1);
+        }
+    }
+}

--- a/src/Illuminate/Database/Eloquent/Model.php
+++ b/src/Illuminate/Database/Eloquent/Model.php
@@ -620,9 +620,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
             return false;
         }
 
-        return tap($query->where(
-            $this->getKeyName(), $this->getKey()
-        )->{$method}($column, $amount, $extra), function () use ($column) {
+        return tap($this->setKeysForSaveQuery($query)->{$method}($column, $amount, $extra), function () use ($column) {
             $this->syncChanges();
 
             $this->fireModelEvent('updated', false);
@@ -813,7 +811,7 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
 

--- a/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/BelongsTo.php
@@ -229,6 +229,16 @@ class BelongsTo extends Relation
     }
 
     /**
+     * Alias of "dissociate" method.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function disassociate()
+    {
+        return $this->dissociate();
+    }
+
+    /**
      * Add the constraints for a relationship query.
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query

--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/AsPivot.php
@@ -88,7 +88,7 @@ trait AsPivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         if (isset($this->attributes[$this->getKeyName()])) {
             return parent::setKeysForSaveQuery($query);

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -2,7 +2,6 @@
 
 namespace Illuminate\Database\Eloquent\Relations;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class MorphPivot extends Pivot

--- a/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphPivot.php
@@ -31,7 +31,7 @@ class MorphPivot extends Pivot
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $query->where($this->morphType, $this->morphClass);
 

--- a/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
+++ b/src/Illuminate/Database/Eloquent/Relations/MorphTo.php
@@ -240,6 +240,16 @@ class MorphTo extends BelongsTo
     }
 
     /**
+     * Alias for the "dissociate" method.
+     *
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function disassociate()
+    {
+        return $this->dissociate();
+    }
+
+    /**
      * Touch all of the related models for the relationship.
      *
      * @return void

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -318,7 +318,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -318,7 +318,7 @@ class PostgresGrammar extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return ['truncate '.$this->wrapTable($query->from).' restart identity cascade' => []];
+        return ['truncate '.$this->wrapTable($query->from).' restart identity' => []];
     }
 
     /**

--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -504,29 +504,31 @@ class Filesystem
     /**
      * Get an array of all files in a directory.
      *
-     * @param  string  $directory
-     * @param  bool  $hidden
+     * @param string $directory
+     * @param bool $hidden
+     * @param array $exclude
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function files($directory, $hidden = false)
+    public function files($directory, $hidden = false, $exclude = [])
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->depth(0)->sortByName(),
-            false
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->exclude($exclude)
+                ->depth(0)->sortByName(), false
         );
     }
 
     /**
      * Get all of the files from the given directory (recursive).
      *
-     * @param  string  $directory
-     * @param  bool  $hidden
+     * @param string $directory
+     * @param bool $hidden
+     * @param array $exclude
      * @return \Symfony\Component\Finder\SplFileInfo[]
      */
-    public function allFiles($directory, $hidden = false)
+    public function allFiles($directory, $hidden = false, $exclude = [])
     {
         return iterator_to_array(
-            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->sortByName(),
+            Finder::create()->files()->ignoreDotFiles(! $hidden)->in($directory)->exclude($exclude)->sortByName(),
             false
         );
     }
@@ -534,14 +536,15 @@ class Filesystem
     /**
      * Get all of the directories within a given directory.
      *
-     * @param  string  $directory
+     * @param string $directory
+     * @param array $exclude
      * @return array
      */
-    public function directories($directory)
+    public function directories($directory, $exclude = [])
     {
         $directories = [];
 
-        foreach (Finder::create()->in($directory)->directories()->depth(0)->sortByName() as $dir) {
+        foreach (Finder::create()->in($directory)->directories()->exclude($exclude)->depth(0)->sortByName() as $dir) {
             $directories[] = $dir->getPathname();
         }
 

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -207,7 +207,7 @@ class FilesystemManager implements FactoryContract
         $root = $s3Config['root'] ?? null;
 
         $options = $config['options'] ?? [];
-        
+
         $streamReads = $config['stream_reads'] ?? false;
 
         return $this->adapt($this->createFlysystem(

--- a/src/Illuminate/Filesystem/FilesystemManager.php
+++ b/src/Illuminate/Filesystem/FilesystemManager.php
@@ -207,9 +207,11 @@ class FilesystemManager implements FactoryContract
         $root = $s3Config['root'] ?? null;
 
         $options = $config['options'] ?? [];
+        
+        $streamReads = $config['stream_reads'] ?? false;
 
         return $this->adapt($this->createFlysystem(
-            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $options), $config
+            new S3Adapter(new S3Client($s3Config), $s3Config['bucket'], $root, $options, $streamReads), $config
         ));
     }
 

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.6.0';
+    const VERSION = '8.7.0';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -31,7 +31,7 @@ class Application extends Container implements ApplicationContract, HttpKernelIn
      *
      * @var string
      */
-    const VERSION = '6.18.40';
+    const VERSION = '6.18.41';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Application.php
+++ b/src/Illuminate/Foundation/Application.php
@@ -33,7 +33,7 @@ class Application extends Container implements ApplicationContract, CachesConfig
      *
      * @var string
      */
-    const VERSION = '8.7.0';
+    const VERSION = '8.7.1';
 
     /**
      * The base path for the Laravel installation.

--- a/src/Illuminate/Foundation/Console/stubs/view-component.stub
+++ b/src/Illuminate/Foundation/Console/stubs/view-component.stub
@@ -19,7 +19,7 @@ class DummyClass extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\Contracts\View\View|string
      */
     public function render()
     {

--- a/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Illuminate/Foundation/Providers/ArtisanServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Cache\Console\ClearCommand as CacheClearCommand;
 use Illuminate\Cache\Console\ForgetCommand as CacheForgetCommand;
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;
+use Illuminate\Console\Scheduling\ScheduleWorkCommand;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Database\Console\DumpCommand;
 use Illuminate\Database\Console\Factories\FactoryMakeCommand;
@@ -113,6 +114,7 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
         'Seed' => 'command.seed',
         'ScheduleFinish' => ScheduleFinishCommand::class,
         'ScheduleRun' => ScheduleRunCommand::class,
+        'ScheduleWork' => ScheduleWorkCommand::class,
         'StorageLink' => 'command.storage.link',
         'Up' => 'command.up',
         'ViewCache' => 'command.view.cache',
@@ -912,6 +914,16 @@ class ArtisanServiceProvider extends ServiceProvider implements DeferrableProvid
     protected function registerScheduleRunCommand()
     {
         $this->app->singleton(ScheduleRunCommand::class);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerScheduleWorkCommand()
+    {
+        $this->app->singleton(ScheduleWorkCommand::class);
     }
 
     /**

--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -673,7 +673,7 @@ if (! function_exists('response')) {
     /**
      * Return a new response from the application.
      *
-     * @param  \Illuminate\View\View|string|array|null  $content
+     * @param  \Illuminate\Contracts\View\View|string|array|null  $content
      * @param  int  $status
      * @param  array  $headers
      * @return \Illuminate\Http\Response|\Illuminate\Contracts\Routing\ResponseFactory
@@ -884,7 +884,7 @@ if (! function_exists('view')) {
      * @param  string|null  $view
      * @param  \Illuminate\Contracts\Support\Arrayable|array  $data
      * @param  array  $mergeData
-     * @return \Illuminate\View\View|\Illuminate\Contracts\View\Factory
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory
      */
     function view($view = null, $data = [], $mergeData = [])
     {

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -314,6 +314,17 @@ class PendingRequest
     }
 
     /**
+     * Specify the user agent for the request.
+     *
+     * @param  string  $userAgent
+     * @return $this
+     */
+    public function withUserAgent($userAgent)
+    {
+        return $this->withHeaders(['User-Agent' => $userAgent]);
+    }
+
+    /**
      * Specify the cookies that should be included with the request.
      *
      * @param  array  $cookies
@@ -339,17 +350,6 @@ class PendingRequest
         return tap($this, function ($request) {
             return $this->options['allow_redirects'] = false;
         });
-    }
-
-    /**
-     * Specify the user agent for the request.
-     *
-     * @param  string  $userAgent
-     * @return $this
-     */
-    public function withUserAgent($userAgent)
-    {
-        return $this->withHeaders(['User-Agent' => $userAgent]);
     }
 
     /**

--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -342,6 +342,17 @@ class PendingRequest
     }
 
     /**
+     * Specify the user agent for the request.
+     *
+     * @param  string  $userAgent
+     * @return $this
+     */
+    public function withUserAgent($userAgent)
+    {
+        return $this->withHeaders(['User-Agent' => $userAgent]);
+    }
+
+    /**
      * Indicate that TLS certificates should not be verified.
      *
      * @return $this

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -209,7 +209,24 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
+        return $this->throwWith(function () {
+            //
+        });
+    }
+
+    /**
+     * Execute the callback and throw an exception if a server of client error occurred.
+     *
+     * @param \Closure $callback
+     * @return $this
+     *
+     * @throws \Illuminate\Http\Client\RequestException
+     */
+    public function throwWith($callback)
+    {
         if ($this->serverError() || $this->clientError()) {
+            $callback($this);
+
             throw new RequestException($this);
         }
 

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -188,7 +188,7 @@ class Response implements ArrayAccess
      */
     public function onError(callable $callback)
     {
-        if ($this->serverError() || $this->clientError()) {
+        if ($this->failed()) {
             $callback($this);
         }
 
@@ -227,7 +227,7 @@ class Response implements ArrayAccess
     {
         $callback = func_get_args()[0] ?? null;
 
-        if ($this->serverError() || $this->clientError()) {
+        if ($this->failed()) {
             throw tap(new RequestException($this), function ($exception) use ($callback) {
                 if ($callback && is_callable($callback)) {
                     $callback($this, $exception);

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -209,9 +209,11 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
-        return $this->throwWith(function () {
-            //
-        });
+        if ($this->serverError() || $this->clientError()) {
+            throw new RequestException($this);
+        }
+
+        return $this;
     }
 
     /**
@@ -219,15 +221,11 @@ class Response implements ArrayAccess
      *
      * @param \Closure $callback
      * @return $this
-     *
-     * @throws \Illuminate\Http\Client\RequestException
      */
-    public function throwWith($callback)
+    public function onError($callback)
     {
         if ($this->serverError() || $this->clientError()) {
             $callback($this);
-
-            throw new RequestException($this);
         }
 
         return $this;

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -181,6 +181,21 @@ class Response implements ArrayAccess
     }
 
     /**
+     * Execute the given callback if there was a server or client error.
+     *
+     * @param  \Closure|callable $callback
+     * @return $this
+     */
+    public function onError(callable $callback)
+    {
+        if ($this->serverError() || $this->clientError()) {
+            $callback($this);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the response cookies.
      *
      * @return \GuzzleHttp\Cookie\CookieJar
@@ -203,29 +218,21 @@ class Response implements ArrayAccess
     /**
      * Throw an exception if a server or client error occurred.
      *
+     * @param  \Closure|null  $callback
      * @return $this
      *
      * @throws \Illuminate\Http\Client\RequestException
      */
     public function throw()
     {
-        if ($this->serverError() || $this->clientError()) {
-            throw new RequestException($this);
-        }
+        $callback = func_get_arg(0);
 
-        return $this;
-    }
-
-    /**
-     * Execute the callback and throw an exception if a server of client error occurred.
-     *
-     * @param \Closure $callback
-     * @return $this
-     */
-    public function onError($callback)
-    {
         if ($this->serverError() || $this->clientError()) {
-            $callback($this);
+            if ($callback && is_callable($callback)) {
+                $callback($this, $exception = new RequestException($this));
+            }
+
+            throw $exception;
         }
 
         return $this;

--- a/src/Illuminate/Http/Client/Response.php
+++ b/src/Illuminate/Http/Client/Response.php
@@ -225,14 +225,14 @@ class Response implements ArrayAccess
      */
     public function throw()
     {
-        $callback = func_get_arg(0);
+        $callback = func_get_args()[0] ?? null;
 
         if ($this->serverError() || $this->clientError()) {
-            if ($callback && is_callable($callback)) {
-                $callback($this, $exception = new RequestException($this));
-            }
-
-            throw $exception;
+            throw tap(new RequestException($this), function ($exception) use ($callback) {
+                if ($callback && is_callable($callback)) {
+                    $callback($this, $exception);
+                }
+            });
         }
 
         return $this;

--- a/src/Illuminate/Routing/RouteRegistrar.php
+++ b/src/Illuminate/Routing/RouteRegistrar.php
@@ -19,7 +19,7 @@ use InvalidArgumentException;
  * @method \Illuminate\Routing\RouteRegistrar domain(string $value)
  * @method \Illuminate\Routing\RouteRegistrar middleware(array|string|null $middleware)
  * @method \Illuminate\Routing\RouteRegistrar name(string $value)
- * @method \Illuminate\Routing\RouteRegistrar namespace(string $value)
+ * @method \Illuminate\Routing\RouteRegistrar namespace(string|null $value)
  * @method \Illuminate\Routing\RouteRegistrar prefix(string  $prefix)
  * @method \Illuminate\Routing\RouteRegistrar where(array  $where)
  */

--- a/src/Illuminate/Testing/Constraints/HasInDatabase.php
+++ b/src/Illuminate/Testing/Constraints/HasInDatabase.php
@@ -111,6 +111,10 @@ class HasInDatabase extends Constraint
      */
     public function toString($options = 0): string
     {
-        return json_encode($this->data, $options);
+        foreach ($this->data as $key => $data) {
+            $output[$key] = $data instanceof Expression ? (string) $data : $data;
+        }
+
+        return json_encode($output ?? [], $options);
     }
 }

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -4,8 +4,19 @@ namespace Illuminate\View;
 
 class AppendableAttributeValue
 {
+    /**
+     * The attribute value.
+     *
+     * @var mixed
+     */
     public $value;
 
+    /**
+     * Create a new appendable attribute value.
+     *
+     * @param  mixed  $value
+     * @return void
+     */
     public function __construct($value)
     {
         $this->value = $value;

--- a/src/Illuminate/View/AppendableAttributeValue.php
+++ b/src/Illuminate/View/AppendableAttributeValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Illuminate\View;
+
+class AppendableAttributeValue
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -5,6 +5,7 @@ namespace Illuminate\View;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -50,20 +51,20 @@ abstract class Component
     /**
      * Get the view / view contents that represent the component.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     abstract public function render();
 
     /**
      * Resolve the Blade view or view file that should be used when rendering the component.
      *
-     * @return \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
+     * @return \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string
      */
     public function resolveView()
     {
         $view = $this->render();
 
-        if ($view instanceof View) {
+        if ($view instanceof ViewContract) {
             return $view;
         }
 

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -219,7 +219,7 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      * @param  mixed  $value
      * @return \Illuminate\View\AppendableAttributeValue
      */
-    public function appends($value)
+    public function prepends($value)
     {
         return new AppendableAttributeValue($value);
     }

--- a/src/Illuminate/View/ComponentAttributeBag.php
+++ b/src/Illuminate/View/ComponentAttributeBag.php
@@ -171,29 +171,74 @@ class ComponentAttributeBag implements ArrayAccess, Htmlable, IteratorAggregate
      */
     public function merge(array $attributeDefaults = [], $escape = true)
     {
-        $attributes = [];
-
         $attributeDefaults = array_map(function ($value) use ($escape) {
-            if (! $escape || is_object($value) || is_null($value) || is_bool($value)) {
-                return $value;
-            }
-
-            return e($value);
+            return $this->shouldEscapeAttributeValue($escape, $value)
+                        ? e($value)
+                        : $value;
         }, $attributeDefaults);
 
-        foreach ($this->attributes as $key => $value) {
-            if ($key !== 'class') {
-                $attributes[$key] = $value;
+        [$appendableAttributes, $nonAppendableAttributes] = collect($this->attributes)
+                    ->partition(function ($value, $key) use ($attributeDefaults) {
+                        return $key === 'class' ||
+                               (isset($attributeDefaults[$key]) &&
+                                $attributeDefaults[$key] instanceof AppendableAttributeValue);
+                    });
 
-                continue;
-            }
+        $attributes = $appendableAttributes->mapWithKeys(function ($value, $key) use ($attributeDefaults, $escape) {
+            $defaultsValue = isset($attributeDefaults[$key]) && $attributeDefaults[$key] instanceof AppendableAttributeValue
+                        ? $this->resolveAppendableAttributeDefault($attributeDefaults, $key, $escape)
+                        : ($attributeDefaults[$key] ?? '');
 
-            $attributes[$key] = implode(' ', array_unique(
-                array_filter([$attributeDefaults[$key] ?? '', $value])
-            ));
-        }
+            return [$key => implode(' ', array_unique(array_filter([$defaultsValue, $value])))];
+        })->merge($nonAppendableAttributes)->all();
 
         return new static(array_merge($attributeDefaults, $attributes));
+    }
+
+    /**
+     * Determine if the specific attribute value should be escaped.
+     *
+     * @param  bool  $escape
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function shouldEscapeAttributeValue($escape, $value)
+    {
+        if (! $escape) {
+            return false;
+        }
+
+        return ! is_object($value) &&
+               ! is_null($value) &&
+               ! is_bool($value);
+    }
+
+    /**
+     * Create a new appendable attribute value.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\View\AppendableAttributeValue
+     */
+    public function appends($value)
+    {
+        return new AppendableAttributeValue($value);
+    }
+
+    /**
+     * Resolve an appendable attribute value default value.
+     *
+     * @param  array  $attributeDefaults
+     * @param  string  $key
+     * @param  bool  $escape
+     * @return mixed
+     */
+    protected function resolveAppendableAttributeDefault($attributeDefaults, $key, $escape)
+    {
+        if ($this->shouldEscapeAttributeValue($escape, $value = $attributeDefaults[$key]->value)) {
+            $value = e($value);
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Illuminate/View/Concerns/ManagesComponents.php
+++ b/src/Illuminate/View/Concerns/ManagesComponents.php
@@ -42,7 +42,7 @@ trait ManagesComponents
     /**
      * Start a component rendering process.
      *
-     * @param  \Illuminate\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
+     * @param  \Illuminate\Contracts\View\View|\Illuminate\Contracts\Support\Htmlable|\Closure|string  $view
      * @param  array  $data
      * @return void
      */

--- a/src/Illuminate/View/DynamicComponent.php
+++ b/src/Illuminate/View/DynamicComponent.php
@@ -42,7 +42,7 @@ class DynamicComponent extends Component
     /**
      * Get the view / contents that represent the component.
      *
-     * @return \Illuminate\View\View|string
+     * @return \Illuminate\Contracts\View\View|string
      */
     public function render()
     {

--- a/tests/Bus/BusBatchTest.php
+++ b/tests/Bus/BusBatchTest.php
@@ -198,7 +198,7 @@ class BusBatchTest extends TestCase
         $this->assertTrue($batch->cancelled());
         $this->assertEquals(1, $_SERVER['__finally.count']);
         $this->assertEquals(1, $_SERVER['__catch.count']);
-        $this->assertEquals('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
+        $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
     public function test_failed_jobs_can_be_recorded_while_allowing_failures()
@@ -236,7 +236,7 @@ class BusBatchTest extends TestCase
         $this->assertFalse($batch->finished());
         $this->assertFalse($batch->cancelled());
         $this->assertEquals(1, $_SERVER['__catch.count']);
-        $this->assertEquals('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
+        $this->assertSame('Something went wrong.', $_SERVER['__catch.exception']->getMessage());
     }
 
     public function test_batch_can_be_cancelled()

--- a/tests/Bus/BusBatchableTest.php
+++ b/tests/Bus/BusBatchableTest.php
@@ -22,7 +22,7 @@ class BusBatchableTest extends TestCase
         };
 
         $this->assertSame($class, $class->withBatchId('test-batch-id'));
-        $this->assertEquals('test-batch-id', $class->batchId);
+        $this->assertSame('test-batch-id', $class->batchId);
 
         Container::setInstance($container = new Container);
 
@@ -30,7 +30,7 @@ class BusBatchableTest extends TestCase
         $repository->shouldReceive('find')->once()->with('test-batch-id')->andReturn('test-batch');
         $container->instance(BatchRepository::class, $repository);
 
-        $this->assertEquals('test-batch', $class->batch());
+        $this->assertSame('test-batch', $class->batch());
 
         Container::setInstance(null);
     }

--- a/tests/Bus/BusPendingBatchTest.php
+++ b/tests/Bus/BusPendingBatchTest.php
@@ -40,8 +40,8 @@ class BusPendingBatchTest extends TestCase
             //
         })->allowFailures()->onConnection('test-connection')->onQueue('test-queue');
 
-        $this->assertEquals('test-connection', $pendingBatch->connection());
-        $this->assertEquals('test-queue', $pendingBatch->queue());
+        $this->assertSame('test-connection', $pendingBatch->connection());
+        $this->assertSame('test-queue', $pendingBatch->queue());
         $this->assertCount(1, $pendingBatch->thenCallbacks());
         $this->assertCount(1, $pendingBatch->catchCallbacks());
 

--- a/tests/Database/DatabaseEloquentFactoryTest.php
+++ b/tests/Database/DatabaseEloquentFactoryTest.php
@@ -94,7 +94,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $user = FactoryTestUserFactory::new()->create(['name' => 'Taylor Otwell']);
         $this->assertInstanceOf(Eloquent::class, $user);
-        $this->assertEquals('Taylor Otwell', $user->name);
+        $this->assertSame('Taylor Otwell', $user->name);
 
         $users = FactoryTestUserFactory::new()->createMany([
             ['name' => 'Taylor Otwell'],
@@ -118,7 +118,7 @@ class DatabaseEloquentFactoryTest extends TestCase
             },
         ]);
 
-        $this->assertEquals('taylor-options', $user->options);
+        $this->assertSame('taylor-options', $user->options);
     }
 
     public function test_make_creates_unpersisted_model_instance()
@@ -129,7 +129,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $user = FactoryTestUserFactory::new()->make(['name' => 'Taylor Otwell']);
 
         $this->assertInstanceOf(Eloquent::class, $user);
-        $this->assertEquals('Taylor Otwell', $user->name);
+        $this->assertSame('Taylor Otwell', $user->name);
         $this->assertCount(0, FactoryTestUser::all());
     }
 
@@ -140,7 +140,7 @@ class DatabaseEloquentFactoryTest extends TestCase
 
         $user = FactoryTestUserFactory::new()->raw(['name' => 'Taylor Otwell']);
         $this->assertIsArray($user);
-        $this->assertEquals('Taylor Otwell', $user['name']);
+        $this->assertSame('Taylor Otwell', $user['name']);
     }
 
     public function test_expanded_model_attributes_can_be_created()
@@ -151,7 +151,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $post = FactoryTestPostFactory::new()->raw(['title' => 'Test Title']);
         $this->assertIsArray($post);
         $this->assertIsInt($post['user_id']);
-        $this->assertEquals('Test Title', $post['title']);
+        $this->assertSame('Test Title', $post['title']);
     }
 
     public function test_after_creating_and_making_callbacks_are_called()
@@ -225,7 +225,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                         ->for(FactoryTestPostFactory::new(['title' => 'Test Title']), 'commentable')
                         ->create();
 
-        $this->assertEquals('Test Title', FactoryTestPost::first()->title);
+        $this->assertSame('Test Title', FactoryTestPost::first()->title);
         $this->assertCount(3, FactoryTestPost::first()->comments);
 
         $this->assertCount(1, FactoryTestPost::all());
@@ -250,7 +250,7 @@ class DatabaseEloquentFactoryTest extends TestCase
         $user = FactoryTestUser::latest()->first();
 
         $this->assertCount(3, $user->roles);
-        $this->assertEquals('Y', $user->roles->first()->pivot->admin);
+        $this->assertSame('Y', $user->roles->first()->pivot->admin);
 
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-role']);
         $this->assertInstanceOf(Eloquent::class, $_SERVER['__test.role.creating-user']);
@@ -266,8 +266,8 @@ class DatabaseEloquentFactoryTest extends TestCase
             ['name' => 'Abigail Otwell'],
         )->create();
 
-        $this->assertEquals('Taylor Otwell', $users[0]->name);
-        $this->assertEquals('Abigail Otwell', $users[1]->name);
+        $this->assertSame('Taylor Otwell', $users[0]->name);
+        $this->assertSame('Abigail Otwell', $users[1]->name);
 
         $user = FactoryTestUserFactory::new()
                         ->hasAttached(
@@ -329,7 +329,7 @@ class DatabaseEloquentFactoryTest extends TestCase
                             ->create();
 
         $this->assertInstanceOf(FactoryTestUser::class, $post->author);
-        $this->assertEquals('Taylor Otwell', $post->author->name);
+        $this->assertSame('Taylor Otwell', $post->author->name);
         $this->assertCount(2, $post->comments);
     }
 

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -67,7 +67,7 @@ class DatabaseEloquentModelTest extends TestCase
         $model->list_items = ['name' => 'taylor'];
         $this->assertEquals(['name' => 'taylor'], $model->list_items);
         $attributes = $model->getAttributes();
-        $this->assertEquals(json_encode(['name' => 'taylor']), $attributes['list_items']);
+        $this->assertSame(json_encode(['name' => 'taylor']), $attributes['list_items']);
     }
 
     public function testSetAttributeWithNumericKey()

--- a/tests/Database/DatabaseEloquentPivotTest.php
+++ b/tests/Database/DatabaseEloquentPivotTest.php
@@ -161,13 +161,13 @@ class DatabaseEloquentPivotTest extends TestCase
         $original->pivotParent = 'foo';
         $original->setRelation('bar', 'baz');
 
-        $this->assertEquals('baz', $original->getRelation('bar'));
+        $this->assertSame('baz', $original->getRelation('bar'));
 
         $pivot = $original->withoutRelations();
 
         $this->assertInstanceOf(Pivot::class, $pivot);
         $this->assertNotSame($pivot, $original);
-        $this->assertEquals('foo', $original->pivotParent);
+        $this->assertSame('foo', $original->pivotParent);
         $this->assertNull($pivot->pivotParent);
         $this->assertTrue($original->relationLoaded('bar'));
         $this->assertFalse($pivot->relationLoaded('bar'));

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -3077,12 +3077,12 @@ SQL;
             $query->from('two')->select('baz')->where('subkey', '=', 'subval');
         }, 'sub');
 
-        $this->assertEquals('select (select "baz" from "two" where "subkey" = ?) as "sub" from "one"', $builder->toSql());
+        $this->assertSame('select (select "baz" from "two" where "subkey" = ?) as "sub" from "one"', $builder->toSql());
         $this->assertEquals(['subval'], $builder->getBindings());
 
         $builder->select('*');
 
-        $this->assertEquals('select * from "one"', $builder->toSql());
+        $this->assertSame('select * from "one"', $builder->toSql());
         $this->assertEquals([], $builder->getBindings());
     }
 

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -237,6 +237,18 @@ class HttpClientTest extends TestCase
         });
     }
 
+    public function testItCanSendUserAgent()
+    {
+        $this->factory->fake();
+
+        $this->factory->withUserAgent('Laravel')->post('http://foo.com/json');
+
+        $this->factory->assertSent(function (Request $request) {
+            return $request->url() === 'http://foo.com/json' &&
+                $request->hasHeader('User-Agent', 'Laravel');
+        });
+    }
+
     public function testSequenceBuilder()
     {
         $this->factory->fake([

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -476,6 +476,42 @@ class HttpClientTest extends TestCase
         throw new RequestException(new Response($response));
     }
 
+    public function testThrowWithCallsClosureOnError()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 401),
+        ]);
+        $response = $client->get('laravel.com');
+
+        try {
+            $response->throwWith(function ($response) use (&$status) {
+                $status = $response->status();
+            });
+        } catch (RequestException $e) {
+            //
+        }
+
+        $this->assertSame(401, $status);
+        $this->assertSame(401, $response->status());
+    }
+
+    public function testThrowWithDoesntCallClosureOnSuccess()
+    {
+        $status = 0;
+        $client = $this->factory->fake([
+            'laravel.com' => $this->factory::response('', 201),
+        ]);
+        $response = $client->get('laravel.com');
+
+        $response->throwWith(function ($response) use (&$status) {
+            $status = $response->status();
+        });
+
+        $this->assertSame(0, $status);
+        $this->assertSame(201, $response->status());
+    }
+
     public function testSinkToFile()
     {
         $this->factory->fakeSequence()->push('abc123');

--- a/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
+++ b/tests/Integration/Database/DatabaseEloquentModelCustomCastingTest.php
@@ -31,7 +31,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $model->syncOriginal();
         $model->uppercase = 'dries';
-        $this->assertEquals('TAYLOR', $model->getOriginal('uppercase'));
+        $this->assertSame('TAYLOR', $model->getOriginal('uppercase'));
 
         $model = new TestEloquentModelWithCustomCast;
         $model->uppercase = 'taylor';
@@ -39,7 +39,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $model->uppercase = 'dries';
         $model->getOriginal();
 
-        $this->assertEquals('DRIES', $model->uppercase);
+        $this->assertSame('DRIES', $model->uppercase);
 
         $model = new TestEloquentModelWithCustomCast;
 
@@ -82,7 +82,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
         $this->assertEquals(['foo' => 'bar'], $model->options);
         $this->assertEquals(['foo' => 'bar'], $model->options);
 
-        $this->assertEquals(json_encode(['foo' => 'bar']), $model->getAttributes()['options']);
+        $this->assertSame(json_encode(['foo' => 'bar']), $model->getAttributes()['options']);
 
         $model = new TestEloquentModelWithCustomCast(['options' => []]);
         $model->syncOriginal();
@@ -104,9 +104,9 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $model->address = new Address('117 Spencer St.', 'Another house.');
 
-        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
-        $this->assertEquals('110 Kingsbrook St.', $model->getOriginal('address')->lineOne);
-        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal('address')->lineOne);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
 
         $model = new TestEloquentModelWithCustomCast([
             'address' => new Address('110 Kingsbrook St.', 'My Childhood House'),
@@ -116,10 +116,10 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
 
         $model->address = new Address('117 Spencer St.', 'Another house.');
 
-        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
-        $this->assertEquals('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
-        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
-        $this->assertEquals('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
+        $this->assertSame('117 Spencer St.', $model->address->lineOne);
+        $this->assertSame('110 Kingsbrook St.', $model->getOriginal()['address_line_one']);
 
         $model = new TestEloquentModelWithCustomCast([
             'address' => new Address('110 Kingsbrook St.', 'My Childhood House'),
@@ -187,7 +187,7 @@ class DatabaseEloquentModelCustomCastingTest extends DatabaseTestCase
             'value_object_caster_with_argument' => null,
         ]);
 
-        $this->assertEquals('argument', $model->value_object_caster_with_argument);
+        $this->assertSame('argument', $model->value_object_caster_with_argument);
 
         $model->setRawAttributes([
             'value_object_caster_with_caster_instance' => serialize(new ValueObject('hello')),

--- a/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
+++ b/tests/Integration/Database/DatabaseSchemaBuilderAlterTableWithEnumTest.php
@@ -22,7 +22,7 @@ class DatabaseSchemaBuilderAlterTableWithEnumTest extends DatabaseMySqlTestCase
             $table->unsignedInteger('age')->charset('')->change();
         });
 
-        $this->assertEquals('integer', Schema::getColumnType('users', 'age'));
+        $this->assertSame('integer', Schema::getColumnType('users', 'age'));
     }
 
     protected function setUp(): void

--- a/tests/Integration/Database/EloquentModelWithoutEventsTest.php
+++ b/tests/Integration/Database/EloquentModelWithoutEventsTest.php
@@ -31,7 +31,7 @@ class EloquentModelWithoutEventsTest extends DatabaseTestCase
 
         $model->save();
 
-        $this->assertEquals('Laravel', $model->project);
+        $this->assertSame('Laravel', $model->project);
     }
 }
 

--- a/tests/Integration/Foundation/MaintenanceModeTest.php
+++ b/tests/Integration/Foundation/MaintenanceModeTest.php
@@ -67,7 +67,7 @@ class MaintenanceModeTest extends TestCase
 
         $response->assertStatus(503);
         $response->assertHeader('Retry-After', '60');
-        $this->assertEquals('Rendered Content', $response->original);
+        $this->assertSame('Rendered Content', $response->original);
     }
 
     public function testMaintenanceModeCanRedirectWithBypassCookie()
@@ -106,7 +106,7 @@ class MaintenanceModeTest extends TestCase
         ])->get('/test');
 
         $response->assertStatus(200);
-        $this->assertEquals('Hello World', $response->original);
+        $this->assertSame('Hello World', $response->original);
     }
 
     public function testMaintenanceModeCantBeBypassedWithInvalidCookie()
@@ -134,7 +134,7 @@ class MaintenanceModeTest extends TestCase
         $cookie = MaintenanceModeBypassCookie::create('test-key');
 
         $this->assertInstanceOf(Cookie::class, $cookie);
-        $this->assertEquals('laravel_maintenance', $cookie->getName());
+        $this->assertSame('laravel_maintenance', $cookie->getName());
 
         $this->assertTrue(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'test-key'));
         $this->assertFalse(MaintenanceModeBypassCookie::isValid($cookie->getValue(), 'wrong-key'));

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -14,7 +14,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('hello', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('Hello Taylor', trim($view));
+        $this->assertSame('Hello Taylor', trim($view));
     }
 
     public function test_rendering_a_component()
@@ -30,7 +30,7 @@ class BladeTest extends TestCase
     {
         $view = View::make('uses-panel-dynamically', ['name' => 'Taylor'])->render();
 
-        $this->assertEquals('<div class="ml-2" wire:model="foo" wire:model.lazy="bar">
+        $this->assertSame('<div class="ml-2" wire:model="foo" wire:model.lazy="bar">
     Hello Taylor
 </div>', trim($view));
     }

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -48,6 +48,15 @@ class BladeTest extends TestCase
 </span>', trim($view));
     }
 
+    public function test_appendable_attributes()
+    {
+        $view = View::make('uses-appendable-panel', ['name' => 'Taylor'])->render();
+
+        $this->assertEquals('<div class="mt-4 bg-gray-100" data-controller="inside-controller outside-controller" foo="bar">
+    Hello Taylor
+</div>', trim($view));
+    }
+
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('view.paths', [__DIR__.'/templates']);

--- a/tests/Integration/View/templates/components/appendable-panel.blade.php
+++ b/tests/Integration/View/templates/components/appendable-panel.blade.php
@@ -1,0 +1,5 @@
+@props(['name'])
+
+<div {{ $attributes->merge(['class' => 'mt-4', 'data-controller' => $attributes->appends('inside-controller')]) }}>
+    Hello {{ $name }}
+</div>

--- a/tests/Integration/View/templates/components/appendable-panel.blade.php
+++ b/tests/Integration/View/templates/components/appendable-panel.blade.php
@@ -1,5 +1,5 @@
 @props(['name'])
 
-<div {{ $attributes->merge(['class' => 'mt-4', 'data-controller' => $attributes->appends('inside-controller')]) }}>
+<div {{ $attributes->merge(['class' => 'mt-4', 'data-controller' => $attributes->prepends('inside-controller')]) }}>
     Hello {{ $name }}
 </div>

--- a/tests/Integration/View/templates/uses-appendable-panel.blade.php
+++ b/tests/Integration/View/templates/uses-appendable-panel.blade.php
@@ -1,0 +1,3 @@
+<x-appendable-panel class="bg-gray-100" :name="$name" data-controller="outside-controller" foo="bar">
+    Panel contents
+</x-appendable-panel>

--- a/tests/Queue/QueueDatabaseQueueUnitTest.php
+++ b/tests/Queue/QueueDatabaseQueueUnitTest.php
@@ -31,7 +31,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid) {
             $this->assertSame('default', $array['queue']);
-            $this->assertEquals(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
+            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);
@@ -59,7 +59,7 @@ class QueueDatabaseQueueUnitTest extends TestCase
         $database->shouldReceive('table')->with('table')->andReturn($query = m::mock(stdClass::class));
         $query->shouldReceive('insertGetId')->once()->andReturnUsing(function ($array) use ($uuid) {
             $this->assertSame('default', $array['queue']);
-            $this->assertEquals(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
+            $this->assertSame(json_encode(['uuid' => $uuid, 'displayName' => 'foo', 'job' => 'foo', 'maxTries' => null, 'maxExceptions' => null, 'backoff' => null, 'timeout' => null, 'data' => ['data']]), $array['payload']);
             $this->assertEquals(0, $array['attempts']);
             $this->assertNull($array['reserved_at']);
             $this->assertIsInt($array['available_at']);

--- a/tests/Redis/RedisConnectorTest.php
+++ b/tests/Redis/RedisConnectorTest.php
@@ -34,7 +34,7 @@ class RedisConnectorTest extends TestCase
 
         $predisClient = $this->redis['predis']->connection()->client();
         $parameters = $predisClient->getConnection()->getParameters();
-        $this->assertEquals('tcp', $parameters->scheme);
+        $this->assertSame('tcp', $parameters->scheme);
         $this->assertEquals($host, $parameters->host);
         $this->assertEquals($port, $parameters->port);
 
@@ -61,7 +61,7 @@ class RedisConnectorTest extends TestCase
         ]);
         $predisClient = $predis->connection()->client();
         $parameters = $predisClient->getConnection()->getParameters();
-        $this->assertEquals('tcp', $parameters->scheme);
+        $this->assertSame('tcp', $parameters->scheme);
         $this->assertEquals($host, $parameters->host);
         $this->assertEquals($port, $parameters->port);
 
@@ -77,7 +77,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient = $phpRedis->connection()->client();
-        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
+        $this->assertSame("tcp://{$host}", $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
     }
 
@@ -99,7 +99,7 @@ class RedisConnectorTest extends TestCase
         ]);
         $predisClient = $predis->connection()->client();
         $parameters = $predisClient->getConnection()->getParameters();
-        $this->assertEquals('tls', $parameters->scheme);
+        $this->assertSame('tls', $parameters->scheme);
         $this->assertEquals($host, $parameters->host);
         $this->assertEquals($port, $parameters->port);
 
@@ -115,7 +115,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient = $phpRedis->connection()->client();
-        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
+        $this->assertSame("tcp://{$host}", $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
     }
 
@@ -139,7 +139,7 @@ class RedisConnectorTest extends TestCase
         ]);
         $predisClient = $predis->connection()->client();
         $parameters = $predisClient->getConnection()->getParameters();
-        $this->assertEquals('tls', $parameters->scheme);
+        $this->assertSame('tls', $parameters->scheme);
         $this->assertEquals($host, $parameters->host);
         $this->assertEquals($port, $parameters->port);
 
@@ -157,7 +157,7 @@ class RedisConnectorTest extends TestCase
             ],
         ]);
         $phpRedisClient = $phpRedis->connection()->client();
-        $this->assertEquals("tcp://{$host}", $phpRedisClient->getHost());
+        $this->assertSame("tcp://{$host}", $phpRedisClient->getHost());
         $this->assertEquals($port, $phpRedisClient->getPort());
     }
 }

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -202,7 +202,7 @@ class RoutingRouteTest extends TestCase
             return 'hello';
         }])->withoutMiddleware(RoutingTestMiddlewareGroupTwo::class);
 
-        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+        $this->assertSame('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
     }
 
     public function testMiddlewareCanBeSkippedFromResources()
@@ -214,7 +214,7 @@ class RoutingRouteTest extends TestCase
             ->middleware('web')
             ->withoutMiddleware(RoutingTestMiddlewareGroupTwo::class);
 
-        $this->assertEquals('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+        $this->assertSame('Hello World', $router->dispatch(Request::create('foo', 'GET'))->getContent());
     }
 
     public function testMiddlewareWorksIfControllerThrowsHttpResponseException()

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -3602,6 +3602,20 @@ class SupportCollectionTest extends TestCase
     /**
      * @dataProvider collectionClassProvider
      */
+    public function testPipeInto($collection)
+    {
+        $data = new $collection([
+            'first', 'second',
+        ]);
+
+        $instance = $data->pipeInto(TestCollectionMapIntoObject::class);
+
+        $this->assertSame($data, $instance->value);
+    }
+
+    /**
+     * @dataProvider collectionClassProvider
+     */
     public function testMedianValueWithArrayCollection($collection)
     {
         $data = new $collection([1, 2, 2, 4]);

--- a/tests/Validation/ValidationValidatorTest.php
+++ b/tests/Validation/ValidationValidatorTest.php
@@ -61,7 +61,7 @@ class ValidationValidatorTest extends TestCase
         ]);
 
         $this->assertFalse($v->passes());
-        $this->assertEquals('post name is required', $v->errors()->all()[0]);
+        $this->assertSame('post name is required', $v->errors()->all()[0]);
     }
 
     public function testSometimesWorksOnNestedArrays()

--- a/tests/View/ViewComponentTest.php
+++ b/tests/View/ViewComponentTest.php
@@ -25,7 +25,7 @@ class ViewComponentTest extends TestCase
 
         $component->withAttributes(['class' => 'foo', 'attributes' => new ComponentAttributeBag(['class' => 'bar', 'type' => 'button'])]);
 
-        $this->assertEquals('class="foo bar" type="button"', (string) $component->attributes);
+        $this->assertSame('class="foo bar" type="button"', (string) $component->attributes);
     }
 
     public function testPublicMethodsWithNoArgsAreConvertedToStringableCallablesInvokedAndNotCached()


### PR DESCRIPTION
Hi!
I do the following PR to modify the following 3 methods:

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L511-L517

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L526-L532

https://github.com/laravel/framework/blob/68725a1a4d0be5afa04489fc1a1b1e678861a180/src/Illuminate/Filesystem/Filesystem.php#L540-L549

Adding the option to pass as a parameter an ```array``` with the files or directories that you want to exclude when these methods are called.


Example:

User has the following structure in ```resources``` directory:

```
resources
├───...
├───js
│   ├───A
│   ├───B
│   └───C
├───...
```

And want to get all the directories in the ```js``` folder, but exclude the ```C``` directory.

```
use Illuminate\Filesystem\Filesystem;

class CustomClass
{
    public function example()
    {
        $filesystem = new Filesystem();

        $exclude = ['C'];

        $directories = $filesystem->directories(resource_path('js'), $exclude);

        return $directories;
    }
}
```

the result would be an array with the following content:

```
array:2 [
  0 => "/path/to/project/resources/js/A"
  0 => "/path/to/project/resources/js/B"
]
```

Similarly you can use the ```files``` method and the ```allFiles``` method
