### PR TITLE
[8.x] increase performance of Str::before by over 60%.

### DIFF
--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -107,11 +107,13 @@ class Str
      */
     public static function before($subject, $search)
     {
-        if ($search !== '' && ($result = strstr($subject, (string) $search, true)) !== false) {
-            return $result;
-        } else {
+        if ($search === '') {
             return $subject;
         }
+
+        $result = strstr($subject, (string) $search, true);
+
+        return $result === false ? $subject : $result;
     }
 
     /**

--- a/src/Illuminate/Support/Str.php
+++ b/src/Illuminate/Support/Str.php
@@ -107,7 +107,11 @@ class Str
      */
     public static function before($subject, $search)
     {
-        return $search === '' ? $subject : explode($search, $subject)[0];
+        if ($search !== '' && ($result = strstr($subject, (string) $search, true)) !== false) {
+            return $result;
+        } else {
+            return $subject;
+        }
     }
 
     /**


### PR DESCRIPTION
This PR proposes a change to the `Str::before` function that improves performance by over 60% compared to the old code (see benchmarks below). Even with an empty search string, the new code is slightly faster.

The string cast of the `$search` parameter is necessary to remain compatible with the `tests/Support/SupportStrTest.php` test, which tests for acceptance of integer values as `$search` parameter. To me, this is a little confusing, because the PHPdoc block declares `$search` as `string`. I didn't change this, but I think the type should be changed to `mixed` for `$search`, if this is really expected behavior.

Alternatively, the test could be changed, but since this would introduce a breaking change, this is not advisable.

As a side node, the new code would be another 10% faster without the string cast. Not using a shorthand if in the return line would further improve performance, but is slightly less readable.

### Benchmarks

Current code:
```
>>> for ($a = 5; $a--;) { $s = microtime(true); $subject = 'vendor/laravel'; $search = '/'; for ($i = 10000000; $i--;) { $search === '' ? $subject : explode($search, $subject)[0]; } echo microtime(true)-$s . "\n"; }
0.95517802238464
0.96321487426758
0.95738410949707
0.95915079116821
0.96855711936951
```

New code:
```
>>> for ($a = 5; $a--;) { $s = microtime(true); $subject = 'vendor/laravel'; $search = '/'; for ($i = 10000000; $i--;) { if ($search === '') { $subject; } else { $result = strstr($subject, (string) $search, true); $result === false ? $subject : $result; } } echo microtime(true)-$s . "\n"; }
0.58452105522156
0.58884692192078
0.5809018611908
0.58099007606506
0.58521318435669
```

Current code with empty search:

```
>>> for ($a = 5; $a--;) { $s = microtime(true); $subject = 'vendor/laravel'; $search = ''; for ($i = 10000000; $i--;) { $search === '' ? $subject : explode($search, $subject)[0]; } echo microtime(true)-$s . "\n"; }
0.16867280006409
0.16797685623169
0.16919302940369
0.16927814483643
0.16803288459778
```

New code with empty search:

```
>>> for ($a = 5; $a--;) { $s = microtime(true); $subject = 'vendor/laravel'; $search = ''; for ($i = 10000000; $i--;) { if ($search === '') { $subject; } else { $result = strstr($subject, (string) $search, true); $result === false ? $subject : $result; } } echo microtime(true)-$s . "\n"; }
0.1334171295166
0.13449788093567
0.13518381118774
0.13393306732178
0.13339805603027
```

New code without string cast:

```
>>> for ($a = 5; $a--;) { $s = microtime(true); $subject = 'vendor/laravel'; $search = '/'; for ($i = 10000000; $i--;) { if ($search === '') { $subject; } else { $result = strstr($subject, $search, true); if ($result === false) { $subject; } else { $result; } } } echo microtime(true)-$s . "\n"; }
0.50580191612244
0.50802898406982
0.51281690597534
0.52838587760925
0.51457190513611
```
