### PR TITLE
[6.x] Add missed RESET_THROTTLED constant to Password Facade

### DIFF
--- a/src/Illuminate/Support/Facades/Password.php
+++ b/src/Illuminate/Support/Facades/Password.php
@@ -41,6 +41,13 @@ class Password extends Facade
     const INVALID_TOKEN = PasswordBroker::INVALID_TOKEN;
 
     /**
+     * Constant representing a throttled reset attempt.
+     *
+     * @var string
+     */
+    const RESET_THROTTLED = PasswordBroker::RESET_THROTTLED;
+
+    /**
      * Get the registered name of the component.
      *
      * @return string


### PR DESCRIPTION
RESET_THROTTLED constant is added one year ago to Illuminate\Contracts\Auth\PasswordBroker but without a synced constant in Password Facade.
