### PR TITLE
[8.x] Add extendsFirst method similar to includesFirst

### DIFF
--- a/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
+++ b/src/Illuminate/View/Compilers/Concerns/CompilesLayouts.php
@@ -29,6 +29,23 @@ trait CompilesLayouts
 
         return '';
     }
+    
+    /**
+     * Compile the extends-first statements into valid PHP.
+     *
+     * @param  string  $expression
+     * @return string
+     */
+    protected function compileExtendsFirst($expression)
+    {
+        $expression = $this->stripParentheses($expression);
+
+        $echo = "<?php echo \$__env->first({$expression}, \Illuminate\Support\Arr::except(get_defined_vars(), ['__data', '__path']))->render(); ?>";
+
+        $this->footer[] = $echo;
+
+        return '';
+    }
 
     /**
      * Compile the section statements into valid PHP.


### PR DESCRIPTION
The reason / need:
To extends a template according to a conditional existance.
For example to use different templates according to some configuration or variable.
To give an example let's have an idea of a marketplace API that sells products for a variety of stores.
So each store could have their own "base template" or in case they don't the API can use the default one.

Example that doesn't work today (using IFs):

```
@if(\View::exists('emails.store.' . $storeId)
@extends('emails.store.' . $storeId)
@else
@extends('emails.store.default')
@endif
```

The actual problem of using this way:
The compiler doesn't use that conditional IF and the content will be showed in double case both files exists. So the content is duplicated! When the view is rendered it returns a duplicated layout =/

The solution:
Added an extendsFirst method on CompilesLayouts using the "first" method