### PR TITLE
[8.x] Change session to get a value from given key

### DIFF
--- a/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
+++ b/src/Illuminate/Foundation/Testing/Concerns/InteractsWithSession.php
@@ -19,13 +19,18 @@ trait InteractsWithSession
 
     /**
      * Set the session to the given array.
+     * Get the value from given key.
      *
-     * @param  array  $data
-     * @return $this
+     * @param  mixed  $data
+     * @return mixed
      */
-    public function session(array $data)
+    public function session($data)
     {
         $this->startSession();
+
+        if (! is_array($data)) {
+            return $this->app['session']->get($data);
+        }
 
         foreach ($data as $key => $value) {
             $this->app['session']->put($key, $value);


### PR DESCRIPTION
Tests now can define a value by sending an array to session and get the value by sending the key string.

$this->session(['name' => 'john']);
$this->session('name'); // john
