### PR TITLE
[6.x] Restore support for nested keys in guarded property for JSON columns

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/GuardsAttributes.php
@@ -189,7 +189,7 @@ trait GuardsAttributes
      * Determines if the given column is in the guarded property,
      * or any level of a JSON column nested key is guarded.
      *
-     * @param $key
+     * @param  string  $key
      * @return bool
      */
     protected function isInGuarded($key)

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -994,6 +994,30 @@ class DatabaseEloquentModelTest extends TestCase
         );
     }
 
+    public function testGuardingJSONAttributes()
+    {
+        $model = new EloquentModelStub;
+
+        EloquentModelStub::setConnectionResolver($resolver = m::mock(Resolver::class));
+        $resolver->shouldReceive('connection')->andReturn($connection = m::mock(stdClass::class));
+        $connection->shouldReceive('getSchemaBuilder->getColumnListing')->andReturn(['name', 'age', 'foo']);
+
+        $model->guard(['foo->name', 'foo->price', 'foo->size->width']);
+        $model->fill(['foo->name' => 'foo', 'foo->price' => 'bar', 'foo->size->height' => 'baz', 'foo->size->width' => 'qux', 'foo->test' => 'fred']);
+        $this->assertEquals(
+            ['foo' => json_encode(['size' => ['height' => 'baz'], 'test' => 'fred'])],
+            $model->toArray()
+        );
+
+        $model = new EloquentModelStub(['foo' => json_encode(['name' => 'Taylor'])]);
+        $model->guard(['foo->name', 'foo->size->width']);
+        $model->fill(['foo->name' => 'foo', 'foo->price' => 'bar', 'foo->size->height' => 'baz', 'foo->size->width' => 'qux', 'foo->test' => 'fred']);
+        $this->assertEquals(
+            ['foo' => json_encode(['name' => 'Taylor', 'price' => 'bar', 'size' => ['height' => 'baz'], 'test' => 'fred'])],
+            $model->toArray()
+        );
+    }
+
     public function testUnguardAllowsAnythingToBeSet()
     {
         $model = new EloquentModelStub;


### PR DESCRIPTION
As a follow up to #34299, here is the proposed fix for the broken mass assignment of JSON columns when using `$guarded` instead of `$fillable` on an Eloquent Model, which was introduced introduced with the security fix #33777 . It is now based on the 6.x branch. Sorry for the delay...

The PR splits key names in JSON `column->path` expression notation and checks all components of the path for presence in the `$guarded` property of the Eloquent Model. Therefore, given a key name of `meta->languages->en`, `isGuarded()` will return `true` if `meta`, `meta->languages` or `meta->languages->en` are guarded.

For the recently added `isGuardableColumn()` check in #33777 , the path after the actual JSON column name is discarded beforehand, thus only `meta` will be checked for actual existence in the table column list, because anything else will of course always be considered guarded.