### PR TITLE
Revert "[8.x] Allow custom names for queued notifications"

### DIFF
--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -101,8 +101,7 @@ class SendQueuedNotifications implements ShouldQueue
      */
     public function displayName()
     {
-        return method_exists($this->notification, 'displayName')
-                        ? $this->notification->displayName() : get_class($this->notification);
+        return get_class($this->notification);
     }
 
     /**


### PR DESCRIPTION
Reverting this for now because it could be a breaking change if someone had this public method for a different reason.