### PR TITLE
[8.x] Fix view type multiple definations.

### DIFF
--- a/src/Illuminate/View/Component.php
+++ b/src/Illuminate/View/Component.php
@@ -5,7 +5,6 @@ namespace Illuminate\View;
 use Closure;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
@@ -64,7 +63,7 @@ abstract class Component
     {
         $view = $this->render();
 
-        if ($view instanceof ViewContract) {
+        if ($view instanceof View) {
             return $view;
         }
 


### PR DESCRIPTION
There is already a definition. There is no need to introduce it as an extra.

- "use Illuminate \ Contracts \ View \ View as ViewContract;" removed. 
- You can use it as "View" instead of (ViewContract).
